### PR TITLE
fix(workflow): Upgrade twine to 6.x for Metadata-Version 2.4 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          pip install build==1.* twine==5.* tomli==2.* packaging pytest
+          pip install build==1.* twine==6.* tomli==2.* packaging pytest
           pip install -e .[test]
 
       - name: Run tests


### PR DESCRIPTION
## Summary

Fixes the release workflow that failed for v0.3.2 due to twine 5.x not supporting Metadata-Version 2.4.

## Problem

The release workflow for v0.3.2 failed with:
```
ERROR InvalidDistribution: Metadata is missing required fields: Name, Version.
Make sure the distribution includes the files where those fields are specified, 
and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.
```

The error message shows twine 5.x only supports Metadata-Version up to 2.3. Modern Python packages built with hatchling use Metadata-Version 2.4, which was introduced in PEP 643.

## Solution

Upgraded twine from `5.*` to `6.*` which adds support for Metadata-Version 2.4.

## Testing

- ✅ Tested locally with twine 5.1.1 - reproduced the error
- ✅ Tested locally with twine 6.2.0 - passes validation
- ✅ Metadata fields (Name, Version) are present in the wheel

After this PR merges, we can push the v0.3.2 tag to trigger the release workflow again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)