### PR TITLE
fix(workflow): Move SHA256SUMS.txt outside dist/ directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Record artifact checksums
         run: |
-          sha256sum dist/* > dist/SHA256SUMS.txt
-          cat dist/SHA256SUMS.txt
+          sha256sum dist/* > SHA256SUMS.txt
+          cat SHA256SUMS.txt
 
       - name: Extract changelog for release
         id: changelog
@@ -70,7 +70,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/SHA256SUMS.txt
+            SHA256SUMS.txt
           draft: false
           prerelease: false
 
@@ -79,7 +79,9 @@ jobs:
         if: always()
         with:
           name: release-distributions
-          path: dist/
+          path: |
+            dist/
+            SHA256SUMS.txt
           retention-days: 30
 
       - name: Report failure if secret missing


### PR DESCRIPTION
The PyPI publish action was trying to upload SHA256SUMS.txt as if it were a Python package, causing "Unknown distribution format" errors.

Moving the checksums file to the root directory (outside dist/) ensures only actual Python packages (.whl and .tar.gz) are published to PyPI.

The checksums file is still included in:
- GitHub Release assets
- CI artifacts for traceability

Fixes PyPI publish step for v0.3.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)