### PR TITLE
Refactor root resolution (2.x): backport canonical resolver consolidation

### DIFF
--- a/src/specify_cli/core/feature_detection.py
+++ b/src/specify_cli/core/feature_detection.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Mapping, Optional
 
+from specify_cli.core.paths import get_main_repo_root as _resolve_main_repo_root
+
 
 # ============================================================================
 # Error Types
@@ -124,19 +126,7 @@ def _get_main_repo_root(repo_root: Path) -> Path:
     Returns:
         Main repository root path
     """
-    # Check if we're in a worktree
-    git_common_dir = repo_root / ".git"
-    if git_common_dir.is_file():
-        # Worktree: .git is a file pointing to actual git dir
-        git_dir_content = git_common_dir.read_text().strip()
-        if git_dir_content.startswith("gitdir: "):
-            git_dir = Path(git_dir_content[8:])  # Remove "gitdir: " prefix
-            # Git dir for worktree is: <main-repo>/.git/worktrees/<name>
-            # Navigate up two levels to get main repo
-            main_git_dir = git_dir.parent.parent
-            return main_git_dir.parent  # Parent of .git is main repo root
-
-    return repo_root
+    return _resolve_main_repo_root(repo_root)
 
 
 def _list_all_features(repo_root: Path) -> list[str]:

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -70,12 +70,13 @@ def _fail(command: str, error_code: str, message: str, data: dict | None = None)
 
 def _get_main_repo_root() -> Path:
     """Resolve main repository root from current working directory."""
-    from specify_cli.core.paths import locate_project_root
+    from specify_cli.core.paths import get_main_repo_root, locate_project_root
 
-    root = locate_project_root()
+    cwd = Path.cwd()
+    root = locate_project_root(cwd)
     if root is None:
-        # Fall back to cwd
-        return Path.cwd()
+        # Fall back to canonical resolver for worktree-aware behavior.
+        return get_main_repo_root(cwd)
     return root
 
 

--- a/src/specify_cli/tasks_support.py
+++ b/src/specify_cli/tasks_support.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from specify_cli.core.paths import get_main_repo_root, locate_project_root
 from specify_cli.legacy_detector import is_legacy_format
 
 # IMPORTANT: Keep in sync with scripts/tasks/task_helpers.py
@@ -52,33 +53,21 @@ def find_repo_root(start: Optional[Path] = None) -> Path:
     """
     current = (start or Path.cwd()).resolve()
 
+    detected_root = locate_project_root(current)
+    if detected_root is not None:
+        return get_main_repo_root(detected_root)
+
+    # Fallback: support plain git repositories that do not contain .kittify yet.
     for candidate in [current, *current.parents]:
         git_path = candidate / ".git"
 
+        if git_path.is_dir():
+            return get_main_repo_root(candidate)
+
         if git_path.is_file():
-            # This is a worktree! The .git file contains a pointer to the main repo.
-            # Format: "gitdir: /path/to/main/.git/worktrees/worktree-name"
-            try:
-                content = git_path.read_text().strip()
-                if content.startswith("gitdir:"):
-                    gitdir = Path(content.split(":", 1)[1].strip())
-                    # Navigate: .git/worktrees/name -> .git -> main repo root
-                    # gitdir points to .git/worktrees/xxx, so .parent.parent is .git
-                    main_git_dir = gitdir.parent.parent
-                    main_repo = main_git_dir.parent
-                    if main_repo.exists():
-                        return main_repo
-            except (OSError, ValueError):
-                # If we can't read or parse the .git file, continue searching
-                pass
-
-        elif git_path.is_dir():
-            # This is the main repo (or a regular git repo)
-            return candidate
-
-        # Also check for .kittify marker (fallback for non-git scenarios)
-        if (candidate / ".kittify").exists():
-            return candidate
+            resolved = get_main_repo_root(candidate)
+            if resolved != candidate:
+                return resolved
 
     raise TaskCliError("Unable to locate repository root (missing .git or .kittify).")
 


### PR DESCRIPTION
## Summary
- backport root-resolution consolidation from main to 2.x
- remove duplicate `get_main_repo_root()` implementation from `cli/commands/merge.py` and import canonical helper from `core.paths`
- make `core/feature_detection._get_main_repo_root()` delegate to `core.paths.get_main_repo_root()`
- make `orchestrator_api` root detection use canonical fallback (`get_main_repo_root(Path.cwd())`)
- consolidate repo-root lookup in both task helper modules:
  - `src/specify_cli/tasks_support.py`
  - `src/specify_cli/scripts/tasks/task_helpers.py`
- preserve malformed-worktree behavior expected by tests (do not treat malformed `.git` files as valid roots)

## Why
2.x still had several duplicate worktree/main-repo root resolution paths with slightly different fallback semantics. This backport reduces drift and centralizes parsing behavior around `core.paths`.

## Validation
- `python3 -m pytest -q tests/specify_cli/test_tasks_support.py tests/specify_cli/core/test_feature_detection.py tests/specify_cli/test_cli/test_merge_workspace_per_wp.py tests/integration/orchestrator_api/test_commands.py`
- `python3 -m compileall -q src/specify_cli/cli/commands/merge.py src/specify_cli/core/feature_detection.py src/specify_cli/orchestrator_api/commands.py src/specify_cli/tasks_support.py src/specify_cli/scripts/tasks/task_helpers.py`
