### PR TITLE
fix(orchestrator-api): keep feature-state/list-ready read-only

### DIFF
--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -201,10 +201,12 @@ def feature_state(
         )
         return
 
-    from specify_cli.status.reducer import materialize
+    from specify_cli.status.reducer import reduce
+    from specify_cli.status.store import read_events
     from specify_cli.core.dependency_graph import build_dependency_graph
 
-    snapshot = materialize(feature_dir)
+    # Query endpoint: reduce from event log without rewriting status.json.
+    snapshot = reduce(read_events(feature_dir))
     dep_graph = build_dependency_graph(feature_dir)
 
     # Build the full WP set from task files + dep graph + snapshot
@@ -263,10 +265,12 @@ def list_ready(
         )
         return
 
-    from specify_cli.status.reducer import materialize
+    from specify_cli.status.reducer import reduce
+    from specify_cli.status.store import read_events
     from specify_cli.core.dependency_graph import build_dependency_graph
 
-    snapshot = materialize(feature_dir)
+    # Query endpoint: reduce from event log without rewriting status.json.
+    snapshot = reduce(read_events(feature_dir))
     dep_graph = build_dependency_graph(feature_dir)
     wp_states = snapshot.work_packages
 

--- a/tests/integration/orchestrator_api/test_commands.py
+++ b/tests/integration/orchestrator_api/test_commands.py
@@ -154,6 +154,21 @@ class TestFeatureState:
         assert data["success"] is False
         assert data["error_code"] == "FEATURE_NOT_FOUND"
 
+    def test_feature_state_does_not_write_status_snapshot(self, tmp_path):
+        repo_root, feature_dir = _make_feature(tmp_path, "099-test-feature")
+        feature_slug = "099-test-feature"
+        status_path = feature_dir / "status.json"
+        assert not status_path.exists()
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(app, ["feature-state", "--feature", feature_slug])
+
+        assert result.exit_code == 0, result.output
+        assert not status_path.exists()
+
 
 # ── list-ready ────────────────────────────────────────────────────
 
@@ -196,6 +211,21 @@ class TestListReady:
         ready_ids = {wp["wp_id"] for wp in data["data"]["ready_work_packages"]}
         assert "WP01" not in ready_ids
         assert "WP02" in ready_ids
+
+    def test_list_ready_does_not_write_status_snapshot(self, tmp_path):
+        repo_root, feature_dir = _make_feature(tmp_path, "099-test-feature")
+        feature_slug = "099-test-feature"
+        status_path = feature_dir / "status.json"
+        assert not status_path.exists()
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(app, ["list-ready", "--feature", feature_slug])
+
+        assert result.exit_code == 0, result.output
+        assert not status_path.exists()
 
 
 # ── start-implementation ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
This patch fixes the high-impact part of #177: `orchestrator-api` read/query commands were mutating repo state.

Changes:
- `feature-state` now reduces directly from `status.events.jsonl` (`read_events` + `reduce`) instead of calling `materialize()`.
- `list-ready` now does the same.
- Added regression tests proving these query commands do **not** create/update `status.json`.

## Why
External orchestrators poll these endpoints frequently. Writing `status.json` during reads dirties git working trees and violates read-only expectations.

## Validation
- `pytest tests/integration/orchestrator_api/test_commands.py -q`
- Result: `34 passed`

## Issue
Refs #177
