### PR TITLE
fix(transitions): allow for_review -> planned with review_ref guard (#223)

### DIFF
--- a/src/specify_cli/status/transitions.py
+++ b/src/specify_cli/status/transitions.py
@@ -1,6 +1,6 @@
 """Transition matrix, guard conditions, alias resolution, and validation.
 
-Implements the 7-lane state machine with 16 legal transition pairs,
+Implements the 7-lane state machine with 17 legal transition pairs,
 guard condition functions, alias resolution, and force-override logic.
 """
 
@@ -31,6 +31,7 @@ ALLOWED_TRANSITIONS: frozenset[tuple[str, str]] = frozenset(
         ("in_progress", "for_review"),
         ("for_review", "done"),
         ("for_review", "in_progress"),
+        ("for_review", "planned"),
         ("in_progress", "planned"),
         ("planned", "blocked"),
         ("claimed", "blocked"),
@@ -52,6 +53,7 @@ _GUARDED_TRANSITIONS: dict[tuple[str, str], str] = {
     ("in_progress", "for_review"): "subtasks_complete_or_force",
     ("for_review", "done"): "reviewer_approval",
     ("for_review", "in_progress"): "review_ref_required",
+    ("for_review", "planned"): "review_ref_required",
     ("in_progress", "planned"): "reason_required",
 }
 
@@ -140,11 +142,11 @@ def _guard_reviewer_approval(
 def _guard_review_ref_required(
     review_ref: str | None,
 ) -> tuple[bool, str | None]:
-    """Guard: for_review -> in_progress requires review feedback reference."""
+    """Guard: for_review -> in_progress/planned requires review feedback reference."""
     if not review_ref or not review_ref.strip():
         return (
             False,
-            "Transition for_review -> in_progress requires review_ref "
+            "Transition from for_review requires review_ref "
             "(review feedback reference)",
         )
     return True, None


### PR DESCRIPTION
## Summary

- Adds `("for_review", "planned")` to `ALLOWED_TRANSITIONS` in the status state machine (16 -> 17 transition pairs)
- Guards the new transition with `review_ref_required` (same guard as `for_review -> in_progress`), ensuring audit trail quality
- Fixes the mismatch where review templates instruct agents to run `--to planned` but the state machine rejected it as illegal

Closes #223

## Changes

**`src/specify_cli/status/transitions.py`**:
- Added `("for_review", "planned")` to `ALLOWED_TRANSITIONS`
- Added `("for_review", "planned"): "review_ref_required"` to `_GUARDED_TRANSITIONS`
- Updated docstring and error message to reflect both rollback targets

**`tests/specify_cli/status/test_transitions.py`** (unit):
- Updated transition count assertion (16 -> 17)
- Added `("for_review", "planned")` to legal transitions parametrize list
- Added 5 new guard tests: accepted with review_ref, rejected without, rejected with empty string, rejected with whitespace

**`tests/integration/test_task_workflow.py`** (integration):
- `TestReviewRejectToPlanned` class with 4 tests exercising the exact CLI reject command from templates:
  - `for_review -> planned` with feedback file succeeds
  - `for_review -> planned` without feedback file is rejected
  - `--force` without feedback file is still rejected
  - Feedback content is persisted in WP file body and frontmatter

## Test plan

- [x] `python -m pytest tests/specify_cli/status/test_transitions.py -x -q` -- 71 passed
- [x] `python -m pytest tests/specify_cli/status/ -x -q` -- 620 passed
- [x] `python -m pytest tests/integration/test_task_workflow.py -x -q` -- 21 passed
- [x] `ruff check src/specify_cli/status/transitions.py` -- all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)