### PR TITLE
release: v2.0.2 tracker + dependency floor hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-02-27
+
+### ✅ Added
+
+- **Flag-gated tracker command group**: added `spec-kitty tracker ...` commands behind `SPEC_KITTY_ENABLE_SAAS_SYNC`, including provider listing, bind/unbind, mapping, local sync pull/push/run, and snapshot publish.
+- **Tracker host-local persistence + credentials support**: added CLI-owned tracker SQLite cache/checkpoints and provider credential handling consistent with existing Spec Kitty host persistence patterns.
+
+### 🔧 Changed
+
+- **Dependency floor hardening for 2.x installs**: added explicit lower bounds for previously unbounded core CLI direct dependencies to reduce resolver drift in fresh environments.
+- **Workflow review lane guard**: review start now requires a valid `for_review` lane state before progressing.
+
 ## [2.0.1] - 2026-02-26
 
 ### 🐛 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "2.0.1"
+version = "2.0.2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary\n- add lower bounds for previously unbounded core CLI direct dependencies\n- bump 2.x version to 2.0.2\n- add 2.0.2 changelog entry covering tracker integration and review lane guard\n\n## Validation\n- python3 scripts/release/validate_release.py --mode branch --tag-pattern 'v2.*.*'\n- uv run pytest tests/specify_cli/upgrade tests/specify_cli/cli/commands/test_tracker.py -q