### PR TITLE
fix(core): backport main-bias fix to 1.x stream

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -80,15 +80,19 @@ def _ensure_target_branch_checked_out(
     # Resolve branch routing (unified logic, no auto-checkout)
     resolution = resolve_target_branch(feature_slug, main_repo_root, current_branch, respect_current=True)
 
-    # Show notification if branches differ
-    if resolution.should_notify and not json_output:
-        console.print(
-            f"[yellow]Note:[/yellow] You are on '{resolution.current}', "
-            f"feature targets '{resolution.target}'. "
-            f"Operations will use '{resolution.current}'."
-        )
+    # Show branch context
+    if not json_output:
+        if not resolution.should_notify:
+            console.print(
+                f"[bold cyan]Branch:[/bold cyan] {current_branch} "
+                f"(target for this feature)"
+            )
+        else:
+            console.print(
+                f"[bold yellow]Branch:[/bold yellow] on '{resolution.current}', "
+                f"feature targets '{resolution.target}'"
+            )
 
-    # Return current branch (no checkout performed)
     return main_repo_root, resolution.current
 
 

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -87,15 +87,6 @@ app = typer.Typer(
 )
 
 
-def _resolve_primary_branch(repo_root: Path) -> str:
-    """Resolve the primary branch name (main, master, etc.).
-
-    Delegates to the centralized implementation in core.git_ops.
-    """
-    from specify_cli.core.git_ops import resolve_primary_branch
-    return resolve_primary_branch(repo_root)
-
-
 def _ensure_target_branch_checked_out(repo_root: Path, feature_slug: str) -> tuple[Path, str]:
     """Resolve branch context without auto-checkout (respects user's current branch).
 
@@ -115,12 +106,11 @@ def _ensure_target_branch_checked_out(repo_root: Path, feature_slug: str) -> tup
     # Resolve branch routing (unified logic, no auto-checkout)
     resolution = resolve_target_branch(feature_slug, main_repo_root, current_branch, respect_current=True)
 
-    # Show notification if branches differ
-    if resolution.should_notify:
-        print(
-            f"Note: You are on '{resolution.current}', feature targets '{resolution.target}'. "
-            f"Operations will use '{resolution.current}'."
-        )
+    # Show branch context
+    if not resolution.should_notify:
+        print(f"Branch: {current_branch} (target for this feature)")
+    else:
+        print(f"Branch: on '{resolution.current}', feature targets '{resolution.target}'")
 
     # Return current branch (no checkout performed)
     return main_repo_root, resolution.current

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -639,7 +639,7 @@ def init(
     steps_lines.append("   - [cyan]/spec-kitty.implement[/] - Execute implementation from /tasks/doing/")
     steps_lines.append("   - [cyan]/spec-kitty.review[/] - Review prompts and move them to /tasks/done/")
     steps_lines.append("   - [cyan]/spec-kitty.accept[/] - Run acceptance checks and verify feature complete")
-    steps_lines.append("   - [cyan]/spec-kitty.merge[/] - Merge feature into main and cleanup worktree")
+    steps_lines.append("   - [cyan]/spec-kitty.merge[/] - Merge feature into target branch and cleanup worktree")
 
     steps_panel = Panel("\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1,2))
     _console.print()

--- a/src/specify_cli/core/git_ops.py
+++ b/src/specify_cli/core/git_ops.py
@@ -294,7 +294,12 @@ def resolve_primary_branch(repo_root: Path) -> str:
     except subprocess.TimeoutExpired:
         pass
 
-    # Method 2: Check which common branch exists
+    # Method 2: Current branch (the user is standing on it for a reason)
+    current = get_current_branch(repo_root)
+    if current and current != "HEAD":
+        return current
+
+    # Method 3: Check which common branch exists
     for branch in ["main", "master", "develop"]:
         try:
             result = subprocess.run(
@@ -312,7 +317,7 @@ def resolve_primary_branch(repo_root: Path) -> str:
         except subprocess.TimeoutExpired:
             continue
 
-    # Method 3: Fallback
+    # Method 4: Fallback
     return "main"
 
 

--- a/src/specify_cli/dashboard/diagnostics.py
+++ b/src/specify_cli/dashboard/diagnostics.py
@@ -127,7 +127,9 @@ def run_diagnostics(project_dir: Path) -> Dict[str, Any]:
 
     observations = []
 
-    if diagnostics['git_branch'] == 'main' and diagnostics['in_worktree']:
+    from specify_cli.core.git_ops import resolve_primary_branch
+    primary = resolve_primary_branch(repo_root)
+    if diagnostics['git_branch'] == primary and diagnostics['in_worktree']:
         observations.append("Unusual: In worktree but on main branch")
 
     current_feature = diagnostics.get('current_feature') or {}

--- a/src/specify_cli/guards.py
+++ b/src/specify_cli/guards.py
@@ -88,7 +88,9 @@ def validate_worktree_location(project_root: Optional[Path] = None) -> WorktreeV
         )
 
     current_branch = result.stdout.strip()
-    is_main_branch = current_branch in {"main", "master"}
+    from specify_cli.core.git_ops import resolve_primary_branch
+    primary = resolve_primary_branch(project_root)
+    is_main_branch = current_branch == primary
     is_feature_branch = bool(re.match(r"^\d{3}-[\w-]+$", current_branch))
 
     errors: List[str] = []

--- a/src/specify_cli/missions/research/command-templates/review.md
+++ b/src/specify_cli/missions/research/command-templates/review.md
@@ -4,7 +4,7 @@ description: Perform structured research review with citation validation.
 
 ## Research Review Overview
 
-Research WPs produce deliverables in a **worktree**, which merge to main like code.
+Research WPs produce deliverables in a **worktree**, which merge to the target branch like code.
 
 ### Two Types of Artifacts
 

--- a/src/specify_cli/missions/software-dev/command-templates/merge.md
+++ b/src/specify_cli/missions/software-dev/command-templates/merge.md
@@ -1,11 +1,11 @@
 ---
-description: Merge a completed feature into the main branch and clean up worktree
+description: Merge a completed feature into the target branch and clean up worktree
 ---
 
-# /spec-kitty.merge - Merge Feature to Main
+# /spec-kitty.merge - Merge Feature to Target Branch
 
 **Version**: 0.11.0+
-**Purpose**: Merge ALL completed work packages for a feature into main branch.
+**Purpose**: Merge ALL completed work packages for a feature into the target branch.
 
 ## CRITICAL: Workspace-per-WP Model (0.11.0)
 
@@ -204,7 +204,7 @@ spec-kitty merge --strategy rebase
 | `--delete-branch` / `--keep-branch` | Delete feature branch after merge | delete |
 | `--remove-worktree` / `--keep-worktree` | Remove feature worktree after merge | remove |
 | `--push` | Push to origin after merge | no push |
-| `--target` | Target branch to merge into | `main` |
+| `--target` | Target branch to merge into | from meta.json |
 | `--dry-run` | Show what would be done without executing | off |
 | `--feature` | Feature slug when merging from main branch | none |
 | `--resume` | Resume an interrupted merge | off |
@@ -232,7 +232,7 @@ my-project/                              # Main repo (main branch)
 **Merge behavior for workspace-per-WP**:
 - Run `spec-kitty merge` from **any** WP worktree for the feature
 - The command automatically detects all WP branches (WP01, WP02, WP03, etc.)
-- Merges each WP branch into main in sequence
+- Merges each WP branch into the target branch in sequence
 - Cleans up all WP worktrees and branches
 
 ### Legacy Pattern (0.10.x)
@@ -375,7 +375,7 @@ Or combine conceptually:
 ```
 
 The `/spec-kitty.accept` command **verifies** your feature is complete.
-The `/spec-kitty.merge` command **integrates** your feature into main.
+The `/spec-kitty.merge` command **integrates** your feature into the target branch.
 
 Together they complete the workflow:
 ```

--- a/src/specify_cli/missions/software-dev/command-templates/review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/review.md
@@ -18,7 +18,7 @@ If no WP ID is provided, it will automatically find the first work package with 
 
 ## Dependency checks (required)
 
-- dependency_check: If the WP frontmatter lists `dependencies`, confirm each dependency WP is merged to main before you review this WP.
+- dependency_check: If the WP frontmatter lists `dependencies`, confirm each dependency WP is merged to the target branch before you review this WP.
 - dependent_check: Identify any WPs that list this WP as a dependency and note their current lanes.
 - rebase_warning: If you request changes AND any dependents exist, warn those agents to rebase and provide a concrete command (example: `cd .worktrees/FEATURE-WP02 && git rebase FEATURE-WP01`).
 - verify_instruction: Confirm dependency declarations match actual code coupling (imports, shared modules, API contracts).

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -158,13 +158,13 @@ Given that feature description, do this:
      "mission": "<selected-mission>",
      "source_description": "$ARGUMENTS",
      "created_at": "<ISO timestamp>",
-     "target_branch": "main",
+     "target_branch": "<current-branch>",
      "vcs": "git"
    }
    ```
 
    **CRITICAL**: Always set these fields explicitly:
-   - `target_branch`: Set to "main" by default (user can change to "2.x" for dual-branch features)
+   - `target_branch`: Set to the current branch (detected via `git branch --show-current`)
    - `vcs`: Set to "git" by default (enables VCS locking and prevents jj fallback)
 
 6. Generate the specification content by following this flow:

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -793,7 +793,7 @@ def accept_feature(
 @app.command(name="merge-feature")
 def merge_feature(
     feature: str = typer.Option(..., "--feature", help="Feature slug"),
-    target: str = typer.Option("main", "--target", help="Target branch to merge into"),
+    target: str = typer.Option(None, "--target", help="Target branch to merge into (auto-detected from meta.json)"),
     strategy: str = typer.Option("merge", "--strategy", help="Merge strategy: merge or squash"),
     push: bool = typer.Option(False, "--push", help="Push target branch after merge"),
     json_output: bool = typer.Option(True, "--json/--no-json", help="Output as JSON"),
@@ -811,6 +811,11 @@ def merge_feature(
         return
 
     main_repo_root = _get_main_repo_root()
+
+    if target is None:
+        from specify_cli.core.feature_detection import get_feature_target_branch
+        target = get_feature_target_branch(main_repo_root, feature)
+
     feature_dir = _resolve_feature_dir(main_repo_root, feature)
     if feature_dir is None:
         _fail(cmd, "FEATURE_NOT_FOUND", f"Feature '{feature}' not found in kitty-specs/")

--- a/tests/specify_cli/test_cli/test_agent_feature.py
+++ b/tests/specify_cli/test_cli/test_agent_feature.py
@@ -362,11 +362,10 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context")
     @patch("specify_cli.cli.commands.agent.feature._commit_to_branch")
     def test_scaffolds_plan_template_json(
-        self, mock_commit: Mock, mock_ensure: Mock, mock_resolve: Mock,
+        self, mock_commit: Mock, mock_show_branch: Mock,
         mock_find: Mock, mock_locate: Mock, tmp_path: Path
     ):
         """Should scaffold plan template and output JSON format."""
@@ -375,7 +374,7 @@ class TestSetupPlanCommand:
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         mock_find.return_value = feature_dir
-        mock_resolve.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
 
         # Create template
         template_dir = tmp_path / ".kittify" / "templates"
@@ -403,11 +402,10 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context")
     @patch("specify_cli.cli.commands.agent.feature._commit_to_branch")
     def test_scaffolds_plan_template_human(
-        self, mock_commit: Mock, mock_ensure: Mock, mock_resolve: Mock,
+        self, mock_commit: Mock, mock_show_branch: Mock,
         mock_find: Mock, mock_locate: Mock, tmp_path: Path
     ):
         """Should scaffold plan template and output human-readable format."""
@@ -416,7 +414,7 @@ class TestSetupPlanCommand:
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         mock_find.return_value = feature_dir
-        mock_resolve.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
 
         # Create template
         template_dir = tmp_path / ".kittify" / "templates"
@@ -433,11 +431,10 @@ class TestSetupPlanCommand:
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
-    @patch("specify_cli.cli.commands.agent.feature._resolve_planning_branch")
-    @patch("specify_cli.cli.commands.agent.feature._ensure_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context")
     @patch("specify_cli.cli.commands.agent.feature.files")
     def test_errors_when_template_not_found(
-        self, mock_files: Mock, mock_ensure: Mock, mock_resolve: Mock,
+        self, mock_files: Mock, mock_show_branch: Mock,
         mock_find: Mock, mock_locate: Mock, tmp_path: Path
     ):
         """Should return error when plan template not found."""
@@ -446,7 +443,7 @@ class TestSetupPlanCommand:
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
         mock_find.return_value = feature_dir
-        mock_resolve.return_value = "main"
+        mock_show_branch.return_value = (tmp_path, "main")
 
         # No template created and package template unavailable
         package_templates = Mock()

--- a/tests/specify_cli/test_core/test_create_feature_branch.py
+++ b/tests/specify_cli/test_core/test_create_feature_branch.py
@@ -1,0 +1,226 @@
+"""Tests for create_feature() branch handling — current branch IS the target branch.
+
+All tests use real git repos. No mocks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.core.git_ops import run_command
+
+
+@pytest.fixture(name="_git_identity")
+def git_identity_fixture(monkeypatch):
+    """Ensure git commands can commit even if the user has no global config."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Spec Kitty")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "spec@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Spec Kitty")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "spec@example.com")
+
+
+def _init_repo(tmp_path: Path, branch_name: str) -> Path:
+    """Create a git repo with a commit on the given branch."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_command(["git", "init", f"--initial-branch={branch_name}"], cwd=repo)
+    (repo / "README.md").write_text("init", encoding="utf-8")
+    run_command(["git", "add", "."], cwd=repo)
+    run_command(["git", "commit", "-m", "Initial"], cwd=repo)
+    return repo
+
+
+def _setup_kittify(repo: Path) -> None:
+    """Create minimal .kittify structure required by create_feature()."""
+    kittify = repo / ".kittify"
+    kittify.mkdir(exist_ok=True)
+    (kittify / "config.yaml").write_text("agents:\n  available:\n    - claude\n", encoding="utf-8")
+    (kittify / "constitution.md").write_text("# Constitution\n", encoding="utf-8")
+    # Create kitty-specs dir
+    (repo / "kitty-specs").mkdir(exist_ok=True)
+
+
+def _read_meta(repo: Path, feature_slug: str) -> dict:
+    """Read and return meta.json for a feature."""
+    meta_file = repo / "kitty-specs" / feature_slug / "meta.json"
+    return json.loads(meta_file.read_text(encoding="utf-8"))
+
+
+def _get_feature_slugs(repo: Path) -> list[str]:
+    """Get list of feature directory names from kitty-specs/."""
+    kitty_specs = repo / "kitty-specs"
+    return sorted(
+        d.name for d in kitty_specs.iterdir()
+        if d.is_dir() and not d.name.startswith(".")
+    )
+
+
+# ============================================================================
+# create_feature records current branch as target
+# ============================================================================
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_2x_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on 2.x records target_branch='2.x' in meta.json."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "2.x")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "2.x"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_2x_with_main_also_existing(tmp_path, monkeypatch):
+    """create_feature on 2.x records target_branch='2.x' even when main exists.
+
+    THIS IS THE CRITICAL REGRESSION TEST.
+    """
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    # Create 2.x branch and switch to it
+    run_command(["git", "branch", "2.x"], cwd=repo)
+    run_command(["git", "checkout", "2.x"], cwd=repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "2.x"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_main_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on main records target_branch='main'."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "main"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_master_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on master records target_branch='master'."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "master")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "master"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_on_custom_branch_records_target_branch(tmp_path, monkeypatch):
+    """create_feature on v3-next records target_branch='v3-next'."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "v3-next")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "v3-next"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_with_explicit_target_branch_flag(tmp_path, monkeypatch):
+    """--target-branch flag overrides current branch."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json", "--target-branch", "2.x"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    slugs = _get_feature_slugs(repo)
+    assert len(slugs) == 1
+    meta = _read_meta(repo, slugs[0])
+    assert meta["target_branch"] == "2.x"
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_rejects_detached_head(tmp_path, monkeypatch):
+    """create_feature fails on detached HEAD."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    # Detach HEAD
+    run_command(["git", "checkout", "--detach"], cwd=repo)
+    monkeypatch.chdir(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code != 0
+
+
+@pytest.mark.usefixtures("_git_identity")
+def test_create_feature_rejects_worktree(tmp_path, monkeypatch):
+    """create_feature fails when run from inside a worktree."""
+    from typer.testing import CliRunner
+    from specify_cli.cli.commands.agent.feature import app
+
+    repo = _init_repo(tmp_path, "main")
+    _setup_kittify(repo)
+    # Create a fake worktree directory
+    worktree = repo / ".worktrees" / "001-test-WP01"
+    worktree.mkdir(parents=True)
+    monkeypatch.chdir(worktree)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["create-feature", "test-feature", "--json"])
+
+    assert result.exit_code != 0

--- a/tests/test_dashboard/test_diagnostics.py
+++ b/tests/test_dashboard/test_diagnostics.py
@@ -102,6 +102,7 @@ def test_run_diagnostics_reports_manifest_and_worktree_state(monkeypatch, tmp_pa
         return types.SimpleNamespace(stdout='feature/testing\n', returncode=0)
 
     monkeypatch.setattr(diagnostics.subprocess, "run", fake_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = diagnostics.run_diagnostics(project_dir)
 
@@ -127,6 +128,7 @@ def test_run_diagnostics_records_git_branch_errors(monkeypatch, tmp_path: Path) 
         raise subprocess.CalledProcessError(1, ['git', 'branch', '--show-current'])
 
     monkeypatch.setattr(diagnostics.subprocess, "run", failing_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = diagnostics.run_diagnostics(project_dir)
 

--- a/tests/unit/agent/test_tasks.py
+++ b/tests/unit/agent/test_tasks.py
@@ -868,8 +868,8 @@ class TestValidateReadyForReview:
             elif "rev-parse" in cmd and "--verify" in cmd:
                 # No in-progress operations (MERGE_HEAD, REBASE_HEAD, etc. don't exist)
                 return Mock(returncode=1, stdout="")
-            elif "rev-list" in cmd and "HEAD..main" in cmd:
-                # Not behind main
+            elif "rev-list" in cmd and any("HEAD.." in c for c in cmd):
+                # Not behind primary branch (branch name is dynamic)
                 return Mock(returncode=0, stdout="0\n")
             elif "rev-list" in cmd:
                 # Has implementation commits

--- a/tests/unit/agent/test_workflow_instructions.py
+++ b/tests/unit/agent/test_workflow_instructions.py
@@ -184,14 +184,14 @@ class TestMoveTaskPreflightCheck:
                 elif "rev-parse" in args and "--verify" in args:
                     # git rev-parse --verify for merge/rebase/cherry-pick - not in progress
                     return MagicMock(returncode=1, stdout="", stderr="")
-                elif "rev-list" in args and "HEAD..main" in args:
-                    # git rev-list HEAD..main - not behind main
+                elif "rev-list" in args and any("HEAD.." in a for a in args):
+                    # git rev-list HEAD..<branch> - not behind primary branch
                     return MagicMock(returncode=0, stdout="0\n", stderr="")
                 elif "status" in args and "--porcelain" in args:
                     # git status for worktree - HAS uncommitted changes
                     return MagicMock(returncode=0, stdout="M  src/test.py\n?? test_new.py\n", stderr="")
-                elif "rev-list" in args and "main..HEAD" in args:
-                    # git rev-list main..HEAD - has commits
+                elif "rev-list" in args and any("..HEAD" in a for a in args):
+                    # git rev-list <branch>..HEAD - has commits
                     return MagicMock(returncode=0, stdout="2\n", stderr="")
                 else:
                     # Default
@@ -244,14 +244,14 @@ class TestMoveTaskPreflightCheck:
                 elif "rev-parse" in args and "--verify" in args:
                     # git rev-parse --verify for merge/rebase/cherry-pick - not in progress
                     return MagicMock(returncode=1, stdout="", stderr="")
-                elif "rev-list" in args and "HEAD..main" in args:
-                    # git rev-list HEAD..main - not behind main
+                elif "rev-list" in args and any("HEAD.." in a for a in args):
+                    # git rev-list HEAD..<branch> - not behind primary branch
                     return MagicMock(returncode=0, stdout="0\n", stderr="")
                 elif "status" in args and "--porcelain" in args:
                     # git status for worktree - clean
                     return MagicMock(returncode=0, stdout="", stderr="")
-                elif "rev-list" in args and "main..HEAD" in args:
-                    # git rev-list main..HEAD - has commits
+                elif "rev-list" in args and any("..HEAD" in a for a in args):
+                    # git rev-list <branch>..HEAD - has commits
                     return MagicMock(returncode=0, stdout="5\n", stderr="")
                 else:
                     # Default

--- a/tests/unit/test_guards.py
+++ b/tests/unit/test_guards.py
@@ -43,6 +43,7 @@ def test_validate_worktree_on_feature_branch(monkeypatch: pytest.MonkeyPatch, fa
         return _make_completed_process(stdout="001-test-feature\n")
 
     monkeypatch.setattr("specify_cli.guards.subprocess.run", mock_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = validate_worktree_location(project_root=fake_project_root)
 
@@ -59,6 +60,7 @@ def test_validate_worktree_on_main_branch(monkeypatch: pytest.MonkeyPatch, fake_
         return _make_completed_process(stdout="main\n")
 
     monkeypatch.setattr("specify_cli.guards.subprocess.run", mock_run)
+    monkeypatch.setattr("specify_cli.core.git_ops.resolve_primary_branch", lambda _: "main")
 
     result = validate_worktree_location(project_root=fake_project_root)
 


### PR DESCRIPTION
## Summary

Backport of PR #175 from 2.x to main (1.x stream).

- **Core fix**: `resolve_primary_branch()` now checks current branch before hardcoded `[main, master, develop]` list
- **create_feature()**: Records current branch as `target_branch` in meta.json, adds `--target-branch` CLI option
- **Consolidation**: New `_show_branch_context()` replaces 3 ad-hoc branch-check functions
- **guards.py**: Uses `resolve_primary_branch()` instead of hardcoded `{"main", "master"}` set
- **orchestrator_api**: `merge-feature --target` auto-detects from meta.json when not specified
- **Templates**: All hardcoded "main" references replaced with "target branch"

## Test plan

- [x] 2076 tests pass (0 failures)
- [x] New tests for `resolve_primary_branch()` with non-standard branches (2.x, release/v3, etc.)
- [x] New test file `test_create_feature_branch.py` — 8 tests covering branch recording in meta.json
- [x] Updated mocks in test_tasks.py, test_workflow_instructions.py for dynamic branch names
- [x] Updated guards and diagnostics test mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)