### PR TITLE
fix: plan.md created in wrong location

### DIFF
--- a/templates/command-templates/plan.md
+++ b/templates/command-templates/plan.md
@@ -16,25 +16,37 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-## Location Pre-flight Check (CRITICAL for AI Agents)
+## Location Pre-flight Check (CRITICAL - RUN FIRST)
 
-Before proceeding with planning, verify you are in the correct working directory by running the shared pre-flight validation:
+**⚠️ STOP: Before doing ANYTHING else, verify you are in the correct directory.**
+
+Run this validation code to confirm you're in a feature worktree (NOT the main repository):
 
 ```python
 from specify_cli.guards import validate_worktree_location
 
-# Validate location
+# Validate location - MUST pass before proceeding
 result = validate_worktree_location()
 if not result.is_valid:
     print(result.format_error())
-    print("\nThis command MUST run from a feature worktree, not the main repository.")
+    print("\n❌ CRITICAL ERROR: This command MUST run from inside the feature worktree directory.")
+    print(f"Current branch: {result.current_branch}")
+    print("\nYou should be in a directory like: .worktrees/001-feature-name/")
+    print("NOT in the main repository root!")
     exit(1)
+
+print(f"✓ Location validated: {result.current_branch}")
 ```
 
-**What this validates**:
-- Current branch follows the feature pattern like `001-feature-name`
-- You're not attempting to run from `main` or any release branch
-- The validator prints clear navigation instructions if you're outside the feature worktree
+**This check ensures**:
+- You're on a feature branch (matches `001-feature-name` pattern)
+- You're NOT on `main` or `master` branch
+- Plans and artifacts will be created in the correct location
+
+**If the check fails**: Navigate to the correct worktree directory before continuing:
+```bash
+cd .worktrees/<feature-name>
+```
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<feature>/tasks/`). Never refer to a folder by name alone.
 


### PR DESCRIPTION
## Problem
The `/plan` command sometimes creates `plan.md` in the main repository root instead of the feature worktree directory, causing workflow confusion and misplaced files.

## Root Cause
The location validation check in `plan.md` template exists but isn't prominent enough. AI agents sometimes miss it and proceed without verifying the current directory, resulting in plans being created in the wrong location.

## Solution

**Enhanced location validation messaging in `templates/command-templates/plan.md`:**

### Visual Improvements
- Added **"⚠️ STOP: Before doing ANYTHING else"** warning at the top
- Changed title from "CRITICAL for AI Agents" to "CRITICAL - RUN FIRST" (more universal)
- Added emojis for visual scanning: ⚠️ (warning), ❌ (error), ✓ (success)

### Clearer Instructions
**Before:**
```
This command MUST run from a feature worktree, not the main repository.
```

**After:**
```
❌ CRITICAL ERROR: This command MUST run from inside the feature worktree directory.
Current branch: {result.current_branch}

You should be in a directory like: .worktrees/001-feature-name/
NOT in the main repository root!
```


### Better Guidance
**Added "If the check fails" section:**
```bash
cd .worktrees/<feature-name>
```

**Added success confirmation:**
```bash
✓ Location validated: {result.current_branch}
```

**Improved Documentation**
Restructured validation explanation:
- "This check ensures" - Clear bullet points
- "If the check fails" - Explicit action steps
- Example paths for reference

**Testing**
- ✅ Verified enhanced warnings visible in template
- ✅ Confirmed validation logic unchanged (only messaging)
- ✅ Tested with AI agents - warning much more prominent
- ✅ Error messages now provide actionable navigation hints

**Impact**
- **Severity:** LOW (workflow annoyance, not breaking)
- **Scope:** Users running `/plan` command from wrong directory
- **Risk:** Very low (template-only change, no code modifications)

**Notes**
This is a documentation/UX improvement only - the underlying validation logic (`validate_worktree_location()`) remains unchanged. The fix makes it much harder for users and AI agents to accidentally skip the location check.


