### PR TITLE
fix(core): resolve primary branch from current branch, not hardcoded list

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -80,27 +80,30 @@ def _ensure_target_branch_checked_out(
     Returns:
         (main_repo_root, current_branch)
     """
-    from specify_cli.core.git_ops import resolve_target_branch
-
-    from specify_cli.core.git_ops import get_current_branch
+    from specify_cli.core.git_ops import get_current_branch, resolve_target_branch
 
     main_repo_root = get_main_repo_root(repo_root)
 
     # Check for detached HEAD using robust branch detection
     current_branch = get_current_branch(main_repo_root)
     if current_branch is None:
-        raise RuntimeError("Planning repo is in detached HEAD state; checkout a branch before continuing")
+        raise RuntimeError("Detached HEAD — checkout a branch before continuing")
 
     # Resolve branch routing (unified logic, no auto-checkout)
     resolution = resolve_target_branch(feature_slug, main_repo_root, current_branch, respect_current=True)
 
-    # Show notification if branches differ
-    if resolution.should_notify and not json_output:
-        console.print(
-            f"[yellow]Note:[/yellow] You are on '{resolution.current}', "
-            f"feature targets '{resolution.target}'. "
-            f"Operations will use '{resolution.current}'."
-        )
+    # Show consistent branch banner
+    if not json_output:
+        if not resolution.should_notify:
+            console.print(
+                f"[bold cyan]Branch:[/bold cyan] {current_branch} "
+                f"(target for this feature)"
+            )
+        else:
+            console.print(
+                f"[bold yellow]Branch:[/bold yellow] on '{resolution.current}', "
+                f"feature targets '{resolution.target}'"
+            )
 
     # Return current branch (no checkout performed)
     return main_repo_root, resolution.current

--- a/src/specify_cli/cli/commands/dashboard.py
+++ b/src/specify_cli/cli/commands/dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import webbrowser
 from typing import Optional
 
@@ -99,14 +100,18 @@ def dashboard(
     console.print("[cyan]" + "=" * 60 + "[/cyan]")
     console.print()
 
-    try:
-        webbrowser.open(dashboard_url)
-        console.print("[green]✅ Opening dashboard in your browser...[/green]")
+    if os.environ.get("SPEC_KITTY_TEST_MODE") or os.environ.get("PWHEADLESS"):
+        console.print(f"[green]✅ Dashboard ready at:[/green] [cyan]{dashboard_url}[/cyan]")
         console.print()
-    except Exception:
-        console.print("[yellow]⚠️  Could not automatically open browser[/yellow]")
-        console.print(f"   Please open this URL manually: [cyan]{dashboard_url}[/cyan]")
-        console.print()
+    else:
+        try:
+            webbrowser.open(dashboard_url)
+            console.print("[green]✅ Opening dashboard in your browser...[/green]")
+            console.print()
+        except Exception:
+            console.print("[yellow]⚠️  Could not automatically open browser[/yellow]")
+            console.print(f"   Please open this URL manually: [cyan]{dashboard_url}[/cyan]")
+            console.print()
 
 
 __all__ = ["dashboard"]

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -932,7 +932,7 @@ def init(
     steps_lines.append("   - [cyan]/spec-kitty.implement[/] - Execute implementation from /tasks/doing/")
     steps_lines.append("   - [cyan]/spec-kitty.review[/] - Review prompts and move them to /tasks/done/")
     steps_lines.append("   - [cyan]/spec-kitty.accept[/] - Run acceptance checks and verify feature complete")
-    steps_lines.append("   - [cyan]/spec-kitty.merge[/] - Merge feature into main and cleanup worktree")
+    steps_lines.append("   - [cyan]/spec-kitty.merge[/] - Merge feature into target branch and cleanup worktree")
 
     steps_panel = Panel("\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1, 2))
     _console.print()

--- a/src/specify_cli/core/git_ops.py
+++ b/src/specify_cli/core/git_ops.py
@@ -264,14 +264,15 @@ def resolve_primary_branch(repo_root: Path) -> str:
 
     Tries multiple methods in order:
     1. origin/HEAD symbolic ref (most reliable for cloned repos)
-    2. Check which common branch exists (main, master, develop)
-    3. Fallback to "main"
+    2. Current branch (the user is standing on it for a reason)
+    3. Check which common branch exists (main, master, develop)
+    4. Fallback to "main"
 
     Args:
         repo_root: Repository root path
 
     Returns:
-        Primary branch name (e.g., "main", "master", "develop")
+        Primary branch name (e.g., "main", "master", "develop", "2.x")
     """
     # Method 1: Get from origin's HEAD
     try:
@@ -294,7 +295,12 @@ def resolve_primary_branch(repo_root: Path) -> str:
     except subprocess.TimeoutExpired:
         pass
 
-    # Method 2: Check which common branch exists
+    # Method 2: Current branch (the user is standing on it for a reason)
+    current = get_current_branch(repo_root)
+    if current and current != "HEAD":
+        return current
+
+    # Method 3: Check which common branch exists
     for branch in ["main", "master", "develop"]:
         try:
             result = subprocess.run(
@@ -309,7 +315,7 @@ def resolve_primary_branch(repo_root: Path) -> str:
         except subprocess.TimeoutExpired:
             continue
 
-    # Method 3: Fallback
+    # Method 4: Fallback
     return "main"
 
 

--- a/src/specify_cli/core/stale_detection.py
+++ b/src/specify_cli/core/stale_detection.py
@@ -32,7 +32,12 @@ class StaleCheckResult:
 
 def get_default_branch(repo_path: Path) -> str:
     """
-    Get the default branch name for the repository.
+    Get the default/base branch name for the repository (for stale detection).
+
+    This is used to find the branch that feature branches diverged FROM.
+    Unlike resolve_primary_branch() in git_ops, this does NOT use the current
+    branch because stale detection always runs from worktrees where the current
+    branch is always the feature branch, never the base branch.
 
     Tries multiple methods to detect the default branch:
     1. Check origin's HEAD symbolic ref

--- a/src/specify_cli/dashboard/diagnostics.py
+++ b/src/specify_cli/dashboard/diagnostics.py
@@ -127,7 +127,9 @@ def run_diagnostics(project_dir: Path) -> Dict[str, Any]:
 
     observations = []
 
-    if diagnostics['git_branch'] == 'main' and diagnostics['in_worktree']:
+    from specify_cli.core.git_ops import resolve_primary_branch
+    primary = resolve_primary_branch(repo_root)
+    if diagnostics['git_branch'] == primary and diagnostics['in_worktree']:
         observations.append("Unusual: In worktree but on main branch")
 
     current_feature = diagnostics.get('current_feature') or {}

--- a/src/specify_cli/guards.py
+++ b/src/specify_cli/guards.py
@@ -88,7 +88,9 @@ def validate_worktree_location(project_root: Optional[Path] = None) -> WorktreeV
         )
 
     current_branch = result.stdout.strip()
-    is_main_branch = current_branch in {"main", "master"}
+    from specify_cli.core.git_ops import resolve_primary_branch
+    primary = resolve_primary_branch(project_root)
+    is_main_branch = current_branch == primary
     is_feature_branch = bool(re.match(r"^\d{3}-[\w-]+$", current_branch))
 
     errors: List[str] = []

--- a/src/specify_cli/missions/research/command-templates/review.md
+++ b/src/specify_cli/missions/research/command-templates/review.md
@@ -4,7 +4,7 @@ description: Perform structured research review with citation validation.
 
 ## Research Review Overview
 
-Research WPs produce deliverables in a **worktree**, which merge to main like code.
+Research WPs produce deliverables in a **worktree**, which merge to the target branch like code.
 
 ### Two Types of Artifacts
 

--- a/src/specify_cli/missions/software-dev/command-templates/merge.md
+++ b/src/specify_cli/missions/software-dev/command-templates/merge.md
@@ -1,11 +1,11 @@
 ---
-description: Merge a completed feature into the main branch and clean up worktree
+description: Merge a completed feature into the target branch and clean up worktree
 ---
 
-# /spec-kitty.merge - Merge Feature to Main
+# /spec-kitty.merge - Merge Feature to Target Branch
 
 **Version**: 0.11.0+
-**Purpose**: Merge ALL completed work packages for a feature into main branch.
+**Purpose**: Merge ALL completed work packages for a feature into the target branch (from meta.json).
 
 ## CRITICAL: Workspace-per-WP Model (0.11.0)
 
@@ -94,7 +94,7 @@ spec-kitty merge 001-cli-hello-world
 3. **Determines** merge order based on WP dependencies (workspace-per-WP)
 4. **Forecasts** conflicts during `--dry-run` and flags auto-resolvable status files
 5. **Verifies** working directory is clean (legacy single-worktree)
-6. **Switches** to the target branch (default: `main`)
+6. **Switches** to the target branch (from meta.json, or current branch)
 7. **Updates** the target branch (`git pull --ff-only`)
 8. **Merges** the feature using your chosen strategy
 9. **Auto-resolves** status file conflicts after each WP merge
@@ -150,7 +150,7 @@ spec-kitty merge --strategy squash --push
 # Keep branch for reference
 spec-kitty merge --keep-branch
 
-# Merge into develop instead of main
+# Merge into a different branch than the one in meta.json
 spec-kitty merge --target develop --push
 ```
 
@@ -191,7 +191,7 @@ spec-kitty merge --strategy rebase
 | `--delete-branch` / `--keep-branch` | Delete feature branch after merge | delete |
 | `--remove-worktree` / `--keep-worktree` | Remove feature worktree after merge | remove |
 | `--push` | Push to origin after merge | no push |
-| `--target` | Target branch to merge into | `main` |
+| `--target` | Target branch to merge into | from meta.json |
 | `--dry-run` | Show what would be done without executing | off |
 | `--feature` | Feature slug when merging from main branch | none |
 | `--resume` | Resume an interrupted merge | off |
@@ -219,7 +219,7 @@ my-project/                              # Main repo (main branch)
 **Merge behavior for workspace-per-WP**:
 - Run `spec-kitty merge` from the main repository root
 - The command automatically detects all WP branches (WP01, WP02, WP03, etc.)
-- Merges each WP branch into main in sequence
+- Merges each WP branch into the target branch in sequence
 - Cleans up all WP worktrees and branches
 
 ### Legacy Pattern (0.10.x)
@@ -361,7 +361,7 @@ Or combine conceptually:
 ```
 
 The `/spec-kitty.accept` command **verifies** your feature is complete.
-The `/spec-kitty.merge` command **integrates** your feature into main.
+The `/spec-kitty.merge` command **integrates** your feature into the target branch.
 
 Together they complete the workflow:
 ```

--- a/src/specify_cli/missions/software-dev/command-templates/review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/review.md
@@ -28,7 +28,7 @@ If no WP ID is provided, it will automatically find the first work package with 
 
 ## Dependency checks (required)
 
-- dependency_check: If the WP frontmatter lists `dependencies`, confirm each dependency WP is merged to main before you review this WP.
+- dependency_check: If the WP frontmatter lists `dependencies`, confirm each dependency WP is merged to the target branch before you review this WP.
 - dependent_check: Identify any WPs that list this WP as a dependency and note their current lanes.
 - rebase_warning: If you request changes AND any dependents exist, warn those agents to rebase and provide a concrete command (example: `cd .worktrees/FEATURE-WP02 && git rebase FEATURE-WP01`).
 - verify_instruction: Confirm dependency declarations match actual code coupling (imports, shared modules, API contracts).

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -169,13 +169,13 @@ Given that feature description, do this:
      "mission": "<selected-mission>",
      "source_description": "$ARGUMENTS",
      "created_at": "<ISO timestamp>",
-     "target_branch": "main",
+     "target_branch": "<current-branch>",
      "vcs": "git"
    }
    ```
 
    **CRITICAL**: Always set these fields explicitly:
-   - `target_branch`: Set to "main" by default (user can change to "2.x" for dual-branch features)
+   - `target_branch`: Set to the current branch (detected via `git branch --show-current`). The branch the user is on when they start is the target branch. Do NOT hardcode "main".
    - `vcs`: Set to "git" by default (enables VCS locking and prevents jj fallback)
 
 6. Generate the specification content by following this flow:

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -758,7 +758,7 @@ def accept_feature(
 @app.command(name="merge-feature")
 def merge_feature(
     feature: str = typer.Option(..., "--feature", help="Feature slug"),
-    target: str = typer.Option("main", "--target", help="Target branch to merge into"),
+    target: str = typer.Option(None, "--target", help="Target branch to merge into (auto-detected from meta.json)"),
     strategy: str = typer.Option("merge", "--strategy", help="Merge strategy: merge, squash, or rebase"),
     push: bool = typer.Option(False, "--push", help="Push target branch after merge"),
     json_output: bool = typer.Option(True, "--json/--no-json", help="Output as JSON"),
@@ -781,6 +781,11 @@ def merge_feature(
     if feature_dir is None:
         _fail(cmd, "FEATURE_NOT_FOUND", f"Feature '{feature}' not found in kitty-specs/")
         return
+
+    # Auto-detect target branch from meta.json if not specified
+    if target is None:
+        from specify_cli.core.feature_detection import get_feature_target_branch
+        target = get_feature_target_branch(main_repo_root, feature)
 
     # Discover worktrees for this feature
     worktrees_root = main_repo_root / ".worktrees"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,16 @@ from tests.utils import REPO_ROOT, run, run_tasks_cli, write_wp
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    # HARDCODED: Never open browser windows during tests.
+    # Propagates to subprocesses too (e.g. dashboard CLI spawned by tests).
+    os.environ["PWHEADLESS"] = "1"
+
+    # Block webbrowser.open() in the test process itself.
+    import webbrowser
+    webbrowser.open = lambda *args, **kwargs: None  # type: ignore[assignment]
+    webbrowser.open_new = lambda *args, **kwargs: None  # type: ignore[assignment]
+    webbrowser.open_new_tab = lambda *args, **kwargs: None  # type: ignore[assignment]
+
     config.addinivalue_line(
         "markers",
         "adversarial: adversarial scenarios for merge and dependency handling",

--- a/tests/specify_cli/test_cli/test_agent_feature.py
+++ b/tests/specify_cli/test_cli/test_agent_feature.py
@@ -148,37 +148,37 @@ class TestCreateFeatureCommand:
     @patch("specify_cli.cli.commands.agent.feature.get_current_branch")
     @patch("specify_cli.cli.commands.agent.feature.get_next_feature_number")
     @patch("specify_cli.cli.commands.agent.feature._commit_to_branch")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_primary_branch")
-    def test_blocks_feature_creation_from_non_primary_branch(
-        self, mock_primary: Mock, mock_commit: Mock, mock_get_number: Mock, mock_branch: Mock,
+    def test_allows_feature_creation_from_any_branch(
+        self, mock_commit: Mock, mock_get_number: Mock, mock_branch: Mock,
         mock_is_git: Mock, mock_locate: Mock, tmp_path: Path
     ):
-        """Should block feature creation when not on the primary branch."""
-        # Setup: On non-primary branch
+        """Should allow feature creation on any branch (records it as target)."""
+        # Setup: On non-main branch — should succeed (not block)
         mock_locate.return_value = tmp_path
         mock_is_git.return_value = True
         mock_branch.return_value = "develop"
-        mock_primary.return_value = "main"
         mock_get_number.return_value = 1
+
+        # Create necessary directories
+        (tmp_path / ".kittify" / "templates").mkdir(parents=True)
+        (tmp_path / ".kittify" / "templates" / "spec-template.md").write_text("# Spec Template")
 
         # Execute
         result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
 
-        # Verify - should fail outside primary branch
-        assert result.exit_code == 1
+        # Verify — should succeed, recording "develop" as target_branch
+        assert result.exit_code == 0
         first_line = result.stdout.strip().split('\n')[0]
         output = json.loads(first_line)
-        assert "error" in output
-        assert "must run on 'main' branch" in output["error"]
+        assert output["result"] == "success"
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature.is_git_repo")
     @patch("specify_cli.cli.commands.agent.feature.get_current_branch")
     @patch("specify_cli.cli.commands.agent.feature.get_next_feature_number")
     @patch("specify_cli.cli.commands.agent.feature._commit_to_branch")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_primary_branch")
     def test_creates_feature_on_primary_branch(
-        self, mock_primary: Mock, mock_commit: Mock, mock_get_number: Mock, mock_branch: Mock,
+        self, mock_commit: Mock, mock_get_number: Mock, mock_branch: Mock,
         mock_is_git: Mock, mock_locate: Mock, tmp_path: Path
     ):
         """Should allow feature creation on the primary branch."""
@@ -186,7 +186,6 @@ class TestCreateFeatureCommand:
         mock_locate.return_value = tmp_path
         mock_is_git.return_value = True
         mock_branch.return_value = "main"
-        mock_primary.return_value = "main"
         mock_get_number.return_value = 1
 
         # Create necessary directories
@@ -460,19 +459,17 @@ class TestFinalizeTasksCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context")
     def test_passes_explicit_feature_to_detection(
         self,
-        mock_ensure_branch: Mock,
-        mock_resolve_branch: Mock,
+        mock_show_branch: Mock,
         mock_find: Mock,
         mock_locate: Mock,
         tmp_path: Path,
     ):
         """Should pass --feature to detection with strict context fallback disabled."""
         mock_locate.return_value = tmp_path
-        mock_resolve_branch.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         mock_find.return_value = feature_dir
 
@@ -521,14 +518,12 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
     @patch("specify_cli.cli.commands.agent.feature._commit_to_branch")
     def test_scaffolds_plan_template_json(
         self,
         mock_commit: Mock,
-        mock_ensure_branch: Mock,
-        mock_resolve_branch: Mock,
+        mock_show_branch: Mock,
         mock_find: Mock,
         mock_locate: Mock,
         tmp_path: Path,
@@ -536,7 +531,7 @@ class TestSetupPlanCommand:
         """Should scaffold plan template and output JSON format."""
         # Setup
         mock_locate.return_value = tmp_path
-        mock_resolve_branch.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         (feature_dir / "spec.md").write_text("# Spec")
@@ -570,14 +565,12 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
     @patch("specify_cli.cli.commands.agent.feature._commit_to_branch")
     def test_scaffolds_plan_template_human(
         self,
         mock_commit: Mock,
-        mock_ensure_branch: Mock,
-        mock_resolve_branch: Mock,
+        mock_show_branch: Mock,
         mock_find: Mock,
         mock_locate: Mock,
         tmp_path: Path,
@@ -585,7 +578,7 @@ class TestSetupPlanCommand:
         """Should scaffold plan template and output human-readable format."""
         # Setup
         mock_locate.return_value = tmp_path
-        mock_resolve_branch.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         (feature_dir / "spec.md").write_text("# Spec")
@@ -606,14 +599,12 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
     @patch("specify_cli.cli.commands.agent.feature.files")
     def test_errors_when_template_not_found(
         self,
         mock_files: Mock,
-        mock_ensure_branch: Mock,
-        mock_resolve_branch: Mock,
+        mock_show_branch: Mock,
         mock_find: Mock,
         mock_locate: Mock,
         tmp_path: Path,
@@ -621,7 +612,7 @@ class TestSetupPlanCommand:
         """Should return error when plan template not found."""
         # Setup
         mock_locate.return_value = tmp_path
-        mock_resolve_branch.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         (feature_dir / "spec.md").write_text("# Spec")
@@ -645,12 +636,10 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
     def test_errors_when_spec_missing(
         self,
-        mock_ensure_branch: Mock,
-        mock_resolve_branch: Mock,
+        mock_show_branch: Mock,
         mock_find: Mock,
         mock_locate: Mock,
         tmp_path: Path,
@@ -658,7 +647,7 @@ class TestSetupPlanCommand:
         """Should return structured error when feature spec.md is missing."""
         # Setup
         mock_locate.return_value = tmp_path
-        mock_resolve_branch.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         mock_find.return_value = feature_dir

--- a/tests/specify_cli/test_core/test_create_feature_branch.py
+++ b/tests/specify_cli/test_core/test_create_feature_branch.py
@@ -1,0 +1,226 @@
+"""Tests for create_feature() branch handling — current branch IS the target branch.
+
+All tests use real git repos. No mocks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.core.git_ops import run_command
+
+
+@pytest.fixture(name="_git_identity")
+def git_identity_fixture(monkeypatch):
+    """Ensure git commands can commit even if the user has no global config."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Spec Kitty")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "spec@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Spec Kitty")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "spec@example.com")
+
+
+def _init_repo(tmp_path: Path, branch_name: str) -> Path:
+    """Create a git repo with a commit on the given branch."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_command(["git", "init", f"--initial-branch={branch_name}"], cwd=repo)
+    (repo / "README.md").write_text("init", encoding="utf-8")
+    run_command(["git", "add", "."], cwd=repo)
+    run_command(["git", "commit", "-m", "Initial"], cwd=repo)
+    return repo
+
+
+def _setup_kittify(repo: Path) -> None:
+    """Create minimal .kittify structure required by create_feature()."""
+    kittify = repo / ".kittify"
+    kittify.mkdir(exist_ok=True)
+    (kittify / "config.yaml").write_text("agents:\n  available:\n    - claude\n", encoding="utf-8")
+    (kittify / "constitution.md").write_text("# Constitution\n", encoding="utf-8")
+    # Create kitty-specs dir
+    (repo / "kitty-specs").mkdir(exist_ok=True)
+
+
+def _read_meta(repo: Path, feature_slug: str) -> dict:
+    """Read and return meta.json for a feature."""
+    meta_file = repo / "kitty-specs" / feature_slug / "meta.json"
+    return json.loads(meta_file.read_text(encoding="utf-8"))
+
+
+def _get_feature_slugs(repo: Path) -> list[str]:
+    """Get list of feature directory names from kitty-specs/."""
+    kitty_specs = repo / "kitty-specs"
+    return sorted(
+        d.name for d in kitty_specs.iterdir()
+        if d.is_dir() and not d.name.startswith(".")
+    )
+
+
+# ============================================================================
+# create_feature records current branch as target
+# ============================================================================
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_2x_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on 2.x records target_branch='2.x' in meta.json."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "2.x")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "2.x"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_2x_with_main_also_existing(tmp_path, monkeypatch):
+    """create_feature on 2.x records target_branch='2.x' even when main exists.
+
+    THIS IS THE CRITICAL REGRESSION TEST.
+    """
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    # Create 2.x branch and switch to it
+    run_command(["git", "branch", "2.x"], cwd=repo)
+    run_command(["git", "checkout", "2.x"], cwd=repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "2.x"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_main_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on main records target_branch='main'."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "main"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_master_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on master records target_branch='master'."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "master")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "master"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_custom_branch_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on v3-next records target_branch='v3-next'."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "v3-next")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "v3-next"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_with_explicit_target_branch_flag(tmp_path, monkeypatch):
+    """--target-branch flag overrides current branch."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json", "--target-branch", "2.x"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "2.x"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_rejects_detached_head(tmp_path, monkeypatch):
+    """create_feature fails on detached HEAD."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    # Detach HEAD
+    run_command(["git", "checkout", "--detach"], cwd=repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code != 0
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_rejects_worktree(tmp_path, monkeypatch):
+    """create_feature fails when run from inside a worktree."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    # Create a fake worktree directory
+    worktree = repo / ".worktrees" / "001-test-WP01"
+    worktree.mkdir(parents=True)
+    monkeypatch.chdir(worktree)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code != 0

--- a/tests/test_dashboard/test_diagnostics.py
+++ b/tests/test_dashboard/test_diagnostics.py
@@ -102,6 +102,7 @@ def test_run_diagnostics_reports_manifest_and_worktree_state(monkeypatch, tmp_pa
         return types.SimpleNamespace(stdout='feature/testing\n', returncode=0)
 
     monkeypatch.setattr(diagnostics.subprocess, "run", fake_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = diagnostics.run_diagnostics(project_dir)
 
@@ -127,6 +128,7 @@ def test_run_diagnostics_records_git_branch_errors(monkeypatch, tmp_path: Path) 
         raise subprocess.CalledProcessError(1, ['git', 'branch', '--show-current'])
 
     monkeypatch.setattr(diagnostics.subprocess, "run", failing_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = diagnostics.run_diagnostics(project_dir)
 

--- a/tests/unit/agent/test_workflow_instructions.py
+++ b/tests/unit/agent/test_workflow_instructions.py
@@ -162,8 +162,8 @@ class TestMoveTaskPreflightCheck:
         feature_dir = tmp_path / "kitty-specs" / feature_slug
         feature_dir.mkdir(parents=True)
         
-        # Create meta.json for software-dev mission
-        (feature_dir / "meta.json").write_text('{"mission": "software-dev"}')
+        # Create meta.json for software-dev mission (target_branch required for branch resolution)
+        (feature_dir / "meta.json").write_text('{"mission": "software-dev", "target_branch": "main"}')
         
         # Create worktree directory
         worktree_path = tmp_path / ".worktrees" / f"{feature_slug}-WP01"
@@ -225,8 +225,8 @@ class TestMoveTaskPreflightCheck:
         feature_dir = tmp_path / "kitty-specs" / feature_slug
         feature_dir.mkdir(parents=True)
         
-        # Create meta.json for software-dev mission
-        (feature_dir / "meta.json").write_text('{"mission": "software-dev"}')
+        # Create meta.json for software-dev mission (target_branch required for branch resolution)
+        (feature_dir / "meta.json").write_text('{"mission": "software-dev", "target_branch": "main"}')
         
         # Create worktree directory
         worktree_path = tmp_path / ".worktrees" / f"{feature_slug}-WP01"

--- a/tests/unit/test_guards.py
+++ b/tests/unit/test_guards.py
@@ -43,6 +43,7 @@ def test_validate_worktree_on_feature_branch(monkeypatch: pytest.MonkeyPatch, fa
         return _make_completed_process(stdout="001-test-feature\n")
 
     monkeypatch.setattr("specify_cli.guards.subprocess.run", mock_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = validate_worktree_location(project_root=fake_project_root)
 
@@ -59,6 +60,7 @@ def test_validate_worktree_on_main_branch(monkeypatch: pytest.MonkeyPatch, fake_
         return _make_completed_process(stdout="main\n")
 
     monkeypatch.setattr("specify_cli.guards.subprocess.run", mock_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = validate_worktree_location(project_root=fake_project_root)
 


### PR DESCRIPTION
## Summary

- **Root fix**: `resolve_primary_branch()` now checks the current branch BEFORE the hardcoded `["main", "master", "develop"]` list, so repos on `2.x` (or any non-standard primary branch) work correctly
- **Removes blocking gate**: `create_feature()` no longer blocks when the current branch isn't `main` — it records the current branch as `target_branch` in meta.json, with an optional `--target-branch` override
- **Consolidates branch helpers**: Deletes 3 ad-hoc functions (`_resolve_primary_branch`, `_resolve_planning_branch`, `_ensure_branch_checked_out`) in favor of one `_show_branch_context()` using the canonical `resolve_target_branch()` from core
- **Updates all templates**: "merge into main" → "merge into target branch" across specify, merge, review, and init templates
- **Fixes browser windows in tests**: Hardcodes `PWHEADLESS=1` in `conftest.py` and guards `webbrowser.open()` in dashboard.py so tests never open browser windows

## Test plan

- [x] 5 new `resolve_primary_branch` tests (2.x, release/v3, origin/HEAD priority, current-branch-wins-over-hardcoded)
- [x] 8 new `create_feature` branch tests (real git repos, no mocks) including critical regression: create on 2.x when main also exists
- [x] Updated existing tests for new branch handling
- [x] Full suite: 4752 passed, 0 failed, no browser windows opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)