### PR TITLE
feat: Display version in banner on init screen

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -42,6 +42,7 @@ from rich.align import Align
 from rich.table import Table
 from rich.tree import Tree
 from typer.core import TyperGroup
+from importlib.metadata import version, PackageNotFoundError
 
 # For cross-platform keyboard input
 import readchar
@@ -789,8 +790,16 @@ def show_banner():
         padded_line = line.ljust(max_width)
         styled_banner.append(padded_line + "\n", style=color)
 
+    # Get package version
+    try:
+        pkg_version = version("spec-kitty-cli")
+        version_text = f"v{pkg_version}"
+    except PackageNotFoundError:
+        version_text = "dev"
+
     console.print(Align.center(styled_banner))
     console.print(Align.center(Text(TAGLINE, style="italic bright_yellow")))
+    console.print(Align.center(Text(version_text, style="dim cyan")))
     console.print()
 
 @app.callback()


### PR DESCRIPTION
## Summary

Adds package version display to the init banner, making it easy for users to see which version of `spec-kitty` they're running.

## Changes

- Imported `version` and `PackageNotFoundError` from `importlib.metadata`
- Modified `show_banner()` to display version below the tagline
- Version appears in dim cyan text (e.g., `v0.3.2`)
- Falls back to `"dev"` when package is not installed (development mode)

## Example Output

```
           Spec Kitty - Spec-Driven Development Toolkit
                          v0.3.2
```

## Testing

```bash
uv run spec-kitty
```

Shows the banner with version `v0.3.2` displayed below the tagline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)