### PR TITLE
test(quality): isolate test lint churn from #276

### DIFF
--- a/tests/adversarial/conftest.py
+++ b/tests/adversarial/conftest.py
@@ -1,4 +1,5 @@
 """Shared fixtures for adversarial tests."""
+
 from __future__ import annotations
 
 import os
@@ -30,24 +31,14 @@ class AttackVector:
 
 PATH_ATTACK_VECTORS = [
     # Directory traversal
-    AttackVector(
-        "traversal_parent", "../kitty-specs/", "path", "reject", "Parent directory escape"
-    ),
-    AttackVector(
-        "traversal_deep", "../../../etc/passwd", "path", "reject", "Deep traversal"
-    ),
-    AttackVector(
-        "traversal_dot_slash", "./kitty-specs/", "path", "reject", "Dot-slash to kitty-specs"
-    ),
-    AttackVector(
-        "traversal_nested", "docs/../../kitty-specs/", "path", "reject", "Nested traversal"
-    ),
+    AttackVector("traversal_parent", "../kitty-specs/", "path", "reject", "Parent directory escape"),
+    AttackVector("traversal_deep", "../../../etc/passwd", "path", "reject", "Deep traversal"),
+    AttackVector("traversal_dot_slash", "./kitty-specs/", "path", "reject", "Dot-slash to kitty-specs"),
+    AttackVector("traversal_nested", "docs/../../kitty-specs/", "path", "reject", "Nested traversal"),
     # Case sensitivity bypass (macOS HFS+/APFS)
     AttackVector("case_upper", "KITTY-SPECS/test/", "path", "reject", "Uppercase bypass"),
     AttackVector("case_mixed", "Kitty-Specs/test/", "path", "reject", "Mixed case bypass"),
-    AttackVector(
-        "case_alternating", "KiTtY-SpEcS/test/", "path", "reject", "Alternating case"
-    ),
+    AttackVector("case_alternating", "KiTtY-SpEcS/test/", "path", "reject", "Alternating case"),
     # Empty/whitespace
     AttackVector("empty_string", "", "path", "reject", "Empty path"),
     AttackVector("whitespace_only", "   ", "path", "reject", "Whitespace-only path"),
@@ -56,14 +47,10 @@ PATH_ATTACK_VECTORS = [
     # Special paths
     AttackVector("home_tilde", "~/research/", "path", "reject", "Home directory reference"),
     AttackVector("absolute_path", "/tmp/research/", "path", "reject", "Absolute path"),
-    AttackVector(
-        "null_byte", "docs/research/\x00evil/", "path", "reject", "Null byte injection"
-    ),
+    AttackVector("null_byte", "docs/research/\x00evil/", "path", "reject", "Null byte injection"),
     # Unicode edge cases
     AttackVector("unicode_valid", "docs/研究/", "path", "handle", "Valid Unicode path"),
-    AttackVector(
-        "unicode_rtl", "docs/\u202e/test/", "path", "reject", "RTL override character"
-    ),
+    AttackVector("unicode_rtl", "docs/\u202e/test/", "path", "reject", "RTL override character"),
     AttackVector("unicode_bidi", "docs/a\u202eb\u202c/", "path", "reject", "BiDi override"),
 ]
 
@@ -86,16 +73,12 @@ def valid_unicode_path(request) -> AttackVector:
 
 CSV_ATTACK_VECTORS = [
     # Formula injection
-    AttackVector(
-        "formula_equals", "=cmd|'/c calc'!A1", "csv", "warn", "Excel formula injection"
-    ),
+    AttackVector("formula_equals", "=cmd|'/c calc'!A1", "csv", "warn", "Excel formula injection"),
     AttackVector("formula_plus", "+1+1", "csv", "warn", "Plus formula"),
     AttackVector("formula_minus", "-1+1", "csv", "warn", "Minus formula"),
     AttackVector("formula_at", "@SUM(A1:A10)", "csv", "warn", "At-sign formula"),
     # Encoding attacks
-    AttackVector(
-        "invalid_utf8", b"\xff\xfe\x00\x01", "csv", "handle", "Invalid UTF-8 sequence"
-    ),
+    AttackVector("invalid_utf8", b"\xff\xfe\x00\x01", "csv", "handle", "Invalid UTF-8 sequence"),
     AttackVector(
         "latin1_encoding",
         "café,naïve,résumé".encode("latin-1"),
@@ -112,25 +95,15 @@ CSV_ATTACK_VECTORS = [
     ),
     AttackVector("null_bytes", b"col1,col2\x00,col3", "csv", "handle", "Null bytes in content"),
     # Schema violations
-    AttackVector(
-        "duplicate_columns", "col1,col1,col2", "csv", "reject", "Duplicate column names"
-    ),
-    AttackVector(
-        "extra_columns", "a,b,c,d,e,f,g,h,i,j", "csv", "reject", "Extra columns beyond schema"
-    ),
+    AttackVector("duplicate_columns", "col1,col1,col2", "csv", "reject", "Duplicate column names"),
+    AttackVector("extra_columns", "a,b,c,d,e,f,g,h,i,j", "csv", "reject", "Extra columns beyond schema"),
     AttackVector("missing_columns", "a,b", "csv", "reject", "Missing required columns"),
-    AttackVector(
-        "whitespace_columns", " col1 , col2 ", "csv", "handle", "Whitespace in column names"
-    ),
+    AttackVector("whitespace_columns", " col1 , col2 ", "csv", "handle", "Whitespace in column names"),
     # Empty/malformed
     AttackVector("empty_file", "", "csv", "handle", "Empty CSV file"),
     AttackVector("headers_only", "col1,col2,col3\n", "csv", "handle", "Headers without data rows"),
-    AttackVector(
-        "mixed_line_endings", "a,b\r\nc,d\ne,f\r", "csv", "handle", "Mixed CRLF/LF/CR"
-    ),
-    AttackVector(
-        "unquoted_comma", "a,b,c with, comma,d", "csv", "handle", "Unquoted field with comma"
-    ),
+    AttackVector("mixed_line_endings", "a,b\r\nc,d\ne,f\r", "csv", "handle", "Mixed CRLF/LF/CR"),
+    AttackVector("unquoted_comma", "a,b,c with, comma,d", "csv", "handle", "Unquoted field with comma"),
 ]
 
 
@@ -185,9 +158,7 @@ def symlinks_supported() -> bool:
 
 
 @pytest.fixture
-def symlink_factory(
-    tmp_path: Path, symlinks_supported: bool
-) -> Callable[[str | Path, str], Path | None]:
+def symlink_factory(tmp_path: Path, symlinks_supported: bool) -> Callable[[str | Path, str], Path | None]:
     """Factory fixture for creating symlinks with platform awareness.
 
     Returns None if symlinks not supported, allowing tests to skip gracefully.
@@ -240,9 +211,7 @@ def temp_git_project(tmp_path: Path) -> Iterator[Path]:
     project.mkdir()
 
     # Initialize git
-    subprocess.run(
-        ["git", "init", "-b", "main"], cwd=project, check=True, capture_output=True
-    )
+    subprocess.run(["git", "init", "-b", "main"], cwd=project, check=True, capture_output=True)
     subprocess.run(
         ["git", "config", "user.email", "test@adversarial.local"],
         cwd=project,

--- a/tests/adversarial/test_csv_attacks.py
+++ b/tests/adversarial/test_csv_attacks.py
@@ -9,6 +9,7 @@ Tests for CSV validation to ensure:
 
 Target: src/specify_cli/validators/csv_schema.py
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -43,16 +44,13 @@ class TestFormulaInjection:
             ("+1+1", "Plus formula"),
             ("-1+1", "Minus formula"),
             ("@SUM(A1:A10)", "At-sign function"),
-            ("=HYPERLINK(\"http://evil.com\",\"Click\")", "Hyperlink injection"),
+            ('=HYPERLINK("http://evil.com","Click")', "Hyperlink injection"),
         ],
     )
     def test_formula_in_cell_handled(self, tmp_path: Path, formula: str, description: str):
         """CSV with formula injection should be validated without execution."""
         csv_path = tmp_path / "test.csv"
-        content = (
-            f"{','.join(EVIDENCE_COLUMNS)}\n"
-            f"2025-01-25T10:00:00,journal,\"{formula}\",Finding,high,Notes\n"
-        )
+        content = f'{",".join(EVIDENCE_COLUMNS)}\n2025-01-25T10:00:00,journal,"{formula}",Finding,high,Notes\n'
         csv_path.write_text(content, encoding="utf-8")
 
         # Should not raise exception

--- a/tests/adversarial/test_infrastructure.py
+++ b/tests/adversarial/test_infrastructure.py
@@ -3,6 +3,7 @@ Infrastructure smoke tests to verify adversarial test setup.
 
 These tests validate that the test infrastructure is correctly configured.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -120,9 +121,7 @@ class TestFactoryFixtures:
         assert path.exists(), "Should create file"
         assert path.read_bytes() == b"\xff\xfe"
 
-    def test_symlink_factory_returns_none_if_unsupported(
-        self, symlink_factory, symlinks_supported, tmp_path
-    ):
+    def test_symlink_factory_returns_none_if_unsupported(self, symlink_factory, symlinks_supported, tmp_path):
         """symlink_factory should return None if symlinks not supported."""
         target = tmp_path / "target"
         target.mkdir()

--- a/tests/adversarial/test_path_validation.py
+++ b/tests/adversarial/test_path_validation.py
@@ -10,6 +10,7 @@ Tests for validate_deliverables_path() to ensure:
 
 Target: src/specify_cli/mission.py:608-637
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -24,14 +25,17 @@ pytestmark = [pytest.mark.adversarial]
 class TestDirectoryTraversal:
     """Test directory traversal attack prevention."""
 
-    @pytest.mark.parametrize("malicious_path,description", [
-        ("../kitty-specs/", "Parent directory to kitty-specs"),
-        ("../../../etc/passwd", "Deep traversal to system files"),
-        ("./kitty-specs/", "Dot-slash to kitty-specs"),
-        ("docs/../../kitty-specs/", "Nested traversal"),
-        ("docs/../../../", "Traversal to root"),
-        ("a/b/c/../../../../kitty-specs/", "Deep nested traversal"),
-    ])
+    @pytest.mark.parametrize(
+        "malicious_path,description",
+        [
+            ("../kitty-specs/", "Parent directory to kitty-specs"),
+            ("../../../etc/passwd", "Deep traversal to system files"),
+            ("./kitty-specs/", "Dot-slash to kitty-specs"),
+            ("docs/../../kitty-specs/", "Nested traversal"),
+            ("docs/../../../", "Traversal to root"),
+            ("a/b/c/../../../../kitty-specs/", "Deep nested traversal"),
+        ],
+    )
     def test_traversal_rejected(self, malicious_path: str, description: str):
         """Directory traversal paths must be rejected."""
         is_valid, error = validate_deliverables_path(malicious_path)
@@ -41,8 +45,9 @@ class TestDirectoryTraversal:
         assert not is_valid, f"Path '{malicious_path}' should be rejected ({description})"
         assert error, f"Should provide error message for: {description}"
         # Error should mention traversal or invalid path
-        assert any(keyword in error.lower() for keyword in ["traversal", "invalid", "not allowed", "kitty-specs"]), \
+        assert any(keyword in error.lower() for keyword in ["traversal", "invalid", "not allowed", "kitty-specs"]), (
             f"Error message should explain rejection: {error}"
+        )
 
     def test_valid_nested_path_allowed(self):
         """Valid nested paths without traversal should be allowed."""
@@ -55,13 +60,16 @@ class TestDirectoryTraversal:
 class TestCaseSensitivityBypass:
     """Test case-sensitivity bypass prevention (macOS/Windows)."""
 
-    @pytest.mark.parametrize("case_variant", [
-        "KITTY-SPECS/test/",
-        "Kitty-Specs/test/",
-        "KiTtY-SpEcS/test/",
-        "kitty-SPECS/test/",
-        "KITTY-specs/test/",
-    ])
+    @pytest.mark.parametrize(
+        "case_variant",
+        [
+            "KITTY-SPECS/test/",
+            "Kitty-Specs/test/",
+            "KiTtY-SpEcS/test/",
+            "kitty-SPECS/test/",
+            "KITTY-specs/test/",
+        ],
+    )
     def test_case_variants_rejected(self, case_variant: str, case_insensitive_fs: bool):
         """Case variants of kitty-specs should be rejected on case-insensitive FS."""
         if not case_insensitive_fs:
@@ -88,14 +96,17 @@ class TestCaseSensitivityBypass:
 class TestEmptyPaths:
     """Test empty and whitespace path handling."""
 
-    @pytest.mark.parametrize("empty_path,description", [
-        ("", "Empty string"),
-        ("   ", "Whitespace only"),
-        ("\t\t", "Tabs only"),
-        ("\n", "Newline only"),
-        ("///", "Slashes that normalize to empty"),
-        ("/", "Single slash (root)"),
-    ])
+    @pytest.mark.parametrize(
+        "empty_path,description",
+        [
+            ("", "Empty string"),
+            ("   ", "Whitespace only"),
+            ("\t\t", "Tabs only"),
+            ("\n", "Newline only"),
+            ("///", "Slashes that normalize to empty"),
+            ("/", "Single slash (root)"),
+        ],
+    )
     def test_empty_rejected(self, empty_path: str, description: str):
         """Empty/whitespace paths must be rejected with clear error."""
         is_valid, error = validate_deliverables_path(empty_path)

--- a/tests/agent/cli/commands/test_glossary.py
+++ b/tests/agent/cli/commands/test_glossary.py
@@ -425,9 +425,7 @@ class TestGlossaryList:
     def test_list_json_with_scope_filter(self, mock_glossary_store, monkeypatch):
         """Verify --json with --scope produces filtered JSON."""
         monkeypatch.chdir(mock_glossary_store)
-        result = runner.invoke(
-            glossary_app, ["list", "--json", "--scope", "mission_local"]
-        )
+        result = runner.invoke(glossary_app, ["list", "--json", "--scope", "mission_local"])
 
         assert result.exit_code == 0
         data = json.loads(result.stdout)
@@ -475,11 +473,7 @@ class TestGlossaryList:
         long_def = "A" * 100
         seed = glossaries_dir / "team_domain.yaml"
         seed.write_text(
-            "terms:\n"
-            "  - surface: longterm\n"
-            f"    definition: {long_def}\n"
-            "    confidence: 0.8\n"
-            "    status: active\n"
+            f"terms:\n  - surface: longterm\n    definition: {long_def}\n    confidence: 0.8\n    status: active\n"
         )
 
         result = runner.invoke(glossary_app, ["list"])
@@ -497,11 +491,7 @@ class TestGlossaryList:
         long_def = "A" * 100
         seed = glossaries_dir / "team_domain.yaml"
         seed.write_text(
-            "terms:\n"
-            "  - surface: longterm\n"
-            f"    definition: {long_def}\n"
-            "    confidence: 0.8\n"
-            "    status: active\n"
+            f"terms:\n  - surface: longterm\n    definition: {long_def}\n    confidence: 0.8\n    status: active\n"
         )
 
         result = runner.invoke(glossary_app, ["list", "--json"])
@@ -563,9 +553,7 @@ class TestGlossaryConflicts:
     def test_conflicts_mission_filter(self, mock_event_log_multi_mission, monkeypatch):
         """Verify --mission filter restricts to specific mission."""
         monkeypatch.chdir(mock_event_log_multi_mission)
-        result = runner.invoke(
-            glossary_app, ["conflicts", "--mission", "documentation"]
-        )
+        result = runner.invoke(glossary_app, ["conflicts", "--mission", "documentation"])
 
         assert result.exit_code == 0
         assert "tutorial" in result.stdout
@@ -575,9 +563,7 @@ class TestGlossaryConflicts:
     def test_conflicts_strictness_filter(self, mock_event_log_multi_mission, monkeypatch):
         """Verify --strictness filter restricts to specific strictness level."""
         monkeypatch.chdir(mock_event_log_multi_mission)
-        result = runner.invoke(
-            glossary_app, ["conflicts", "--strictness", "max"]
-        )
+        result = runner.invoke(glossary_app, ["conflicts", "--strictness", "max"])
 
         assert result.exit_code == 0
         assert "tutorial" in result.stdout
@@ -587,9 +573,7 @@ class TestGlossaryConflicts:
     def test_conflicts_invalid_strictness(self, mock_event_log, monkeypatch):
         """Verify error on invalid --strictness value."""
         monkeypatch.chdir(mock_event_log)
-        result = runner.invoke(
-            glossary_app, ["conflicts", "--strictness", "invalid"]
-        )
+        result = runner.invoke(glossary_app, ["conflicts", "--strictness", "invalid"])
 
         assert result.exit_code == 1
         assert "Invalid strictness" in result.stdout
@@ -683,9 +667,7 @@ class TestGlossaryConflicts:
         assert "valid" in result.stdout
         assert "Total: 1 conflict(s)" in result.stdout
 
-    def test_conflicts_summary_shows_unresolved_count(
-        self, mock_event_log_unresolved, monkeypatch
-    ):
+    def test_conflicts_summary_shows_unresolved_count(self, mock_event_log_unresolved, monkeypatch):
         """Verify unresolved summary count is displayed."""
         monkeypatch.chdir(mock_event_log_unresolved)
         result = runner.invoke(glossary_app, ["conflicts"])
@@ -752,13 +734,7 @@ class TestGlossaryResolve:
         assert "resolved successfully" in result.stdout.lower()
 
         # Verify event was written
-        event_file = (
-            mock_event_log_unresolved
-            / ".kittify"
-            / "events"
-            / "glossary"
-            / "software-dev.events.jsonl"
-        )
+        event_file = mock_event_log_unresolved / ".kittify" / "events" / "glossary" / "software-dev.events.jsonl"
         lines = event_file.read_text().strip().split("\n")
         last_event = json.loads(lines[-1])
         assert last_event["event_type"] == "GlossaryClarificationResolved"
@@ -780,13 +756,7 @@ class TestGlossaryResolve:
         assert "resolved successfully" in result.stdout.lower()
 
         # Verify BOTH events were written
-        event_file = (
-            mock_event_log_unresolved
-            / ".kittify"
-            / "events"
-            / "glossary"
-            / "software-dev.events.jsonl"
-        )
+        event_file = mock_event_log_unresolved / ".kittify" / "events" / "glossary" / "software-dev.events.jsonl"
         lines = event_file.read_text().strip().split("\n")
 
         # Second-to-last: GlossaryClarificationResolved
@@ -881,13 +851,7 @@ class TestGlossaryResolve:
         assert "resolved successfully" in result.stdout.lower()
 
         # Verify event was written to custom mission log
-        custom_file = (
-            mock_event_log_unresolved
-            / ".kittify"
-            / "events"
-            / "glossary"
-            / "custom-mission.events.jsonl"
-        )
+        custom_file = mock_event_log_unresolved / ".kittify" / "events" / "glossary" / "custom-mission.events.jsonl"
         assert custom_file.exists()
         lines = custom_file.read_text().strip().split("\n")
         last_event = json.loads(lines[-1])
@@ -971,9 +935,7 @@ class TestExtractConflicts:
                 "timestamp": "2026-01-01T00:00:00Z",
                 "blocked": True,
                 "effective_strictness": "medium",
-                "findings": [
-                    {"term": {"surface_text": "test"}, "conflict_type": "unknown", "severity": "low"}
-                ],
+                "findings": [{"term": {"surface_text": "test"}, "conflict_type": "unknown", "severity": "low"}],
             },
             {
                 "event_type": "GlossaryClarificationRequested",
@@ -1007,9 +969,7 @@ class TestExtractConflicts:
                 "timestamp": "2026-01-01T00:00:00Z",
                 "blocked": True,
                 "effective_strictness": "medium",
-                "findings": [
-                    {"term": {"surface_text": "test"}, "conflict_type": "ambiguous", "severity": "high"}
-                ],
+                "findings": [{"term": {"surface_text": "test"}, "conflict_type": "ambiguous", "severity": "high"}],
             },
             {
                 "event_type": "GlossaryClarificationRequested",
@@ -1502,13 +1462,7 @@ class TestRegressionSenseUpdatedOnCustomResolve:
         assert result.exit_code == 0
 
         # Read all events
-        event_file = (
-            mock_event_log_unresolved
-            / ".kittify"
-            / "events"
-            / "glossary"
-            / "software-dev.events.jsonl"
-        )
+        event_file = mock_event_log_unresolved / ".kittify" / "events" / "glossary" / "software-dev.events.jsonl"
         lines = event_file.read_text().strip().split("\n")
         new_events = [json.loads(line) for line in lines]
 
@@ -1523,9 +1477,7 @@ class TestRegressionSenseUpdatedOnCustomResolve:
         assert sense_events[-1]["new_sense"]["definition"] == "Custom workspace definition"
         assert sense_events[-1]["term_surface"] == "workspace"
 
-    def test_candidate_resolve_does_not_emit_sense_updated(
-        self, mock_event_log_unresolved, monkeypatch
-    ):
+    def test_candidate_resolve_does_not_emit_sense_updated(self, mock_event_log_unresolved, monkeypatch):
         """Verify selecting a candidate (not custom) does NOT emit SenseUpdated."""
         monkeypatch.chdir(mock_event_log_unresolved)
 
@@ -1537,13 +1489,7 @@ class TestRegressionSenseUpdatedOnCustomResolve:
         assert result.exit_code == 0
 
         # Read all events
-        event_file = (
-            mock_event_log_unresolved
-            / ".kittify"
-            / "events"
-            / "glossary"
-            / "software-dev.events.jsonl"
-        )
+        event_file = mock_event_log_unresolved / ".kittify" / "events" / "glossary" / "software-dev.events.jsonl"
         lines = event_file.read_text().strip().split("\n")
         new_events = [json.loads(line) for line in lines]
 
@@ -1566,9 +1512,7 @@ class TestRegressionDeprecatedStatus:
     rendered as "draft", and --status deprecated always returned empty.
     """
 
-    def test_deprecated_seed_term_surfaces_with_status_filter(
-        self, tmp_path, monkeypatch
-    ):
+    def test_deprecated_seed_term_surfaces_with_status_filter(self, tmp_path, monkeypatch):
         """Verify glossary list --status deprecated shows deprecated seed terms."""
         monkeypatch.chdir(tmp_path)
 
@@ -1594,9 +1538,7 @@ class TestRegressionDeprecatedStatus:
         assert "legacy-api" in result.stdout
         assert "Total: 1 term(s)" in result.stdout
 
-    def test_deprecated_seed_term_shown_with_correct_status_in_json(
-        self, tmp_path, monkeypatch
-    ):
+    def test_deprecated_seed_term_shown_with_correct_status_in_json(self, tmp_path, monkeypatch):
         """Verify JSON output contains status: deprecated, not draft."""
         monkeypatch.chdir(tmp_path)
 

--- a/tests/agent/cli/commands/test_status_cli.py
+++ b/tests/agent/cli/commands/test_status_cli.py
@@ -53,12 +53,7 @@ def feature_dir(tmp_path: Path) -> Path:
     tasks_dir.mkdir()
     wp_file = tasks_dir / "WP01-test-task.md"
     wp_file.write_text(
-        "---\n"
-        "work_package_id: WP01\n"
-        "title: Test Task\n"
-        "lane: planned\n"
-        "---\n"
-        "\n# WP01\n",
+        "---\nwork_package_id: WP01\ntitle: Test Task\nlane: planned\n---\n\n# WP01\n",
         encoding="utf-8",
     )
     return fd
@@ -132,9 +127,12 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "claimed",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
+                    "--to",
+                    "claimed",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
                 ],
             )
 
@@ -160,9 +158,12 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "done",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
+                    "--to",
+                    "done",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
                 ],
             )
 
@@ -184,9 +185,12 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "claimed",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
+                    "--to",
+                    "claimed",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
                     "--json",
                 ],
             )
@@ -220,9 +224,12 @@ class TestEmitCommand:
                     [
                         "emit",
                         "WP01",
-                        "--to", to_lane,
-                        "--actor", "test-agent",
-                        "--feature", "034-test-feature",
+                        "--to",
+                        to_lane,
+                        "--actor",
+                        "test-agent",
+                        "--feature",
+                        "034-test-feature",
                     ],
                 )
                 assert r.exit_code == 0, f"Failed at {to_lane}: {r.output}"
@@ -246,10 +253,14 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "done",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
-                    "--evidence-json", json.dumps(evidence),
+                    "--to",
+                    "done",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
+                    "--evidence-json",
+                    json.dumps(evidence),
                     "--json",
                 ],
             )
@@ -272,10 +283,14 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "done",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
-                    "--evidence-json", "not valid json",
+                    "--to",
+                    "done",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
+                    "--evidence-json",
+                    "not valid json",
                 ],
             )
 
@@ -296,10 +311,14 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "done",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
-                    "--evidence-json", "{bad",
+                    "--to",
+                    "done",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
+                    "--evidence-json",
+                    "{bad",
                     "--json",
                 ],
             )
@@ -322,11 +341,15 @@ class TestEmitCommand:
                 [
                     "emit",
                     "WP01",
-                    "--to", "in_progress",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
+                    "--to",
+                    "in_progress",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
                     "--force",
-                    "--reason", "resuming after crash",
+                    "--reason",
+                    "resuming after crash",
                 ],
             )
 
@@ -353,7 +376,8 @@ class TestMaterializeCommand:
                 app,
                 [
                     "materialize",
-                    "--feature", "034-test-feature",
+                    "--feature",
+                    "034-test-feature",
                 ],
             )
 
@@ -377,7 +401,8 @@ class TestMaterializeCommand:
                 app,
                 [
                     "materialize",
-                    "--feature", "034-test-feature",
+                    "--feature",
+                    "034-test-feature",
                     "--json",
                 ],
             )
@@ -403,7 +428,8 @@ class TestMaterializeCommand:
                 app,
                 [
                     "materialize",
-                    "--feature", "034-test-feature",
+                    "--feature",
+                    "034-test-feature",
                 ],
             )
 
@@ -422,7 +448,8 @@ class TestMaterializeCommand:
                 app,
                 [
                     "materialize",
-                    "--feature", "034-test-feature",
+                    "--feature",
+                    "034-test-feature",
                     "--json",
                 ],
             )
@@ -491,7 +518,8 @@ class TestMaterializeCommand:
                 app,
                 [
                     "materialize",
-                    "--feature", "034-test-feature",
+                    "--feature",
+                    "034-test-feature",
                     "--json",
                 ],
             )
@@ -528,9 +556,12 @@ class TestEmitThenMaterialize:
                 [
                     "emit",
                     "WP01",
-                    "--to", "claimed",
-                    "--actor", "test-agent",
-                    "--feature", "034-test-feature",
+                    "--to",
+                    "claimed",
+                    "--actor",
+                    "test-agent",
+                    "--feature",
+                    "034-test-feature",
                     "--json",
                 ],
             )
@@ -546,7 +577,8 @@ class TestEmitThenMaterialize:
                 app,
                 [
                     "materialize",
-                    "--feature", "034-test-feature",
+                    "--feature",
+                    "034-test-feature",
                     "--json",
                 ],
             )

--- a/tests/agent/glossary/test_conflict.py
+++ b/tests/agent/glossary/test_conflict.py
@@ -3,13 +3,9 @@
 import pytest
 from datetime import datetime
 
-from specify_cli.glossary.models import (
-    TermSurface, TermSense, Provenance, SenseStatus, ConflictType, Severity
-)
+from specify_cli.glossary.models import TermSurface, TermSense, Provenance, SenseStatus, ConflictType, Severity
 from specify_cli.glossary.extraction import ExtractedTerm
-from specify_cli.glossary.conflict import (
-    classify_conflict, score_severity, create_conflict, make_sense_ref
-)
+from specify_cli.glossary.conflict import classify_conflict, score_severity, create_conflict, make_sense_ref
 
 pytestmark = pytest.mark.fast
 
@@ -204,9 +200,7 @@ def test_score_severity_inconsistent() -> None:
 
 def test_score_severity_unresolved_critical() -> None:
     """Test HIGH severity for unresolved critical term."""
-    severity = score_severity(
-        ConflictType.UNRESOLVED_CRITICAL, 0.3, is_critical_step=True
-    )
+    severity = score_severity(ConflictType.UNRESOLVED_CRITICAL, 0.3, is_critical_step=True)
 
     assert severity == Severity.HIGH
 

--- a/tests/agent/glossary/test_extraction.py
+++ b/tests/agent/glossary/test_extraction.py
@@ -1,7 +1,8 @@
 """Tests for term extraction (WP03)."""
 
-import pytest
 import time
+
+import pytest
 
 from specify_cli.glossary.extraction import (
     extract_metadata_hints,

--- a/tests/agent/glossary/test_generation_gate.py
+++ b/tests/agent/glossary/test_generation_gate.py
@@ -601,9 +601,7 @@ class TestEdgeCases:
         assert exc_info.value.strictness == Strictness.MEDIUM
         assert len(exc_info.value.conflicts) == 1
 
-    def test_event_emission_error_is_logged(
-        self, mock_context, high_severity_conflict, monkeypatch, caplog
-    ):
+    def test_event_emission_error_is_logged(self, mock_context, high_severity_conflict, monkeypatch, caplog):
         """When event emission fails, the error is logged."""
         import logging
         from specify_cli.glossary import events

--- a/tests/agent/glossary/test_integration_workflows.py
+++ b/tests/agent/glossary/test_integration_workflows.py
@@ -107,9 +107,7 @@ def _setup_multi_scope_repo(tmp_path):
 class TestFullWorkflowSpecifyClarifyResume:
     """End-to-end: specify step -> extraction -> conflict -> clarification -> gate passes."""
 
-    def test_interactive_clarification_resolves_conflict_and_pipeline_completes(
-        self, tmp_path, monkeypatch
-    ):
+    def test_interactive_clarification_resolves_conflict_and_pipeline_completes(self, tmp_path, monkeypatch):
         """User selects a candidate sense for an ambiguous term. The pipeline
         should complete without raising BlockedByConflict, even under MEDIUM
         strictness (which would block unresolved HIGH-severity conflicts)."""
@@ -133,9 +131,7 @@ class TestFullWorkflowSpecifyClarifyResume:
             mission_id="software-dev",
             run_id="run-int-001",
             inputs={
-                "description": (
-                    "Implement workspace management feature with artifact storage"
-                ),
+                "description": ("Implement workspace management feature with artifact storage"),
             },
             metadata={
                 "glossary_check": "enabled",
@@ -160,18 +156,14 @@ class TestFullWorkflowSpecifyClarifyResume:
         assert "workspace" in prompt_calls
 
         # Conflict was resolved (moved to resolved_conflicts, not in conflicts)
-        remaining_workspace = [
-            c for c in result.conflicts if c.term.surface_text == "workspace"
-        ]
+        remaining_workspace = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(remaining_workspace) == 0
 
         resolved = getattr(result, "resolved_conflicts", [])
         resolved_surfaces = [c.term.surface_text for c in resolved]
         assert "workspace" in resolved_surfaces
 
-    def test_custom_definition_resolves_and_emits_sense_update(
-        self, tmp_path, monkeypatch
-    ):
+    def test_custom_definition_resolves_and_emits_sense_update(self, tmp_path, monkeypatch):
         """User provides a custom definition for an ambiguous term.
         Pipeline should complete and the custom sense is treated as resolution."""
         _setup_multi_scope_repo(tmp_path)
@@ -211,9 +203,7 @@ class TestFullWorkflowSpecifyClarifyResume:
         assert len(resolved) >= 1
         assert resolved[0].term.surface_text == "workspace"
 
-    def test_multi_term_workflow_only_ambiguous_terms_prompt(
-        self, tmp_path, monkeypatch
-    ):
+    def test_multi_term_workflow_only_ambiguous_terms_prompt(self, tmp_path, monkeypatch):
         """When input contains both ambiguous and unambiguous terms, only the
         ambiguous ones trigger clarification prompts."""
         _setup_multi_scope_repo(tmp_path)
@@ -267,9 +257,7 @@ class TestDeferWorkflow:
     """User defers conflict resolution. Conflict should remain unresolved
     and the generation gate should block (under MEDIUM/MAX strictness)."""
 
-    def test_defer_leaves_conflict_unresolved_and_gate_blocks(
-        self, tmp_path, monkeypatch
-    ):
+    def test_defer_leaves_conflict_unresolved_and_gate_blocks(self, tmp_path, monkeypatch):
         """Deferring a HIGH-severity ambiguous conflict under MEDIUM strictness
         should result in BlockedByConflict."""
         _setup_multi_scope_repo(tmp_path)
@@ -307,9 +295,7 @@ class TestDeferWorkflow:
         conflict_terms = {c.term.surface_text for c in exc_info.value.conflicts}
         assert "workspace" in conflict_terms
 
-    def test_defer_under_off_strictness_completes(
-        self, tmp_path, monkeypatch
-    ):
+    def test_defer_under_off_strictness_completes(self, tmp_path, monkeypatch):
         """Even when user defers, OFF strictness never blocks."""
         _setup_multi_scope_repo(tmp_path)
 
@@ -343,9 +329,7 @@ class TestDeferWorkflow:
 
         assert result.effective_strictness == Strictness.OFF
         # Conflict remains unresolved (deferred)
-        workspace_conflicts = [
-            c for c in result.conflicts if c.term.surface_text == "workspace"
-        ]
+        workspace_conflicts = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(workspace_conflicts) >= 1
 
     def test_non_interactive_mode_defers_all(self, tmp_path):
@@ -497,9 +481,7 @@ class TestStrictnessModes:
 
         assert result.effective_strictness == Strictness.OFF
         # Conflicts are detected but not blocking
-        workspace_conflicts = [
-            c for c in result.conflicts if c.term.surface_text == "workspace"
-        ]
+        workspace_conflicts = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(workspace_conflicts) >= 1
         assert workspace_conflicts[0].conflict_type == ConflictType.AMBIGUOUS
 
@@ -693,9 +675,7 @@ class TestMultipleConflictsSingleStep:
         assert "workspace" in conflict_terms
         assert "mission" in conflict_terms
 
-    def test_resolve_all_multiple_conflicts_interactively(
-        self, tmp_path, monkeypatch
-    ):
+    def test_resolve_all_multiple_conflicts_interactively(self, tmp_path, monkeypatch):
         """User resolves all conflicts interactively. Pipeline completes."""
         _create_seed_file(
             tmp_path,
@@ -889,9 +869,7 @@ class TestScopeHierarchyIntegration:
         )
         result = pipeline.process(ctx)
 
-        unknown_conflicts = [
-            c for c in result.conflicts if c.term.surface_text == "xylophone"
-        ]
+        unknown_conflicts = [c for c in result.conflicts if c.term.surface_text == "xylophone"]
         assert len(unknown_conflicts) == 1
         assert unknown_conflicts[0].conflict_type == ConflictType.UNKNOWN
 
@@ -958,9 +936,7 @@ class TestEventEmissionEndToEnd:
             config={},
         )
 
-        event = emit_term_candidate_observed(
-            term=term, context=ctx, repo_root=tmp_path
-        )
+        event = emit_term_candidate_observed(term=term, context=ctx, repo_root=tmp_path)
 
         assert event is not None
         assert event["event_type"] == "TermCandidateObserved"
@@ -1144,9 +1120,7 @@ class TestEventEmissionEndToEnd:
 class TestProductionCodePath:
     """Verify full integration through the production execute_with_glossary hook."""
 
-    def test_full_e2e_production_specify_clarify_proceed(
-        self, tmp_path, monkeypatch
-    ):
+    def test_full_e2e_production_specify_clarify_proceed(self, tmp_path, monkeypatch):
         """Full production path: hook -> pipeline -> clarify -> primitive."""
         from specify_cli.missions.glossary_hook import execute_with_glossary
 
@@ -1164,11 +1138,13 @@ class TestProductionCodePath:
         primitive_results = []
 
         def my_specify_primitive(context):
-            primitive_results.append({
-                "strictness": context.effective_strictness,
-                "remaining_conflicts": len(context.conflicts),
-                "terms_extracted": len(context.extracted_terms),
-            })
+            primitive_results.append(
+                {
+                    "strictness": context.effective_strictness,
+                    "remaining_conflicts": len(context.conflicts),
+                    "terms_extracted": len(context.extracted_terms),
+                }
+            )
             return primitive_results[-1]
 
         ctx = PrimitiveExecutionContext(
@@ -1201,9 +1177,7 @@ class TestProductionCodePath:
         assert result["strictness"] == Strictness.MEDIUM
         assert result["terms_extracted"] >= 1
 
-    def test_production_path_disabled_skips_pipeline_runs_primitive(
-        self, tmp_path
-    ):
+    def test_production_path_disabled_skips_pipeline_runs_primitive(self, tmp_path):
         """When glossary is disabled, the primitive still runs."""
         from specify_cli.missions.glossary_hook import execute_with_glossary
 
@@ -1255,9 +1229,7 @@ class TestErrorHandlingEdgeCases:
             config={},
         )
 
-        pipeline = create_standard_pipeline(
-            tmp_path, runtime_strictness=Strictness.OFF
-        )
+        pipeline = create_standard_pipeline(tmp_path, runtime_strictness=Strictness.OFF)
 
         # Should not crash
         result = pipeline.process(ctx)
@@ -1278,9 +1250,7 @@ class TestErrorHandlingEdgeCases:
             config={},
         )
 
-        pipeline = create_standard_pipeline(
-            tmp_path, runtime_strictness=Strictness.OFF
-        )
+        pipeline = create_standard_pipeline(tmp_path, runtime_strictness=Strictness.OFF)
 
         result = pipeline.process(ctx)
         assert result is not None
@@ -1297,9 +1267,7 @@ class TestErrorHandlingEdgeCases:
             config={},
         )
 
-        pipeline = create_standard_pipeline(
-            tmp_path, runtime_strictness=Strictness.OFF
-        )
+        pipeline = create_standard_pipeline(tmp_path, runtime_strictness=Strictness.OFF)
 
         result = pipeline.process(ctx)
         assert result is not None
@@ -1426,9 +1394,7 @@ class TestIntegrationPerformance:
             pipeline.process(ctx)
 
         elapsed = time.perf_counter() - start
-        assert elapsed < 5.0, (
-            f"10 pipeline iterations too slow: {elapsed:.2f}s (expected < 5.0s)"
-        )
+        assert elapsed < 5.0, f"10 pipeline iterations too slow: {elapsed:.2f}s (expected < 5.0s)"
 
     def test_hundred_watch_terms_under_200ms(self, tmp_path):
         """Pipeline with 100 metadata watch terms completes in < 200ms."""
@@ -1444,9 +1410,7 @@ class TestIntegrationPerformance:
             config={},
         )
 
-        pipeline = create_standard_pipeline(
-            tmp_path, runtime_strictness=Strictness.OFF
-        )
+        pipeline = create_standard_pipeline(tmp_path, runtime_strictness=Strictness.OFF)
 
         start = time.perf_counter()
         pipeline.process(ctx)

--- a/tests/agent/glossary/test_pipeline.py
+++ b/tests/agent/glossary/test_pipeline.py
@@ -94,6 +94,7 @@ class TestPipelineExecution:
             def side_effect(ctx):
                 call_order.append(name)
                 return ctx
+
             return side_effect
 
         mw1 = _MockMiddleware("mw1", side_effect=make_side_effect("mw1"))
@@ -200,10 +201,8 @@ class TestPipelineExceptionPropagation:
             severity=Severity.HIGH,
             confidence=0.9,
             candidate_senses=[
-                MagicMock(surface="workspace", scope="team_domain",
-                          definition="def1", confidence=0.9),
-                MagicMock(surface="workspace", scope="team_domain",
-                          definition="def2", confidence=0.7),
+                MagicMock(surface="workspace", scope="team_domain", definition="def1", confidence=0.9),
+                MagicMock(surface="workspace", scope="team_domain", definition="def2", confidence=0.7),
             ],
         )
 
@@ -330,9 +329,7 @@ class TestCreateStandardPipeline:
 
     def test_runtime_strictness_passed_to_gate(self, tmp_path):
         (tmp_path / ".kittify").mkdir()
-        pipeline = create_standard_pipeline(
-            tmp_path, runtime_strictness=Strictness.OFF
-        )
+        pipeline = create_standard_pipeline(tmp_path, runtime_strictness=Strictness.OFF)
 
         # Gate is at index 3 (after clarification at index 2)
         gate = pipeline.middleware[3]
@@ -351,20 +348,14 @@ class TestCreateStandardPipeline:
         glossaries = tmp_path / ".kittify" / "glossaries"
         glossaries.mkdir()
         (glossaries / "team_domain.yaml").write_text(
-            "terms:\n"
-            "  - surface: workspace\n"
-            "    definition: A git worktree\n"
-            "    confidence: 1.0\n"
-            "    status: active\n"
+            "terms:\n  - surface: workspace\n    definition: A git worktree\n    confidence: 1.0\n    status: active\n"
         )
 
         pipeline = create_standard_pipeline(tmp_path)
 
         # The SemanticCheckMiddleware should have a store with the loaded term
         check_mw = pipeline.middleware[1]
-        results = check_mw.glossary_store.lookup(
-            "workspace", ("team_domain",)
-        )
+        results = check_mw.glossary_store.lookup("workspace", ("team_domain",))
         assert len(results) >= 1
         assert results[0].definition == "A git worktree"
 
@@ -373,9 +364,7 @@ class TestCreateStandardPipeline:
         from specify_cli.glossary.clarification import ClarificationMiddleware
 
         (tmp_path / ".kittify").mkdir()
-        pipeline = create_standard_pipeline(
-            tmp_path, interaction_mode="interactive"
-        )
+        pipeline = create_standard_pipeline(tmp_path, interaction_mode="interactive")
         # Clarification is at index 2 (before gate at index 3)
         clarification = pipeline.middleware[2]
         assert isinstance(clarification, ClarificationMiddleware)
@@ -387,9 +376,7 @@ class TestCreateStandardPipeline:
 
 
         (tmp_path / ".kittify").mkdir()
-        pipeline = create_standard_pipeline(
-            tmp_path, interaction_mode="non-interactive"
-        )
+        pipeline = create_standard_pipeline(tmp_path, interaction_mode="non-interactive")
         # Clarification is at index 2 (before gate at index 3)
         clarification = pipeline.middleware[2]
         assert isinstance(clarification, ClarificationMiddleware)
@@ -449,10 +436,7 @@ class TestInteractiveClarificationResolves:
         assert resolved[0].term.surface_text == "workspace"
 
         # The remaining conflicts should not include the resolved one
-        remaining_workspace = [
-            c for c in result.conflicts
-            if c.term.surface_text == "workspace"
-        ]
+        remaining_workspace = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(remaining_workspace) == 0
 
 
@@ -476,9 +460,7 @@ class TestMutableContextDocumentation:
                 context.extracted_terms.append("tracked")
                 return context
 
-        pipeline = GlossaryMiddlewarePipeline(
-            middleware=[TrackingMiddleware(), TrackingMiddleware()]
-        )
+        pipeline = GlossaryMiddlewarePipeline(middleware=[TrackingMiddleware(), TrackingMiddleware()])
         ctx = _make_context()
         original_id = id(ctx)
         result = pipeline.process(ctx)

--- a/tests/agent/glossary/test_pipeline_integration.py
+++ b/tests/agent/glossary/test_pipeline_integration.py
@@ -139,10 +139,7 @@ class TestPipelineConflictDetection:
 
         # With strictness=OFF, pipeline completes (no blocking)
         # but conflicts are still detected
-        workspace_conflicts = [
-            c for c in result.conflicts
-            if c.term.surface_text == "workspace"
-        ]
+        workspace_conflicts = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(workspace_conflicts) >= 1
         assert workspace_conflicts[0].conflict_type == ConflictType.AMBIGUOUS
 
@@ -464,10 +461,7 @@ class TestPipelineUnknownTerms:
         result = pipeline.process(ctx)
 
         # frobulator not in any seed file -> UNKNOWN
-        unknown_conflicts = [
-            c for c in result.conflicts
-            if c.term.surface_text == "frobulator"
-        ]
+        unknown_conflicts = [c for c in result.conflicts if c.term.surface_text == "frobulator"]
         assert len(unknown_conflicts) == 1
         assert unknown_conflicts[0].conflict_type == ConflictType.UNKNOWN
 
@@ -496,10 +490,7 @@ class TestPipelineSeedFileEdgeCases:
         result = pipeline.process(ctx)
 
         # workspace not found -> UNKNOWN conflict
-        assert any(
-            c.conflict_type == ConflictType.UNKNOWN
-            for c in result.conflicts
-        )
+        assert any(c.conflict_type == ConflictType.UNKNOWN for c in result.conflicts)
 
     def test_malformed_seed_file_skipped(self, tmp_path):
         """Pipeline continues when seed file is malformed YAML."""
@@ -651,10 +642,7 @@ class TestEndToEndSpecifyWithConflict:
             mission_id="software-dev",
             run_id="run-abc-123",
             inputs={
-                "description": (
-                    "Create a new feature that manages workspace configuration "
-                    "for parallel development"
-                ),
+                "description": ("Create a new feature that manages workspace configuration for parallel development"),
             },
             metadata={
                 "glossary_check": "enabled",
@@ -725,10 +713,7 @@ class TestEndToEndSpecifyWithConflict:
         # Pipeline completes, conflicts detected but not blocked
         assert result.effective_strictness == Strictness.OFF
         # workspace is ambiguous but we don't block
-        workspace_conflicts = [
-            c for c in result.conflicts
-            if c.term.surface_text == "workspace"
-        ]
+        workspace_conflicts = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(workspace_conflicts) >= 1
 
     def test_specify_step_no_conflicts_clean_glossary(self, tmp_path):
@@ -1037,10 +1022,7 @@ class TestClarificationBeforeGate:
         # Verify: conflict was resolved (not blocked)
         assert result.effective_strictness == Strictness.MEDIUM
         # The resolved conflict was moved out of context.conflicts
-        remaining_workspace = [
-            c for c in result.conflicts
-            if c.term.surface_text == "workspace"
-        ]
+        remaining_workspace = [c for c in result.conflicts if c.term.surface_text == "workspace"]
         assert len(remaining_workspace) == 0
 
         # The resolved conflict is available in resolved_conflicts
@@ -1246,10 +1228,12 @@ class TestExecuteWithGlossaryEndToEnd:
 
         def my_specify_primitive(context):
             """Simulate a real specify step primitive."""
-            primitive_results.append({
-                "strictness": context.effective_strictness,
-                "remaining_conflicts": len(context.conflicts),
-            })
+            primitive_results.append(
+                {
+                    "strictness": context.effective_strictness,
+                    "remaining_conflicts": len(context.conflicts),
+                }
+            )
             return primitive_results[-1]
 
         ctx = _make_context(

--- a/tests/agent/glossary/test_prompts.py
+++ b/tests/agent/glossary/test_prompts.py
@@ -14,8 +14,6 @@ from specify_cli.glossary.models import (
     SenseRef,
 )
 
-pytestmark = pytest.mark.fast
-
 from specify_cli.glossary.prompts import (
     PromptChoice,
     is_interactive,
@@ -25,6 +23,8 @@ from specify_cli.glossary.prompts import (
     prompt_context_change_confirmation,
     log_non_interactive_context,
 )
+
+pytestmark = pytest.mark.fast
 
 
 @pytest.fixture
@@ -113,10 +113,17 @@ class TestIsInteractive:
         mock_sys.stdin.isatty.return_value = True
         # Clear all CI env vars
         env_clean = {
-            k: v for k, v in os.environ.items()
-            if k not in [
-                "CI", "GITHUB_ACTIONS", "JENKINS_HOME",
-                "GITLAB_CI", "CIRCLECI", "TRAVIS", "BUILDKITE",
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in [
+                "CI",
+                "GITHUB_ACTIONS",
+                "JENKINS_HOME",
+                "GITLAB_CI",
+                "CIRCLECI",
+                "TRAVIS",
+                "BUILDKITE",
             ]
         }
         with patch.dict(os.environ, env_clean, clear=True):
@@ -198,10 +205,7 @@ class TestPromptConflictResolution:
         assert choice == PromptChoice.CUSTOM_SENSE
         assert value == "Valid definition"
         # Verify error message was shown
-        error_calls = [
-            str(c) for c in mock_echo.call_args_list
-            if "empty" in str(c).lower()
-        ]
+        error_calls = [str(c) for c in mock_echo.call_args_list if "empty" in str(c).lower()]
         assert len(error_calls) > 0
 
     @patch("specify_cli.glossary.prompts.typer.echo")
@@ -211,10 +215,7 @@ class TestPromptConflictResolution:
         choice, value = prompt_conflict_resolution(ambiguous_conflict)
         assert choice == PromptChoice.DEFER
         # Verify error message was shown for 'X'
-        error_calls = [
-            str(c) for c in mock_echo.call_args_list
-            if "invalid" in str(c).lower()
-        ]
+        error_calls = [str(c) for c in mock_echo.call_args_list if "invalid" in str(c).lower()]
         assert len(error_calls) > 0
 
     @patch("specify_cli.glossary.prompts.typer.echo")
@@ -226,8 +227,7 @@ class TestPromptConflictResolution:
         assert value == 0
         # Verify error message was shown for '99'
         error_calls = [
-            str(c) for c in mock_echo.call_args_list
-            if "between 1 and" in str(c).lower() or "enter" in str(c).lower()
+            str(c) for c in mock_echo.call_args_list if "between 1 and" in str(c).lower() or "enter" in str(c).lower()
         ]
         assert len(error_calls) > 0
 
@@ -260,9 +260,7 @@ class TestPromptConflictResolution:
 
     @patch("specify_cli.glossary.prompts.typer.echo")
     @patch("specify_cli.glossary.prompts.typer.prompt", side_effect=["3", "D"])
-    def test_number_rejected_when_no_candidates(
-        self, mock_prompt, mock_echo, no_candidate_conflict
-    ):
+    def test_number_rejected_when_no_candidates(self, mock_prompt, mock_echo, no_candidate_conflict):
         """Number input rejected when conflict has no candidates."""
         choice, value = prompt_conflict_resolution(no_candidate_conflict)
         assert choice == PromptChoice.DEFER
@@ -273,9 +271,7 @@ class TestPromptConflictResolutionSafe:
 
     @patch("specify_cli.glossary.prompts.is_interactive", return_value=False)
     @patch("specify_cli.glossary.prompts.typer.echo")
-    def test_non_interactive_auto_defers(
-        self, mock_echo, mock_is_interactive, ambiguous_conflict
-    ):
+    def test_non_interactive_auto_defers(self, mock_echo, mock_is_interactive, ambiguous_conflict):
         """Non-interactive mode auto-defers."""
         choice, value = prompt_conflict_resolution_safe(ambiguous_conflict)
         assert choice == PromptChoice.DEFER
@@ -283,9 +279,7 @@ class TestPromptConflictResolutionSafe:
 
     @patch("specify_cli.glossary.prompts.is_interactive", return_value=False)
     @patch("specify_cli.glossary.prompts.typer.echo")
-    def test_non_interactive_prints_message(
-        self, mock_echo, mock_is_interactive, ambiguous_conflict
-    ):
+    def test_non_interactive_prints_message(self, mock_echo, mock_is_interactive, ambiguous_conflict):
         """Non-interactive mode prints auto-defer message."""
         prompt_conflict_resolution_safe(ambiguous_conflict)
         echo_text = str(mock_echo.call_args_list)
@@ -296,9 +290,7 @@ class TestPromptConflictResolutionSafe:
         "specify_cli.glossary.prompts.prompt_conflict_resolution",
         return_value=(PromptChoice.SELECT_CANDIDATE, 0),
     )
-    def test_interactive_delegates_to_prompt(
-        self, mock_prompt, mock_is_interactive, ambiguous_conflict
-    ):
+    def test_interactive_delegates_to_prompt(self, mock_prompt, mock_is_interactive, ambiguous_conflict):
         """Interactive mode delegates to prompt_conflict_resolution."""
         choice, value = prompt_conflict_resolution_safe(ambiguous_conflict)
         assert choice == PromptChoice.SELECT_CANDIDATE
@@ -313,27 +305,21 @@ class TestPromptContextChangeConfirmation:
     @patch("specify_cli.glossary.prompts.typer.echo")
     def test_user_confirms(self, mock_echo, mock_confirm):
         """User confirming returns True."""
-        result = prompt_context_change_confirmation(
-            "abcdef1234567890abcdef", "1234567890abcdef1234"
-        )
+        result = prompt_context_change_confirmation("abcdef1234567890abcdef", "1234567890abcdef1234")
         assert result is True
 
     @patch("specify_cli.glossary.prompts.typer.confirm", return_value=False)
     @patch("specify_cli.glossary.prompts.typer.echo")
     def test_user_declines(self, mock_echo, mock_confirm):
         """User declining returns False."""
-        result = prompt_context_change_confirmation(
-            "abcdef1234567890abcdef", "1234567890abcdef1234"
-        )
+        result = prompt_context_change_confirmation("abcdef1234567890abcdef", "1234567890abcdef1234")
         assert result is False
 
     @patch("specify_cli.glossary.prompts.typer.confirm", return_value=False)
     @patch("specify_cli.glossary.prompts.typer.echo")
     def test_shows_hash_comparison(self, mock_echo, mock_confirm):
         """Shows original and current hash in output."""
-        prompt_context_change_confirmation(
-            "abcdef1234567890abcdef", "1234567890abcdef1234"
-        )
+        prompt_context_change_confirmation("abcdef1234567890abcdef", "1234567890abcdef1234")
         echo_text = str(mock_echo.call_args)
         assert "abcdef1234567890" in echo_text  # First 16 chars
         assert "1234567890abcdef" in echo_text

--- a/tests/agent/glossary/test_rendering.py
+++ b/tests/agent/glossary/test_rendering.py
@@ -294,9 +294,7 @@ class TestRenderConflict:
 class TestRenderConflictBatch:
     """Test render_conflict_batch function."""
 
-    def test_sorts_by_severity_high_first(
-        self, mock_console, high_conflict, medium_conflict, low_conflict
-    ):
+    def test_sorts_by_severity_high_first(self, mock_console, high_conflict, medium_conflict, low_conflict):
         """Conflicts are sorted by severity (high -> medium -> low)."""
         result = render_conflict_batch(
             mock_console,
@@ -320,9 +318,7 @@ class TestRenderConflictBatch:
             )
             for i in range(5)
         ]
-        result = render_conflict_batch(
-            mock_console, conflicts, max_questions=3
-        )
+        result = render_conflict_batch(mock_console, conflicts, max_questions=3)
         assert len(result) == 3
 
     def test_truncation_message_shown(self, mock_console):
@@ -342,37 +338,23 @@ class TestRenderConflictBatch:
 
         # Check that a truncation message was printed
         all_calls = mock_console.print.call_args_list
-        print_texts = [
-            str(c[0][0]) if c[0] else str(c)
-            for c in all_calls
-        ]
+        print_texts = [str(c[0][0]) if c[0] else str(c) for c in all_calls]
         truncation_found = any("Showing 3 of 5" in t for t in print_texts)
         assert truncation_found, f"Expected truncation message in: {print_texts}"
 
-    def test_no_truncation_message_when_under_limit(
-        self, mock_console, high_conflict
-    ):
+    def test_no_truncation_message_when_under_limit(self, mock_console, high_conflict):
         """No truncation message when conflicts fit within max_questions."""
-        result = render_conflict_batch(
-            mock_console, [high_conflict], max_questions=3
-        )
+        result = render_conflict_batch(mock_console, [high_conflict], max_questions=3)
         assert len(result) == 1
 
         # Only panel + blank line should be printed, no truncation msg
-        print_texts = [
-            str(c[0][0]) if c[0] else ""
-            for c in mock_console.print.call_args_list
-        ]
+        print_texts = [str(c[0][0]) if c[0] else "" for c in mock_console.print.call_args_list]
         truncation_found = any("Showing" in t and "of" in t for t in print_texts)
         assert not truncation_found
 
-    def test_returns_all_when_under_limit(
-        self, mock_console, high_conflict, medium_conflict
-    ):
+    def test_returns_all_when_under_limit(self, mock_console, high_conflict, medium_conflict):
         """Returns all conflicts when count <= max_questions."""
-        result = render_conflict_batch(
-            mock_console, [high_conflict, medium_conflict], max_questions=5
-        )
+        result = render_conflict_batch(mock_console, [high_conflict, medium_conflict], max_questions=5)
         assert len(result) == 2
 
     def test_empty_conflicts_list(self, mock_console):
@@ -398,9 +380,7 @@ class TestRenderConflictBatch:
             candidate_senses=[],
             context="test",
         )
-        result = render_conflict_batch(
-            mock_console, [c1, c2], max_questions=5
-        )
+        result = render_conflict_batch(mock_console, [c1, c2], max_questions=5)
         assert result[0].term.surface_text == "alpha"
         assert result[1].term.surface_text == "zebra"
 
@@ -420,13 +400,9 @@ class TestRenderConflictBatch:
         result = render_conflict_batch(mock_console, conflicts)
         assert len(result) == 3
 
-    def test_renders_each_conflict_panel(
-        self, mock_console, high_conflict, medium_conflict
-    ):
+    def test_renders_each_conflict_panel(self, mock_console, high_conflict, medium_conflict):
         """Each conflict produces a Panel + blank line print call."""
-        render_conflict_batch(
-            mock_console, [high_conflict, medium_conflict], max_questions=5
-        )
+        render_conflict_batch(mock_console, [high_conflict, medium_conflict], max_questions=5)
         # Each conflict: 1 Panel + 1 blank line = 2 calls per conflict
         # Total: 2 conflicts * 2 calls = 4
         assert mock_console.print.call_count == 4

--- a/tests/agent/glossary/test_resolution.py
+++ b/tests/agent/glossary/test_resolution.py
@@ -24,54 +24,64 @@ def glossary_store(tmp_path: Path) -> GlossaryStore:
     )
 
     # mission_local: workspace (Git worktree)
-    store.add_sense(TermSense(
-        surface=TermSurface("workspace"),
-        scope=GlossaryScope.MISSION_LOCAL.value,
-        definition="Git worktree directory for a work package",
-        provenance=provenance,
-        confidence=1.0,
-        status=SenseStatus.ACTIVE,
-    ))
+    store.add_sense(
+        TermSense(
+            surface=TermSurface("workspace"),
+            scope=GlossaryScope.MISSION_LOCAL.value,
+            definition="Git worktree directory for a work package",
+            provenance=provenance,
+            confidence=1.0,
+            status=SenseStatus.ACTIVE,
+        )
+    )
 
     # team_domain: workspace (VS Code workspace)
-    store.add_sense(TermSense(
-        surface=TermSurface("workspace"),
-        scope=GlossaryScope.TEAM_DOMAIN.value,
-        definition="VS Code workspace configuration file",
-        provenance=provenance,
-        confidence=0.9,
-        status=SenseStatus.ACTIVE,
-    ))
+    store.add_sense(
+        TermSense(
+            surface=TermSurface("workspace"),
+            scope=GlossaryScope.TEAM_DOMAIN.value,
+            definition="VS Code workspace configuration file",
+            provenance=provenance,
+            confidence=0.9,
+            status=SenseStatus.ACTIVE,
+        )
+    )
 
     # team_domain: mission (workflow machine)
-    store.add_sense(TermSense(
-        surface=TermSurface("mission"),
-        scope=GlossaryScope.TEAM_DOMAIN.value,
-        definition="Purpose-specific workflow machine",
-        provenance=provenance,
-        confidence=1.0,
-        status=SenseStatus.ACTIVE,
-    ))
+    store.add_sense(
+        TermSense(
+            surface=TermSurface("mission"),
+            scope=GlossaryScope.TEAM_DOMAIN.value,
+            definition="Purpose-specific workflow machine",
+            provenance=provenance,
+            confidence=1.0,
+            status=SenseStatus.ACTIVE,
+        )
+    )
 
     # audience_domain: mission (user-facing definition)
-    store.add_sense(TermSense(
-        surface=TermSurface("mission"),
-        scope=GlossaryScope.AUDIENCE_DOMAIN.value,
-        definition="A project goal or objective",
-        provenance=provenance,
-        confidence=0.8,
-        status=SenseStatus.ACTIVE,
-    ))
+    store.add_sense(
+        TermSense(
+            surface=TermSurface("mission"),
+            scope=GlossaryScope.AUDIENCE_DOMAIN.value,
+            definition="A project goal or objective",
+            provenance=provenance,
+            confidence=0.8,
+            status=SenseStatus.ACTIVE,
+        )
+    )
 
     # spec_kitty_core: feature (canonical definition)
-    store.add_sense(TermSense(
-        surface=TermSurface("feature"),
-        scope=GlossaryScope.SPEC_KITTY_CORE.value,
-        definition="A unit of work with specifications and work packages",
-        provenance=provenance,
-        confidence=1.0,
-        status=SenseStatus.ACTIVE,
-    ))
+    store.add_sense(
+        TermSense(
+            surface=TermSurface("feature"),
+            scope=GlossaryScope.SPEC_KITTY_CORE.value,
+            definition="A unit of work with specifications and work packages",
+            provenance=provenance,
+            confidence=1.0,
+            status=SenseStatus.ACTIVE,
+        )
+    )
 
     return store
 
@@ -145,14 +155,16 @@ def test_resolve_term_normalized_surface(glossary_store: GlossaryStore) -> None:
         source="user_clarification",
     )
 
-    glossary_store.add_sense(TermSense(
-        surface=TermSurface("worktree"),
-        scope=GlossaryScope.TEAM_DOMAIN.value,
-        definition="Git worktree",
-        provenance=provenance,
-        confidence=1.0,
-        status=SenseStatus.ACTIVE,
-    ))
+    glossary_store.add_sense(
+        TermSense(
+            surface=TermSurface("worktree"),
+            scope=GlossaryScope.TEAM_DOMAIN.value,
+            definition="Git worktree",
+            provenance=provenance,
+            confidence=1.0,
+            status=SenseStatus.ACTIVE,
+        )
+    )
 
     # Resolution should work with exact normalized surface
     results = resolve_term("worktree", SCOPE_RESOLUTION_ORDER, glossary_store)

--- a/tests/agent/glossary/test_strictness.py
+++ b/tests/agent/glossary/test_strictness.py
@@ -1,6 +1,13 @@
 """Tests for strictness policy system (WP05)."""
 
 import pytest
+
+from specify_cli.glossary.models import (
+    SemanticConflict,
+    Severity,
+    TermSurface,
+    ConflictType,
+)
 from specify_cli.glossary.strictness import (
     Strictness,
     resolve_strictness,
@@ -10,13 +17,6 @@ from specify_cli.glossary.strictness import (
 )
 
 pytestmark = pytest.mark.fast
-
-from specify_cli.glossary.models import (
-    SemanticConflict,
-    Severity,
-    TermSurface,
-    ConflictType,
-)
 
 
 class TestStrictnessEnum:
@@ -106,9 +106,7 @@ class TestResolvePrecedence:
             (Strictness.MAX, None, None, None, Strictness.MAX),
         ],
     )
-    def test_precedence_combinations(
-        self, global_val, mission_val, step_val, runtime_val, expected
-    ):
+    def test_precedence_combinations(self, global_val, mission_val, step_val, runtime_val, expected):
         """Test all precedence combinations systematically."""
         result = resolve_strictness(
             global_default=global_val,

--- a/tests/agent/test_agent_config_migration.py
+++ b/tests/agent/test_agent_config_migration.py
@@ -103,9 +103,7 @@ class TestMigrationRespectsConfig:
         migration = ImprovedWorkflowTemplatesMigration()
 
         # Create old template for opencode (will be updated)
-        opencode_implement = (
-            mock_project_with_config / ".opencode" / "command" / "spec-kitty.implement.md"
-        )
+        opencode_implement = mock_project_with_config / ".opencode" / "command" / "spec-kitty.implement.md"
         opencode_implement.write_text("# Old implement without scroll warning")
 
         # Create old template for claude (should NOT be updated - not configured)
@@ -288,9 +286,7 @@ class TestDryRunBehavior:
         migration = ImprovedWorkflowTemplatesMigration()
 
         # Create old template for opencode
-        opencode_implement = (
-            mock_project_with_config / ".opencode" / "command" / "spec-kitty.implement.md"
-        )
+        opencode_implement = mock_project_with_config / ".opencode" / "command" / "spec-kitty.implement.md"
         opencode_implement.write_text("# Old implement")
 
         # Run dry-run

--- a/tests/agent/test_csv_schema.py
+++ b/tests/agent/test_csv_schema.py
@@ -27,8 +27,7 @@ def wrong_column_names_csv(tmp_path: Path) -> Path:
     """CSV file with wrong column names."""
     csv_file = tmp_path / "test.csv"
     csv_file.write_text(
-        "timestamp,type,ref,finding,confidence,notes\n"
-        "2025-01-25T10:00:00,journal,Citation,Finding,high,Notes\n",
+        "timestamp,type,ref,finding,confidence,notes\n2025-01-25T10:00:00,journal,Citation,Finding,high,Notes\n",
         encoding="utf-8",
     )
     return csv_file
@@ -50,9 +49,7 @@ def wrong_column_order_csv(tmp_path: Path) -> Path:
 def missing_columns_csv(tmp_path: Path) -> Path:
     """CSV file with missing columns."""
     csv_file = tmp_path / "test.csv"
-    csv_file.write_text(
-        "timestamp,citation,key_finding\n" "2025-01-25T10:00:00,Citation,Finding\n", encoding="utf-8"
-    )
+    csv_file.write_text("timestamp,citation,key_finding\n2025-01-25T10:00:00,Citation,Finding\n", encoding="utf-8")
     return csv_file
 
 

--- a/tests/agent/test_dependency_graph.py
+++ b/tests/agent/test_dependency_graph.py
@@ -125,9 +125,7 @@ class TestBuildDependencyGraph:
         tasks_dir = feature_dir / "tasks"
         tasks_dir.mkdir(parents=True)
 
-        (tasks_dir / "WP02-mismatch.md").write_text(
-            "---\nwork_package_id: WP03\ndependencies: []\n---"
-        )
+        (tasks_dir / "WP02-mismatch.md").write_text("---\nwork_package_id: WP03\ndependencies: []\n---")
 
         with pytest.raises(ValueError, match="WP ID mismatch"):
             build_dependency_graph(feature_dir)
@@ -157,12 +155,7 @@ class TestBuildDependencyGraph:
         (tasks_dir / "WP04.md").write_text("---\nwork_package_id: WP04\ndependencies: [WP01]\n---")
 
         graph = build_dependency_graph(feature_dir)
-        assert graph == {
-            "WP01": [],
-            "WP02": ["WP01"],
-            "WP03": ["WP01"],
-            "WP04": ["WP01"]
-        }
+        assert graph == {"WP01": [], "WP02": ["WP01"], "WP03": ["WP01"], "WP04": ["WP01"]}
 
     def test_build_graph_complex_dag(self, tmp_path: Path):
         """Test graph building with complex DAG (diamond pattern)."""
@@ -176,12 +169,7 @@ class TestBuildDependencyGraph:
         (tasks_dir / "WP04.md").write_text("---\nwork_package_id: WP04\ndependencies: [WP02, WP03]\n---")
 
         graph = build_dependency_graph(feature_dir)
-        assert graph == {
-            "WP01": [],
-            "WP02": ["WP01"],
-            "WP03": ["WP01"],
-            "WP04": ["WP02", "WP03"]
-        }
+        assert graph == {"WP01": [], "WP02": ["WP01"], "WP03": ["WP01"], "WP04": ["WP02", "WP03"]}
 
 
 # T003: Tests for cycle detection
@@ -215,11 +203,7 @@ class TestDetectCycles:
 
     def test_detect_cycles_complex(self):
         """Test detection of complex cycle (WP01 → WP02 → WP03 → WP01)."""
-        graph = {
-            "WP01": ["WP02"],
-            "WP02": ["WP03"],
-            "WP03": ["WP01"]
-        }
+        graph = {"WP01": ["WP02"], "WP02": ["WP03"], "WP03": ["WP01"]}
         cycles = detect_cycles(graph)
 
         assert cycles is not None
@@ -230,12 +214,7 @@ class TestDetectCycles:
 
     def test_detect_cycles_complex_dag_no_cycles(self):
         """Test complex DAG (diamond) has no cycles."""
-        graph = {
-            "WP01": [],
-            "WP02": ["WP01"],
-            "WP03": ["WP01"],
-            "WP04": ["WP02", "WP03"]
-        }
+        graph = {"WP01": [], "WP02": ["WP01"], "WP03": ["WP01"], "WP04": ["WP02", "WP03"]}
         cycles = detect_cycles(graph)
         assert cycles is None
 
@@ -304,12 +283,7 @@ class TestGetDependents:
 
     def test_get_dependents_fan_out(self):
         """Test finding dependents in fan-out pattern."""
-        graph = {
-            "WP01": [],
-            "WP02": ["WP01"],
-            "WP03": ["WP01"],
-            "WP04": ["WP01"]
-        }
+        graph = {"WP01": [], "WP02": ["WP01"], "WP03": ["WP01"], "WP04": ["WP01"]}
         dependents = get_dependents("WP01", graph)
         assert set(dependents) == {"WP02", "WP03", "WP04"}
 
@@ -324,7 +298,7 @@ class TestGetDependents:
         graph = {
             "WP01": [],
             "WP02": ["WP01"],
-            "WP03": ["WP02"]  # WP03 depends on WP02, not directly on WP01
+            "WP03": ["WP02"],  # WP03 depends on WP02, not directly on WP01
         }
         dependents = get_dependents("WP01", graph)
         assert dependents == ["WP02"]  # Only direct dependent

--- a/tests/agent/test_doc_generators.py
+++ b/tests/agent/test_doc_generators.py
@@ -114,11 +114,9 @@ def test_rustdoc_does_not_detect_python_project(tmp_path):
 def test_jsdoc_configure_creates_config(tmp_path):
     """Test JSDoc configure() creates jsdoc.json."""
     generator = JSDocGenerator()
-    config_file = generator.configure(tmp_path, {
-        "project_name": "Test Project",
-        "description": "Test",
-        "version": "1.0.0"
-    })
+    config_file = generator.configure(
+        tmp_path, {"project_name": "Test Project", "description": "Test", "version": "1.0.0"}
+    )
 
     assert config_file.exists()
     assert config_file.name == "jsdoc.json"
@@ -132,11 +130,9 @@ def test_jsdoc_configure_creates_config(tmp_path):
 def test_sphinx_configure_creates_conf_py(tmp_path):
     """Test Sphinx configure() creates conf.py."""
     generator = SphinxGenerator()
-    config_file = generator.configure(tmp_path, {
-        "project_name": "Test Project",
-        "author": "Test Author",
-        "version": "1.0.0"
-    })
+    config_file = generator.configure(
+        tmp_path, {"project_name": "Test Project", "author": "Test Author", "version": "1.0.0"}
+    )
 
     assert config_file.exists()
     assert config_file.name == "conf.py"
@@ -150,9 +146,7 @@ def test_sphinx_configure_creates_conf_py(tmp_path):
 def test_rustdoc_configure_creates_instructions(tmp_path):
     """Test rustdoc configure() creates instructions file."""
     generator = RustdocGenerator()
-    config_file = generator.configure(tmp_path, {
-        "project_name": "Test Project"
-    })
+    config_file = generator.configure(tmp_path, {"project_name": "Test Project"})
 
     assert config_file.exists()
     assert config_file.name == "rustdoc-config.md"
@@ -165,6 +159,7 @@ def test_rustdoc_configure_creates_instructions(tmp_path):
 # T065: Test Graceful Degradation
 def test_jsdoc_raises_error_when_npx_missing(tmp_path, monkeypatch):
     """Test JSDoc raises GeneratorError when npx not installed."""
+
     # Mock subprocess to simulate missing npx
     def mock_run(cmd, *args, **kwargs):
         if cmd[0] in ["npx", "jsdoc"]:
@@ -220,11 +215,7 @@ def greet(name: str) -> str:
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     generator = SphinxGenerator()
-    config_file = generator.configure(docs_dir, {
-        "project_name": "Test",
-        "author": "Test Author",
-        "version": "0.1.0"
-    })
+    config_file = generator.configure(docs_dir, {"project_name": "Test", "author": "Test Author", "version": "0.1.0"})
 
     assert config_file.exists()
 
@@ -251,10 +242,7 @@ def test_sphinx_configure_validates_required_options(tmp_path):
     generator = SphinxGenerator()
 
     # Should work with minimal options
-    config = generator.configure(tmp_path, {
-        "project_name": "Test",
-        "author": "Author"
-    })
+    config = generator.configure(tmp_path, {"project_name": "Test", "author": "Author"})
     assert config.exists()
 
 
@@ -265,7 +253,7 @@ def test_generator_result_repr():
         output_dir=Path("/tmp/docs"),
         errors=[],
         warnings=["Minor warning"],
-        generated_files=[Path("/tmp/docs/index.html")]
+        generated_files=[Path("/tmp/docs/index.html")],
     )
 
     repr_str = repr(result)

--- a/tests/agent/test_gap_analysis.py
+++ b/tests/agent/test_gap_analysis.py
@@ -77,13 +77,16 @@ type: tutorial
     assert confidence == 1.0  # High confidence
 
 
-@pytest.mark.parametrize("type_str,expected_type", [
-    ("tutorial", DivioType.TUTORIAL),
-    ("how-to", DivioType.HOWTO),
-    ("howto", DivioType.HOWTO),
-    ("reference", DivioType.REFERENCE),
-    ("explanation", DivioType.EXPLANATION),
-])
+@pytest.mark.parametrize(
+    "type_str,expected_type",
+    [
+        ("tutorial", DivioType.TUTORIAL),
+        ("how-to", DivioType.HOWTO),
+        ("howto", DivioType.HOWTO),
+        ("reference", DivioType.REFERENCE),
+        ("explanation", DivioType.EXPLANATION),
+    ],
+)
 def test_classify_from_frontmatter_types(type_str, expected_type):
     """Test all Divio type values in frontmatter."""
     content = f"""---
@@ -196,7 +199,7 @@ def test_coverage_matrix_initialization():
             ("auth", "tutorial"): Path("docs/tutorials/auth.md"),
             ("auth", "reference"): Path("docs/reference/auth.md"),
             ("api", "reference"): Path("docs/reference/api.md"),
-        }
+        },
     )
 
     assert len(matrix.project_areas) == 2
@@ -212,7 +215,7 @@ def test_coverage_matrix_get_gaps():
             ("auth", "tutorial"): Path("docs/tutorials/auth.md"),
             ("auth", "reference"): Path("docs/reference/auth.md"),
             # Missing: auth/how-to, auth/explanation, api/tutorial, api/how-to, api/reference, api/explanation
-        }
+        },
     )
 
     gaps = matrix.get_gaps()
@@ -231,7 +234,7 @@ def test_coverage_matrix_percentage():
             ("auth", "tutorial"): Path("docs/tutorials/auth.md"),
             ("auth", "reference"): Path("docs/reference/auth.md"),
             ("api", "reference"): Path("docs/reference/api.md"),
-        }
+        },
     )
 
     # 3 filled out of 8 total cells (2 areas × 4 types)
@@ -247,7 +250,7 @@ def test_coverage_matrix_markdown_table():
         cells={
             ("auth", "tutorial"): Path("docs/tutorials/auth.md"),
             ("auth", "reference"): Path("docs/reference/auth.md"),
-        }
+        },
     )
 
     table = matrix.to_markdown_table()
@@ -304,8 +307,8 @@ def test_gaps_sorted_by_priority():
     """Test gaps sorted with HIGH first, then MEDIUM, then LOW."""
     gaps = [
         ("auth", "explanation"),  # LOW
-        ("auth", "tutorial"),     # MEDIUM (auth is core with 3 areas)
-        ("auth", "how-to"),       # MEDIUM
+        ("auth", "tutorial"),  # MEDIUM (auth is core with 3 areas)
+        ("auth", "how-to"),  # MEDIUM
     ]
     project_areas = ["auth", "api", "cli"]  # auth is core (first half)
 
@@ -323,17 +326,14 @@ def test_gaps_sorted_by_priority():
 # Additional tests for GapAnalysis dataclass
 def test_gap_analysis_dataclass():
     """Test GapAnalysis dataclass construction."""
-    matrix = CoverageMatrix(
-        project_areas=["auth"],
-        cells={("auth", "tutorial"): Path("docs/tutorial.md")}
-    )
+    matrix = CoverageMatrix(project_areas=["auth"], cells={("auth", "tutorial"): Path("docs/tutorial.md")})
 
     analysis = GapAnalysis(
         project_name="test-project",
         analysis_date=datetime.now(),
         framework=DocFramework.SPHINX,
         coverage_matrix=matrix,
-        gaps=[]
+        gaps=[],
     )
 
     assert analysis.framework == DocFramework.SPHINX

--- a/tests/contract/test_handoff_fixtures.py
+++ b/tests/contract/test_handoff_fixtures.py
@@ -167,9 +167,7 @@ def _event_test_id(event_data: dict) -> str:
 class TestFixtureValidation:
     """Validate that every fixture event passes the Pydantic Event model."""
 
-    @pytest.mark.parametrize(
-        "event_data", FIXTURE_EVENTS, ids=_event_test_id
-    )
+    @pytest.mark.parametrize("event_data", FIXTURE_EVENTS, ids=_event_test_id)
     def test_fixture_validates_against_event_model(self, event_data: dict):
         """Each fixture event must parse successfully via the Pydantic Event model."""
         event = Event(**event_data)
@@ -179,43 +177,33 @@ class TestFixtureValidation:
         assert event.lamport_clock == event_data["lamport_clock"]
         assert event.node_id == event_data["node_id"]
 
-    @pytest.mark.parametrize(
-        "event_data", FIXTURE_EVENTS, ids=_event_test_id
-    )
+    @pytest.mark.parametrize("event_data", FIXTURE_EVENTS, ids=_event_test_id)
     def test_fixture_event_id_is_valid_ulid(self, event_data: dict):
         """event_id must be exactly 26 Crockford Base32 characters."""
         import re
+
         ulid_pattern = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
         assert ulid_pattern.match(event_data["event_id"]), (
             f"event_id {event_data['event_id']!r} does not match ULID pattern"
         )
 
-    @pytest.mark.parametrize(
-        "event_data", FIXTURE_EVENTS, ids=_event_test_id
-    )
+    @pytest.mark.parametrize("event_data", FIXTURE_EVENTS, ids=_event_test_id)
     def test_fixture_payload_passes_emitter_rules(self, event_data: dict):
         """Each fixture payload must satisfy _PAYLOAD_RULES from the emitter."""
         event_type = event_data["event_type"]
         payload = event_data["payload"]
         rules = _PAYLOAD_RULES.get(event_type)
-        assert rules is not None, (
-            f"No payload rules found for event type: {event_type}"
-        )
+        assert rules is not None, f"No payload rules found for event type: {event_type}"
 
         # Check required fields
         missing = rules["required"] - set(payload.keys())
-        assert not missing, (
-            f"{event_type} payload missing required fields: {missing}"
-        )
+        assert not missing, f"{event_type} payload missing required fields: {missing}"
 
         # Run field-level validators
         for field_name, validator in rules["validators"].items():
             if field_name in payload:
                 value = payload[field_name]
-                assert validator(value), (
-                    f"{event_type} payload field '{field_name}' has "
-                    f"invalid value: {value!r}"
-                )
+                assert validator(value), f"{event_type} payload field '{field_name}' has invalid value: {value!r}"
 
 
 class TestEventTypeCoverage:
@@ -235,8 +223,7 @@ class TestEventTypeCoverage:
             "DependencyResolved",
         }
         assert fixture_types == expected_types, (
-            f"Missing types: {expected_types - fixture_types}, "
-            f"Extra types: {fixture_types - expected_types}"
+            f"Missing types: {expected_types - fixture_types}, Extra types: {fixture_types - expected_types}"
         )
 
     def test_valid_event_types_match_emitter(self):
@@ -261,11 +248,7 @@ class TestEventTypeCoverage:
 class TestFixtureJsonFiles:
     """Validate the fixture JSON files in contracts/fixtures/."""
 
-    FIXTURES_DIR = (
-        Path(__file__).resolve().parent.parent.parent
-        / "contracts"
-        / "fixtures"
-    )
+    FIXTURES_DIR = Path(__file__).resolve().parent.parent.parent / "contracts" / "fixtures"
 
     def _load_fixture(self, filename: str) -> dict:
         """Load and parse a fixture JSON file."""
@@ -312,10 +295,7 @@ class TestFixtureJsonFiles:
         """fixture_03 (duplicate) must use the same event_id as fixture_01."""
         f01 = self._load_fixture("fixture_01_single_wp_status_changed.json")
         f03 = self._load_fixture("fixture_03_duplicate_event.json")
-        assert (
-            f01["request"]["events"][0]["event_id"]
-            == f03["request"]["events"][0]["event_id"]
-        )
+        assert f01["request"]["events"][0]["event_id"] == f03["request"]["events"][0]["event_id"]
 
     def test_fixture_04_has_rejection(self):
         """fixture_04 expected response has 'rejected' status."""
@@ -343,9 +323,5 @@ class TestLaneMapping:
         for event_data in FIXTURE_EVENTS:
             if event_data["event_type"] == "WPStatusChanged":
                 payload = event_data["payload"]
-                assert payload["from_lane"] in valid_lanes, (
-                    f"Invalid from_lane: {payload['from_lane']}"
-                )
-                assert payload["to_lane"] in valid_lanes, (
-                    f"Invalid to_lane: {payload['to_lane']}"
-                )
+                assert payload["from_lane"] in valid_lanes, f"Invalid from_lane: {payload['from_lane']}"
+                assert payload["to_lane"] in valid_lanes, f"Invalid to_lane: {payload['to_lane']}"

--- a/tests/cross_cutting/packaging/test_manifest_cli_filtering.py
+++ b/tests/cross_cutting/packaging/test_manifest_cli_filtering.py
@@ -48,10 +48,8 @@ This command uses spec-kitty CLI.
     scripts = manifest._get_referenced_scripts()
 
     # Assert: CLI commands should NOT be treated as scripts
-    assert "spec-kitty" not in scripts, \
-        f"'spec-kitty' should not be in scripts list, got: {scripts}"
-    assert len(scripts) == 0, \
-        f"No scripts should be detected for CLI commands, got: {scripts}"
+    assert "spec-kitty" not in scripts, f"'spec-kitty' should not be in scripts list, got: {scripts}"
+    assert len(scripts) == 0, f"No scripts should be detected for CLI commands, got: {scripts}"
 
 
 def test_actual_kittify_scripts_are_included(tmp_path: Path):
@@ -91,7 +89,7 @@ sh: .kittify/scripts/helper.sh
     scripts = manifest._get_referenced_scripts()
 
     # Assert: Actual scripts SHOULD be included (platform-specific)
-    if platform.system() == 'Windows':
+    if platform.system() == "Windows":
         assert "scripts/helper.ps1" in scripts
     else:
         assert "scripts/helper.sh" in scripts

--- a/tests/cross_cutting/packaging/test_packaging_safety.py
+++ b/tests/cross_cutting/packaging/test_packaging_safety.py
@@ -16,8 +16,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _require_build() -> None:
-    if subprocess.run([sys.executable, "-m", "build", "--help"],
-                      capture_output=True, text=True).returncode != 0:
+    if subprocess.run([sys.executable, "-m", "build", "--help"], capture_output=True, text=True).returncode != 0:
         pytest.skip("python -m build not available; install build to run packaging tests")
 
 
@@ -57,10 +56,7 @@ def test_wheel_contains_no_kittify_paths(build_artifacts: dict[str, Path]) -> No
         all_files = zf.namelist()
 
     kittify_files = [f for f in all_files if ".kittify/" in f]
-    assert not kittify_files, (
-        "Wheel contains .kittify/ paths (packaging contamination): "
-        f"{kittify_files}"
-    )
+    assert not kittify_files, f"Wheel contains .kittify/ paths (packaging contamination): {kittify_files}"
 
 
 def test_wheel_contains_no_filled_constitution(build_artifacts: dict[str, Path]) -> None:
@@ -73,13 +69,9 @@ def test_wheel_contains_no_filled_constitution(build_artifacts: dict[str, Path])
     constitution_files = [f for f in all_files if "constitution.md" in f.lower()]
 
     for const_file in constitution_files:
-        assert "memory/constitution" not in const_file, (
-            "Wheel contains filled constitution from memory/: "
-            f"{const_file}"
-        )
+        assert "memory/constitution" not in const_file, f"Wheel contains filled constitution from memory/: {const_file}"
         assert "templates/" in const_file or "missions/" in const_file, (
-            "Found non-template constitution in wheel: "
-            f"{const_file}"
+            f"Found non-template constitution in wheel: {const_file}"
         )
 
 
@@ -102,15 +94,10 @@ def test_wheel_contains_only_src_package(build_artifacts: dict[str, Path]) -> No
     wheel_path = build_artifacts["wheel"]
 
     with zipfile.ZipFile(wheel_path) as zf:
-        all_files = [
-            f for f in zf.namelist()
-            if ".dist-info/" not in f
-        ]
+        all_files = [f for f in zf.namelist() if ".dist-info/" not in f]
 
     for file_path in all_files:
-        assert file_path.startswith("specify_cli/"), (
-            f"File outside package directory: {file_path}"
-        )
+        assert file_path.startswith("specify_cli/"), f"File outside package directory: {file_path}"
 
 
 def test_sdist_contains_no_kittify_paths(build_artifacts: dict[str, Path]) -> None:
@@ -120,12 +107,6 @@ def test_sdist_contains_no_kittify_paths(build_artifacts: dict[str, Path]) -> No
     with tarfile.open(sdist_path, "r:gz") as tar:
         all_files = tar.getnames()
 
-    bad_kittify_files = [
-        f for f in all_files
-        if ".kittify/" in f and "/src/" not in f
-    ]
+    bad_kittify_files = [f for f in all_files if ".kittify/" in f and "/src/" not in f]
 
-    assert not bad_kittify_files, (
-        "Source dist contains .kittify/ paths outside src/: "
-        f"{bad_kittify_files}"
-    )
+    assert not bad_kittify_files, f"Source dist contains .kittify/ paths outside src/: {bad_kittify_files}"

--- a/tests/cross_cutting/versioning/test_upgrade_version_update.py
+++ b/tests/cross_cutting/versioning/test_upgrade_version_update.py
@@ -15,10 +15,7 @@ def test_upgrade_updates_metadata_to_correct_version(tmp_path):
     kittify_dir.mkdir()
 
     # Create initial metadata with old version
-    metadata = ProjectMetadata(
-        version="0.12.0",
-        initialized_at=datetime.fromisoformat("2026-01-01T00:00:00")
-    )
+    metadata = ProjectMetadata(version="0.12.0", initialized_at=datetime.fromisoformat("2026-01-01T00:00:00"))
     metadata.save(kittify_dir)
 
     # Verify initial state
@@ -33,16 +30,15 @@ def test_upgrade_updates_metadata_to_correct_version(tmp_path):
     updated = ProjectMetadata.load(kittify_dir)
 
     # Should have updated to ACTUAL version, not "0.5.0-dev" or "0.0.0-dev"
-    assert updated.version == __version__, \
-        f"Metadata should update to {__version__}, got {updated.version}"
+    assert updated.version == __version__, f"Metadata should update to {__version__}, got {updated.version}"
 
     assert updated.version != "0.5.0-dev", "Should not use old fallback"
     assert updated.version != "0.0.0-dev", "Should not use new fallback"
 
     # Version should be valid semver
     import re
-    assert re.match(r'^\d+\.\d+\.\d+', updated.version), \
-        f"Invalid version in metadata: {updated.version}"
+
+    assert re.match(r"^\d+\.\d+\.\d+", updated.version), f"Invalid version in metadata: {updated.version}"
 
 
 def test_upgrade_dry_run_does_not_update_version(tmp_path):
@@ -53,10 +49,7 @@ def test_upgrade_dry_run_does_not_update_version(tmp_path):
     kittify_dir = tmp_path / ".kittify"
     kittify_dir.mkdir()
 
-    metadata = ProjectMetadata(
-        version="0.12.0",
-        initialized_at=datetime.now()
-    )
+    metadata = ProjectMetadata(version="0.12.0", initialized_at=datetime.now())
     metadata.save(kittify_dir)
 
     # Run upgrade in dry-run mode
@@ -67,8 +60,7 @@ def test_upgrade_dry_run_does_not_update_version(tmp_path):
     after_dry_run = ProjectMetadata.load(kittify_dir)
 
     # Version should NOT have changed
-    assert after_dry_run.version == "0.12.0", \
-        "Dry run should not update version"
+    assert after_dry_run.version == "0.12.0", "Dry run should not update version"
 
 
 def test_cli_version_is_not_fallback():
@@ -76,12 +68,10 @@ def test_cli_version_is_not_fallback():
     from specify_cli import __version__
 
     # Should NOT be any fallback value
-    assert __version__ != "0.5.0-dev", \
-        "CLI is using old hardcoded fallback - upgrade will write wrong version"
-    assert __version__ != "0.0.0-dev", \
-        "CLI is using new fallback - version detection failed"
+    assert __version__ != "0.5.0-dev", "CLI is using old hardcoded fallback - upgrade will write wrong version"
+    assert __version__ != "0.0.0-dev", "CLI is using new fallback - version detection failed"
 
     # Should be valid semver
     import re
-    assert re.match(r'^\d+\.\d+\.\d+', __version__), \
-        f"Invalid __version__ format: {__version__}"
+
+    assert re.match(r"^\d+\.\d+\.\d+", __version__), f"Invalid __version__ format: {__version__}"

--- a/tests/docs/test_versioned_docs_integrity.py
+++ b/tests/docs/test_versioned_docs_integrity.py
@@ -79,15 +79,11 @@ def test_versioned_docs_relative_links_resolve(source_path: Path) -> None:
         try:
             destination.relative_to(REPO_ROOT.resolve())
         except ValueError:
-            failures.append(
-                f"{source_path.relative_to(REPO_ROOT)}:{line_number} link escapes repo: {target}"
-            )
+            failures.append(f"{source_path.relative_to(REPO_ROOT)}:{line_number} link escapes repo: {target}")
             continue
 
         if not destination.exists():
-            failures.append(
-                f"{source_path.relative_to(REPO_ROOT)}:{line_number} missing file target: {target}"
-            )
+            failures.append(f"{source_path.relative_to(REPO_ROOT)}:{line_number} missing file target: {target}")
 
     assert not failures, "\n".join(failures)
 

--- a/tests/doctrine/test_artifact_compliance.py
+++ b/tests/doctrine/test_artifact_compliance.py
@@ -55,9 +55,7 @@ _ARTIFACT_CASES = _artifact_cases()
 _ARTIFACT_IDS = [f"{kind}:{path.relative_to(REPO_ROOT)}" for kind, path in _ARTIFACT_CASES]
 
 
-@pytest.mark.parametrize(
-    ("artifact_type", "artifact_path"), _ARTIFACT_CASES, ids=_ARTIFACT_IDS
-)
+@pytest.mark.parametrize(("artifact_type", "artifact_path"), _ARTIFACT_CASES, ids=_ARTIFACT_IDS)
 def test_artifact_files_validate_schema(artifact_type: str, artifact_path: Path) -> None:
     validator = _schema_validator(artifact_type)
     payload = _load_yaml(artifact_path)
@@ -81,9 +79,7 @@ def tactic_ids() -> set[str]:
     sorted((DOCTRINE_DIR / "directives").glob("*.directive.yaml")),
     ids=lambda p: str(p.relative_to(REPO_ROOT)),
 )
-def test_directive_tactic_refs_resolve(
-    directive_path: Path, tactic_ids: set[str]
-) -> None:
+def test_directive_tactic_refs_resolve(directive_path: Path, tactic_ids: set[str]) -> None:
     directive = _load_yaml(directive_path)
     unresolved = []
     for tactic_ref in directive.get("tactic_refs", []):
@@ -103,18 +99,12 @@ def test_directive_tactic_refs_resolve(
 def test_toolguide_guide_path_exists(toolguide_path: Path) -> None:
     toolguide = _load_yaml(toolguide_path)
     guide_path = toolguide["guide_path"]
-    assert isinstance(guide_path, str), (
-        f"{toolguide_path.relative_to(REPO_ROOT)} guide_path must be a string"
-    )
+    assert isinstance(guide_path, str), f"{toolguide_path.relative_to(REPO_ROOT)} guide_path must be a string"
 
     target = (REPO_ROOT / guide_path).resolve()
     try:
         target.relative_to(REPO_ROOT.resolve())
     except ValueError as exc:
-        raise AssertionError(
-            f"{toolguide_path.relative_to(REPO_ROOT)} guide_path escapes repo: {guide_path}"
-        ) from exc
+        raise AssertionError(f"{toolguide_path.relative_to(REPO_ROOT)} guide_path escapes repo: {guide_path}") from exc
 
-    assert target.is_file(), (
-        f"{toolguide_path.relative_to(REPO_ROOT)} guide_path not found: {guide_path}"
-    )
+    assert target.is_file(), f"{toolguide_path.relative_to(REPO_ROOT)} guide_path not found: {guide_path}"

--- a/tests/doctrine/test_glossary_link_integrity.py
+++ b/tests/doctrine/test_glossary_link_integrity.py
@@ -74,17 +74,11 @@ def test_glossary_relative_links_resolve(source_path: Path) -> None:
         try:
             destination.relative_to(REPO_ROOT.resolve())
         except ValueError:
-            failures.append(
-                f"{source_path.relative_to(REPO_ROOT)}:{line_number} "
-                f"link escapes repository: {target}"
-            )
+            failures.append(f"{source_path.relative_to(REPO_ROOT)}:{line_number} link escapes repository: {target}")
             continue
 
         if link_path and not destination.exists():
-            failures.append(
-                f"{source_path.relative_to(REPO_ROOT)}:{line_number} "
-                f"missing file target: {target}"
-            )
+            failures.append(f"{source_path.relative_to(REPO_ROOT)}:{line_number} missing file target: {target}")
             continue
 
         if fragment and destination.suffix.lower() == ".md" and fragment not in _anchors_for(destination):

--- a/tests/doctrine/test_tactic_compliance.py
+++ b/tests/doctrine/test_tactic_compliance.py
@@ -128,9 +128,7 @@ def test_tactic_schema_valid(tactic_path: Path) -> None:
 
 
 @pytest.mark.parametrize("tactic_path", _tactic_files, ids=_tactic_ids)
-def test_references_resolve(
-    tactic_path: Path, artifact_index: dict[str, set[str]]
-) -> None:
+def test_references_resolve(tactic_path: Path, artifact_index: dict[str, set[str]]) -> None:
     """Every reference (root and step) must point to an existing artifact."""
     tactic = _load_yaml(tactic_path)
     unresolved = []
@@ -141,8 +139,7 @@ def test_references_resolve(
         known_ids = artifact_index.get(ref_type, set())
         if ref_id not in known_ids:
             unresolved.append(
-                f"  root reference: type={ref_type} id={ref_id}"
-                f" (known {ref_type} ids: {sorted(known_ids) or 'none'})"
+                f"  root reference: type={ref_type} id={ref_id} (known {ref_type} ids: {sorted(known_ids) or 'none'})"
             )
 
     for step_idx, step_title, ref in _extract_step_references(tactic):
@@ -155,9 +152,7 @@ def test_references_resolve(
                 f" (known {ref_type} ids: {sorted(known_ids) or 'none'})"
             )
 
-    assert not unresolved, (
-        f"{tactic_path.name} has unresolved references:\n" + "\n".join(unresolved)
-    )
+    assert not unresolved, f"{tactic_path.name} has unresolved references:\n" + "\n".join(unresolved)
 
 
 # ---------------------------------------------------------------------------
@@ -182,10 +177,7 @@ def test_step_references_not_over_duplicated(tactic_path: Path) -> None:
         ref_step_sets.setdefault(key, set()).add(step_idx)
 
     # Build set of root-level ref keys (already elevated — no violation).
-    root_keys = {
-        (ref.get("type", ""), ref.get("id", ""))
-        for ref in _extract_root_references(tactic)
-    }
+    root_keys = {(ref.get("type", ""), ref.get("id", "")) for ref in _extract_root_references(tactic)}
 
     violations = []
     for (ref_type, ref_id), step_indices in ref_step_sets.items():
@@ -199,8 +191,7 @@ def test_step_references_not_over_duplicated(tactic_path: Path) -> None:
 
     assert not violations, (
         f"{tactic_path.name} has step references that should be elevated to root"
-        f" (>={int(ELEVATION_THRESHOLD * 100)}% threshold):\n"
-        + "\n".join(violations)
+        f" (>={int(ELEVATION_THRESHOLD * 100)}% threshold):\n" + "\n".join(violations)
     )
 
 
@@ -214,10 +205,7 @@ def test_root_references_not_repeated_in_steps(tactic_path: Path) -> None:
     """A reference declared at root level must not also appear in steps."""
     tactic = _load_yaml(tactic_path)
 
-    root_keys = {
-        (ref.get("type", ""), ref.get("id", ""))
-        for ref in _extract_root_references(tactic)
-    }
+    root_keys = {(ref.get("type", ""), ref.get("id", "")) for ref in _extract_root_references(tactic)}
 
     if not root_keys:
         return
@@ -231,7 +219,6 @@ def test_root_references_not_repeated_in_steps(tactic_path: Path) -> None:
                 f" is already a root-level reference — remove from step"
             )
 
-    assert not redundant, (
-        f"{tactic_path.name} has step references that duplicate root-level refs:\n"
-        + "\n".join(redundant)
+    assert not redundant, f"{tactic_path.name} has step references that duplicate root-level refs:\n" + "\n".join(
+        redundant
     )

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -29,11 +29,14 @@ class TestFullCLIWorkflow:
         """Step 1: create-feature produces feature directory and spec.md."""
         result = run_cli(
             e2e_project,
-            "agent", "feature", "create-feature", "smoke-test", "--json",
+            "agent",
+            "feature",
+            "create-feature",
+            "smoke-test",
+            "--json",
         )
         assert result.returncode == 0, (
-            f"create-feature failed (rc={result.returncode}):\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            f"create-feature failed (rc={result.returncode}):\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
         output = json.loads(result.stdout)
@@ -55,7 +58,11 @@ class TestFullCLIWorkflow:
         # Create feature first
         result = run_cli(
             e2e_project,
-            "agent", "feature", "create-feature", "plan-smoke", "--json",
+            "agent",
+            "feature",
+            "create-feature",
+            "plan-smoke",
+            "--json",
         )
         assert result.returncode == 0, f"create-feature failed: {result.stderr}"
         output = json.loads(result.stdout)
@@ -65,12 +72,15 @@ class TestFullCLIWorkflow:
         # Run setup-plan
         result = run_cli(
             e2e_project,
-            "agent", "feature", "setup-plan",
-            "--feature", feature_slug, "--json",
+            "agent",
+            "feature",
+            "setup-plan",
+            "--feature",
+            feature_slug,
+            "--json",
         )
         assert result.returncode == 0, (
-            f"setup-plan failed (rc={result.returncode}):\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            f"setup-plan failed (rc={result.returncode}):\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
         plan_file = feature_dir / "plan.md"
@@ -88,11 +98,13 @@ class TestFullCLIWorkflow:
         # === Step 1: Create feature ===
         result = run_cli(
             repo,
-            "agent", "feature", "create-feature", "full-e2e", "--json",
+            "agent",
+            "feature",
+            "create-feature",
+            "full-e2e",
+            "--json",
         )
-        assert result.returncode == 0, (
-            f"create-feature failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"create-feature failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
         create_output = json.loads(result.stdout)
         assert create_output["result"] == "success"
 
@@ -104,12 +116,14 @@ class TestFullCLIWorkflow:
         # === Step 2: Setup plan ===
         result = run_cli(
             repo,
-            "agent", "feature", "setup-plan",
-            "--feature", feature_slug, "--json",
+            "agent",
+            "feature",
+            "setup-plan",
+            "--feature",
+            feature_slug,
+            "--json",
         )
-        assert result.returncode == 0, (
-            f"setup-plan failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"setup-plan failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
         plan_output = json.loads(result.stdout)
         assert plan_output["result"] == "success"
         assert (feature_dir / "plan.md").exists()
@@ -184,6 +198,7 @@ Create a hello module.
 
         # Create meta.json (required by finalize-tasks for event emission)
         import json as json_mod
+
         meta_content = {
             "feature_number": "001",
             "feature_slug": feature_slug,
@@ -191,27 +206,36 @@ Create a hello module.
             "vcs": "git",
         }
         (feature_dir / "meta.json").write_text(
-            json_mod.dumps(meta_content, indent=2), encoding="utf-8",
+            json_mod.dumps(meta_content, indent=2),
+            encoding="utf-8",
         )
 
         # Commit the tasks so finalize-tasks has a clean working tree
         subprocess.run(
-            ["git", "add", "."], cwd=repo, check=True, capture_output=True,
+            ["git", "add", "."],
+            cwd=repo,
+            check=True,
+            capture_output=True,
         )
         subprocess.run(
             ["git", "commit", "-m", "Add tasks for smoke test"],
-            cwd=repo, check=True, capture_output=True,
+            cwd=repo,
+            check=True,
+            capture_output=True,
         )
 
         # === Step 4: Finalize tasks ===
         # Use explicit feature binding to keep fresh sessions deterministic.
         result = run_cli(
             repo,
-            "agent", "feature", "finalize-tasks", "--feature", feature_slug, "--json",
+            "agent",
+            "feature",
+            "finalize-tasks",
+            "--feature",
+            feature_slug,
+            "--json",
         )
-        assert result.returncode == 0, (
-            f"finalize-tasks failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"finalize-tasks failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
 
         # Verify WP file still exists and has dependencies field
         wp01_path = tasks_dir / "WP01-hello-world.md"
@@ -222,8 +246,10 @@ Create a hello module.
         # === Step 5: Implement WP01 (create workspace) ===
         result = run_cli(
             repo,
-            "implement", "WP01",
-            "--feature", feature_slug,
+            "implement",
+            "WP01",
+            "--feature",
+            feature_slug,
             "--json",
         )
 
@@ -235,8 +261,10 @@ Create a hello module.
             # Try without --json (implement might not support it cleanly)
             result = run_cli(
                 repo,
-                "implement", "WP01",
-                "--feature", feature_slug,
+                "implement",
+                "WP01",
+                "--feature",
+                feature_slug,
             )
 
         # Verify worktree was created
@@ -257,26 +285,39 @@ Create a hello module.
             encoding="utf-8",
         )
         subprocess.run(
-            ["git", "add", "."], cwd=worktree_dir, check=True, capture_output=True,
+            ["git", "add", "."],
+            cwd=worktree_dir,
+            check=True,
+            capture_output=True,
         )
         subprocess.run(
             ["git", "commit", "-m", "feat(WP01): add hello module"],
-            cwd=worktree_dir, check=True, capture_output=True,
+            cwd=worktree_dir,
+            check=True,
+            capture_output=True,
         )
 
         # Verify the commit landed in the worktree
         log_result = subprocess.run(
             ["git", "log", "--oneline", "-1"],
-            cwd=worktree_dir, capture_output=True, text=True, check=True,
+            cwd=worktree_dir,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         assert "hello" in log_result.stdout.lower(), "Commit not found in worktree"
 
         # === Step 7: Move WP01 to for_review ===
         result = run_cli(
             repo,
-            "agent", "tasks", "move-task", "WP01",
-            "--to", "for_review",
-            "--feature", feature_slug,
+            "agent",
+            "tasks",
+            "move-task",
+            "WP01",
+            "--to",
+            "for_review",
+            "--feature",
+            feature_slug,
             "--json",
         )
 
@@ -297,14 +338,15 @@ Create a hello module.
         # Verify git history has the expected commits
         log_result = subprocess.run(
             ["git", "log", "--oneline", "--all"],
-            cwd=repo, capture_output=True, text=True, check=True,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         log_text = log_result.stdout.lower()
         assert "spec" in log_text, "spec commit missing from git log"
         assert "plan" in log_text, "plan commit missing from git log"
-        assert "tasks" in log_text or "finalize" in log_text, (
-            "tasks/finalize commit missing from git log"
-        )
+        assert "tasks" in log_text or "finalize" in log_text, "tasks/finalize commit missing from git log"
 
 
 @pytest.mark.e2e
@@ -315,7 +357,11 @@ class TestWorkflowEdgeCases:
         """create-feature rejects non-kebab-case slugs."""
         result = run_cli(
             e2e_project,
-            "agent", "feature", "create-feature", "Bad_Slug", "--json",
+            "agent",
+            "feature",
+            "create-feature",
+            "Bad_Slug",
+            "--json",
         )
         assert result.returncode != 0, "Should reject non-kebab-case slug"
         # The JSON output may contain Rich console formatting escape codes,
@@ -329,17 +375,19 @@ class TestWorkflowEdgeCases:
         """setup-plan fails gracefully when no feature exists."""
         result = run_cli(
             e2e_project,
-            "agent", "feature", "setup-plan", "--json",
+            "agent",
+            "feature",
+            "setup-plan",
+            "--json",
         )
         # Should fail because no feature exists yet
-        assert result.returncode != 0, (
-            "setup-plan should fail when no feature exists"
-        )
+        assert result.returncode != 0, "setup-plan should fail when no feature exists"
 
     def test_implement_requires_existing_wp(self, e2e_project: Path, run_cli) -> None:
         """implement fails gracefully when WP does not exist."""
         result = run_cli(
             e2e_project,
-            "implement", "WP99",
+            "implement",
+            "WP99",
         )
         assert result.returncode != 0, "implement should fail for non-existent WP"

--- a/tests/init/test_central_templates.py
+++ b/tests/init/test_central_templates.py
@@ -69,8 +69,9 @@ def test_central_implement_template_workspace_creation() -> None:
     content_lower = content.lower()
     assert "spec-kitty implement" in content, "implement.md should mention spec-kitty implement"
     assert "--base" in content, "implement.md should mention --base"
-    assert "worktree" in content_lower or "workspace" in content_lower, \
+    assert "worktree" in content_lower or "workspace" in content_lower, (
         "implement.md should mention worktree/workspace creation"
+    )
 
 
 def test_central_review_template_dependency_checks() -> None:

--- a/tests/manual_test_bug_117.py
+++ b/tests/manual_test_bug_117.py
@@ -32,11 +32,12 @@ def simulate_slow_health_check_scenario():
     mock_pid = 99999
     mock_port = 9237
 
-    with patch("specify_cli.dashboard.lifecycle.start_dashboard") as mock_start, \
-         patch("specify_cli.dashboard.lifecycle._check_dashboard_health") as mock_health, \
-         patch("specify_cli.dashboard.lifecycle._is_process_alive") as mock_alive, \
-         patch("specify_cli.dashboard.lifecycle._write_dashboard_file") as mock_write:
-
+    with (
+        patch("specify_cli.dashboard.lifecycle.start_dashboard") as mock_start,
+        patch("specify_cli.dashboard.lifecycle._check_dashboard_health") as mock_health,
+        patch("specify_cli.dashboard.lifecycle._is_process_alive") as mock_alive,
+        patch("specify_cli.dashboard.lifecycle._write_dashboard_file") as mock_write,
+    ):
         # Setup: Process starts successfully
         mock_start.return_value = (mock_port, mock_pid)
 
@@ -80,6 +81,7 @@ def simulate_slow_health_check_scenario():
 
     # Cleanup
     import shutil
+
     shutil.rmtree(test_dir, ignore_errors=True)
 
 
@@ -121,6 +123,7 @@ def test_specific_error_messages():
 
     # Cleanup
     import shutil
+
     shutil.rmtree(test_dir, ignore_errors=True)
 
     print("\n✅ All error message tests passed!")

--- a/tests/missions/test_documentation_mission.py
+++ b/tests/missions/test_documentation_mission.py
@@ -1,7 +1,8 @@
 """Tests for documentation mission configuration."""
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 from specify_cli.mission import Mission
 

--- a/tests/missions/test_mission_schema_unit.py
+++ b/tests/missions/test_mission_schema_unit.py
@@ -220,9 +220,7 @@ class TestGetFeatureMissionKey:
         """Should extract research mission key."""
         assert get_feature_mission_key(feature_with_research_mission) == "research"
 
-    def test_defaults_to_software_dev_when_no_mission_field(
-        self, legacy_feature: Path
-    ) -> None:
+    def test_defaults_to_software_dev_when_no_mission_field(self, legacy_feature: Path) -> None:
         """Should default to software-dev when mission field is missing."""
         assert get_feature_mission_key(legacy_feature) == "software-dev"
 
@@ -243,34 +241,22 @@ class TestGetFeatureMissionKey:
 class TestGetMissionForFeature:
     """Tests for get_mission_for_feature() function (T004)."""
 
-    def test_returns_correct_mission(
-        self, feature_with_mission: Path, sample_kittify_dir: Path
-    ) -> None:
+    def test_returns_correct_mission(self, feature_with_mission: Path, sample_kittify_dir: Path) -> None:
         """Should return the mission specified in meta.json."""
-        mission = get_mission_for_feature(
-            feature_with_mission, sample_kittify_dir.parent
-        )
+        mission = get_mission_for_feature(feature_with_mission, sample_kittify_dir.parent)
         assert mission.name == "Software Dev Kitty"
         assert mission.domain == "software"
 
-    def test_returns_research_mission(
-        self, feature_with_research_mission: Path, sample_kittify_dir: Path
-    ) -> None:
+    def test_returns_research_mission(self, feature_with_research_mission: Path, sample_kittify_dir: Path) -> None:
         """Should return research mission when specified."""
-        mission = get_mission_for_feature(
-            feature_with_research_mission, sample_kittify_dir.parent
-        )
+        mission = get_mission_for_feature(feature_with_research_mission, sample_kittify_dir.parent)
         assert mission.name == "Deep Research Kitty"
         assert mission.domain == "research"
 
-    def test_falls_back_on_invalid_mission(
-        self, feature_with_invalid_mission: Path, sample_kittify_dir: Path
-    ) -> None:
+    def test_falls_back_on_invalid_mission(self, feature_with_invalid_mission: Path, sample_kittify_dir: Path) -> None:
         """Should fall back to software-dev when mission doesn't exist."""
         with pytest.warns(UserWarning, match="not found"):
-            mission = get_mission_for_feature(
-                feature_with_invalid_mission, sample_kittify_dir.parent
-            )
+            mission = get_mission_for_feature(feature_with_invalid_mission, sample_kittify_dir.parent)
         assert mission.domain == "software"
 
     def test_raises_when_no_kittify_dir(self, tmp_path: Path) -> None:
@@ -287,17 +273,13 @@ class TestGetMissionForFeature:
 class TestGetMissionForFeatureLegacy:
     """Tests for backward compatibility with legacy features (T005)."""
 
-    def test_legacy_feature_defaults_to_software_dev(
-        self, legacy_feature: Path, sample_kittify_dir: Path
-    ) -> None:
+    def test_legacy_feature_defaults_to_software_dev(self, legacy_feature: Path, sample_kittify_dir: Path) -> None:
         """Features without mission field should use software-dev."""
         mission = get_mission_for_feature(legacy_feature, sample_kittify_dir.parent)
         assert mission.domain == "software"
         assert "software" in mission.name.lower()
 
-    def test_legacy_feature_no_warning(
-        self, legacy_feature: Path, sample_kittify_dir: Path
-    ) -> None:
+    def test_legacy_feature_no_warning(self, legacy_feature: Path, sample_kittify_dir: Path) -> None:
         """Legacy features should not produce warning (default is intentional)."""
         import warnings as w
 
@@ -305,9 +287,7 @@ class TestGetMissionForFeatureLegacy:
             w.simplefilter("always")
             get_mission_for_feature(legacy_feature, sample_kittify_dir.parent)
             # Should not warn since software-dev exists and is the default
-            mission_warnings = [
-                c for c in caught if "mission" in str(c.message).lower()
-            ]
+            mission_warnings = [c for c in caught if "mission" in str(c.message).lower()]
             assert len(mission_warnings) == 0
 
 
@@ -351,9 +331,7 @@ class TestDiscoverMissions:
         assert "broken" not in missions
         assert "software-dev" in missions
 
-    def test_skips_directories_without_mission_yaml(
-        self, sample_kittify_dir: Path
-    ) -> None:
+    def test_skips_directories_without_mission_yaml(self, sample_kittify_dir: Path) -> None:
         """Should skip directories that don't have mission.yaml."""
         # Create directory without mission.yaml
         empty_dir = sample_kittify_dir / "missions" / "empty-dir"

--- a/tests/research/test_research_csv_schema_migration.py
+++ b/tests/research/test_research_csv_schema_migration.py
@@ -97,7 +97,7 @@ def research_feature_with_wrong_source_schema(mock_research_project):
 
     # WRONG source-register.csv schema
     (research_dir / "source-register.csv").write_text(
-        "id,reference,link,date,priority\n" "1,Reference,http://example.com,2025-01-25,high\n",
+        "id,reference,link,date,priority\n1,Reference,http://example.com,2025-01-25,high\n",
         encoding="utf-8",
     )
 
@@ -224,9 +224,7 @@ class TestMigrationApply:
         captured = capsys.readouterr()
         assert "schema mismatch" in captured.out.lower()
 
-    def test_apply_provides_migration_tips(
-        self, research_feature_with_wrong_evidence_schema, capsys
-    ):
+    def test_apply_provides_migration_tips(self, research_feature_with_wrong_evidence_schema, capsys):
         """Test migration provides actionable migration tips."""
         migration = ResearchCSVSchemaCheckMigration()
         migration.apply(research_feature_with_wrong_evidence_schema, dry_run=False)
@@ -274,9 +272,7 @@ class TestMultipleFeatures:
         (correct_feature / "meta.json").write_text(json.dumps({"mission": "research"}))
         research_dir = correct_feature / "research"
         research_dir.mkdir()
-        (research_dir / "evidence-log.csv").write_text(
-            "timestamp,source_type,citation,key_finding,confidence,notes\n"
-        )
+        (research_dir / "evidence-log.csv").write_text("timestamp,source_type,citation,key_finding,confidence,notes\n")
 
         # Create one wrong feature
         wrong_feature = mock_research_project / "kitty-specs" / "002-wrong"

--- a/tests/research/test_research_implement_template_migration.py
+++ b/tests/research/test_research_implement_template_migration.py
@@ -85,7 +85,7 @@ def mock_research_project_one_agent(tmp_path):
 
     # Old research template
     (opencode / "spec-kitty.implement.md").write_text(
-        "## Sprint Planning Artifacts (Separate)\n\n" "Planning artifacts\n",
+        "## Sprint Planning Artifacts (Separate)\n\nPlanning artifacts\n",
         encoding="utf-8",
     )
 
@@ -113,11 +113,7 @@ def mock_software_dev_project(tmp_path):
 
         # Software-dev template (no Sprint Planning Artifacts)
         (agent_path / "spec-kitty.implement.md").write_text(
-            "---\n"
-            "description: Implement software WP\n"
-            "---\n\n"
-            "## Implementation Workflow\n\n"
-            "Navigate to worktree\n",
+            "---\ndescription: Implement software WP\n---\n\n## Implementation Workflow\n\nNavigate to worktree\n",
             encoding="utf-8",
         )
 
@@ -183,9 +179,7 @@ class TestMigrationApply:
         assert len(result.errors) == 0
 
         # Check this agent's template was updated
-        template_path = (
-            mock_research_project_all_agents / agent_dir / subdir / "spec-kitty.implement.md"
-        )
+        template_path = mock_research_project_all_agents / agent_dir / subdir / "spec-kitty.implement.md"
         content = template_path.read_text()
 
         # Should have Research CSV Schemas section
@@ -213,9 +207,7 @@ class TestMigrationApply:
         # Create opencode directory (configured)
         opencode = tmp_path / ".opencode" / "command"
         opencode.mkdir(parents=True)
-        (opencode / "spec-kitty.implement.md").write_text(
-            "## Sprint Planning Artifacts (Separate)\n"
-        )
+        (opencode / "spec-kitty.implement.md").write_text("## Sprint Planning Artifacts (Separate)\n")
 
         # Create claude directory (NOT configured)
         claude = tmp_path / ".claude" / "commands"
@@ -249,12 +241,8 @@ class TestMigrationApply:
         assert result.success is True
 
         # Software-dev templates should NOT have schema section
-        claude_content = (
-            mock_software_dev_project / ".claude" / "commands" / "spec-kitty.implement.md"
-        ).read_text()
-        opencode_content = (
-            mock_software_dev_project / ".opencode" / "command" / "spec-kitty.implement.md"
-        ).read_text()
+        claude_content = (mock_software_dev_project / ".claude" / "commands" / "spec-kitty.implement.md").read_text()
+        opencode_content = (mock_software_dev_project / ".opencode" / "command" / "spec-kitty.implement.md").read_text()
 
         assert "Research CSV Schemas" not in claude_content
         assert "Research CSV Schemas" not in opencode_content
@@ -269,12 +257,7 @@ class TestMigrationApply:
         assert result1.success is True
 
         # Read updated content
-        opencode_template = (
-            mock_research_project_one_agent
-            / ".opencode"
-            / "command"
-            / "spec-kitty.implement.md"
-        )
+        opencode_template = mock_research_project_one_agent / ".opencode" / "command" / "spec-kitty.implement.md"
         content_after_first = opencode_template.read_text()
 
         # Run migration second time
@@ -293,12 +276,7 @@ class TestMigrationApply:
         migration = UpdateResearchImplementTemplatesMigration()
 
         # Read original content
-        opencode_template = (
-            mock_research_project_one_agent
-            / ".opencode"
-            / "command"
-            / "spec-kitty.implement.md"
-        )
+        opencode_template = mock_research_project_one_agent / ".opencode" / "command" / "spec-kitty.implement.md"
         original_content = opencode_template.read_text()
 
         # Run dry run
@@ -334,12 +312,7 @@ class TestMigrationApply:
         migration = UpdateResearchImplementTemplatesMigration()
         migration.apply(mock_research_project_one_agent, dry_run=False)
 
-        opencode_template = (
-            mock_research_project_one_agent
-            / ".opencode"
-            / "command"
-            / "spec-kitty.implement.md"
-        )
+        opencode_template = mock_research_project_one_agent / ".opencode" / "command" / "spec-kitty.implement.md"
         content = opencode_template.read_text()
 
         # Should have append examples
@@ -352,12 +325,7 @@ class TestMigrationApply:
         migration = UpdateResearchImplementTemplatesMigration()
         migration.apply(mock_research_project_one_agent, dry_run=False)
 
-        opencode_template = (
-            mock_research_project_one_agent
-            / ".opencode"
-            / "command"
-            / "spec-kitty.implement.md"
-        )
+        opencode_template = mock_research_project_one_agent / ".opencode" / "command" / "spec-kitty.implement.md"
         content = opencode_template.read_text()
 
         # Should document enum values (escaped pipes in markdown tables)

--- a/tests/tasks/test_frontmatter.py
+++ b/tests/tasks/test_frontmatter.py
@@ -14,10 +14,12 @@ pytestmark = pytest.mark.fast
 @pytest.fixture
 def temp_wp_file(tmp_path):
     """Create a temporary work package file."""
+
     def _create_file(content: str, filename: str = "WP01.md") -> Path:
         file_path = tmp_path / filename
         file_path.write_text(content)
         return file_path
+
     return _create_file
 
 

--- a/tests/test_isolation_helpers.py
+++ b/tests/test_isolation_helpers.py
@@ -82,16 +82,11 @@ def assert_test_isolation() -> None:
 
     if installed != source:
         pytest.fail(
-            f"Test isolation broken! Source: {source}, Installed: {installed}. "
-            f"Run: pip uninstall spec-kitty-cli -y"
+            f"Test isolation broken! Source: {source}, Installed: {installed}. Run: pip uninstall spec-kitty-cli -y"
         )
 
 
-def run_cli_subprocess(
-    project_path: Path,
-    *args: str,
-    check: bool = False
-) -> subprocess.CompletedProcess[str]:
+def run_cli_subprocess(project_path: Path, *args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
     """Run CLI in subprocess with guaranteed source version.
 
     This is a lower-level helper for tests that need full control.

--- a/tests/test_template/test_manager.py
+++ b/tests/test_template/test_manager.py
@@ -60,9 +60,7 @@ def test_copy_specify_base_from_local_copies_expected_assets(tmp_path: Path) -> 
     assert (project_path / ".kittify" / "missions" / "default" / "rules.md").exists()
 
 
-def test_copy_specify_base_from_package_uses_packaged_assets(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_copy_specify_base_from_package_uses_packaged_assets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     fake_pkg = tmp_path / "package_data"
     (fake_pkg / "memory").mkdir(parents=True)
     (fake_pkg / "memory" / "seed.txt").write_text("seed", encoding="utf-8")

--- a/tests/upgrade/migrations/test_m_0_12_1_remove_kitty_specs_from_gitignore.py
+++ b/tests/upgrade/migrations/test_m_0_12_1_remove_kitty_specs_from_gitignore.py
@@ -17,25 +17,31 @@ pytestmark = pytest.mark.fast
 class TestIsBlockingPattern:
     """Test the pattern detection logic."""
 
-    @pytest.mark.parametrize("pattern", [
-        "kitty-specs",
-        "kitty-specs/",
-        "/kitty-specs",
-        "/kitty-specs/",
-    ])
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "kitty-specs",
+            "kitty-specs/",
+            "/kitty-specs",
+            "/kitty-specs/",
+        ],
+    )
     def test_blocking_patterns_detected(self, pattern: str):
         """Patterns that block the entire kitty-specs directory should be detected."""
         assert is_blocking_pattern(pattern) is True
 
-    @pytest.mark.parametrize("pattern", [
-        "kitty-specs/**/tasks/*.md",
-        "kitty-specs/*/tasks/*.md",
-        "kitty-specs/**/tasks/",
-        "# kitty-specs/",  # Comment
-        "",  # Empty line
-        "node_modules/",  # Unrelated
-        ".kittify/",  # Unrelated
-    ])
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "kitty-specs/**/tasks/*.md",
+            "kitty-specs/*/tasks/*.md",
+            "kitty-specs/**/tasks/",
+            "# kitty-specs/",  # Comment
+            "",  # Empty line
+            "node_modules/",  # Unrelated
+            ".kittify/",  # Unrelated
+        ],
+    )
     def test_non_blocking_patterns_ignored(self, pattern: str):
         """Patterns that don't block entire directory should NOT be detected."""
         assert is_blocking_pattern(pattern) is False

--- a/tests/upgrade/migrations/test_m_0_16_2_remove_wp_status_gitignore_rule.py
+++ b/tests/upgrade/migrations/test_m_0_16_2_remove_wp_status_gitignore_rule.py
@@ -137,8 +137,7 @@ class TestMigration:
     def test_apply(self, tmp_path: Path) -> None:
         gitignore = tmp_path / ".gitignore"
         gitignore.write_text(
-            "# Block WP status files (managed in main repo, prevents merge conflicts)\n"
-            "kitty-specs/**/tasks/*.md\n",
+            "# Block WP status files (managed in main repo, prevents merge conflicts)\nkitty-specs/**/tasks/*.md\n",
             encoding="utf-8",
         )
 

--- a/tests/upgrade/migrations/test_m_2_0_0_retire_git_hooks.py
+++ b/tests/upgrade/migrations/test_m_2_0_0_retire_git_hooks.py
@@ -120,4 +120,3 @@ class TestRetireGitHooksMigration:
 
         assert result.success is True
         assert "No .git/hooks directory found" in result.changes_made
-

--- a/tests/upgrade/test_clarify_template_migration.py
+++ b/tests/upgrade/test_clarify_template_migration.py
@@ -187,12 +187,7 @@ class TestMigrationApply:
         assert len(result.errors) == 0
 
         # Check this agent's template was updated
-        template_path = (
-            mock_project_all_agents_broken_placeholder
-            / agent_dir
-            / subdir
-            / "spec-kitty.clarify.md"
-        )
+        template_path = mock_project_all_agents_broken_placeholder / agent_dir / subdir / "spec-kitty.clarify.md"
         content = template_path.read_text()
 
         # Should have correct command
@@ -220,12 +215,7 @@ class TestMigrationApply:
         assert len(result.errors) == 0
 
         # Check this agent's template was updated
-        template_path = (
-            mock_project_all_agents_old_manual_detection
-            / agent_dir
-            / subdir
-            / "spec-kitty.clarify.md"
-        )
+        template_path = mock_project_all_agents_old_manual_detection / agent_dir / subdir / "spec-kitty.clarify.md"
         content = template_path.read_text()
 
         # Should have correct command
@@ -246,9 +236,7 @@ class TestMigrationApply:
         # Create opencode directory (configured)
         opencode = tmp_path / ".opencode" / "command"
         opencode.mkdir(parents=True)
-        (opencode / "spec-kitty.clarify.md").write_text(
-            "1. Run `(Missing script command for sh)` from repo root\n"
-        )
+        (opencode / "spec-kitty.clarify.md").write_text("1. Run `(Missing script command for sh)` from repo root\n")
 
         # Create claude directory (NOT configured)
         claude = tmp_path / ".claude" / "commands"
@@ -284,9 +272,7 @@ class TestMigrationApply:
         assert result1.success is True
 
         # Read updated content
-        opencode_template = (
-            mock_project_one_agent / ".opencode" / "command" / "spec-kitty.clarify.md"
-        )
+        opencode_template = mock_project_one_agent / ".opencode" / "command" / "spec-kitty.clarify.md"
         content_after_first = opencode_template.read_text()
 
         # Run migration second time
@@ -302,9 +288,7 @@ class TestMigrationApply:
         migration = FixClarifyTemplateMigration()
 
         # Read original content
-        opencode_template = (
-            mock_project_one_agent / ".opencode" / "command" / "spec-kitty.clarify.md"
-        )
+        opencode_template = mock_project_one_agent / ".opencode" / "command" / "spec-kitty.clarify.md"
         original_content = opencode_template.read_text()
 
         # Run dry run
@@ -341,9 +325,7 @@ class TestTemplateContent:
 
     def test_template_source_exists(self):
         """Test that clarify template source file exists."""
-        template_path = Path(
-            "src/specify_cli/missions/software-dev/command-templates/clarify.md"
-        )
+        template_path = Path("src/specify_cli/missions/software-dev/command-templates/clarify.md")
         assert template_path.exists()
 
         content = template_path.read_text()
@@ -359,9 +341,7 @@ class TestTemplateContent:
 
     def test_template_matches_tasks_pattern(self):
         """Test clarify template uses same pattern as tasks.md for consistency."""
-        clarify_path = Path(
-            "src/specify_cli/missions/software-dev/command-templates/clarify.md"
-        )
+        clarify_path = Path("src/specify_cli/missions/software-dev/command-templates/clarify.md")
         tasks_path = Path("src/specify_cli/missions/software-dev/command-templates/tasks.md")
 
         clarify_content = clarify_path.read_text()
@@ -372,8 +352,6 @@ class TestTemplateContent:
         assert "check-prerequisites --json --paths-only" in tasks_content
 
         # Clarify should NOT have --include-tasks flag (that's only for tasks.md)
-        clarify_lines = [
-            line for line in clarify_content.split("\n") if "check-prerequisites" in line
-        ]
+        clarify_lines = [line for line in clarify_content.split("\n") if "check-prerequisites" in line]
         for line in clarify_lines:
             assert "--include-tasks" not in line

--- a/tests/upgrade/test_m_0_12_0_documentation_mission_unit.py
+++ b/tests/upgrade/test_m_0_12_0_documentation_mission_unit.py
@@ -117,8 +117,9 @@ def test_apply_installs_mission(migration: InstallDocumentationMission, tmp_path
     result = migration.apply(tmp_path)
 
     assert result.success
-    assert any("copied" in change.lower() or "documentation mission" in change.lower()
-              for change in result.changes_made)
+    assert any(
+        "copied" in change.lower() or "documentation mission" in change.lower() for change in result.changes_made
+    )
 
     # Verify mission directory exists
     doc_mission = kittify / "missions" / "documentation"
@@ -166,8 +167,7 @@ def test_apply_already_installed(migration: InstallDocumentationMission, tmp_pat
     result = migration.apply(tmp_path)
 
     assert result.success
-    assert any("already installed" in change.lower() or "skipped" in change.lower()
-              for change in result.changes_made)
+    assert any("already installed" in change.lower() or "skipped" in change.lower() for change in result.changes_made)
 
 
 # ============================================================================
@@ -175,9 +175,7 @@ def test_apply_already_installed(migration: InstallDocumentationMission, tmp_pat
 # ============================================================================
 
 
-def test_migration_preserves_software_dev_mission(
-    migration: InstallDocumentationMission, tmp_path: Path
-) -> None:
+def test_migration_preserves_software_dev_mission(migration: InstallDocumentationMission, tmp_path: Path) -> None:
     """Verify migration doesn't touch software-dev mission."""
     # Create fake project with software-dev mission
     kittify = tmp_path / ".kittify"
@@ -199,9 +197,7 @@ def test_migration_preserves_software_dev_mission(
     assert after_content == original_content
 
 
-def test_migration_preserves_research_mission(
-    migration: InstallDocumentationMission, tmp_path: Path
-) -> None:
+def test_migration_preserves_research_mission(migration: InstallDocumentationMission, tmp_path: Path) -> None:
     """Verify migration doesn't touch research mission."""
     # Create fake project with research mission
     kittify = tmp_path / ".kittify"
@@ -223,9 +219,7 @@ def test_migration_preserves_research_mission(
     assert after_content == original_content
 
 
-def test_migration_only_touches_documentation_mission(
-    migration: InstallDocumentationMission, tmp_path: Path
-) -> None:
+def test_migration_only_touches_documentation_mission(migration: InstallDocumentationMission, tmp_path: Path) -> None:
     """Verify migration only modifies .kittify/missions/documentation/."""
     # Create fake project
     kittify = tmp_path / ".kittify"
@@ -273,8 +267,7 @@ def test_migration_is_idempotent(migration: InstallDocumentationMission, tmp_pat
     # Second run (should be no-op)
     result2 = migration.apply(tmp_path)
     assert result2.success
-    assert any("already installed" in change.lower() or "skipped" in change.lower()
-              for change in result2.changes_made)
+    assert any("already installed" in change.lower() or "skipped" in change.lower() for change in result2.changes_made)
 
     # Verify no changes
     file_count_2 = len(list(doc_mission.rglob("*")))
@@ -285,9 +278,7 @@ def test_migration_is_idempotent(migration: InstallDocumentationMission, tmp_pat
     assert result3.success
 
 
-def test_migration_detect_after_apply(
-    migration: InstallDocumentationMission, tmp_path: Path
-) -> None:
+def test_migration_detect_after_apply(migration: InstallDocumentationMission, tmp_path: Path) -> None:
     """Verify detect() returns False after apply()."""
     kittify = tmp_path / ".kittify"
     kittify.mkdir()
@@ -346,9 +337,7 @@ def test_migration_has_correct_metadata(migration: InstallDocumentationMission) 
 # ============================================================================
 
 
-def test_apply_handles_missing_source(
-    migration: InstallDocumentationMission, tmp_path: Path, monkeypatch
-) -> None:
+def test_apply_handles_missing_source(migration: InstallDocumentationMission, tmp_path: Path, monkeypatch) -> None:
     """Apply handles case where source mission cannot be found."""
     kittify = tmp_path / ".kittify"
     kittify.mkdir()
@@ -362,9 +351,7 @@ def test_apply_handles_missing_source(
     assert any("could not find" in error.lower() for error in result.errors)
 
 
-def test_find_source_mission_returns_none_if_missing(
-    migration: InstallDocumentationMission
-) -> None:
+def test_find_source_mission_returns_none_if_missing(migration: InstallDocumentationMission) -> None:
     """_find_source_mission returns None if mission.yaml doesn't exist."""
     # We can't easily test this without mocking Path operations,
     # but we can verify the method exists and has correct signature

--- a/tests/upgrade/test_m_0_13_8_target_branch.py
+++ b/tests/upgrade/test_m_0_13_8_target_branch.py
@@ -128,9 +128,7 @@ def test_apply_detects_025_as_2x_target(repo_with_features: Path):
     assert result.success is True
 
     # Check Feature 025
-    meta_025_file = (
-        repo_with_features / "kitty-specs" / "025-cli-event-log-integration" / "meta.json"
-    )
+    meta_025_file = repo_with_features / "kitty-specs" / "025-cli-event-log-integration" / "meta.json"
     meta_025 = json.loads(meta_025_file.read_text())
     assert meta_025["target_branch"] == "2.x"
 
@@ -169,9 +167,7 @@ def test_apply_dry_run_does_not_modify_files(repo_with_features: Path):
     migration = TargetBranchMigration()
 
     # Read original meta files
-    meta_020_before = (
-        repo_with_features / "kitty-specs" / "020-legacy-feature" / "meta.json"
-    ).read_text()
+    meta_020_before = (repo_with_features / "kitty-specs" / "020-legacy-feature" / "meta.json").read_text()
 
     result = migration.apply(repo_with_features, dry_run=True)
 
@@ -179,9 +175,7 @@ def test_apply_dry_run_does_not_modify_files(repo_with_features: Path):
     assert len(result.changes_made) >= 2
 
     # Verify file unchanged
-    meta_020_after = (
-        repo_with_features / "kitty-specs" / "020-legacy-feature" / "meta.json"
-    ).read_text()
+    meta_020_after = (repo_with_features / "kitty-specs" / "020-legacy-feature" / "meta.json").read_text()
     assert meta_020_before == meta_020_after
 
     # Check dry run messages


### PR DESCRIPTION
## Summary

Split out of #276 to isolate the `tests/` Python lint churn from policy/test-surface changes and source churn.

### Included here

- `tests/**/*.py` lint-driven cleanup from the original branch
- typing modernization in tests
- import cleanup
- line wrapping / formatting
- test-only lint fixes outside the explicitly policy/test-surface files split into the companion PR

### Not included here

- docs/test policy checks moved to the policy-surface PR
- top-level dossier test additions moved to the policy-surface PR
- `src/**/*.py` churn

### Why split this way

This keeps test-only maintenance separate from runtime code review and separates mechanical cleanup from new test contracts.

### Validation

- `pytest --collect-only -q tests/specify_cli/cli/commands/test_ops.py`
