### PR TITLE
Fix orchestrator deadlock

### DIFF
--- a/src/specify_cli/orchestrator/integration.py
+++ b/src/specify_cli/orchestrator/integration.py
@@ -847,6 +847,18 @@ async def process_wp(
 
         # ===== REVIEW PHASE =====
         if wp.status == WPStatus.IMPLEMENTATION:
+            # Implementation should only enter review after completion timestamp is set.
+            # If missing, this is an interrupted implementation and must be resumed first.
+            if not wp.implementation_completed:
+                logger.warning(
+                    f"{wp_id} in IMPLEMENTATION without completion timestamp; "
+                    "restarting implementation before review"
+                )
+                wp.status = WPStatus.PENDING
+                wp.implementation_started = None
+                save_state(state, repo_root)
+                continue
+
             # Implementation just completed, start review
 
             # Check if review is needed (skip in single-agent mode with no review config)

--- a/tests/specify_cli/orchestrator/test_exception_handling.py
+++ b/tests/specify_cli/orchestrator/test_exception_handling.py
@@ -4,10 +4,8 @@ This test verifies that when a WP task raises an exception,
 the WP is properly marked as FAILED so dependent WPs can be unblocked.
 """
 
-import asyncio
 from datetime import datetime, timezone
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
After a WP is finished implementing, it incorrectly fails. The whole orchestrator fails with "No progress possible." and each WP is listed with "Blocked by failed dependencies". However, the WP completed but never reached the review state, even though it finished. After a few tries, I noticed that the problem arose while a WP was in the review state.

**Issue 1: Exception handling**
When a task raised an exception, the WP was not marked as FAILED, causing dependent WPs to be incorrectly marked as "Blocked by failed dependencies".
Fix (lines 1216-1225): When an exception is caught, the WP is now properly marked as FAILED with the error message, and save_state is called to persist the change.

**Issue 2: WPs stuck in REVIEW/IMPLEMENTATION status**
When a task completed but left a WP in 1REVIEW or IMPLEMENTATION status (e.g., because the review phase wasn't started yet), the orchestrator would declare a deadlock and fail the WP.
Fix (lines 1202-1242):
- After a task completes, check if the WP is in IMPLEMENTATION or REVIEW status
- If so, add it to a wps_to_restart list
- Immediately restart the task (before the deadlock check) to continue processing
- Only check for deadlock after handling all restarts