### PR TITLE
fix: add missing --actor option to agent feature accept

### DIFF
--- a/src/specify_cli/cli/commands/agent/feature.py
+++ b/src/specify_cli/cli/commands/agent/feature.py
@@ -1184,6 +1184,13 @@ def accept_feature(
             help="Skip strict metadata validation"
         )
     ] = False,
+    actor: Annotated[
+        Optional[str],
+        typer.Option(
+            "--actor",
+            help="Name to record as the acceptance actor (agent identity)"
+        )
+    ] = None,
     no_commit: Annotated[
         bool,
         typer.Option(
@@ -1218,7 +1225,7 @@ def accept_feature(
         top_level_accept(
             feature=feature,
             mode=mode,
-            actor=None,  # Agent commands don't use --actor
+            actor=actor,
             test=[],  # Agent commands don't use --test
             json_output=json_output,
             lenient=lenient,

--- a/tests/integration/test_agent_command_wrappers.py
+++ b/tests/integration/test_agent_command_wrappers.py
@@ -561,6 +561,7 @@ class TestAgentFeatureAccept:
         accept_feature(
             feature="001-test",
             mode="auto",
+            actor="antigravity",
             json_output=True,
             lenient=False,
             no_commit=False,
@@ -570,7 +571,7 @@ class TestAgentFeatureAccept:
         mock_accept.assert_called_once_with(
             feature="001-test",
             mode="auto",
-            actor=None,  # Agent doesn't use actor
+            actor="antigravity",
             test=[],  # Agent doesn't use test
             json_output=True,
             lenient=False,
@@ -591,6 +592,7 @@ class TestAgentFeatureAccept:
             accept_feature(
                 feature="001-test",
                 mode="auto",
+                actor=None,
                 json_output=False,
                 lenient=False,
                 no_commit=False,


### PR DESCRIPTION
## Summary
- Adds `--actor` CLI option to the `agent feature accept` command wrapper, which was previously hardcoded to `None`
- Passes the `--actor` value through to the top-level `accept` command so agents can identify themselves during acceptance workflows
- Updates integration tests to cover the new parameter

Closes #296

## Test plan
- [ ] Verify `spec-kitty agent feature accept --actor antigravity --json` no longer errors with "No such option"
- [ ] Run `pytest tests/integration/test_agent_command_wrappers.py::TestAgentFeatureAccept` to confirm updated tests pass
- [ ] Confirm `--actor` appears in `spec-kitty agent feature accept --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)