### PR TITLE
Release 2.0.6 upgrade consistency sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6] - 2026-03-10
+
+### 🐛 Fixed
+
+- **Upgrade consistency sweep**: added a new `2.0.6_consistency_sweep` migration that backfills missing or blank feature `meta.json`, infers `target_branch` from feature docs or the repo primary branch, reconstructs missing `status.events.jsonl`, regenerates `status.json` and generated `tasks.md` status blocks, normalizes legacy WP frontmatter lane aliases/quoting, rewrites stale prompt paths, and archives orphan empty `status.json` snapshots before rebuilding canonical state.
+- **Worktree upgrade coverage**: `spec-kitty upgrade` now upgrades worktrees that have `kitty-specs/` or legacy `.specify/` state even when `.kittify/` has not been created yet.
+- **Detector false positives**: runtime-managed 2.x installs no longer trip legacy project-local mission migrations, and the constitution migration only flags the legacy `.kittify/memory/constitution.md` path.
+- **Target-branch backfill correctness**: the `0.13.8_target_branch` migration now uses repo-aware branch inference instead of the obsolete hardcoded Feature 025 exception.
+
 ## [2.0.5] - 2026-03-10
 
 ### ✅ Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "2.0.5"
+version = "2.0.6"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/upgrade/compat.py
+++ b/src/specify_cli/upgrade/compat.py
@@ -1,0 +1,35 @@
+"""Shared runtime-detection helpers used by multiple migrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+from specify_cli.runtime.home import get_kittify_home
+
+from .metadata import ProjectMetadata
+
+
+def global_runtime_configured() -> bool:
+    """Return True when ``~/.kittify`` has been bootstrapped."""
+    try:
+        home = get_kittify_home()
+    except RuntimeError:
+        return False
+    return (home / "cache" / "version.lock").is_file()
+
+
+def uses_centralized_runtime(project_path: Path) -> bool:
+    """Return True when project state indicates 2.x global runtime usage."""
+    if not global_runtime_configured():
+        return False
+
+    metadata = ProjectMetadata.load(project_path / ".kittify")
+    if metadata is not None:
+        try:
+            return Version(metadata.version) >= Version("2.0.0")
+        except InvalidVersion:
+            return False
+
+    return (project_path / "kitty-specs").exists()

--- a/src/specify_cli/upgrade/feature_meta.py
+++ b/src/specify_cli/upgrade/feature_meta.py
@@ -1,0 +1,162 @@
+"""Helpers for feature metadata repair during upgrades."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from specify_cli.core.git_ops import resolve_primary_branch
+
+_BRANCH_PATTERNS = (
+    re.compile(r"(?im)^\*\*target branch\*\*:\s*`?([^\n`]+)`?\s*$"),
+    re.compile(r"(?im)^\*\*base branch\*\*:\s*`?([^\n`]+)`?\s*$"),
+    re.compile(r"(?im)^target repo branch:\s*`?([^\n`]+)`?\s*$"),
+    re.compile(r"(?im)^branch:\s*`?([^\n`]+)`?\s*$"),
+    re.compile(r"(?i)must be done on .*?`([^`]+)` branch"),
+    re.compile(r"(?i)all work packages branch from and merge back to [`“]?([^`”\n]+)[`”]?"),
+    re.compile(r"(?i)merge back to [`“]?([^`”\n]+)[`”]?"),
+    re.compile(r"(?i)repository[^\n]*branch [`(]?([A-Za-z0-9._/-]+)"),
+)
+
+
+def load_feature_meta(feature_dir: Path) -> dict[str, Any] | None:
+    """Load ``meta.json`` for a feature if it exists and is valid."""
+    meta_path = feature_dir / "meta.json"
+    if not meta_path.exists():
+        return None
+    return json.loads(meta_path.read_text(encoding="utf-8"))
+
+
+def write_feature_meta(feature_dir: Path, meta: dict[str, Any]) -> None:
+    """Write ``meta.json`` with stable formatting."""
+    meta_path = feature_dir / "meta.json"
+    meta_path.write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def infer_target_branch(
+    feature_dir: Path,
+    repo_root: Path,
+    *,
+    fallback: str | None = None,
+) -> str:
+    """Infer ``target_branch`` from explicit feature docs or repo context."""
+    fallback_branch = fallback or resolve_primary_branch(repo_root)
+    candidates: list[str] = []
+
+    for name in ("spec.md", "plan.md", "tasks.md", "quickstart.md"):
+        doc = feature_dir / name
+        if not doc.exists():
+            continue
+        content = doc.read_text(encoding="utf-8", errors="ignore")
+        for pattern in _BRANCH_PATTERNS:
+            for raw in pattern.findall(content):
+                candidate = _normalize_branch_candidate(raw)
+                if candidate and candidate not in candidates:
+                    candidates.append(candidate)
+
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1 and fallback_branch in candidates:
+        return fallback_branch
+    return fallback_branch
+
+
+def infer_mission(
+    feature_dir: Path,
+    *,
+    existing_meta: dict[str, Any] | None = None,
+) -> str:
+    """Infer a feature mission when ``meta.json`` is missing."""
+    if existing_meta:
+        mission = str(existing_meta.get("mission", "")).strip()
+        if mission:
+            return mission
+
+    if (feature_dir / "research").exists():
+        return "research"
+    return "software-dev"
+
+
+def infer_created_at(
+    feature_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Infer a stable ``created_at`` timestamp from the earliest file mtime."""
+    timestamps = [
+        path.stat().st_mtime
+        for path in feature_dir.rglob("*")
+        if path.is_file()
+    ]
+    if feature_dir.exists():
+        timestamps.append(feature_dir.stat().st_mtime)
+
+    if timestamps:
+        created_at = datetime.fromtimestamp(min(timestamps), tz=timezone.utc)
+    else:
+        created_at = now or datetime.now(timezone.utc)
+    return created_at.isoformat()
+
+
+def build_baseline_feature_meta(
+    feature_dir: Path,
+    repo_root: Path,
+    *,
+    existing_meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the minimum viable ``meta.json`` payload for a feature."""
+    feature_slug = feature_dir.name
+    feature_number, _, slug_tail = feature_slug.partition("-")
+    meta = dict(existing_meta or {})
+
+    _set_if_blank(
+        meta,
+        "feature_number",
+        feature_number if feature_number.isdigit() else "",
+    )
+    _set_if_blank(meta, "slug", feature_slug)
+    _set_if_blank(meta, "feature_slug", feature_slug)
+    _set_if_blank(
+        meta,
+        "friendly_name",
+        slug_tail.replace("-", " ").strip() or feature_slug,
+    )
+    _set_if_blank(meta, "mission", infer_mission(feature_dir, existing_meta=meta))
+    _set_if_blank(
+        meta,
+        "target_branch",
+        infer_target_branch(feature_dir, repo_root),
+    )
+    _set_if_blank(meta, "created_at", infer_created_at(feature_dir))
+    return meta
+
+
+def _normalize_branch_candidate(value: str) -> str | None:
+    """Normalize a branch candidate extracted from feature docs."""
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if " or " in cleaned.lower():
+        return None
+    cleaned = cleaned.strip("`'\"*[]() ")
+    match = re.search(r"[A-Za-z0-9._/-]+", cleaned)
+    if match is None:
+        return None
+    return match.group(0)
+
+
+def _set_if_blank(meta: dict[str, Any], key: str, value: Any) -> None:
+    """Populate a metadata field when it is missing or blank."""
+    current = meta.get(key)
+    if current is None:
+        meta[key] = value
+        return
+
+    if isinstance(current, str) and not current.strip():
+        meta[key] = value

--- a/src/specify_cli/upgrade/migrations/m_0_12_0_documentation_mission.py
+++ b/src/specify_cli/upgrade/migrations/m_0_12_0_documentation_mission.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+from ..compat import uses_centralized_runtime
 from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
@@ -35,6 +36,10 @@ class InstallDocumentationMission(BaseMigration):
         Returns:
             True if documentation mission is missing, False if already installed
         """
+        if uses_centralized_runtime(project_path):
+            # Centralized runtime provides managed missions globally in 2.x.
+            return False
+
         kittify_dir = project_path / ".kittify"
 
         if not kittify_dir.exists():

--- a/src/specify_cli/upgrade/migrations/m_0_13_8_target_branch.py
+++ b/src/specify_cli/upgrade/migrations/m_0_13_8_target_branch.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from specify_cli.upgrade.feature_meta import infer_target_branch
+
 from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
@@ -87,30 +89,11 @@ class TargetBranchMigration(BaseMigration):
                 if "target_branch" in meta:
                     continue
 
-                # Detect target from spec.md for Feature 025
-                target_branch = "main"  # Default for all features
-
-                if meta.get("feature_number") == "025":
-                    spec_file = feature_dir / "spec.md"
-                    if spec_file.exists():
-                        try:
-                            content = spec_file.read_text(encoding="utf-8")
-                            # Look for explicit target branch markers
-                            if any(
-                                marker in content
-                                for marker in [
-                                    "**Target Branch**: 2.x",
-                                    "Target Branch**: 2.x development",
-                                    "**Target**: 2.x branch",
-                                ]
-                            ):
-                                target_branch = "2.x"
-                                warnings.append(
-                                    f"Feature 025 auto-detected as 2.x target from spec.md"
-                                )
-                        except OSError:
-                            # Can't read spec, use default
-                            pass
+                target_branch = infer_target_branch(feature_dir, project_path)
+                if target_branch != "main":
+                    warnings.append(
+                        f"{feature_dir.name} auto-detected target_branch={target_branch}"
+                    )
 
                 # Add target_branch field
                 meta["target_branch"] = target_branch

--- a/src/specify_cli/upgrade/migrations/m_0_6_7_ensure_missions.py
+++ b/src/specify_cli/upgrade/migrations/m_0_6_7_ensure_missions.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import List
 
+from ..compat import uses_centralized_runtime
 from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
@@ -30,6 +31,10 @@ class EnsureMissionsMigration(BaseMigration):
 
     def detect(self, project_path: Path) -> bool:
         """Check if any required missions are missing."""
+        if uses_centralized_runtime(project_path):
+            # In the 2.x centralized runtime model, project-local missions are optional.
+            return False
+
         missions_dir = project_path / ".kittify" / "missions"
 
         if not missions_dir.exists():

--- a/src/specify_cli/upgrade/migrations/m_2_0_0_constitution_directory.py
+++ b/src/specify_cli/upgrade/migrations/m_2_0_0_constitution_directory.py
@@ -23,8 +23,7 @@ class ConstitutionDirectoryMigration(BaseMigration):
     def detect(self, project_path: Path) -> bool:
         """Return True when legacy constitution location is still in use."""
         old_path = project_path / ".kittify" / "memory" / "constitution.md"
-        new_path = project_path / ".kittify" / "constitution" / "constitution.md"
-        return old_path.exists() or new_path.exists()
+        return old_path.exists()
 
     def can_apply(self, project_path: Path) -> tuple[bool, str]:
         """This migration only requires project filesystem access."""

--- a/src/specify_cli/upgrade/migrations/m_2_0_6_consistency_sweep.py
+++ b/src/specify_cli/upgrade/migrations/m_2_0_6_consistency_sweep.py
@@ -1,0 +1,470 @@
+"""Migration: repair feature metadata/state drift and legacy worktree assets."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from specify_cli.agent_utils.directories import AGENT_DIRS
+from specify_cli.frontmatter import FrontmatterError, FrontmatterManager
+from specify_cli.runtime.doctor import check_stale_legacy_assets
+from specify_cli.status.legacy_bridge import update_all_views
+from specify_cli.status.migrate import feature_requires_historical_migration, migrate_feature
+from specify_cli.status.phase import resolve_phase
+from specify_cli.status.reducer import SNAPSHOT_FILENAME, materialize, reduce
+from specify_cli.status.store import EVENTS_FILENAME, StoreError, read_events
+from specify_cli.status.transitions import CANONICAL_LANES, resolve_lane_alias
+from specify_cli.status.validate import (
+    validate_derived_views,
+    validate_materialization_drift,
+)
+from specify_cli.upgrade.feature_meta import (
+    build_baseline_feature_meta,
+    load_feature_meta,
+    write_feature_meta,
+)
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+
+_PROMPT_LINE_RE = re.compile(r"^(\*\*Prompt\*\*:\s*`?)([^`\n]+)(`?)$", re.MULTILINE)
+
+
+@MigrationRegistry.register
+class ConsistencySweepMigration(BaseMigration):
+    """Repair version-stamped projects that still have structural drift."""
+
+    migration_id = "2.0.6_consistency_sweep"
+    description = "Repair feature metadata/state drift and clean legacy worktree assets"
+    target_version = "2.0.6"
+
+    def detect(self, project_path: Path) -> bool:
+        """Return True when project state still needs 2.0.6 consistency repair."""
+        if check_stale_legacy_assets(project_path).passed is False:
+            return True
+        if _has_legacy_worktree_assets(project_path):
+            return True
+
+        for feature_dir in _iter_feature_dirs(project_path):
+            if _feature_requires_repair(feature_dir, project_path):
+                return True
+        return False
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        """Consistency repair only needs a spec project root."""
+        if (project_path / ".kittify").exists() or (project_path / "kitty-specs").exists():
+            return True, ""
+        return False, "No .kittify/ or kitty-specs/ directory found"
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        """Run the 2.0.6 consistency sweep."""
+        changes: list[str] = []
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        runtime_changes, runtime_warnings = _migrate_runtime_assets(project_path, dry_run)
+        changes.extend(runtime_changes)
+        warnings.extend(runtime_warnings)
+
+        worktree_changes, worktree_errors = _cleanup_legacy_worktree_assets(project_path, dry_run)
+        changes.extend(worktree_changes)
+        errors.extend(worktree_errors)
+
+        for feature_dir in _iter_feature_dirs(project_path):
+            feature_changes, feature_warnings = _repair_feature(feature_dir, project_path, dry_run)
+            changes.extend(feature_changes)
+            warnings.extend(feature_warnings)
+
+        if not changes and not warnings and not errors:
+            changes.append("Project already consistent for 2.0.6")
+
+        return MigrationResult(
+            success=not errors,
+            changes_made=changes,
+            warnings=warnings,
+            errors=errors,
+        )
+
+
+def _iter_feature_dirs(project_path: Path) -> list[Path]:
+    kitty_specs = project_path / "kitty-specs"
+    if not kitty_specs.exists():
+        return []
+    return [
+        path
+        for path in sorted(kitty_specs.iterdir())
+        if path.is_dir()
+    ]
+
+
+def _feature_requires_repair(feature_dir: Path, repo_root: Path) -> bool:
+    try:
+        meta = load_feature_meta(feature_dir)
+    except json.JSONDecodeError:
+        return True
+    if meta is None:
+        return True
+    if not str(meta.get("target_branch", "")).strip():
+        return True
+    if _tasks_md_has_legacy_prompt_refs(feature_dir):
+        return True
+    if _has_orphan_status_snapshot(feature_dir):
+        return True
+    if _wp_frontmatter_needs_normalization(feature_dir):
+        return True
+    if _status_events_need_repair(feature_dir):
+        return True
+    if _feature_has_status_drift(feature_dir, repo_root):
+        return True
+    return False
+
+
+def _repair_feature(
+    feature_dir: Path,
+    repo_root: Path,
+    dry_run: bool,
+) -> tuple[list[str], list[str]]:
+    changes: list[str] = []
+    warnings: list[str] = []
+
+    meta = None
+    try:
+        meta = load_feature_meta(feature_dir)
+    except json.JSONDecodeError as exc:
+        warnings.append(f"{feature_dir.name}: invalid meta.json ({exc})")
+
+    desired_meta = build_baseline_feature_meta(
+        feature_dir,
+        repo_root,
+        existing_meta=meta,
+    )
+    if meta != desired_meta:
+        action = "Would write" if dry_run else "Wrote"
+        changes.append(f"{feature_dir.name}: {action.lower()} baseline meta.json")
+        if not dry_run:
+            write_feature_meta(feature_dir, desired_meta)
+
+    normalized_count, normalize_warnings = _normalize_wp_frontmatter(feature_dir, dry_run)
+    warnings.extend(f"{feature_dir.name}: {warning}" for warning in normalize_warnings)
+    if normalized_count:
+        verb = "Would normalize" if dry_run else "Normalized"
+        changes.append(f"{feature_dir.name}: {verb.lower()} {normalized_count} work package files")
+
+    orphan_change, orphan_warning = _cleanup_orphan_status_snapshot(feature_dir, dry_run)
+    if orphan_change:
+        changes.append(f"{feature_dir.name}: {orphan_change}")
+    if orphan_warning:
+        warnings.append(f"{feature_dir.name}: {orphan_warning}")
+
+    events_rebuilt = False
+    if _status_events_need_repair(feature_dir):
+        if dry_run:
+            changes.append(f"{feature_dir.name}: would reconstruct status.events.jsonl from frontmatter history")
+        else:
+            migration_result = migrate_feature(feature_dir, dry_run=False)
+            if migration_result.status == "migrated":
+                events_rebuilt = True
+                changes.append(f"{feature_dir.name}: reconstructed status.events.jsonl")
+            elif migration_result.status == "failed":
+                warnings.append(f"{feature_dir.name}: {migration_result.error}")
+
+    if _feature_has_event_log(feature_dir):
+        if dry_run:
+            if _feature_has_status_drift(feature_dir, repo_root):
+                changes.append(f"{feature_dir.name}: would regenerate status.json and tasks.md views")
+        else:
+            snapshot = materialize(feature_dir)
+            update_all_views(feature_dir, snapshot, repo_root=repo_root)
+            if events_rebuilt or _feature_has_status_drift(feature_dir, repo_root):
+                changes.append(f"{feature_dir.name}: regenerated status.json and compatibility views")
+
+    prompt_rewrites = _rewrite_tasks_prompt_refs(feature_dir, dry_run)
+    if prompt_rewrites:
+        verb = "Would rewrite" if dry_run else "Rewrote"
+        changes.append(f"{feature_dir.name}: {verb.lower()} {prompt_rewrites} legacy prompt reference(s)")
+
+    return changes, warnings
+
+
+def _normalize_wp_frontmatter(feature_dir: Path, dry_run: bool) -> tuple[int, list[str]]:
+    tasks_dir = feature_dir / "tasks"
+    if not tasks_dir.exists():
+        return 0, []
+
+    manager = FrontmatterManager()
+    normalized = 0
+    warnings: list[str] = []
+
+    for wp_file in sorted(tasks_dir.glob("WP*.md")):
+        try:
+            original = wp_file.read_text(encoding="utf-8-sig")
+            frontmatter, body = manager.read(wp_file)
+        except FrontmatterError as exc:
+            warnings.append(f"{wp_file.name}: {exc}")
+            continue
+
+        raw_lane = frontmatter.get("lane") or "planned"
+        canonical_lane = resolve_lane_alias(str(raw_lane))
+        if canonical_lane in CANONICAL_LANES:
+            frontmatter["lane"] = canonical_lane
+
+        rendered = _render_frontmatter(manager, frontmatter, body)
+        if original == rendered:
+            continue
+
+        normalized += 1
+        if not dry_run:
+            wp_file.write_text(rendered, encoding="utf-8")
+
+    return normalized, warnings
+
+
+def _render_frontmatter(manager: FrontmatterManager, frontmatter: dict, body: str) -> str:
+    buffer = io.StringIO()
+    buffer.write("---\n")
+    manager.yaml.dump(manager._normalize_frontmatter(frontmatter), buffer)
+    buffer.write("---\n")
+    buffer.write(body)
+    return buffer.getvalue()
+
+
+def _rewrite_tasks_prompt_refs(feature_dir: Path, dry_run: bool) -> int:
+    tasks_md = feature_dir / "tasks.md"
+    tasks_dir = feature_dir / "tasks"
+    if not tasks_md.exists() or not tasks_dir.exists():
+        return 0
+
+    content = tasks_md.read_text(encoding="utf-8")
+    rewrites = 0
+
+    def replacer(match: re.Match[str]) -> str:
+        nonlocal rewrites
+        prefix, prompt_path, suffix = match.groups()
+        if "tasks/" not in prompt_path:
+            return match.group(0)
+
+        wp_match = re.search(r"(WP\d{2})", prompt_path)
+        if wp_match is None:
+            return match.group(0)
+
+        candidates = sorted(tasks_dir.glob(f"{wp_match.group(1)}*.md"))
+        if not candidates:
+            return match.group(0)
+
+        tasks_index = prompt_path.find("tasks/")
+        if tasks_index == -1:
+            return match.group(0)
+
+        new_path = prompt_path[:tasks_index] + "tasks/" + candidates[0].name
+        if new_path == prompt_path:
+            return match.group(0)
+
+        rewrites += 1
+        return f"{prefix}{new_path}{suffix}"
+
+    updated = _PROMPT_LINE_RE.sub(replacer, content)
+    if rewrites and not dry_run:
+        tasks_md.write_text(updated, encoding="utf-8")
+    return rewrites
+
+
+def _status_events_need_repair(feature_dir: Path) -> bool:
+    tasks_dir = feature_dir / "tasks"
+    if not tasks_dir.exists() or not list(tasks_dir.glob("WP*.md")):
+        return False
+
+    events_path = feature_dir / EVENTS_FILENAME
+    if not events_path.exists():
+        return feature_requires_historical_migration(feature_dir)
+
+    content = events_path.read_text(encoding="utf-8").strip()
+    if not content:
+        return feature_requires_historical_migration(feature_dir)
+
+    try:
+        events = read_events(feature_dir)
+    except StoreError:
+        return True
+
+    if not events:
+        return feature_requires_historical_migration(feature_dir)
+    if any(event.reason and "historical_frontmatter_to_jsonl:v1" in event.reason for event in events):
+        return False
+    if any(not event.actor.startswith("migration") for event in events):
+        return False
+    return feature_requires_historical_migration(feature_dir)
+
+
+def _feature_has_event_log(feature_dir: Path) -> bool:
+    events_path = feature_dir / EVENTS_FILENAME
+    return events_path.exists() and bool(events_path.read_text(encoding="utf-8").strip())
+
+
+def _feature_has_status_drift(feature_dir: Path, repo_root: Path) -> bool:
+    if not _feature_has_event_log(feature_dir):
+        return False
+
+    if validate_materialization_drift(feature_dir):
+        return True
+
+    try:
+        snapshot = reduce(read_events(feature_dir))
+    except StoreError:
+        return True
+
+    phase, _source = resolve_phase(repo_root, snapshot.feature_slug or feature_dir.name)
+    findings = validate_derived_views(feature_dir, snapshot.work_packages, phase)
+    return bool(findings)
+
+
+def _tasks_md_has_legacy_prompt_refs(feature_dir: Path) -> bool:
+    tasks_md = feature_dir / "tasks.md"
+    if not tasks_md.exists():
+        return False
+    for line in tasks_md.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if not line.startswith("**Prompt**:"):
+            continue
+        if any(segment in line for segment in ("tasks/planned/", "tasks/doing/", "tasks/for_review/", "tasks/done/")):
+            return True
+    return False
+
+
+def _wp_frontmatter_needs_normalization(feature_dir: Path) -> bool:
+    tasks_dir = feature_dir / "tasks"
+    if not tasks_dir.exists():
+        return False
+    manager = FrontmatterManager()
+    for wp_file in sorted(tasks_dir.glob("WP*.md")):
+        content = wp_file.read_text(encoding="utf-8-sig", errors="ignore")
+        if re.search(r'^lane:\s*["\']', content, re.MULTILINE):
+            return True
+        if re.search(r"^lane:\s*doing\s*$", content, re.MULTILINE):
+            return True
+        try:
+            frontmatter, _body = manager.read(wp_file)
+        except FrontmatterError:
+            return True
+        raw_lane = frontmatter.get("lane")
+        if raw_lane is None or not str(raw_lane).strip():
+            return True
+    return False
+
+
+def _has_orphan_status_snapshot(feature_dir: Path) -> bool:
+    status_path = feature_dir / SNAPSHOT_FILENAME
+    events_path = feature_dir / EVENTS_FILENAME
+    if not status_path.exists() or events_path.exists():
+        return False
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return (
+        data.get("event_count") == 0
+        and data.get("work_packages") == {}
+        and data.get("summary") == {lane: 0 for lane in CANONICAL_LANES}
+        and data.get("feature_slug", "") in {"", feature_dir.name}
+    )
+
+
+def _cleanup_orphan_status_snapshot(feature_dir: Path, dry_run: bool) -> tuple[str | None, str | None]:
+    status_path = feature_dir / SNAPSHOT_FILENAME
+    if not _has_orphan_status_snapshot(feature_dir):
+        if status_path.exists() and not (feature_dir / EVENTS_FILENAME).exists() and not (feature_dir / "tasks").exists():
+            return None, "status.json has no matching event log and could not be auto-repaired"
+        return None, None
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_name = f"{SNAPSHOT_FILENAME}.orphan.bak.{timestamp}"
+    if not dry_run:
+        status_path.rename(feature_dir / backup_name)
+    return f"archived orphan {SNAPSHOT_FILENAME} to {backup_name}", None
+
+
+def _migrate_runtime_assets(project_path: Path, dry_run: bool) -> tuple[list[str], list[str]]:
+    kittify_dir = project_path / ".kittify"
+    if not kittify_dir.exists():
+        return [], []
+
+    try:
+        from specify_cli.runtime.migrate import execute_migration
+
+        report = execute_migration(project_path, dry_run=dry_run)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return [], [f"runtime asset cleanup skipped: {exc}"]
+
+    changes: list[str] = []
+    moved = len(report.moved)
+    removed = len(report.removed)
+    if moved or removed:
+        verb = "Would migrate" if dry_run else "Migrated"
+        changes.append(
+            f"{verb.lower()} {removed} identical and {moved} customized legacy runtime asset(s)"
+        )
+    return changes, []
+
+
+def _has_legacy_worktree_assets(project_path: Path) -> bool:
+    return any(_iter_worktree_cleanup_roots(project_path))
+
+
+def _iter_worktree_cleanup_roots(project_path: Path) -> list[Path]:
+    if ".worktrees" in project_path.parts:
+        return [project_path]
+
+    worktrees_dir = project_path / ".worktrees"
+    if not worktrees_dir.exists():
+        return []
+    return [path for path in sorted(worktrees_dir.iterdir()) if path.is_dir()]
+
+
+def _cleanup_legacy_worktree_assets(project_path: Path, dry_run: bool) -> tuple[list[str], list[str]]:
+    changes: list[str] = []
+    errors: list[str] = []
+    cleaned = 0
+
+    for root in _iter_worktree_cleanup_roots(project_path):
+        root_cleaned = False
+        for agent_dir, subdir in AGENT_DIRS:
+            commands_dir = root / agent_dir / subdir
+            if commands_dir.is_symlink() or commands_dir.exists():
+                root_cleaned = True
+                if dry_run:
+                    changes.append(f"[{root.name}] would remove {agent_dir}/{subdir}/")
+                else:
+                    try:
+                        if commands_dir.is_symlink():
+                            commands_dir.unlink()
+                        else:
+                            shutil.rmtree(commands_dir)
+                        parent = commands_dir.parent
+                        if parent.exists() and not any(parent.iterdir()):
+                            parent.rmdir()
+                    except OSError as exc:
+                        errors.append(f"[{root.name}] failed to remove {agent_dir}/{subdir}/: {exc}")
+
+        scripts_dir = root / ".kittify" / "scripts"
+        if scripts_dir.is_symlink() or scripts_dir.exists():
+            root_cleaned = True
+            if dry_run:
+                changes.append(f"[{root.name}] would remove .kittify/scripts/")
+            else:
+                try:
+                    if scripts_dir.is_symlink():
+                        scripts_dir.unlink()
+                    else:
+                        shutil.rmtree(scripts_dir)
+                except OSError as exc:
+                    errors.append(f"[{root.name}] failed to remove .kittify/scripts/: {exc}")
+
+        if root_cleaned:
+            cleaned += 1
+
+    if cleaned:
+        verb = "Would clean" if dry_run else "Cleaned"
+        changes.append(f"{verb.lower()} {cleaned} worktree(s) with legacy command/script assets")
+    return changes, errors

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -228,7 +228,8 @@ class MigrationRunner:
                 continue
 
             wt_kittify = worktree / KITTIFY_DIR
-            if not wt_kittify.exists():
+            has_upgradeable_state = wt_kittify.exists() or (worktree / "kitty-specs").exists() or (worktree / ".specify").exists()
+            if not has_upgradeable_state:
                 continue
 
             # Load or create worktree metadata

--- a/tests/specify_cli/upgrade/migrations/test_constitution_migration.py
+++ b/tests/specify_cli/upgrade/migrations/test_constitution_migration.py
@@ -5,11 +5,30 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from specify_cli.upgrade.migrations.m_2_0_0_constitution_directory import Migration
+from specify_cli.upgrade.migrations.m_2_0_0_constitution_directory import (
+    ConstitutionDirectoryMigration,
+    Migration,
+)
 
 
 class TestConstitutionDirectoryMigration:
     """Test the constitution directory migration."""
+
+    def test_detect_only_flags_legacy_path(self, tmp_path: Path):
+        """detect() should not fire when only the canonical path exists."""
+        migration = ConstitutionDirectoryMigration()
+
+        canonical = tmp_path / ".kittify" / "constitution" / "constitution.md"
+        canonical.parent.mkdir(parents=True)
+        canonical.write_text("# Canonical")
+
+        assert migration.detect(tmp_path) is False
+
+        legacy = tmp_path / ".kittify" / "memory" / "constitution.md"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("# Legacy")
+
+        assert migration.detect(tmp_path) is True
 
     def test_scenario_1_old_exists_new_doesnt(self, tmp_path: Path):
         """Scenario 1: Old path exists, new doesn't → file moved."""

--- a/tests/specify_cli/upgrade/migrations/test_m_0_6_7_ensure_missions.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_0_6_7_ensure_missions.py
@@ -1,0 +1,29 @@
+"""Tests for the 0.6.7 ensure-missions detector in runtime-managed installs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.migrations.m_0_6_7_ensure_missions import (
+    EnsureMissionsMigration,
+)
+
+
+def test_detect_skips_when_global_runtime_is_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2.x runtime-managed installs do not require project-local missions."""
+    home = tmp_path / "home"
+    (home / "cache").mkdir(parents=True)
+    (home / "cache" / "version.lock").write_text("2.0.5", encoding="utf-8")
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(home))
+
+    project = tmp_path / "project"
+    (project / ".kittify").mkdir(parents=True)
+    (project / "kitty-specs").mkdir()
+
+    migration = EnsureMissionsMigration()
+    assert migration.detect(project) is False

--- a/tests/specify_cli/upgrade/migrations/test_m_2_0_6_consistency_sweep.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_2_0_6_consistency_sweep.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.status.store import EVENTS_FILENAME, read_events
+from specify_cli.status.transitions import CANONICAL_LANES
+from specify_cli.upgrade.migrations.m_2_0_6_consistency_sweep import (
+    ConsistencySweepMigration,
+    _status_events_need_repair,
+)
+
+
+def _write_wp(tasks_dir: Path, wp_id: str, lane: str) -> Path:
+    wp_file = tasks_dir / f"{wp_id}-upgrade.md"
+    wp_file.write_text(
+        "\n".join(
+            [
+                "---",
+                f'work_package_id: "{wp_id}"',
+                f'title: "{wp_id} Upgrade"',
+                f'lane: "{lane}"',
+                "---",
+                f"# {wp_id}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return wp_file
+
+
+def test_detect_flags_malformed_meta_as_repairable(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    feature_dir = repo_root / "kitty-specs" / "001-broken-meta"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text("{not-json", encoding="utf-8")
+
+    migration = ConsistencySweepMigration()
+    assert migration.detect(repo_root) is True
+
+
+def test_apply_repairs_feature_state_and_legacy_prompt_refs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    feature_dir = repo_root / "kitty-specs" / "001-upgrade-sweep"
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+
+    _write_wp(tasks_dir, "WP01", "doing")
+    (feature_dir / "tasks.md").write_text(
+        "\n".join(
+            [
+                "# Tasks",
+                "",
+                "**Prompt**: `.claude/prompts/tasks/doing/WP01-upgrade.md`",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (feature_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "feature_slug": "",
+                "event_count": 0,
+                "work_packages": {},
+                "summary": {lane: 0 for lane in CANONICAL_LANES},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.upgrade.feature_meta.resolve_primary_branch",
+        lambda _repo_root: "2.x",
+    )
+    monkeypatch.setattr(
+        "specify_cli.upgrade.migrations.m_2_0_6_consistency_sweep._migrate_runtime_assets",
+        lambda _project_path, dry_run: ([], []),
+    )
+
+    migration = ConsistencySweepMigration()
+    result = migration.apply(repo_root, dry_run=False)
+
+    assert result.success is True
+
+    meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+    assert meta["target_branch"] == "2.x"
+    assert meta["mission"] == "software-dev"
+
+    wp_text = (tasks_dir / "WP01-upgrade.md").read_text(encoding="utf-8")
+    assert 'lane: "doing"' not in wp_text
+    assert "lane: in_progress" in wp_text
+
+    tasks_md = (feature_dir / "tasks.md").read_text(encoding="utf-8")
+    assert ".claude/prompts/tasks/WP01-upgrade.md" in tasks_md
+    assert "<!-- status-model:start -->" in tasks_md
+    assert "- WP01: in_progress" in tasks_md
+
+    assert (feature_dir / EVENTS_FILENAME).exists()
+    assert read_events(feature_dir)
+
+    backup_files = sorted(feature_dir.glob("status.json.orphan.bak.*"))
+    assert len(backup_files) == 1
+
+    status = json.loads((feature_dir / "status.json").read_text(encoding="utf-8"))
+    assert status["work_packages"]["WP01"]["lane"] == "in_progress"
+
+
+def test_apply_cleans_legacy_worktree_assets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    worktree = repo_root / ".worktrees" / "001-feature-WP01"
+    commands_dir = worktree / ".claude" / "commands"
+    scripts_dir = worktree / ".kittify" / "scripts"
+    commands_dir.mkdir(parents=True)
+    scripts_dir.mkdir(parents=True)
+    (commands_dir / "spec-kitty.tasks.md").write_text("legacy", encoding="utf-8")
+    (scripts_dir / "task.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "specify_cli.upgrade.migrations.m_2_0_6_consistency_sweep._migrate_runtime_assets",
+        lambda _project_path, dry_run: ([], []),
+    )
+
+    migration = ConsistencySweepMigration()
+    result = migration.apply(repo_root, dry_run=False)
+
+    assert result.success is True
+    assert not commands_dir.exists()
+    assert not scripts_dir.exists()
+    assert any("cleaned 1 worktree" in change for change in result.changes_made)
+
+
+# ---------------------------------------------------------------------------
+# _status_events_need_repair
+# ---------------------------------------------------------------------------
+
+_DELEGATION_TARGET = (
+    "specify_cli.upgrade.migrations.m_2_0_6_consistency_sweep"
+    ".feature_requires_historical_migration"
+)
+
+
+def _make_event_line(
+    *,
+    wp_id: str = "WP01",
+    actor: str = "cli:task:start",
+    reason: str | None = None,
+) -> str:
+    """Build a minimal valid JSONL event line."""
+    event = {
+        "event_id": "01ABCDE000000000000000TEST",
+        "feature_slug": "099-test",
+        "wp_id": wp_id,
+        "from_lane": "planned",
+        "to_lane": "in_progress",
+        "at": "2026-01-01T00:00:00+00:00",
+        "actor": actor,
+        "force": False,
+        "execution_mode": "direct_repo",
+    }
+    if reason is not None:
+        event["reason"] = reason
+    return json.dumps(event)
+
+
+class TestStatusEventsNeedRepair:
+    """Tests for _status_events_need_repair covering all code paths."""
+
+    def test_no_tasks_dir(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "099-test"
+        feature_dir.mkdir()
+        assert _status_events_need_repair(feature_dir) is False
+
+    def test_tasks_dir_no_wp_files(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / "README.md").write_text("not a WP", encoding="utf-8")
+        assert _status_events_need_repair(feature_dir) is False
+
+    def test_no_events_file_delegates_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "planned")
+        monkeypatch.setattr(_DELEGATION_TARGET, lambda _fd: True)
+        assert _status_events_need_repair(feature_dir) is True
+
+    def test_no_events_file_delegates_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "planned")
+        monkeypatch.setattr(_DELEGATION_TARGET, lambda _fd: False)
+        assert _status_events_need_repair(feature_dir) is False
+
+    def test_empty_events_file_delegates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "planned")
+        (feature_dir / EVENTS_FILENAME).write_text("  \n", encoding="utf-8")
+        monkeypatch.setattr(_DELEGATION_TARGET, lambda _fd: True)
+        assert _status_events_need_repair(feature_dir) is True
+
+    def test_corrupt_jsonl_returns_true(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "planned")
+        (feature_dir / EVENTS_FILENAME).write_text("{bad json\n", encoding="utf-8")
+        assert _status_events_need_repair(feature_dir) is True
+
+    def test_events_with_historical_marker_returns_false(
+        self, tmp_path: Path
+    ) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "in_progress")
+        line = _make_event_line(
+            actor="migration:frontmatter",
+            reason="historical_frontmatter_to_jsonl:v1",
+        )
+        (feature_dir / EVENTS_FILENAME).write_text(line + "\n", encoding="utf-8")
+        assert _status_events_need_repair(feature_dir) is False
+
+    def test_events_with_non_migration_actor_returns_false(
+        self, tmp_path: Path
+    ) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "in_progress")
+        line = _make_event_line(actor="cli:task:start")
+        (feature_dir / EVENTS_FILENAME).write_text(line + "\n", encoding="utf-8")
+        assert _status_events_need_repair(feature_dir) is False
+
+    def test_all_migration_actors_no_marker_delegates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir = tmp_path / "099-test"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        _write_wp(tasks_dir, "WP01", "in_progress")
+        line = _make_event_line(actor="migration:upgrade", reason="some other reason")
+        (feature_dir / EVENTS_FILENAME).write_text(line + "\n", encoding="utf-8")
+        monkeypatch.setattr(_DELEGATION_TARGET, lambda _fd: True)
+        assert _status_events_need_repair(feature_dir) is True

--- a/tests/specify_cli/upgrade/test_feature_meta.py
+++ b/tests/specify_cli/upgrade/test_feature_meta.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.feature_meta import build_baseline_feature_meta, infer_target_branch
+
+
+def test_build_baseline_feature_meta_replaces_blank_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blank metadata values are repaired, not preserved."""
+    repo_root = tmp_path / "repo"
+    feature_dir = repo_root / "kitty-specs" / "023-repair-me"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "specify_cli.upgrade.feature_meta.resolve_primary_branch",
+        lambda _repo_root: "2.x",
+    )
+
+    meta = build_baseline_feature_meta(
+        feature_dir,
+        repo_root,
+        existing_meta={
+            "feature_number": "",
+            "slug": "",
+            "feature_slug": "",
+            "friendly_name": "",
+            "mission": "",
+            "target_branch": "",
+            "created_at": "",
+        },
+    )
+
+    assert meta["feature_number"] == "023"
+    assert meta["slug"] == "023-repair-me"
+    assert meta["feature_slug"] == "023-repair-me"
+    assert meta["friendly_name"] == "repair me"
+    assert meta["mission"] == "software-dev"
+    assert meta["target_branch"] == "2.x"
+    assert meta["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# infer_target_branch
+# ---------------------------------------------------------------------------
+
+_MONKEYPATCH_TARGET = "specify_cli.upgrade.feature_meta.resolve_primary_branch"
+
+
+def _setup_feature(tmp_path: Path, doc_name: str, content: str) -> tuple[Path, Path]:
+    """Create a minimal feature dir with a single doc file."""
+    repo_root = tmp_path / "repo"
+    feature_dir = repo_root / "kitty-specs" / "099-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / doc_name).write_text(content, encoding="utf-8")
+    return feature_dir, repo_root
+
+
+class TestInferTargetBranch:
+    """Tests for infer_target_branch covering all regex patterns and edge cases."""
+
+    def test_no_doc_files_returns_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        feature_dir = repo_root / "kitty-specs" / "099-empty"
+        feature_dir.mkdir(parents=True)
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "main"
+
+    def test_explicit_fallback_kwarg(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        feature_dir = repo_root / "kitty-specs" / "099-empty"
+        feature_dir.mkdir(parents=True)
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root, fallback="develop") == "develop"
+
+    def test_pattern_target_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "**Target Branch**: release/1.0\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "release/1.0"
+
+    def test_pattern_base_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "**Base Branch**: develop\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "develop"
+
+    def test_pattern_target_repo_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "target repo branch: staging\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "staging"
+
+    def test_pattern_branch_colon(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "branch: 2.x\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "2.x"
+
+    def test_pattern_must_be_done_on_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "All work must be done on the `feature/v3` branch.\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "feature/v3"
+
+    def test_pattern_merge_back_to(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "merge back to `develop`\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "develop"
+
+    def test_pattern_repository_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "repository https://github.com/org/repo branch `2.x`\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "2.x"
+
+    def test_backtick_wrapped_branch_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "**Target Branch**: `hotfix/urgent`\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "hotfix/urgent"
+
+    def test_multiple_candidates_fallback_among_them(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content = (
+            "**Target Branch**: develop\n"
+            "branch: main\n"
+        )
+        feature_dir, repo_root = _setup_feature(tmp_path, "spec.md", content)
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "main"
+
+    def test_multiple_candidates_fallback_not_among_them(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content = (
+            "**Target Branch**: release/1.0\n"
+            "branch: staging\n"
+        )
+        feature_dir, repo_root = _setup_feature(tmp_path, "spec.md", content)
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "main"
+
+    def test_branch_found_in_tasks_md(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "tasks.md", "**Target Branch**: release/2.0\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "release/2.0"
+
+    def test_or_in_value_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md", "**Target Branch**: main or develop\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "main"
+
+    def test_deduplication_same_branch_two_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        feature_dir = repo_root / "kitty-specs" / "099-dedup"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "spec.md").write_text("branch: release/3.0\n", encoding="utf-8")
+        (feature_dir / "tasks.md").write_text("branch: release/3.0\n", encoding="utf-8")
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "release/3.0"
+
+    def test_all_work_packages_branch_from_pattern(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feature_dir, repo_root = _setup_feature(
+            tmp_path, "spec.md",
+            "all work packages branch from and merge back to `2.x`\n"
+        )
+        monkeypatch.setattr(_MONKEYPATCH_TARGET, lambda _r: "main")
+        assert infer_target_branch(feature_dir, repo_root) == "2.x"

--- a/tests/specify_cli/upgrade/test_m_0_13_8_target_branch.py
+++ b/tests/specify_cli/upgrade/test_m_0_13_8_target_branch.py
@@ -134,7 +134,33 @@ def test_apply_detects_025_as_2x_target(repo_with_features: Path):
     assert meta_025["target_branch"] == "2.x"
 
     # Should have a warning about auto-detection
-    assert any("auto-detected" in warning for warning in result.warnings)
+    assert any("auto-detected target_branch=2.x" in warning for warning in result.warnings)
+
+
+def test_apply_uses_primary_branch_as_default(
+    repo_with_features: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Features without explicit markers inherit the repo's primary branch."""
+    monkeypatch.setattr(
+        "specify_cli.upgrade.feature_meta.resolve_primary_branch",
+        lambda _repo_root: "2.x",
+    )
+
+    migration = TargetBranchMigration()
+    result = migration.apply(repo_with_features, dry_run=False)
+
+    assert result.success is True
+
+    meta_020 = json.loads(
+        (repo_with_features / "kitty-specs" / "020-legacy-feature" / "meta.json").read_text()
+    )
+    meta_024 = json.loads(
+        (repo_with_features / "kitty-specs" / "024-another-feature" / "meta.json").read_text()
+    )
+
+    assert meta_020["target_branch"] == "2.x"
+    assert meta_024["target_branch"] == "2.x"
 
 
 def test_apply_dry_run_does_not_modify_files(repo_with_features: Path):

--- a/tests/specify_cli/upgrade/test_runner_status_classification.py
+++ b/tests/specify_cli/upgrade/test_runner_status_classification.py
@@ -91,3 +91,31 @@ def test_already_applied_migration_is_reported_as_skipped(
     assert result.migrations_applied == []
     assert result.migrations_skipped == [migration.migration_id]
     assert any("already applied" in warning for warning in result.warnings)
+
+
+def test_upgrade_creates_worktree_metadata_when_only_kitty_specs_exists(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Worktrees without .kittify should still be upgraded when they have kitty-specs."""
+    project_path = _setup_project(tmp_path)
+    worktree = project_path / ".worktrees" / "001-feature-WP01"
+    (worktree / "kitty-specs" / "001-feature" / "tasks").mkdir(parents=True)
+    (worktree / "kitty-specs" / "001-feature" / "tasks" / "WP01-test.md").write_text(
+        "---\nwork_package_id: WP01\nlane: planned\ndependencies: []\n---\n# WP01\n",
+        encoding="utf-8",
+    )
+
+    runner = MigrationRunner(project_path)
+    migration = _AppliedMigration()
+
+    monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+    monkeypatch.setattr(
+        "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+        lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+    )
+
+    result = runner.upgrade("9.9.9", include_worktrees=True)
+
+    assert result.success is True
+    assert (worktree / ".kittify" / "metadata.yaml").exists()

--- a/tests/unit/test_m_0_12_0_documentation_mission.py
+++ b/tests/unit/test_m_0_12_0_documentation_mission.py
@@ -45,6 +45,24 @@ def test_detect_non_kittify_project(migration: InstallDocumentationMission, tmp_
     assert migration.detect(tmp_path) is False
 
 
+def test_detect_skips_when_global_runtime_is_configured(
+    migration: InstallDocumentationMission,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2.x runtime-managed installs do not require project-local missions."""
+    home = tmp_path / "home"
+    (home / "cache").mkdir(parents=True)
+    (home / "cache" / "version.lock").write_text("2.0.5", encoding="utf-8")
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(home))
+
+    kittify = tmp_path / ".kittify"
+    kittify.mkdir()
+    (tmp_path / "kitty-specs").mkdir()
+
+    assert migration.detect(tmp_path) is False
+
+
 def test_detect_no_missions_dir(migration: InstallDocumentationMission, tmp_path: Path) -> None:
     """Migration detects when missions directory doesn't exist."""
     kittify = tmp_path / ".kittify"


### PR DESCRIPTION
## Summary
- add a `2.0.6_consistency_sweep` migration that repairs missing or blank `meta.json`, infers `target_branch`, rebuilds missing status event logs, regenerates canonical status views, rewrites stale prompt paths, normalizes legacy lane frontmatter, archives orphan empty `status.json`, and removes stale worktree command/script assets
- make older upgrade paths align with the centralized runtime model by fixing worktree discovery, using repo-aware `target_branch` inference, and suppressing obsolete local-mission/constitution false positives on 2.x installs
- bump the CLI version to `2.0.6`, document the release, and add focused regression coverage for the new sweep and detector behavior

## Testing
- `pytest tests/specify_cli/upgrade tests/specify_cli/status/test_migrate.py tests/specify_cli/status/test_validate.py tests/specify_cli/status/test_legacy_bridge.py tests/specify_cli/status/test_reducer.py`
