### PR TITLE
feat(dashboard): collapsible sidebar navigation

### DIFF
--- a/src/specify_cli/dashboard/static/dashboard/dashboard.css
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.css
@@ -186,10 +186,56 @@ body {
 .sidebar {
     width: 250px;
     background: var(--creamy-white);
-    padding: 20px 0;
+    padding: 40px 0 20px;
     box-shadow: 2px 0 10px rgba(0,0,0,0.1);
     overflow-y: auto;
     border-right: 2px solid var(--light-gray);
+    position: relative;
+    transition: width 0.2s ease;
+    min-width: 60px;
+}
+
+.sidebar-toggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: 1px solid var(--light-gray);
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 4px 8px;
+    font-size: 0.7em;
+    color: #9ca3af;
+    transition: all 0.2s;
+    z-index: 1;
+    margin-bottom: 10px;
+}
+
+.sidebar-toggle:hover {
+    background: var(--light-gray);
+    color: var(--medium-text);
+}
+
+.sidebar.collapsed {
+    width: 60px;
+}
+
+.sidebar.collapsed .sidebar-label,
+.sidebar.collapsed .sidebar-last-update,
+.sidebar.collapsed .sidebar-section-header {
+    display: none;
+}
+
+.sidebar.collapsed .sidebar-item {
+    padding: 12px 0;
+    justify-content: center;
+    gap: 0;
+}
+
+.sidebar.collapsed .sidebar-toggle {
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 .sidebar-item {

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -141,6 +141,28 @@ function saveState(feature, page) {
     }
 }
 
+function toggleSidebar() {
+    const sidebar = document.getElementById('sidebar');
+    const toggle = document.getElementById('sidebar-toggle');
+    const collapsed = sidebar.classList.toggle('collapsed');
+    toggle.textContent = collapsed ? '›' : '‹';
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+    document.cookie = `sidebarCollapsed=${collapsed}; expires=${expires.toUTCString()}; path=/; SameSite=Strict`;
+}
+
+function restoreSidebarState() {
+    const match = document.cookie.match(/sidebarCollapsed=(\w+)/);
+    if (match && match[1] === 'true') {
+        const sidebar = document.getElementById('sidebar');
+        const toggle = document.getElementById('sidebar-toggle');
+        sidebar.classList.add('collapsed');
+        toggle.textContent = '›';
+    }
+}
+
+restoreSidebarState();
+
 function setFeatureSelectActive(isActive) {
     if (isActive) {
         featureSelectActive = true;

--- a/src/specify_cli/dashboard/templates/index.html
+++ b/src/specify_cli/dashboard/templates/index.html
@@ -41,58 +41,59 @@
     </div>
 
     <div class="container">
-        <div class="sidebar">
-            <div class="sidebar-item" data-page="constitution" onclick="switchPage('constitution')">
-                📜 Constitution
+        <div class="sidebar" id="sidebar">
+            <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle sidebar">‹</button>
+            <div class="sidebar-item" data-page="constitution" onclick="switchPage('constitution')" title="Constitution">
+                📜 <span class="sidebar-label">Constitution</span>
             </div>
             <div class="last-update sidebar-last-update">Last updated: <span id="last-update">Loading...</span></div>
-            <div style="padding: 15px 30px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
+            <div class="sidebar-section-header" style="padding: 15px 30px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
                 Workflow
             </div>
-            <div class="sidebar-item active" data-page="overview" data-step="overview" onclick="switchPage('overview')">
-                <span id="icon-overview">📊</span> Overview
+            <div class="sidebar-item active" data-page="overview" data-step="overview" onclick="switchPage('overview')" title="Overview">
+                <span id="icon-overview">📊</span> <span class="sidebar-label">Overview</span>
             </div>
-            <div class="sidebar-item" data-page="spec" data-step="specify" onclick="switchPage('spec')">
-                <span id="icon-specify">⏳</span> Specify
+            <div class="sidebar-item" data-page="spec" data-step="specify" onclick="switchPage('spec')" title="Specify">
+                <span id="icon-specify">⏳</span> <span class="sidebar-label">Specify</span>
             </div>
-            <div class="sidebar-item" data-page="plan" data-step="plan" onclick="switchPage('plan')">
-                <span id="icon-plan">⏳</span> Plan
+            <div class="sidebar-item" data-page="plan" data-step="plan" onclick="switchPage('plan')" title="Plan">
+                <span id="icon-plan">⏳</span> <span class="sidebar-label">Plan</span>
             </div>
-            <div class="sidebar-item" data-page="tasks" data-step="tasks" onclick="switchPage('tasks')">
-                <span id="icon-tasks">⏳</span> Tasks
+            <div class="sidebar-item" data-page="tasks" data-step="tasks" onclick="switchPage('tasks')" title="Tasks">
+                <span id="icon-tasks">⏳</span> <span class="sidebar-label">Tasks</span>
             </div>
-            <div class="sidebar-item" data-page="kanban" data-step="implement" onclick="switchPage('kanban')">
-                <span id="icon-implement">⏳</span> Implement
+            <div class="sidebar-item" data-page="kanban" data-step="implement" onclick="switchPage('kanban')" title="Implement">
+                <span id="icon-implement">⏳</span> <span class="sidebar-label">Implement</span>
             </div>
-            <div style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
+            <div class="sidebar-section-header" style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
                 Artifacts
             </div>
-            <div class="sidebar-item" data-page="research" onclick="switchPage('research')">
-                🔬 Research
+            <div class="sidebar-item" data-page="research" onclick="switchPage('research')" title="Research">
+                🔬 <span class="sidebar-label">Research</span>
             </div>
-            <div class="sidebar-item" data-page="contracts" onclick="switchPage('contracts')">
-                📜 Contracts
+            <div class="sidebar-item" data-page="contracts" onclick="switchPage('contracts')" title="Contracts">
+                📜 <span class="sidebar-label">Contracts</span>
             </div>
-            <div class="sidebar-item" data-page="checklists" onclick="switchPage('checklists')">
-                ✅ Checklists
+            <div class="sidebar-item" data-page="checklists" onclick="switchPage('checklists')" title="Checklists">
+                ✅ <span class="sidebar-label">Checklists</span>
             </div>
-            <div class="sidebar-item" data-page="quickstart" onclick="switchPage('quickstart')">
-                🚀 Quickstart
+            <div class="sidebar-item" data-page="quickstart" onclick="switchPage('quickstart')" title="Quickstart">
+                🚀 <span class="sidebar-label">Quickstart</span>
             </div>
-            <div class="sidebar-item" data-page="data-model" onclick="switchPage('data-model')">
-                💾 Data Model
+            <div class="sidebar-item" data-page="data-model" onclick="switchPage('data-model')" title="Data Model">
+                💾 <span class="sidebar-label">Data Model</span>
             </div>
-            <div style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
+            <div class="sidebar-section-header" style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
                 System
             </div>
-            <div class="sidebar-item" data-page="diagnostics" onclick="switchPage('diagnostics')">
-                🔍 Diagnostics
+            <div class="sidebar-item" data-page="diagnostics" onclick="switchPage('diagnostics')" title="Diagnostics">
+                🔍 <span class="sidebar-label">Diagnostics</span>
             </div>
-            <div style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
+            <div class="sidebar-section-header" style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
                 Dossier
             </div>
-            <div class="sidebar-item" data-page="dossier" onclick="switchPage('dossier')">
-                📦 Dossier
+            <div class="sidebar-item" data-page="dossier" onclick="switchPage('dossier')" title="Dossier">
+                📦 <span class="sidebar-label">Dossier</span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Adds a collapse/expand toggle button to the dashboard sidebar
- Collapsed mode shows icons only (60px width), giving more space to content
- State persists across page reloads via cookie

## Files changed
- `index.html` — toggle button, `sidebar-label` spans, section header classes, title attributes for tooltips
- `dashboard.css` — `.sidebar-toggle`, `.sidebar.collapsed` styles with smooth transition
- `dashboard.js` — `toggleSidebar()` + `restoreSidebarState()` with cookie persistence

## Test plan
- [x] Toggle button visible, subtle grey styling
- [x] Clicking collapses sidebar to 60px icon-only mode
- [x] Clicking again restores full 250px width
- [x] Smooth CSS transition between states
- [x] Hovering collapsed icons shows tooltip with page name
- [x] Section headers hidden when collapsed
- [x] Collapsed state persists after page reload (cookie)
- [x] Existing dashboard tests pass

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)