### PR TITLE
Hotfix 0.4.10: CRITICAL - Include missing missions directory in PyPI package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "0.4.9"
+version = "0.4.10"
 description = "Spec Kitty CLI, a community fork of GitHub's Spec Kit for bootstrapping Spec-Driven Development (SDD) projects."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -69,3 +69,4 @@ packages = ["src/specify_cli"]
 "templates" = "specify_cli/templates"
 "scripts" = "specify_cli/scripts"
 "memory" = "specify_cli/memory"
+".kittify/missions" = "specify_cli/missions"


### PR DESCRIPTION
## CRITICAL Issue

The 0.4.9 PyPI package is missing the  directory, causing complete workflow failure for all new installations.

## Evidence

Fresh install from PyPI 0.4.9:
```
Error: Active mission directory not found: .kittify/missions/software-dev
Available missions: none
```

All bash workflow scripts fail because missions directory doesn't exist.

## Root Cause

`pyproject.toml` was missing missions from the force-include list:
```python
[tool.hatch.build.targets.wheel.force-include]
"templates" = "specify_cli/templates"
"scripts" = "specify_cli/scripts"
"memory" = "specify_cli/memory"
# ❌ missions was NOT included
```

## Fix

Added missions to force-include:
```python
".kittify/missions" = "specify_cli/missions"
```

## Impact

- 100% of users installing 0.4.9 from PyPI affected
- Workflow completely broken
- Requires immediate hotfix

## Testing

✅ Verified missions exist in source repo
✅ Version bumped to 0.4.10
✅ CHANGELOG updated

## Files Changed

- pyproject.toml: Added missions to force-include
- CHANGELOG.md: Added 0.4.10 entry

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)