### PR TITLE
Fix release-readiness version policy for parallel major streams

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -120,7 +120,7 @@ jobs:
             echo "This branch is ready for release:" >> $GITHUB_STEP_SUMMARY
             echo "- Version is properly bumped" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog entry exists and is populated" >> $GITHUB_STEP_SUMMARY
-            echo "- Version progression is monotonic" >> $GITHUB_STEP_SUMMARY
+            echo "- Version progression is monotonic within its major stream" >> $GITHUB_STEP_SUMMARY
             echo "- Tests pass" >> $GITHUB_STEP_SUMMARY
             echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
           else
@@ -132,7 +132,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "1. **Version Bump** - Update version in \`pyproject.toml\`" >> $GITHUB_STEP_SUMMARY
             echo "2. **Changelog Entry** - Add release notes under \`## [X.Y.Z]\` or \`## [X.Y.ZaN/bN/rcN]\` in \`CHANGELOG.md\`" >> $GITHUB_STEP_SUMMARY
-            echo "3. **Version Progression** - Ensure new version > latest tag" >> $GITHUB_STEP_SUMMARY
+            echo "3. **Version Progression** - Ensure version is not behind the latest tag in the same major stream" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "See the validation output above for specific errors." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -33,7 +33,7 @@ python scripts/release/validate_release.py \
   - Validates:
     * Version in `pyproject.toml` is valid semantic version (X.Y.Z)
     * CHANGELOG.md contains a populated section for the current version
-    * New version > latest git tag (monotonic progression)
+    * Current version is not behind the latest git tag in the same major stream
   - Does NOT require a tag to be present
   - Exit code: 0 (success) or 1 (validation failed)
 
@@ -192,8 +192,9 @@ python scripts/release/extract_changelog.py 0.2.4
 **Problem**: Your version is equal to or less than an existing tag.
 
 **Solution**:
-1. Check latest tag: `git tag --list 'v*' --sort=-version:refname | head -1`
-2. Bump version in `pyproject.toml` to be higher
+1. Check latest tag in your stream: `git tag --list 'v1*' --sort=-version:refname | head -1` (replace `1` with your major)
+2. In branch mode, ensure version is at least the latest tag in that major stream
+3. In tag mode, ensure version is greater than the latest published tag in that major stream
 3. Re-run validator
 
 ### "CHANGELOG.md lacks a populated section"


### PR DESCRIPTION
## Summary
- scope release version progression checks to tags in the same major stream
- keep tag-mode strict (must advance), but allow branch-mode parity (must not regress)
- add regression tests for parallel 1.x/2.x tracks and branch parity behavior
- update release-readiness summary wording/docs to match the new policy

## Why
main and 2.x are active in parallel. The old check compared against the global latest tag, which incorrectly blocked mainline 1.x validation after 2.x tags were published.

## Validation
- `python3 -m pytest -q tests/release/test_validate_release.py`
- `python3 scripts/release/validate_release.py --mode branch`
