### PR TITLE
fix(merge): transition approved WPs to done even without review metadata

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -43,6 +43,7 @@ from specify_cli.tasks_support import TaskCliError, find_repo_root
 from specify_cli.frontmatter import read_frontmatter
 from specify_cli.status.emit import emit_status_transition, TransitionError
 from specify_cli.status.history_parser import extract_done_evidence
+from specify_cli.status.models import DoneEvidence, ReviewApproval
 from specify_cli.status.transitions import resolve_lane_alias
 
 
@@ -72,11 +73,22 @@ def _mark_wp_merged_done(
 
     evidence = extract_done_evidence(frontmatter, wp_id)
     if evidence is None:
-        console.print(
-            f"[yellow]Warning:[/yellow] {wp_id} has no recorded approval metadata; "
-            "skipping automatic move to done after merge."
-        )
-        return
+        if lane == "approved":
+            # WP was approved via move-task (no legacy review_status/reviewed_by).
+            # The approved lane itself is sufficient evidence for merge→done.
+            evidence = DoneEvidence(
+                review=ReviewApproval(
+                    reviewer=str(frontmatter.get("agent", "unknown")).strip() or "unknown",
+                    verdict="approved",
+                    reference=f"lane-approved:{wp_id}",
+                )
+            )
+        else:
+            console.print(
+                f"[yellow]Warning:[/yellow] {wp_id} has no recorded approval metadata; "
+                "skipping automatic move to done after merge."
+            )
+            return
 
     if lane == "for_review":
         try:

--- a/tests/specify_cli/test_merge_done_recording.py
+++ b/tests/specify_cli/test_merge_done_recording.py
@@ -44,7 +44,10 @@ def test_mark_wp_merged_done_emits_done_transition(tmp_path: Path, monkeypatch) 
     assert kwargs["evidence"]["review"]["reviewer"] == "reviewer-1"
 
 
-def test_mark_wp_merged_done_skips_without_approval_metadata(tmp_path: Path, monkeypatch) -> None:
+def test_mark_wp_merged_done_approved_without_review_metadata_synthesizes_evidence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """WPs in approved lane without review_status/reviewed_by should still transition to done."""
     repo_root = tmp_path
     feature_dir = repo_root / "kitty-specs" / "021-test"
     tasks_dir = feature_dir / "tasks"
@@ -52,6 +55,34 @@ def test_mark_wp_merged_done_skips_without_approval_metadata(tmp_path: Path, mon
     _write_wp(
         tasks_dir / "WP01-test.md",
         lane="approved",
+        review_status="",
+        reviewed_by="",
+    )
+
+    emit_mock = Mock()
+    monkeypatch.setattr("specify_cli.cli.commands.merge.emit_status_transition", emit_mock)
+
+    _mark_wp_merged_done(repo_root, "021-test", "WP01", "main")
+
+    emit_mock.assert_called_once()
+    kwargs = emit_mock.call_args.kwargs
+    assert kwargs["to_lane"] == "done"
+    assert kwargs["actor"] == "merge"
+    assert kwargs["evidence"]["review"]["verdict"] == "approved"
+    assert kwargs["evidence"]["review"]["reference"] == "lane-approved:WP01"
+
+
+def test_mark_wp_merged_done_for_review_without_metadata_skips(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """WPs in for_review lane without approval metadata should NOT transition to done."""
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "021-test"
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    _write_wp(
+        tasks_dir / "WP01-test.md",
+        lane="for_review",
         review_status="",
         reviewed_by="",
     )


### PR DESCRIPTION
## Summary

- When WPs are approved via `move-task --to approved`, the `review_status`/`reviewed_by` frontmatter fields are not populated, causing `extract_done_evidence()` to return `None`
- This silently skipped the `approved → done` transition during merge — all WPs stayed in `approved` after a successful merge
- Now synthesizes minimal `DoneEvidence` from the approved lane itself (the lane IS the proof of approval), using `lane-approved:{wp_id}` as the evidence reference
- Non-approved WPs without evidence still skip with a warning (no behavior change for `for_review` or other lanes)

## Test plan

- [x] `test_mark_wp_merged_done_approved_without_review_metadata_synthesizes_evidence` — approved lane + no metadata → emits done transition with synthesized evidence
- [x] `test_mark_wp_merged_done_for_review_without_metadata_skips` — for_review lane + no metadata → still skips (unchanged behavior)
- [x] Existing tests pass (202 merge tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)