### PR TITLE
Add flag-gated tracker CLI surface and local tracker store

### DIFF
--- a/src/specify_cli/cli/commands/__init__.py
+++ b/src/specify_cli/cli/commands/__init__.py
@@ -23,10 +23,16 @@ from specify_cli import orchestrator_api as orchestrator_api_module
 from . import repair as repair_module
 from . import research as research_module
 from . import sync as sync_module
+from specify_cli.tracker.feature_flags import is_saas_sync_enabled
 from . import upgrade as upgrade_module
 from . import validate_encoding as validate_encoding_module
 from . import validate_tasks as validate_tasks_module
 from . import verify as verify_module
+
+if is_saas_sync_enabled():
+    from . import tracker as tracker_module
+else:  # pragma: no cover - deterministic environment gate
+    tracker_module = None
 
 
 def register_commands(app: typer.Typer) -> None:
@@ -52,6 +58,8 @@ def register_commands(app: typer.Typer) -> None:
     app.add_typer(repair_module.app, name="repair", help="Repair broken templates")
     app.command()(research_module.research)
     app.add_typer(sync_module.app, name="sync", help="Synchronization commands")
+    if tracker_module is not None:
+        app.add_typer(tracker_module.app, name="tracker", help="Task tracker commands")
     app.command()(upgrade_module.upgrade)
     app.command(name="list-legacy-features")(upgrade_module.list_legacy_features)
     app.command(name="validate-encoding")(validate_encoding_module.validate_encoding)

--- a/src/specify_cli/cli/commands/tracker.py
+++ b/src/specify_cli/cli/commands/tracker.py
@@ -1,0 +1,311 @@
+"""Tracker commands for provider bindings, mappings, and sync operations."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import typer
+
+from specify_cli.tracker.config import require_repo_root
+from specify_cli.tracker.feature_flags import is_saas_sync_enabled, saas_sync_disabled_message
+from specify_cli.tracker.service import TrackerService, TrackerServiceError, parse_kv_pairs
+
+app = typer.Typer(help="Task tracker integration commands")
+map_app = typer.Typer(help="Work-package mapping commands")
+sync_app = typer.Typer(help="Tracker synchronization commands")
+app.add_typer(map_app, name="map")
+app.add_typer(sync_app, name="sync")
+
+
+def _print_json(payload: Any) -> None:
+    typer.echo(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+
+def _require_enabled() -> None:
+    if is_saas_sync_enabled():
+        return
+    typer.secho(saas_sync_disabled_message(), fg=typer.colors.RED, err=True)
+    raise typer.Exit(1)
+
+
+def _service() -> TrackerService:
+    repo_root = require_repo_root()
+    return TrackerService(repo_root)
+
+
+def _doctrine_modes() -> tuple[str, ...]:
+    return (
+        "external_authoritative",
+        "spec_kitty_authoritative",
+        "split_ownership",
+    )
+
+
+def _run_or_exit(fn):
+    try:
+        return fn()
+    except (RuntimeError, ValueError) as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from exc
+
+
+@app.callback()
+def tracker_callback() -> None:
+    """Guard tracker commands behind the SaaS sync feature flag."""
+    _require_enabled()
+
+
+@app.command("providers")
+def providers_command(as_json: bool = typer.Option(False, "--json", help="Render provider list as JSON")) -> None:
+    """List supported tracker providers."""
+
+    def _run() -> None:
+        providers = list(TrackerService.supported_providers())
+        if as_json:
+            _print_json({"providers": providers})
+            return
+
+        typer.echo("Supported providers:")
+        for provider in providers:
+            typer.echo(f"- {provider}")
+
+    _run_or_exit(_run)
+
+
+@app.command("bind")
+def bind_command(
+    provider: str = typer.Option(..., "--provider", help="Provider name (jira, linear, azure_devops, github, gitlab, beads, fp)"),
+    workspace: str = typer.Option(..., "--workspace", help="Provider workspace/team/project identifier"),
+    doctrine_mode: str = typer.Option(
+        "external_authoritative",
+        "--doctrine-mode",
+        help="Doctrine mode: external_authoritative | spec_kitty_authoritative | split_ownership",
+    ),
+    field_owners: list[str] = typer.Option([], "--field-owner", help="Split ownership mapping: field=owner"),
+    credentials: list[str] = typer.Option([], "--credential", help="Provider credential key/value: key=value"),
+) -> None:
+    """Bind the current project to an issue tracker workspace."""
+
+    def _run() -> None:
+        mode = doctrine_mode.strip().lower()
+        if mode not in set(_doctrine_modes()):
+            raise TrackerServiceError(
+                f"Invalid doctrine mode '{doctrine_mode}'. Expected one of: {', '.join(_doctrine_modes())}"
+            )
+
+        parsed_field_owners = parse_kv_pairs(field_owners)
+        parsed_credentials = parse_kv_pairs(credentials)
+
+        config = _service().bind(
+            provider=provider,
+            workspace=workspace,
+            doctrine_mode=mode,
+            doctrine_field_owners=parsed_field_owners,
+            credentials=parsed_credentials,
+        )
+
+        typer.echo("Tracker binding saved")
+        typer.echo(f"- provider: {config.provider}")
+        typer.echo(f"- workspace: {config.workspace}")
+        typer.echo(f"- doctrine_mode: {config.doctrine_mode}")
+        typer.echo(f"- field_owners: {len(config.doctrine_field_owners)}")
+        typer.echo(f"- credentials_saved: {'yes' if bool(parsed_credentials) else 'no'}")
+
+    _run_or_exit(_run)
+
+
+@app.command("status")
+def status_command(as_json: bool = typer.Option(False, "--json", help="Render status as JSON")) -> None:
+    """Show tracker binding and local cache status."""
+
+    def _run() -> None:
+        payload = _service().status()
+
+        if as_json:
+            _print_json(payload)
+            return
+
+        if not payload.get("configured"):
+            typer.echo("Tracker is not configured")
+            return
+
+        typer.echo("Tracker status")
+        typer.echo(f"- provider: {payload.get('provider')}")
+        typer.echo(f"- workspace: {payload.get('workspace')}")
+        typer.echo(f"- doctrine_mode: {payload.get('doctrine_mode')}")
+        typer.echo(f"- db_path: {payload.get('db_path')}")
+        typer.echo(f"- issue_count: {payload.get('issue_count')}")
+        typer.echo(f"- mapping_count: {payload.get('mapping_count')}")
+        typer.echo(f"- credentials_present: {'yes' if payload.get('credentials_present') else 'no'}")
+
+    _run_or_exit(_run)
+
+
+@map_app.command("add")
+def map_add_command(
+    wp_id: str = typer.Option(..., "--wp-id", help="Work package ID (e.g., WP01)"),
+    external_id: str = typer.Option(..., "--external-id", help="External issue ID"),
+    external_key: str | None = typer.Option(None, "--external-key", help="External issue key"),
+    external_url: str | None = typer.Option(None, "--external-url", help="External issue URL"),
+) -> None:
+    """Add or update a local WP-to-external issue mapping."""
+
+    def _run() -> None:
+        _service().map_add(
+            wp_id=wp_id,
+            external_id=external_id,
+            external_key=external_key,
+            external_url=external_url,
+        )
+        typer.echo(f"Mapping saved: {wp_id} -> {external_id}")
+
+    _run_or_exit(_run)
+
+
+@map_app.command("list")
+def map_list_command(as_json: bool = typer.Option(False, "--json", help="Render mappings as JSON")) -> None:
+    """List local tracker mappings."""
+
+    def _run() -> None:
+        mappings = _service().map_list()
+        if as_json:
+            _print_json({"mappings": mappings})
+            return
+
+        if not mappings:
+            typer.echo("No mappings found")
+            return
+
+        typer.echo("Mappings")
+        for row in mappings:
+            key = row.get("external_key") or row.get("external_id")
+            typer.echo(f"- {row.get('wp_id')}: {row.get('system')}:{key}")
+
+    _run_or_exit(_run)
+
+
+@sync_app.command("pull")
+def sync_pull_command(
+    limit: int = typer.Option(100, "--limit", min=1, max=10000),
+    as_json: bool = typer.Option(False, "--json", help="Render sync result as JSON"),
+) -> None:
+    """Pull tracker updates into the local cache."""
+
+    def _run() -> None:
+        payload = _service().sync_pull(limit=limit)
+        if as_json:
+            _print_json(payload)
+            return
+
+        stats = payload.get("stats", {})
+        typer.echo(f"Pulled from {payload.get('provider')}")
+        typer.echo(f"- created: {stats.get('pulled_created', 0)}")
+        typer.echo(f"- updated: {stats.get('pulled_updated', 0)}")
+        typer.echo(f"- skipped: {stats.get('skipped', 0)}")
+        typer.echo(f"- conflicts: {len(payload.get('conflicts', []))}")
+        typer.echo(f"- errors: {len(payload.get('errors', []))}")
+
+    _run_or_exit(_run)
+
+
+@sync_app.command("push")
+def sync_push_command(
+    limit: int = typer.Option(100, "--limit", min=1, max=10000),
+    as_json: bool = typer.Option(False, "--json", help="Render sync result as JSON"),
+) -> None:
+    """Push local tracker changes to the upstream provider."""
+
+    def _run() -> None:
+        payload = _service().sync_push(limit=limit)
+        if as_json:
+            _print_json(payload)
+            return
+
+        stats = payload.get("stats", {})
+        typer.echo(f"Pushed to {payload.get('provider')}")
+        typer.echo(f"- created: {stats.get('pushed_created', 0)}")
+        typer.echo(f"- updated: {stats.get('pushed_updated', 0)}")
+        typer.echo(f"- skipped: {stats.get('skipped', 0)}")
+        typer.echo(f"- conflicts: {len(payload.get('conflicts', []))}")
+        typer.echo(f"- errors: {len(payload.get('errors', []))}")
+
+    _run_or_exit(_run)
+
+
+@sync_app.command("run")
+def sync_run_command(
+    limit: int = typer.Option(100, "--limit", min=1, max=10000),
+    as_json: bool = typer.Option(False, "--json", help="Render sync result as JSON"),
+) -> None:
+    """Run pull+push synchronization in one operation."""
+
+    def _run() -> None:
+        payload = _service().sync_run(limit=limit)
+        if as_json:
+            _print_json(payload)
+            return
+
+        stats = payload.get("stats", {})
+        typer.echo(f"Sync run completed ({payload.get('provider')})")
+        typer.echo(f"- pulled_created: {stats.get('pulled_created', 0)}")
+        typer.echo(f"- pulled_updated: {stats.get('pulled_updated', 0)}")
+        typer.echo(f"- pushed_created: {stats.get('pushed_created', 0)}")
+        typer.echo(f"- pushed_updated: {stats.get('pushed_updated', 0)}")
+        typer.echo(f"- skipped: {stats.get('skipped', 0)}")
+        typer.echo(f"- conflicts: {len(payload.get('conflicts', []))}")
+        typer.echo(f"- errors: {len(payload.get('errors', []))}")
+
+    _run_or_exit(_run)
+
+
+@sync_app.command("publish")
+def sync_publish_command(
+    server_url: str = typer.Option(
+        os.getenv("SAAS_API_URL", ""),
+        "--server-url",
+        help="Spec Kitty SaaS base URL",
+    ),
+    auth_token: str | None = typer.Option(
+        os.getenv("SAAS_AUTH_TOKEN") or None,
+        "--auth-token",
+        help="Bearer token for SaaS API authentication",
+    ),
+    timeout_seconds: float = typer.Option(10.0, "--timeout-seconds", min=1.0, max=120.0),
+    as_json: bool = typer.Option(False, "--json", help="Render publish result as JSON"),
+) -> None:
+    """Publish local tracker snapshot to Spec Kitty SaaS."""
+
+    def _run() -> None:
+        if not server_url.strip():
+            raise TrackerServiceError("Missing --server-url (or SAAS_API_URL)")
+
+        payload = _service().sync_publish(
+            server_url=server_url,
+            auth_token=auth_token,
+            timeout_seconds=timeout_seconds,
+        )
+
+        if as_json:
+            _print_json(payload)
+            return
+
+        typer.echo("Snapshot publish complete")
+        typer.echo(f"- endpoint: {payload.get('endpoint')}")
+        typer.echo(f"- status_code: {payload.get('status_code')}")
+        typer.echo(f"- ok: {'yes' if payload.get('ok') else 'no'}")
+        typer.echo(f"- idempotency_key: {payload.get('idempotency_key')}")
+
+    _run_or_exit(_run)
+
+
+@app.command("unbind")
+def unbind_command() -> None:
+    """Remove tracker binding and provider credentials for this project."""
+
+    def _run() -> None:
+        _service().unbind()
+        typer.echo("Tracker binding removed")
+
+    _run_or_exit(_run)

--- a/src/specify_cli/tracker/__init__.py
+++ b/src/specify_cli/tracker/__init__.py
@@ -1,0 +1,13 @@
+"""Tracker integration surface for Spec Kitty CLI."""
+
+from specify_cli.tracker.feature_flags import (
+    SAAS_SYNC_ENV_VAR,
+    is_saas_sync_enabled,
+    saas_sync_disabled_message,
+)
+
+__all__ = [
+    "SAAS_SYNC_ENV_VAR",
+    "is_saas_sync_enabled",
+    "saas_sync_disabled_message",
+]

--- a/src/specify_cli/tracker/config.py
+++ b/src/specify_cli/tracker/config.py
@@ -1,0 +1,140 @@
+"""Project-scoped tracker configuration in .kittify/config.yaml."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from specify_cli.core.paths import locate_project_root
+
+
+class TrackerConfigError(RuntimeError):
+    """Raised when tracker configuration is invalid."""
+
+
+@dataclass(slots=True)
+class TrackerProjectConfig:
+    """Tracker configuration stored inside .kittify/config.yaml."""
+
+    provider: str | None = None
+    workspace: str | None = None
+    doctrine_mode: str = "external_authoritative"
+    doctrine_field_owners: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.provider and self.workspace)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "workspace": self.workspace,
+            "doctrine": {
+                "mode": self.doctrine_mode,
+                "field_owners": dict(self.doctrine_field_owners),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object] | None) -> "TrackerProjectConfig":
+        if not isinstance(data, dict):
+            return cls()
+
+        doctrine = data.get("doctrine")
+        doctrine_mode = "external_authoritative"
+        doctrine_field_owners: dict[str, str] = {}
+        if isinstance(doctrine, dict):
+            mode_value = doctrine.get("mode")
+            if isinstance(mode_value, str) and mode_value.strip():
+                doctrine_mode = mode_value.strip()
+            field_owners = doctrine.get("field_owners")
+            if isinstance(field_owners, dict):
+                doctrine_field_owners = {
+                    str(key): str(value)
+                    for key, value in field_owners.items()
+                    if str(key).strip() and str(value).strip()
+                }
+
+        provider = data.get("provider")
+        workspace = data.get("workspace")
+        return cls(
+            provider=str(provider).strip() if isinstance(provider, str) and provider.strip() else None,
+            workspace=str(workspace).strip() if isinstance(workspace, str) and workspace.strip() else None,
+            doctrine_mode=doctrine_mode,
+            doctrine_field_owners=doctrine_field_owners,
+        )
+
+
+def require_repo_root() -> Path:
+    """Resolve the current project root or raise a user-facing error."""
+    repo_root = locate_project_root(Path.cwd())
+    if repo_root is None:
+        raise TrackerConfigError(
+            "Not inside a spec-kitty project. Run this command from a project with .kittify/."
+        )
+    return repo_root
+
+
+def _config_path(repo_root: Path) -> Path:
+    return repo_root / ".kittify" / "config.yaml"
+
+
+def load_tracker_config(repo_root: Path) -> TrackerProjectConfig:
+    """Load tracker config from .kittify/config.yaml."""
+    config_path = _config_path(repo_root)
+    if not config_path.exists():
+        return TrackerProjectConfig()
+
+    yaml = YAML()
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            payload = yaml.load(handle) or {}
+    except Exception as exc:  # pragma: no cover - defensive
+        raise TrackerConfigError(f"Failed to parse {config_path}: {exc}") from exc
+
+    tracker_data = payload.get("tracker") if isinstance(payload, dict) else None
+    return TrackerProjectConfig.from_dict(tracker_data if isinstance(tracker_data, dict) else None)
+
+
+def save_tracker_config(repo_root: Path, config: TrackerProjectConfig) -> None:
+    """Persist tracker config into .kittify/config.yaml, preserving other sections."""
+    config_path = _config_path(repo_root)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as handle:
+            payload = yaml.load(handle) or {}
+    else:
+        payload = {}
+
+    if not isinstance(payload, dict):
+        payload = {}
+
+    payload["tracker"] = config.to_dict()
+
+    with config_path.open("w", encoding="utf-8") as handle:
+        yaml.dump(payload, handle)
+
+
+def clear_tracker_config(repo_root: Path) -> None:
+    """Remove tracker config from .kittify/config.yaml if present."""
+    config_path = _config_path(repo_root)
+    if not config_path.exists():
+        return
+
+    yaml = YAML()
+    with config_path.open("r", encoding="utf-8") as handle:
+        payload = yaml.load(handle) or {}
+
+    if not isinstance(payload, dict) or "tracker" not in payload:
+        return
+
+    del payload["tracker"]
+
+    with config_path.open("w", encoding="utf-8") as handle:
+        yaml.dump(payload, handle)

--- a/src/specify_cli/tracker/credentials.py
+++ b/src/specify_cli/tracker/credentials.py
@@ -1,0 +1,159 @@
+"""Tracker credential storage in ~/.spec-kitty/credentials."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tomllib
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+try:  # pragma: no cover - optional dependency
+    import toml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    toml = None  # type: ignore[assignment]
+
+if sys.platform == "win32":
+    import msvcrt
+else:  # pragma: no cover - platform-specific
+    import fcntl
+
+
+class TrackerCredentialError(RuntimeError):
+    """Raised when credentials cannot be loaded or stored."""
+
+
+def _spec_kitty_dir() -> Path:
+    return Path.home() / ".spec-kitty"
+
+
+def _credentials_path() -> Path:
+    return _spec_kitty_dir() / "credentials"
+
+
+def _toml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_scalar(item) for item in value) + "]"
+    if value is None:
+        return '""'
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _write_toml(payload: dict[str, Any]) -> str:
+    if toml is not None:  # pragma: no branch
+        return str(toml.dumps(payload))
+
+    lines: list[str] = []
+
+    def emit_table(prefix: str, table: dict[str, Any]) -> None:
+        lines.append(f"[{prefix}]")
+        scalar_keys = sorted(key for key, value in table.items() if not isinstance(value, dict))
+        nested_keys = sorted(key for key, value in table.items() if isinstance(value, dict))
+
+        for key in scalar_keys:
+            lines.append(f"{key} = {_toml_scalar(table[key])}")
+
+        for key in nested_keys:
+            lines.append("")
+            emit_table(f"{prefix}.{key}", table[key])
+
+    root_scalar_keys = sorted(key for key, value in payload.items() if not isinstance(value, dict))
+    root_table_keys = sorted(key for key, value in payload.items() if isinstance(value, dict))
+
+    for key in root_scalar_keys:
+        lines.append(f"{key} = {_toml_scalar(payload[key])}")
+
+    for key in root_table_keys:
+        if lines:
+            lines.append("")
+        emit_table(key, payload[key])
+
+    return ("\n".join(lines).rstrip() + "\n") if lines else ""
+
+
+@contextmanager
+def _locked_file(path: Path, mode: str) -> Iterator[Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, mode, encoding="utf-8") as handle:
+        if sys.platform == "win32":
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:  # pragma: no cover - platform-specific
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield handle
+        finally:
+            if sys.platform == "win32":
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:  # pragma: no cover - platform-specific
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class TrackerCredentialStore:
+    """Store tracker provider credentials in ~/.spec-kitty/credentials."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or _credentials_path()
+
+    def load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {}
+
+        try:
+            with _locked_file(self.path, "r") as handle:
+                raw = handle.read()
+            payload = tomllib.loads(raw) if raw.strip() else {}
+        except Exception as exc:  # pragma: no cover - defensive
+            raise TrackerCredentialError(f"Failed to load credentials: {exc}") from exc
+
+        return payload if isinstance(payload, dict) else {}
+
+    def save(self, payload: dict[str, Any]) -> None:
+        try:
+            with _locked_file(self.path, "w") as handle:
+                handle.write(_write_toml(payload))
+            if os.name != "nt":
+                os.chmod(self.path, 0o600)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise TrackerCredentialError(f"Failed to save credentials: {exc}") from exc
+
+    def get_provider(self, provider: str) -> dict[str, Any]:
+        payload = self.load()
+        tracker = payload.get("tracker") if isinstance(payload, dict) else None
+        providers = tracker.get("providers") if isinstance(tracker, dict) else None
+        provider_payload = providers.get(provider) if isinstance(providers, dict) else None
+        return dict(provider_payload) if isinstance(provider_payload, dict) else {}
+
+    def set_provider(self, provider: str, values: dict[str, Any]) -> None:
+        payload = self.load()
+        tracker = payload.setdefault("tracker", {})
+        if not isinstance(tracker, dict):
+            tracker = {}
+            payload["tracker"] = tracker
+
+        providers = tracker.setdefault("providers", {})
+        if not isinstance(providers, dict):
+            providers = {}
+            tracker["providers"] = providers
+
+        providers[provider] = {
+            str(key): value
+            for key, value in values.items()
+            if str(key).strip() and value is not None and str(value).strip()
+        }
+        self.save(payload)
+
+    def clear_provider(self, provider: str) -> None:
+        payload = self.load()
+        tracker = payload.get("tracker") if isinstance(payload, dict) else None
+        providers = tracker.get("providers") if isinstance(tracker, dict) else None
+        if not isinstance(providers, dict) or provider not in providers:
+            return
+
+        del providers[provider]
+        self.save(payload)

--- a/src/specify_cli/tracker/factory.py
+++ b/src/specify_cli/tracker/factory.py
@@ -1,0 +1,137 @@
+"""Connector factory for spec-kitty tracker integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class TrackerFactoryError(RuntimeError):
+    """Raised when connector construction fails."""
+
+
+SUPPORTED_PROVIDERS: tuple[str, ...] = (
+    "jira",
+    "linear",
+    "azure_devops",
+    "github",
+    "gitlab",
+    "beads",
+    "fp",
+)
+
+_PROVIDER_ALIASES = {
+    "azure-devops": "azure_devops",
+    "azure": "azure_devops",
+}
+
+
+def normalize_provider(provider: str) -> str:
+    key = provider.strip().lower()
+    return _PROVIDER_ALIASES.get(key, key)
+
+
+def _require(values: Mapping[str, Any], key: str, provider: str) -> str:
+    value = values.get(key)
+    if value is None or not str(value).strip():
+        raise TrackerFactoryError(f"Missing required credential '{key}' for provider '{provider}'")
+    return str(value).strip()
+
+
+def build_connector(
+    *,
+    provider: str,
+    workspace: str,
+    credentials: Mapping[str, Any],
+) -> Any:
+    """Build a TaskTrackerConnector instance from provider+credentials."""
+    provider_name = normalize_provider(provider)
+    if provider_name not in SUPPORTED_PROVIDERS:
+        raise TrackerFactoryError(
+            f"Unsupported provider '{provider}'. Supported: {', '.join(SUPPORTED_PROVIDERS)}"
+        )
+
+    try:
+        from spec_kitty_tracker import (
+            AzureDevOpsConnector,
+            AzureDevOpsConnectorConfig,
+            BeadsConnector,
+            BeadsConnectorConfig,
+            FPConnector,
+            FPConnectorConfig,
+            GitHubConnector,
+            GitHubConnectorConfig,
+            GitLabConnector,
+            GitLabConnectorConfig,
+            JiraConnector,
+            JiraConnectorConfig,
+            LinearConnector,
+            LinearConnectorConfig,
+        )
+    except Exception as exc:  # pragma: no cover - dependency boundary
+        raise TrackerFactoryError(
+            "spec-kitty-tracker is not installed. Install it to use tracker commands."
+        ) from exc
+
+    if provider_name == "jira":
+        config = JiraConnectorConfig(
+            base_url=_require(credentials, "base_url", provider_name),
+            email=_require(credentials, "email", provider_name),
+            api_token=_require(credentials, "api_token", provider_name),
+            project_key=_require(credentials, "project_key", provider_name),
+        )
+        return JiraConnector(config)
+
+    if provider_name == "linear":
+        config = LinearConnectorConfig(
+            api_key=_require(credentials, "api_key", provider_name),
+            team_id=_require(credentials, "team_id", provider_name),
+            workspace=workspace,
+            graphql_url=str(credentials.get("graphql_url") or "https://api.linear.app/graphql"),
+        )
+        return LinearConnector(config)
+
+    if provider_name == "azure_devops":
+        pat = credentials.get("personal_access_token") or credentials.get("pat")
+        config = AzureDevOpsConnectorConfig(
+            organization=_require(credentials, "organization", provider_name),
+            project=_require(credentials, "project", provider_name),
+            personal_access_token=_require({"personal_access_token": pat}, "personal_access_token", provider_name),
+            base_url=str(credentials.get("base_url") or "https://dev.azure.com"),
+        )
+        return AzureDevOpsConnector(config)
+
+    if provider_name == "github":
+        config = GitHubConnectorConfig(
+            owner=_require(credentials, "owner", provider_name),
+            repo=_require(credentials, "repo", provider_name),
+            token=_require(credentials, "token", provider_name),
+            base_url=str(credentials.get("base_url") or "https://api.github.com"),
+        )
+        return GitHubConnector(config)
+
+    if provider_name == "gitlab":
+        config = GitLabConnectorConfig(
+            project_id=_require(credentials, "project_id", provider_name),
+            token=_require(credentials, "token", provider_name),
+            base_url=str(credentials.get("base_url") or "https://gitlab.com/api/v4"),
+        )
+        return GitLabConnector(config)
+
+    if provider_name == "beads":
+        config = BeadsConnectorConfig(
+            workspace=workspace,
+            command=str(credentials.get("command") or "bd"),
+            cwd=str(credentials.get("cwd")) if credentials.get("cwd") else None,
+        )
+        return BeadsConnector(config)
+
+    if provider_name == "fp":
+        config = FPConnectorConfig(
+            workspace=workspace,
+            command=str(credentials.get("command") or "fp"),
+            cwd=str(credentials.get("cwd")) if credentials.get("cwd") else None,
+        )
+        return FPConnector(config)
+
+    raise TrackerFactoryError(f"Unhandled provider: {provider_name}")

--- a/src/specify_cli/tracker/feature_flags.py
+++ b/src/specify_cli/tracker/feature_flags.py
@@ -1,0 +1,22 @@
+"""Feature flags for tracker integration."""
+
+from __future__ import annotations
+
+import os
+
+SAAS_SYNC_ENV_VAR = "SPEC_KITTY_ENABLE_SAAS_SYNC"
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_saas_sync_enabled() -> bool:
+    """Return True when SaaS connectivity is explicitly enabled."""
+    raw_value = os.getenv(SAAS_SYNC_ENV_VAR, "")
+    return raw_value.strip().lower() in _TRUTHY_VALUES
+
+
+def saas_sync_disabled_message() -> str:
+    """Return a consistent operator-facing message for disabled SaaS sync."""
+    return (
+        "SaaS sync is disabled by feature flag. "
+        f"Set {SAAS_SYNC_ENV_VAR}=1 to enable."
+    )

--- a/src/specify_cli/tracker/service.py
+++ b/src/specify_cli/tracker/service.py
@@ -1,0 +1,369 @@
+"""High-level tracker orchestration for CLI commands."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import httpx
+from ruamel.yaml import YAML
+
+from specify_cli.tracker.config import (
+    TrackerProjectConfig,
+    clear_tracker_config,
+    load_tracker_config,
+    save_tracker_config,
+)
+from specify_cli.tracker.credentials import TrackerCredentialStore
+from specify_cli.tracker.factory import SUPPORTED_PROVIDERS, build_connector, normalize_provider
+from specify_cli.tracker.store import TrackerSqliteStore, default_tracker_db_path
+
+
+class TrackerServiceError(RuntimeError):
+    """Raised when tracker service operations fail."""
+
+
+def parse_kv_pairs(entries: list[str]) -> dict[str, str]:
+    """Parse repeated key=value CLI arguments into a dictionary."""
+    parsed: dict[str, str] = {}
+    for entry in entries:
+        if "=" not in entry:
+            raise TrackerServiceError(f"Invalid --credential value '{entry}'. Expected key=value.")
+        key, value = entry.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise TrackerServiceError(f"Invalid --credential value '{entry}'. Expected key=value.")
+        parsed[key] = value
+    return parsed
+
+
+class TrackerService:
+    """Service wrapper around config, credentials, store and connector sync."""
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root
+        self.credential_store = TrackerCredentialStore()
+
+    @staticmethod
+    def supported_providers() -> tuple[str, ...]:
+        return SUPPORTED_PROVIDERS
+
+    def bind(
+        self,
+        *,
+        provider: str,
+        workspace: str,
+        doctrine_mode: str,
+        doctrine_field_owners: dict[str, str],
+        credentials: dict[str, str],
+    ) -> TrackerProjectConfig:
+        normalized_provider = normalize_provider(provider)
+        config = TrackerProjectConfig(
+            provider=normalized_provider,
+            workspace=workspace,
+            doctrine_mode=doctrine_mode,
+            doctrine_field_owners=dict(doctrine_field_owners),
+        )
+        save_tracker_config(self.repo_root, config)
+
+        if credentials:
+            self.credential_store.set_provider(normalized_provider, credentials)
+
+        return config
+
+    def unbind(self) -> None:
+        config = load_tracker_config(self.repo_root)
+        if config.provider:
+            self.credential_store.clear_provider(config.provider)
+        clear_tracker_config(self.repo_root)
+
+    def status(self) -> dict[str, Any]:
+        config = load_tracker_config(self.repo_root)
+        if not config.is_configured:
+            return {
+                "configured": False,
+                "provider": None,
+                "workspace": None,
+                "db_path": None,
+                "issue_count": 0,
+                "mapping_count": 0,
+            }
+
+        credentials = self.credential_store.get_provider(config.provider or "")
+        db_path = self._resolve_db_path(config, credentials)
+        store = TrackerSqliteStore(db_path)
+
+        issues = self._run_async(store.list_issues(system=config.provider))
+        mappings = store.list_mappings()
+
+        return {
+            "configured": True,
+            "provider": config.provider,
+            "workspace": config.workspace,
+            "doctrine_mode": config.doctrine_mode,
+            "field_owners": config.doctrine_field_owners,
+            "db_path": str(db_path),
+            "issue_count": len(issues),
+            "mapping_count": len(mappings),
+            "credentials_present": bool(credentials),
+        }
+
+    def map_add(
+        self,
+        *,
+        wp_id: str,
+        external_id: str,
+        external_key: str | None,
+        external_url: str | None,
+    ) -> None:
+        try:
+            from spec_kitty_tracker.models import ExternalRef
+        except Exception as exc:  # pragma: no cover - dependency boundary
+            raise TrackerServiceError(
+                "spec-kitty-tracker is not installed. Install it to use tracker commands."
+            ) from exc
+
+        config, credentials, store = self._load_runtime()
+        ref = ExternalRef(
+            system=str(config.provider),
+            workspace=str(config.workspace),
+            id=external_id,
+            key=external_key,
+            url=external_url,
+        )
+        store.upsert_mapping(wp_id=wp_id, ref=ref)
+
+    def map_list(self) -> list[dict[str, Any]]:
+        _, _, store = self._load_runtime()
+        return store.list_mappings()
+
+    def sync_pull(self, *, limit: int = 100) -> dict[str, Any]:
+        config, credentials, store = self._load_runtime()
+
+        async def _run() -> dict[str, Any]:
+            connector, engine = self._build_engine(config, credentials, store)
+            checkpoint = store.get_checkpoint(checkpoint_key=f"{config.provider}:{config.workspace}")
+            if checkpoint is not None:
+                setattr(engine, "_checkpoint", checkpoint)
+
+            result = await engine.pull(limit=limit)
+            store.set_checkpoint(engine.checkpoint, checkpoint_key=f"{config.provider}:{config.workspace}")
+            return self._sync_result(result, connector.name)
+
+        return self._run_async(_run())
+
+    def sync_push(self, *, limit: int = 100) -> dict[str, Any]:
+        config, credentials, store = self._load_runtime()
+
+        async def _run() -> dict[str, Any]:
+            connector, engine = self._build_engine(config, credentials, store)
+            result = await engine.push(limit=limit)
+            return self._sync_result(result, connector.name)
+
+        return self._run_async(_run())
+
+    def sync_run(self, *, limit: int = 100) -> dict[str, Any]:
+        config, credentials, store = self._load_runtime()
+
+        async def _run() -> dict[str, Any]:
+            connector, engine = self._build_engine(config, credentials, store)
+            checkpoint = store.get_checkpoint(checkpoint_key=f"{config.provider}:{config.workspace}")
+            if checkpoint is not None:
+                setattr(engine, "_checkpoint", checkpoint)
+
+            result = await engine.sync(limit=limit)
+            store.set_checkpoint(engine.checkpoint, checkpoint_key=f"{config.provider}:{config.workspace}")
+            return self._sync_result(result, connector.name)
+
+        return self._run_async(_run())
+
+    def sync_publish(
+        self,
+        *,
+        server_url: str,
+        auth_token: str | None = None,
+        timeout_seconds: float = 10.0,
+    ) -> dict[str, Any]:
+        config, credentials, store = self._load_runtime()
+
+        provider = str(config.provider)
+        workspace = str(config.workspace)
+        issues = self._run_async(store.list_issues(system=provider))
+        mappings = store.list_mappings()
+        checkpoint = store.get_checkpoint(checkpoint_key=f"{provider}:{workspace}")
+
+        project_identity = self._project_identity()
+
+        payload = {
+            "provider": provider,
+            "workspace": workspace,
+            "doctrine_mode": config.doctrine_mode,
+            "doctrine_field_owners": dict(config.doctrine_field_owners),
+            "project_uuid": project_identity.get("uuid"),
+            "project_slug": project_identity.get("slug"),
+            "issues": [self._issue_snapshot(issue) for issue in issues],
+            "mappings": mappings,
+            "checkpoint": {
+                "cursor": checkpoint.cursor if checkpoint else None,
+                "updated_since": checkpoint.updated_since.isoformat() if checkpoint and checkpoint.updated_since else None,
+            },
+        }
+
+        endpoint = server_url.rstrip("/") + "/api/v1/connectors/trackers/snapshots/"
+        idempotency_key = hashlib.sha256(
+            f"{provider}|{workspace}|{len(issues)}|{len(mappings)}|{payload['checkpoint']['cursor']}".encode("utf-8")
+        ).hexdigest()
+
+        token = auth_token or str(credentials.get("access_token") or credentials.get("token") or "").strip()
+        headers = {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotency_key,
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        with httpx.Client(timeout=timeout_seconds) as client:
+            response = client.post(endpoint, json=payload, headers=headers)
+
+        content_type = response.headers.get("content-type", "")
+        body: Any
+        if "application/json" in content_type:
+            body = response.json()
+        else:
+            body = response.text
+
+        return {
+            "endpoint": endpoint,
+            "status_code": response.status_code,
+            "ok": response.is_success,
+            "body": body,
+            "idempotency_key": idempotency_key,
+        }
+
+    def _load_runtime(self) -> tuple[TrackerProjectConfig, dict[str, Any], TrackerSqliteStore]:
+        config = load_tracker_config(self.repo_root)
+        if not config.is_configured:
+            raise TrackerServiceError("Tracker is not configured. Run 'spec-kitty tracker bind' first.")
+
+        if config.provider is None or config.workspace is None:
+            raise TrackerServiceError("Tracker provider/workspace configuration is incomplete.")
+
+        credentials = self.credential_store.get_provider(config.provider)
+        db_path = self._resolve_db_path(config, credentials)
+        store = TrackerSqliteStore(db_path)
+        return config, credentials, store
+
+    def _resolve_db_path(self, config: TrackerProjectConfig, credentials: dict[str, Any]) -> Path:
+        server_url = str(credentials.get("server_url") or credentials.get("base_url") or "")
+        username = str(credentials.get("username") or credentials.get("email") or "")
+        team_slug = str(credentials.get("team_slug") or "")
+        return default_tracker_db_path(
+            provider=str(config.provider),
+            workspace=str(config.workspace),
+            server_url=server_url,
+            username=username,
+            team_slug=team_slug,
+        )
+
+    def _build_engine(self, config: TrackerProjectConfig, credentials: dict[str, Any], store: TrackerSqliteStore) -> Any:
+        try:
+            from spec_kitty_tracker import FieldOwner, OwnershipMode, OwnershipPolicy, SyncEngine
+        except Exception as exc:  # pragma: no cover - dependency boundary
+            raise TrackerServiceError(
+                "spec-kitty-tracker is not installed. Install it to use tracker commands."
+            ) from exc
+
+        connector = build_connector(
+            provider=str(config.provider),
+            workspace=str(config.workspace),
+            credentials=credentials,
+        )
+
+        mode_name = (config.doctrine_mode or "external_authoritative").strip().lower()
+        if mode_name == OwnershipMode.EXTERNAL_AUTHORITATIVE.value:
+            policy = OwnershipPolicy.external_authoritative()
+        elif mode_name == OwnershipMode.SPEC_KITTY_AUTHORITATIVE.value:
+            policy = OwnershipPolicy.local_authoritative()
+        else:
+            field_owners = {
+                field: FieldOwner(owner)
+                for field, owner in config.doctrine_field_owners.items()
+                if owner in {item.value for item in FieldOwner}
+            }
+            policy = OwnershipPolicy.split(field_owners=field_owners, default_owner=FieldOwner.SHARED)
+
+        engine = SyncEngine(connector=connector, store=store, policy=policy)
+        return connector, engine
+
+    @staticmethod
+    def _issue_snapshot(issue: Any) -> dict[str, Any]:
+        return {
+            "ref": {
+                "system": issue.ref.system,
+                "workspace": issue.ref.workspace,
+                "id": issue.ref.id,
+                "key": issue.ref.key,
+                "url": issue.ref.url,
+            },
+            "title": issue.title,
+            "body": issue.body,
+            "status": issue.status.value,
+            "issue_type": issue.issue_type.value,
+            "priority": issue.priority,
+            "assignees": list(issue.assignees),
+            "labels": list(issue.labels),
+            "updated_at": issue.updated_at.isoformat() if issue.updated_at else None,
+        }
+
+    @staticmethod
+    def _sync_result(result: Any, provider_name: str) -> dict[str, Any]:
+        return {
+            "provider": provider_name,
+            "stats": {
+                "pulled_created": result.stats.pulled_created,
+                "pulled_updated": result.stats.pulled_updated,
+                "pushed_created": result.stats.pushed_created,
+                "pushed_updated": result.stats.pushed_updated,
+                "skipped": result.stats.skipped,
+            },
+            "conflicts": [
+                {
+                    "field_name": conflict.field_name,
+                    "strategy": conflict.strategy.value,
+                    "manual_review_required": conflict.manual_review_required,
+                }
+                for conflict in result.conflicts
+            ],
+            "errors": list(result.errors),
+        }
+
+    def _project_identity(self) -> dict[str, str | None]:
+        config_path = self.repo_root / ".kittify" / "config.yaml"
+        if not config_path.exists():
+            return {"uuid": None, "slug": None}
+
+        yaml = YAML()
+        try:
+            with config_path.open("r", encoding="utf-8") as handle:
+                payload = yaml.load(handle) or {}
+        except Exception:
+            return {"uuid": None, "slug": None}
+
+        project = payload.get("project") if isinstance(payload, dict) else None
+        if not isinstance(project, dict):
+            return {"uuid": None, "slug": None}
+
+        uuid = project.get("uuid")
+        slug = project.get("slug")
+        return {
+            "uuid": str(uuid) if uuid is not None else None,
+            "slug": str(slug) if slug is not None else None,
+        }
+
+    @staticmethod
+    def _run_async(awaitable: Any) -> Any:
+        import asyncio
+
+        return asyncio.run(awaitable)

--- a/src/specify_cli/tracker/store.py
+++ b/src/specify_cli/tracker/store.py
@@ -1,0 +1,507 @@
+"""CLI-owned SQLite cache/checkpoint storage for tracker sync."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+
+def _spec_kitty_dir() -> Path:
+    return Path.home() / ".spec-kitty"
+
+
+def _trackers_dir() -> Path:
+    return _spec_kitty_dir() / "trackers"
+
+
+_TRACKER_MODELS: dict[str, Any] | None | bool = False
+
+
+def _get_tracker_models() -> dict[str, Any] | None:
+    global _TRACKER_MODELS
+    if _TRACKER_MODELS is False:
+        try:
+            from spec_kitty_tracker.models import (
+                CanonicalIssue,
+                CanonicalIssueType,
+                CanonicalLink,
+                CanonicalStatus,
+                ExternalRef,
+                LinkType,
+                SyncCheckpoint,
+            )
+
+            _TRACKER_MODELS = {
+                "CanonicalIssue": CanonicalIssue,
+                "CanonicalIssueType": CanonicalIssueType,
+                "CanonicalLink": CanonicalLink,
+                "CanonicalStatus": CanonicalStatus,
+                "ExternalRef": ExternalRef,
+                "LinkType": LinkType,
+                "SyncCheckpoint": SyncCheckpoint,
+            }
+        except Exception:
+            _TRACKER_MODELS = None
+
+    return _TRACKER_MODELS if isinstance(_TRACKER_MODELS, dict) else None
+
+
+def _read_attr(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _enum_value(value: Any, default: str) -> str:
+    if value is None:
+        return default
+    enum_val = getattr(value, "value", None)
+    if enum_val is not None:
+        return str(enum_val)
+    return str(value)
+
+
+def _ref_identity(ref: Any) -> str:
+    identity = _read_attr(ref, "identity")
+    if isinstance(identity, str) and identity.strip():
+        return identity
+
+    system = str(_read_attr(ref, "system", "")).strip()
+    workspace = str(_read_attr(ref, "workspace", "")).strip()
+    issue_id = str(_read_attr(ref, "id", "")).strip()
+    if not (system and workspace and issue_id):
+        raise ValueError("External reference must include system, workspace, and id")
+    return f"{system}:{workspace}:{issue_id}"
+
+
+def build_tracker_scope(
+    *,
+    provider: str,
+    workspace: str,
+    server_url: str | None,
+    username: str | None,
+    team_slug: str | None,
+) -> str:
+    server = (server_url or "local").strip().lower()
+    user = (username or "anonymous").strip().lower()
+    team = (team_slug or "no-team").strip().lower()
+    identity = f"{provider.strip().lower()}|{workspace.strip().lower()}|{server}|{user}|{team}"
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+
+
+def default_tracker_db_path(
+    *,
+    provider: str,
+    workspace: str,
+    server_url: str | None = None,
+    username: str | None = None,
+    team_slug: str | None = None,
+) -> Path:
+    scope = build_tracker_scope(
+        provider=provider,
+        workspace=workspace,
+        server_url=server_url,
+        username=username,
+        team_slug=team_slug,
+    )
+    return _trackers_dir() / f"{scope}.db"
+
+
+def _serialize_ref(ref: Any) -> dict[str, Any]:
+    if isinstance(ref, dict):
+        payload = ref
+    else:
+        payload = {
+            "system": _read_attr(ref, "system"),
+            "workspace": _read_attr(ref, "workspace"),
+            "id": _read_attr(ref, "id"),
+            "key": _read_attr(ref, "key"),
+            "url": _read_attr(ref, "url"),
+        }
+
+    return {
+        "system": str(payload.get("system") or ""),
+        "workspace": str(payload.get("workspace") or ""),
+        "id": str(payload.get("id") or ""),
+        "key": str(payload["key"]) if payload.get("key") is not None else None,
+        "url": str(payload["url"]) if payload.get("url") is not None else None,
+    }
+
+
+def _deserialize_ref(payload: dict[str, Any]) -> Any:
+    models = _get_tracker_models()
+    if models is None:
+        return {
+            "system": str(payload.get("system") or ""),
+            "workspace": str(payload.get("workspace") or ""),
+            "id": str(payload.get("id") or ""),
+            "key": str(payload["key"]) if payload.get("key") is not None else None,
+            "url": str(payload["url"]) if payload.get("url") is not None else None,
+            "identity": f"{payload.get('system','')}:{payload.get('workspace','')}:{payload.get('id','')}",
+        }
+
+    ExternalRef = models["ExternalRef"]
+    return ExternalRef(
+        system=str(payload.get("system") or ""),
+        workspace=str(payload.get("workspace") or ""),
+        id=str(payload.get("id") or ""),
+        key=str(payload["key"]) if payload.get("key") is not None else None,
+        url=str(payload["url"]) if payload.get("url") is not None else None,
+    )
+
+
+def _serialize_issue(issue: Any) -> dict[str, Any]:
+    ref = _serialize_ref(_read_attr(issue, "ref", {}))
+
+    links: list[dict[str, Any]] = []
+    for link in list(_read_attr(issue, "links", []) or []):
+        links.append(
+            {
+                "type": _enum_value(_read_attr(link, "type"), "relates_to"),
+                "target": _serialize_ref(_read_attr(link, "target", {})),
+            }
+        )
+
+    parent_raw = _read_attr(issue, "parent")
+    parent = _serialize_ref(parent_raw) if parent_raw is not None else None
+
+    created_at = _read_attr(issue, "created_at")
+    updated_at = _read_attr(issue, "updated_at")
+
+    return {
+        "ref": ref,
+        "title": str(_read_attr(issue, "title", "Untitled")),
+        "body": _read_attr(issue, "body"),
+        "status": _enum_value(_read_attr(issue, "status"), "todo"),
+        "issue_type": _enum_value(_read_attr(issue, "issue_type"), "task"),
+        "priority": _read_attr(issue, "priority"),
+        "assignees": [str(item) for item in list(_read_attr(issue, "assignees", []) or [])],
+        "labels": [str(item) for item in list(_read_attr(issue, "labels", []) or [])],
+        "parent": parent,
+        "links": links,
+        "custom_fields": dict(_read_attr(issue, "custom_fields", {}) or {}),
+        "created_at": created_at.isoformat() if isinstance(created_at, datetime) else None,
+        "updated_at": updated_at.isoformat() if isinstance(updated_at, datetime) else None,
+        "raw": _read_attr(issue, "raw"),
+    }
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _deserialize_issue(payload: dict[str, Any]) -> Any:
+    models = _get_tracker_models()
+    if models is None:
+        return payload
+
+    CanonicalIssue = models["CanonicalIssue"]
+    CanonicalIssueType = models["CanonicalIssueType"]
+    CanonicalLink = models["CanonicalLink"]
+    CanonicalStatus = models["CanonicalStatus"]
+    LinkType = models["LinkType"]
+
+    def safe_enum(enum_cls: Any, value: str, fallback: Any) -> Any:
+        try:
+            return enum_cls(value)
+        except Exception:
+            return fallback
+
+    links_payload = payload.get("links")
+    links: list[Any] = []
+    if isinstance(links_payload, list):
+        for entry in links_payload:
+            if not isinstance(entry, dict):
+                continue
+            target_payload = entry.get("target")
+            if not isinstance(target_payload, dict):
+                continue
+            links.append(
+                CanonicalLink(
+                    type=safe_enum(LinkType, str(entry.get("type", LinkType.RELATES_TO.value)), LinkType.RELATES_TO),
+                    target=_deserialize_ref(target_payload),
+                )
+            )
+
+    parent_payload = payload.get("parent")
+    parent = _deserialize_ref(parent_payload) if isinstance(parent_payload, dict) else None
+
+    custom_fields = payload.get("custom_fields")
+    raw = payload.get("raw")
+
+    priority_raw = payload.get("priority")
+    priority = int(priority_raw) if isinstance(priority_raw, int) or str(priority_raw).isdigit() else None
+
+    return CanonicalIssue(
+        ref=_deserialize_ref(payload["ref"]),
+        title=str(payload.get("title") or "Untitled"),
+        body=str(payload["body"]) if payload.get("body") is not None else None,
+        status=safe_enum(CanonicalStatus, str(payload.get("status", CanonicalStatus.TODO.value)), CanonicalStatus.TODO),
+        issue_type=safe_enum(
+            CanonicalIssueType,
+            str(payload.get("issue_type", CanonicalIssueType.TASK.value)),
+            CanonicalIssueType.TASK,
+        ),
+        priority=priority,
+        assignees=[str(item) for item in payload.get("assignees", [])],
+        labels=[str(item) for item in payload.get("labels", [])],
+        parent=parent,
+        links=links,
+        custom_fields=dict(custom_fields) if isinstance(custom_fields, dict) else {},
+        created_at=_parse_datetime(payload.get("created_at")),
+        updated_at=_parse_datetime(payload.get("updated_at")),
+        raw=dict(raw) if isinstance(raw, dict) else None,
+    )
+
+
+class TrackerSqliteStore:
+    """SQLite-backed issue cache/checkpoint/mapping store for CLI."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tracker_issues (
+                    identity TEXT PRIMARY KEY,
+                    system TEXT NOT NULL,
+                    workspace TEXT NOT NULL,
+                    issue_id TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    updated_at TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tracker_checkpoints (
+                    checkpoint_key TEXT PRIMARY KEY,
+                    cursor TEXT,
+                    updated_since TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tracker_mappings (
+                    wp_id TEXT NOT NULL,
+                    system TEXT NOT NULL,
+                    workspace TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    external_key TEXT,
+                    external_url TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (wp_id, system),
+                    UNIQUE (system, workspace, external_id)
+                )
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    async def list_issues(self, *, system: str | None = None) -> Sequence[Any]:
+        conn = self._connect()
+        try:
+            if system is None:
+                cursor = conn.execute("SELECT payload FROM tracker_issues ORDER BY identity ASC")
+            else:
+                cursor = conn.execute(
+                    "SELECT payload FROM tracker_issues WHERE system = ? ORDER BY identity ASC",
+                    (system,),
+                )
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
+
+        results: list[Any] = []
+        for row in rows:
+            payload = json.loads(str(row["payload"]))
+            results.append(_deserialize_issue(payload))
+        return results
+
+    async def get_issue(self, ref: Any) -> Any | None:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT payload FROM tracker_issues WHERE identity = ?",
+                (_ref_identity(ref),),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return None
+        payload = json.loads(str(row["payload"]))
+        return _deserialize_issue(payload)
+
+    async def upsert_issue(self, issue: Any) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        payload = json.dumps(_serialize_issue(issue), separators=(",", ":"))
+        ref = _read_attr(issue, "ref", {})
+
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO tracker_issues(identity, system, workspace, issue_id, payload, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?)
+                ON CONFLICT(identity) DO UPDATE SET
+                    system = excluded.system,
+                    workspace = excluded.workspace,
+                    issue_id = excluded.issue_id,
+                    payload = excluded.payload,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    _ref_identity(ref),
+                    str(_read_attr(ref, "system", "")),
+                    str(_read_attr(ref, "workspace", "")),
+                    str(_read_attr(ref, "id", "")),
+                    payload,
+                    now,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    async def delete_issue(self, ref: Any) -> None:
+        conn = self._connect()
+        try:
+            conn.execute("DELETE FROM tracker_issues WHERE identity = ?", (_ref_identity(ref),))
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_checkpoint(self, checkpoint_key: str = "default") -> Any | None:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT cursor, updated_since FROM tracker_checkpoints WHERE checkpoint_key = ?",
+                (checkpoint_key,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return None
+
+        cursor = str(row["cursor"]) if row["cursor"] is not None else None
+        updated_since = _parse_datetime(row["updated_since"])
+
+        models = _get_tracker_models()
+        if models is None:
+            return {
+                "cursor": cursor,
+                "updated_since": updated_since,
+            }
+
+        SyncCheckpoint = models["SyncCheckpoint"]
+        return SyncCheckpoint(
+            cursor=cursor,
+            updated_since=updated_since,
+        )
+
+    def set_checkpoint(self, checkpoint: Any, checkpoint_key: str = "default") -> None:
+        cursor = _read_attr(checkpoint, "cursor")
+        updated_since = _read_attr(checkpoint, "updated_since")
+
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO tracker_checkpoints(checkpoint_key, cursor, updated_since)
+                VALUES(?, ?, ?)
+                ON CONFLICT(checkpoint_key) DO UPDATE SET
+                    cursor = excluded.cursor,
+                    updated_since = excluded.updated_since
+                """,
+                (
+                    checkpoint_key,
+                    str(cursor) if cursor is not None else None,
+                    updated_since.isoformat() if isinstance(updated_since, datetime) else None,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def upsert_mapping(self, *, wp_id: str, ref: Any) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO tracker_mappings(
+                    wp_id, system, workspace, external_id, external_key, external_url, created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(wp_id, system) DO UPDATE SET
+                    workspace = excluded.workspace,
+                    external_id = excluded.external_id,
+                    external_key = excluded.external_key,
+                    external_url = excluded.external_url,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    wp_id,
+                    str(_read_attr(ref, "system", "")),
+                    str(_read_attr(ref, "workspace", "")),
+                    str(_read_attr(ref, "id", "")),
+                    str(_read_attr(ref, "key")) if _read_attr(ref, "key") is not None else None,
+                    str(_read_attr(ref, "url")) if _read_attr(ref, "url") is not None else None,
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_mappings(self) -> list[dict[str, Any]]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT wp_id, system, workspace, external_id, external_key, external_url, created_at, updated_at
+                FROM tracker_mappings
+                ORDER BY wp_id ASC, system ASC
+                """
+            ).fetchall()
+        finally:
+            conn.close()
+
+        return [
+            {
+                "wp_id": str(row["wp_id"]),
+                "system": str(row["system"]),
+                "workspace": str(row["workspace"]),
+                "external_id": str(row["external_id"]),
+                "external_key": str(row["external_key"]) if row["external_key"] is not None else None,
+                "external_url": str(row["external_url"]) if row["external_url"] is not None else None,
+                "created_at": str(row["created_at"]),
+                "updated_at": str(row["updated_at"]),
+            }
+            for row in rows
+        ]

--- a/tests/specify_cli/cli/commands/test_tracker.py
+++ b/tests/specify_cli/cli/commands/test_tracker.py
@@ -1,0 +1,53 @@
+"""Tests for tracker command registration and gating."""
+
+from __future__ import annotations
+
+import importlib
+
+import typer
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _build_root_app(*, enabled: bool, monkeypatch) -> typer.Typer:
+    if enabled:
+        monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+    else:
+        monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
+
+    import specify_cli.cli.commands as commands_module
+
+    commands_module = importlib.reload(commands_module)
+    app = typer.Typer()
+    commands_module.register_commands(app)
+    return app
+
+
+def test_tracker_not_registered_when_flag_disabled(monkeypatch) -> None:
+    app = _build_root_app(enabled=False, monkeypatch=monkeypatch)
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "tracker" not in result.output
+
+
+def test_tracker_registered_when_flag_enabled(monkeypatch) -> None:
+    app = _build_root_app(enabled=True, monkeypatch=monkeypatch)
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "tracker" in result.output
+
+
+def test_tracker_direct_invocation_fails_when_flag_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
+
+    from specify_cli.cli.commands import tracker as tracker_module
+
+    result = runner.invoke(tracker_module.app, ["providers"])
+
+    assert result.exit_code == 1
+    assert "SaaS sync is disabled by feature flag" in result.output

--- a/tests/specify_cli/tracker/test_credentials.py
+++ b/tests/specify_cli/tracker/test_credentials.py
@@ -1,0 +1,47 @@
+"""Tests for tracker credential storage."""
+
+from __future__ import annotations
+
+import os
+
+from specify_cli.tracker.credentials import TrackerCredentialStore
+
+
+def test_provider_credentials_round_trip(tmp_path) -> None:
+    path = tmp_path / "credentials"
+    store = TrackerCredentialStore(path)
+
+    store.set_provider(
+        "jira",
+        {
+            "base_url": "https://jira.example.com",
+            "email": "alice@example.com",
+            "api_token": "secret",
+        },
+    )
+
+    loaded = store.get_provider("jira")
+    assert loaded["base_url"] == "https://jira.example.com"
+    assert loaded["email"] == "alice@example.com"
+    assert loaded["api_token"] == "secret"
+
+
+def test_provider_credentials_clear(tmp_path) -> None:
+    path = tmp_path / "credentials"
+    store = TrackerCredentialStore(path)
+
+    store.set_provider("linear", {"api_key": "token", "team_id": "team-1"})
+    assert store.get_provider("linear")
+
+    store.clear_provider("linear")
+    assert store.get_provider("linear") == {}
+
+
+def test_credentials_file_permissions_posix(tmp_path) -> None:
+    path = tmp_path / "credentials"
+    store = TrackerCredentialStore(path)
+    store.set_provider("github", {"token": "abc", "owner": "org", "repo": "repo"})
+
+    if os.name != "nt":
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600

--- a/tests/specify_cli/tracker/test_store.py
+++ b/tests/specify_cli/tracker/test_store.py
@@ -1,0 +1,106 @@
+"""Tests for tracker SQLite store behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+from specify_cli.tracker.store import TrackerSqliteStore, default_tracker_db_path
+
+
+async def _upsert(store: TrackerSqliteStore, issue: dict) -> None:
+    await store.upsert_issue(issue)
+
+
+async def _list(store: TrackerSqliteStore, system: str | None = None):
+    return await store.list_issues(system=system)
+
+
+async def _delete(store: TrackerSqliteStore, ref: dict) -> None:
+    await store.delete_issue(ref)
+
+
+def _sample_issue(issue_id: str) -> dict:
+    return {
+        "ref": {
+            "system": "jira",
+            "workspace": "team-a",
+            "id": issue_id,
+            "key": f"PRJ-{issue_id}",
+            "url": f"https://example.atlassian.net/browse/PRJ-{issue_id}",
+        },
+        "title": f"Issue {issue_id}",
+        "body": "Body",
+        "status": "todo",
+        "issue_type": "task",
+        "priority": 2,
+        "assignees": ["alice"],
+        "labels": ["backend"],
+        "links": [],
+        "custom_fields": {"source": "test"},
+    }
+
+
+def test_issue_persistence_across_instances(tmp_path) -> None:
+    db_path = tmp_path / "tracker.db"
+    store_a = TrackerSqliteStore(db_path)
+    store_b = TrackerSqliteStore(db_path)
+
+    issue = _sample_issue("100")
+    asyncio.run(_upsert(store_a, issue))
+
+    issues = asyncio.run(_list(store_b, system="jira"))
+    assert len(issues) == 1
+
+    ref = {"system": "jira", "workspace": "team-a", "id": "100"}
+    asyncio.run(_delete(store_b, ref))
+
+    remaining = asyncio.run(_list(store_a, system="jira"))
+    assert remaining == []
+
+
+def test_mapping_and_checkpoint_round_trip(tmp_path) -> None:
+    db_path = tmp_path / "tracker.db"
+    store = TrackerSqliteStore(db_path)
+
+    ref = {
+        "system": "linear",
+        "workspace": "team-alpha",
+        "id": "abc123",
+        "key": "LIN-1",
+        "url": "https://linear.app/team/issue/LIN-1",
+    }
+    store.upsert_mapping(wp_id="WP01", ref=ref)
+
+    mappings = store.list_mappings()
+    assert len(mappings) == 1
+    assert mappings[0]["wp_id"] == "WP01"
+    assert mappings[0]["external_id"] == "abc123"
+
+    store.set_checkpoint({"cursor": "next-page", "updated_since": None}, checkpoint_key="linear:team-alpha")
+    checkpoint = store.get_checkpoint("linear:team-alpha")
+    assert checkpoint is not None
+    if isinstance(checkpoint, dict):
+        assert checkpoint["cursor"] == "next-page"
+    else:
+        assert getattr(checkpoint, "cursor") == "next-page"
+
+
+def test_scope_hash_segregates_by_identity() -> None:
+    first = default_tracker_db_path(
+        provider="jira",
+        workspace="team-a",
+        server_url="https://jira.example.com",
+        username="alice@example.com",
+        team_slug="alpha",
+    )
+    second = default_tracker_db_path(
+        provider="jira",
+        workspace="team-a",
+        server_url="https://jira.example.com",
+        username="bob@example.com",
+        team_slug="alpha",
+    )
+
+    assert first != second
+    assert first.name.endswith(".db")
+    assert second.name.endswith(".db")


### PR DESCRIPTION
## Summary
- add a new `tracker` command group with provider/bind/status/mapping/sync operations
- register tracker commands only when `SPEC_KITTY_ENABLE_SAAS_SYNC` is enabled
- add CLI-owned tracker modules for project config, credential storage (locked TOML), connector factory, service orchestration, and SQLite cache/checkpoint/mapping store
- keep direct invocation guarded with a consistent feature-disabled error

## Tests
- `python3 -m pytest tests/specify_cli/cli/commands/test_tracker.py tests/specify_cli/tracker/test_store.py tests/specify_cli/tracker/test_credentials.py`
