### PR TITLE
fix(dashboard): use project-level constitution status (issue #164)

### DIFF
--- a/src/specify_cli/dashboard/constitution_path.py
+++ b/src/specify_cli/dashboard/constitution_path.py
@@ -1,0 +1,24 @@
+"""Constitution path resolution helpers for dashboard features/API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_project_constitution_path(project_dir: Path) -> Path | None:
+    """Resolve the project-level constitution file path.
+
+    Resolution order:
+    1. .kittify/constitution/constitution.md (canonical)
+    2. .kittify/memory/constitution.md (legacy)
+    """
+    project_root = Path(project_dir)
+    candidate_paths = (
+        project_root / ".kittify" / "constitution" / "constitution.md",
+        project_root / ".kittify" / "memory" / "constitution.md",
+    )
+
+    for candidate in candidate_paths:
+        if candidate.exists():
+            return candidate
+    return None

--- a/src/specify_cli/dashboard/handlers/api.py
+++ b/src/specify_cli/dashboard/handlers/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ..constitution_path import resolve_project_constitution_path
 from ..diagnostics import run_diagnostics
 from ..scanner import format_path_for_display, resolve_active_feature, scan_all_features
 from ..templates import get_dashboard_html
@@ -107,9 +108,9 @@ class APIHandler(DashboardHandler):
     def handle_constitution(self) -> None:
         """Serve project-level constitution from .kittify/memory/constitution.md"""
         try:
-            constitution_path = Path(self.project_dir) / ".kittify" / "memory" / "constitution.md"
+            constitution_path = resolve_project_constitution_path(Path(self.project_dir))
 
-            if not constitution_path.exists():
+            if not constitution_path:
                 self.send_response(404)
                 self.send_header('Content-type', 'text/plain')
                 self.end_headers()

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -322,7 +322,7 @@ return `
 
     const artifacts = feature.artifacts;
     const artifactList = [
-        {name: 'Constitution', key: 'constitution', icon: '⚖️'},
+        {name: 'Project Constitution', key: 'constitution', icon: '⚖️'},
         {name: 'Specification', key: 'spec', icon: '📄'},
         {name: 'Plan', key: 'plan', icon: '🏗️'},
         {name: 'Tasks', key: 'tasks', icon: '📋'},

--- a/tests/test_dashboard/test_api_constitution.py
+++ b/tests/test_dashboard/test_api_constitution.py
@@ -1,0 +1,62 @@
+"""Tests for dashboard constitution API path resolution behavior."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from specify_cli.dashboard.handlers.api import APIHandler
+
+
+class _DummyAPIHandler:
+    """Minimal handler shim to execute APIHandler methods in isolation."""
+
+    def __init__(self, project_dir: Path) -> None:
+        self.project_dir = project_dir
+        self.status_code = None
+        self.headers: dict[str, str] = {}
+        self.wfile = io.BytesIO()
+
+    def send_response(self, code: int) -> None:
+        self.status_code = code
+
+    def send_header(self, key: str, value: str) -> None:
+        self.headers[key] = value
+
+    def end_headers(self) -> None:
+        return None
+
+
+def test_handle_constitution_prefers_new_path(tmp_path: Path) -> None:
+    new_path = tmp_path / ".kittify" / "constitution" / "constitution.md"
+    legacy_path = tmp_path / ".kittify" / "memory" / "constitution.md"
+    new_path.parent.mkdir(parents=True)
+    legacy_path.parent.mkdir(parents=True)
+    new_path.write_text("new-path-content", encoding="utf-8")
+    legacy_path.write_text("legacy-content", encoding="utf-8")
+
+    handler = _DummyAPIHandler(tmp_path)
+    APIHandler.handle_constitution(handler)  # type: ignore[arg-type]
+
+    assert handler.status_code == 200
+    assert handler.wfile.getvalue().decode("utf-8") == "new-path-content"
+
+
+def test_handle_constitution_uses_legacy_when_new_missing(tmp_path: Path) -> None:
+    legacy_path = tmp_path / ".kittify" / "memory" / "constitution.md"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text("legacy-content", encoding="utf-8")
+
+    handler = _DummyAPIHandler(tmp_path)
+    APIHandler.handle_constitution(handler)  # type: ignore[arg-type]
+
+    assert handler.status_code == 200
+    assert handler.wfile.getvalue().decode("utf-8") == "legacy-content"
+
+
+def test_handle_constitution_returns_404_when_missing(tmp_path: Path) -> None:
+    handler = _DummyAPIHandler(tmp_path)
+    APIHandler.handle_constitution(handler)  # type: ignore[arg-type]
+
+    assert handler.status_code == 404
+    assert handler.wfile.getvalue() == b"Constitution not found"

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 
 from specify_cli.dashboard import scanner
+from specify_cli.dashboard.constitution_path import resolve_project_constitution_path
 from specify_cli.core.feature_detection import FeatureContext
 
 
-def _create_feature(tmp_path: Path) -> Path:
-    feature_dir = tmp_path / "kitty-specs" / "001-demo-feature"
+def _create_feature(tmp_path: Path, slug: str = "001-demo-feature") -> Path:
+    feature_dir = tmp_path / "kitty-specs" / slug
     (feature_dir / "tasks" / "planned").mkdir(parents=True)
     (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
     (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
@@ -75,3 +76,50 @@ def test_resolve_active_feature_falls_back_to_first(tmp_path, monkeypatch):
     resolved = scanner.resolve_active_feature(tmp_path, features)
     assert resolved is not None
     assert resolved["id"] == "009-old-feature"
+
+
+def test_project_constitution_propagates_to_all_features(tmp_path):
+    _create_feature(tmp_path, "001-demo-feature")
+    _create_feature(tmp_path, "002-another-feature")
+    constitution = tmp_path / ".kittify" / "constitution" / "constitution.md"
+    constitution.parent.mkdir(parents=True)
+    constitution.write_text("# Project Constitution\n", encoding="utf-8")
+
+    features = scanner.scan_all_features(tmp_path)
+    assert len(features) == 2
+    assert all(feature["artifacts"]["constitution"]["exists"] for feature in features)
+
+
+def test_feature_local_constitution_is_ignored_without_project_constitution(tmp_path):
+    first = _create_feature(tmp_path, "001-demo-feature")
+    _create_feature(tmp_path, "002-another-feature")
+    (first / "constitution.md").write_text("# Legacy Feature Constitution\n", encoding="utf-8")
+
+    features = scanner.scan_all_features(tmp_path)
+    assert len(features) == 2
+    assert all(not feature["artifacts"]["constitution"]["exists"] for feature in features)
+
+
+def test_legacy_constitution_path_supported(tmp_path):
+    _create_feature(tmp_path, "001-demo-feature")
+    _create_feature(tmp_path, "002-another-feature")
+    legacy = tmp_path / ".kittify" / "memory" / "constitution.md"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("# Legacy Project Constitution\n", encoding="utf-8")
+
+    features = scanner.scan_all_features(tmp_path)
+    assert len(features) == 2
+    assert all(feature["artifacts"]["constitution"]["exists"] for feature in features)
+
+
+def test_new_path_preferred_when_both_exist(tmp_path):
+    _create_feature(tmp_path)
+    new_path = tmp_path / ".kittify" / "constitution" / "constitution.md"
+    legacy_path = tmp_path / ".kittify" / "memory" / "constitution.md"
+    new_path.parent.mkdir(parents=True)
+    legacy_path.parent.mkdir(parents=True)
+    new_path.write_text("new", encoding="utf-8")
+    legacy_path.write_text("legacy", encoding="utf-8")
+
+    resolved = resolve_project_constitution_path(tmp_path)
+    assert resolved == new_path


### PR DESCRIPTION
## Summary
- add shared dashboard constitution path resolver with new->legacy fallback
- make feature artifact constitution status project-level instead of feature-local
- reuse the same resolver in /api/constitution
- relabel overview artifact from Constitution to Project Constitution
- add scanner and API regression tests for issue #164

## Validation
- pytest tests/test_dashboard/test_scanner.py tests/test_dashboard/test_api_constitution.py -q
- Manual matrix validated:
  - root constitution only -> all features show available
  - feature-local constitution only -> all features show unavailable
  - both new+legacy root files -> API returns new-path content
