### PR TITLE
fix(release): allow lane-scoped 1.x publish validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v1*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Optional release tag to validate/publish (defaults to pyproject version)
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -76,8 +81,29 @@ jobs:
           python -m pytest -v --tb=short 2>&1 | tee pytest-output.txt
           exit ${PIPESTATUS[0]}
 
+      - name: Determine release context
+        id: release_context
+        env:
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+          elif [ -n "${INPUT_RELEASE_TAG}" ]; then
+            RELEASE_TAG="${INPUT_RELEASE_TAG}"
+          else
+            RELEASE_TAG="v$(python -c 'import tomllib; print(tomllib.load(open(\"pyproject.toml\", \"rb\"))[\"project\"][\"version\"])')"
+          fi
+
+          echo "Release tag: ${RELEASE_TAG}"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+
       - name: Validate release metadata
-        run: python scripts/release/validate_release.py --mode tag --tag "${GITHUB_REF_NAME}"
+        run: |
+          python scripts/release/validate_release.py \
+            --mode tag \
+            --tag "${{ steps.release_context.outputs.release_tag }}" \
+            --tag-pattern "v1*"
 
       - name: Validate repository URLs
         run: |
@@ -161,7 +187,7 @@ jobs:
       - name: Extract changelog for release
         id: changelog
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ steps.release_context.outputs.release_version }}"
           python scripts/release/extract_changelog.py "${VERSION}" > release-notes.md
           cat release-notes.md
 

--- a/scripts/release/validate_release.py
+++ b/scripts/release/validate_release.py
@@ -105,6 +105,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Path to changelog file (default: %(default)s)",
     )
     parser.add_argument(
+        "--tag-pattern",
+        default="v*",
+        help="Git tag glob pattern used for version progression checks "
+        "(default: %(default)s).",
+    )
+    parser.add_argument(
         "--fail-on-missing-tag",
         action="store_true",
         help="Treat missing tag detection as a hard failure (defaults to failure in tag mode).",
@@ -182,8 +188,10 @@ def find_repo_root(start: Path) -> Path:
     return Path(output)
 
 
-def discover_release_tags(repo_root: Path, exclude: Optional[str] = None) -> List[str]:
-    output = git("tag", "--list", "v*", cwd=repo_root)
+def discover_release_tags(
+    repo_root: Path, tag_pattern: str, exclude: Optional[str] = None
+) -> List[str]:
+    output = git("tag", "--list", tag_pattern, cwd=repo_root)
     tags = [line.strip() for line in output.splitlines() if line.strip()]
     filtered: List[str] = []
     for tag in tags:
@@ -330,12 +338,14 @@ def run_validation(args: argparse.Namespace) -> ValidationResult:
             if mismatch:
                 issues.append(mismatch)
 
-        existing_tags = discover_release_tags(repo_root, exclude=tag)
+        existing_tags = discover_release_tags(
+            repo_root, tag_pattern=args.tag_pattern, exclude=tag
+        )
         progression_issue = validate_version_progression(version, existing_tags)
         if progression_issue:
             issues.append(progression_issue)
     else:
-        existing_tags = discover_release_tags(repo_root)
+        existing_tags = discover_release_tags(repo_root, tag_pattern=args.tag_pattern)
         progression_issue = validate_version_progression(version, existing_tags)
         if progression_issue:
             issues.append(progression_issue)


### PR DESCRIPTION
## Summary\n- add tag-pattern support to release validator\n- scope main-line validation to v1* tags\n- add workflow_dispatch release context resolution for manual 1.x publish runs\n\n## Why\nRecent dual-lane tagging introduced v2.0.0, which caused main 1.x tag validation to fail progression checks even for valid v1 pre-releases.\n\n## Validation\n- uv run python scripts/release/validate_release.py --mode tag --tag v1.0.0a1 --tag-pattern 'v1*'