### PR TITLE
Fix Windows charmap encoding errors via UTF-8 stdout reconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2026-01-25
+
+### 🐛 Fixed
+
+**Windows Charmap Encoding Errors (Comprehensive Fix)**:
+- Fixed `'charmap' codec can't encode characters` errors across multiple commands on Windows
+- **Root cause**: Windows default file encoding (cp1252) cannot handle Unicode characters when writing files
+  - `Path.write_text()` without explicit `encoding` parameter uses system default (cp1252 on Windows)
+  - Unicode characters include: box-drawing (├─└), typographic dashes (– —), and other UTF-8 content
+- **Files fixed** (5 modules, 7 write_text() calls):
+  1. `cli/commands/agent/feature.py` - Feature creation templates
+  2. `core/worktree.py` - Worktree README generation
+  3. `gap_analysis.py` - Documentation gap reports
+  4. `doc_generators.py` - JSDoc, Sphinx, and rustdoc configs (3 instances)
+  5. `core/agent_context.py` - Agent context file updates
+- **Solution**: Added explicit `encoding="utf-8"` parameter to all `Path.write_text()` calls
+  - Ensures files written with UTF-8 encoding regardless of system default
+  - Simple, minimal fix (no module-level reconfiguration needed - __init__.py main() handles stdout)
+- **Impact**: 
+  - Unicode box-drawing characters (├─└) and typographic dashes (– —) now render correctly across all commands
+  - JSON output works correctly on Windows systems
+  - Documentation generators work with UTF-8 content
+  - Agent context updates preserve Unicode characters
+  - Cross-platform compatible (Windows, Linux, macOS, Docker)
+  - No user configuration required (no `PYTHONIOENCODING` environment variable needed)
+
+### ✨ Enhancement
+
+**Preserved Unicode Formatting in Templates**:
+- Tasks README templates retain beautiful Unicode box-drawing characters for better readability
+- Typographic dashes properly rendered in all environments
+- Consistent appearance across all supported platforms
+
 ## [0.12.1] - 2026-01-24
 
 ### 🐛 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "0.12.1"
+version = "0.12.2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/cli/commands/agent/feature.py
+++ b/src/specify_cli/cli/commands/agent/feature.py
@@ -333,7 +333,7 @@ spec-kitty agent tasks move-task WP01 --to doing
 - Format: `WP01-kebab-case-slug.md`
 - Examples: `WP01-setup-infrastructure.md`, `WP02-user-auth.md`
 '''
-        (tasks_dir / "README.md").write_text(tasks_readme_content)
+        (tasks_dir / "README.md").write_text(tasks_readme_content, encoding="utf-8")
 
         # Copy spec template if it exists
         spec_file = feature_dir / "spec.md"

--- a/src/specify_cli/core/agent_context.py
+++ b/src/specify_cli/core/agent_context.py
@@ -280,7 +280,7 @@ def update_agent_context(
     final_content = preserve_manual_additions(old_content, new_content)
 
     # Write updated content
-    agent_file_path.write_text(final_content)
+    agent_file_path.write_text(final_content, encoding="utf-8")
 
 
 def get_supported_agent_types() -> List[str]:

--- a/src/specify_cli/core/worktree.py
+++ b/src/specify_cli/core/worktree.py
@@ -347,7 +347,7 @@ spec-kitty agent tasks move-task WP01 --to doing
 - Format: `WP01-kebab-case-slug.md`
 - Examples: `WP01-setup-infrastructure.md`, `WP02-user-auth.md`
 '''
-    (tasks_dir / "README.md").write_text(tasks_readme_content)
+    (tasks_dir / "README.md").write_text(tasks_readme_content, encoding="utf-8")
 
     # Create worktree .kittify directory if it doesn't exist
     worktree_kittify = worktree_path / ".kittify"

--- a/src/specify_cli/doc_generators.py
+++ b/src/specify_cli/doc_generators.py
@@ -209,7 +209,7 @@ class JSDocGenerator:
         config_file = output_dir / "jsdoc.json"
         output_dir.mkdir(parents=True, exist_ok=True)
         try:
-            config_file.write_text(json.dumps(config, indent=2))
+            config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
             return config_file
         except OSError as e:
             raise GeneratorError(f"Failed to write jsdoc.json: {e}")
@@ -384,7 +384,7 @@ sys.path.insert(0, os.path.abspath('..'))
         config_file = output_dir / "conf.py"
         output_dir.mkdir(parents=True, exist_ok=True)
         try:
-            config_file.write_text(config_content)
+            config_file.write_text(config_content, encoding="utf-8")
             return config_file
         except OSError as e:
             raise GeneratorError(f"Failed to write conf.py: {e}")
@@ -541,7 +541,7 @@ No separate configuration file is needed for rustdoc.
         instructions_file = output_dir / "rustdoc-config.md"
         output_dir.mkdir(parents=True, exist_ok=True)
         try:
-            instructions_file.write_text(instructions)
+            instructions_file.write_text(instructions, encoding="utf-8")
             return instructions_file
         except OSError as e:
             raise GeneratorError(f"Failed to write rustdoc instructions: {e}")

--- a/src/specify_cli/gap_analysis.py
+++ b/src/specify_cli/gap_analysis.py
@@ -884,7 +884,7 @@ def generate_gap_analysis_report(
 
     # Write to file
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    output_file.write_text(report_content)
+    output_file.write_text(report_content, encoding="utf-8")
 
     return analysis
 


### PR DESCRIPTION
Fixes #101

### Problem

On Windows, commands fail with `'charmap' codec can't encode characters` when writing files containing Unicode characters (box-drawing `├─└`, dashes `–`).

### Fix

Added `encoding="utf-8"` to `write_text()` calls in 5 files:
- `feature.py` - feature templates
- `worktree.py` - worktree README
- `gap_analysis.py` - gap reports  
- `doc_generators.py` - JSDoc/Sphinx/rustdoc configs
- `agent_context.py` - agent context files

### Tested

✅ Feature creation works on Windows  
✅ Unicode characters preserved in files  
✅ Cross-platform (Linux/macOS unaffected)