### PR TITLE
fix: Use standalone copilot CLI and add real-time dashboard updates

### DIFF
--- a/src/specify_cli/orchestrator/integration.py
+++ b/src/specify_cli/orchestrator/integration.py
@@ -547,6 +547,8 @@ Fix the issues described above and ensure all requirements are met.
 
     if is_success(result):
         logger.info(f"{wp_id} implementation completed successfully")
+        # Move to for_review lane for dashboard visibility
+        await transition_wp_lane(wp, "complete_implementation", repo_root)
         save_state(state, repo_root)
         return True
 


### PR DESCRIPTION
Two fixes:

1. CopilotInvoker now uses standalone 'copilot' CLI
   - Replaces deprecated 'gh copilot' extension
   - Uses -p/--yolo/-s flags for automation
   - Simple shutil.which check for installation

2. Add transition_wp_lane after successful implementation
   - Moves WP to 'for_review' lane immediately on success
   - Dashboard now shows real-time progress during orchestration
   - Previously WPs stayed in 'doing' until manually updated