### PR TITLE
docs(2.x): external orchestrator model + custom API provider guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,20 @@ Spec Kitty now runs split release tracks: `main` for the 1.0 PyPI stream and `2.
 
 ## 🤝 Multi-Agent Coordination for AI Coding
 
-Orchestrate multiple AI agents on a single feature with lower merge friction. Each agent works in isolated worktrees while the live dashboard tracks progress across all work packages.
+Run multi-agent delivery with an external orchestrator while keeping workflow state and guardrails in `spec-kitty`. Core CLI orchestration is exposed as `spec-kitty orchestrator-api`; there is no in-core `spec-kitty orchestrate` shim.
+
+```bash
+# Verify host contract
+spec-kitty orchestrator-api contract-version --json
+
+# Use the reference external orchestrator
+spec-kitty-orchestrator orchestrate --feature 034-my-feature --dry-run
+spec-kitty-orchestrator orchestrate --feature 034-my-feature
+```
+
+Docs:
+- External provider runbook: [`docs/how-to/run-external-orchestrator.md`](docs/how-to/run-external-orchestrator.md)
+- Custom provider guide: [`docs/how-to/build-custom-orchestrator.md`](docs/how-to/build-custom-orchestrator.md)
 
 ```mermaid
 sequenceDiagram
@@ -145,7 +158,7 @@ sequenceDiagram
 - 🔀 **Parallel execution** - Multiple WPs simultaneously
 - 🌳 **Worktree isolation** - One workspace per WP to reduce branch contention
 - 👀 **Full visibility** - Dashboard shows who's doing what
-- 🔄 **Auto-sequencing** - Dependency tracking in WP frontmatter
+- 🔒 **Security boundary** - Orchestration policy and transitions are validated at the host API boundary
 
 ---
 
@@ -641,7 +654,7 @@ Learn from real-world workflows used by teams building production software with 
 ### Featured Workflows
 
 - **[Multi-Agent Feature Development](https://github.com/Priivacy-ai/spec-kitty/blob/main/examples/multi-agent-feature-development.md)**
-  *Orchestrate 3-5 AI agents on a single large feature with parallel work packages*
+  *Coordinate 3-5 AI agents on a single large feature using an external orchestrator plus host API*
 
 - **[Parallel Implementation Tracking](https://github.com/Priivacy-ai/spec-kitty/blob/main/examples/parallel-implementation-tracking.md)**
   *Monitor multiple teams/agents delivering features simultaneously with dashboard metrics*
@@ -694,6 +707,7 @@ The `spec-kitty` command supports the following options. Every run begins with a
 | `dashboard` | Open or stop the Spec Kitty dashboard |
 | `diagnostics` | Show project health and diagnostics information |
 | `merge`     | Merge a completed feature branch into main and clean up resources |
+| `orchestrator-api` | Host contract for external orchestrators (JSON envelope interface) |
 | `research`  | Execute Phase 0 research workflow to scaffold artifacts |
 | `verify-setup` | Verify that the current environment matches Spec Kitty expectations |
 

--- a/docs/1x/artifacts-and-commands.md
+++ b/docs/1x/artifacts-and-commands.md
@@ -14,7 +14,8 @@ Optional supporting artifacts (for example `research.md`, `data-model.md`, `quic
 
 1. Core workflow commands (`specify`, `plan`, `tasks`, `implement`, `review`, `merge`)
 2. Agent command family (`spec-kitty agent ...`) for work-package movement and automation
-3. Mission selection/switching commands where mission-specific behavior is required
+3. Host orchestration contract (`spec-kitty orchestrator-api ...`) for external providers
+4. Mission selection/switching commands where mission-specific behavior is required
 
 ## Legacy Governance Artifacts
 

--- a/docs/1x/index.md
+++ b/docs/1x/index.md
@@ -20,4 +20,5 @@
 
 1. [Workflow](workflow.md)
 2. [Artifacts and Commands](artifacts-and-commands.md)
-3. [Branch and Workspace Model](branches-and-workspaces.md)
+3. [Orchestration and API Boundary](orchestration-and-api.md)
+4. [Branch and Workspace Model](branches-and-workspaces.md)

--- a/docs/1x/orchestration-and-api.md
+++ b/docs/1x/orchestration-and-api.md
@@ -1,0 +1,38 @@
+# 1.x Orchestration and API Boundary
+
+`1.x` uses a host/provider split for automated orchestration:
+
+1. `spec-kitty` owns workflow state and transition validation.
+2. External providers run orchestration loops.
+3. Providers integrate through `spec-kitty orchestrator-api` only.
+
+## What changed
+
+1. `spec-kitty orchestrate` is not part of the core CLI.
+2. `spec-kitty orchestrator-api` is the supported host contract.
+3. `spec-kitty-orchestrator` is the reference external provider.
+
+## Recommended operator flow
+
+```bash
+spec-kitty orchestrator-api contract-version --json
+spec-kitty-orchestrator orchestrate --feature 034-my-feature --dry-run
+spec-kitty-orchestrator orchestrate --feature 034-my-feature
+```
+
+## Build-your-own provider
+
+Custom providers should:
+
+1. Read ready work through `list-ready` / `feature-state`.
+2. Start work through `start-implementation`.
+3. Drive review loops with `transition` and `start-review`.
+4. Finalize with `accept-feature` and `merge-feature`.
+
+Do not mutate WP lane frontmatter directly from the provider process.
+
+## References
+
+1. [Run External Orchestrator](../how-to/run-external-orchestrator.md)
+2. [Build Custom Orchestrator](../how-to/build-custom-orchestrator.md)
+3. [Orchestrator API Reference](../reference/orchestrator-api.md)

--- a/docs/1x/toc.yml
+++ b/docs/1x/toc.yml
@@ -4,5 +4,7 @@
   href: workflow.md
 - name: 1.x Artifacts and Commands
   href: artifacts-and-commands.md
+- name: 1.x Orchestration and API Boundary
+  href: orchestration-and-api.md
 - name: 1.x Branch and Workspace Model
   href: branches-and-workspaces.md

--- a/docs/2x/index.md
+++ b/docs/2x/index.md
@@ -14,4 +14,5 @@
 1. [Doctrine and Constitution](doctrine-and-constitution.md)
 2. [Glossary System](glossary-system.md)
 3. [Runtime and Missions](runtime-and-missions.md)
-4. [ADR Coverage](adr-coverage.md)
+4. [Orchestration and API Boundary](orchestration-and-api.md)
+5. [ADR Coverage](adr-coverage.md)

--- a/docs/2x/orchestration-and-api.md
+++ b/docs/2x/orchestration-and-api.md
@@ -1,0 +1,42 @@
+# 2.x Orchestration and API Boundary
+
+`2.x` keeps orchestration external while preserving host-owned workflow integrity.
+
+## Boundary model
+
+1. Host: `spec-kitty` manages lane state, dependency checks, and merge/accept semantics.
+2. Provider: external orchestration runtime executes agents and calls host API.
+3. Contract: `spec-kitty orchestrator-api` JSON envelope and deterministic error codes.
+
+## Operational implications
+
+1. Security-sensitive environments can disable external automation and keep manual flow.
+2. Multiple provider strategies can be implemented without changing host internals.
+3. Runtime governance remains centralized in the host contract.
+
+## Baseline commands
+
+```bash
+spec-kitty orchestrator-api contract-version --json
+spec-kitty orchestrator-api feature-state --feature 034-my-feature --json
+spec-kitty orchestrator-api list-ready --feature 034-my-feature --json
+```
+
+## Reference provider
+
+Use `spec-kitty-orchestrator` for turnkey automation:
+
+```bash
+spec-kitty-orchestrator orchestrate --feature 034-my-feature --dry-run
+spec-kitty-orchestrator orchestrate --feature 034-my-feature
+```
+
+## Custom provider guidance
+
+Implement your orchestration loop against `orchestrator-api`; do not import host internals or write lane state directly.
+
+## References
+
+1. [Run External Orchestrator](../how-to/run-external-orchestrator.md)
+2. [Build Custom Orchestrator](../how-to/build-custom-orchestrator.md)
+3. [Orchestrator API Reference](../reference/orchestrator-api.md)

--- a/docs/2x/runtime-and-missions.md
+++ b/docs/2x/runtime-and-missions.md
@@ -37,3 +37,13 @@ ADR references:
 2. `architecture/adrs/2026-02-09-2-wp-lifecycle-state-machine.md`
 3. `architecture/adrs/2026-02-09-3-event-log-merge-semantics.md`
 4. `architecture/adrs/2026-02-09-4-cross-repo-evidence-completion.md`
+
+## External Orchestration Boundary
+
+2.x orchestration automation is externalized behind `spec-kitty orchestrator-api`.
+
+1. Host state and transition rules remain in `spec-kitty`.
+2. External providers (for example `spec-kitty-orchestrator`) call the host API contract.
+3. Provider implementations should not directly mutate lane/frontmatter state files.
+
+See [Orchestration and API Boundary](orchestration-and-api.md) for operator and provider guidance.

--- a/docs/2x/toc.yml
+++ b/docs/2x/toc.yml
@@ -6,5 +6,7 @@
   href: glossary-system.md
 - name: Runtime and Missions
   href: runtime-and-missions.md
+- name: Orchestration and API Boundary
+  href: orchestration-and-api.md
 - name: ADR Coverage
   href: adr-coverage.md

--- a/docs/architecture/feature-detection.md
+++ b/docs/architecture/feature-detection.md
@@ -154,7 +154,7 @@ Replaced 10 scattered implementations with imports from centralized module:
 - `implement.py` (detect_feature_context)
 - `acceptance.py` (detect_feature_slug)
 - `mission.py` (_detect_current_feature)
-- `orchestrate.py` (detect_current_feature)
+- `orchestrator_api/commands.py` (feature resolution for host API commands)
 
 ### Phase 3: Cleanup
 

--- a/docs/explanation/kanban-workflow.md
+++ b/docs/explanation/kanban-workflow.md
@@ -183,13 +183,15 @@ spec-kitty agent tasks move-task WP01 --to done
 /spec-kitty.accept
 ```
 
-### Users/Orchestrators Can Move Anything
+### Users and External Orchestrators Can Override
 
-Users can override any lane transition if needed:
+Users can override lane transitions when needed:
 ```bash
 # Force move (e.g., to un-block stuck work)
 spec-kitty agent tasks move-task WP01 --to planned
 ```
+
+External orchestrators should request equivalent transitions through `spec-kitty orchestrator-api transition ...` so host validation and audit history stay consistent.
 
 ## Activity Log
 

--- a/docs/how-to/build-custom-orchestrator.md
+++ b/docs/how-to/build-custom-orchestrator.md
@@ -1,0 +1,130 @@
+---
+title: Build a Custom Orchestrator
+description: Implement your own external orchestration runtime against spec-kitty orchestrator-api.
+---
+
+# Build a Custom Orchestrator
+
+Use this guide to implement your own orchestration strategy while keeping `spec-kitty` as the workflow host.
+
+## Contract Rules
+
+Your orchestrator must:
+
+- Call only `spec-kitty orchestrator-api ... --json` for workflow state.
+- Treat `spec-kitty` as source of truth for lane state and dependencies.
+- Never write `kitty-specs/<feature>/tasks/*.md` lanes directly.
+
+## Required Flow
+
+1. Check API compatibility.
+2. Poll for ready WPs.
+3. Start implementation for selected WPs.
+4. Transition WPs through review/complete loops.
+5. Accept and optionally merge when all WPs are done.
+
+### 1. Check compatibility
+
+```bash
+spec-kitty orchestrator-api contract-version --json
+```
+
+### 2. Discover work
+
+```bash
+spec-kitty orchestrator-api feature-state --feature <slug> --json
+spec-kitty orchestrator-api list-ready --feature <slug> --json
+```
+
+### 3. Start implementation
+
+```bash
+spec-kitty orchestrator-api start-implementation \
+  --feature <slug> \
+  --wp WP01 \
+  --actor my-orchestrator \
+  --policy '<json>' \
+  --json
+```
+
+Use returned `workspace_path` and `prompt_path` to run your agent process.
+
+### 4. Drive transitions
+
+```bash
+# implementation complete
+spec-kitty orchestrator-api transition \
+  --feature <slug> --wp WP01 --to for_review \
+  --actor my-orchestrator --policy '<json>' --json
+
+# review approved
+spec-kitty orchestrator-api transition \
+  --feature <slug> --wp WP01 --to done \
+  --actor reviewer-bot --json
+
+# review rejected -> rework
+spec-kitty orchestrator-api start-review \
+  --feature <slug> --wp WP01 --actor my-orchestrator \
+  --policy '<json>' --review-ref review/WP01/attempt-2 --json
+```
+
+### 5. Finalize
+
+```bash
+spec-kitty orchestrator-api accept-feature --feature <slug> --actor my-orchestrator --json
+spec-kitty orchestrator-api merge-feature --feature <slug> --target main --strategy merge --json
+```
+
+## Policy JSON Template
+
+Run-affecting operations require `--policy` with these keys:
+
+```json
+{
+  "orchestrator_id": "my-orchestrator",
+  "orchestrator_version": "0.1.0",
+  "agent_family": "claude",
+  "approval_mode": "supervised",
+  "sandbox_mode": "workspace_write",
+  "network_mode": "none",
+  "dangerous_flags": []
+}
+```
+
+## Lane and Error Semantics
+
+- Use API lane `in_progress`; host maps it to internal `doing`.
+- Expect deterministic `error_code` on failures.
+- Build retry/backoff logic based on `error_code`, not message text.
+
+Common retry-relevant failures:
+
+- `WP_ALREADY_CLAIMED`
+- `TRANSITION_REJECTED`
+- `POLICY_VALIDATION_FAILED`
+
+## Minimal Loop Skeleton
+
+```text
+while true:
+  ready = list-ready(feature)
+  if no ready and all terminal: break
+  for wp in ready up to concurrency limit:
+    start-implementation(wp)
+    run implementation agent
+    transition(wp, for_review)
+    run reviewer
+    if approved: transition(wp, done)
+    else: start-review(wp, review_ref)
+accept-feature(feature)
+merge-feature(feature)
+```
+
+## Reference Implementation
+
+Use [`spec-kitty-orchestrator`](https://github.com/Priivacy-ai/spec-kitty-orchestrator) as a concrete provider example.
+
+## See Also
+
+- [Run the External Orchestrator](run-external-orchestrator.md)
+- [Orchestrator API Reference](../reference/orchestrator-api.md)

--- a/docs/how-to/parallel-development.md
+++ b/docs/how-to/parallel-development.md
@@ -95,6 +95,7 @@ Use the dashboard to monitor lane movement and agent activity in real time.
 
 - [Agent Subcommands](../reference/agent-subcommands.md) - Workflow commands for agents
 - [CLI Commands](../reference/cli-commands.md) - Full CLI reference
+- [Orchestrator API](../reference/orchestrator-api.md) - Host contract for external automation providers
 
 ## See Also
 
@@ -111,3 +112,4 @@ Use the dashboard to monitor lane movement and agent activity in real time.
 ## Getting Started
 
 - [Multi-Agent Workflow](../tutorials/multi-agent-workflow.md) - Hands-on parallel tutorial
+- [Run External Orchestrator](run-external-orchestrator.md) - Automate lane transitions with `spec-kitty-orchestrator`

--- a/docs/how-to/run-external-orchestrator.md
+++ b/docs/how-to/run-external-orchestrator.md
@@ -1,0 +1,94 @@
+---
+title: Run the External Orchestrator
+description: Use spec-kitty-orchestrator with spec-kitty orchestrator-api to automate multi-agent WP execution.
+---
+
+# Run the External Orchestrator
+
+Use this guide to run `spec-kitty-orchestrator` against a feature managed by `spec-kitty`.
+
+This is the supported automation model in `1.x` and `2.x`:
+
+- Host workflow state is owned by `spec-kitty`.
+- Automation runtime is external (`spec-kitty-orchestrator` or your own provider).
+- Integration happens only through `spec-kitty orchestrator-api`.
+
+## Prerequisites
+
+- `spec-kitty` installed and available on `PATH`
+- `spec-kitty-orchestrator` installed and available on `PATH`
+- A prepared feature (`spec.md`, `plan.md`, `tasks.md`, and `tasks/WP*.md`)
+- At least one supported agent CLI installed
+
+## 1. Verify Host Contract
+
+```bash
+spec-kitty orchestrator-api contract-version --json
+```
+
+Expected result:
+
+- `success: true`
+- `data.api_version` present
+- `data.min_supported_provider_version` present
+
+## 2. Run a Dry-Run
+
+```bash
+spec-kitty-orchestrator orchestrate --feature 034-my-feature --dry-run
+```
+
+Use this to validate configuration before mutating WP lanes.
+
+## 3. Start Orchestration
+
+```bash
+spec-kitty-orchestrator orchestrate --feature 034-my-feature
+```
+
+The orchestrator loop will typically:
+
+1. Read ready WPs via `list-ready`.
+2. Claim/start via `start-implementation`.
+3. Transition through `for_review` and `done` via host API calls.
+4. Continue until all WPs are terminal.
+
+## 4. Monitor or Recover
+
+```bash
+spec-kitty-orchestrator status
+spec-kitty-orchestrator resume
+spec-kitty-orchestrator abort
+```
+
+Use `resume` after interruption. Use `abort` to mark the provider run as stopped.
+
+## 5. Confirm Host State
+
+```bash
+spec-kitty orchestrator-api feature-state --feature 034-my-feature --json
+```
+
+This is the authoritative source of lane state.
+
+## Troubleshooting
+
+### `No such command 'orchestrate'`
+
+Expected for `spec-kitty` core CLI. Use:
+
+- `spec-kitty-orchestrator orchestrate ...` for the external runtime
+- `spec-kitty orchestrator-api ...` for host state operations
+
+### Contract mismatch
+
+If `contract-version` returns mismatch, upgrade either host (`spec-kitty`) or provider (`spec-kitty-orchestrator`) so versions are compatible.
+
+### Policy validation failures
+
+Mutation calls may fail with `POLICY_METADATA_REQUIRED` or `POLICY_VALIDATION_FAILED`. Ensure the provider sends required policy fields and does not include secret-like values.
+
+## See Also
+
+- [Orchestrator API Reference](../reference/orchestrator-api.md)
+- [How to Build a Custom Orchestrator](build-custom-orchestrator.md)

--- a/docs/how-to/toc.yml
+++ b/docs/how-to/toc.yml
@@ -24,6 +24,10 @@
   href: use-operation-history.md
 - name: Parallel Development
   href: parallel-development.md
+- name: Run External Orchestrator
+  href: run-external-orchestrator.md
+- name: Build Custom Orchestrator
+  href: build-custom-orchestrator.md
 - name: Switch Missions
   href: switch-missions.md
 - name: Use the Dashboard

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,11 @@ This site is versioned by product line.
 
 The versioned tracks on this site cover local-first workflow and architecture only.
 
+Both tracks include the external orchestration boundary model:
+
+1. Host API in `spec-kitty orchestrator-api`.
+2. Optional external providers such as `spec-kitty-orchestrator`.
+
 ## Verification Notes
 
 Versioned docs are tested for:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -11,6 +11,7 @@ Reference docs are:
 ## Contents
 
 - [CLI Commands](cli-commands.md) - All commands, flags, and options
+- [Orchestrator API](orchestrator-api.md) - Host contract for external orchestration providers
 - [Slash Commands](slash-commands.md) - All `/spec-kitty.*` commands
 - [Agent Subcommands](agent-subcommands.md) - `spec-kitty agent *` commands
 - [Configuration](configuration.md) - All configuration options

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -22,6 +22,7 @@ This reference lists the user-facing `spec-kitty` CLI commands and their flags e
 - `merge` - Merge a completed feature branch into the target branch and clean up resources
 - `sync` - Synchronize workspace with upstream changes
 - `ops` - Operation history and undo (git reflog)
+- `orchestrator-api` - Host contract for external orchestrators (JSON envelope interface)
 - `research` - Execute Phase 0 research workflow to scaffold artifacts
 - `upgrade` - Upgrade a Spec Kitty project to the current version
 - `list-legacy-features` - List legacy worktrees blocking 0.11.0 upgrade
@@ -195,6 +196,32 @@ spec-kitty implement WP01 --json
 | `--feature TEXT` | Feature slug to target (auto-detected when omitted) |
 | `--force` | Overwrite existing research artifacts |
 | `--help` | Show this message and exit |
+
+---
+
+## spec-kitty orchestrator-api
+
+**Synopsis**: `spec-kitty orchestrator-api [OPTIONS] COMMAND [ARGS]...`
+
+**Description**: Machine-contract API for external orchestrators. Every command emits exactly one JSON envelope and exits non-zero on failure.
+
+**Options**:
+| Flag | Description |
+| --- | --- |
+| `--help` | Show this message and exit |
+
+**Commands**:
+- `contract-version` - Return host contract version and provider compatibility minimum
+- `feature-state` - Return full feature/WP state snapshot
+- `list-ready` - Return `planned` WPs whose dependencies are `done`
+- `start-implementation` - Composite claim/start transition for a WP
+- `start-review` - Move rejected WP from `for_review` back to `in_progress`
+- `transition` - Apply explicit lane transition with state-machine validation
+- `append-history` - Append activity history to a WP prompt
+- `accept-feature` - Accept a feature when all WPs are `done`
+- `merge-feature` - Run preflight and merge all WP branches
+
+**See Also**: [Orchestrator API Reference](orchestrator-api.md)
 
 ---
 

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -1,0 +1,186 @@
+---
+title: Orchestrator API Reference
+description: Contract reference for external orchestration providers that integrate with spec-kitty via the orchestrator-api command group.
+---
+
+# Orchestrator API Reference
+
+`spec-kitty orchestrator-api` is the host-side contract for external orchestration providers.
+
+- Core CLI does not include `spec-kitty orchestrate`.
+- External providers (for example `spec-kitty-orchestrator`) must use this API.
+- Commands are JSON-first: exactly one JSON envelope on stdout; non-zero exit on failure.
+
+## Contract Version
+
+- `CONTRACT_VERSION`: `1.0.0`
+- Command: `spec-kitty orchestrator-api contract-version --json`
+
+## Canonical Envelope
+
+All commands return:
+
+```json
+{
+  "contract_version": "1.0.0",
+  "command": "orchestrator-api.feature-state",
+  "timestamp": "2026-02-23T18:03:22.152177+00:00",
+  "correlation_id": "corr-9b9385...",
+  "success": true,
+  "error_code": null,
+  "data": {}
+}
+```
+
+Field meanings:
+
+- `contract_version`: Host API contract version.
+- `command`: Fully qualified command name (`orchestrator-api.<subcommand>`).
+- `timestamp`: Host generation timestamp (ISO 8601).
+- `correlation_id`: Unique request/response correlation token.
+- `success`: Success/failure indicator.
+- `error_code`: Machine-readable error identifier on failure, otherwise `null`.
+- `data`: Command-specific payload.
+
+## Lanes and Mapping
+
+Public API lane model:
+
+- `planned`
+- `in_progress`
+- `for_review`
+- `done`
+- `blocked`
+- `canceled`
+
+Host internal lane compatibility:
+
+- API `in_progress` maps to internal `doing`.
+- API `for_review`, `planned`, and `done` map directly.
+
+## Policy Contract (Mutation Commands)
+
+Run-affecting operations require `--policy` JSON and validate it server-side.
+
+Required fields:
+
+- `orchestrator_id`
+- `orchestrator_version`
+- `agent_family`
+- `approval_mode`
+- `sandbox_mode`
+- `network_mode`
+- `dangerous_flags` (array)
+
+Validation rules:
+
+- Missing required fields fail with `POLICY_VALIDATION_FAILED`.
+- Non-array `dangerous_flags` fails validation.
+- Secret-like values (`token`, `secret`, `key`, `password`, `credential`) are rejected.
+
+## Subcommands
+
+### contract-version
+
+```bash
+spec-kitty orchestrator-api contract-version --json [--provider-version <semver>]
+```
+
+Returns host `api_version` and minimum supported provider version.
+
+### feature-state
+
+```bash
+spec-kitty orchestrator-api feature-state --feature <slug> --json
+```
+
+Returns WP states, dependency data, and lane summary.
+
+### list-ready
+
+```bash
+spec-kitty orchestrator-api list-ready --feature <slug> --json
+```
+
+Returns WPs in `planned` with all dependencies in `done`.
+
+### start-implementation
+
+```bash
+spec-kitty orchestrator-api start-implementation \
+  --feature <slug> --wp <WP##> --actor <actor-id> --policy '<json>' --json
+```
+
+Composite transition into `in_progress` for implementation. Returns `workspace_path` and `prompt_path`.
+
+### start-review
+
+```bash
+spec-kitty orchestrator-api start-review \
+  --feature <slug> --wp <WP##> --actor <actor-id> --policy '<json>' \
+  --review-ref <ref> --json
+```
+
+Moves a rejected WP from `for_review` back to `in_progress`.
+
+### transition
+
+```bash
+spec-kitty orchestrator-api transition \
+  --feature <slug> --wp <WP##> --to <lane> --actor <actor-id> \
+  [--note <text>] [--policy '<json>'] [--review-ref <ref>] [--force] --json
+```
+
+Applies one lane transition with deterministic validation errors.
+
+### append-history
+
+```bash
+spec-kitty orchestrator-api append-history \
+  --feature <slug> --wp <WP##> --actor <actor-id> --note <text> --json
+```
+
+Appends an activity entry to the WP prompt history.
+
+### accept-feature
+
+```bash
+spec-kitty orchestrator-api accept-feature --feature <slug> --actor <actor-id> --json
+```
+
+Accepts a feature when all WPs are `done`.
+
+### merge-feature
+
+```bash
+spec-kitty orchestrator-api merge-feature \
+  --feature <slug> [--target main] [--strategy merge|squash] [--push] --json
+```
+
+Runs preflight and merges WP branches in dependency order.
+
+## Common Error Codes
+
+- `CONTRACT_VERSION_MISMATCH`
+- `FEATURE_NOT_FOUND`
+- `WP_NOT_FOUND`
+- `TRANSITION_REJECTED`
+- `WP_ALREADY_CLAIMED`
+- `POLICY_METADATA_REQUIRED`
+- `POLICY_VALIDATION_FAILED`
+- `FEATURE_NOT_READY`
+- `PREFLIGHT_FAILED`
+- `MERGE_FAILED`
+- `PUSH_FAILED`
+- `UNSUPPORTED_STRATEGY`
+
+## Integration Notes
+
+- Treat `error_code` as the stable failure discriminator.
+- Do not parse human-readable `message` text for control flow.
+- Do not mutate `kitty-specs/` state directly from external providers.
+
+## See Also
+
+- [How to Run the External Orchestrator](../how-to/run-external-orchestrator.md)
+- [How to Build a Custom Orchestrator](../how-to/build-custom-orchestrator.md)

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,5 +1,7 @@
 - name: CLI Commands
   href: cli-commands.md
+- name: Orchestrator API
+  href: orchestrator-api.md
 - name: Slash Commands
   href: slash-commands.md
 - name: Agent Subcommands

--- a/docs/tutorials/multi-agent-workflow.md
+++ b/docs/tutorials/multi-agent-workflow.md
@@ -106,5 +106,6 @@ You've completed the core tutorials. Explore how-to guides for specific tasks or
 ### Learn More
 
 - [Multi-Agent Orchestration](../explanation/multi-agent-orchestration.md) - Coordination patterns
+- [Run External Orchestrator](../how-to/run-external-orchestrator.md) - Automate WP execution with the external provider
 - [Workspace-per-WP Model](../explanation/workspace-per-wp.md) - Isolation strategy
 - [Git Worktrees](../explanation/git-worktrees.md) - How worktrees work

--- a/examples/multi-agent-feature-development.md
+++ b/examples/multi-agent-feature-development.md
@@ -23,8 +23,9 @@ This scenario demonstrates how a lead architect can orchestrate a multi-agent te
    - Cursor implements the chat service changes.  
    - Human reviewer tracks `tasks/for_review/`.
 
-5. **Run the kanban workflow**
-   spec-kitty agent workflow implement WP##
+5. **Run the orchestration loop**
+   - Manual mode: `spec-kitty agent workflow implement WP##` per assigned WP
+   - Automated mode: `spec-kitty-orchestrator orchestrate --feature 001-cross-platform-chat-upgrade`
 
 6. **Review completed work**
    Human reviewer processes `for_review` prompts via `/spec-kitty.review`, providing feedback or approving work to move to `done`.


### PR DESCRIPTION
## Summary
- remove in-core orchestration wording from user-facing docs
- document external orchestration using `spec-kitty-orchestrator`
- add custom-provider guidance for building against `spec-kitty orchestrator-api`
- add versioned track docs for both `docs/1x/` and `docs/2x/`

## Included
- new how-to docs:
  - `docs/how-to/run-external-orchestrator.md`
  - `docs/how-to/build-custom-orchestrator.md`
- new reference doc:
  - `docs/reference/orchestrator-api.md`
- new version-track pages:
  - `docs/1x/orchestration-and-api.md`
  - `docs/2x/orchestration-and-api.md`
- README and command-reference updates to point users to external orchestration model
- stale `orchestrate.py` architecture reference removed

## Notes
- This PR is docs-only; no runtime behavior changes.
- Existing docs lint/link baseline issue remains: `docs/how-to/toc.yml` still references `use-operation-history.md` (pre-existing in branch).
