### PR TITLE
Backport broken Claude Code guide README fix to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 <p align="center">
     <a href="#-getting-started-complete-workflow">Quick Start</a> •
-    <a href="docs/claude-code-integration.md"><strong>Claude Code Guide</strong></a> •
+    <a href="docs/tutorials/claude-code-integration.md"><strong>Claude Code Guide</strong></a> •
     <a href="#-real-time-dashboard">Live Dashboard</a> •
     <a href="#-supported-ai-agents">12 AI Agents</a> •
     <a href="https://github.com/Priivacy-ai/spec-kitty/blob/main/spec-driven.md">Full Docs</a>


### PR DESCRIPTION
## Summary\n- backport the README Claude Code guide link fix from main\n- point the shortcut to docs/tutorials/claude-code-integration.md on 2.x\n\nBackport of #310 for branch parity.