### PR TITLE
fix: correct variable name in copilot asset generation

### DIFF
--- a/src/specify_cli/template/asset_generator.py
+++ b/src/specify_cli/template/asset_generator.py
@@ -38,7 +38,7 @@ def generate_agent_assets(command_templates_dir: Path, project_path: Path, agent
         (output_dir / filename).write_text(rendered, encoding="utf-8")
 
     if agent_key == "copilot":
-        vscode_settings = commands_dir.parent / "vscode-settings.json"
+        vscode_settings = command_templates_dir.parent / "vscode-settings.json"
         if vscode_settings.exists():
             vscode_dest = project_path / ".vscode"
             vscode_dest.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem
When initializing a project with `--ai=copilot`, the command fails with:
```
NameError: name 'commands_dir' is not defined
```

## Root Cause
In `src/specify_cli/template/asset_generator.py` line 41, the code references `commands_dir` but the function parameter is named `command_templates_dir`.

## Solution
Changed variable name from `commands_dir` to `command_templates_dir` to match the function parameter.

## Testing
- ✅ Tested on Windows with `spec-kitty init . --ai=copilot`
- ✅ Copilot commands generated successfully
- ✅ VS Code settings copied correctly

## Files Changed
- `src/specify_cli/template/asset_generator.py` (1 line)

Fixes the issue reported by users initializing projects with GitHub Copilot.