### PR TITLE
feat: structured API for requirement-ref mapping

### DIFF
--- a/src/specify_cli/cli/commands/agent/feature.py
+++ b/src/specify_cli/cli/commands/agent/feature.py
@@ -1477,22 +1477,41 @@ def finalize_tasks(
             all_spec_requirement_ids = set(spec_requirement_ids["all"])
             functional_spec_requirement_ids = set(spec_requirement_ids["functional"])
 
-        # Parse dependencies and requirement refs from tasks.md (if it exists)
+        # Parse dependencies and requirement refs using 3-tier priority:
+        # 1. requirement-mapping.json (structured API store — deterministic)
+        # 2. tasks.md text parsing (backward compat for pre-API projects)
+        # 3. WP frontmatter (existing fallback)
+        from specify_cli.requirement_mapping import load_requirement_mapping
+
         tasks_md = feature_dir / "tasks.md"
         wp_dependencies = {}
         wp_requirement_refs = {}
+        mapping_source = "none"
+
+        # PRIMARY: Read from requirement-mapping.json (structured API store)
+        api_mappings = load_requirement_mapping(feature_dir)
+        if api_mappings:
+            wp_requirement_refs = api_mappings
+            mapping_source = "api"
+
         if tasks_md.exists():
-            # Read tasks.md and parse dependency + requirement mapping
+            # Read tasks.md and parse dependency mapping (always needed)
             tasks_content = tasks_md.read_text(encoding="utf-8")
             wp_dependencies = _parse_dependencies_from_tasks_md(tasks_content)
-            wp_requirement_refs = _parse_requirement_refs_from_tasks_md(tasks_content)
 
-        # Fallback: if tasks.md lacks requirement refs, recover from WP frontmatter.
-        # This keeps finalize-tasks deterministic even when an agent edits WP files first.
+            # FALLBACK 1: Parse requirement refs from tasks.md text
+            if not wp_requirement_refs:
+                wp_requirement_refs = _parse_requirement_refs_from_tasks_md(tasks_content)
+                if any(refs for refs in wp_requirement_refs.values()):
+                    mapping_source = "tasks_md"
+
+        # FALLBACK 2: WP frontmatter (existing)
         wp_requirement_refs_from_frontmatter = _parse_requirement_refs_from_wp_files(wp_files)
         for wp_id, refs in wp_requirement_refs_from_frontmatter.items():
             if refs and not wp_requirement_refs.get(wp_id):
                 wp_requirement_refs[wp_id] = refs
+                if mapping_source == "none":
+                    mapping_source = "frontmatter"
 
         # Validate dependencies (detect cycles, invalid references)
         if wp_dependencies:
@@ -1721,6 +1740,7 @@ def finalize_tasks(
                     "files_committed": files_committed,
                     "dependencies_parsed": wp_dependencies,
                     "requirement_refs_parsed": wp_requirement_refs,
+                    "mapping_source": mapping_source,
                 }
             )
 
@@ -1842,14 +1862,9 @@ def _parse_requirement_refs_from_wp_files(wp_files: list[Path]) -> dict[str, lis
 
 
 def _parse_requirement_ids_from_spec_md(spec_content: str) -> dict[str, list[str]]:
-    """Parse requirement IDs from spec.md content."""
-    all_ids = {
-        req_id.upper()
-        for req_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", spec_content, re.IGNORECASE)
-    }
-    functional_ids = {req_id for req_id in all_ids if req_id.startswith("FR-")}
+    """Parse requirement IDs from spec.md content.
 
-    return {
-        "all": sorted(all_ids),
-        "functional": sorted(functional_ids),
-    }
+    Delegates to the shared implementation in requirement_mapping module.
+    """
+    from specify_cli.requirement_mapping import parse_requirement_ids_from_spec_md
+    return parse_requirement_ids_from_spec_md(spec_content)

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -2001,3 +2001,197 @@ def list_dependents(
     except Exception as e:
         _output_error(json_output, str(e))
         raise typer.Exit(1)
+
+
+@app.command(name="map-requirements")
+def map_requirements(
+    wp: Annotated[Optional[str], typer.Option("--wp", help="WP ID (e.g., WP04)")] = None,
+    refs: Annotated[Optional[str], typer.Option("--refs", help="Comma-separated requirement refs (e.g., FR-001,FR-002)")] = None,
+    batch: Annotated[Optional[str], typer.Option("--batch", help='JSON batch mapping (e.g., \'{"WP01":["FR-001"],"WP02":["FR-003"]}\')')] = None,
+    feature: Annotated[Optional[str], typer.Option("--feature", help="Feature slug (auto-detected if omitted)")] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output JSON format")] = False,
+) -> None:
+    """Register requirement-to-WP mappings with immediate validation.
+
+    Validates each ref against spec.md, checks WP files exist, and stores
+    mappings in requirement-mapping.json. finalize-tasks reads this as its
+    primary source.
+
+    Individual mode: --wp WP04 --refs FR-005,FR-006
+    Batch mode:      --batch '{"WP01":["FR-001"],"WP04":["FR-005","FR-006"]}'
+
+    Examples:
+        spec-kitty agent tasks map-requirements --wp WP01 --refs FR-001,FR-002 --json
+        spec-kitty agent tasks map-requirements --batch '{"WP01":["FR-001"]}' --json
+    """
+    from specify_cli.requirement_mapping import (
+        compute_coverage,
+        load_requirement_mapping,
+        parse_requirement_ids_from_spec_md,
+        save_requirement_mapping,
+        validate_ref_format,
+        validate_refs,
+    )
+
+    try:
+        # --- Validate input mode ---
+        if batch and (wp or refs):
+            msg = "Cannot combine --batch with --wp/--refs. Use one mode."
+            _output_error(json_output, msg)
+            raise typer.Exit(1)
+
+        if not batch and not (wp and refs):
+            msg = "Provide either --wp + --refs (individual) or --batch (batch mode)."
+            _output_error(json_output, msg)
+            raise typer.Exit(1)
+
+        # --- Resolve feature directory ---
+        repo_root = locate_project_root()
+        if repo_root is None:
+            _output_error(json_output, "Could not locate project root")
+            raise typer.Exit(1)
+
+        feature_slug = _find_feature_slug(explicit_feature=feature)
+        main_repo_root, _ = _ensure_target_branch_checked_out(
+            repo_root, feature_slug, json_output
+        )
+        feature_dir = main_repo_root / "kitty-specs" / feature_slug
+
+        if not feature_dir.exists():
+            _output_error(json_output, f"Feature directory not found: {feature_dir}")
+            raise typer.Exit(1)
+
+        # --- Read spec.md for validation ---
+        spec_md = feature_dir / "spec.md"
+        if not spec_md.exists():
+            _output_error(json_output, f"spec.md not found: {spec_md}")
+            raise typer.Exit(1)
+
+        spec_content = spec_md.read_text(encoding="utf-8")
+        spec_ids = parse_requirement_ids_from_spec_md(spec_content)
+        all_spec_ids = set(spec_ids["all"])
+        functional_ids = set(spec_ids["functional"])
+
+        # --- Parse input into new_mappings ---
+        new_mappings: dict[str, list[str]] = {}
+
+        if batch:
+            try:
+                parsed_batch = json.loads(batch)
+            except json.JSONDecodeError as e:
+                _output_error(json_output, f"Invalid JSON in --batch: {e}")
+                raise typer.Exit(1)
+            if not isinstance(parsed_batch, dict):
+                _output_error(json_output, "--batch must be a JSON object {WP_ID: [refs]}")
+                raise typer.Exit(1)
+            for wp_id, ref_list in parsed_batch.items():
+                if not isinstance(ref_list, list):
+                    _output_error(json_output, f"Refs for {wp_id} must be a list, got {type(ref_list).__name__}")
+                    raise typer.Exit(1)
+                new_mappings[wp_id.upper()] = [r.upper() for r in ref_list]
+        else:
+            # Individual mode
+            assert wp is not None and refs is not None
+            ref_list_parsed = [r.strip() for r in refs.split(",") if r.strip()]
+            new_mappings[wp.upper()] = [r.upper() for r in ref_list_parsed]
+
+        # --- Validate WP files exist ---
+        tasks_dir = feature_dir / "tasks"
+        existing_wps: set[str] = set()
+        if tasks_dir.exists():
+            for f in tasks_dir.glob("WP*.md"):
+                m = re.match(r"(WP\d{2})", f.name)
+                if m:
+                    existing_wps.add(m.group(1))
+
+        unknown_wps = sorted(
+            wp_id for wp_id in new_mappings if wp_id not in existing_wps
+        )
+        if unknown_wps:
+            hint = f"Available WPs: {', '.join(sorted(existing_wps))}" if existing_wps else "No WP files found in tasks/"
+            if json_output:
+                print(json.dumps({
+                    "error": "Unknown WP IDs",
+                    "unknown_wps": unknown_wps,
+                    "hint": hint,
+                }))
+            else:
+                console.print(f"[red]Error:[/red] Unknown WP IDs: {', '.join(unknown_wps)}")
+                console.print(f"  {hint}")
+            raise typer.Exit(1)
+
+        # --- Validate ref format ---
+        all_new_refs: list[str] = []
+        for ref_list in new_mappings.values():
+            all_new_refs.extend(ref_list)
+
+        _, malformed = validate_ref_format(all_new_refs)
+        if malformed:
+            if json_output:
+                print(json.dumps({
+                    "error": "Invalid requirement ref format",
+                    "malformed_refs": malformed,
+                    "hint": "Refs must match FR-NNN, NFR-NNN, or C-NNN format",
+                }))
+            else:
+                console.print(f"[red]Error:[/red] Invalid ref format: {', '.join(malformed)}")
+            raise typer.Exit(1)
+
+        # --- Validate refs exist in spec.md ---
+        _, unknown_refs = validate_refs(all_new_refs, all_spec_ids)
+        if unknown_refs:
+            available_range = f"Available: {', '.join(sorted(all_spec_ids))}" if all_spec_ids else "No requirement IDs found in spec.md"
+            if json_output:
+                print(json.dumps({
+                    "error": "Invalid requirement refs",
+                    "unknown_refs": sorted(set(unknown_refs)),
+                    "hint": f"Refs not found in spec.md. {available_range}",
+                }))
+            else:
+                console.print(f"[red]Error:[/red] Unknown refs: {', '.join(sorted(set(unknown_refs)))}")
+                console.print(f"  {available_range}")
+            raise typer.Exit(1)
+
+        # --- Load existing and merge ---
+        existing = load_requirement_mapping(feature_dir)
+
+        if batch:
+            # Batch mode: replace all mappings
+            merged = dict(new_mappings)
+        else:
+            # Individual mode: merge into existing
+            merged = dict(existing)
+            for wp_id, ref_list in new_mappings.items():
+                merged[wp_id] = sorted(set(ref_list))
+
+        save_requirement_mapping(feature_dir, merged)
+
+        # --- Compute coverage ---
+        coverage = compute_coverage(merged, functional_ids)
+
+        # --- Output ---
+        payload = {
+            "result": "success",
+            "mapped": {wp_id: sorted(refs) for wp_id, refs in new_mappings.items()},
+            "total_mappings": {wp_id: sorted(refs) for wp_id, refs in merged.items()},
+            "coverage": coverage,
+        }
+        if json_output:
+            print(json.dumps(payload))
+        else:
+            console.print("[green]✓[/green] Requirement mappings saved")
+            for wp_id, ref_list in sorted(new_mappings.items()):
+                console.print(f"  {wp_id}: {', '.join(ref_list)}")
+            console.print(
+                f"\n  Coverage: {coverage['mapped_functional']}/{coverage['total_functional']} FRs mapped"
+            )
+            if coverage["unmapped_functional"]:
+                console.print(
+                    f"  [yellow]Unmapped:[/yellow] {', '.join(coverage['unmapped_functional'])}"
+                )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        _output_error(json_output, str(e))
+        raise typer.Exit(1)

--- a/src/specify_cli/missions/software-dev/command-templates/tasks.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks.md
@@ -239,20 +239,23 @@ The WP prompt must show the correct command so agents don't branch from the wron
 
 ## Requirement Reference Mapping (MANDATORY)
 
-`finalize-tasks` validates requirement coverage from `tasks.md`. Each WP section must include a requirement mapping line in this format:
+After creating all WP sections and prompt files, register requirement mappings using the CLI.
+The CLI validates each mapping against spec.md immediately — if a ref is invalid or missing,
+you get instant feedback.
 
-```markdown
-### Requirement Refs
-- FR-001, FR-007
+**Batch mode (recommended)** — register all WP mappings at once:
+```bash
+spec-kitty agent tasks map-requirements --batch '{"WP01":["FR-001","FR-002"],"WP02":["FR-003","FR-004"]}' --json
 ```
 
-or
-
-```markdown
-**Requirements Refs**: FR-001, FR-007
+**Individual mode** — register one WP at a time:
+```bash
+spec-kitty agent tasks map-requirements --wp WP01 --refs FR-001,FR-002 --json
 ```
 
-Do not rely on WP frontmatter alone for requirement mapping; keep the canonical mapping in `tasks.md`.
+The response includes a coverage summary showing which FRs are still unmapped. Keep calling
+until `unmapped_functional` is empty. `finalize-tasks` reads from this mapping — do NOT rely
+on markdown text for requirement refs.
 
 ## Work Package Sizing Guidelines (CRITICAL)
 

--- a/src/specify_cli/requirement_mapping.py
+++ b/src/specify_cli/requirement_mapping.py
@@ -1,0 +1,131 @@
+"""Structured requirement-to-WP mapping storage and validation.
+
+Provides a deterministic, JSON-based requirement mapping that replaces
+fragile regex parsing of markdown text in tasks.md.  The LLM registers
+mappings via ``spec-kitty agent tasks map-requirements`` and
+``finalize-tasks`` reads them as the primary source.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import datetime as _dt
+from pathlib import Path
+
+MAPPING_FILENAME = "requirement-mapping.json"
+
+# Matches FR-001, NFR-002, C-003 etc.
+_REF_PATTERN = re.compile(r"^(?:FR|NFR|C)-\d+$", re.IGNORECASE)
+
+
+def load_requirement_mapping(feature_dir: Path) -> dict[str, list[str]]:
+    """Load mappings from requirement-mapping.json.
+
+    Returns:
+        Dict of WP ID -> list of requirement ref strings.
+        Empty dict if file is missing or malformed.
+    """
+    path = feature_dir / MAPPING_FILENAME
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        mappings = data.get("mappings", {})
+        if not isinstance(mappings, dict):
+            return {}
+        # Normalize: uppercase all refs
+        return {
+            wp_id: [ref.upper() for ref in refs]
+            for wp_id, refs in mappings.items()
+            if isinstance(refs, list)
+        }
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_requirement_mapping(
+    feature_dir: Path, mappings: dict[str, list[str]]
+) -> None:
+    """Save mappings to requirement-mapping.json with version + timestamp."""
+    path = feature_dir / MAPPING_FILENAME
+    data = {
+        "version": 1,
+        "mappings": {
+            wp_id: sorted({ref.upper() for ref in refs})
+            for wp_id, refs in mappings.items()
+        },
+        "updated_at": _dt.datetime.now(_dt.UTC).isoformat(),
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def validate_refs(
+    refs: list[str], spec_requirement_ids: set[str]
+) -> tuple[list[str], list[str]]:
+    """Validate refs against spec.
+
+    Returns:
+        (valid_refs, unknown_refs) — both lists are uppercased.
+    """
+    valid: list[str] = []
+    unknown: list[str] = []
+    for ref in refs:
+        upper = ref.upper()
+        if upper in spec_requirement_ids:
+            valid.append(upper)
+        else:
+            unknown.append(upper)
+    return valid, unknown
+
+
+def validate_ref_format(refs: list[str]) -> tuple[list[str], list[str]]:
+    """Check refs match FR|NFR|C-\\d+ format.
+
+    Returns:
+        (well_formed, malformed) — both lists are uppercased.
+    """
+    well_formed: list[str] = []
+    malformed: list[str] = []
+    for ref in refs:
+        upper = ref.upper()
+        if _REF_PATTERN.match(upper):
+            well_formed.append(upper)
+        else:
+            malformed.append(upper)
+    return well_formed, malformed
+
+
+def compute_coverage(
+    mappings: dict[str, list[str]], functional_ids: set[str]
+) -> dict:
+    """Compute coverage summary: total, mapped, unmapped FRs."""
+    mapped: set[str] = set()
+    for refs in mappings.values():
+        mapped.update(ref.upper() for ref in refs)
+    mapped_functional = sorted(mapped & functional_ids)
+    unmapped_functional = sorted(functional_ids - mapped)
+    return {
+        "total_functional": len(functional_ids),
+        "mapped_functional": len(mapped_functional),
+        "unmapped_functional": unmapped_functional,
+    }
+
+
+def parse_requirement_ids_from_spec_md(spec_content: str) -> dict[str, list[str]]:
+    """Parse requirement IDs from spec.md content.
+
+    Shared between map-requirements and finalize-tasks.
+
+    Returns:
+        {"all": [...], "functional": [...]}
+    """
+    all_ids = {
+        req_id.upper()
+        for req_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", spec_content, re.IGNORECASE)
+    }
+    functional_ids = {req_id for req_id in all_ids if req_id.startswith("FR-")}
+    return {
+        "all": sorted(all_ids),
+        "functional": sorted(functional_ids),
+    }

--- a/tests/specify_cli/test_cli/test_map_requirements.py
+++ b/tests/specify_cli/test_cli/test_map_requirements.py
@@ -1,0 +1,397 @@
+"""Tests for the map-requirements command and finalize-tasks integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.agent.tasks import app as tasks_app
+from specify_cli.cli.commands.agent.feature import app as feature_app
+
+runner = CliRunner()
+
+# --- Helpers ---
+
+SPEC_CONTENT = """\
+# Spec
+## Functional Requirements
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | First requirement | Done | proposed |
+| FR-002 | Second requirement | Done | proposed |
+| FR-003 | Third requirement | Done | proposed |
+
+## Non-Functional Requirements
+| ID | Requirement |
+| --- | --- |
+| NFR-001 | Performance |
+"""
+
+
+def _setup_feature(tmp_path: Path, *, wp_ids: list[str] | None = None) -> Path:
+    """Create a minimal feature directory with spec.md and WP files."""
+    feature_dir = tmp_path / "kitty-specs" / "001-test"
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+
+    (feature_dir / "spec.md").write_text(SPEC_CONTENT, encoding="utf-8")
+
+    for wp_id in (wp_ids or ["WP01", "WP02"]):
+        (tasks_dir / f"{wp_id}-test.md").write_text(
+            f"---\nwork_package_id: \"{wp_id}\"\ntitle: \"{wp_id}\"\n---\n\n# {wp_id}\n",
+            encoding="utf-8",
+        )
+
+    return feature_dir
+
+
+# --- map-requirements command tests ---
+
+class TestMapRequirementsIndividual:
+    """Tests for individual mode (--wp + --refs)."""
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_stores_correctly(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path)
+
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP01", "--refs", "FR-001,FR-002", "--json"],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout.strip())
+        assert payload["result"] == "success"
+        assert payload["mapped"]["WP01"] == ["FR-001", "FR-002"]
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_merge_individual(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        """Second individual call merges, doesn't replace existing WPs."""
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path)
+
+        # First call
+        runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP01", "--refs", "FR-001", "--json"],
+        )
+        # Second call for different WP
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP02", "--refs", "FR-002", "--json"],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        # Both WPs should be in total_mappings
+        assert "WP01" in payload["total_mappings"]
+        assert "WP02" in payload["total_mappings"]
+
+
+class TestMapRequirementsBatch:
+    """Tests for batch mode (--batch)."""
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_stores_all_mappings(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path)
+
+        batch = json.dumps({"WP01": ["FR-001", "FR-002"], "WP02": ["FR-003"]})
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--batch", batch, "--json"],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert payload["result"] == "success"
+        assert payload["mapped"]["WP01"] == ["FR-001", "FR-002"]
+        assert payload["mapped"]["WP02"] == ["FR-003"]
+
+
+class TestMapRequirementsValidation:
+    """Tests for validation errors."""
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_validates_unknown_refs(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path)
+
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP01", "--refs", "FR-999", "--json"],
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip())
+        assert payload["error"] == "Invalid requirement refs"
+        assert "FR-999" in payload["unknown_refs"]
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_validates_wp_exists(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path, wp_ids=["WP01"])
+
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP99", "--refs", "FR-001", "--json"],
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip())
+        assert payload["error"] == "Unknown WP IDs"
+        assert "WP99" in payload["unknown_wps"]
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_validates_ref_format(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path)
+
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP01", "--refs", "INVALID-REF", "--json"],
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip())
+        assert payload["error"] == "Invalid requirement ref format"
+
+    def test_rejects_mixed_modes(self):
+        """Cannot combine --batch with --wp/--refs."""
+        result = runner.invoke(
+            tasks_app,
+            [
+                "map-requirements",
+                "--wp", "WP01",
+                "--refs", "FR-001",
+                "--batch", '{"WP01":["FR-001"]}',
+                "--json",
+            ],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip())
+        assert "Cannot combine" in payload["error"]
+
+    def test_rejects_no_args(self):
+        """Must provide either --wp + --refs or --batch."""
+        result = runner.invoke(tasks_app, ["map-requirements", "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip())
+        assert "Provide either" in payload["error"]
+
+
+class TestMapRequirementsCoverage:
+    """Tests for coverage summary."""
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_feature_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_coverage_summary(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        _setup_feature(tmp_path)
+
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP01", "--refs", "FR-001", "--json"],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        coverage = payload["coverage"]
+        assert coverage["total_functional"] == 3
+        assert coverage["mapped_functional"] == 1
+        assert "FR-002" in coverage["unmapped_functional"]
+        assert "FR-003" in coverage["unmapped_functional"]
+
+
+# --- finalize-tasks integration with requirement-mapping.json ---
+
+class TestFinalizeTasksWithMappingJson:
+    """Tests for finalize-tasks reading from requirement-mapping.json."""
+
+    @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
+    @patch("specify_cli.cli.commands.agent.feature.safe_commit", return_value=True)
+    @patch("specify_cli.cli.commands.agent.feature.run_command", return_value=(0, "a" * 40, ""))
+    def test_reads_from_mapping_json(
+        self,
+        mock_run: Mock,
+        mock_commit: Mock,
+        mock_show_branch: Mock,
+        mock_find: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        """finalize-tasks should use requirement-mapping.json as primary source."""
+        mock_locate.return_value = tmp_path
+        feature_dir = _setup_feature(tmp_path)
+        mock_find.return_value = feature_dir
+
+        # Write tasks.md (no requirement refs in it)
+        (feature_dir / "tasks.md").write_text(
+            "## Work Package WP01\n**Dependencies**: None\n"
+            "## Work Package WP02\n**Dependencies**: WP01\n",
+            encoding="utf-8",
+        )
+
+        # Write requirement-mapping.json via the module
+        from specify_cli.requirement_mapping import save_requirement_mapping
+        save_requirement_mapping(feature_dir, {
+            "WP01": ["FR-001", "NFR-001"],
+            "WP02": ["FR-002", "FR-003"],
+        })
+
+        result = runner.invoke(feature_app, ["finalize-tasks", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        json_lines = [line for line in result.stdout.splitlines() if line.strip().startswith("{")]
+        payload = json.loads(json_lines[-1])
+        assert payload["result"] == "success"
+        assert payload["mapping_source"] == "api"
+        assert payload["requirement_refs_parsed"]["WP01"] == ["FR-001", "NFR-001"]
+        assert payload["requirement_refs_parsed"]["WP02"] == ["FR-002", "FR-003"]
+
+    @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
+    @patch("specify_cli.cli.commands.agent.feature.safe_commit", return_value=True)
+    @patch("specify_cli.cli.commands.agent.feature.run_command", return_value=(0, "a" * 40, ""))
+    def test_falls_back_to_tasks_md(
+        self,
+        mock_run: Mock,
+        mock_commit: Mock,
+        mock_show_branch: Mock,
+        mock_find: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        """No mapping JSON → parses tasks.md (backward compat)."""
+        mock_locate.return_value = tmp_path
+        feature_dir = _setup_feature(tmp_path, wp_ids=["WP01"])
+        mock_find.return_value = feature_dir
+
+        # Write tasks.md WITH requirement refs (old-style)
+        (feature_dir / "tasks.md").write_text(
+            "## Work Package WP01\n**Dependencies**: None\n**Requirement Refs**: FR-001, FR-002, FR-003\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(feature_app, ["finalize-tasks", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        json_lines = [line for line in result.stdout.splitlines() if line.strip().startswith("{")]
+        payload = json.loads(json_lines[-1])
+        assert payload["result"] == "success"
+        assert payload["mapping_source"] == "tasks_md"
+        assert "FR-001" in payload["requirement_refs_parsed"]["WP01"]
+
+    @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
+    @patch("specify_cli.cli.commands.agent.feature._show_branch_context", return_value=(None, "main"))
+    @patch("specify_cli.cli.commands.agent.feature.safe_commit", return_value=True)
+    @patch("specify_cli.cli.commands.agent.feature.run_command", return_value=(0, "a" * 40, ""))
+    def test_reports_mapping_source(
+        self,
+        mock_run: Mock,
+        mock_commit: Mock,
+        mock_show_branch: Mock,
+        mock_find: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        """JSON output includes mapping_source field."""
+        mock_locate.return_value = tmp_path
+        feature_dir = _setup_feature(tmp_path, wp_ids=["WP01"])
+        mock_find.return_value = feature_dir
+
+        (feature_dir / "tasks.md").write_text(
+            "## Work Package WP01\n**Dependencies**: None\n",
+            encoding="utf-8",
+        )
+        # WP frontmatter has refs
+        (feature_dir / "tasks" / "WP01-test.md").write_text(
+            "---\nwork_package_id: \"WP01\"\ntitle: \"WP01\"\nrequirement_refs:\n  - FR-001\n  - FR-002\n  - FR-003\n---\n\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(feature_app, ["finalize-tasks", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        json_lines = [line for line in result.stdout.splitlines() if line.strip().startswith("{")]
+        payload = json.loads(json_lines[-1])
+        assert payload["result"] == "success"
+        assert payload["mapping_source"] == "frontmatter"

--- a/tests/specify_cli/test_requirement_mapping.py
+++ b/tests/specify_cli/test_requirement_mapping.py
@@ -1,0 +1,146 @@
+"""Unit tests for requirement_mapping module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.requirement_mapping import (
+    MAPPING_FILENAME,
+    compute_coverage,
+    load_requirement_mapping,
+    parse_requirement_ids_from_spec_md,
+    save_requirement_mapping,
+    validate_ref_format,
+    validate_refs,
+)
+
+
+class TestLoadSaveRoundTrip:
+    """Test JSON persistence round-trip."""
+
+    def test_load_returns_empty_when_missing(self, tmp_path: Path):
+        assert load_requirement_mapping(tmp_path) == {}
+
+    def test_save_and_load_round_trip(self, tmp_path: Path):
+        mappings = {"WP01": ["FR-001", "FR-002"], "WP02": ["NFR-001"]}
+        save_requirement_mapping(tmp_path, mappings)
+        loaded = load_requirement_mapping(tmp_path)
+        assert loaded == {"WP01": ["FR-001", "FR-002"], "WP02": ["NFR-001"]}
+
+    def test_save_uppercases_refs(self, tmp_path: Path):
+        save_requirement_mapping(tmp_path, {"WP01": ["fr-001", "nfr-002"]})
+        loaded = load_requirement_mapping(tmp_path)
+        assert loaded == {"WP01": ["FR-001", "NFR-002"]}
+
+    def test_save_deduplicates_refs(self, tmp_path: Path):
+        save_requirement_mapping(tmp_path, {"WP01": ["FR-001", "FR-001", "FR-002"]})
+        loaded = load_requirement_mapping(tmp_path)
+        assert loaded["WP01"] == ["FR-001", "FR-002"]
+
+    def test_load_returns_empty_on_malformed_json(self, tmp_path: Path):
+        (tmp_path / MAPPING_FILENAME).write_text("not json", encoding="utf-8")
+        assert load_requirement_mapping(tmp_path) == {}
+
+    def test_load_returns_empty_on_missing_mappings_key(self, tmp_path: Path):
+        (tmp_path / MAPPING_FILENAME).write_text('{"version": 1}', encoding="utf-8")
+        assert load_requirement_mapping(tmp_path) == {}
+
+    def test_save_includes_version_and_timestamp(self, tmp_path: Path):
+        save_requirement_mapping(tmp_path, {"WP01": ["FR-001"]})
+        data = json.loads((tmp_path / MAPPING_FILENAME).read_text(encoding="utf-8"))
+        assert data["version"] == 1
+        assert "updated_at" in data
+        assert "mappings" in data
+
+
+class TestValidateRefs:
+    """Test ref validation against spec IDs."""
+
+    def test_all_valid(self):
+        valid, unknown = validate_refs(
+            ["FR-001", "NFR-002"], {"FR-001", "NFR-002", "FR-003"}
+        )
+        assert valid == ["FR-001", "NFR-002"]
+        assert unknown == []
+
+    def test_some_unknown(self):
+        valid, unknown = validate_refs(
+            ["FR-001", "FR-999"], {"FR-001", "FR-002"}
+        )
+        assert valid == ["FR-001"]
+        assert unknown == ["FR-999"]
+
+    def test_case_insensitive(self):
+        valid, unknown = validate_refs(["fr-001"], {"FR-001"})
+        assert valid == ["FR-001"]
+        assert unknown == []
+
+
+class TestValidateRefFormat:
+    """Test ref format validation."""
+
+    def test_valid_formats(self):
+        well_formed, malformed = validate_ref_format(
+            ["FR-001", "NFR-002", "C-003"]
+        )
+        assert well_formed == ["FR-001", "NFR-002", "C-003"]
+        assert malformed == []
+
+    def test_malformed_formats(self):
+        well_formed, malformed = validate_ref_format(
+            ["FR-001", "INVALID", "REQ-001"]
+        )
+        assert well_formed == ["FR-001"]
+        assert malformed == ["INVALID", "REQ-001"]
+
+
+class TestComputeCoverage:
+    """Test coverage summary computation."""
+
+    def test_full_coverage(self):
+        mappings = {"WP01": ["FR-001", "FR-002"], "WP02": ["FR-003"]}
+        coverage = compute_coverage(mappings, {"FR-001", "FR-002", "FR-003"})
+        assert coverage["total_functional"] == 3
+        assert coverage["mapped_functional"] == 3
+        assert coverage["unmapped_functional"] == []
+
+    def test_partial_coverage(self):
+        mappings = {"WP01": ["FR-001"]}
+        coverage = compute_coverage(
+            mappings, {"FR-001", "FR-002", "FR-003"}
+        )
+        assert coverage["total_functional"] == 3
+        assert coverage["mapped_functional"] == 1
+        assert sorted(coverage["unmapped_functional"]) == ["FR-002", "FR-003"]
+
+    def test_empty_mappings(self):
+        coverage = compute_coverage({}, {"FR-001", "FR-002"})
+        assert coverage["total_functional"] == 2
+        assert coverage["mapped_functional"] == 0
+        assert len(coverage["unmapped_functional"]) == 2
+
+
+class TestParseRequirementIdsFromSpecMd:
+    """Test spec.md ID extraction."""
+
+    def test_extracts_fr_nfr_c(self):
+        content = """
+| FR-001 | First req |
+| FR-002 | Second req |
+| NFR-001 | Non-functional |
+| C-001 | Constraint |
+"""
+        result = parse_requirement_ids_from_spec_md(content)
+        assert "FR-001" in result["all"]
+        assert "NFR-001" in result["all"]
+        assert "C-001" in result["all"]
+        assert result["functional"] == ["FR-001", "FR-002"]
+
+    def test_case_insensitive(self):
+        content = "fr-001 and nfr-002"
+        result = parse_requirement_ids_from_spec_md(content)
+        assert "FR-001" in result["all"]
+        assert "NFR-002" in result["all"]


### PR DESCRIPTION
## Summary

- Adds `spec-kitty agent tasks map-requirements` command with individual (`--wp` + `--refs`) and batch (`--batch`) modes for registering requirement-to-WP mappings
- Validates refs against spec.md immediately at call time (format check, existence check, WP existence check) with JSON error responses the LLM can act on
- Stores mappings in `requirement-mapping.json` — `finalize-tasks` reads this as primary source with backward-compatible fallbacks to tasks.md text parsing and WP frontmatter
- Adds `mapping_source` field to finalize-tasks JSON output so agents know which source was used
- Updates tasks.md template to instruct LLMs to use the CLI instead of writing markdown requirement ref lines

## Test plan

- [x] 17 unit tests for `requirement_mapping.py` (load/save round-trip, validation, coverage)
- [x] 9 command tests for `map-requirements` (individual, batch, merge, validation errors, coverage)
- [x] 3 finalize-tasks integration tests (reads from JSON, falls back to tasks.md, reports mapping_source)
- [x] 4 existing finalize-tasks tests still pass (backward compat)
- [x] `ruff check` clean on new module

🤖 Generated with [Claude Code](https://claude.com/claude-code)