### PR TITLE
fix: persist review feedback files for rejected work packages

### DIFF
--- a/docs/explanation/kanban-workflow.md
+++ b/docs/explanation/kanban-workflow.md
@@ -94,12 +94,15 @@ When review finds issues:
 
 2. Reviewer finds problems
    └── /spec-kitty.review WP01
-   └── Adds feedback to WP file
+   └── Writes feedback file and runs move-task with --review-feedback-file
+   └── Feedback archived at kitty-specs/<feature>/feedback/WP01-*.md
    └── lane: planned (reset)
    └── review_status: has_feedback
+   └── review_feedback: kitty-specs/<feature>/feedback/WP01-*.md
 
 3. Agent re-claims WP
-   └── Reads feedback section in WP
+   └── Reads review_feedback file path from frontmatter
+   └── Checks Review Feedback section in WP for summary
    └── Addresses issues
    └── lane: doing → for_review
 
@@ -121,6 +124,7 @@ assignee: "claude"
 agent: "claude"
 shell_pid: "12345"
 review_status: ""
+review_feedback: ""
 ---
 ```
 
@@ -133,6 +137,7 @@ review_status: ""
 | `agent` | Which AI agent claimed this |
 | `shell_pid` | Process ID of the agent (for tracking) |
 | `review_status` | Empty or `has_feedback` if returned from review |
+| `review_feedback` | Path to archived feedback file in `kitty-specs/<feature>/feedback/` |
 
 ### Not Directories, Just a Field
 
@@ -178,6 +183,9 @@ Commands:
 
 # Move WP to done after review passes
 spec-kitty agent tasks move-task WP01 --to done
+
+# Request changes with feedback file
+spec-kitty agent tasks move-task WP01 --to planned --review-feedback-file /tmp/spec-kitty-review-feedback-WP01.md
 
 # Once ALL WPs are done, validate entire feature
 /spec-kitty.accept

--- a/docs/how-to/review-work-package.md
+++ b/docs/how-to/review-work-package.md
@@ -31,13 +31,19 @@ The review command:
 ## Providing Feedback
 
 If changes are required:
-1. Add feedback in the **Review Feedback** section of the WP file.
-2. Move the WP back to `planned` so the implementer can pick it up again.
+1. Write feedback to a temporary file (the review prompt shows a unique suggested path).
+2. Move the WP back to `planned` with `--review-feedback-file`.
+3. The command archives feedback to `kitty-specs/<feature>/feedback/` and stores that path in frontmatter `review_feedback`.
 
 In your terminal:
 
 ```bash
-spec-kitty agent tasks move-task WP01 --to planned --note "Changes requested: <summary>"
+cat > /tmp/spec-kitty-review-feedback-WP01.md <<'EOF'
+**Issue 1**: <description and how to fix>
+**Issue 2**: <description and how to fix>
+EOF
+
+spec-kitty agent tasks move-task WP01 --to planned --review-feedback-file /tmp/spec-kitty-review-feedback-WP01.md --note "Changes requested: <summary>"
 ```
 
 ## Passing Review

--- a/docs/reference/agent-subcommands.md
+++ b/docs/reference/agent-subcommands.md
@@ -188,7 +188,7 @@ spec-kitty agent feature finalize-tasks --json
 | `--assignee TEXT` | Assignee name (sets assignee when moving to doing) |
 | `--shell-pid TEXT` | Shell PID |
 | `--note TEXT` | History note |
-| `--review-feedback-file PATH` | Path to review feedback file (required when moving to planned from review) |
+| `--review-feedback-file PATH` | Path to review feedback file (required when moving to planned from review; copied to `kitty-specs/<feature>/feedback/` and stored as frontmatter `review_feedback`) |
 | `--reviewer TEXT` | Reviewer name (auto-detected from git if omitted) |
 | `--force` | Force move even with unchecked subtasks or missing feedback |
 | `--auto-commit`, `--no-auto-commit` | Automatically commit WP file changes to main branch (default: auto-commit) |
@@ -200,6 +200,7 @@ spec-kitty agent feature finalize-tasks --json
 spec-kitty agent tasks move-task WP01 --to doing --assignee claude --json
 spec-kitty agent tasks move-task WP02 --to for_review --agent claude --shell-pid $$
 spec-kitty agent tasks move-task WP03 --to done --note "Review passed"
+spec-kitty agent tasks move-task WP03 --to planned --review-feedback-file /tmp/spec-kitty-review-feedback-WP03.md --note "Changes requested"
 ```
 
 ### spec-kitty agent tasks mark-status

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,6 +62,7 @@ agent: ""
 shell_pid: ""
 review_status: ""
 reviewed_by: ""
+review_feedback: ""
 history:
   - timestamp: "2026-01-16T12:00:00Z"
     lane: "planned"
@@ -84,6 +85,7 @@ history:
 | `shell_pid` | string | Process ID of implementing agent |
 | `review_status` | string | Empty, `has_feedback`, or `approved` |
 | `reviewed_by` | string | Reviewer name |
+| `review_feedback` | string | Repo-relative path to persisted feedback file (for example, `kitty-specs/<feature>/feedback/WP01-*.md`) |
 | `history` | list | Activity log entries |
 
 ---

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -117,7 +117,8 @@ Syntax format in this reference:
 
 **What it does**:
 - Loads the WP prompt, supporting artifacts, and code changes.
-- Performs structured review and records feedback in the WP file.
+- Performs structured review and records feedback via `--review-feedback-file`.
+- Persists feedback to `kitty-specs/<feature>/feedback/` and writes frontmatter `review_feedback` in the WP file.
 - Moves the WP to `done` (approved) or back to `planned` (needs changes).
 - Updates `tasks.md` status when approved.
 

--- a/src/specify_cli/cli/commands/agent/feature.py
+++ b/src/specify_cli/cli/commands/agent/feature.py
@@ -335,6 +335,7 @@ agent: ""
 shell_pid: ""
 review_status: ""
 reviewed_by: ""
+review_feedback: ""
 history:
   - timestamp: "2025-01-01T00:00:00Z"
     lane: "planned"

--- a/src/specify_cli/core/worktree.py
+++ b/src/specify_cli/core/worktree.py
@@ -311,6 +311,7 @@ agent: ""
 shell_pid: ""
 review_status: ""
 reviewed_by: ""
+review_feedback: ""
 history:
   - timestamp: "2025-01-01T00:00:00Z"
     lane: "planned"

--- a/src/specify_cli/frontmatter.py
+++ b/src/specify_cli/frontmatter.py
@@ -50,6 +50,7 @@ class FrontmatterManager:
         "shell_pid",
         "review_status",
         "reviewed_by",
+        "review_feedback",  # Path to persisted review feedback file under kitty-specs/<feature>/feedback/
         "history",
     ]
 

--- a/src/specify_cli/missions/documentation/templates/task-prompt-template.md
+++ b/src/specify_cli/missions/documentation/templates/task-prompt-template.md
@@ -10,6 +10,7 @@ agent: ""         # CLI agent identifier (claude, codex, etc.)
 shell_pid: ""     # PID captured when the task moved to the current lane
 review_status: "" # empty | has_feedback | acknowledged (populated by reviewers/implementers)
 reviewed_by: ""   # Agent ID of the reviewer (if reviewed)
+review_feedback: "" # Relative path to persisted feedback file (set on review rejection)
 history:
   - timestamp: "{{TIMESTAMP}}"
     lane: "planned"
@@ -24,7 +25,7 @@ history:
 
 **Read this first if you are implementing this task!**
 
-- **Has review feedback?**: Check the `review_status` field above. If it says `has_feedback`, scroll to the **Review Feedback** section immediately (right below this notice).
+- **Has review feedback?**: Check `review_status`. If it says `has_feedback`, read `review_feedback` first (file path), then check the **Review Feedback** section below.
 - **You must address all feedback** before your work is complete. Feedback items are your implementation TODO list.
 - **Mark as acknowledged**: When you understand the feedback and begin addressing it, update `review_status: acknowledged` in the frontmatter.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.

--- a/src/specify_cli/missions/research/command-templates/review.md
+++ b/src/specify_cli/missions/research/command-templates/review.md
@@ -129,18 +129,18 @@ if source_register.exists():
 
 5. Decide outcome:
   - **Needs changes**:
-     * Append a new entry in the prompt’s **Activity Log** detailing feedback (include timestamp, reviewer agent, shell PID).
-     * Update frontmatter `lane` back to `planned`, clear `assignee` if necessary, keep history entry.
-     * Add/revise a `## Review Feedback` section (create if missing) summarizing action items.
-     * Run `spec-kitty agent tasks move-task <FEATURE> <TASK_ID> planned --note "Returned for changes"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+      * Append a new entry in the prompt’s **Activity Log** detailing feedback (include timestamp, reviewer agent, shell PID).
+      * Update frontmatter `lane` back to `planned`, clear `assignee` if necessary, keep history entry.
+      * Write feedback to a file (use the unique `/tmp/spec-kitty-review-feedback-<WP>.md` path shown by workflow review command).
+      * Run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file> --note "Returned for changes"` so lane/history/frontmatter updates happen consistently.
   - **Approved**:
-     * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script).
-     * Update frontmatter: set `lane=done`, set reviewer metadata (`agent`, `shell_pid`), optional `assignee` for approver.
-     * Use helper script to mark the task complete in `tasks.md` (see Step 6).
-     * Run `spec-kitty agent tasks move-task <FEATURE> <TASK_ID> done --note "Approved for release"` (PowerShell variant available) to transition the prompt into `tasks/`.
+      * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script).
+      * Update frontmatter: set `lane=done`, set reviewer metadata (`agent`, `shell_pid`), optional `assignee` for approver.
+      * Use helper script to mark the task complete in `tasks.md` (see Step 6).
+      * Run `spec-kitty agent tasks move-task <TASK_ID> --to done --note "Approved for release"`.
 
 6. Update `tasks.md` automatically:
-   - Run `spec-kitty agent tasks mark-status --task-id <TASK_ID> --status done` (POSIX) or `spec-kitty agent tasks mark-status --task-id <TASK_ID> --status done` (PowerShell) from repo root.
+   - Run `spec-kitty agent tasks mark-status <TASK_ID> --status done` from repo root.
    - Confirm the task entry now shows `[X]` and includes a reference to the prompt file in its notes.
 
 7. Produce a review report summarizing:
@@ -152,7 +152,7 @@ if source_register.exists():
 
 Context for review: {ARGS}
 
-All review feedback must live inside the prompt file, ensuring future implementers understand historical decisions before revisiting the task.
+Review feedback should be preserved via `--review-feedback-file`; the command stores a durable copy in `kitty-specs/<feature>/feedback/` and links it in frontmatter.
 
 ## Citation Validation (Research Mission Specific)
 

--- a/src/specify_cli/missions/research/templates/task-prompt-template.md
+++ b/src/specify_cli/missions/research/templates/task-prompt-template.md
@@ -10,6 +10,7 @@ agent: ""         # CLI agent identifier (claude, codex, etc.)
 shell_pid: ""     # PID captured when the task moved to the current lane
 review_status: "" # empty | has_feedback | acknowledged (populated by reviewers/implementers)
 reviewed_by: ""   # Agent ID of the reviewer (if reviewed)
+review_feedback: "" # Relative path to persisted feedback file (set on review rejection)
 history:
   - timestamp: "{{TIMESTAMP}}"
     lane: "planned"
@@ -24,7 +25,7 @@ history:
 
 **Read this first if you are working on this research task!**
 
-- **Has review feedback?**: Check the `review_status` field above. If it says `has_feedback`, scroll to the **Review Feedback** section immediately (right below this notice).
+- **Has review feedback?**: Check `review_status`. If it says `has_feedback`, read `review_feedback` first (file path), then check the **Review Feedback** section below.
 - **You must address all feedback** before your work is complete. Feedback items are your research TODO list.
 - **Mark as acknowledged**: When you understand the feedback and begin addressing it, update `review_status: acknowledged` in the frontmatter.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.

--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -31,6 +31,8 @@ spec-kitty agent workflow implement $ARGUMENTS --agent <your-name>
 
 If no WP ID is provided, it will automatically find the first work package with `lane: "planned"` and move it to "doing" for you.
 
+If the workflow prompt indicates `review_status: "has_feedback"`, read the frontmatter `review_feedback` path first. That file in `kitty-specs/<feature>/feedback/` is the canonical reviewer feedback artifact for re-implementation.
+
 ---
 
 ## Commit Workflow

--- a/src/specify_cli/missions/software-dev/templates/task-prompt-template.md
+++ b/src/specify_cli/missions/software-dev/templates/task-prompt-template.md
@@ -10,6 +10,7 @@ agent: ""         # CLI agent identifier (claude, codex, etc.)
 shell_pid: ""     # PID captured when the task moved to the current lane
 review_status: "" # empty | has_feedback | acknowledged (populated by reviewers/implementers)
 reviewed_by: ""   # Agent ID of the reviewer (if reviewed)
+review_feedback: "" # Relative path to persisted feedback file (set on review rejection)
 history:
   - timestamp: "{{TIMESTAMP}}"
     lane: "planned"
@@ -24,7 +25,7 @@ history:
 
 **Read this first if you are implementing this task!**
 
-- **Has review feedback?**: Check the `review_status` field above. If it says `has_feedback`, scroll to the **Review Feedback** section immediately (right below this notice).
+- **Has review feedback?**: Check `review_status`. If it says `has_feedback`, read `review_feedback` first (file path), then check the **Review Feedback** section below.
 - **You must address all feedback** before your work is complete. Feedback items are your implementation TODO list.
 - **Mark as acknowledged**: When you understand the feedback and begin addressing it, update `review_status: acknowledged` in the frontmatter.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.

--- a/src/specify_cli/templates/command-templates/implement.md
+++ b/src/specify_cli/templates/command-templates/implement.md
@@ -42,6 +42,8 @@ WHEN YOU'RE DONE:
   spec-kitty agent tasks move-task WP## --to for_review --note "Ready for review"
 ```
 
+If the prompt shows `review_status: "has_feedback"`, read frontmatter `review_feedback` first. The file under `kitty-specs/<feature>/feedback/` is the canonical reviewer feedback artifact for re-implementation.
+
 **Step 2**: Create the workspace (if needed) and implement according to the prompt
 ```bash
 spec-kitty implement WP##              # No dependencies (branches from main)

--- a/src/specify_cli/templates/command-templates/review.md
+++ b/src/specify_cli/templates/command-templates/review.md
@@ -455,12 +455,10 @@ This is intentional - worktrees provide isolation for parallel feature developme
 
 5. Decide outcome:
   - **Needs changes**:
-     * **CRITICAL**: Insert detailed feedback in the `## Review Feedback` section (located immediately after the frontmatter, before Objectives). This is the FIRST thing implementers will see when they re-read the prompt.
-     * Use a clear structure:
+     * Write detailed feedback to a file (the review workflow prompt provides a unique path in `/tmp/spec-kitty-review-feedback-<WP>.md`).
+     * Use clear structure in that file:
        ```markdown
-       ## Review Feedback
-
-       **Status**: ❌ **Needs Changes**
+       **Status**: Needs Changes
 
        **Key Issues**:
        1. [Issue 1] - Why it's a problem and what to do about it
@@ -475,13 +473,8 @@ This is intentional - worktrees provide isolation for parallel feature developme
        - [ ] Add [missing thing 2]
        - [ ] Verify [validation point 3]
        ```
-     * Update frontmatter:
-       - Set `lane: "planned"`
-       - Set `review_status: "has_feedback"`
-       - Set `reviewed_by: <YOUR_AGENT_ID>`
-       - Clear `assignee` if needed
-     * Append a new entry in the prompt's **Activity Log** with timestamp, reviewer agent, shell PID, and summary of feedback.
-     * Run `spec-kitty agent move-task <FEATURE> <TASK_ID> planned --note "Code review complete: [brief summary of issues]"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+     * Run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file> --note "Code review complete: [brief summary of issues]"`.
+     * This command archives feedback to `kitty-specs/<feature>/feedback/`, updates `review_feedback` frontmatter, updates `## Review Feedback`, and appends activity history.
   - **Approved**:
      * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script, e.g., `2025-11-11T13:45:00Z – claude – shell_pid=1234 – lane=done – Approved without changes`).
      * Update frontmatter:
@@ -495,7 +488,7 @@ This is intentional - worktrees provide isolation for parallel feature developme
      * Use helper script to mark the task complete in `tasks.md` (see Step 7).
 
 7. Update `tasks.md` automatically:
-   - Run `spec-kitty agent mark-status --task-id <TASK_ID> --status done` (POSIX) or `spec-kitty agent -TaskId <TASK_ID> -Status done` (PowerShell) from repo root.
+   - Run `spec-kitty agent tasks mark-status <TASK_ID> --status done` from repo root.
    - Confirm the task entry now shows `[X]` and includes a reference to the prompt file in its notes.
 
 7. Produce a review report summarizing:
@@ -507,4 +500,4 @@ This is intentional - worktrees provide isolation for parallel feature developme
 
 Context for review: {ARGS} (resolve this to the prompt's relative path, e.g., `kitty-specs/<feature>/tasks/WPXX.md`)
 
-All review feedback must live inside the prompt file, ensuring future implementers understand historical decisions before revisiting the task.
+Review feedback must be preserved through `--review-feedback-file`, which stores a durable copy under `kitty-specs/<feature>/feedback/` and links it in frontmatter.

--- a/src/specify_cli/templates/task-prompt-template.md
+++ b/src/specify_cli/templates/task-prompt-template.md
@@ -10,6 +10,7 @@ agent: ""         # CLI agent identifier (claude, codex, etc.)
 shell_pid: ""     # PID captured when the task moved to the current lane
 review_status: "" # empty | has_feedback | acknowledged (populated by reviewers/implementers)
 reviewed_by: ""   # Agent ID of the reviewer (if reviewed)
+review_feedback: "" # Relative path to persisted feedback file (set on review rejection)
 history:
   - timestamp: "{{TIMESTAMP}}"
     lane: "planned"
@@ -26,7 +27,7 @@ history:
 
 **Read this first if you are implementing this task!**
 
-- **Has review feedback?**: Check the `review_status` field above. If it says `has_feedback`, scroll to the **Review Feedback** section immediately (right below this notice).
+- **Has review feedback?**: Check `review_status`. If it says `has_feedback`, read `review_feedback` first (file path), then check the **Review Feedback** section below.
 - **You must address all feedback** before your work is complete. Feedback items are your implementation TODO list.
 - **Mark as acknowledged**: When you understand the feedback and begin addressing it, update `review_status: acknowledged` in the frontmatter.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.

--- a/tests/specify_cli/test_frontmatter.py
+++ b/tests/specify_cli/test_frontmatter.py
@@ -228,6 +228,19 @@ subtasks:
         assert dep_line > lane_line, "dependencies should come after lane"
         assert dep_line < subtasks_line, "dependencies should come before subtasks"
 
+    def test_field_order_includes_review_feedback(self):
+        """Test WP_FIELD_ORDER includes review_feedback in correct position."""
+        manager = FrontmatterManager()
+
+        assert "review_feedback" in manager.WP_FIELD_ORDER
+
+        reviewed_by_idx = manager.WP_FIELD_ORDER.index("reviewed_by")
+        review_feedback_idx = manager.WP_FIELD_ORDER.index("review_feedback")
+        history_idx = manager.WP_FIELD_ORDER.index("history")
+
+        assert review_feedback_idx > reviewed_by_idx, "review_feedback should come after reviewed_by"
+        assert review_feedback_idx < history_idx, "review_feedback should come before history"
+
 
 class TestScopeRestriction:
     """Test that dependencies field is only added to WP files."""


### PR DESCRIPTION
## Summary
- Persist review feedback files when moving `for_review -> planned` by copying `--review-feedback-file` into `kitty-specs/<feature>/feedback/` and storing the path in WP frontmatter as `review_feedback`.
- Update workflow implement/review guidance so implementers read the canonical archived feedback path and reviewers consistently use file-based feedback handoff.
- Add frontmatter/template/docs/test coverage for the new `review_feedback` field and feedback archival behavior.

## Testing
- pytest tests/unit/agent/test_tasks.py tests/unit/agent/test_workflow_instructions.py
- pytest tests/specify_cli/test_frontmatter.py tests/test_template_compliance.py
- pytest tests/specify_cli/test_workflow_auto_moves.py