### PR TITLE
fix(dashboard): fixed sidebar during content scroll

### DIFF
--- a/src/specify_cli/dashboard/static/dashboard/dashboard.css
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.css
@@ -20,9 +20,10 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: var(--baby-blue);
     color: var(--dark-text);
-    min-height: 100vh;
+    height: 100vh;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 .header {
@@ -185,6 +186,7 @@ body {
 
 .sidebar {
     width: 250px;
+    flex-shrink: 0;
     background: var(--creamy-white);
     padding: 40px 0 20px;
     box-shadow: 2px 0 10px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- Sidebar now stays in place while main content scrolls
- Prevents losing navigation when viewing long pages (overview, kanban, spec, etc.)
- Two CSS changes: `body { height: 100vh; overflow: hidden }` and `sidebar { flex-shrink: 0 }`

## Test plan
- [x] Scroll long content — sidebar stays visible
- [x] Sidebar still collapses/expands (from #293)
- [x] All dashboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)