### PR TITLE
fix: Merge-Feature.ps1 calls undefined Get-Python3 function

### DIFF
--- a/scripts/powershell/Merge-Feature.ps1
+++ b/scripts/powershell/Merge-Feature.ps1
@@ -34,5 +34,9 @@ if (-not (Test-Path $helper)) {
     exit 1
 }
 
-$python = Get-Python3
-& $python $helper merge @Remaining
+if (-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
+    Write-Error "python3 is required but was not found on PATH."
+    exit 1
+}
+
+python3 $helper merge @Remaining


### PR DESCRIPTION
## Problem
`Merge-Feature.ps1` script fails with "Get-Python3 is not recognized" error when attempting to merge features on Windows.

## Root Cause
Script calls undefined `Get-Python3()` function that doesn't exist in the codebase.

## Solution
Replaced with standard python3 check pattern used throughout other PowerShell scripts:
- Uses `Get-Command python3 -ErrorAction SilentlyContinue`
- Clear error message if python3 not found
- Exits with code 1 on failure
- Calls `python3` directly (no variable needed)

## Testing
- ✅ Verified pattern matches 7+ other scripts in codebase
- ✅ Script runs successfully when python3 available
- ✅ Shows clear error when python3 missing

## Impact
- **Severity**: HIGH (breaks merge workflow on Windows)
- **Scope**: Windows users merging features
- **Risk**: Very low (standard pattern replacement)