### PR TITLE
refactor: deduplicate gitignore, init agent map, and worktree scanning

### DIFF
--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -32,9 +32,10 @@ from specify_cli.core.git_ops import exclude_from_git_index
 from specify_cli.core.vcs import (
     is_git_available,
     VCSBackend,
+    VCSNotFoundError,
 )
 from specify_cli.dashboard import ensure_dashboard_running
-from specify_cli.gitignore_manager import GitignoreManager, ProtectionResult
+from specify_cli.gitignore_manager import AGENT_DIRECTORIES, GitignoreManager, ProtectionResult
 from specify_cli.core.agent_config import (
     AgentConfig,
     save_agent_config,
@@ -63,12 +64,6 @@ _ensure_executable_scripts: Callable[[Path, StepTracker | None], None] | None = 
 # =============================================================================
 # VCS Detection and Configuration
 # =============================================================================
-
-
-class VCSNotFoundError(Exception):
-    """Raised when no VCS tools are available."""
-
-    pass
 
 
 def _is_truthy_env(value: str | None) -> bool:
@@ -581,20 +576,7 @@ def init(
     _console.print("\n[bold green]Project ready.[/bold green]")
 
     # Agent folder security notice
-    agent_folder_map = {
-        "claude": ".claude/",
-        "gemini": ".gemini/",
-        "cursor": ".cursor/",
-        "qwen": ".qwen/",
-        "opencode": ".opencode/",
-        "codex": ".codex/",
-        "windsurf": ".windsurf/",
-        "kilocode": ".kilocode/",
-        "auggie": ".augment/",
-        "copilot": ".github/",
-        "roo": ".roo/",
-        "q": ".amazonq/"
-    }
+    agent_folder_map = {agent.name: agent.directory for agent in AGENT_DIRECTORIES}
 
     notice_entries = []
     for agent_key in selected_agents:

--- a/src/specify_cli/core/worktree.py
+++ b/src/specify_cli/core/worktree.py
@@ -99,28 +99,15 @@ def get_next_feature_number(repo_root: Path) -> int:
     """
     max_number = 0
 
-    # Scan kitty-specs/ for feature numbers
-    specs_dir = repo_root / KITTY_SPECS_DIR
-    if specs_dir.exists():
-        for item in sorted(specs_dir.iterdir(), key=lambda p: p.name):
+    for scan_dir in (repo_root / KITTY_SPECS_DIR, repo_root / WORKTREES_DIR):
+        if not scan_dir.exists():
+            continue
+        for item in scan_dir.iterdir():
             if item.is_dir() and len(item.name) >= 3 and item.name[:3].isdigit():
                 try:
                     number = int(item.name[:3])
                     max_number = max(max_number, number)
                 except ValueError:
-                    # Not a valid number, skip
-                    continue
-
-    # Also scan .worktrees/ for feature numbers
-    worktrees_dir = repo_root / WORKTREES_DIR
-    if worktrees_dir.exists():
-        for item in sorted(worktrees_dir.iterdir(), key=lambda p: p.name):
-            if item.is_dir() and len(item.name) >= 3 and item.name[:3].isdigit():
-                try:
-                    number = int(item.name[:3])
-                    max_number = max(max_number, number)
-                except ValueError:
-                    # Not a valid number, skip
                     continue
 
     return max_number + 1

--- a/src/specify_cli/gitignore_manager.py
+++ b/src/specify_cli/gitignore_manager.py
@@ -9,7 +9,7 @@ It replaces the fragmented approach where only .codex/ was protected.
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import List
 
 
 @dataclass
@@ -187,6 +187,61 @@ class GitignoreManager:
         # Return a copy to prevent external modification
         return AGENT_DIRECTORIES.copy()
 
+    def _protect_directories(
+        self,
+        directories: List[str],
+        error_context: str,
+    ) -> ProtectionResult:
+        """
+        Shared implementation for adding directories to .gitignore.
+
+        Args:
+            directories: List of directory patterns to add
+            error_context: Description for error messages (e.g., "agent directories")
+
+        Returns:
+            ProtectionResult containing details of the operation
+        """
+        result = ProtectionResult(success=True, modified=False)
+
+        if not directories:
+            result.warnings.append("No valid directories to add")
+            return result
+
+        try:
+            # Track existing entries before modification
+            existing_before: set[str] = set()
+            if self.gitignore_path.exists():
+                content = self.gitignore_path.read_text(encoding="utf-8-sig")
+                existing_before = set(content.splitlines())
+
+            # Attempt to add directories
+            modified = self.ensure_entries(directories)
+            result.modified = modified
+
+            # Track what was added vs skipped
+            if self.gitignore_path.exists():
+                content = self.gitignore_path.read_text(encoding="utf-8-sig")
+                existing_after = set(content.splitlines())
+
+                for directory in directories:
+                    if directory in existing_after:
+                        if directory not in existing_before:
+                            result.entries_added.append(directory)
+                        else:
+                            result.entries_skipped.append(directory)
+
+        except PermissionError:
+            result.success = False
+            result.errors.append(
+                f"Cannot update .gitignore: Permission denied. Run: chmod u+w {self.gitignore_path}"
+            )
+        except Exception as exc:
+            result.success = False
+            result.errors.append(f"Error protecting {error_context}: {exc}")
+
+        return result
+
     def protect_all_agents(self) -> ProtectionResult:
         """
         Add all known agent directories to .gitignore.
@@ -199,48 +254,9 @@ class GitignoreManager:
         Returns:
             ProtectionResult containing details of the operation
         """
-        result = ProtectionResult(success=True, modified=False)
-
-        try:
-            # Get all agent directories
-            all_directories = [agent.directory for agent in AGENT_DIRECTORIES]
-
-            # Add runtime files that should never be tracked
-            all_directories.extend(RUNTIME_PROTECTED_ENTRIES)
-
-            # Track existing entries before modification
-            existing_before = set()
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_before = set(content.splitlines())
-
-
-            # Attempt to add all directories
-            modified = self.ensure_entries(all_directories)
-            result.modified = modified
-
-            # Track what was added vs skipped
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_after = set(content.splitlines())
-
-                for directory in all_directories:
-                    if directory in existing_after:
-                        if directory not in existing_before:
-                            result.entries_added.append(directory)
-                        else:
-                            result.entries_skipped.append(directory)
-
-        except PermissionError as e:
-            result.success = False
-            result.errors.append(
-                f"Cannot update .gitignore: Permission denied. Run: chmod u+w {self.gitignore_path}"
-            )
-        except Exception as e:
-            result.success = False
-            result.errors.append(f"Error protecting agent directories: {str(e)}")
-
-        return result
+        all_directories = [agent.directory for agent in AGENT_DIRECTORIES]
+        all_directories.extend(RUNTIME_PROTECTED_ENTRIES)
+        return self._protect_directories(all_directories, "agent directories")
 
     def protect_selected_agents(self, agents: List[str]) -> ProtectionResult:
         """
@@ -253,54 +269,20 @@ class GitignoreManager:
             ProtectionResult containing details of the operation
         """
         result = ProtectionResult(success=True, modified=False)
+        agent_map = {agent.name: agent for agent in AGENT_DIRECTORIES}
 
-        try:
-            # Build mapping of agent names to directories
-            agent_map = {agent.name: agent for agent in AGENT_DIRECTORIES}
+        directories_to_add = []
+        for agent_name in agents:
+            if agent_name in agent_map:
+                directories_to_add.append(agent_map[agent_name].directory)
+            else:
+                result.warnings.append(f"Unknown agent name: {agent_name}")
 
-            # Collect directories for selected agents
-            directories_to_add = []
-            for agent_name in agents:
-                if agent_name in agent_map:
-                    agent = agent_map[agent_name]
-                    directories_to_add.append(agent.directory)
+        if not directories_to_add:
+            result.warnings.append("No valid agent directories to add")
+            return result
 
-                else:
-                    result.warnings.append(f"Unknown agent name: {agent_name}")
-
-            if not directories_to_add:
-                result.warnings.append("No valid agent directories to add")
-                return result
-
-            # Track existing entries before modification
-            existing_before = set()
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_before = set(content.splitlines())
-
-            # Attempt to add selected directories
-            modified = self.ensure_entries(directories_to_add)
-            result.modified = modified
-
-            # Track what was added vs skipped
-            if self.gitignore_path.exists():
-                content = self.gitignore_path.read_text(encoding="utf-8-sig")
-                existing_after = set(content.splitlines())
-
-                for directory in directories_to_add:
-                    if directory in existing_after:
-                        if directory not in existing_before:
-                            result.entries_added.append(directory)
-                        else:
-                            result.entries_skipped.append(directory)
-
-        except PermissionError as e:
-            result.success = False
-            result.errors.append(
-                f"Cannot update .gitignore: Permission denied. Run: chmod u+w {self.gitignore_path}"
-            )
-        except Exception as e:
-            result.success = False
-            result.errors.append(f"Error protecting selected agents: {str(e)}")
-
-        return result
+        protection = self._protect_directories(directories_to_add, "selected agents")
+        # Merge the protection result, preserving any warnings collected above
+        protection.warnings = result.warnings + protection.warnings
+        return protection


### PR DESCRIPTION
## Summary

- **Extract shared `_protect_directories()` in `GitignoreManager`**: `protect_all_agents()` and `protect_selected_agents()` had ~50 lines of identical copy-pasted boilerplate (read existing entries, call `ensure_entries`, diff what was added vs skipped, catch `PermissionError`/`Exception`). Both now delegate to `_protect_directories()`.
- **Remove duplicate `VCSNotFoundError` class from `init.py`**: It defined its own `VCSNotFoundError(Exception)` while `specify_cli.core.vcs.exceptions` already exports `VCSNotFoundError(VCSError)`. The init.py version is now replaced with an import.
- **Replace hardcoded `agent_folder_map` in `init.py`**: A 12-entry dict mapping agent names to folder paths was hardcoded inline, duplicating data from `AGENT_DIRECTORIES` in `gitignore_manager.py`. Now derived from the canonical registry so new agents are automatically included.
- **Consolidate duplicated scanning loop in `get_next_feature_number()`**: Two identical loops (one for `kitty-specs/`, one for `.worktrees/`) collapsed into a single loop iterating over both directories.
- **Remove unused imports**: `Optional` and `Set` from `typing` were imported but never used in `gitignore_manager.py`.
- **Fix unused exception variable captures**: `except PermissionError as e:` captured `e` but never used it.

## Risk Assessment

All changes are **LOW RISK**:
- No public API signatures changed - `protect_all_agents()` and `protect_selected_agents()` return identical `ProtectionResult` objects
- `_protect_directories()` is a private method (underscore-prefixed), not part of any public interface
- `VCSNotFoundError` was only used locally within `init.py` and still behaves identically (it's still catchable as `Exception`)
- The `agent_folder_map` derivation produces the exact same mapping as the hardcoded dict
- `get_next_feature_number()` produces identical results (just scans the same dirs with fewer lines)

All changes are **HIGH IMPACT**:
- Eliminates ~50 lines of duplicated code that could drift out of sync
- Prevents the hardcoded agent folder map from getting stale when new agents are added to the registry
- Removes a confusing duplicate exception class definition
- Net: **-49 lines** (61 added, 110 removed)

## Test plan

- [x] All 29 unit tests in `tests/unit/test_gitignore_manager.py` pass
- [x] All 5 tests in `tests/test_gitignore_manager_simple.py` pass
- [x] All 8 tests in `tests/test_gitignore_management.py` pass
- [x] All 7 tests in `tests/integration/test_init_flow.py` pass
- [x] All 4 tests in `tests/test_performance.py` pass
- [x] All 71 VCS tests pass (57 jj skipped as expected)
- [x] All 56 feature detection tests pass
- [x] All 25 worktree topology tests pass
- [x] All 23 init/agent-config CLI tests pass
- [x] Full test suite: 663 passed, 63 skipped, 1 pre-existing failure (banner visibility, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)