### PR TITLE
Fix #97: Correct next step suggestion in constitution.md templates

### DIFF
--- a/.kittify/missions/software-dev/command-templates/constitution.md
+++ b/.kittify/missions/software-dev/command-templates/constitution.md
@@ -419,7 +419,7 @@ Consider updating constitution if exceptions become common.
 After writing, provide:
 - Location of the file
 - Phases completed and questions answered
-- Next steps (review, share with team, run /spec-kitty.plan)
+- Next steps (review, share with team, run /spec-kitty.specify)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] - 2026-01-25
+
+### 🐛 Fixed
+
+**Incorrect Next Step Suggestion After Running /spec-kitty.constitution** ([#97](https://github.com/Priivacy-ai/spec-kitty/issues/97)):
+- Fixed constitution command template to suggest correct next step
+- Changed suggestion from `/spec-kitty.plan` to `/spec-kitty.specify`
+- Users are now correctly guided to run `/spec-kitty.specify` after creating their project constitution
+- Updated all three constitution template files:
+  - `.kittify/missions/software-dev/command-templates/constitution.md`
+  - `src/specify_cli/missions/software-dev/command-templates/constitution.md`
+  - `src/specify_cli/templates/command-templates/constitution.md`
+- **Contributors**: Jerome Lacube, Claude Sonnet 4.5
+
+## [0.12.2] - 2026-01-25
+
+### 🐛 Fixed
+
+**Dashboard Command Template Generating Python Code Instead of Running CLI** ([#94](https://github.com/Priivacy-ai/spec-kitty/issues/94)):
+- Fixed `/spec-kitty.dashboard` command template to use `spec-kitty dashboard` CLI command
+- Removed outdated Python code that manually checked dashboard status and opened browsers
+- Dashboard now properly:
+  - Starts automatically if not running
+  - Opens in default browser
+  - Handles worktree detection automatically
+- Updated all three dashboard template files:
+  - `.kittify/missions/software-dev/command-templates/dashboard.md`
+  - `src/specify_cli/missions/software-dev/command-templates/dashboard.md`
+  - `src/specify_cli/templates/command-templates/dashboard.md`
+- Reduced template code from ~264 lines to ~47 lines
+- **Contributors**: Claude Sonnet 4.5, User
+
 ## [0.12.1] - 2026-01-24
 
 ### 🐛 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "0.12.1"
+version = "0.12.3"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/missions/software-dev/command-templates/constitution.md
+++ b/src/specify_cli/missions/software-dev/command-templates/constitution.md
@@ -419,7 +419,7 @@ Consider updating constitution if exceptions become common.
 After writing, provide:
 - Location of the file
 - Phases completed and questions answered
-- Next steps (review, share with team, run /spec-kitty.plan)
+- Next steps (review, share with team, run /spec-kitty.specify)
 
 ---
 

--- a/src/specify_cli/templates/command-templates/constitution.md
+++ b/src/specify_cli/templates/command-templates/constitution.md
@@ -419,7 +419,7 @@ Consider updating constitution if exceptions become common.
 After writing, provide:
 - Location of the file
 - Phases completed and questions answered
-- Next steps (review, share with team, run /spec-kitty.plan)
+- Next steps (review, share with team, run /spec-kitty.specify)
 
 ---
 


### PR DESCRIPTION
Changed the next step suggestion from '/spec-kitty.plan' to '/spec-kitty.specify' in all constitution.md template files:
- .kittify/missions/software-dev/command-templates/constitution.md
- src/specify_cli/missions/software-dev/command-templates/constitution.md
- src/specify_cli/templates/command-templates/constitution.md

This ensures users are guided to run the correct command after creating their project constitution.