### PR TITLE
Limit ASCII banner to init/version invocations

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -70,6 +70,7 @@ def activate_mission(project_path: Path, mission_key: str, mission_display: str,
 def version_callback(value: bool) -> None:
     """Display version and exit."""
     if value:
+        show_banner(force=True)
         console.print(f"spec-kitty-cli version {__version__}")
         raise typer.Exit()
 

--- a/src/specify_cli/cli/helpers.py
+++ b/src/specify_cli/cli/helpers.py
@@ -69,8 +69,21 @@ def _format_simple_help(group: TyperGroup, ctx, formatter) -> None:
             formatter.write_dl(commands)
 
 
-def show_banner() -> None:
+def _should_render_banner_for_invocation(argv: list[str] | None = None) -> bool:
+    """Return True only for invocations that should render ASCII art."""
+    tokens = [token.strip().lower() for token in (argv if argv is not None else sys.argv[1:]) if token.strip()]
+    if "--version" in tokens or "-v" in tokens:
+        return True
+
+    command = next((token for token in tokens if not token.startswith("-")), None)
+    return command == "init"
+
+
+def show_banner(force: bool = False) -> None:
     """Display the ASCII art banner with gradient styling."""
+    if not force and not _should_render_banner_for_invocation():
+        return
+
     banner_lines = BANNER.strip().split("\n")
     colors = ["bright_blue", "blue", "cyan", "bright_cyan", "white", "bright_white"]
     max_width = max((len(line) for line in banner_lines), default=0)

--- a/tests/specify_cli/test_banner_visibility.py
+++ b/tests/specify_cli/test_banner_visibility.py
@@ -1,0 +1,42 @@
+"""Banner visibility tests for CLI invocations."""
+
+from __future__ import annotations
+
+import importlib
+import pytest
+import typer
+
+from specify_cli.cli import helpers
+
+cli_module = importlib.import_module("specify_cli.__init__")
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["init"], True),
+        (["--version"], True),
+        (["-v"], True),
+        (["merge", "--feature", "001-test"], False),
+        (["research"], False),
+        (["agent", "feature", "check-prerequisites", "--json"], False),
+    ],
+)
+def test_banner_scope_is_limited_to_init_and_version(argv: list[str], expected: bool) -> None:
+    """ASCII art should be limited to init and version invocations."""
+    assert helpers._should_render_banner_for_invocation(argv) is expected
+
+
+def test_version_callback_renders_banner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--version should still render the banner before printing version text."""
+    calls: list[bool] = []
+
+    def _fake_show_banner(*, force: bool = False) -> None:
+        calls.append(force)
+
+    monkeypatch.setattr(cli_module, "show_banner", _fake_show_banner)
+
+    with pytest.raises(typer.Exit):
+        cli_module.version_callback(True)
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- restrict banner rendering to `spec-kitty init` and `spec-kitty --version`/`-v`
- make `--version` explicitly render the banner before printing version text
- keep command behavior unchanged otherwise; slash-command-launched CLI flows no longer emit ASCII art

## Testing
- pytest -q tests/specify_cli/test_banner_visibility.py tests/test_version_detection.py
