### PR TITLE
Release CLI 1.0.2 with MIT-cleared dependency train pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-03-04
+
+### 🔧 Changed
+
+- **MIT-cleared dependency pin for 1.x CLI**: replaced prerelease `spec-kitty-events==0.4.0a0` with stable `spec-kitty-events==0.4.1`.
+- **Release train compatibility matrix update**: recorded explicit train entries for `spec-kitty-events`, `spec-kitty-runtime`, and `spec-kitty-tracker` to keep future releases aligned to MIT-cleared PyPI packages.
+
 ## [1.0.1] - 2026-02-27
 
 ### 🔧 Changed

--- a/docs/releases/dependency-compatibility-matrix.toml
+++ b/docs/releases/dependency-compatibility-matrix.toml
@@ -16,3 +16,14 @@ order = [
 
 [cli."1.0.1"]
 notes = "Legacy release with prerelease events pin; do not copy for new releases."
+
+[cli."1.0.2".dependencies]
+"spec-kitty-events" = "0.4.1"
+
+[cli."1.0.2".train]
+"spec-kitty-events" = "0.4.1"
+"spec-kitty-runtime" = "0.4.0"
+"spec-kitty-tracker" = "0.1.0"
+
+[cli."1.0.2"]
+notes = "Release train pinned to MIT-cleared dependency versions on PyPI."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "1.0.1"
+version = "1.0.2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -61,7 +61,7 @@ dependencies = [
     "packaging>=23.0",
     "psutil>=5.9.0",  # Cross-platform process management for dashboard
     "python-ulid>=1.1.0",  # For spec_kitty_events (vendored)
-    "spec-kitty-events==0.4.0a0",
+    "spec-kitty-events==0.4.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary\n- bump spec-kitty-cli to 1.0.2\n- pin direct dependency to spec-kitty-events==0.4.1\n- update compatibility matrix for 1.0.2 with train pins:\n  - spec-kitty-events=0.4.1\n  - spec-kitty-runtime=0.4.0\n  - spec-kitty-tracker=0.1.0\n- add changelog entry for 1.0.2\n\n## Validation\n- python3 scripts/release/validate_release.py --mode branch\n- python3 scripts/release/validate_dependency_matrix.py\n- python3 scripts/release/validate_dependency_policy.py\n- python3 -m build\n- python3 scripts/release/validate_distribution_metadata.py --package spec-kitty-cli\n- pytest -q (in local .venv): 2133 passed, 11 skipped, 34 xfailed, 18 xpassed