### PR TITLE
Add ADRs for tracker integration gating, persistence, and SaaS journey

### DIFF
--- a/architecture/adrs/2026-02-27-1-cli-tracker-surface-gated-by-saas-sync-flag.md
+++ b/architecture/adrs/2026-02-27-1-cli-tracker-surface-gated-by-saas-sync-flag.md
@@ -1,0 +1,111 @@
+# CLI Tracker Surface Gated by SaaS Sync Flag
+
+**Filename:** `2026-02-27-1-cli-tracker-surface-gated-by-saas-sync-flag.md`
+
+**Status:** Accepted
+
+**Date:** 2026-02-27
+
+**Deciders:** CLI Team, Platform Team, Product
+
+**Technical Story:** Tracker command rollout must respect the existing SaaS sync feature gate and remain invisible when disabled.
+
+---
+
+## Context and Problem Statement
+
+SpecKitty already uses `SPEC_KITTY_ENABLE_SAAS_SYNC` as the rollout boundary for SaaS-synced functionality. Introducing tracker commands outside this boundary creates policy drift, user confusion, and inconsistent behavior between installations.
+
+The tracker integration introduces new CLI commands (`spec-kitty tracker ...`) and sync orchestration paths. Without strict gating, users with SaaS sync disabled could still discover partially functional tracker behavior.
+
+## Decision Drivers
+
+1. Preserve existing feature-flag contract for SaaS-dependent capabilities.
+2. Avoid fragmented UX where command help exposes disabled products.
+3. Ensure deterministic behavior in environments where SaaS sync is intentionally off.
+4. Minimize operational/support burden from accidental partial enablement.
+
+## Considered Options
+
+1. Always register tracker commands and show runtime warnings.
+2. Gate only mutating commands, keep read-only commands visible.
+3. Register tracker command group only when SaaS sync flag is enabled (chosen).
+
+## Decision Outcome
+
+**Chosen option:** register tracker commands only when `SPEC_KITTY_ENABLE_SAAS_SYNC` is enabled, and hard-fail through legacy/direct paths with existing disabled-message semantics.
+
+### Required Behavior
+
+1. `tracker` command group is not registered when flag is disabled.
+2. Any direct/legacy invocation path uses the same disabled response pattern as sync/auth command guards.
+3. No background tracker sync hooks run when flag is disabled.
+
+### Consequences
+
+#### Positive
+
+1. Feature rollout remains consistent with established policy.
+2. Help surface accurately reflects usable command set.
+3. Lower risk of unsupported local states.
+
+#### Negative
+
+1. Teams wanting tracker-only local mode must enable SaaS sync flag in v1.
+2. Additional guard-path tests are required.
+
+#### Neutral
+
+1. Future decoupling from SaaS flag remains possible but is explicitly deferred.
+
+### Confirmation
+
+This decision is validated when:
+
+1. `spec-kitty --help` excludes tracker commands when flag is off.
+2. `spec-kitty --help` includes tracker commands when flag is on.
+3. Direct invocation while disabled returns standard disabled guidance.
+
+## Pros and Cons of the Options
+
+### Option 1: Always register + runtime warnings
+
+**Pros:**
+
+1. Easier command discoverability during development.
+
+**Cons:**
+
+1. Violates established gate model.
+2. Increases accidental usage/support overhead.
+
+### Option 2: Partially gate command set
+
+**Pros:**
+
+1. Offers limited read-only visibility.
+
+**Cons:**
+
+1. Blurry policy boundary.
+2. Inconsistent user expectations.
+
+### Option 3: Full command registration gating (Chosen)
+
+**Pros:**
+
+1. Clear binary rollout behavior.
+2. Aligns with existing sync/auth guard patterns.
+
+**Cons:**
+
+1. Defers tracker-only mode experimentation.
+
+## More Information
+
+1. CLI command registration:
+   `src/specify_cli/cli/commands/__init__.py`
+2. Tracker command module:
+   `src/specify_cli/cli/commands/tracker.py`
+3. Flag guard helper:
+   `src/specify_cli/tracker/feature_flags.py`

--- a/architecture/adrs/2026-02-27-2-host-owned-tracker-persistence-boundary.md
+++ b/architecture/adrs/2026-02-27-2-host-owned-tracker-persistence-boundary.md
@@ -1,0 +1,119 @@
+# Host-Owned Tracker Persistence Boundary
+
+**Filename:** `2026-02-27-2-host-owned-tracker-persistence-boundary.md`
+
+**Status:** Accepted
+
+**Date:** 2026-02-27
+
+**Deciders:** Architecture Team, CLI Team, Tracker Core Team
+
+**Technical Story:** `spec-kitty-tracker` must remain connector protocol/adapters only; durable persistence belongs to host integrations.
+
+---
+
+## Context and Problem Statement
+
+Tracker integration requires local cache and checkpoint persistence. One proposal added durable SQLite stores directly to `spec-kitty-tracker` core. That approach conflicts with existing SpecKitty architecture where persistence is host-owned and context-specific.
+
+Current patterns in CLI:
+
+1. SQLite queue in `sync/queue.py`
+2. JSONL state/event store in `status/store.py`
+3. Credential storage + locking in `sync/auth.py`
+
+Adding core persistence in `spec-kitty-tracker` would blur boundaries and make connector core responsible for deployment-specific storage concerns.
+
+## Decision Drivers
+
+1. Keep `spec-kitty-tracker` reusable across CLI and SaaS hosts.
+2. Preserve existing host-owned persistence architecture.
+3. Avoid premature storage coupling in connector core.
+4. Keep connector testability simple with in-memory stores.
+
+## Considered Options
+
+1. Add `SqliteIssueStore` and `SqliteCheckpointStore` to `spec-kitty-tracker`.
+2. Host-owned durable store implementations (`spec-kitty` CLI and future SaaS adapters), with protocol interfaces in core (chosen).
+3. No durable local store in v1.
+
+## Decision Outcome
+
+**Chosen option:** host-owned persistence with protocol-only core.
+
+### Required Behavior
+
+1. `spec-kitty-tracker` defines protocols/contracts and connectors.
+2. `spec-kitty-tracker` may include in-memory testing stores only.
+3. Durable SQLite tracker store/checkpoint implementations live in `spec-kitty` CLI.
+4. SaaS may implement separate durable projections without changing core contracts.
+
+### Consequences
+
+#### Positive
+
+1. Clear architectural boundary and ownership.
+2. Reusable connector core with minimal runtime assumptions.
+3. Storage technology remains host-selectable.
+
+#### Negative
+
+1. Host implementations duplicate some store wiring logic.
+2. Shared migration helpers are deferred.
+
+#### Neutral
+
+1. Core docs must explicitly state persistence responsibility.
+
+### Confirmation
+
+This decision is validated when:
+
+1. No durable store classes are present in `spec-kitty-tracker` core.
+2. CLI durable tracker cache/checkpoint persistence exists in `spec-kitty`.
+3. Tracker connector tests run using protocol/in-memory store patterns.
+
+## Pros and Cons of the Options
+
+### Option 1: Durable SQLite in core
+
+**Pros:**
+
+1. Single implementation point.
+
+**Cons:**
+
+1. Couples connector core to storage/runtime assumptions.
+2. Conflicts with established host-owned pattern.
+
+### Option 2: Host-owned persistence (Chosen)
+
+**Pros:**
+
+1. Architecture consistency with existing SpecKitty patterns.
+2. Better portability across hosts.
+
+**Cons:**
+
+1. More host-side implementation effort.
+
+### Option 3: No durable store
+
+**Pros:**
+
+1. Simplifies short-term implementation.
+
+**Cons:**
+
+1. Fails operational requirements for checkpointed sync.
+
+## More Information
+
+1. Existing host persistence references:
+   `src/specify_cli/sync/queue.py`
+   `src/specify_cli/status/store.py`
+   `src/specify_cli/sync/auth.py`
+2. CLI tracker store implementation:
+   `src/specify_cli/tracker/store.py`
+3. Core architecture docs:
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-tracker/docs/ARCHITECTURE.md`

--- a/architecture/adrs/2026-02-27-3-saas-tracker-integration-via-existing-connectors-journey.md
+++ b/architecture/adrs/2026-02-27-3-saas-tracker-integration-via-existing-connectors-journey.md
@@ -1,0 +1,117 @@
+# SaaS Tracker Integration via Existing Connectors Journey
+
+**Filename:** `2026-02-27-3-saas-tracker-integration-via-existing-connectors-journey.md`
+
+**Status:** Accepted
+
+**Date:** 2026-02-27
+
+**Deciders:** SaaS Team, Product, UX, Architecture Team
+
+**Technical Story:** Tracker functionality in SaaS must be integrated into existing connectors/dashboard flow, not delivered as an isolated app surface.
+
+---
+
+## Context and Problem Statement
+
+Tracker integration requires team binding, work-package mapping, sync telemetry, drift reporting, and snapshot ingestion. A separate disconnected SaaS surface would duplicate navigation and break established user flows.
+
+SpecKitty SaaS already has connector patterns, dashboards, and activity feed conventions that users rely on.
+
+## Decision Drivers
+
+1. Preserve coherent user journey in existing app information architecture.
+2. Reuse mature connectors domain and webhook style patterns.
+3. Minimize regression risk in production dashboards/nav.
+4. Enable phased rollout with team-scoped flags.
+
+## Considered Options
+
+1. Build standalone tracker app area/navigation.
+2. Integrate tracker capability into existing `apps/connectors` + dashboard views (chosen).
+3. Delay SaaS integration and keep tracker entirely CLI-local.
+
+## Decision Outcome
+
+**Chosen option:** integrate tracker binding, snapshot ingestion, and tracker projections into existing connectors + dashboard flow.
+
+### Required Behavior
+
+1. Add tracker binding and mapping models inside `apps/connectors`.
+2. Expose tracker APIs under `/api/v1/connectors/trackers/...`.
+3. Add snapshot ingestion endpoint (`/api/v1/connectors/trackers/snapshots/`) with idempotency receipts.
+4. Render tracker health/state in existing project/work-package detail surfaces.
+5. Render tracker sync/drift events in existing activity feed patterns.
+6. Roll out via team-scoped waffle flag for SaaS tracker capability.
+
+### Consequences
+
+#### Positive
+
+1. Faster adoption through familiar navigation and pages.
+2. Lower implementation risk through reuse of established domain boundaries.
+3. Better observability consistency with existing event rows/cards.
+
+#### Negative
+
+1. Requires careful migration/test coverage in existing pages.
+2. Some model growth in connectors domain.
+
+#### Neutral
+
+1. v1 is read/map/observe on SaaS side; outbound writes are deferred.
+
+### Confirmation
+
+This decision is validated when:
+
+1. Connectors pages show tracker binding status without separate app navigation.
+2. Project detail includes tracker health summary.
+3. Work-package detail shows mapped external issue state.
+4. Snapshot ingestion is idempotent by receipt key.
+5. Existing GitHub webhook behavior remains unchanged.
+
+## Pros and Cons of the Options
+
+### Option 1: Standalone tracker app surface
+
+**Pros:**
+
+1. Strong functional separation.
+
+**Cons:**
+
+1. Fragmented UX and duplicate navigation.
+2. Higher delivery/regression risk.
+
+### Option 2: Existing connectors/dashboard integration (Chosen)
+
+**Pros:**
+
+1. Cohesive user journey.
+2. Maximum reuse of existing patterns.
+
+**Cons:**
+
+1. Tighter coupling to current page architecture.
+
+### Option 3: CLI-only tracker with no SaaS journey
+
+**Pros:**
+
+1. Lowest SaaS implementation effort.
+
+**Cons:**
+
+1. No team-level visibility or centralized operations.
+
+## More Information
+
+1. Connectors models and endpoints:
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-saas/apps/connectors/models.py`
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-saas/apps/connectors/urls.py`
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-saas/apps/connectors/views.py`
+2. Dashboard integrations:
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-saas/apps/web/views.py`
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-saas/templates/web/dashboards/project_detail.html`
+   `/Users/robert/ClaudeCowork/Spec-Kitty-Cowork/spec-kitty-saas/templates/web/dashboards/wp_detail.html`


### PR DESCRIPTION
## Summary\n- add ADR for SaaS-flag-gated tracker CLI surface\n- add ADR for host-owned tracker persistence boundary\n- add ADR for integrating SaaS tracker capability into existing connectors/dashboard journey\n\n## Scope\n- documentation-only changes under architecture/adrs\n