### PR TITLE
fix(workflow): Upgrade twine to 6.x for Metadata-Version 2.4 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          pip install build==1.* twine==5.* tomli==2.* packaging pytest
+          pip install build==1.* twine==6.* tomli==2.* packaging pytest
           pip install -e .[test]
 
       - name: Run tests


### PR DESCRIPTION
Twine 5.x does not support Metadata-Version 2.4 (only up to 2.3), causing "Metadata is missing required fields: Name, Version" errors when checking modern Python packages built with hatchling.

Twine 6.x adds support for Metadata-Version 2.4, resolving this issue.

Fixes release workflow failure for v0.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)