### PR TITLE
ci: skip docs deploy job on non-main branches

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -51,6 +51,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Problem
`Deploy Docs to GitHub Pages` fails on `2.x` because the `github-pages` environment only allows deployment from `main`.

Failure from run [22322879699](https://github.com/Priivacy-ai/spec-kitty/actions/runs/22322879699):
- "Branch \"2.x\" is not allowed to deploy to github-pages due to environment protection rules."

## Fix
- Keep docs build on `main` and `2.x`.
- Gate the deploy job to run only on `main`:
  - `if: github.ref == 'refs/heads/main'`

## Result
- `2.x` docs pushes continue validating/building docs.
- Pages deployment is attempted only where environment policy allows it (`main`).
