### PR TITLE
fix(constitution): resolve_doctrine_root fallback for pip-installed users

### DIFF
--- a/src/specify_cli/constitution/catalog.py
+++ b/src/specify_cli/constitution/catalog.py
@@ -41,7 +41,15 @@ def load_doctrine_catalog() -> DoctrineCatalog:
 
 
 def resolve_doctrine_root() -> Path:
-    """Resolve the doctrine package root in installed and development layouts."""
+    """Resolve the doctrine package root in installed and development layouts.
+
+    Resolution order:
+    1. ``doctrine`` Python package (importlib.resources)
+    2. ``src/doctrine/`` sibling directory (development layout)
+    3. ``specify_cli/`` package root (installed layout — paradigms/directives
+       won't exist but missions/ will, and callers handle empty sets gracefully)
+    """
+    # 1. Installed doctrine package
     try:
         doctrine_pkg = importlib.resources.files("doctrine")
         doctrine_root = Path(str(doctrine_pkg))
@@ -50,9 +58,19 @@ def resolve_doctrine_root() -> Path:
     except (ModuleNotFoundError, TypeError):
         pass
 
+    # 2. Development layout: src/doctrine/ next to src/specify_cli/
     dev_root = Path(__file__).parent.parent.parent / "doctrine"
     if dev_root.is_dir():
         return dev_root
+
+    # 3. Installed layout: doctrine is not a separate package on PyPI.
+    #    Fall back to the specify_cli package root so that callers can still
+    #    discover missions/ (via get_package_asset_root) and receive empty
+    #    sets for paradigms/directives which don't ship in the wheel.
+    try:
+        return get_package_asset_root().parent
+    except FileNotFoundError:
+        pass
 
     raise FileNotFoundError("Cannot locate doctrine root. Ensure doctrine assets are packaged.")
 


### PR DESCRIPTION
## Summary
- `resolve_doctrine_root()` in `catalog.py` crashed with "Cannot locate doctrine root" for all pip-installed users because the `doctrine` package is not included in the wheel (only `specify_cli` is)
- PR #172 fixed the same pattern in `runtime/home.py` but missed `constitution/catalog.py`
- Adds a third resolution tier: fall back to `specify_cli` package root, which lets callers discover `missions/` while gracefully getting empty sets for `paradigms/`/`directives/`
- All 114 constitution tests + 142 runtime tests pass

Fixes #278

## Test plan
- [x] `python -m pytest tests/specify_cli/constitution/ -x -q` — 114 passed
- [x] `python -m pytest tests/unit/runtime/ -x -q` — 142 passed
- [x] Verified `_load_yaml_id_catalog()` and `_index_yaml_assets()` both return empty collections when subdirs don't exist (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)