### PR TITLE
2.x: enforce planned rollback feedback capture and align review guidance

### DIFF
--- a/src/doctrine/missions/research/command-templates/review.md
+++ b/src/doctrine/missions/research/command-templates/review.md
@@ -138,7 +138,7 @@ if source_register.exists():
   - Append a new entry in the prompt’s **Activity Log** detailing feedback (include timestamp, reviewer agent, shell PID).
   - Update frontmatter `lane` back to `planned`, clear `assignee` if necessary, keep history entry.
   - Add/revise a `## Review Feedback` section (create if missing) summarizing action items.
-  - Run `spec-kitty agent tasks move-task <FEATURE> <TASK_ID> planned --note "Returned for changes"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+  - Save feedback to a file and run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file>` (use the PowerShell equivalent on Windows) so rollback validation captures the feedback source deterministically.
 - **Approved**:
   - Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script).
   - Update frontmatter: set `lane=done`, set reviewer metadata (`agent`, `shell_pid`), optional `assignee` for approver.

--- a/src/doctrine/templates/command-templates/review.md
+++ b/src/doctrine/templates/command-templates/review.md
@@ -485,7 +485,7 @@ This is intentional - worktrees provide isolation for parallel feature developme
     - Set `reviewed_by: <YOUR_AGENT_ID>`
     - Clear `assignee` if needed
   - Append a new entry in the prompt's **Activity Log** with timestamp, reviewer agent, shell PID, and summary of feedback.
-  - Run `spec-kitty agent move-task <FEATURE> <TASK_ID> planned --note "Code review complete: [brief summary of issues]"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+  - Save feedback to a file and run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file>` (use the PowerShell equivalent on Windows) so rollback validation captures the feedback source deterministically.
 - **Approved**:
   - Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script, e.g., `2025-11-11T13:45:00Z – claude – shell_pid=1234 – lane=done – Approved without changes`).
   - Update frontmatter:

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -722,10 +722,10 @@ def move_task(
     assignee: Annotated[Optional[str], typer.Option("--assignee", help="Assignee name (sets assignee when moving to doing)")] = None,
     shell_pid: Annotated[Optional[str], typer.Option("--shell-pid", help="Shell PID")] = None,
     note: Annotated[Optional[str], typer.Option("--note", help="History note")] = None,
-    review_feedback_file: Annotated[Optional[Path], typer.Option("--review-feedback-file", help="Path to review feedback file (required for --to planned unless --force)")] = None,
+    review_feedback_file: Annotated[Optional[Path], typer.Option("--review-feedback-file", help="Path to review feedback file (required for --to planned, including with --force)")] = None,
     approval_ref: Annotated[Optional[str], typer.Option("--approval-ref", help="Approval reference for done transitions (e.g., PR#42)")] = None,
     reviewer: Annotated[Optional[str], typer.Option("--reviewer", help="Reviewer name (auto-detected from git if omitted)")] = None,
-    force: Annotated[bool, typer.Option("--force", help="Force move even with unchecked subtasks or missing feedback")] = False,
+    force: Annotated[bool, typer.Option("--force", help="Force move even with unchecked subtasks (does not bypass planned rollback feedback requirement)")] = False,
     auto_commit: Annotated[bool, typer.Option("--auto-commit/--no-auto-commit", help="Automatically commit WP file changes to target branch")] = True,
     json_output: Annotated[bool, typer.Option("--json", help="Output JSON format")] = False,
 ) -> None:
@@ -794,13 +794,14 @@ def move_task(
         review_feedback_content: Optional[str] = None
 
         # Strictly enforce deterministic review feedback capture on planned rollbacks.
-        if target_lane == "planned" and not force:
+        # This requirement is never bypassed, including with --force.
+        if target_lane == "planned":
             if not review_feedback_file:
                 error_msg = f"❌ Moving {task_id} to 'planned' requires review feedback.\n\n"
                 error_msg += "Please provide feedback:\n"
                 error_msg += "  1. Create feedback file: echo '**Issue**: Description' > feedback.md\n"
                 error_msg += f"  2. Run: spec-kitty agent tasks move-task {task_id} --to planned --review-feedback-file feedback.md\n\n"
-                error_msg += "OR use --force to skip feedback (not recommended)"
+                error_msg += "This requirement cannot be bypassed with --force."
                 _output_error(json_output, error_msg)
                 raise typer.Exit(1)
 

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1058,6 +1058,9 @@ def review(
             lines.append("─" * 80)
             lines.append("")
 
+        # Create unique temp file path for review feedback (avoids conflicts between agents)
+        review_feedback_path = Path(tempfile.gettempdir()) / f"spec-kitty-review-feedback-{normalized_wp_id}.md"
+
         # Next steps
         lines.append("=" * 80)
         lines.append("WHEN YOU'RE DONE:")
@@ -1066,8 +1069,8 @@ def review(
         lines.append(f"  spec-kitty agent tasks move-task {normalized_wp_id} --to done --note \"Review passed\"")
         lines.append("")
         lines.append(f"⚠️  Changes requested:")
-        lines.append(f"  1. Add feedback to the WP file's '## Review Feedback' section")
-        lines.append(f"  2. spec-kitty agent tasks move-task {normalized_wp_id} --to planned --note \"Changes requested\"")
+        lines.append(f"  1. Write feedback to: {review_feedback_path}")
+        lines.append(f"  2. spec-kitty agent tasks move-task {normalized_wp_id} --to planned --review-feedback-file {review_feedback_path}")
         lines.append("=" * 80)
         lines.append("")
         lines.append(f"📍 WORKING DIRECTORY:")
@@ -1106,9 +1109,6 @@ def review(
         lines.append(f"✅ APPROVE (no issues found):")
         lines.append(f"   spec-kitty agent tasks move-task {normalized_wp_id} --to done --note \"Review passed: <summary>\"")
         lines.append("")
-        # Create unique temp file path for review feedback (avoids conflicts between agents)
-        review_feedback_path = Path(tempfile.gettempdir()) / f"spec-kitty-review-feedback-{normalized_wp_id}.md"
-
         lines.append(f"❌ REQUEST CHANGES (issues found):")
         lines.append(f"   1. Write feedback:")
         lines.append(f"      cat > {review_feedback_path} <<'EOF'")
@@ -1126,9 +1126,6 @@ def review(
         # Write full prompt to file
         full_content = "\n".join(lines)
         prompt_file = _write_prompt_to_file("review", normalized_wp_id, full_content)
-
-        # Create unique temp file path for review feedback (same as in prompt)
-        review_feedback_path = Path(tempfile.gettempdir()) / f"spec-kitty-review-feedback-{normalized_wp_id}.md"
 
         # Output concise summary with directive to read the prompt
         print()

--- a/src/specify_cli/missions/research/command-templates/review.md
+++ b/src/specify_cli/missions/research/command-templates/review.md
@@ -132,7 +132,7 @@ if source_register.exists():
      * Append a new entry in the prompt’s **Activity Log** detailing feedback (include timestamp, reviewer agent, shell PID).
      * Update frontmatter `lane` back to `planned`, clear `assignee` if necessary, keep history entry.
      * Add/revise a `## Review Feedback` section (create if missing) summarizing action items.
-     * Run `spec-kitty agent tasks move-task <FEATURE> <TASK_ID> planned --note "Returned for changes"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+     * Save feedback to a file and run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file>` (use the PowerShell equivalent on Windows) so rollback validation captures the feedback source deterministically.
   - **Approved**:
      * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script).
      * Update frontmatter: set `lane=done`, set reviewer metadata (`agent`, `shell_pid`), optional `assignee` for approver.

--- a/src/specify_cli/next/prompt_builder.py
+++ b/src/specify_cli/next/prompt_builder.py
@@ -174,7 +174,7 @@ def _build_wp_prompt(
         lines.append(f"  spec-kitty agent tasks move-task {wp_id} --to for_review --note \"Ready for review\"")
     else:
         lines.append(f"  APPROVE: spec-kitty agent tasks move-task {wp_id} --to done --note \"Review passed\"")
-        lines.append(f"  REJECT:  spec-kitty agent tasks move-task {wp_id} --to planned --note \"Changes requested\"")
+        lines.append(f"  REJECT:  spec-kitty agent tasks move-task {wp_id} --to planned --review-feedback-file <feedback-file>")
 
     return "\n".join(lines)
 

--- a/src/specify_cli/templates/command-templates/review.md
+++ b/src/specify_cli/templates/command-templates/review.md
@@ -481,7 +481,7 @@ This is intentional - worktrees provide isolation for parallel feature developme
        - Set `reviewed_by: <YOUR_AGENT_ID>`
        - Clear `assignee` if needed
      * Append a new entry in the prompt's **Activity Log** with timestamp, reviewer agent, shell PID, and summary of feedback.
-     * Run `spec-kitty agent move-task <FEATURE> <TASK_ID> planned --note "Code review complete: [brief summary of issues]"` (use the PowerShell equivalent on Windows) so the move and history update are staged consistently.
+     * Save feedback to a file and run `spec-kitty agent tasks move-task <TASK_ID> --to planned --review-feedback-file <feedback-file>` (use the PowerShell equivalent on Windows) so rollback validation captures the feedback source deterministically.
   - **Approved**:
      * Append Activity Log entry capturing approval details (capture shell PID via `echo $$` or helper script, e.g., `2025-11-11T13:45:00Z – claude – shell_pid=1234 – lane=done – Approved without changes`).
      * Update frontmatter:

--- a/tests/integration/test_task_workflow.py
+++ b/tests/integration/test_task_workflow.py
@@ -256,6 +256,27 @@ class TestFullWorkflow:
         output3 = _parse_json_output(result3.stdout)
         assert "requires review feedback" in output3["error"]
 
+    def test_reject_planned_rollback_with_force_without_feedback_file(self, task_repo: Path, monkeypatch):
+        """--force must not bypass review feedback file requirement for planned rollbacks."""
+        monkeypatch.chdir(task_repo)
+
+        # planned -> doing -> for_review
+        assert runner.invoke(
+            app, ["move-task", "WP01", "--to", "doing", "--feature", "001-test-feature", "--json"]
+        ).exit_code == 0
+        assert runner.invoke(
+            app, ["move-task", "WP01", "--to", "for_review", "--feature", "001-test-feature", "--json"]
+        ).exit_code == 0
+
+        # for_review -> planned with --force still requires --review-feedback-file
+        result = runner.invoke(
+            app,
+            ["move-task", "WP01", "--to", "planned", "--feature", "001-test-feature", "--force", "--json"],
+        )
+        assert result.exit_code == 1
+        output = _parse_json_output(result.stdout)
+        assert "requires review feedback" in output["error"]
+
     def test_persist_feedback_content_and_feedback_file_path(self, task_repo: Path, monkeypatch):
         """Should persist feedback text and source file path deterministically."""
         monkeypatch.chdir(task_repo)


### PR DESCRIPTION
## Summary
- require `--review-feedback-file` for `move-task --to planned` even with `--force`
- remove conflicting `workflow review` reject guidance that suggested `--to planned --note`
- align generated review guidance in `next/prompt_builder.py`
- update stale review command templates in both `specify_cli` and `doctrine` trees
- add unit/integration regressions that confirm `--force` cannot bypass feedback capture

## Validation
- `python3 -m pytest tests/unit/agent/test_tasks.py -k "planned" -q`
- `python3 -m pytest tests/integration/test_task_workflow.py -k "planned_rollback" -q`
- `python3 -m pytest tests/unit/next/test_prompt_builder.py -q`
