### PR TITLE
fix(dashboard): use project-level constitution status on v1 line (issue #164)

### DIFF
--- a/src/specify_cli/dashboard/constitution_path.py
+++ b/src/specify_cli/dashboard/constitution_path.py
@@ -1,0 +1,24 @@
+"""Constitution path resolution helpers for dashboard features/API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_project_constitution_path(project_dir: Path) -> Path | None:
+    """Resolve the project-level constitution file path.
+
+    Resolution order:
+    1. .kittify/constitution/constitution.md (canonical)
+    2. .kittify/memory/constitution.md (legacy)
+    """
+    project_root = Path(project_dir)
+    candidate_paths = (
+        project_root / ".kittify" / "constitution" / "constitution.md",
+        project_root / ".kittify" / "memory" / "constitution.md",
+    )
+
+    for candidate in candidate_paths:
+        if candidate.exists():
+            return candidate
+    return None

--- a/src/specify_cli/dashboard/handlers/api.py
+++ b/src/specify_cli/dashboard/handlers/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ..constitution_path import resolve_project_constitution_path
 from ..diagnostics import run_diagnostics
 from ..scanner import format_path_for_display, resolve_active_feature, scan_all_features
 from ..templates import get_dashboard_html
@@ -107,9 +108,9 @@ class APIHandler(DashboardHandler):
     def handle_constitution(self) -> None:
         """Serve project-level constitution from .kittify/memory/constitution.md"""
         try:
-            constitution_path = Path(self.project_dir) / ".kittify" / "memory" / "constitution.md"
+            constitution_path = resolve_project_constitution_path(Path(self.project_dir))
 
-            if not constitution_path.exists():
+            if not constitution_path:
                 self.send_response(404)
                 self.send_header('Content-type', 'text/plain')
                 self.end_headers()

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from specify_cli.dashboard.constitution_path import resolve_project_constitution_path
 from specify_cli.core.feature_detection import detect_feature
 from specify_cli.legacy_detector import is_legacy_format
 from specify_cli.template import parse_frontmatter
@@ -158,10 +159,25 @@ def _get_artifact_info(path: Path) -> Dict[str, any]:
     }
 
 
-def get_feature_artifacts(feature_dir: Path) -> Dict[str, Dict[str, any]]:
-    """Return which artifacts exist for a feature with modification info."""
+def get_feature_artifacts(
+    feature_dir: Path,
+    project_dir: Optional[Path] = None,
+) -> Dict[str, Dict[str, any]]:
+    """Return which artifacts exist for a feature with modification info.
+
+    Constitution status is project-level. If project_dir is omitted, we fall back
+    to feature_dir.parent.parent for compatibility with older call sites.
+    """
+    project_root = project_dir if project_dir is not None else feature_dir.parent.parent
+    constitution_path = resolve_project_constitution_path(project_root)
+    constitution_info = (
+        _get_artifact_info(constitution_path)
+        if constitution_path is not None
+        else {"exists": False, "mtime": None, "size": None}
+    )
+
     return {
-        "constitution": _get_artifact_info(feature_dir / "constitution.md"),
+        "constitution": constitution_info,
         "spec": _get_artifact_info(feature_dir / "spec.md"),
         "plan": _get_artifact_info(feature_dir / "plan.md"),
         "tasks": _get_artifact_info(feature_dir / "tasks.md"),
@@ -307,7 +323,7 @@ def scan_all_features(project_dir: Path) -> List[Dict[str, Any]]:
             except json.JSONDecodeError:
                 meta_data = None
 
-        artifacts = get_feature_artifacts(feature_dir)
+        artifacts = get_feature_artifacts(feature_dir, project_dir)
         workflow = get_workflow_status(artifacts)
 
         kanban_stats = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "done": 0}

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -322,7 +322,7 @@ return `
 
     const artifacts = feature.artifacts;
     const artifactList = [
-        {name: 'Constitution', key: 'constitution', icon: '⚖️'},
+        {name: 'Project Constitution', key: 'constitution', icon: '⚖️'},
         {name: 'Specification', key: 'spec', icon: '📄'},
         {name: 'Plan', key: 'plan', icon: '🏗️'},
         {name: 'Tasks', key: 'tasks', icon: '📋'},

--- a/tests/test_dashboard/test_api_constitution.py
+++ b/tests/test_dashboard/test_api_constitution.py
@@ -1,0 +1,62 @@
+"""Tests for dashboard constitution API path resolution behavior."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from specify_cli.dashboard.handlers.api import APIHandler
+
+
+class _DummyAPIHandler:
+    """Minimal handler shim to execute APIHandler methods in isolation."""
+
+    def __init__(self, project_dir: Path) -> None:
+        self.project_dir = project_dir
+        self.status_code = None
+        self.headers: dict[str, str] = {}
+        self.wfile = io.BytesIO()
+
+    def send_response(self, code: int) -> None:
+        self.status_code = code
+
+    def send_header(self, key: str, value: str) -> None:
+        self.headers[key] = value
+
+    def end_headers(self) -> None:
+        return None
+
+
+def test_handle_constitution_prefers_new_path(tmp_path: Path) -> None:
+    new_path = tmp_path / ".kittify" / "constitution" / "constitution.md"
+    legacy_path = tmp_path / ".kittify" / "memory" / "constitution.md"
+    new_path.parent.mkdir(parents=True)
+    legacy_path.parent.mkdir(parents=True)
+    new_path.write_text("new-path-content", encoding="utf-8")
+    legacy_path.write_text("legacy-content", encoding="utf-8")
+
+    handler = _DummyAPIHandler(tmp_path)
+    APIHandler.handle_constitution(handler)  # type: ignore[arg-type]
+
+    assert handler.status_code == 200
+    assert handler.wfile.getvalue().decode("utf-8") == "new-path-content"
+
+
+def test_handle_constitution_uses_legacy_when_new_missing(tmp_path: Path) -> None:
+    legacy_path = tmp_path / ".kittify" / "memory" / "constitution.md"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text("legacy-content", encoding="utf-8")
+
+    handler = _DummyAPIHandler(tmp_path)
+    APIHandler.handle_constitution(handler)  # type: ignore[arg-type]
+
+    assert handler.status_code == 200
+    assert handler.wfile.getvalue().decode("utf-8") == "legacy-content"
+
+
+def test_handle_constitution_returns_404_when_missing(tmp_path: Path) -> None:
+    handler = _DummyAPIHandler(tmp_path)
+    APIHandler.handle_constitution(handler)  # type: ignore[arg-type]
+
+    assert handler.status_code == 404
+    assert handler.wfile.getvalue() == b"Constitution not found"

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 
 from specify_cli.dashboard import scanner
+from specify_cli.dashboard.constitution_path import resolve_project_constitution_path
 from specify_cli.core.feature_detection import FeatureContext
 
 
-def _create_feature(tmp_path: Path) -> Path:
-    feature_dir = tmp_path / "kitty-specs" / "001-demo-feature"
+def _create_feature(tmp_path: Path, slug: str = "001-demo-feature") -> Path:
+    feature_dir = tmp_path / "kitty-specs" / slug
     (feature_dir / "tasks" / "planned").mkdir(parents=True)
     (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
     (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
@@ -75,3 +76,50 @@ def test_resolve_active_feature_falls_back_to_first(tmp_path, monkeypatch):
     resolved = scanner.resolve_active_feature(tmp_path, features)
     assert resolved is not None
     assert resolved["id"] == "009-old-feature"
+
+
+def test_project_constitution_propagates_to_all_features(tmp_path):
+    _create_feature(tmp_path, "001-demo-feature")
+    _create_feature(tmp_path, "002-another-feature")
+    constitution = tmp_path / ".kittify" / "constitution" / "constitution.md"
+    constitution.parent.mkdir(parents=True)
+    constitution.write_text("# Project Constitution\n", encoding="utf-8")
+
+    features = scanner.scan_all_features(tmp_path)
+    assert len(features) == 2
+    assert all(feature["artifacts"]["constitution"]["exists"] for feature in features)
+
+
+def test_feature_local_constitution_is_ignored_without_project_constitution(tmp_path):
+    first = _create_feature(tmp_path, "001-demo-feature")
+    _create_feature(tmp_path, "002-another-feature")
+    (first / "constitution.md").write_text("# Legacy Feature Constitution\n", encoding="utf-8")
+
+    features = scanner.scan_all_features(tmp_path)
+    assert len(features) == 2
+    assert all(not feature["artifacts"]["constitution"]["exists"] for feature in features)
+
+
+def test_legacy_constitution_path_supported(tmp_path):
+    _create_feature(tmp_path, "001-demo-feature")
+    _create_feature(tmp_path, "002-another-feature")
+    legacy = tmp_path / ".kittify" / "memory" / "constitution.md"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("# Legacy Project Constitution\n", encoding="utf-8")
+
+    features = scanner.scan_all_features(tmp_path)
+    assert len(features) == 2
+    assert all(feature["artifacts"]["constitution"]["exists"] for feature in features)
+
+
+def test_new_path_preferred_when_both_exist(tmp_path):
+    _create_feature(tmp_path)
+    new_path = tmp_path / ".kittify" / "constitution" / "constitution.md"
+    legacy_path = tmp_path / ".kittify" / "memory" / "constitution.md"
+    new_path.parent.mkdir(parents=True)
+    legacy_path.parent.mkdir(parents=True)
+    new_path.write_text("new", encoding="utf-8")
+    legacy_path.write_text("legacy", encoding="utf-8")
+
+    resolved = resolve_project_constitution_path(tmp_path)
+    assert resolved == new_path


### PR DESCRIPTION
## Summary
- add shared dashboard constitution path resolver with new->legacy fallback
- make feature artifact constitution status project-level instead of feature-local
- reuse the same resolver in 
- relabel overview artifact from  to 
- add scanner and API regression tests for issue #164

## Validation
- ============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-8.4.2, pluggy-1.6.0
rootdir: /private/tmp/spec-kitty-issue-164-20260226-180152/worktrees/spec-kitty-v1
configfile: pytest.ini
plugins: anyio-4.12.1, asyncio-0.24.0, playwright-0.7.2, html-4.1.1, xdist-3.8.0, metadata-3.1.1, Faker-33.1.0, cov-4.1.0, mock-3.12.0, hypothesis-6.151.2, base-url-2.1.0, typeguard-4.4.4, baml-0.19.1
asyncio: mode=Mode.AUTO, default_loop_scope=function
collected 11 items

tests/test_dashboard/test_scanner.py ........                            [ 72%]
tests/test_dashboard/test_api_constitution.py ...                        [100%]

============================== 11 passed in 0.26s ==============================
- Manual matrix validated:
  - root constitution only -> all features show available
  - feature-local constitution only -> all features show unavailable
  - both new+legacy root files -> API returns new-path content
