### PR TITLE
refactor(gitignore): deduplicate protect methods and remove dead imports

### DIFF
--- a/src/specify_cli/gitignore_manager.py
+++ b/src/specify_cli/gitignore_manager.py
@@ -9,7 +9,7 @@ It replaces the fragmented approach where only .codex/ was protected.
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import List
 
 
 @dataclass
@@ -187,6 +187,50 @@ class GitignoreManager:
         # Return a copy to prevent external modification
         return AGENT_DIRECTORIES.copy()
 
+    def _protect_entries(self, directories: List[str], error_context: str) -> ProtectionResult:
+        """
+        Shared implementation for adding entries to .gitignore with tracking.
+
+        Args:
+            directories: List of gitignore patterns to add
+            error_context: Description for error messages (e.g., "agent directories")
+
+        Returns:
+            ProtectionResult containing details of the operation
+        """
+        result = ProtectionResult(success=True, modified=False)
+
+        try:
+            # Snapshot existing entries before modification
+            existing_before: set[str] = set()
+            if self.gitignore_path.exists():
+                content = self.gitignore_path.read_text(encoding="utf-8-sig")
+                existing_before = set(content.splitlines())
+
+            # Attempt to add entries
+            modified = self.ensure_entries(directories)
+            result.modified = modified
+
+            # Classify entries as added vs skipped without re-reading the file:
+            # ensure_entries() guarantees that after it runs, all requested entries
+            # are present. So we just check against the before-snapshot.
+            for directory in directories:
+                if directory in existing_before:
+                    result.entries_skipped.append(directory)
+                else:
+                    result.entries_added.append(directory)
+
+        except PermissionError:
+            result.success = False
+            result.errors.append(
+                f"Cannot update .gitignore: Permission denied. Run: chmod u+w {self.gitignore_path}"
+            )
+        except Exception as exc:
+            result.success = False
+            result.errors.append(f"Error protecting {error_context}: {exc}")
+
+        return result
+
     def protect_all_agents(self) -> ProtectionResult:
         """
         Add all known agent directories to .gitignore.
@@ -199,48 +243,13 @@ class GitignoreManager:
         Returns:
             ProtectionResult containing details of the operation
         """
-        result = ProtectionResult(success=True, modified=False)
+        # Get all agent directories
+        all_directories = [agent.directory for agent in AGENT_DIRECTORIES]
 
-        try:
-            # Get all agent directories
-            all_directories = [agent.directory for agent in AGENT_DIRECTORIES]
+        # Add runtime files that should never be tracked
+        all_directories.extend(RUNTIME_PROTECTED_ENTRIES)
 
-            # Add runtime files that should never be tracked
-            all_directories.extend(RUNTIME_PROTECTED_ENTRIES)
-
-            # Track existing entries before modification
-            existing_before = set()
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_before = set(content.splitlines())
-
-
-            # Attempt to add all directories
-            modified = self.ensure_entries(all_directories)
-            result.modified = modified
-
-            # Track what was added vs skipped
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_after = set(content.splitlines())
-
-                for directory in all_directories:
-                    if directory in existing_after:
-                        if directory not in existing_before:
-                            result.entries_added.append(directory)
-                        else:
-                            result.entries_skipped.append(directory)
-
-        except PermissionError as e:
-            result.success = False
-            result.errors.append(
-                f"Cannot update .gitignore: Permission denied. Run: chmod u+w {self.gitignore_path}"
-            )
-        except Exception as e:
-            result.success = False
-            result.errors.append(f"Error protecting agent directories: {str(e)}")
-
-        return result
+        return self._protect_entries(all_directories, "agent directories")
 
     def protect_selected_agents(self, agents: List[str]) -> ProtectionResult:
         """
@@ -254,53 +263,26 @@ class GitignoreManager:
         """
         result = ProtectionResult(success=True, modified=False)
 
-        try:
-            # Build mapping of agent names to directories
-            agent_map = {agent.name: agent for agent in AGENT_DIRECTORIES}
+        # Build mapping of agent names to directories
+        agent_map = {agent.name: agent for agent in AGENT_DIRECTORIES}
 
-            # Collect directories for selected agents
-            directories_to_add = []
-            for agent_name in agents:
-                if agent_name in agent_map:
-                    agent = agent_map[agent_name]
-                    directories_to_add.append(agent.directory)
+        # Collect directories for selected agents
+        directories_to_add = []
+        for agent_name in agents:
+            if agent_name in agent_map:
+                directories_to_add.append(agent_map[agent_name].directory)
+            else:
+                result.warnings.append(f"Unknown agent name: {agent_name}")
 
-                else:
-                    result.warnings.append(f"Unknown agent name: {agent_name}")
+        if not directories_to_add:
+            result.warnings.append("No valid agent directories to add")
+            return result
 
-            if not directories_to_add:
-                result.warnings.append("No valid agent directories to add")
-                return result
-
-            # Track existing entries before modification
-            existing_before = set()
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_before = set(content.splitlines())
-
-            # Attempt to add selected directories
-            modified = self.ensure_entries(directories_to_add)
-            result.modified = modified
-
-            # Track what was added vs skipped
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_after = set(content.splitlines())
-
-                for directory in directories_to_add:
-                    if directory in existing_after:
-                        if directory not in existing_before:
-                            result.entries_added.append(directory)
-                        else:
-                            result.entries_skipped.append(directory)
-
-        except PermissionError as e:
-            result.success = False
-            result.errors.append(
-                f"Cannot update .gitignore: Permission denied. Run: chmod u+w {self.gitignore_path}"
-            )
-        except Exception as e:
-            result.success = False
-            result.errors.append(f"Error protecting selected agents: {str(e)}")
-
+        protection = self._protect_entries(directories_to_add, "selected agents")
+        # Merge protection result into result (which may already have warnings)
+        result.success = protection.success
+        result.modified = protection.modified
+        result.entries_added = protection.entries_added
+        result.entries_skipped = protection.entries_skipped
+        result.errors = protection.errors
         return result


### PR DESCRIPTION
## Summary

- **Extract shared `_protect_entries()` helper** from `protect_all_agents()` and `protect_selected_agents()`, which had nearly identical implementations (~40 duplicated lines) for entry tracking, error handling, and file I/O
- **Eliminate redundant `.gitignore` re-read**: the old code read `.gitignore` once before `ensure_entries()` and then again after it, just to compute a diff. The before-snapshot is sufficient since `ensure_entries()` guarantees all requested entries are present after it runs
- **Remove unused `Set` and `Optional` imports** from `typing` (dead code)
- **Fix `except PermissionError as e`** where `e` was never referenced (2 occurrences)
- **Fix `except Exception as e`** where `e` was only used via `str(e)` -- renamed to `exc` for clarity and used directly in f-string
- **Remove extra blank line** (cosmetic)

## Risk Assessment

All changes are **LOW RISK**:

| Change | Why Low Risk |
|--------|-------------|
| Extract `_protect_entries()` | Private method (`_` prefix), both public methods delegate to it. Behavior is identical -- 42 existing tests all pass unchanged |
| Remove double file read | `ensure_entries()` contract guarantees all entries are present after it runs, so re-reading is redundant. Confirmed by test suite |
| Remove unused imports | Pure dead code removal, no behavioral change |
| Fix exception variable naming | `PermissionError` handler never used `e`; `Exception` handler now uses `exc` directly instead of `str(e)` wrapping |

## Test plan

- [x] All 42 gitignore tests pass (`tests/test_gitignore_management.py`, `tests/test_gitignore_manager_simple.py`, `tests/unit/test_gitignore_manager.py`)
- [x] All 3 gitignore integration tests pass (`tests/integration/test_gitignore_isolation.py`)
- [x] Import verification: `from specify_cli.gitignore_manager import GitignoreManager, ProtectionResult, AgentDirectory` works

Generated with [Claude Code](https://claude.com/claude-code)