### PR TITLE
Refactor root resolution: use core.paths as single source of truth

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -15,6 +15,7 @@ import typer
 
 from specify_cli.cli import StepTracker
 from specify_cli.cli.helpers import check_version_compatibility, console, show_banner
+from specify_cli.core.paths import get_main_repo_root
 from specify_cli.core.git_ops import has_remote, has_tracking_branch, run_command
 from specify_cli.core.vcs import VCSBackend, get_vcs
 from specify_cli.core.context_validation import require_main_repo
@@ -84,41 +85,6 @@ def _all_feature_wps_done(repo_root: Path, feature_slug: str) -> bool:
         if lane_match.group(1).strip().lower() != "done":
             return False
     return True
-
-
-def get_main_repo_root(repo_root: Path) -> Path:
-    """Get the main repository root, even if called from a worktree.
-
-    If repo_root is a worktree, find its main repository.
-    Otherwise, return repo_root as-is.
-    """
-    git_dir = repo_root / ".git"
-
-    # If .git is a directory, we're in the main repo
-    if git_dir.is_dir():
-        return repo_root
-
-    # If .git is a file, we're in a worktree - read it to find main repo
-    if git_dir.is_file():
-        git_file_content = git_dir.read_text().strip()
-        # Format: "gitdir: /path/to/main/repo/.git/worktrees/feature-name"
-        if git_file_content.startswith("gitdir: "):
-            gitdir_path = Path(git_file_content[8:])  # Remove "gitdir: " prefix
-            # Go up from .git/worktrees/feature-name to main repo root
-            # gitdir_path points to: /main/repo/.git/worktrees/feature-name
-            # We want: /main/repo
-            if "worktrees" in gitdir_path.parts:
-                # Find the .git parent
-                main_git_dir = gitdir_path
-                while main_git_dir.name != ".git":
-                    main_git_dir = main_git_dir.parent
-                    if main_git_dir == main_git_dir.parent:
-                        # Reached root without finding .git
-                        break
-                return main_git_dir.parent
-
-    # Fallback: return as-is
-    return repo_root
 
 
 def detect_worktree_structure(repo_root: Path, feature_slug: str) -> str:

--- a/src/specify_cli/core/feature_detection.py
+++ b/src/specify_cli/core/feature_detection.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Mapping, Optional
 
+from specify_cli.core.paths import get_main_repo_root as _resolve_main_repo_root
+
 
 # ============================================================================
 # Error Types
@@ -124,19 +126,7 @@ def _get_main_repo_root(repo_root: Path) -> Path:
     Returns:
         Main repository root path
     """
-    # Check if we're in a worktree
-    git_common_dir = repo_root / ".git"
-    if git_common_dir.is_file():
-        # Worktree: .git is a file pointing to actual git dir
-        git_dir_content = git_common_dir.read_text().strip()
-        if git_dir_content.startswith("gitdir: "):
-            git_dir = Path(git_dir_content[8:])  # Remove "gitdir: " prefix
-            # Git dir for worktree is: <main-repo>/.git/worktrees/<name>
-            # Navigate up two levels to get main repo
-            main_git_dir = git_dir.parent.parent
-            return main_git_dir.parent  # Parent of .git is main repo root
-
-    return repo_root
+    return _resolve_main_repo_root(repo_root)
 
 
 def _list_all_features(repo_root: Path) -> list[str]:

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -17,7 +17,7 @@ from typing import Any
 import typer
 
 from specify_cli.core.dependency_graph import build_dependency_graph
-from specify_cli.core.paths import locate_project_root
+from specify_cli.core.paths import get_main_repo_root, locate_project_root
 from specify_cli.git.commit_helpers import safe_commit
 from specify_cli.merge import get_merge_order, run_preflight
 from specify_cli.tasks_support import (
@@ -65,9 +65,10 @@ def _fail(command: str, error_code: str, message: str, data: dict[str, Any] | No
 
 
 def _get_main_repo_root() -> Path:
-    root = locate_project_root()
+    cwd = Path.cwd()
+    root = locate_project_root(cwd)
     if root is None:
-        return Path.cwd()
+        return get_main_repo_root(cwd)
     return root
 
 

--- a/src/specify_cli/task_helpers_shared.py
+++ b/src/specify_cli/task_helpers_shared.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from specify_cli.core.paths import get_main_repo_root, locate_project_root
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -72,30 +74,21 @@ def find_repo_root(start: Optional[Path] = None) -> Path:
     """
     current = (start or Path.cwd()).resolve()
 
+    detected_root = locate_project_root(current)
+    if detected_root is not None:
+        return get_main_repo_root(detected_root)
+
+    # Fallback: support plain git repositories that do not contain .kittify yet.
     for candidate in [current, *current.parents]:
         git_path = candidate / ".git"
 
+        if git_path.is_dir():
+            return get_main_repo_root(candidate)
+
         if git_path.is_file():
-            # This is a worktree! The .git file contains a pointer to the main
-            # repo.  Format: "gitdir: /path/to/main/.git/worktrees/name"
-            try:
-                content = git_path.read_text().strip()
-                if content.startswith("gitdir:"):
-                    gitdir = Path(content.split(":", 1)[1].strip())
-                    # Navigate: .git/worktrees/name -> .git -> main repo root
-                    main_git_dir = gitdir.parent.parent
-                    main_repo = main_git_dir.parent
-                    if main_repo.exists():
-                        return main_repo
-            except (OSError, ValueError):
-                pass
-
-        elif git_path.is_dir():
-            return candidate
-
-        # Also check for .kittify marker (fallback for non-git scenarios)
-        if (candidate / ".kittify").exists():
-            return candidate
+            resolved = get_main_repo_root(candidate)
+            if resolved != candidate:
+                return resolved
 
     raise TaskCliError("Unable to locate repository root (missing .git or .kittify).")
 


### PR DESCRIPTION
## Summary
- remove duplicate `get_main_repo_root()` implementation from `cli/commands/merge.py` and import canonical helper from `core.paths`
- make `core/feature_detection._get_main_repo_root()` delegate to canonical `core.paths.get_main_repo_root()`
- make `orchestrator_api` root detection use canonical fallback (`get_main_repo_root(Path.cwd())`)
- simplify `task_helpers_shared.find_repo_root()` to rely on canonical root resolution while preserving `TaskCliError` behavior for malformed worktree pointers

## Why
Continues the remediation track for duplicated root-resolution code paths. This reduces behavioral drift between modules and keeps one canonical parser for worktree `.git` pointers.

## Validation
- `python3 -m pytest -q tests/specify_cli/test_tasks_support.py::test_find_repo_root_malformed_worktree_git_file tests/specify_cli/test_tasks_support.py::test_find_repo_root_walks_upward tests/specify_cli/core/test_feature_detection.py tests/specify_cli/test_cli/test_merge_workspace_per_wp.py`
- `python3 -m pytest -q tests/integration/orchestrator_api/test_commands.py`
- `python3 -m compileall -q src/specify_cli/cli/commands/merge.py src/specify_cli/core/feature_detection.py src/specify_cli/orchestrator_api/commands.py src/specify_cli/task_helpers_shared.py`
