### PR TITLE
fix(orchestrator-api): JSON envelope for parser errors, remove dead --no-json (#177)

### DIFF
--- a/docs/1x/orchestration-and-api.md
+++ b/docs/1x/orchestration-and-api.md
@@ -15,7 +15,7 @@
 ## Recommended operator flow
 
 ```bash
-spec-kitty orchestrator-api contract-version --json
+spec-kitty orchestrator-api contract-version
 spec-kitty-orchestrator orchestrate --feature 034-my-feature --dry-run
 spec-kitty-orchestrator orchestrate --feature 034-my-feature
 ```

--- a/docs/2x/orchestration-and-api.md
+++ b/docs/2x/orchestration-and-api.md
@@ -17,9 +17,9 @@
 ## Baseline commands
 
 ```bash
-spec-kitty orchestrator-api contract-version --json
-spec-kitty orchestrator-api feature-state --feature 034-my-feature --json
-spec-kitty orchestrator-api list-ready --feature 034-my-feature --json
+spec-kitty orchestrator-api contract-version
+spec-kitty orchestrator-api feature-state --feature 034-my-feature
+spec-kitty orchestrator-api list-ready --feature 034-my-feature
 ```
 
 ## Reference provider

--- a/docs/explanation/multi-agent-orchestration.md
+++ b/docs/explanation/multi-agent-orchestration.md
@@ -42,7 +42,7 @@ spec-kitty agent tasks move-task WP01 --to done
 Automated coordination is run by external providers such as `spec-kitty-orchestrator`.
 
 ```bash
-spec-kitty orchestrator-api contract-version --json
+spec-kitty orchestrator-api contract-version
 spec-kitty-orchestrator orchestrate --feature 034-my-feature --dry-run
 spec-kitty-orchestrator orchestrate --feature 034-my-feature
 ```

--- a/docs/how-to/build-custom-orchestrator.md
+++ b/docs/how-to/build-custom-orchestrator.md
@@ -11,7 +11,7 @@ Use this guide to implement your own orchestration strategy while keeping `spec-
 
 Your orchestrator must:
 
-- Call only `spec-kitty orchestrator-api ... --json` for workflow state.
+- Call only `spec-kitty orchestrator-api ...` subcommands for workflow state (output is always JSON).
 - Treat `spec-kitty` as source of truth for lane state and dependencies.
 - Never write `kitty-specs/<feature>/tasks/*.md` lanes directly.
 
@@ -26,15 +26,12 @@ Your orchestrator must:
 ### 1. Check compatibility
 
 ```bash
-spec-kitty orchestrator-api contract-version --json
-```
+spec-kitty orchestrator-api contract-version```
 
 ### 2. Discover work
 
 ```bash
-spec-kitty orchestrator-api feature-state --feature <slug> --json
-spec-kitty orchestrator-api list-ready --feature <slug> --json
-```
+spec-kitty orchestrator-api feature-state --feature <slug>spec-kitty orchestrator-api list-ready --feature <slug>```
 
 ### 3. Start implementation
 
@@ -44,8 +41,7 @@ spec-kitty orchestrator-api start-implementation \
   --wp WP01 \
   --actor my-orchestrator \
   --policy '<json>' \
-  --json
-```
+ ```
 
 Use returned `workspace_path` and `prompt_path` to run your agent process.
 
@@ -55,25 +51,20 @@ Use returned `workspace_path` and `prompt_path` to run your agent process.
 # implementation complete
 spec-kitty orchestrator-api transition \
   --feature <slug> --wp WP01 --to for_review \
-  --actor my-orchestrator --policy '<json>' --json
-
+  --actor my-orchestrator --policy '<json>'
 # review approved
 spec-kitty orchestrator-api transition \
   --feature <slug> --wp WP01 --to done \
-  --actor reviewer-bot --json
-
+  --actor reviewer-bot
 # review rejected -> rework
 spec-kitty orchestrator-api start-review \
   --feature <slug> --wp WP01 --actor my-orchestrator \
-  --policy '<json>' --review-ref review/WP01/attempt-2 --json
-```
+  --policy '<json>' --review-ref review/WP01/attempt-2```
 
 ### 5. Finalize
 
 ```bash
-spec-kitty orchestrator-api accept-feature --feature <slug> --actor my-orchestrator --json
-spec-kitty orchestrator-api merge-feature --feature <slug> --target main --strategy merge --json
-```
+spec-kitty orchestrator-api accept-feature --feature <slug> --actor my-orchestratorspec-kitty orchestrator-api merge-feature --feature <slug> --target main --strategy merge```
 
 ## Policy JSON Template
 

--- a/docs/how-to/run-external-orchestrator.md
+++ b/docs/how-to/run-external-orchestrator.md
@@ -23,7 +23,7 @@ This is the supported automation model in `1.x` and `2.x`:
 ## 1. Verify Host Contract
 
 ```bash
-spec-kitty orchestrator-api contract-version --json
+spec-kitty orchestrator-api contract-version
 ```
 
 Expected result:
@@ -66,7 +66,7 @@ Use `resume` after interruption. Use `abort` to mark the provider run as stopped
 ## 5. Confirm Host State
 
 ```bash
-spec-kitty orchestrator-api feature-state --feature 034-my-feature --json
+spec-kitty orchestrator-api feature-state --feature 034-my-feature
 ```
 
 This is the authoritative source of lane state.

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -9,12 +9,13 @@ description: Contract reference for external orchestration providers that integr
 
 - Core CLI does not include `spec-kitty orchestrate`.
 - External providers (for example `spec-kitty-orchestrator`) must use this API.
-- Commands are JSON-first: exactly one JSON envelope on stdout; non-zero exit on failure.
+- Commands always emit JSON: exactly one JSON envelope on stdout; non-zero exit on failure.
+- Parser/usage errors (missing required args, unknown options) also return a JSON envelope with error code `USAGE_ERROR`.
 
 ## Contract Version
 
 - `CONTRACT_VERSION`: `1.0.0`
-- Command: `spec-kitty orchestrator-api contract-version --json`
+- Command: `spec-kitty orchestrator-api contract-version`
 
 ## Canonical Envelope
 
@@ -91,16 +92,14 @@ Returns host `api_version` and minimum supported provider version.
 ### feature-state
 
 ```bash
-spec-kitty orchestrator-api feature-state --feature <slug> --json
-```
+spec-kitty orchestrator-api feature-state --feature <slug>```
 
 Returns WP states, dependency data, and lane summary.
 
 ### list-ready
 
 ```bash
-spec-kitty orchestrator-api list-ready --feature <slug> --json
-```
+spec-kitty orchestrator-api list-ready --feature <slug>```
 
 Returns WPs in `planned` with all dependencies in `done`.
 
@@ -108,8 +107,7 @@ Returns WPs in `planned` with all dependencies in `done`.
 
 ```bash
 spec-kitty orchestrator-api start-implementation \
-  --feature <slug> --wp <WP##> --actor <actor-id> --policy '<json>' --json
-```
+  --feature <slug> --wp <WP##> --actor <actor-id> --policy '<json>'```
 
 Composite transition into `in_progress` for implementation. Returns `workspace_path` and `prompt_path`.
 
@@ -118,8 +116,7 @@ Composite transition into `in_progress` for implementation. Returns `workspace_p
 ```bash
 spec-kitty orchestrator-api start-review \
   --feature <slug> --wp <WP##> --actor <actor-id> --policy '<json>' \
-  --review-ref <ref> --json
-```
+  --review-ref <ref>```
 
 Moves a rejected WP from `for_review` back to `in_progress`.
 
@@ -128,8 +125,7 @@ Moves a rejected WP from `for_review` back to `in_progress`.
 ```bash
 spec-kitty orchestrator-api transition \
   --feature <slug> --wp <WP##> --to <lane> --actor <actor-id> \
-  [--note <text>] [--policy '<json>'] [--review-ref <ref>] [--force] --json
-```
+  [--note <text>] [--policy '<json>'] [--review-ref <ref>] [--force]```
 
 Applies one lane transition with deterministic validation errors.
 
@@ -137,16 +133,14 @@ Applies one lane transition with deterministic validation errors.
 
 ```bash
 spec-kitty orchestrator-api append-history \
-  --feature <slug> --wp <WP##> --actor <actor-id> --note <text> --json
-```
+  --feature <slug> --wp <WP##> --actor <actor-id> --note <text>```
 
 Appends an activity entry to the WP prompt history.
 
 ### accept-feature
 
 ```bash
-spec-kitty orchestrator-api accept-feature --feature <slug> --actor <actor-id> --json
-```
+spec-kitty orchestrator-api accept-feature --feature <slug> --actor <actor-id>```
 
 Accepts a feature when all WPs are `done`.
 
@@ -154,13 +148,13 @@ Accepts a feature when all WPs are `done`.
 
 ```bash
 spec-kitty orchestrator-api merge-feature \
-  --feature <slug> [--target main] [--strategy merge|squash] [--push] --json
-```
+  --feature <slug> [--target main] [--strategy merge|squash] [--push]```
 
 Runs preflight and merges WP branches in dependency order.
 
 ## Common Error Codes
 
+- `USAGE_ERROR`
 - `CONTRACT_VERSION_MISMATCH`
 - `FEATURE_NOT_FOUND`
 - `WP_NOT_FOUND`

--- a/tests/integration/orchestrator_api/test_json_envelope_contract.py
+++ b/tests/integration/orchestrator_api/test_json_envelope_contract.py
@@ -1,0 +1,204 @@
+"""Regression tests for orchestrator-api JSON envelope contract (issue #177).
+
+Tests cover:
+  Repro 2 -- Parser-level errors (missing required args, unknown options,
+             missing option values) must return a JSON envelope with
+             ``success: false`` and ``error_code: "USAGE_ERROR"``.
+  Repro 3 -- The dead ``--no-json`` flag has been removed; passing it must
+             be rejected with a ``USAGE_ERROR`` envelope.
+"""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from specify_cli.orchestrator_api.commands import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_envelope(output: str) -> dict:
+    """Parse the last non-empty line of output as JSON.
+
+    The error handler may emit a single JSON line; we grab it reliably even
+    if other output is mixed in (e.g. traceback noise from CliRunner).
+    """
+    for line in reversed(output.strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            return json.loads(line)
+    raise AssertionError(f"No JSON envelope found in output:\n{output}")
+
+
+def _assert_usage_error(output: str, *, substring: str | None = None) -> dict:
+    """Assert the output is a USAGE_ERROR JSON envelope and return it."""
+    env = _parse_envelope(output)
+    assert env["success"] is False, f"Expected success=false, got: {env}"
+    assert env["error_code"] == "USAGE_ERROR", f"Expected USAGE_ERROR, got: {env['error_code']}"
+    assert "message" in env["data"], f"Expected 'message' in data, got: {env['data']}"
+    if substring is not None:
+        assert substring.lower() in env["data"]["message"].lower(), (
+            f"Expected '{substring}' in message '{env['data']['message']}'"
+        )
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Repro 2: Parser-level errors must be JSON envelopes
+# ---------------------------------------------------------------------------
+
+
+class TestParserErrorsReturnJSON:
+    """Missing required args and unknown options must return USAGE_ERROR JSON."""
+
+    def test_feature_state_missing_required_feature(self):
+        """feature-state requires --feature; omitting it should be USAGE_ERROR."""
+        result = runner.invoke(app, ["feature-state"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--feature")
+
+    def test_list_ready_missing_required_feature(self):
+        """list-ready requires --feature; omitting it should be USAGE_ERROR."""
+        result = runner.invoke(app, ["list-ready"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--feature")
+
+    def test_transition_missing_required_args(self):
+        """transition requires --feature, --wp, --to, --actor; omitting all should error."""
+        result = runner.invoke(app, ["transition"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output)
+
+    def test_start_implementation_missing_all_args(self):
+        """start-implementation requires --feature, --wp, --actor."""
+        result = runner.invoke(app, ["start-implementation"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output)
+
+    def test_accept_feature_missing_required_args(self):
+        """accept-feature requires --feature and --actor."""
+        result = runner.invoke(app, ["accept-feature"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output)
+
+    def test_append_history_missing_required_args(self):
+        """append-history requires --feature, --wp, --actor, --note."""
+        result = runner.invoke(app, ["append-history"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output)
+
+    def test_unknown_option_returns_json(self):
+        """An unknown option like --bogus should return USAGE_ERROR JSON."""
+        result = runner.invoke(app, ["contract-version", "--bogus"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--bogus")
+
+    def test_unknown_subcommand_returns_json(self):
+        """An unknown subcommand should return USAGE_ERROR JSON."""
+        result = runner.invoke(app, ["nonexistent-subcommand"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="nonexistent-subcommand")
+
+    def test_missing_option_value_returns_json(self):
+        """--feature without a value should return USAGE_ERROR JSON."""
+        result = runner.invoke(app, ["feature-state", "--feature"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--feature")
+
+
+# ---------------------------------------------------------------------------
+# Repro 2: Envelope shape validation
+# ---------------------------------------------------------------------------
+
+
+class TestUsageErrorEnvelopeShape:
+    """The USAGE_ERROR envelope must have the full canonical shape."""
+
+    def test_envelope_has_all_required_keys(self):
+        result = runner.invoke(app, ["feature-state"])
+        env = _parse_envelope(result.output)
+        required_keys = {
+            "contract_version",
+            "command",
+            "timestamp",
+            "correlation_id",
+            "success",
+            "error_code",
+            "data",
+        }
+        assert required_keys.issubset(set(env.keys())), (
+            f"Missing keys: {required_keys - set(env.keys())}"
+        )
+
+    def test_envelope_command_is_unknown(self):
+        """Parser errors happen before the command is known, so command='orchestrator-api.unknown'."""
+        result = runner.invoke(app, ["feature-state"])
+        env = _parse_envelope(result.output)
+        assert env["command"] == "orchestrator-api.unknown"
+
+    def test_correlation_id_present(self):
+        result = runner.invoke(app, ["feature-state"])
+        env = _parse_envelope(result.output)
+        assert env["correlation_id"].startswith("corr-")
+
+
+# ---------------------------------------------------------------------------
+# Repro 3: --no-json flag is removed (breaking change)
+# ---------------------------------------------------------------------------
+
+
+class TestNoJsonFlagRemoved:
+    """The --no-json flag must no longer be accepted."""
+
+    def test_no_json_flag_rejected_on_contract_version(self):
+        result = runner.invoke(app, ["contract-version", "--no-json"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--no-json")
+
+    def test_no_json_flag_rejected_on_feature_state(self):
+        result = runner.invoke(app, ["feature-state", "--feature", "dummy", "--no-json"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--no-json")
+
+    def test_no_json_flag_rejected_on_transition(self):
+        result = runner.invoke(app, [
+            "transition", "--feature", "dummy", "--wp", "WP01",
+            "--to", "done", "--actor", "test", "--no-json",
+        ])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--no-json")
+
+    def test_json_flag_also_rejected(self):
+        """--json was part of --json/--no-json pair; both must be gone."""
+        result = runner.invoke(app, ["contract-version", "--json"])
+        assert result.exit_code != 0
+        _assert_usage_error(result.output, substring="--json")
+
+
+# ---------------------------------------------------------------------------
+# Positive control: valid commands still work
+# ---------------------------------------------------------------------------
+
+
+class TestValidCommandsStillWork:
+    """Ensure the JSON error handler doesn't break normal command execution."""
+
+    def test_contract_version_still_returns_success(self):
+        result = runner.invoke(app, ["contract-version"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["error_code"] is None
+
+    def test_contract_version_with_provider_version(self):
+        result = runner.invoke(app, ["contract-version", "--provider-version", "0.1.0"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True


### PR DESCRIPTION
## Summary

Fixes repros 2 and 3 from #177 (repro 1 was already fixed by #182).

- **Repro 2 (parser errors not JSON):** Parser-level errors (missing required args, unknown options, unknown subcommands, missing option values) now emit a canonical JSON envelope with `error_code: "USAGE_ERROR"` instead of plain-text Click/Typer usage errors. Implemented via a custom `TyperGroup` subclass (`_JSONErrorGroup`) that overrides `main()` with `standalone_mode=False` to intercept `click.UsageError` exceptions.

- **Repro 3 (dead `--no-json` flag):** Removed the `--json/--no-json` flag from all 9 orchestrator-api commands. The orchestrator-api is a machine contract that always emits JSON; the flag was declared but never referenced in any command body.

## Breaking Changes

- **`--json` and `--no-json` flags removed** from all orchestrator-api subcommands. Callers passing either flag will now receive a `USAGE_ERROR` JSON envelope. Since `--no-json` was dead code (output was always JSON regardless), and `--json` was the default, this should not affect well-behaved orchestrators.

## Changes

- `src/specify_cli/orchestrator_api/commands.py`: Added `_JSONErrorGroup` (TyperGroup subclass), removed all `json_output` parameters, fixed unused variable lint
- `tests/integration/orchestrator_api/test_json_envelope_contract.py`: 18 new regression tests covering parser errors, envelope shape, `--no-json` removal, and positive controls
- `docs/reference/orchestrator-api.md`: Updated to remove `--json` from examples, added `USAGE_ERROR` to error codes
- 5 other doc files: Removed `--json` from orchestrator-api command examples

## Test plan

- [x] All 18 new regression tests pass (parser errors, unknown options, unknown subcommands, --no-json rejection, envelope shape)
- [x] All 34 existing orchestrator-api integration tests pass (no regressions)
- [x] All 10 unit tests for envelope module pass
- [x] `ruff check` clean on `src/specify_cli/orchestrator_api/`

Closes #177

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>