### PR TITLE
[2.x] fix(dashboard): show feature numbers in switcher

### DIFF
--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -136,6 +136,20 @@ def format_path_for_display(path_str: Optional[str]) -> Optional[str]:
     return f"~{os.sep}{relative_str}"
 
 
+def format_feature_display_name(feature_id: str, friendly_name: str) -> str:
+    """Return a dashboard label that preserves the numeric feature prefix."""
+    label = friendly_name.strip() or feature_id
+    number_match = re.match(r"^(\d+)", feature_id)
+    if not number_match:
+        return label
+
+    feature_number = number_match.group(1)
+    if re.match(rf"^{re.escape(feature_number)}(?:\b|[-:_\s])", label):
+        return label
+
+    return f"{feature_number} - {label}"
+
+
 def work_package_sort_key(task: Dict[str, Any]) -> tuple:
     """Provide a natural sort key for work package identifiers."""
     work_id = str(task.get("id", "")).strip()
@@ -354,11 +368,13 @@ def scan_all_features(project_dir: Path) -> List[Dict[str, Any]]:
         worktree_root = project_dir / ".worktrees"
         worktree_path = worktree_root / feature_dir.name
         worktree_exists = worktree_path.exists()
+        display_name = format_feature_display_name(feature_id, friendly_name)
 
         features.append(
             {
                 "id": feature_id,
                 "name": friendly_name,
+                "display_name": display_name,
                 "path": str(feature_dir.relative_to(project_dir)),
                 "artifacts": artifacts,
                 "workflow": workflow,

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -1070,6 +1070,14 @@ function updateWorkflowIcons(workflow) {
     document.getElementById('icon-implement').textContent = iconMap[workflow.implement] || '⏳';
 }
 
+function getFeatureDisplayName(feature) {
+    if (!feature) {
+        return 'Unknown feature';
+    }
+
+    return feature.display_name || feature.name || feature.id || 'Unknown feature';
+}
+
 function updateFeatureList(features, activeFeatureId = null) {
     allFeatures = features;
     const selectContainer = document.getElementById('feature-selector-container');
@@ -1124,7 +1132,7 @@ function updateFeatureList(features, activeFeatureId = null) {
     if (features.length === 1) {
         selectContainer.style.display = 'none';
         singleFeatureName.style.display = 'block';
-        singleFeatureName.textContent = `Feature: ${features[0].name}`;
+        singleFeatureName.textContent = `Feature: ${getFeatureDisplayName(features[0])}`;
         currentFeature = activeFeatureId || features[0].id;
         setFeatureSelectActive(false);
     } else {
@@ -1142,7 +1150,7 @@ function updateFeatureList(features, activeFeatureId = null) {
         }
 
         select.innerHTML = features.map(f =>
-            `<option value="${f.id}" ${f.id === currentFeature ? 'selected' : ''}>${f.name}</option>`
+            `<option value="${f.id}" ${f.id === currentFeature ? 'selected' : ''}>${escapeHtml(getFeatureDisplayName(f))}</option>`
         ).join('');
         select.value = currentFeature;
     }

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from specify_cli.dashboard import scanner
@@ -32,6 +33,31 @@ def test_scan_all_features_detects_feature(tmp_path):
     assert features, "Expected at least one feature"
     assert features[0]["id"] == feature_dir.name
     assert features[0]["artifacts"]["spec"]
+
+
+def test_scan_all_features_builds_switcher_display_name(tmp_path):
+    feature_dir = _create_feature(tmp_path)
+    (feature_dir / "meta.json").write_text(
+        json.dumps({"friendly_name": "Demo Feature"}),
+        encoding="utf-8",
+    )
+
+    features = scanner.scan_all_features(tmp_path)
+
+    assert features[0]["name"] == "Demo Feature"
+    assert features[0]["display_name"] == "001 - Demo Feature"
+
+
+def test_scan_all_features_display_name_avoids_duplicate_prefix(tmp_path):
+    feature_dir = _create_feature(tmp_path)
+    (feature_dir / "meta.json").write_text(
+        json.dumps({"friendly_name": "001 - Demo Feature"}),
+        encoding="utf-8",
+    )
+
+    features = scanner.scan_all_features(tmp_path)
+
+    assert features[0]["display_name"] == "001 - Demo Feature"
 
 
 def test_scan_feature_kanban_returns_prompt(tmp_path):


### PR DESCRIPTION
Refs #297.

## Summary
- add a dedicated dashboard `display_name` that preserves the numeric feature prefix
- use that display label in the feature switcher and single-feature header without changing other feature labels
- add scanner regression tests for prefixed and already-prefixed friendly names

## Testing
- python3 -m pytest tests/test_dashboard/test_scanner.py
