### PR TITLE
chore(release): start main as 1.0.0rc1 stream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
             dist/*.tar.gz
             SHA256SUMS.txt
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, 'rc') }}
 
       - name: Upload test output
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0rc1] - 2026-02-22
+
+### 🔧 Changed
+
+- **Release track shift to 1.0 RC on `main`**: project version now starts the `1.0` release-candidate stream (`1.0.0rc1`) while preserving `0.16.2` as the latest stable release.
+- **Release automation RC support**: release validation and changelog extraction now accept `X.Y.ZrcN` versions/tags, and GitHub Releases are marked prerelease automatically for `rc` tags.
+
 ## [0.16.2] - 2026-02-21
 
 ### 🐛 Fixed

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ graph LR
 </div>
 
 **Recent stable release:** `v0.16.2` (2026-02-21)
+**Current release candidate:** `v1.0.0rc1` (2026-02-22)
 
-**0.16.x highlights:**
+**1.0 RC highlights:**
 - Deterministic review feedback enforcement with persisted feedback file paths
 - Safer review transitions with automatic WP worktree rebase handling
 - Dashboard browser launch is now opt-in via `--open`
@@ -101,13 +102,14 @@ graph LR
 
 ## 📌 Release Track
 
-Spec Kitty is currently published on a stable `0.16.x` track from the `main` branch.
+Spec Kitty now tracks `1.0` release candidates from `main` while `2.x` remains the experimental stream.
 
 | Branch | Version | Status | Install |
 |--------|---------|--------|---------|
-| **main** | **0.16.x** | Active stable releases | `pip install spec-kitty-cli` |
+| **main** | **1.0.0rc** | Active 1.0 release candidates | `pip install --pre spec-kitty-cli` |
+| **2.x** | **2.x** | Experimental next-generation development | Install from source |
 
-**For users:** install from PyPI (`pip install spec-kitty-cli`).
+**For users:** install stable from PyPI (`pip install spec-kitty-cli`) or opt into the `1.0` RC stream (`pip install --pre spec-kitty-cli`).
 **For contributors:** target `main` unless maintainers specify otherwise in an issue or PR discussion.
 
 ---

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -10,6 +10,7 @@ Use this checklist to ensure consistent, high-quality releases of spec-kitty.
   - **Patch** (X.Y.Z): Bug fixes, small improvements
   - **Minor** (X.Y.0): New features, backward compatible
   - **Major** (X.0.0): Breaking changes
+  - **Release Candidate** (X.Y.ZrcN): Pre-release candidate on the path to a major/minor/patch release
 
 ### Code Quality
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "0.16.2"
+version = "1.0.0rc1"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scripts/release/extract_changelog.py
+++ b/scripts/release/extract_changelog.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 
 CHANGELOG_HEADING_RE = re.compile(
-    r"^##\s*(?:\[\s*)?(?P<version>\d+\.\d+\.\d+)(?:\s*\]|)(?:\s*-.*)?$"
+    r"^##\s*(?:\[\s*)?(?P<version>\d+\.\d+\.\d+(?:rc\d+)?)(?:\s*\]|)(?:\s*-.*)?$"
 )
 
 

--- a/tests/release/test_extract_changelog.py
+++ b/tests/release/test_extract_changelog.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXTRACTOR = REPO_ROOT / "scripts" / "release" / "extract_changelog.py"
+
+
+def run_extract(tmp_path: Path, version: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(EXTRACTOR), version],
+        cwd=tmp_path,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_extracts_rc_section(tmp_path: Path) -> None:
+    (tmp_path / "CHANGELOG.md").write_text(
+        dedent(
+            """
+            # Changelog
+
+            ## [1.0.0rc1] - 2026-02-22
+
+            - RC notes
+
+            ## [0.16.2] - 2026-02-21
+
+            - Stable notes
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_extract(tmp_path, "1.0.0rc1")
+
+    assert result.returncode == 0
+    assert "RC notes" in result.stdout
+    assert "Stable notes" not in result.stdout
+
+
+def test_returns_fallback_when_missing(tmp_path: Path) -> None:
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+
+    result = run_extract(tmp_path, "9.9.9rc9")
+
+    assert result.returncode == 0
+    assert "No changelog entry found" in result.stdout

--- a/tests/release/test_validate_release.py
+++ b/tests/release/test_validate_release.py
@@ -200,3 +200,82 @@ def test_tag_mode_fails_on_regression(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "does not advance beyond latest tag v0.2.3" in result.stderr
+
+
+def test_branch_mode_accepts_rc_version(tmp_path: Path) -> None:
+    init_repo(tmp_path)
+    write_release_files(
+        tmp_path,
+        "0.16.2",
+        changelog_for_versions(("0.16.2", "- Stable baseline")),
+    )
+    stage_and_commit(tmp_path, "chore: bootstrap stable")
+    tag(tmp_path, "v0.16.2")
+
+    write_release_files(
+        tmp_path,
+        "1.0.0rc1",
+        changelog_for_versions(
+            ("1.0.0rc1", "- Begin release-candidate track"),
+            ("0.16.2", "- Stable baseline"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: prep 1.0.0rc1")
+
+    result = run_validator(tmp_path, "--mode", "branch")
+
+    assert result.returncode == 0, result.stderr
+    assert "Version: 1.0.0rc1" in result.stdout
+
+
+def test_tag_mode_accepts_rc_tag_alignment(tmp_path: Path) -> None:
+    init_repo(tmp_path)
+    write_release_files(
+        tmp_path,
+        "0.16.2",
+        changelog_for_versions(("0.16.2", "- Stable baseline")),
+    )
+    stage_and_commit(tmp_path, "chore: bootstrap stable")
+    tag(tmp_path, "v0.16.2")
+
+    write_release_files(
+        tmp_path,
+        "1.0.0rc1",
+        changelog_for_versions(
+            ("1.0.0rc1", "- Begin release-candidate track"),
+            ("0.16.2", "- Stable baseline"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: prep 1.0.0rc1")
+    tag(tmp_path, "v1.0.0rc1")
+
+    result = run_validator(tmp_path, "--mode", "tag", "--tag", "v1.0.0rc1")
+
+    assert result.returncode == 0, result.stderr
+    assert "Tag: v1.0.0rc1" in result.stdout
+
+
+def test_tag_mode_fails_on_rc_regression_against_newer_rc(tmp_path: Path) -> None:
+    init_repo(tmp_path)
+    write_release_files(
+        tmp_path,
+        "1.0.0rc2",
+        changelog_for_versions(("1.0.0rc2", "- Later RC")),
+    )
+    stage_and_commit(tmp_path, "chore: bootstrap rc2")
+    tag(tmp_path, "v1.0.0rc2")
+
+    write_release_files(
+        tmp_path,
+        "1.0.0rc1",
+        changelog_for_versions(
+            ("1.0.0rc1", "- Earlier RC"),
+            ("1.0.0rc2", "- Later RC"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: regress rc version")
+
+    result = run_validator(tmp_path, "--mode", "tag", "--tag", "v1.0.0rc1")
+
+    assert result.returncode == 1
+    assert "does not advance beyond latest tag v1.0.0rc2" in result.stderr


### PR DESCRIPTION
## Summary
- move `main` project version to `1.0.0rc1`
- update README release-track messaging to show `main` as the 1.0 RC stream
- add changelog entry for `1.0.0rc1`
- extend release tooling to support `X.Y.ZrcN` versions/tags
- mark GitHub Releases as prerelease automatically for `rc` tags
- add regression tests for RC tag/version validation and changelog extraction

## Validation
- `python3 -m pytest -q tests/release`
- `python3 scripts/release/validate_release.py --mode branch`
