### PR TITLE
feat: Display version in banner on init screen

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -42,6 +42,7 @@ from rich.align import Align
 from rich.table import Table
 from rich.tree import Tree
 from typer.core import TyperGroup
+from importlib.metadata import version, PackageNotFoundError
 
 # For cross-platform keyboard input
 import readchar
@@ -789,8 +790,16 @@ def show_banner():
         padded_line = line.ljust(max_width)
         styled_banner.append(padded_line + "\n", style=color)
 
+    # Get package version
+    try:
+        pkg_version = version("spec-kitty-cli")
+        version_text = f"v{pkg_version}"
+    except PackageNotFoundError:
+        version_text = "dev"
+
     console.print(Align.center(styled_banner))
     console.print(Align.center(Text(TAGLINE, style="italic bright_yellow")))
+    console.print(Align.center(Text(version_text, style="dim cyan")))
     console.print()
 
 @app.callback()


### PR DESCRIPTION
Add package version display to the init banner using importlib.metadata. The version now appears below the tagline in dim cyan text.

When package is not installed (development mode), displays "dev" as fallback.

Example output:
  Spec Kitty - Spec-Driven Development Toolkit (forked from GitHub Spec Kit)
  v0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)