### PR TITLE
chore(release): enforce dependency train and MIT metadata gates

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -102,6 +102,16 @@ jobs:
             python scripts/release/validate_release.py --mode branch
           fi
 
+      - name: Validate dependency compatibility matrix
+        id: matrix
+        continue-on-error: true
+        run: python scripts/release/validate_dependency_matrix.py
+
+      - name: Validate spec-kitty library dependency policy
+        id: deps_policy
+        continue-on-error: true
+        run: python scripts/release/validate_dependency_policy.py --allow-missing
+
       - name: Test packaging
         run: |
           echo "::group::Building wheel to catch packaging issues"
@@ -114,15 +124,21 @@ jobs:
           echo "# Release Readiness Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [[ "${{ steps.validate.outcome }}" == "success" ]]; then
+          if [[ "${{ steps.validate.outcome }}" == "success" && "${{ steps.matrix.outcome }}" == "success" ]]; then
             echo "✅ **All readiness checks passed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "This branch is ready for release:" >> $GITHUB_STEP_SUMMARY
             echo "- Version is properly bumped" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog entry exists and is populated" >> $GITHUB_STEP_SUMMARY
             echo "- Version progression is monotonic within its major stream" >> $GITHUB_STEP_SUMMARY
+            echo "- Dependency compatibility matrix matches pyproject pins" >> $GITHUB_STEP_SUMMARY
             echo "- Tests pass" >> $GITHUB_STEP_SUMMARY
             echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
+            if [[ "${{ steps.deps_policy.outcome }}" != "success" ]]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "⚠️ **Dependency policy warning**: prerelease/direct-reference pins detected." >> $GITHUB_STEP_SUMMARY
+              echo "This does not block PR readiness, but it WILL block the release workflow unless explicitly approved." >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "❌ **Readiness checks failed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -133,6 +149,8 @@ jobs:
             echo "1. **Version Bump** - Update version in \`pyproject.toml\`" >> $GITHUB_STEP_SUMMARY
             echo "2. **Changelog Entry** - Add release notes under \`## [X.Y.Z]\` or \`## [X.Y.ZaN/bN/rcN]\` in \`CHANGELOG.md\`" >> $GITHUB_STEP_SUMMARY
             echo "3. **Version Progression** - Ensure version is not behind the latest tag in the same major stream" >> $GITHUB_STEP_SUMMARY
+            echo "4. **Dependency Matrix** - Update \`docs/releases/dependency-compatibility-matrix.toml\` for this version" >> $GITHUB_STEP_SUMMARY
+            echo "5. **Dependency Policy** - Use exact PyPI pins and MIT-clearly-labeled dependency releases" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "See the validation output above for specific errors." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -140,7 +158,7 @@ jobs:
           fi
 
       - name: Fail if validation failed
-        if: steps.validate.outcome != 'success'
+        if: steps.validate.outcome != 'success' || steps.matrix.outcome != 'success'
         run: |
           echo "::error::Release readiness checks failed. Review the validation output and job summary for details."
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
         description: Optional release tag to validate/publish (defaults to pyproject version)
         required: false
         type: string
+      approve_prerelease_dependencies:
+        description: Explicitly allow prerelease spec-kitty-* dependency pins for this run
+        required: false
+        default: false
+        type: boolean
+      approve_direct_reference_dependencies:
+        description: Explicitly allow direct URL spec-kitty-* dependencies for this run
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -105,6 +115,29 @@ jobs:
             --tag "${{ steps.release_context.outputs.release_tag }}" \
             --tag-pattern "v1*"
 
+      - name: Validate dependency compatibility matrix
+        run: python scripts/release/validate_dependency_matrix.py
+
+      - name: Validate spec-kitty library dependency policy
+        env:
+          INPUT_ALLOW_PRERELEASE: ${{ github.event.inputs.approve_prerelease_dependencies }}
+          INPUT_ALLOW_DIRECT_REF: ${{ github.event.inputs.approve_direct_reference_dependencies }}
+          SECRET_ALLOW_PRERELEASE: ${{ secrets.RELEASE_APPROVE_PRERELEASE_DEPS }}
+          SECRET_ALLOW_DIRECT_REF: ${{ secrets.RELEASE_APPROVE_DIRECT_REFERENCE_DEPS }}
+        run: |
+          set -euo pipefail
+          POLICY_ARGS=(--allow-missing)
+
+          if [[ "${INPUT_ALLOW_PRERELEASE}" == "true" || "${SECRET_ALLOW_PRERELEASE}" == "1" ]]; then
+            POLICY_ARGS+=(--allow-prerelease)
+          fi
+
+          if [[ "${INPUT_ALLOW_DIRECT_REF}" == "true" || "${SECRET_ALLOW_DIRECT_REF}" == "1" ]]; then
+            POLICY_ARGS+=(--allow-direct-reference)
+          fi
+
+          python scripts/release/validate_dependency_policy.py "${POLICY_ARGS[@]}"
+
       - name: Validate repository URLs
         run: |
           python << 'EOF'
@@ -141,6 +174,9 @@ jobs:
 
       - name: Build distributions
         run: python -m build
+
+      - name: Validate distribution metadata
+        run: python scripts/release/validate_distribution_metadata.py --package spec-kitty-cli
 
       - name: Verify wheel contents
         run: |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -12,6 +12,20 @@ Use this checklist to ensure consistent, high-quality releases of spec-kitty.
   - **Major** (X.0.0): Breaking changes
   - **Release Candidate** (X.Y.ZrcN): Pre-release candidate on the path to a major/minor/patch release
 
+### Dependency Release Train (Required)
+
+- [ ] Release `spec-kitty-events` first and confirm the pinned version is available on PyPI.
+- [ ] Release `spec-kitty-runtime` first if CLI depends on it.
+- [ ] Release `spec-kitty-tracker` first if CLI depends on it.
+- [ ] Ensure dependency versions used in `pyproject.toml` are exact `==` pins.
+- [ ] Ensure all pinned `spec-kitty-*` library versions have clear MIT metadata on PyPI.
+- [ ] Update `docs/releases/dependency-compatibility-matrix.toml` with `[cli.\"X.Y.Z\".dependencies]`.
+- [ ] Run release dependency guards locally:
+  ```bash
+  python scripts/release/validate_dependency_matrix.py
+  python scripts/release/validate_dependency_policy.py --allow-missing
+  ```
+
 ### Code Quality
 
 - [ ] Run full test suite: `pytest tests/ -v`

--- a/docs/releases/dependency-compatibility-matrix.toml
+++ b/docs/releases/dependency-compatibility-matrix.toml
@@ -1,0 +1,18 @@
+[release_train]
+order = [
+  "spec-kitty-events",
+  "spec-kitty-runtime",
+  "spec-kitty-tracker",
+  "spec-kitty-cli",
+]
+
+[cli."1.0.1".dependencies]
+"spec-kitty-events" = "0.4.0a0"
+
+[cli."1.0.1".train]
+"spec-kitty-events" = "0.4.0a0"
+"spec-kitty-runtime" = "not-used"
+"spec-kitty-tracker" = "0.1.0"
+
+[cli."1.0.1"]
+notes = "Legacy release with prerelease events pin; do not copy for new releases."

--- a/docs/releases/dependency-release-train.md
+++ b/docs/releases/dependency-release-train.md
@@ -1,0 +1,33 @@
+# Dependency Release Train
+
+This release train prevents CLI releases from shipping with unlicensed or non-reproducible dependency pins.
+
+## Order
+
+1. Release `spec-kitty-events` with clear MIT metadata on PyPI.
+2. Release `spec-kitty-runtime` with clear MIT metadata on PyPI (if used by CLI).
+3. Release `spec-kitty-tracker` with clear MIT metadata on PyPI (if used by CLI).
+4. Release `spec-kitty-cli` with exact `==` pins to the versions above.
+
+## Required Checks
+
+- `scripts/release/validate_dependency_matrix.py`
+- `scripts/release/validate_dependency_policy.py`
+- `scripts/release/validate_distribution_metadata.py`
+
+## Compatibility Matrix Maintenance
+
+Update [dependency-compatibility-matrix.toml](dependency-compatibility-matrix.toml) in every release PR:
+
+- Add a new `[cli."X.Y.Z".dependencies]` section.
+- Add a new `[cli."X.Y.Z".train]` section and set all release-train libraries:
+  - `spec-kitty-events`
+  - `spec-kitty-runtime` (`not-used` when not bundled)
+  - `spec-kitty-tracker` (use concrete version even when embedded)
+- Record every `spec-kitty-*` dependency used by CLI.
+- Keep `release_train.order` unchanged unless release ownership changes.
+
+## Exception Policy
+
+Non-PyPI direct references and prerelease dependency pins are blocked by default.
+They are only allowed for a specific release when an explicit CI approval secret is set.

--- a/docs/releases/readiness-checklist.md
+++ b/docs/releases/readiness-checklist.md
@@ -1,0 +1,5 @@
+# Release Readiness Checklist
+
+Use the root [RELEASE_CHECKLIST.md](../../RELEASE_CHECKLIST.md) as the authoritative checklist.
+
+Release PRs must also satisfy the dependency train process in [dependency-release-train.md](dependency-release-train.md).

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -125,6 +125,59 @@ Output:
 
 **Integration**: Used by `.github/workflows/release.yml` to populate GitHub Release body
 
+### `validate_dependency_matrix.py`
+
+Validates that `pyproject.toml` dependency pins for `spec-kitty-*` libraries match the release compatibility matrix in `docs/releases/dependency-compatibility-matrix.toml` and that all release-train libraries are explicitly recorded in the `.train` table.
+
+**Purpose**: Ensures every CLI release explicitly records which library versions it is pinned to.
+
+**Usage**:
+
+```bash
+python scripts/release/validate_dependency_matrix.py
+```
+
+### `validate_dependency_policy.py`
+
+Validates policy constraints for `spec-kitty-*` dependencies:
+
+- Must be exact `==` pins
+- Must resolve on PyPI (no hidden/unpublished versions)
+- Must have clear MIT metadata on PyPI
+- No direct URL references or prerelease pins unless explicitly approved
+
+**Usage**:
+
+```bash
+python scripts/release/validate_dependency_policy.py --allow-missing
+```
+
+Optional explicit approvals (for exceptional releases only):
+
+```bash
+python scripts/release/validate_dependency_policy.py \
+  --allow-missing \
+  --allow-prerelease \
+  --allow-direct-reference
+```
+
+### `validate_distribution_metadata.py`
+
+Validates built wheel/sdist metadata for explicit MIT licensing.
+
+Checks include:
+
+- Wheel METADATA exposes MIT classifier/license metadata
+- Wheel METADATA includes `License-File: LICENSE`
+- Source distribution contains `LICENSE`
+
+**Usage**:
+
+```bash
+python -m build
+python scripts/release/validate_distribution_metadata.py --package spec-kitty-cli
+```
+
 ## Workflow Integration
 
 ### Release Readiness (PR Checks)
@@ -133,6 +186,12 @@ Output:
 ```yaml
 - name: Validate release metadata
   run: python scripts/release/validate_release.py --mode branch
+
+- name: Validate dependency compatibility matrix
+  run: python scripts/release/validate_dependency_matrix.py
+
+- name: Validate spec-kitty library dependency policy
+  run: python scripts/release/validate_dependency_policy.py --allow-missing
 ```
 
 ### Release Publication (Tag Push)
@@ -141,6 +200,12 @@ Output:
 ```yaml
 - name: Validate release metadata
   run: python scripts/release/validate_release.py --mode tag --tag "${GITHUB_REF_NAME}"
+
+- name: Validate dependency compatibility matrix
+  run: python scripts/release/validate_dependency_matrix.py
+
+- name: Validate spec-kitty library dependency policy
+  run: python scripts/release/validate_dependency_policy.py --allow-missing
 
 - name: Extract changelog for release
   run: |

--- a/scripts/release/validate_dependency_matrix.py
+++ b/scripts/release/validate_dependency_matrix.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validate pyproject spec-kitty pins against the compatibility matrix."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+from packaging.requirements import Requirement
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument(
+        "--matrix", default="docs/releases/dependency-compatibility-matrix.toml"
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        raise SystemExit(f"File not found: {path}")
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_dep_value(raw: str) -> str:
+    req = Requirement(raw)
+    if req.url:
+        return f"url:{req.url}"
+    specs = list(req.specifier)
+    if len(specs) == 1 and specs[0].operator == "==" and not specs[0].version.endswith(".*"):
+        return specs[0].version
+    return raw.strip()
+
+
+def project_spec_kitty_deps(pyproject_data: Dict[str, object]) -> Dict[str, str]:
+    project = pyproject_data.get("project")
+    if not isinstance(project, dict):
+        raise SystemExit("Invalid pyproject.toml: missing [project]")
+
+    deps = project.get("dependencies")
+    if not isinstance(deps, list):
+        raise SystemExit("Invalid pyproject.toml: [project].dependencies must be a list")
+
+    result: Dict[str, str] = {}
+    for raw in deps:
+        req = Requirement(str(raw))
+        if req.name.startswith("spec-kitty-") and req.name != "spec-kitty-cli":
+            result[req.name] = normalize_dep_value(str(raw))
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    pyproject = load_toml(Path(args.pyproject))
+    matrix = load_toml(Path(args.matrix))
+
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        raise SystemExit("Invalid pyproject.toml: missing [project]")
+
+    version = project.get("version")
+    if not isinstance(version, str):
+        raise SystemExit("Invalid pyproject.toml: missing [project].version")
+
+    cli = matrix.get("cli")
+    if not isinstance(cli, dict):
+        raise SystemExit("Compatibility matrix missing [cli] table")
+
+    entry = cli.get(version)
+    if not isinstance(entry, dict):
+        raise SystemExit(
+            f"Compatibility matrix missing [cli.\"{version}\"] entry for current version"
+        )
+
+    expected_deps = entry.get("dependencies")
+    if not isinstance(expected_deps, dict):
+        raise SystemExit(
+            f"Compatibility matrix entry [cli.\"{version}\"] must include .dependencies table"
+        )
+
+    expected_train = entry.get("train")
+    if not isinstance(expected_train, dict):
+        raise SystemExit(
+            f"Compatibility matrix entry [cli.\"{version}\"] must include .train table"
+        )
+
+    release_train = matrix.get("release_train")
+    order = release_train.get("order") if isinstance(release_train, dict) else None
+    if not isinstance(order, list):
+        raise SystemExit("Compatibility matrix missing [release_train].order list")
+
+    actual = project_spec_kitty_deps(pyproject)
+
+    issues: List[str] = []
+
+    for lib in order:
+        if not isinstance(lib, str):
+            issues.append(f"release_train.order contains non-string entry: {lib!r}")
+            continue
+        if lib == "spec-kitty-cli":
+            continue
+        value = expected_train.get(lib)
+        if not isinstance(value, str) or not value.strip():
+            issues.append(
+                f"Matrix [cli.\"{version}\".train] missing value for {lib}."
+            )
+
+    for package, pinned in actual.items():
+        expected_pin = expected_deps.get(package)
+        if not isinstance(expected_pin, str):
+            issues.append(
+                f"Matrix missing expected pin for {package} in [cli.\"{version}\".dependencies]"
+            )
+            continue
+        if pinned != expected_pin:
+            issues.append(
+                f"Pin mismatch for {package}: pyproject='{pinned}' vs matrix='{expected_pin}'"
+            )
+
+        train_pin = expected_train.get(package)
+        if isinstance(train_pin, str) and train_pin.strip() and train_pin not in {
+            "n/a",
+            "na",
+            "not-used",
+            "not used",
+        }:
+            if train_pin != pinned:
+                issues.append(
+                    f"Train mismatch for {package}: dependencies table has '{pinned}' but train has '{train_pin}'"
+                )
+
+    print("Dependency Matrix Summary")
+    print("-------------------------")
+    print(f"- CLI version: {version}")
+    for package, pinned in sorted(actual.items()):
+        print(f"- dependency {package}: {pinned}")
+    for lib in order:
+        if isinstance(lib, str) and lib != "spec-kitty-cli":
+            print(f"- train {lib}: {expected_train.get(lib, '<missing>')}")
+
+    if issues:
+        print("\nMatrix validation failures:")
+        for idx, issue in enumerate(issues, start=1):
+            print(f"  {idx}. {issue}")
+        return 1
+
+    print("\nDependency matrix check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/validate_dependency_policy.py
+++ b/scripts/release/validate_dependency_policy.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Validate spec-kitty library dependency policy before release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+from packaging.requirements import Requirement
+from packaging.version import InvalidVersion, Version
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument(
+        "--matrix", default="docs/releases/dependency-compatibility-matrix.toml"
+    )
+    parser.add_argument(
+        "--libraries",
+        default="spec-kitty-events,spec-kitty-runtime,spec-kitty-tracker",
+        help="Comma-separated library names to validate.",
+    )
+    parser.add_argument(
+        "--allow-prerelease",
+        action="store_true",
+        help="Allow prerelease pins for this run.",
+    )
+    parser.add_argument(
+        "--allow-direct-reference",
+        action="store_true",
+        help="Allow direct-reference dependency URLs for this run.",
+    )
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="Allow libraries that are neither dependencies nor train entries.",
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        raise SystemExit(f"File not found: {path}")
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def load_dependencies(pyproject_data: Dict[str, object]) -> List[str]:
+    deps = pyproject_data.get("project", {}).get("dependencies")
+    if not isinstance(deps, list):
+        raise SystemExit("Invalid pyproject.toml: [project].dependencies must be a list")
+    return [str(dep) for dep in deps]
+
+
+def load_project_version(pyproject_data: Dict[str, object]) -> str:
+    version = pyproject_data.get("project", {}).get("version")
+    if not isinstance(version, str):
+        raise SystemExit("Invalid pyproject.toml: missing [project].version")
+    return version
+
+
+def parse_requirement(raw: str) -> Optional[Requirement]:
+    try:
+        return Requirement(raw)
+    except Exception:
+        return None
+
+
+def lookup_dependency(dependencies: List[str], package: str) -> List[str]:
+    matches: List[str] = []
+    for dep in dependencies:
+        req = parse_requirement(dep)
+        if req and req.name.lower() == package.lower():
+            matches.append(dep)
+            continue
+        if dep.lower().startswith(f"{package.lower()} "):
+            matches.append(dep)
+    return matches
+
+
+def exact_pin(req: Requirement) -> Optional[str]:
+    specs = list(req.specifier)
+    if len(specs) != 1:
+        return None
+    spec = specs[0]
+    if spec.operator != "==" or spec.version.endswith(".*"):
+        return None
+    return spec.version
+
+
+def fetch_pypi_info(package: str, version: str) -> Dict[str, object]:
+    url = f"https://pypi.org/pypi/{package}/{version}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise SystemExit(f"Pinned version not found on PyPI: {package}=={version}")
+        raise
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Unable to reach PyPI for {package}=={version}: {exc}") from exc
+
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        raise SystemExit(f"Unexpected PyPI payload for {package}=={version}")
+    return info
+
+
+def has_mit_metadata(info: Dict[str, object]) -> bool:
+    classifiers = info.get("classifiers")
+    classifier_ok = isinstance(classifiers, list) and any(
+        isinstance(c, str) and c.strip() == "License :: OSI Approved :: MIT License"
+        for c in classifiers
+    )
+
+    license_field = info.get("license")
+    license_expr = info.get("license_expression")
+    license_ok = isinstance(license_field, str) and "mit" in license_field.lower()
+    license_expr_ok = isinstance(license_expr, str) and "mit" in license_expr.lower()
+
+    return classifier_ok or license_ok or license_expr_ok
+
+
+def parse_train_versions(matrix_data: Dict[str, object], version: str) -> Dict[str, str]:
+    cli = matrix_data.get("cli")
+    if not isinstance(cli, dict):
+        return {}
+
+    entry = cli.get(version)
+    if not isinstance(entry, dict):
+        return {}
+
+    train = entry.get("train")
+    if not isinstance(train, dict):
+        return {}
+
+    parsed: Dict[str, str] = {}
+    for key, value in train.items():
+        if isinstance(key, str) and isinstance(value, str):
+            parsed[key] = value.strip()
+    return parsed
+
+
+def validate_pinned_version(
+    library: str,
+    pinned: str,
+    *,
+    allow_prerelease: bool,
+    issues: List[str],
+    summary: List[str],
+    source: str,
+) -> None:
+    try:
+        parsed = Version(pinned)
+    except InvalidVersion:
+        issues.append(f"{library}: invalid pinned version '{pinned}' ({source}).")
+        return
+
+    if parsed.is_prerelease and not allow_prerelease:
+        issues.append(
+            f"{library}: prerelease pin '{pinned}' is not allowed without explicit approval."
+        )
+
+    try:
+        info = fetch_pypi_info(library, pinned)
+    except SystemExit as exc:
+        issues.append(str(exc))
+        return
+    if not has_mit_metadata(info):
+        issues.append(
+            f"{library}=={pinned}: missing clear MIT metadata on PyPI "
+            "(classifier/license/license_expression)."
+        )
+
+    summary.append(f"{library}: validated {pinned} ({source})")
+
+
+def main() -> int:
+    args = parse_args()
+
+    pyproject_data = load_toml(Path(args.pyproject))
+    dependencies = load_dependencies(pyproject_data)
+    version = load_project_version(pyproject_data)
+
+    matrix_path = Path(args.matrix)
+    matrix_data = load_toml(matrix_path) if matrix_path.exists() else {}
+    train_versions = parse_train_versions(matrix_data, version)
+
+    libraries = [lib.strip() for lib in args.libraries.split(",") if lib.strip()]
+
+    issues: List[str] = []
+    summary: List[str] = []
+
+    for library in libraries:
+        matches = lookup_dependency(dependencies, library)
+
+        if len(matches) > 1:
+            issues.append(f"Multiple dependency entries found for {library}: {matches}")
+            continue
+
+        if matches:
+            raw = matches[0]
+            req = parse_requirement(raw)
+            if req is None:
+                issues.append(f"Unable to parse dependency requirement: {raw}")
+                continue
+
+            if req.url:
+                if args.allow_direct_reference:
+                    summary.append(f"{library}: direct reference approved ({req.url}).")
+                    continue
+                issues.append(
+                    f"{library}: direct reference is not allowed ({raw}). "
+                    "Publish to PyPI and pin with == instead."
+                )
+                continue
+
+            pinned_version = exact_pin(req)
+            if not pinned_version:
+                issues.append(
+                    f"{library}: dependency must be exact-pinned with == (found: {raw})."
+                )
+                continue
+
+            train_value = train_versions.get(library)
+            if train_value and train_value.lower() not in {"n/a", "na", "not-used", "not used"}:
+                if train_value != pinned_version:
+                    issues.append(
+                        f"{library}: dependency pin {pinned_version} does not match release-train entry {train_value}."
+                    )
+
+            validate_pinned_version(
+                library,
+                pinned_version,
+                allow_prerelease=args.allow_prerelease,
+                issues=issues,
+                summary=summary,
+                source="dependency pin",
+            )
+            continue
+
+        train_value = train_versions.get(library, "").strip()
+        if train_value and train_value.lower() not in {"n/a", "na", "not-used", "not used"}:
+            validate_pinned_version(
+                library,
+                train_value,
+                allow_prerelease=args.allow_prerelease,
+                issues=issues,
+                summary=summary,
+                source="release-train matrix",
+            )
+            continue
+
+        if not args.allow_missing:
+            issues.append(
+                f"Missing required library entry for {library} (dependency or release-train matrix)."
+            )
+
+    print("Dependency Policy Summary")
+    print("-------------------------")
+    for line in summary:
+        print(f"- {line}")
+
+    if issues:
+        print("\nDependency policy violations:")
+        for idx, issue in enumerate(issues, start=1):
+            print(f"  {idx}. {issue}")
+        return 1
+
+    print("\nAll dependency policy checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/validate_distribution_metadata.py
+++ b/scripts/release/validate_distribution_metadata.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate built distribution metadata for explicit MIT licensing."""
+
+from __future__ import annotations
+
+import argparse
+import email
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import List
+
+
+MIT_CLASSIFIER = "License :: OSI Approved :: MIT License"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist-dir", default="dist")
+    parser.add_argument("--package", default="spec-kitty-cli")
+    return parser.parse_args()
+
+
+def read_wheel_metadata(wheel_path: Path) -> email.message.Message:
+    with zipfile.ZipFile(wheel_path) as zf:
+        metadata_names = [
+            name for name in zf.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if not metadata_names:
+            raise SystemExit(f"No METADATA file found in wheel: {wheel_path}")
+        content = zf.read(metadata_names[0]).decode("utf-8", errors="replace")
+    return email.message_from_string(content)
+
+
+def assert_mit_metadata(metadata: email.message.Message, label: str) -> List[str]:
+    issues: List[str] = []
+    classifiers = metadata.get_all("Classifier", [])
+    license_value = metadata.get("License", "")
+    license_expr = metadata.get("License-Expression", "")
+    license_files = metadata.get_all("License-File", [])
+
+    has_mit_classifier = MIT_CLASSIFIER in classifiers
+    has_mit_text = "mit" in (license_value or "").lower() or "mit" in (
+        license_expr or ""
+    ).lower()
+
+    if not (has_mit_classifier or has_mit_text):
+        issues.append(f"{label}: METADATA must declare MIT via classifier/license fields")
+
+    if "LICENSE" not in license_files:
+        issues.append(f"{label}: METADATA must include 'License-File: LICENSE'")
+
+    return issues
+
+
+def assert_sdist_contains_license(sdist_path: Path) -> List[str]:
+    issues: List[str] = []
+    with tarfile.open(sdist_path, "r:gz") as tf:
+        names = tf.getnames()
+    if not any(name.endswith("/LICENSE") or name == "LICENSE" for name in names):
+        issues.append(f"{sdist_path.name}: source distribution must include LICENSE file")
+    return issues
+
+
+def main() -> int:
+    args = parse_args()
+    dist_dir = Path(args.dist_dir)
+    if not dist_dir.exists():
+        raise SystemExit(f"Distribution directory not found: {dist_dir}")
+
+    package_prefix = args.package.replace("-", "_")
+    wheels = sorted(
+        wheel
+        for wheel in dist_dir.glob("*.whl")
+        if wheel.name.startswith(package_prefix)
+    )
+    sdists = sorted(
+        sdist
+        for sdist in dist_dir.glob("*.tar.gz")
+        if sdist.name.startswith(package_prefix)
+    )
+
+    if not wheels:
+        raise SystemExit("No wheel files found in dist directory")
+    if not sdists:
+        raise SystemExit("No source distributions (.tar.gz) found in dist directory")
+
+    issues: List[str] = []
+
+    for wheel in wheels:
+        metadata = read_wheel_metadata(wheel)
+        issues.extend(assert_mit_metadata(metadata, wheel.name))
+
+    for sdist in sdists:
+        issues.extend(assert_sdist_contains_license(sdist))
+
+    print("Distribution Metadata Summary")
+    print("-----------------------------")
+    for wheel in wheels:
+        print(f"- wheel: {wheel.name}")
+    for sdist in sdists:
+        print(f"- sdist: {sdist.name}")
+
+    if issues:
+        print("\nMetadata validation failures:")
+        for idx, issue in enumerate(issues, start=1):
+            print(f"  {idx}. {issue}")
+        return 1
+
+    print("\nDistribution metadata check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\nEnforce release-train ordering and MIT licensing checks for CLI dependencies and artifacts.\n\n## Changes\n- add dependency compatibility matrix + train docs\n- add dependency matrix validator\n- add dependency policy validator (PyPI+MIT checks, prerelease/direct-ref guardrails)\n- add distribution metadata validator\n- wire validators into release and release-readiness workflows\n- update release checklist and release docs\n\n## Why\nPrevents CLI releases pinned to unpublished or unclear-license library versions.