### PR TITLE
fix: correct scripts source path from root directory

### DIFF
--- a/src/specify_cli/template/manager.py
+++ b/src/specify_cli/template/manager.py
@@ -60,10 +60,9 @@ def copy_specify_base_from_local(repo_root: Path, project_path: Path, script_typ
             shutil.rmtree(memory_dest)
         shutil.copytree(memory_src, memory_dest)
 
-    # Copy from .kittify/scripts/ (not root /scripts/)
-    # The .kittify/scripts/ directory has the full implementation including
-    # worktree symlink code for shared constitution
-    scripts_src = repo_root / ".kittify" / "scripts"
+    # Copy scripts from root /scripts/ directory
+    # The scripts/ directory contains bash/ and powershell/ variants plus tasks/
+    scripts_src = repo_root / "scripts"
     if scripts_src.exists():
         scripts_dest = specify_root / "scripts"
         if scripts_dest.exists():


### PR DESCRIPTION
## Problem
During project initialization with `spec-kitty init`, PowerShell scripts are not copied to the project, breaking core workflow functionality.

Users are missing critical scripts like:
- `create-new-feature.ps1`
- `setup-plan.ps1`
- Task management scripts
- And others...

## Root Cause
In `src/specify_cli/template/manager.py` line 66, the code looks for scripts in `.kittify/scripts/` but the actual scripts are located in the root `/scripts/` directory:

**Incorrect:**
```python
scripts_src = repo_root / ".kittify" / "scripts"  # ❌ Wrong location
```

**Correct:**
```python
scripts_src = repo_root / "scripts"  # ✅ Actual location
```

## Solution
Changed the scripts source path from [`.kittify/scripts/`] to [`scripts/`] to match the actual repository structure.

**Testing**
- ✅ Tested on Windows with spec-kitty init . --ai=copilot --script=ps
- ✅ PowerShell scripts now correctly copied to .kittify/scripts/powershell/
- ✅ Verified all workflow scripts present (create-new-feature, setup-plan, tasks, etc.)
- ✅ Scripts properly executable on POSIX systems

**Impact**
- **Severity**: Critical - affects ALL Powershell / Windows users regardless of AI agent
- **Before fix**: No scripts installed, workflow completely broken
- **After fix**: All scripts correctly installed and ready to use

**Files Changed**
- `manager.py` (3 lines)

This is a critical bug that prevents the Spec Kitty workflow from fetching missions from remote repository
