### PR TITLE
fix(dashboard): remove Dossier from dashboard UI

### DIFF
--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -279,8 +279,8 @@ function updateSidebarState() {
 
     document.querySelectorAll('.sidebar-item').forEach(item => {
         const page = item.dataset.page;
-        // System pages (constitution, diagnostics, dossier) should never be disabled
-        if (!page || page === 'constitution' || page === 'diagnostics' || page === 'dossier') {
+        // System pages (constitution, diagnostics) should never be disabled
+        if (!page || page === 'constitution' || page === 'diagnostics') {
             item.classList.remove('disabled');
             return;
         }
@@ -311,8 +311,6 @@ function loadCurrentPage() {
         loadChecklists();
     } else if (currentPage === 'research') {
         loadResearch();
-    } else if (currentPage === 'dossier') {
-        loadDossier();
     } else {
         loadArtifact(currentPage);
     }
@@ -356,10 +354,8 @@ return `
         {name: 'Data Model', key: 'data_model', icon: '💾'},
         {name: 'Contracts', key: 'contracts', icon: '📜'},
         {name: 'Checklists', key: 'checklists', icon: '✅'},
-        {name: 'Dossier', key: 'dossier', icon: '📦'},
     ].map(a => {
-        // Dossier is always available (system page)
-        const isAvailable = a.key === 'dossier' || artifacts[a.key]?.exists;
+        const isAvailable = artifacts[a.key]?.exists;
         return `
         <div style="padding: 10px; background: ${isAvailable ? '#ecfdf5' : '#fef2f2'};
              border-radius: 6px; border-left: 3px solid ${isAvailable ? '#10b981' : '#ef4444'};">
@@ -1300,30 +1296,6 @@ function showDiagnostics() {
     loadDiagnostics();
 }
 
-function loadDossier() {
-    if (!currentFeature) return;
-
-    // Initialize and render dossier panel
-    const container = document.getElementById('dossier-panel-container');
-    if (!container) {
-        console.error('Dossier panel container not found');
-        return;
-    }
-
-    // Create panel instance if it doesn't exist
-    if (!window.dossierPanel) {
-        window.dossierPanel = new DossierPanel('dossier-panel-container');
-    }
-
-    // Initialize with current feature
-    window.dossierPanel.init(currentFeature).catch(error => {
-        console.error('Error loading dossier:', error);
-        const container = document.getElementById('dossier-panel-container');
-        if (container) {
-            container.innerHTML = `<div class="dossier-error"><p>Error loading dossier: ${error.message}</p></div>`;
-        }
-    });
-}
 
 function loadDiagnostics() {
     // Show loading state

--- a/src/specify_cli/dashboard/templates/index.html
+++ b/src/specify_cli/dashboard/templates/index.html
@@ -89,12 +89,6 @@
             <div class="sidebar-item" data-page="diagnostics" onclick="switchPage('diagnostics')" title="Diagnostics">
                 🔍 <span class="sidebar-label">Diagnostics</span>
             </div>
-            <div class="sidebar-section-header" style="padding: 15px 30px; margin-top: 20px; font-size: 0.75em; color: #9ca3af; text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">
-                Dossier
-            </div>
-            <div class="sidebar-item" data-page="dossier" onclick="switchPage('dossier')" title="Dossier">
-                📦 <span class="sidebar-label">Dossier</span>
-            </div>
         </div>
 
         <div class="main-content">
@@ -219,23 +213,6 @@
                 </div>
             </div>
 
-            <div id="page-dossier" class="page">
-                <div class="content-card">
-                    <h2>📦 Dossier</h2>
-                    <div id="dossier-panel-container" class="dossier-panel-container">
-                        <div class="dossier-overview"></div>
-                        <div class="dossier-filters"></div>
-                        <div class="dossier-artifact-list"></div>
-                    </div>
-                    <div id="dossier-detail-modal" class="modal" style="display: none;">
-                        <div class="modal-overlay"></div>
-                        <div class="modal-content dossier-modal">
-                            <button class="modal-close">&times;</button>
-                            <div class="artifact-detail"></div>
-                        </div>
-                    </div>
-                </div>
-            </div>
 
             <div id="page-welcome" class="page">
                 <div class="content-card">
@@ -281,7 +258,6 @@
         </div>
     </div>
 
-    <script src="/static/js/dossier-panel.js"></script>
     <script src="/static/dashboard/dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Removes the Dossier section header and nav item from the sidebar
- Removes the Dossier page container, modal, and `dossier-panel.js` script tag
- Removes `loadDossier()` function and all dossier references from `dashboard.js`
- Backend API handler (`/api/dossier/*`) left intact

## Test plan
- [x] Dossier no longer appears in sidebar
- [x] No JS errors from missing dossier references
- [x] All dashboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)