### PR TITLE
chore(release): promote 1.0.0 stable on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-02-24
+
+### 🔧 Changed
+
+- **Promoted the 1.x line to stable**: `1.0.0` supersedes `0.16.2` as the default recommended PyPI install.
+- **Release lane policy hardened**: `main` continues to publish the 1.x PyPI stream while `2.x` remains GitHub-release-only.
+
 ## [1.0.0a1] - 2026-02-23
 
 ### 💥 Breaking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "1.0.0a1"
+version = "1.0.0"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary\n- bump project version from 1.0.0a1 to 1.0.0\n- add 1.0.0 changelog entry\n\n## Why\n- make 1.x the recommended PyPI install (non-prerelease)\n\n## Validation\n- uv run python scripts/release/validate_release.py --mode tag --tag v1.0.0 --tag-pattern 'v1*'\n- uv run python scripts/release/extract_changelog.py 1.0.0