### PR TITLE
fix: allow review reject for_review->planned with feedback (#223)

### DIFF
--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -232,6 +232,7 @@ def _validate_transition(
         ("planned", "in_progress"),
         ("in_progress", "for_review"),
         ("for_review", "in_progress"),
+        ("for_review", "planned"),
         ("for_review", "done"),
     }
 
@@ -243,6 +244,9 @@ def _validate_transition(
 
     if from_api_lane == "for_review" and to_api_lane == "in_progress" and not review_ref:
         return "--review-ref is required for for_review -> in_progress"
+
+    if from_api_lane == "for_review" and to_api_lane == "planned" and not review_ref:
+        return "--review-ref is required for for_review -> planned (review rejection)"
 
     return None
 


### PR DESCRIPTION
## Summary
- allow orchestrator transition `for_review -> planned` in `_validate_transition`
- require `--review-ref` for `for_review -> planned` (review rejection evidence)
- add integration tests for reject-without-ref (fails) and reject-with-ref (succeeds)

## Why
Issue #223 reported a contract mismatch: docs/templates instruct reject via `--to planned`, but orchestrator API rejected it.

## Validation
- `python3 -m pytest tests/integration/orchestrator_api/test_commands.py -q` (22 passed)
- `python3 -m pytest tests/unit/agent/test_tasks.py tests/integration/test_task_workflow.py tests/unit/test_move_task_git_validation.py -v` (61 passed)

Closes #223
