### PR TITLE
fix(status): map in_progress to Doing lane in agent tasks status (#204)

### DIFF
--- a/tests/integration/test_dual_branch_status_routing.py
+++ b/tests/integration/test_dual_branch_status_routing.py
@@ -173,7 +173,7 @@ def test_status_routes_to_main_for_legacy_features(dual_branch_repo):
     assert result.returncode == 0, f"Failed to move task: {result.stderr}\n{result.stdout}"
 
     # Verify status commit on main
-    assert_commit_on_branch(repo, "main", "Move WP01 to doing")
+    assert_commit_on_branch(repo, "main", "Move WP01 to in_progress")
 
     # Verify 2.x branch unaffected (should only have initial commits)
     result_2x = subprocess.run(
@@ -219,7 +219,7 @@ def test_status_routes_to_2x_for_dual_branch_features(dual_branch_repo):
     assert result.returncode == 0, f"Failed to move task: {result.stderr}\n{result.stdout}"
 
     # Verify status commit on 2.x
-    assert_commit_on_branch(repo, "2.x", "Move WP01 to doing")
+    assert_commit_on_branch(repo, "2.x", "Move WP01 to in_progress")
 
     # Verify main branch does NOT have this status commit
     # Main should only have the "Add 025-saas-feature" commit
@@ -236,7 +236,7 @@ def test_status_routes_to_2x_for_dual_branch_features(dual_branch_repo):
 
     # Should have feature creation commit but NOT status move commit
     assert any("Add 025-saas-feature" in msg for msg in main_commits), "Feature creation commit missing"
-    assert not any("Move WP01 to doing" in msg for msg in main_commits), "Status commit leaked to main"
+    assert not any("Move WP01 to in_progress" in msg for msg in main_commits), "Status commit leaked to main"
 
 
 def test_status_routing_from_worktree_context(dual_branch_repo):
@@ -510,7 +510,7 @@ def test_fallback_when_target_missing(dual_branch_repo):
         "Should warn about missing target branch"
 
     # Commit should land on current branch (main)
-    assert_commit_on_branch(repo, "main", "Move WP01 to doing")
+    assert_commit_on_branch(repo, "main", "Move WP01 to in_progress")
 
 
 def test_migration_detection_and_routing(dual_branch_repo):
@@ -546,7 +546,7 @@ def test_migration_detection_and_routing(dual_branch_repo):
     assert result.returncode == 0, f"Failed to move task: {result.stderr}"
 
     # Verify commit on main
-    assert_commit_on_branch(repo, "main", "Move WP01 to doing")
+    assert_commit_on_branch(repo, "main", "Move WP01 to in_progress")
 
 
 def verify_ancestry(repo: Path, ancestor: str, descendant: str) -> bool:
@@ -634,7 +634,7 @@ def test_multiple_lane_transitions_same_target(dual_branch_repo):
         assert result.returncode == 0, f"Failed to move {wp_id}: {result.stderr}"
 
         # Verify commit on 2.x
-        assert_commit_on_branch(repo, "2.x", f"Move {wp_id} to doing")
+        assert_commit_on_branch(repo, "2.x", f"Move {wp_id} to in_progress")
 
         # Sync main to avoid file conflicts in next iteration
         subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
@@ -647,7 +647,7 @@ def test_multiple_lane_transitions_same_target(dual_branch_repo):
 
     # Verify: All 3 status commits originated on 2.x
     commits_2x = get_commits_on_branch(repo, "2.x")
-    status_commits = [c for c in commits_2x if "Move WP0" in c and "to doing" in c]
+    status_commits = [c for c in commits_2x if "Move WP0" in c and "to in_progress" in c]
     assert len(status_commits) == 3, f"Expected 3 status commits on 2.x, found {len(status_commits)}"
 
 
@@ -703,7 +703,7 @@ def test_target_branch_detection_from_worktree_path(dual_branch_repo):
     assert result.returncode == 0, f"Failed from worktree: {result.stderr}"
 
     # Verify commit on 2.x (target detection worked)
-    assert_commit_on_branch(repo, "2.x", "Move WP01 to doing")
+    assert_commit_on_branch(repo, "2.x", "Move WP01 to in_progress")
 
     # Cleanup
     subprocess.run(

--- a/tests/unit/agent/test_tasks.py
+++ b/tests/unit/agent/test_tasks.py
@@ -1084,3 +1084,91 @@ class TestFindFeatureSlug:
 
         with pytest.raises(Exit):
             _find_feature_slug()
+
+
+class TestStatusInProgressLane:
+    """Tests for status subcommand lane alias resolution (issue #204).
+
+    The 7-lane model persists 'in_progress' as the canonical lane name,
+    but the status subcommand previously used 'doing' as the dict key,
+    causing WPs with lane: in_progress to fall through to 'other'.
+    """
+
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    def test_in_progress_wp_appears_in_json_output(
+        self, mock_slug: Mock, mock_root: Mock, mock_branch: Mock, tmp_path: Path
+    ):
+        """WP with lane: in_progress must appear in by_lane count, not vanish."""
+        repo_root = tmp_path
+        (repo_root / ".kittify").mkdir()
+        tasks_dir = repo_root / "kitty-specs" / "042-test" / "tasks"
+        tasks_dir.mkdir(parents=True)
+
+        # WP with canonical 'in_progress' lane (as persisted by 7-lane model)
+        (tasks_dir / "WP01-alpha.md").write_text(
+            '---\nwork_package_id: "WP01"\ntitle: "Alpha"\nlane: "in_progress"\n---\nContent\n'
+        )
+        # WP with legacy alias 'doing'
+        (tasks_dir / "WP02-beta.md").write_text(
+            '---\nwork_package_id: "WP02"\ntitle: "Beta"\nlane: "doing"\n---\nContent\n'
+        )
+        # WP already planned
+        (tasks_dir / "WP03-gamma.md").write_text(
+            '---\nwork_package_id: "WP03"\ntitle: "Gamma"\nlane: "planned"\n---\nContent\n'
+        )
+
+        mock_root.return_value = repo_root
+        mock_slug.return_value = "042-test"
+        mock_branch.return_value = (repo_root, "main")
+
+        with patch(
+            "specify_cli.core.stale_detection.check_doing_wps_for_staleness",
+            return_value={},
+        ):
+            result = runner.invoke(app, ["status", "--feature", "042-test", "--json"])
+
+        assert result.exit_code == 0, f"stdout: {result.stdout}"
+        output = json.loads(result.stdout)
+
+        # Both WP01 (in_progress) and WP02 (doing alias) should be counted
+        # under the canonical 'in_progress' key
+        assert output["by_lane"].get("in_progress", 0) == 2, (
+            f"Expected 2 in_progress WPs, got by_lane: {output['by_lane']}"
+        )
+        assert output["by_lane"].get("planned", 0) == 1
+
+        # Verify individual WP lane values are canonicalized
+        wp_lanes = {wp["id"]: wp["lane"] for wp in output["work_packages"]}
+        assert wp_lanes["WP01"] == "in_progress"
+        assert wp_lanes["WP02"] == "in_progress"  # 'doing' resolved to 'in_progress'
+
+    @patch("specify_cli.core.stale_detection.check_doing_wps_for_staleness", return_value={})
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    def test_in_progress_wp_appears_in_rich_output(
+        self, mock_slug: Mock, mock_root: Mock, mock_branch: Mock,
+        mock_stale: Mock, tmp_path: Path
+    ):
+        """WP with lane: in_progress must appear in the Doing column of the kanban board."""
+        repo_root = tmp_path
+        (repo_root / ".kittify").mkdir()
+        tasks_dir = repo_root / "kitty-specs" / "042-test" / "tasks"
+        tasks_dir.mkdir(parents=True)
+
+        (tasks_dir / "WP01-alpha.md").write_text(
+            '---\nwork_package_id: "WP01"\ntitle: "Alpha Task"\nlane: "in_progress"\n---\nContent\n'
+        )
+
+        mock_root.return_value = repo_root
+        mock_slug.return_value = "042-test"
+        mock_branch.return_value = (repo_root, "main")
+
+        result = runner.invoke(app, ["status", "--feature", "042-test"])
+
+        assert result.exit_code == 0, f"stdout: {result.stdout}"
+        # The WP should appear in the output (not silently dropped)
+        assert "WP01" in result.stdout
+        assert "In Progress" in result.stdout or "Doing" in result.stdout


### PR DESCRIPTION
## Summary

- Fix `agent tasks status` command where WPs with `lane: in_progress` (canonical 7-lane model name) silently fell through and never appeared in the Doing column of the kanban board
- The `by_lane` dict used `"doing"` as the key but the status model persists `"in_progress"` -- now uses `resolve_lane_alias()` when reading frontmatter and `"in_progress"` as the canonical dict key
- Also fix dependency completeness check (`_check_dependent_warnings`) to use canonical lane names via `resolve_lane_alias()`
- Update integration test assertions in `test_dual_branch_status_routing.py` to expect canonical `"in_progress"` in commit messages

## Test plan

- [x] New `TestStatusInProgressLane` test class with two tests:
  - `test_in_progress_wp_appears_in_json_output`: verifies both `in_progress` and `doing` alias WPs appear under canonical `in_progress` key in JSON output
  - `test_in_progress_wp_appears_in_rich_output`: verifies WP with `in_progress` lane appears in the rich table output
- [x] All existing `TestMoveTask` and `TestFindFeatureSlug` tests pass (14/14)
- [x] `ruff check` introduces no new violations (all are pre-existing)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)