### PR TITLE
release: v1.0.1 dependency floor hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-02-27
+
+### 🔧 Changed
+
+- **Dependency floor hardening for PyPI installs**: added explicit lower bounds for previously unbounded core CLI dependencies (`typer`, `rich`, `httpx[socks]`, `platformdirs`, `readchar`) to reduce resolver drift across clean environments.
+- **Release validation robustness**: release-readiness validation now remains scoped to valid version tags for the active major stream and supports `a`/`b`/`rc` tag parity checks.
+
 ## [1.0.0] - 2026-02-24
 
 ### 🔧 Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "1.0.0"
+version = "1.0.1"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary\n- add lower bounds for previously unbounded core CLI direct dependencies\n- bump project version to 1.0.1\n- add changelog entry for 1.0.1\n\n## Validation\n- python3 scripts/release/validate_release.py --mode branch --tag-pattern 'v1*'\n- uv run pytest tests/specify_cli/upgrade/test_migration_robustness.py -q