### PR TITLE
fix(dashboard): add approved lane to kanban board

### DIFF
--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -285,7 +285,7 @@ def resolve_active_feature(
 
 def _count_wps_by_lane_frontmatter(tasks_dir: Path) -> Dict[str, int]:
     """Count work packages by lane from frontmatter (new format)."""
-    counts = {"planned": 0, "doing": 0, "for_review": 0, "done": 0}
+    counts = {"planned": 0, "doing": 0, "for_review": 0, "approved": 0, "done": 0}
 
     if not tasks_dir.exists():
         return counts
@@ -297,6 +297,10 @@ def _count_wps_by_lane_frontmatter(tasks_dir: Path) -> Dict[str, int]:
 
         frontmatter, _, _ = parse_frontmatter(content)
         lane = frontmatter.get("lane", "planned") if isinstance(frontmatter, dict) else "planned"
+        if lane == "claimed":
+            lane = "planned"
+        elif lane == "in_progress":
+            lane = "doing"
         if lane in counts:
             counts[lane] += 1
 
@@ -327,7 +331,7 @@ def scan_all_features(project_dir: Path) -> List[Dict[str, Any]]:
         artifacts = get_feature_artifacts(feature_dir, project_dir)
         workflow = get_workflow_status(artifacts)
 
-        kanban_stats = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "done": 0}
+        kanban_stats = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "approved": 0, "done": 0}
         if artifacts["kanban"]:
             tasks_dir = feature_dir / "tasks"
             use_legacy = is_legacy_format(feature_dir)
@@ -429,6 +433,7 @@ def scan_feature_kanban(project_dir: Path, feature_id: str) -> Dict[str, List[Di
         "planned": [],
         "doing": [],
         "for_review": [],
+        "approved": [],
         "done": [],
     }
 
@@ -465,6 +470,10 @@ def scan_feature_kanban(project_dir: Path, feature_id: str) -> Dict[str, List[Di
                 task_data = _process_wp_file(prompt_file, project_dir, "planned")
                 if task_data is not None:
                     lane = task_data.get("lane", "planned")
+                    if lane == "claimed":
+                        lane = "planned"
+                    elif lane == "in_progress":
+                        lane = "doing"
                     if lane not in lanes:
                         lane = "planned"
                     lanes[lane].append(task_data)

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.css
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.css
@@ -316,6 +316,7 @@ body {
 .status-card.total { border-left-color: var(--baby-blue); }
 .status-card.progress { border-left-color: var(--sunny-yellow); }
 .status-card.review { border-left-color: var(--lavender); }
+.status-card.approved { border-left-color: var(--soft-peach); }
 .status-card.completed { border-left-color: var(--grassy-green); }
 .status-card.agents { border-left-color: var(--soft-peach); }
 
@@ -378,7 +379,7 @@ body {
 /* Kanban board styles */
 .kanban-board {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     gap: 20px;
 }
 
@@ -418,6 +419,9 @@ body {
 .lane.for_review { border-top-color: var(--lavender); }
 .lane.for_review .lane-header { border-color: var(--lavender); color: var(--lavender); }
 
+.lane.approved { border-top-color: var(--soft-peach); }
+.lane.approved .lane-header { border-color: var(--soft-peach); color: #c07b2a; }
+
 .lane.done { border-top-color: var(--grassy-green); }
 .lane.done .lane-header { border-color: var(--grassy-green); color: var(--grassy-green); }
 
@@ -440,6 +444,7 @@ body {
 .lane.planned .card { border-left-color: var(--baby-blue); }
 .lane.doing .card { border-left-color: var(--sunny-yellow); }
 .lane.for_review .card { border-left-color: var(--lavender); }
+.lane.approved .card { border-left-color: var(--soft-peach); }
 .lane.done .card { border-left-color: var(--grassy-green); }
 
 .card-id {

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -365,6 +365,10 @@ return `
                 <div class="status-label">Review</div>
                 <div class="status-value">${stats.for_review}</div>
             </div>
+            <div class="status-card approved">
+                <div class="status-label">Approved</div>
+                <div class="status-value">${stats.approved || 0}</div>
+            </div>
             <div class="status-card completed">
                 <div class="status-label">Completed</div>
                 <div class="status-value">${completed}</div>
@@ -395,7 +399,7 @@ function loadKanban() {
 }
 
 function renderKanban(lanes) {
-    const total = lanes.planned.length + lanes.doing.length + lanes.for_review.length + lanes.done.length;
+    const total = lanes.planned.length + lanes.doing.length + lanes.for_review.length + (lanes.approved || []).length + lanes.done.length;
     const completed = lanes.done.length;
     const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
 
@@ -419,6 +423,10 @@ function renderKanban(lanes) {
         <div class="status-card review">
             <div class="status-label">Review</div>
             <div class="status-value">${lanes.for_review.length}</div>
+        </div>
+        <div class="status-card approved">
+            <div class="status-label">Approved</div>
+            <div class="status-value">${(lanes.approved || []).length}</div>
         </div>
         <div class="status-card completed">
             <div class="status-label">Completed</div>
@@ -469,6 +477,13 @@ function renderKanban(lanes) {
             </div>
             <div>${lanes.for_review.length === 0 ? '<div class="empty-state">No tasks</div>' : lanes.for_review.map(createCard).join('')}</div>
         </div>
+        <div class="lane approved">
+            <div class="lane-header">
+                <span>👍 Approved</span>
+                <span class="count">${(lanes.approved || []).length}</span>
+            </div>
+            <div>${(lanes.approved || []).length === 0 ? '<div class="empty-state">No tasks</div>' : (lanes.approved || []).map(createCard).join('')}</div>
+        </div>
         <div class="lane done">
             <div class="lane-header">
                 <span>✅ Done</span>
@@ -478,7 +493,7 @@ function renderKanban(lanes) {
         </div>
     `;
 
-    ['planned', 'doing', 'for_review', 'done'].forEach(laneName => {
+    ['planned', 'doing', 'for_review', 'approved', 'done'].forEach(laneName => {
         const laneCards = document.querySelectorAll(`.lane.${laneName} .card`);
         laneCards.forEach((card, index) => {
             const task = lanes[laneName][index];

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -123,3 +123,31 @@ def test_new_path_preferred_when_both_exist(tmp_path):
 
     resolved = resolve_project_constitution_path(tmp_path)
     assert resolved == new_path
+
+
+def test_scan_feature_kanban_approved_lane(tmp_path):
+    """WPs with lane: approved should land in the approved column, not planned."""
+    feature_dir = tmp_path / "kitty-specs" / "001-demo"
+    (feature_dir / "tasks").mkdir(parents=True)
+    (feature_dir / "tasks" / "WP01.md").write_text(
+        "---\nwork_package_id: WP01\nlane: approved\n---\n# Work Package Prompt: WP01\n",
+        encoding="utf-8",
+    )
+    lanes = scanner.scan_feature_kanban(tmp_path, "001-demo")
+    assert len(lanes["approved"]) == 1
+    assert len(lanes["planned"]) == 0
+    assert lanes["approved"][0]["id"] == "WP01"
+
+
+def test_scan_feature_kanban_lane_mapping(tmp_path):
+    """claimed maps to planned, in_progress maps to doing."""
+    feature_dir = tmp_path / "kitty-specs" / "001-demo"
+    (feature_dir / "tasks").mkdir(parents=True)
+    for wp_id, lane in [("WP01", "claimed"), ("WP02", "in_progress")]:
+        (feature_dir / "tasks" / f"{wp_id}.md").write_text(
+            f"---\nwork_package_id: {wp_id}\nlane: {lane}\n---\n# Work Package Prompt: {wp_id}\n",
+            encoding="utf-8",
+        )
+    lanes = scanner.scan_feature_kanban(tmp_path, "001-demo")
+    assert len(lanes["planned"]) == 1  # claimed -> planned
+    assert len(lanes["doing"]) == 1  # in_progress -> doing


### PR DESCRIPTION
## Summary
- WPs with `lane: "approved"` were silently falling back to the "planned" column via scanner.py fallback logic, making them invisible on the dashboard
- Adds **Approved** as a 5th kanban column between For Review and Done (soft-peach styling)
- Maps `claimed` → planned and `in_progress` → doing at the scanner level for consistent lane normalization

## Changes
- **scanner.py**: Added `"approved": 0` / `"approved": []` to all lane dicts; added `claimed`/`in_progress` mapping in `_count_wps_by_lane_frontmatter()` and `scan_feature_kanban()`
- **dashboard.css**: Grid 4→5 columns, new `.lane.approved` / `.status-card.approved` styles
- **dashboard.js**: Approved status card in overview + kanban, new kanban column, card event attachment
- **test_scanner.py**: Tests for approved lane routing and claimed/in_progress mapping

## Test plan
- [x] `python -m pytest tests/test_dashboard/test_scanner.py -x -q` — 10/10 pass
- [ ] Start dashboard against a project with approved WPs, verify 5-column kanban renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)