### PR TITLE
Docs: make README capabilities section version-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 ---
 
-## 🚀 What You Get in 0.15.x
+## 🚀 Core Capabilities
 
 | Capability | What Spec Kitty provides |
 |------------|--------------------------|


### PR DESCRIPTION
## Summary\n- rename `What You Get in 0.15.x` to `Core Capabilities`\n- keep the existing capability table content intact\n- remove version-specific framing from this README section\n\n## Validation\n- README render-safe text change only