### PR TITLE
fix(init): default to current directory when project name is omitted (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Spec Kitty differentiates between the **project** that holds your entire codebas
 - Multiple features (each with its own spec/plan/tasks)
 - Shared automation under `.kittify/`
 
-**Commands**: Initialize with `spec-kitty init my-project` (or `spec-kitty init --here` for the current directory).
+**Commands**: Initialize with `spec-kitty init` for the current directory by default (or pass `spec-kitty init my-project` to create a project directory).
 
 ---
 
@@ -721,7 +721,7 @@ The `spec-kitty` command supports the following options. Every run begins with a
 
 | Argument/Option        | Type     | Description                                                                  |
 |------------------------|----------|------------------------------------------------------------------------------|
-| `<project-name>`       | Argument | Name for your new project directory (optional if using `--here`, or use `.` for current directory) |
+| `<project-name>`       | Argument | Name for your new project directory (omit to initialize in the current directory, same as `--here`) |
 | `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, `roo`, or `q` |
 | `--script`             | Option   | (Deprecated in v0.10.0) Script variant - all commands now use Python CLI     |
 | `--mission`            | Option   | Mission key to seed templates (`software-dev`, `research`, ...)             |
@@ -739,7 +739,10 @@ If you omit `--mission`, the CLI will prompt you to pick one during `spec-kitty 
 ### Examples
 
 ```bash
-# Basic project initialization
+# Basic initialization in current directory (default)
+spec-kitty init --ai claude
+
+# Basic project initialization in a new directory
 spec-kitty init my-project
 
 # Initialize with specific AI assistant

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -13,6 +13,7 @@
 Spec Kitty CLI - setup tooling for Spec Kitty projects.
 
 Usage:
+    spec-kitty init
     spec-kitty init <project-name>
     spec-kitty init .
     spec-kitty init --here

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -182,7 +182,10 @@ def _install_git_hooks(project_path: Path, templates_root: Path | None = None, t
 
 
 def init(
-    project_name: str = typer.Argument(None, help="Name for your new project directory (optional if using --here, or use '.' for current directory)"),
+    project_name: str = typer.Argument(
+        None,
+        help="Name for your new project directory (omit to initialize current directory, equivalent to --here)",
+    ),
     ai_assistant: str = typer.Option(None, "--ai", help="Comma-separated AI assistants (claude,codex,gemini,...)", rich_help_panel="Selection"),
     script_type: str = typer.Option(None, "--script", help="Script type to use: sh or ps", rich_help_panel="Selection"),
     mission_key: str = typer.Option(None, "--mission", hidden=True, help="[DEPRECATED] Mission selection moved to /spec-kitty.specify"),
@@ -211,12 +214,12 @@ def init(
         here = True
         project_name = None  # Clear project_name to use existing validation logic
 
+    # Default behavior: no positional argument initializes in the current directory.
+    if not here and not project_name:
+        here = True
+
     if here and project_name:
         _console.print("[red]Error:[/red] Cannot specify both project name and --here flag")
-        raise typer.Exit(1)
-
-    if not here and not project_name:
-        _console.print("[red]Error:[/red] Must specify either a project name, use '.' for current directory, or use --here flag")
         raise typer.Exit(1)
 
     if here:

--- a/src/specify_cli/cli/commands/init_help.py
+++ b/src/specify_cli/cli/commands/init_help.py
@@ -3,6 +3,9 @@
 INIT_COMMAND_DOC = """
 Initialize a new Spec Kitty project from templates.
 
+If PROJECT_NAME is omitted, init runs in the current directory by default
+(equivalent to --here).
+
 Interactive Mode (default):
 - Prompts you to select AI assistants
 
@@ -42,6 +45,7 @@ For development installs from source, use either:
   spec-kitty init my-project --ai claude --template-root=$(pwd)
 
 Examples:
+  spec-kitty init --ai codex                    # Current directory (default)
   spec-kitty init my-project                    # Interactive mode
   spec-kitty init my-project --ai codex         # Non-interactive with Codex
   spec-kitty init my-project --ai codex,claude  # Multiple agents

--- a/tests/specify_cli/test_cli/test_init_command.py
+++ b/tests/specify_cli/test_cli/test_init_command.py
@@ -341,6 +341,171 @@ def test_init_non_interactive_requires_ai(cli_app, monkeypatch: pytest.MonkeyPat
     assert "--ai is required in non-interactive mode" in console_output
 
 
+def test_init_non_interactive_no_project_name_defaults_to_current_directory(
+    cli_app, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    app, console, _ = cli_app
+    monkeypatch.chdir(tmp_path)
+
+    def fake_local_repo(override_path=None):
+        return tmp_path / "templates"
+
+    def fake_copy(local_repo: Path, project_path: Path, script: str):
+        commands_dir = project_path / ".templates"
+        commands_dir.mkdir(parents=True, exist_ok=True)
+        return commands_dir
+
+    def fake_assets(commands_dir: Path, project_path: Path, agent_key: str, script: str):
+        target = project_path / f".{agent_key}" / f"run.{script}"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(agent_key, encoding="utf-8")
+
+    monkeypatch.setattr(init_module, "get_local_repo_root", fake_local_repo)
+    monkeypatch.setattr(init_module, "copy_specify_base_from_local", fake_copy)
+    monkeypatch.setattr(init_module, "generate_agent_assets", fake_assets)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--ai",
+            "claude",
+            "--script",
+            "sh",
+            "--no-git",
+            "--non-interactive",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".templates").exists()
+    assert (tmp_path / ".claude" / "run.sh").exists()
+    console_output = console.file.getvalue()
+    assert "Target Path" not in console_output
+
+
+def test_init_non_interactive_no_project_name_requires_force_for_nonempty_directory(
+    cli_app, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    app, console, _ = cli_app
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "existing.txt").write_text("data", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--ai",
+            "claude",
+            "--script",
+            "sh",
+            "--no-git",
+            "--non-interactive",
+        ],
+    )
+
+    assert result.exit_code == 1
+    console_output = console.file.getvalue()
+    assert "Non-interactive mode requires --force when using --here" in console_output
+
+
+def test_init_non_interactive_no_project_name_allows_force_for_nonempty_directory(
+    cli_app, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    app, console, _ = cli_app
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "existing.txt").write_text("data", encoding="utf-8")
+
+    def fake_local_repo(override_path=None):
+        return tmp_path / "templates"
+
+    def fake_copy(local_repo: Path, project_path: Path, script: str):
+        commands_dir = project_path / ".templates"
+        commands_dir.mkdir(parents=True, exist_ok=True)
+        return commands_dir
+
+    def fake_assets(commands_dir: Path, project_path: Path, agent_key: str, script: str):
+        target = project_path / f".{agent_key}" / f"run.{script}"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(agent_key, encoding="utf-8")
+
+    monkeypatch.setattr(init_module, "get_local_repo_root", fake_local_repo)
+    monkeypatch.setattr(init_module, "copy_specify_base_from_local", fake_copy)
+    monkeypatch.setattr(init_module, "generate_agent_assets", fake_assets)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--ai",
+            "claude",
+            "--script",
+            "sh",
+            "--no-git",
+            "--force",
+            "--non-interactive",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".templates").exists()
+    console_output = console.file.getvalue()
+    assert "--force supplied: skipping confirmation and proceeding with merge" in console_output
+
+
+def test_init_interactive_no_project_name_prompts_for_nonempty_directory(
+    cli_app, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    app, _, _ = cli_app
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "existing.txt").write_text("data", encoding="utf-8")
+    monkeypatch.setattr(init_module, "_is_non_interactive_mode", lambda flag: False)
+    confirm_prompts: list[str] = []
+
+    def fake_confirm(prompt: str) -> bool:
+        confirm_prompts.append(prompt)
+        return True
+
+    monkeypatch.setattr(init_module.typer, "confirm", fake_confirm)
+
+    def fake_local_repo(override_path=None):
+        return tmp_path / "templates"
+
+    def fake_copy(local_repo: Path, project_path: Path, script: str):
+        commands_dir = project_path / ".templates"
+        commands_dir.mkdir(parents=True, exist_ok=True)
+        return commands_dir
+
+    def fake_assets(commands_dir: Path, project_path: Path, agent_key: str, script: str):
+        target = project_path / f".{agent_key}" / f"run.{script}"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(agent_key, encoding="utf-8")
+
+    monkeypatch.setattr(init_module, "get_local_repo_root", fake_local_repo)
+    monkeypatch.setattr(init_module, "copy_specify_base_from_local", fake_copy)
+    monkeypatch.setattr(init_module, "generate_agent_assets", fake_assets)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--ai",
+            "claude",
+            "--script",
+            "sh",
+            "--no-git",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".templates").exists()
+    assert confirm_prompts
+
+
 def test_init_non_interactive_requires_force_for_nonempty_here(cli_app, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     app, console, _ = cli_app
     monkeypatch.chdir(tmp_path)
@@ -470,4 +635,3 @@ def test_init_rejects_removed_agent_strategy_option(cli_app, monkeypatch: pytest
     assert result.exit_code == 2
     plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
     assert re.search(r"No such option:\s+-{1,2}agent-strategy", plain_output)
-


### PR DESCRIPTION
## Summary
- default `spec-kitty init` with no positional `PROJECT_NAME` to initialize in the current directory (equivalent to `--here`)
- keep existing non-empty directory safety checks and `--force` behavior intact
- update init help/docs/examples to reflect the new default behavior
- add tests covering no-arg init in empty and non-empty directories, including force and interactive-confirmation flows

## Validation
- Reproduced bug before fix on main:
  - `spec-kitty init --non-interactive --ai codex --no-git` failed with: "Must specify either a project name..."
- After fix:
  - `spec-kitty init --non-interactive --ai codex --no-git` succeeds in cwd
- Tests:
  - `pytest tests/specify_cli/test_cli/test_init_command.py -q`

Refs #244