### PR TITLE
fix(workflow): Move SHA256SUMS.txt outside dist/ directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Record artifact checksums
         run: |
-          sha256sum dist/* > dist/SHA256SUMS.txt
-          cat dist/SHA256SUMS.txt
+          sha256sum dist/* > SHA256SUMS.txt
+          cat SHA256SUMS.txt
 
       - name: Extract changelog for release
         id: changelog
@@ -70,7 +70,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/SHA256SUMS.txt
+            SHA256SUMS.txt
           draft: false
           prerelease: false
 
@@ -79,7 +79,9 @@ jobs:
         if: always()
         with:
           name: release-distributions
-          path: dist/
+          path: |
+            dist/
+            SHA256SUMS.txt
           retention-days: 30
 
       - name: Report failure if secret missing


### PR DESCRIPTION
## Summary

Fixes the PyPI publish step that was failing because the action tried to upload `SHA256SUMS.txt` as a Python package.

## Problem

The workflow stored checksums in `dist/SHA256SUMS.txt`, but the PyPI publish action uploads everything in `dist/`, causing:
```
ERROR InvalidDistribution: Unknown distribution format: 'SHA256SUMS.txt'
```

## Solution

Moved `SHA256SUMS.txt` to the root directory (outside `dist/`) so only actual Python packages (`.whl` and `.tar.gz`) are published to PyPI.

The checksums file is still included in:
- GitHub Release assets  
- CI artifacts for traceability

## Next Steps

After this merges, we still need to configure `PYPI_API_TOKEN` secret or set up Trusted Publishers to complete the PyPI publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)