### PR TITLE
Fix planned rollback feedback enforcement in review flow

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1057,6 +1057,9 @@ def review(
             lines.append("─" * 80)
             lines.append("")
 
+        # Create unique temp file path for review feedback (avoids conflicts between agents)
+        review_feedback_path = Path(tempfile.gettempdir()) / f"spec-kitty-review-feedback-{normalized_wp_id}.md"
+
         # Next steps
         lines.append("=" * 80)
         lines.append("WHEN YOU'RE DONE:")
@@ -1065,8 +1068,8 @@ def review(
         lines.append(f"  spec-kitty agent tasks move-task {normalized_wp_id} --to done --note \"Review passed\"")
         lines.append("")
         lines.append(f"⚠️  Changes requested:")
-        lines.append(f"  1. Add feedback to the WP file's '## Review Feedback' section")
-        lines.append(f"  2. spec-kitty agent tasks move-task {normalized_wp_id} --to planned --note \"Changes requested\"")
+        lines.append(f"  1. Write feedback to: {review_feedback_path}")
+        lines.append(f"  2. spec-kitty agent tasks move-task {normalized_wp_id} --to planned --review-feedback-file {review_feedback_path}")
         lines.append("=" * 80)
         lines.append("")
         lines.append(f"📍 WORKING DIRECTORY:")
@@ -1105,9 +1108,6 @@ def review(
         lines.append(f"✅ APPROVE (no issues found):")
         lines.append(f"   spec-kitty agent tasks move-task {normalized_wp_id} --to done --note \"Review passed: <summary>\"")
         lines.append("")
-        # Create unique temp file path for review feedback (avoids conflicts between agents)
-        review_feedback_path = Path(tempfile.gettempdir()) / f"spec-kitty-review-feedback-{normalized_wp_id}.md"
-
         lines.append(f"❌ REQUEST CHANGES (issues found):")
         lines.append(f"   1. Write feedback:")
         lines.append(f"      cat > {review_feedback_path} <<'EOF'")
@@ -1125,9 +1125,6 @@ def review(
         # Write full prompt to file
         full_content = "\n".join(lines)
         prompt_file = _write_prompt_to_file("review", normalized_wp_id, full_content)
-
-        # Create unique temp file path for review feedback (same as in prompt)
-        review_feedback_path = Path(tempfile.gettempdir()) / f"spec-kitty-review-feedback-{normalized_wp_id}.md"
 
         # Output concise summary with directive to read the prompt
         print()

--- a/src/specify_cli/missions/research/command-templates/review.md
+++ b/src/specify_cli/missions/research/command-templates/review.md
@@ -132,7 +132,7 @@ if source_register.exists():
      * Append a new entry in the prompt’s **Activity Log** detailing feedback (include timestamp, reviewer agent, shell PID).
      * Update frontmatter `lane` back to `planned`, clear `assignee` if necessary, keep history entry.
      * Add/revise a `## Review Feedback` section (create if missing) summarizing action items.
-     * Run `spec-kitty agent tasks move-task <FEATURE> <TASK_ID> planned --note "Returned for changes"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+     * Save feedback to a file and run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file>` (use the PowerShell equivalent on Windows) so rollback validation captures the feedback source deterministically.
   - **Approved**:
      * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script).
      * Update frontmatter: set `lane=done`, set reviewer metadata (`agent`, `shell_pid`), optional `assignee` for approver.

--- a/src/specify_cli/templates/command-templates/review.md
+++ b/src/specify_cli/templates/command-templates/review.md
@@ -481,7 +481,7 @@ This is intentional - worktrees provide isolation for parallel feature developme
        - Set `reviewed_by: <YOUR_AGENT_ID>`
        - Clear `assignee` if needed
      * Append a new entry in the prompt's **Activity Log** with timestamp, reviewer agent, shell PID, and summary of feedback.
-     * Run `spec-kitty agent move-task <FEATURE> <TASK_ID> planned --note "Code review complete: [brief summary of issues]"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+     * Save feedback to a file and run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file>` (use the PowerShell equivalent on Windows) so rollback validation captures the feedback source deterministically.
   - **Approved**:
      * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script, e.g., `2025-11-11T13:45:00Z – claude – shell_pid=1234 – lane=done – Approved without changes`).
      * Update frontmatter:

--- a/tests/unit/agent/test_tasks.py
+++ b/tests/unit/agent/test_tasks.py
@@ -199,6 +199,36 @@ class TestMoveTask:
     @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
     @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
     @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    def test_move_task_to_planned_force_still_requires_feedback_file(
+        self, mock_slug: Mock, mock_root: Mock, mock_branch: Mock,
+        mock_task_file: Path
+    ):
+        """--force must not bypass review feedback capture on planned rollbacks."""
+        repo_root = mock_task_file.parent.parent.parent.parent
+        mock_root.return_value = repo_root
+        mock_slug.return_value = "008-test-feature"
+        mock_branch.return_value = (repo_root, "main")
+
+        # Simulate review-in-progress state
+        mock_task_file.write_text(
+            mock_task_file.read_text().replace('lane: "planned"', 'lane: "doing"'),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            ["move-task", "WP01", "--to", "planned", "--force", "--json", "--no-auto-commit"],
+        )
+
+        assert result.exit_code == 1
+        first_line = result.stdout.strip().split('\n')[0]
+        output = json.loads(first_line)
+        assert "requires review feedback" in output["error"]
+        assert "cannot be bypassed with --force" in output["error"]
+
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
     def test_move_task_to_planned_rejects_missing_feedback_file(
         self, mock_slug: Mock, mock_root: Mock, mock_branch: Mock,
         mock_task_file: Path, tmp_path: Path


### PR DESCRIPTION
## Summary
- require `--review-feedback-file` for `move-task --to planned` even when `--force` is set
- remove conflicting `workflow review` reject guidance that suggested `--to planned --note` without a feedback file
- update stale review command templates to the enforced rollback command
- add unit/integration regressions to ensure `--force` cannot bypass feedback capture

## Validation
- `python3 -m pytest tests/unit/agent/test_tasks.py -k "planned" -q`
- `python3 -m pytest tests/integration/test_task_workflow.py -k "planned_rollback" -q`
