### PR TITLE
Tighten spec/task requirement traceability and finalize validation

### DIFF
--- a/src/doctrine/missions/software-dev/command-templates/specify.md
+++ b/src/doctrine/missions/software-dev/command-templates/specify.md
@@ -30,6 +30,14 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## DO NOT
+
+- Do not mix functional, non-functional, and constraint requirements in one list.
+- Do not emit requirements without stable IDs (`FR-###`, `NFR-###`, `C-###`).
+- Do not leave requirement status fields empty.
+- Do not write non-functional requirements without measurable thresholds.
+- Do not proceed to planning with unresolved requirement quality checklist failures.
+
 ## Constitution Context Bootstrap (required)
 
 Before discovery questions, load constitution context for this action:
@@ -189,7 +197,8 @@ Given that feature description, do this:
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
-    - Generate Functional Requirements (each requirement must be testable)
+    - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
+    - Ensure each requirement entry has a status value and testable wording
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 
@@ -217,6 +226,10 @@ Given that feature description, do this:
       
       - [ ] No [NEEDS CLARIFICATION] markers remain
       - [ ] Requirements are testable and unambiguous
+      - [ ] Requirement types are separated (Functional / Non-Functional / Constraints)
+      - [ ] IDs are unique across FR-###, NFR-###, and C-### entries
+      - [ ] All requirement rows include a non-empty Status value
+      - [ ] Non-functional requirements include measurable thresholds
       - [ ] Success criteria are measurable
       - [ ] Success criteria are technology-agnostic (no implementation details)
       - [ ] All acceptance scenarios are defined

--- a/src/doctrine/missions/software-dev/command-templates/tasks-finalize.md
+++ b/src/doctrine/missions/software-dev/command-templates/tasks-finalize.md
@@ -36,8 +36,13 @@ spec-kitty agent feature finalize-tasks --json
 This command will:
 
 - Parse dependencies from tasks.md
-- Update WP frontmatter with `dependencies` field
+- Parse `Requirement Refs` from tasks.md
+- Update WP frontmatter with `dependencies` and `requirement_refs` fields
 - Validate dependencies (check for cycles, invalid references)
+- Validate requirement mapping:
+  - Every WP has at least one requirement reference
+  - Referenced requirement IDs exist in spec.md
+  - Every FR-### in spec.md is mapped to at least one WP
 - Commit all tasks to target branch
 
 ### 2. Check Output
@@ -48,6 +53,8 @@ The JSON output includes:
 - `"commit_hash"` — the commit hash if created
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
+- `"requirement_refs_parsed"` — requirement reference mapping found
+- Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
 ### 3. Verify
 
@@ -74,7 +81,9 @@ Provide a concise outcome summary:
 After completing this step:
 
 - All WP files have `dependencies` field in frontmatter
+- All WP files have `requirement_refs` field in frontmatter
 - Dependencies are validated (no cycles, no invalid references)
+- Requirement references are validated against spec.md
 - Task artifacts are committed to the target branch
 
 **Next step**: `spec-kitty next --agent <name>` will advance to implementation.

--- a/src/doctrine/missions/software-dev/command-templates/tasks-outline.md
+++ b/src/doctrine/missions/software-dev/command-templates/tasks-outline.md
@@ -91,7 +91,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 - Root in a single user story or cohesive subsystem
 - Ensure every subtask appears in exactly one work package
 - Name with succinct goal (e.g., "User Story 1 – Real-time chat happy path")
-- Record metadata: priority, success criteria, risks, dependencies, included subtasks
+- Record metadata: priority, success criteria, risks, dependencies, included subtasks, and requirement references
+- Every WP must include a `Requirement Refs` line listing IDs from `spec.md` (FR/NFR/C)
 
 ### 5. Write `tasks.md`
 
@@ -100,10 +101,12 @@ Write to `FEATURE_DIR/tasks.md` using the bundled tasks template (`.kittify/miss
 - Populate Work Package sections (setup, foundational, per-story, polish) with `WPxx` entries
 - Under each work package include:
   - Summary (goal, priority, independent test)
+  - Requirement references (`Requirement Refs: FR-001, NFR-001, C-001`)
   - Included subtasks (checkbox list referencing `Txxx`)
   - Implementation sketch (high-level sequence)
   - Parallel opportunities, dependencies, and risks
   - **Estimated prompt size** (e.g., "~400 lines")
+- Add a `Requirements Coverage Summary` section mapping every requirement ID in `spec.md` to one or more WPs
 - Preserve the checklist style so implementers can mark progress
 
 **DO NOT generate WP prompt files in this step.** That happens in the next step.

--- a/src/doctrine/missions/software-dev/command-templates/tasks-packages.md
+++ b/src/doctrine/missions/software-dev/command-templates/tasks-packages.md
@@ -51,6 +51,7 @@ For each work package defined in `tasks.md`:
 4. Use the bundled task prompt template (`.kittify/missions/software-dev/templates/task-prompt-template.md`)
 5. Include frontmatter with:
    - `work_package_id`, `subtasks` array, `lane: "planned"`, `dependencies`, history entry
+   - `requirement_refs` array from the WP's `Requirement Refs` line in `tasks.md`
 6. Include in body:
    - Objective, context, detailed guidance per subtask
    - Test strategy (only if requested)
@@ -73,6 +74,7 @@ work_package_id: "WP02"
 title: "Build API"
 lane: "planned"
 dependencies: ["WP01"]  # From tasks.md
+requirement_refs: ["FR-001", "NFR-001"]  # From tasks.md Requirement Refs
 subtasks: ["T001", "T002"]
 ---
 ```

--- a/src/doctrine/missions/software-dev/templates/spec-template.md
+++ b/src/doctrine/missions/software-dev/templates/spec-template.md
@@ -79,22 +79,36 @@
 ## Requirements *(mandatory)*
 
 <!--
-  ACTION REQUIRED: The content in this section represents placeholders.
-  Fill them out with the right functional requirements.
+  ACTION REQUIRED:
+  1) Keep requirement types separated (Functional / Non-Functional / Constraints)
+  2) Use unique IDs per type (FR-###, NFR-###, C-###)
+  3) Keep Status populated for every row
+  4) Non-functional requirements must include measurable thresholds
 -->
 
 ### Functional Requirements
 
-- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
-- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
-- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
-- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
-- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+| ID | Title | User Story | Priority | Status |
+|----|-------|------------|----------|--------|
+| FR-001 | [Short title] | As a [role], I want [goal] so that [benefit]. | High | Open |
+| FR-002 | [Short title] | As a [role], I want [goal] so that [benefit]. | Medium | Open |
+| FR-003 | [Short title] | As a [role], I want [goal] so that [benefit]. | Low | Open |
 
-*Example of marking unclear requirements:*
+### Non-Functional Requirements
 
-- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
-- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+| ID | Title | Requirement | Category | Priority | Status |
+|----|-------|-------------|----------|----------|--------|
+| NFR-001 | [Short title] | [Measurable threshold, e.g., p95 latency under 300ms] | Performance | High | Open |
+| NFR-002 | [Short title] | [Measurable threshold] | Security | High | Open |
+| NFR-003 | [Short title] | [Measurable threshold] | Reliability | Medium | Open |
+
+### Constraints
+
+| ID | Title | Constraint | Category | Priority | Status |
+|----|-------|------------|----------|----------|--------|
+| C-001 | [Short title] | [Required boundary or limitation] | Technical | High | Open |
+| C-002 | [Short title] | [Required boundary or limitation] | Business | Medium | Open |
+| C-003 | [Short title] | [Required boundary or limitation] | Regulatory | Medium | Open |
 
 ### Key Entities *(include if feature involves data)*
 

--- a/src/doctrine/missions/software-dev/templates/tasks-template.md
+++ b/src/doctrine/missions/software-dev/templates/tasks-template.md
@@ -34,6 +34,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: Establish project skeleton and shared tooling.
 **Independent Test**: Project bootstraps locally with linting and formatter tooling configured.
 **Prompt**: `/tasks/WP01-setup-and-environment.md`
+**Requirement Refs**: C-001
 
 ### Included Subtasks
 
@@ -64,6 +65,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: Deliver shared services all user stories depend on.
 **Independent Test**: Foundational services pass smoke tests; downstream work packages can start.
 **Prompt**: `/tasks/WP02-foundational-platform.md`
+**Requirement Refs**: FR-001, NFR-001, C-001
 
 ### Included Subtasks
 
@@ -97,6 +99,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: [Brief description of story outcome]
 **Independent Test**: [Describe how to validate the story independently]
 **Prompt**: `/tasks/WP03-user-story-1.md`
+**Requirement Refs**: FR-002, NFR-002
 
 ### Included Subtasks
 
@@ -132,6 +135,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: Cross-story improvements and hardening work.
 **Independent Test**: Regression suite passes; observability and documentation updated.
 **Prompt**: `/tasks/WP0N-polish-and-cross-cutting.md`
+**Requirement Refs**: FR-003, NFR-003, C-002
 
 ### Included Subtasks
 
@@ -164,6 +168,18 @@ description: "Work package task list template for feature implementation"
 - **Sequence**: WP01 → WP02 → Story-driven packages (priority order) → WP0N polish.
 - **Parallelization**: Highlight safe parallel combinations once prerequisites complete.
 - **MVP Scope**: Call out which work packages constitute the minimal release.
+
+---
+
+## Requirements Coverage Summary
+
+| Requirement ID | Covered By Work Package(s) |
+|----------------|----------------------------|
+| FR-001 | WP02 |
+| FR-002 | WP03 |
+| NFR-001 | WP02 |
+| NFR-002 | WP03 |
+| C-001 | WP01, WP02 |
 
 ---
 

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -30,6 +30,14 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## DO NOT
+
+- Do not mix functional, non-functional, and constraint requirements in one list.
+- Do not emit requirements without stable IDs (`FR-###`, `NFR-###`, `C-###`).
+- Do not leave requirement status fields empty.
+- Do not write non-functional requirements without measurable thresholds.
+- Do not proceed to planning with unresolved requirement quality checklist failures.
+
 ## Constitution Context Bootstrap (required)
 
 Before discovery questions, load constitution context for this action:
@@ -188,7 +196,8 @@ Given that feature description, do this:
       * Record any interim assumption in the Assumptions section
       * Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
-    - Generate Functional Requirements (each requirement must be testable)
+    - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
+    - Ensure each requirement entry has a status value and testable wording
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 
@@ -216,6 +225,10 @@ Given that feature description, do this:
       
       - [ ] No [NEEDS CLARIFICATION] markers remain
       - [ ] Requirements are testable and unambiguous
+      - [ ] Requirement types are separated (Functional / Non-Functional / Constraints)
+      - [ ] IDs are unique across FR-###, NFR-###, and C-### entries
+      - [ ] All requirement rows include a non-empty Status value
+      - [ ] Non-functional requirements include measurable thresholds
       - [ ] Success criteria are measurable
       - [ ] Success criteria are technology-agnostic (no implementation details)
       - [ ] All acceptance scenarios are defined

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-finalize.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-finalize.md
@@ -35,8 +35,13 @@ spec-kitty agent feature finalize-tasks --json
 
 This command will:
 - Parse dependencies from tasks.md
-- Update WP frontmatter with `dependencies` field
+- Parse `Requirement Refs` from tasks.md
+- Update WP frontmatter with `dependencies` and `requirement_refs` fields
 - Validate dependencies (check for cycles, invalid references)
+- Validate requirement mapping:
+  - Every WP has at least one requirement reference
+  - Referenced requirement IDs exist in spec.md
+  - Every FR-### in spec.md is mapped to at least one WP
 - Commit all tasks to target branch
 
 ### 2. Check Output
@@ -46,6 +51,8 @@ The JSON output includes:
 - `"commit_hash"` — the commit hash if created
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
+- `"requirement_refs_parsed"` — requirement reference mapping found
+- Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
 ### 3. Verify
 
@@ -69,7 +76,9 @@ Provide a concise outcome summary:
 
 After completing this step:
 - All WP files have `dependencies` field in frontmatter
+- All WP files have `requirement_refs` field in frontmatter
 - Dependencies are validated (no cycles, no invalid references)
+- Requirement references are validated against spec.md
 - Task artifacts are committed to the target branch
 
 **Next step**: `spec-kitty next --agent <name>` will advance to implementation.

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-outline.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-outline.md
@@ -87,7 +87,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 - Root in a single user story or cohesive subsystem
 - Ensure every subtask appears in exactly one work package
 - Name with succinct goal (e.g., "User Story 1 – Real-time chat happy path")
-- Record metadata: priority, success criteria, risks, dependencies, included subtasks
+- Record metadata: priority, success criteria, risks, dependencies, included subtasks, and requirement references
+- Every WP must include a `Requirement Refs` line listing IDs from `spec.md` (FR/NFR/C)
 
 ### 5. Write `tasks.md`
 
@@ -95,10 +96,12 @@ Write to `FEATURE_DIR/tasks.md` using the bundled tasks template (`.kittify/miss
 - Populate Work Package sections (setup, foundational, per-story, polish) with `WPxx` entries
 - Under each work package include:
   - Summary (goal, priority, independent test)
+  - Requirement references (`Requirement Refs: FR-001, NFR-001, C-001`)
   - Included subtasks (checkbox list referencing `Txxx`)
   - Implementation sketch (high-level sequence)
   - Parallel opportunities, dependencies, and risks
   - **Estimated prompt size** (e.g., "~400 lines")
+- Add a `Requirements Coverage Summary` section mapping every requirement ID in `spec.md` to one or more WPs
 - Preserve the checklist style so implementers can mark progress
 
 **DO NOT generate WP prompt files in this step.** That happens in the next step.

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
@@ -50,6 +50,7 @@ For each work package defined in `tasks.md`:
 4. Use the bundled task prompt template (`.kittify/missions/software-dev/templates/task-prompt-template.md`)
 5. Include frontmatter with:
    - `work_package_id`, `subtasks` array, `lane: "planned"`, `dependencies`, history entry
+   - `requirement_refs` array from the WP's `Requirement Refs` line in `tasks.md`
 6. Include in body:
    - Objective, context, detailed guidance per subtask
    - Test strategy (only if requested)
@@ -71,6 +72,7 @@ work_package_id: "WP02"
 title: "Build API"
 lane: "planned"
 dependencies: ["WP01"]  # From tasks.md
+requirement_refs: ["FR-001", "NFR-001"]  # From tasks.md Requirement Refs
 subtasks: ["T001", "T002"]
 ---
 ```

--- a/src/specify_cli/missions/software-dev/templates/spec-template.md
+++ b/src/specify_cli/missions/software-dev/templates/spec-template.md
@@ -79,22 +79,36 @@
 ## Requirements *(mandatory)*
 
 <!--
-  ACTION REQUIRED: The content in this section represents placeholders.
-  Fill them out with the right functional requirements.
+  ACTION REQUIRED:
+  1) Keep requirement types separated (Functional / Non-Functional / Constraints)
+  2) Use unique IDs per type (FR-###, NFR-###, C-###)
+  3) Keep Status populated for every row
+  4) Non-functional requirements must include measurable thresholds
 -->
 
 ### Functional Requirements
 
-- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
-- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
-- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
-- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
-- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+| ID | Title | User Story | Priority | Status |
+|----|-------|------------|----------|--------|
+| FR-001 | [Short title] | As a [role], I want [goal] so that [benefit]. | High | Open |
+| FR-002 | [Short title] | As a [role], I want [goal] so that [benefit]. | Medium | Open |
+| FR-003 | [Short title] | As a [role], I want [goal] so that [benefit]. | Low | Open |
 
-*Example of marking unclear requirements:*
+### Non-Functional Requirements
 
-- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
-- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+| ID | Title | Requirement | Category | Priority | Status |
+|----|-------|-------------|----------|----------|--------|
+| NFR-001 | [Short title] | [Measurable threshold, e.g., p95 latency under 300ms] | Performance | High | Open |
+| NFR-002 | [Short title] | [Measurable threshold] | Security | High | Open |
+| NFR-003 | [Short title] | [Measurable threshold] | Reliability | Medium | Open |
+
+### Constraints
+
+| ID | Title | Constraint | Category | Priority | Status |
+|----|-------|------------|----------|----------|--------|
+| C-001 | [Short title] | [Required boundary or limitation] | Technical | High | Open |
+| C-002 | [Short title] | [Required boundary or limitation] | Business | Medium | Open |
+| C-003 | [Short title] | [Required boundary or limitation] | Regulatory | Medium | Open |
 
 ### Key Entities *(include if feature involves data)*
 

--- a/src/specify_cli/missions/software-dev/templates/tasks-template.md
+++ b/src/specify_cli/missions/software-dev/templates/tasks-template.md
@@ -32,6 +32,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: Establish project skeleton and shared tooling.
 **Independent Test**: Project bootstraps locally with linting and formatter tooling configured.
 **Prompt**: `/tasks/WP01-setup-and-environment.md`
+**Requirement Refs**: C-001
 
 ### Included Subtasks
 - [ ] T001 Create project structure per implementation plan
@@ -57,6 +58,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: Deliver shared services all user stories depend on.
 **Independent Test**: Foundational services pass smoke tests; downstream work packages can start.
 **Prompt**: `/tasks/WP02-foundational-platform.md`
+**Requirement Refs**: FR-001, NFR-001, C-001
 
 ### Included Subtasks
 - [ ] T004 Setup database schema and migrations framework
@@ -85,6 +87,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: [Brief description of story outcome]
 **Independent Test**: [Describe how to validate the story independently]
 **Prompt**: `/tasks/WP03-user-story-1.md`
+**Requirement Refs**: FR-002, NFR-002
 
 ### Included Subtasks
 - [ ] T010 [P] Contract test for [endpoint] in `tests/contract/test_[name].py`
@@ -115,6 +118,7 @@ description: "Work package task list template for feature implementation"
 **Goal**: Cross-story improvements and hardening work.
 **Independent Test**: Regression suite passes; observability and documentation updated.
 **Prompt**: `/tasks/WP0N-polish-and-cross-cutting.md`
+**Requirement Refs**: FR-003, NFR-003, C-002
 
 ### Included Subtasks
 - [ ] T0XX Documentation updates in `docs/`
@@ -142,6 +146,18 @@ description: "Work package task list template for feature implementation"
 - **Sequence**: WP01 → WP02 → Story-driven packages (priority order) → WP0N polish.
 - **Parallelization**: Highlight safe parallel combinations once prerequisites complete.
 - **MVP Scope**: Call out which work packages constitute the minimal release.
+
+---
+
+## Requirements Coverage Summary
+
+| Requirement ID | Covered By Work Package(s) |
+|----------------|----------------------------|
+| FR-001 | WP02 |
+| FR-002 | WP03 |
+| NFR-001 | WP02 |
+| NFR-002 | WP03 |
+| C-001 | WP01, WP02 |
 
 ---
 

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -114,6 +114,31 @@ class TestFullCLIWorkflow:
         assert plan_output["result"] == "success"
         assert (feature_dir / "plan.md").exists()
 
+        # Populate spec requirements referenced by tasks.md
+        (feature_dir / "spec.md").write_text(
+            """# E2E Smoke Spec
+
+## Functional Requirements
+
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | Deliver WP01 hello-world implementation. | WP01 maps to FR-001 and finalizes successfully. | proposed |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Measurable Threshold | Status |
+| --- | --- | --- | --- |
+| NFR-001 | Finalization remains repeatable. | Running finalize twice yields stable output. | proposed |
+
+## Constraints
+
+| ID | Constraint | Rationale | Status |
+| --- | --- | --- | --- |
+| C-001 | Keep artifacts under kitty-specs. | Preserve planning workflow conventions. | fixed |
+""",
+            encoding="utf-8",
+        )
+
         # === Step 3: Simulate LLM task generation (write tasks.md + WP files) ===
         tasks_dir = feature_dir / "tasks"
 
@@ -121,6 +146,7 @@ class TestFullCLIWorkflow:
 
 ## Work Package WP01: Hello World
 **Dependencies**: None
+**Requirement Refs**: FR-001, NFR-001, C-001
 
 ### Included Subtasks
 - T001 Create hello module

--- a/tests/integration/test_finalize_tasks_json_output.py
+++ b/tests/integration/test_finalize_tasks_json_output.py
@@ -71,9 +71,41 @@ def create_test_feature(repo: Path) -> Path:
     }
     (feature_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n")
 
+    # Create spec.md with requirement IDs used by tasks.md
+    (feature_dir / "spec.md").write_text(
+        """# Feature Spec
+
+## Functional Requirements
+
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | The workflow supports finalize task metadata updates. | finalize-tasks updates WP frontmatter. | proposed |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Measurable Threshold | Status |
+| --- | --- | --- | --- |
+| NFR-001 | Finalization remains deterministic. | Re-running does not change committed files. | proposed |
+
+## Constraints
+
+| ID | Constraint | Rationale | Status |
+| --- | --- | --- | --- |
+| C-001 | Keep backward-compatible output fields. | Existing agents rely on commit fields. | fixed |
+""",
+        encoding="utf-8",
+    )
+
     # Create tasks.md
     (feature_dir / "tasks.md").write_text(
-        "# Tasks\n\n## WP01\n\nSetup\n\n## WP02\n\nDepends on WP01\n"
+        "# Tasks\n\n"
+        "## WP01\n\n"
+        "**Requirement Refs**: FR-001, C-001\n\n"
+        "Setup\n\n"
+        "## WP02\n\n"
+        "**Dependencies**: Depends on WP01\n"
+        "**Requirement Refs**: FR-001, NFR-001\n\n"
+        "Depends on WP01\n"
     )
 
     # Create WP files

--- a/tests/integration/test_planning_workflow.py
+++ b/tests/integration/test_planning_workflow.py
@@ -249,6 +249,34 @@ def test_full_planning_workflow_no_worktrees(test_project: Path, run_cli) -> Non
     assert result.returncode == 0, "Plan setup failed"
     assert (feature_dir / "plan.md").exists(), "plan.md not created"
 
+    # Populate spec requirements referenced by tasks.md
+    spec_md = feature_dir / "spec.md"
+    spec_md.write_text(
+        """# Full Workflow Test Spec
+
+## Functional Requirements
+
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | Foundation tasks are implemented first. | WP01 is planned and finalized. | proposed |
+| FR-002 | API tasks can depend on foundation tasks. | WP02 depends on WP01. | proposed |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Measurable Threshold | Status |
+| --- | --- | --- | --- |
+| NFR-001 | Finalization must be deterministic. | Re-running finalize does not rewrite unchanged files. | proposed |
+| NFR-002 | Dependency parsing must remain explicit. | Dependency links are represented in WP frontmatter. | proposed |
+
+## Constraints
+
+| ID | Constraint | Rationale | Status |
+| --- | --- | --- | --- |
+| C-001 | Keep generated artifacts in kitty-specs. | Maintains planning workflow structure. | fixed |
+""",
+        encoding="utf-8",
+    )
+
     # Step 3: Generate sample WP files and tasks.md (simulating /spec-kitty.tasks LLM output)
     tasks_dir = feature_dir / "tasks"
 
@@ -258,6 +286,7 @@ def test_full_planning_workflow_no_worktrees(test_project: Path, run_cli) -> Non
 
 ## Work Package WP01: Foundation
 **Dependencies**: None
+**Requirement Refs**: FR-001, NFR-001, C-001
 
 ### Included Subtasks
 - T001 Setup infrastructure
@@ -267,6 +296,7 @@ def test_full_planning_workflow_no_worktrees(test_project: Path, run_cli) -> Non
 
 ## Work Package WP02: API Layer
 **Dependencies**: Depends on WP01
+**Requirement Refs**: FR-002, NFR-002
 
 ### Included Subtasks
 - T003 Build REST endpoints

--- a/tests/specify_cli/cli/commands/test_event_emission.py
+++ b/tests/specify_cli/cli/commands/test_event_emission.py
@@ -303,14 +303,28 @@ def test_finalize_tasks_emits_wp_created_only(monkeypatch: pytest.MonkeyPatch, t
     feature_dir = repo_root / "kitty-specs" / "001-demo-feature"
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True)
-    (feature_dir / "tasks.md").write_text("## Work Package WP01\n", encoding="utf-8")
+    (feature_dir / "spec.md").write_text(
+        """# Demo spec
+
+## Functional Requirements
+
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | Emit WP created events during finalize. | finalize-tasks succeeds with WP refs. | proposed |
+""",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks.md").write_text(
+        "## Work Package WP01\n**Requirement Refs**: FR-001\n",
+        encoding="utf-8",
+    )
     wp_path = tasks_dir / "WP01-test.md"
     _write_wp(wp_path, "WP01")
 
     monkeypatch.setattr("specify_cli.cli.commands.agent.feature.locate_project_root", lambda: repo_root)
     monkeypatch.setattr(
         "specify_cli.cli.commands.agent.feature._find_feature_directory",
-        lambda _repo_root, _cwd: feature_dir,
+        lambda _repo_root, _cwd, **_kwargs: feature_dir,
     )
     monkeypatch.setattr(
         "specify_cli.cli.commands.agent.feature._resolve_planning_branch",


### PR DESCRIPTION
## Summary
- Restructures software-dev spec template requirements into explicit `FR-###`, `NFR-###`, and `C-###` tables (runtime + doctrine).
- Adds requirement traceability expectations to tasks templates/commands:
  - `Requirement Refs` line per WP
  - `Requirements Coverage Summary` in tasks template
  - `requirement_refs` frontmatter requirement in task package generation
- Extends `agent feature finalize-tasks` to:
  - parse `Requirement Refs` from `tasks.md`
  - parse requirement IDs from `spec.md`
  - write `requirement_refs` and `dependencies` into each WP frontmatter
  - validate mapping with explicit failures for:
    - WPs missing requirement refs
    - unknown requirement IDs not in spec
    - unmapped functional requirements (`FR-*`)
  - include parsed dependency/requirement maps + `wp_count` in JSON success output

## Tests
- `pytest -q tests/specify_cli/test_cli/test_agent_feature.py tests/specify_cli/cli/commands/test_event_emission.py -k "finalize_tasks or finalize-tasks or requirement_refs"`
- `pytest -q tests/integration/test_finalize_tasks_json_output.py tests/integration/test_planning_workflow.py -k "finalize_tasks or full_planning_workflow"`
- `pytest -q tests/e2e/test_cli_smoke.py -k "full_workflow_sequence"`

## Notes
- Updated finalize-task related test fixtures to include spec requirement IDs and WP `Requirement Refs` so they align with the stricter validation contract.
