### PR TITLE
Fix #158: block kitty-specs contamination from WP worktrees

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -434,7 +434,10 @@ def _auto_rebase_worktree_if_needed(
         guidance.append("Commit or stash worktree changes first, then retry:")
         guidance.append(f"  cd {worktree_path}")
         guidance.append("  git status")
-        guidance.append("  git add -A && git commit -m \"feat: <describe implementation>\"")
+        guidance.append(
+            "  git add <deliverable-path-1> <deliverable-path-2> && "
+            "git commit -m \"feat: <describe implementation>\""
+        )
         guidance.append("  # or: git stash push -u")
         return False, guidance, False
 
@@ -477,129 +480,6 @@ def _auto_rebase_worktree_if_needed(
         for line in stderr.splitlines()[:3]:
             guidance.append(f"  {line}")
     return False, guidance, False
-
-
-def _maybe_mirror_move_commit_to_wp_branch(
-    cwd: Path,
-    main_repo_root: Path,
-    feature_slug: str,
-    wp_id: str,
-    main_wp_path: Path,
-    updated_doc: str,
-    commit_message: str,
-) -> bool:
-    """Mirror lane transition commit into active WP branch when in its worktree.
-
-    Move-task updates planning artifacts on the planning branch by design.
-    When agents run from a WP worktree, mirror the same status change commit
-    into the active WP branch to keep branch history aligned with lane changes.
-    """
-    from specify_cli.core.git_ops import get_current_branch
-
-    if not is_worktree_context(cwd):
-        return False
-
-    # Resolve enclosing worktree root from current directory.
-    worktree_root: Path | None = None
-    for candidate in [cwd, *cwd.parents]:
-        if candidate == main_repo_root:
-            break
-        if (candidate / ".git").is_file():
-            worktree_root = candidate
-            break
-    if worktree_root is None:
-        return False
-
-    expected_branch = f"{feature_slug}-{wp_id}"
-    current_branch = get_current_branch(worktree_root)
-    if current_branch != expected_branch:
-        return False
-
-    try:
-        rel_wp_path = main_wp_path.resolve().relative_to(main_repo_root.resolve())
-    except ValueError:
-        return False
-
-    checkout_result = subprocess.run(
-        [
-            "git",
-            "checkout",
-            "--ignore-skip-worktree-bits",
-            "HEAD",
-            "--",
-            str(rel_wp_path),
-        ],
-        cwd=worktree_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
-    if checkout_result.returncode != 0:
-        return False
-
-    wp_branch_path = worktree_root / rel_wp_path
-    wp_branch_path.parent.mkdir(parents=True, exist_ok=True)
-    wp_branch_path.write_text(updated_doc, encoding="utf-8")
-
-    add_result = subprocess.run(
-        ["git", "add", "--sparse", str(rel_wp_path)],
-        cwd=worktree_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
-    if add_result.returncode != 0:
-        # Fallback for older Git versions without --sparse support.
-        if "unknown option" in (add_result.stderr or "").lower():
-            add_result = subprocess.run(
-                ["git", "add", str(rel_wp_path)],
-                cwd=worktree_root,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=False,
-            )
-    if add_result.returncode != 0:
-        subprocess.run(
-            ["git", "restore", "--worktree", "--staged", str(rel_wp_path)],
-            cwd=worktree_root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-        )
-        return False
-
-    commit_result = subprocess.run(
-        ["git", "commit", "-m", commit_message],
-        cwd=worktree_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
-    if commit_result.returncode == 0:
-        return True
-    if "nothing to commit" in (commit_result.stdout or "") or "nothing to commit" in (commit_result.stderr or ""):
-        return True
-
-    subprocess.run(
-        ["git", "restore", "--worktree", "--staged", str(rel_wp_path)],
-        cwd=worktree_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
-    return False
 
 
 def _validate_ready_for_review(
@@ -819,7 +699,7 @@ def _validate_ready_for_review(
                 guidance.append("")
                 guidance.append("Commit your work first:")
                 guidance.append(f"  cd {worktree_path}")
-                guidance.append("  git add -A")
+                guidance.append("  git add <deliverable-path-1> <deliverable-path-2> ...")
                 guidance.append(f"  git commit -m \"feat({wp_id}): <describe implementation>\"")
                 guidance.append("")
                 guidance.append(f"Then retry: spec-kitty agent tasks move-task {wp_id} --to for_review")
@@ -851,13 +731,77 @@ def _validate_ready_for_review(
                 guidance.append("  2. Or verify work is complete (use --force if nothing to commit)")
                 guidance.append("")
                 guidance.append(f"  cd {worktree_path}")
-                guidance.append("  git add -A")
+                guidance.append("  git add <deliverable-path-1> <deliverable-path-2> ...")
                 guidance.append(f"  git commit -m \"feat({wp_id}): <describe implementation>\"")
                 guidance.append("")
                 guidance.append(f"Then retry: spec-kitty agent tasks move-task {wp_id} --to for_review")
                 return False, guidance
 
+            contamination_files = _list_wp_branch_kitty_specs_changes(
+                worktree_path=worktree_path,
+                base_branch=check_branch,
+            )
+            if contamination_files:
+                guidance.append("WP branch contains forbidden planning changes under kitty-specs/!")
+                guidance.append("")
+                guidance.append("Committed kitty-specs files on this WP branch:")
+                for path in contamination_files[:5]:
+                    guidance.append(f"  {path}")
+                if len(contamination_files) > 5:
+                    guidance.append(f"  ... and {len(contamination_files) - 5} more")
+                guidance.append("")
+                guidance.append("Clean the branch before moving to for_review:")
+                guidance.append(f"  cd {worktree_path}")
+                guidance.append(f"  git restore --source {check_branch} --staged --worktree -- kitty-specs/")
+                guidance.append("  git commit -m \"chore: remove planning artifacts from WP branch\"")
+                guidance.append("")
+                guidance.append(f"Then retry: spec-kitty agent tasks move-task {wp_id} --to for_review")
+                return False, guidance
+
     return True, []
+
+
+def _list_wp_branch_kitty_specs_changes(worktree_path: Path, base_branch: str) -> List[str]:
+    """Return kitty-specs/ files changed on the WP branch compared to its base."""
+    merge_base_result = subprocess.run(
+        ["git", "merge-base", "HEAD", base_branch],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if merge_base_result.returncode != 0:
+        return []
+
+    merge_base = merge_base_result.stdout.strip()
+    if not merge_base:
+        return []
+
+    diff_result = subprocess.run(
+        ["git", "diff", "--name-only", f"{merge_base}..HEAD", "--", "kitty-specs/"],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if diff_result.returncode != 0:
+        return []
+
+    seen: set[str] = set()
+    files: List[str] = []
+    for raw in diff_result.stdout.splitlines():
+        path = raw.strip()
+        if not path or not path.startswith("kitty-specs/"):
+            continue
+        if path in seen:
+            continue
+        seen.add(path)
+        files.append(path)
+    return files
 
 
 def _upsert_review_feedback_section(
@@ -1168,25 +1112,8 @@ def move_task(
                 )
 
                 if commit_success:
-                    # Mirror review/done lane transitions into active WP branch when
-                    # command is run from its worktree context.
-                    mirrored = False
-                    if target_lane in ("for_review", "done"):
-                        mirrored = _maybe_mirror_move_commit_to_wp_branch(
-                            cwd=cwd,
-                            main_repo_root=main_repo_root,
-                            feature_slug=feature_slug,
-                            wp_id=task_id,
-                            main_wp_path=actual_file_path,
-                            updated_doc=updated_doc,
-                            commit_message=commit_msg,
-                        )
                     if not json_output:
                         console.print(f"[cyan]→ Committed status change to {target_branch} branch[/cyan]")
-                        if mirrored:
-                            console.print(
-                                "[cyan]→ Mirrored status change to active WP branch[/cyan]"
-                            )
                 else:
                     # Commit failed (safe_commit returned False)
                     if not json_output:

--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -47,7 +47,8 @@ If no WP ID is provided, it will automatically find the first work package with 
 
 ```bash
 cd .worktrees/###-feature-WP##/
-git add -A
+# Stage only expected deliverables for this WP (never use `git add -A`)
+git add <deliverable-path-1> <deliverable-path-2> ...
 git commit -m "feat(WP##): <describe your implementation>"
 ```
 
@@ -55,7 +56,8 @@ git commit -m "feat(WP##): <describe your implementation>"
 
 ```powershell
 Set-Location .worktrees\###-feature-WP##\
-git add -A
+# Stage only expected deliverables for this WP (never use `git add -A`)
+git add <deliverable-path-1> <deliverable-path-2> ...
 git commit -m "feat(WP##): <describe your implementation>"
 ```
 

--- a/src/specify_cli/templates/git-hooks/pre-commit-agent-check
+++ b/src/specify_cli/templates/git-hooks/pre-commit-agent-check
@@ -36,4 +36,25 @@ if [ -n "$STAGED_AGENT_FILES" ]; then
     exit 1
 fi
 
+# WP worktree branches must never commit planning artifacts.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if echo "$CURRENT_BRANCH" | grep -Eq -- '-WP[0-9]+$'; then
+    STAGED_KITTY_SPECS=$(git diff --cached --name-only | grep -E '^kitty-specs/' || true)
+
+    if [ -n "$STAGED_KITTY_SPECS" ]; then
+        echo "❌ COMMIT BLOCKED: WP branches must not commit kitty-specs/"
+        echo ""
+        echo "Branch: $CURRENT_BRANCH"
+        echo "Staged planning files:"
+        echo "$STAGED_KITTY_SPECS" | sed 's/^/  /'
+        echo ""
+        echo "To fix:"
+        echo "  1. Unstage planning files: git restore --staged kitty-specs/"
+        echo "  2. Keep commits limited to deliverable paths (src/, docs/, tests/, etc.)"
+        echo ""
+        echo "To bypass this check (NOT recommended): git commit --no-verify"
+        exit 1
+    fi
+fi
+
 exit 0

--- a/tests/integration/test_gitignore_isolation.py
+++ b/tests/integration/test_gitignore_isolation.py
@@ -344,15 +344,15 @@ dependencies: []
         f".git/info/exclude should exist at {exclude_path}"
     )
 
-    # Verify it contains the exclusion pattern for WP status files
+    # Verify it contains the exclusion pattern for the full planning tree
     exclude_content = exclude_path.read_text()
-    assert "kitty-specs/**/tasks/*.md" in exclude_content, (
-        ".git/info/exclude should contain 'kitty-specs/**/tasks/*.md' pattern. "
+    assert "kitty-specs/" in exclude_content, (
+        ".git/info/exclude should contain 'kitty-specs/' pattern. "
         f"Content:\n{exclude_content}"
     )
 
     # Verify comment is included
-    assert "Block WP status files" in exclude_content or "managed in planning branch" in exclude_content, (
+    assert "Excluded via sparse-checkout" in exclude_content, (
         ".git/info/exclude should contain explanatory comment. "
         f"Content:\n{exclude_content}"
     )

--- a/tests/unit/agent/test_workflow_instructions.py
+++ b/tests/unit/agent/test_workflow_instructions.py
@@ -211,7 +211,10 @@ class TestMoveTaskPreflightCheck:
                 any(keyword in line.lower() for keyword in ["uncommitted", "staged", "unstaged"]) 
                 for line in guidance
             ), f"No uncommitted/staged message in: {guidance}"
-            assert any("git add -A" in line for line in guidance), f"No 'git add -A' in: {guidance}"
+            assert any(
+                "git add <deliverable-path-1> <deliverable-path-2>" in line
+                for line in guidance
+            ), f"No explicit staging guidance in: {guidance}"
             assert any("git commit" in line for line in guidance), f"No 'git commit' in: {guidance}"
 
     def test_validate_ready_for_review_allows_clean_worktree(self, tmp_path):

--- a/tests/unit/test_move_task_git_validation.py
+++ b/tests/unit/test_move_task_git_validation.py
@@ -333,14 +333,54 @@ class TestMoveTaskGitValidation:
 
     @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
     @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
-    def test_move_for_review_from_worktree_mirrors_commit_to_wp_branch(
+    def test_move_for_review_blocks_when_wp_branch_has_kitty_specs_commits(
+        self,
+        mock_slug: Mock,
+        mock_root: Mock,
+        git_repo_with_worktree: tuple[Path, Path],
+    ):
+        """for_review gate should block WP branches that committed planning artifacts."""
+        repo_root, worktree = git_repo_with_worktree
+        mock_root.return_value = repo_root
+        mock_slug.return_value = "017-test-feature"
+
+        contaminated_file = (
+            worktree / "kitty-specs" / "017-test-feature" / "tasks" / "WP01-test-task.md"
+        )
+        contaminated_file.write_text(
+            contaminated_file.read_text(encoding="utf-8") + "\n<!-- accidental edit -->\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["git", "add", str(contaminated_file)],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "accidental: planning edit in WP branch"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+        )
+
+        result = runner.invoke(app, ["move-task", "WP01", "--to", "for_review", "--json"])
+        assert result.exit_code == 1
+        first_line = result.stdout.strip().split("\n")[0]
+        output = json.loads(first_line)
+        assert "error" in output
+        assert "kitty-specs" in output["error"].lower()
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    def test_move_for_review_from_worktree_does_not_mirror_commit_to_wp_branch(
         self,
         mock_slug: Mock,
         mock_root: Mock,
         git_repo_with_worktree: tuple[Path, Path],
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Moving from a WP worktree should mirror lane commit to WP branch."""
+        """Moving from a WP worktree should not add kitty-specs commits to the WP branch."""
         repo_root, worktree = git_repo_with_worktree
         mock_root.return_value = repo_root
         mock_slug.return_value = "017-test-feature"
@@ -369,4 +409,5 @@ class TestMoveTaskGitValidation:
         ).stdout.strip()
 
         assert "Move WP01 to for_review" in main_head_msg
-        assert "Move WP01 to for_review" in wp_head_msg
+        assert "Move WP01 to for_review" not in wp_head_msg
+        assert "Add implementation" in wp_head_msg

--- a/tests/unit/test_pre_commit_wp_guard.py
+++ b/tests/unit/test_pre_commit_wp_guard.py
@@ -1,0 +1,97 @@
+"""Tests for WP branch pre-commit protection in hook templates."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _init_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    (repo / "README.md").write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _install_hook(repo: Path) -> Path:
+    hook_template = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "specify_cli"
+        / "templates"
+        / "git-hooks"
+        / "pre-commit-agent-check"
+    )
+    hook_path = repo / ".git" / "hooks" / "pre-commit-agent-check"
+    hook_path.write_text(hook_template.read_text(encoding="utf-8"), encoding="utf-8")
+    hook_path.chmod(0o755)
+    return hook_path
+
+
+def test_wp_branch_hook_blocks_kitty_specs(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    hook_path = _install_hook(repo)
+
+    subprocess.run(
+        ["git", "checkout", "-b", "001-test-feature-WP01"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    blocked_file = repo / "kitty-specs" / "001-test-feature" / "tasks" / "WP01-test.md"
+    blocked_file.parent.mkdir(parents=True)
+    blocked_file.write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "add", str(blocked_file)], cwd=repo, check=True, capture_output=True)
+
+    result = subprocess.run(
+        [str(hook_path)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "wp branches must not commit kitty-specs/" in result.stdout.lower()
+
+
+def test_wp_branch_hook_allows_non_wp_branches(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    hook_path = _install_hook(repo)
+
+    allowed_file = repo / "kitty-specs" / "001-test-feature" / "tasks" / "WP01-test.md"
+    allowed_file.parent.mkdir(parents=True)
+    allowed_file.write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "add", str(allowed_file)], cwd=repo, check=True, capture_output=True)
+
+    result = subprocess.run(
+        [str(hook_path)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
Fixes the WP worktree contamination chain described in #158.

### What changed
- Replaced `git add -A` guidance in software-dev implement workflow with explicit path staging examples.
- Expanded worktree exclusion behavior to cover full `kitty-specs/` (not only `tasks/*.md`).
- Added WP-branch pre-commit guard that blocks staged `kitty-specs/` files on `*-WP##` branches.
- Added `move-task --to for_review` contamination gate that blocks if WP branch commits include `kitty-specs/` deltas.
- Physically removes `kitty-specs/` from sparse worktrees after sparse-checkout application/repair.

### Additional hardening
- Stopped mirroring planning status commits into active WP branches to avoid re-introducing `kitty-specs/` changes in WP history.

## Validation
- `pytest -q tests/specify_cli/core/vcs/test_git.py tests/integration/test_gitignore_isolation.py tests/unit/agent/test_workflow_instructions.py tests/unit/test_move_task_git_validation.py tests/unit/test_pre_commit_wp_guard.py`
- `pytest -q tests/integration/test_workspace_per_wp_workflow.py`
- `pytest -q tests/integration/test_dual_branch_status_routing.py`
- `pytest -q tests/integration/test_feature_025_workflow.py`

Fixes #158
