### PR TITLE
Fix broken Claude Code guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 <p align="center">
     <a href="#-getting-started-complete-workflow">Quick Start</a> •
-    <a href="docs/claude-code-integration.md"><strong>Claude Code Guide</strong></a> •
+    <a href="docs/tutorials/claude-code-integration.md"><strong>Claude Code Guide</strong></a> •
     <a href="#-real-time-dashboard">Live Dashboard</a> •
     <a href="#-supported-ai-agents">12 AI Agents</a> •
     <a href="https://github.com/Priivacy-ai/spec-kitty/blob/main/spec-driven.md">Full Docs</a>


### PR DESCRIPTION
## Summary\n- fix the README shortcut link for the Claude Code guide\n- point it to the existing tutorial under docs/tutorials/claude-code-integration.md\n\nCloses #308