### PR TITLE
fix: prevent wrong feature auto-selection when multiple features exist

### DIFF
--- a/src/specify_cli/acceptance.py
+++ b/src/specify_cli/acceptance.py
@@ -44,7 +44,6 @@ def detect_feature_slug(
     *,
     env: Optional[Mapping[str, str]] = None,
     cwd: Optional[Path] = None,
-    announce_fallback: bool = True,
 ) -> str:
     """Detect feature slug using centralized detection.
 
@@ -68,7 +67,6 @@ def detect_feature_slug(
             env=env,
             cwd=cwd,
             mode="strict",
-            announce_fallback=announce_fallback,
         )
     except FeatureDetectionError as e:
         raise AcceptanceError(str(e)) from e

--- a/src/specify_cli/cli/commands/accept.py
+++ b/src/specify_cli/cli/commands/accept.py
@@ -117,10 +117,7 @@ def accept(
     try:
         feature_slug = (
             feature
-            or detect_feature_slug(
-                repo_root,
-                announce_fallback=not json_output,
-            )
+            or detect_feature_slug(repo_root)
         ).strip()
     except AcceptanceError as exc:
         if json_output:

--- a/src/specify_cli/cli/commands/agent/context.py
+++ b/src/specify_cli/cli/commands/agent/context.py
@@ -55,8 +55,7 @@ def _find_feature_directory(repo_root: Path, cwd: Path, explicit_feature: str | 
             repo_root,
             explicit_feature=explicit_feature,
             cwd=cwd,
-            mode="strict",  # Raise error if ambiguous
-            allow_latest_incomplete_fallback=False,
+            mode="strict",
         )
     except FeatureDetectionError as e:
         # Convert to ValueError for backward compatibility

--- a/src/specify_cli/cli/commands/agent/feature.py
+++ b/src/specify_cli/cli/commands/agent/feature.py
@@ -250,8 +250,6 @@ def _find_feature_directory(
     repo_root: Path,
     cwd: Path,
     explicit_feature: str | None = None,
-    *,
-    allow_latest_incomplete_fallback: bool = True,
 ) -> Path:
     """Find the current feature directory using centralized detection.
 
@@ -276,7 +274,6 @@ def _find_feature_directory(
             explicit_feature=explicit_feature,
             cwd=cwd,
             mode="strict",
-            allow_latest_incomplete_fallback=allow_latest_incomplete_fallback,
         )
     except FeatureDetectionError as e:
         # Convert to ValueError for backward compatibility
@@ -700,7 +697,6 @@ def check_prerequisites(
                 repo_root,
                 cwd,
                 explicit_feature=feature,
-                allow_latest_incomplete_fallback=False,
             )
         except ValueError as detection_error:
             command_args: list[str] = []
@@ -806,15 +802,12 @@ def setup_plan(
         )
 
         # Determine feature directory using centralized detection.
-        # For planning bootstrap, disallow latest-incomplete fallback so the agent
-        # cannot silently bind to the wrong feature in fresh sessions.
         cwd = Path.cwd().resolve()
         try:
             feature_dir = _find_feature_directory(
                 repo_root,
                 cwd,
                 explicit_feature=feature,
-                allow_latest_incomplete_fallback=False,
             )
         except ValueError as detection_error:
             payload = _build_setup_plan_detection_error(repo_root, str(detection_error), feature)
@@ -1431,7 +1424,6 @@ def finalize_tasks(
                 repo_root,
                 cwd,
                 explicit_feature=feature,
-                allow_latest_incomplete_fallback=False,
             )
         except ValueError as detection_error:
             payload = _build_setup_plan_detection_error(

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -107,14 +107,11 @@ def _ensure_target_branch_checked_out(
     return main_repo_root, resolution.current
 
 
-def _find_feature_slug(explicit_feature: str | None = None, *, allow_latest_incomplete_fallback: bool = False) -> str:
+def _find_feature_slug(explicit_feature: str | None = None) -> str:
     """Find the current feature slug using centralized detection.
 
     Args:
         explicit_feature: Optional explicit feature slug from --feature flag
-        allow_latest_incomplete_fallback: Allow fallback to highest-numbered
-            incomplete feature. Default False — task commands should error
-            rather than silently pick the wrong feature.
 
     Returns:
         Feature slug (e.g., "008-unified-python-cli")
@@ -134,7 +131,6 @@ def _find_feature_slug(explicit_feature: str | None = None, *, allow_latest_inco
             explicit_feature=explicit_feature,
             cwd=cwd,
             mode="strict",
-            allow_latest_incomplete_fallback=allow_latest_incomplete_fallback,
         )
     except FeatureDetectionError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -117,14 +117,11 @@ def _ensure_target_branch_checked_out(repo_root: Path, feature_slug: str) -> tup
     return main_repo_root, resolution.current
 
 
-def _find_feature_slug(explicit_feature: str | None = None, *, allow_latest_incomplete_fallback: bool = False) -> str:
+def _find_feature_slug(explicit_feature: str | None = None) -> str:
     """Find the current feature slug using centralized detection.
 
     Args:
         explicit_feature: Optional explicit feature slug from --feature flag
-        allow_latest_incomplete_fallback: Allow fallback to highest-numbered
-            incomplete feature. Default False — workflow commands should error
-            rather than silently pick the wrong feature.
 
     Returns:
         Feature slug (e.g., "008-unified-python-cli")
@@ -145,7 +142,6 @@ def _find_feature_slug(explicit_feature: str | None = None, *, allow_latest_inco
             explicit_feature=explicit_feature,
             cwd=cwd,
             mode="strict",
-            allow_latest_incomplete_fallback=allow_latest_incomplete_fallback,
         )
     except FeatureDetectionError as e:
         print(f"Error: {e}")

--- a/src/specify_cli/core/feature_detection.py
+++ b/src/specify_cli/core/feature_detection.py
@@ -18,8 +18,7 @@ Priority order:
 3. Git branch name (strips -WP## suffix for worktree branches)
 4. Current directory path (walk up looking for ###-feature-name)
 5. Single feature auto-detect (only if exactly one feature exists)
-6. Fallback to latest incomplete feature (auto-selects if no explicit context)
-7. Error with clear guidance (if all features complete or ambiguous)
+6. Error with clear guidance (if multiple features or ambiguous)
 """
 
 import os
@@ -332,41 +331,6 @@ def is_feature_complete(feature_dir: Path) -> bool:
     return True
 
 
-def find_latest_incomplete_feature(repo_root: Path) -> Optional[str]:
-    """Find the highest numbered incomplete feature.
-
-    An incomplete feature is one where at least one WP has lane != 'done'.
-
-    Args:
-        repo_root: Repository root path
-
-    Returns:
-        Feature slug of the latest incomplete feature, or None if all complete
-    """
-    all_features = _list_all_features(repo_root)
-    if not all_features:
-        return None
-
-    main_repo_root = _get_main_repo_root(repo_root)
-    kitty_specs_dir = main_repo_root / "kitty-specs"
-    incomplete = []
-
-    for slug in all_features:
-        feature_dir = kitty_specs_dir / slug
-        if not is_feature_complete(feature_dir):
-            incomplete.append(slug)
-
-    if not incomplete:
-        return None
-
-    # Extract numbers and find highest
-    def extract_num(s: str) -> int:
-        m = re.match(r'^(\d{3})-', s)
-        return int(m.group(1)) if m else 0
-
-    return max(incomplete, key=extract_num)
-
-
 # ============================================================================
 # Core Detection Function
 # ============================================================================
@@ -380,8 +344,6 @@ def detect_feature(
     env: Mapping[str, str] | None = None,
     mode: Literal["strict", "lenient"] = "strict",
     allow_single_auto: bool = True,
-    announce_fallback: bool = True,
-    allow_latest_incomplete_fallback: bool = True,
 ) -> FeatureContext | None:
     """
     Unified feature detection with configurable behavior.
@@ -392,9 +354,7 @@ def detect_feature(
     3. Git branch name (strips -WP## suffix)
     4. Current directory path (walks up to find ###-feature-name)
     5. Single feature auto-detect (if allow_single_auto=True)
-    6. Fallback to latest incomplete feature (if allow_latest_incomplete_fallback=True
-       and explicit_feature is None)
-    7. Error (strict mode) or None (lenient mode)
+    6. Error (strict mode) or None (lenient mode)
 
     Args:
         repo_root: Repository root path
@@ -403,11 +363,6 @@ def detect_feature(
         env: Environment variables (defaults to os.environ)
         mode: "strict" raises error if ambiguous, "lenient" returns None
         allow_single_auto: Auto-detect if exactly one feature exists
-        announce_fallback: Emit console notice when fallback_latest_incomplete is selected
-        allow_latest_incomplete_fallback: Allow fallback to highest-numbered incomplete
-            feature when no other detection method succeeds. Default True for backward
-            compatibility; set False for commands where picking the wrong feature is
-            dangerous (e.g., implement, move-task).
 
     Returns:
         FeatureContext with detection details, or None in lenient mode
@@ -480,57 +435,39 @@ def detect_feature(
             detected_slug = all_features[0]
             detection_method = "single_auto"
         elif len(all_features) > 1:
-            # Priority 6: Fallback to latest incomplete feature
-            # Only activate if no explicit feature requested AND fallback is allowed
-            if explicit_feature is None and allow_latest_incomplete_fallback:
-                latest = find_latest_incomplete_feature(repo_root)
-                if latest:
-                    # Import console only if needed (avoid circular imports at module level)
-                    if announce_fallback:
-                        try:
-                            from rich.console import Console
-                            console = Console()
-                            console.print(f"[yellow]ℹ️  Auto-selected latest incomplete: {latest}[/yellow]")
-                        except ImportError:
-                            pass  # Silently skip if rich not available
+            # Multiple features: error (no auto-selection)
+            # Check if all features are complete
+            main_repo_root = _get_main_repo_root(repo_root)
+            kitty_specs_dir = main_repo_root / "kitty-specs"
+            all_complete = all(
+                is_feature_complete(kitty_specs_dir / slug)
+                for slug in all_features
+            )
 
-                    detected_slug = latest
-                    detection_method = "fallback_latest_incomplete"
-
-            # Priority 7: Error (no fallback available or all features complete)
-            if not detected_slug:
-                # Check if all features are complete
-                main_repo_root = _get_main_repo_root(repo_root)
-                kitty_specs_dir = main_repo_root / "kitty-specs"
-                all_complete = all(
-                    is_feature_complete(kitty_specs_dir / slug)
-                    for slug in all_features
+            if all_complete:
+                error_msg = (
+                    f"All features are complete ({len(all_features)} features).\n\n"
+                    + "Please specify explicitly using:\n"
+                    + "  --feature <feature-slug>  (e.g., --feature 020-my-feature)\n"
+                    + "  SPECIFY_FEATURE=<feature-slug>  (environment variable)\n"
+                    + "  Or create a new feature using:\n"
+                    + "  spec-kitty specify\n"
+                    + "  /spec-kitty.specify  (in agent workflow)"
+                )
+            else:
+                error_msg = (
+                    f"Multiple features found ({len(all_features)}), cannot auto-detect:\n"
+                    + "\n".join(f"  - {f}" for f in all_features[:10])
+                    + ("\n  ... and more" if len(all_features) > 10 else "")
+                    + "\n\nPlease specify explicitly using:\n"
+                    + "  --feature <feature-slug>  (e.g., --feature 020-my-feature)\n"
+                    + "  SPECIFY_FEATURE=<feature-slug>  (environment variable)\n"
+                    + "  Or run from inside a feature directory or worktree"
                 )
 
-                if all_complete:
-                    error_msg = (
-                        f"All features are complete ({len(all_features)} features).\n\n"
-                        + "Please specify explicitly using:\n"
-                        + "  --feature <feature-slug>  (e.g., --feature 020-my-feature)\n"
-                        + "  SPECIFY_FEATURE=<feature-slug>  (environment variable)\n"
-                        + "  Or create a new feature using:\n"
-                        + "  spec-kitty specify\n"
-                        + "  /spec-kitty.specify  (in agent workflow)"
-                    )
-                else:
-                    error_msg = (
-                        f"Multiple features found ({len(all_features)}), cannot auto-detect:\n"
-                        + "\n".join(f"  - {f}" for f in all_features[:10])
-                        + ("\n  ... and more" if len(all_features) > 10 else "")
-                        + "\n\nPlease specify explicitly using:\n"
-                        + "  --feature <feature-slug>  (e.g., --feature 020-my-feature)\n"
-                        + "  SPECIFY_FEATURE=<feature-slug>  (environment variable)\n"
-                        + "  Or run from inside a feature directory or worktree"
-                    )
-
-                if mode == "strict":
-                    raise MultipleFeaturesError(all_features, error_msg)
-                return None
+            if mode == "strict":
+                raise MultipleFeaturesError(all_features, error_msg)
+            return None
         else:
             # No features found
             error_msg = (

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -286,7 +286,6 @@ def resolve_active_feature(
         project_dir,
         cwd=project_dir,
         mode="lenient",
-        announce_fallback=False,
     )
     if context:
         for feature in features:

--- a/tests/specify_cli/core/test_feature_detection.py
+++ b/tests/specify_cli/core/test_feature_detection.py
@@ -705,141 +705,9 @@ def test_is_feature_complete_parse_error(tmp_path: Path):
     assert is_feature_complete(feature_dir) is False
 
 
-def test_find_latest_incomplete_multiple(tmp_path: Path):
-    """Test find_latest_incomplete_feature with multiple incomplete features."""
-    from specify_cli.core.feature_detection import find_latest_incomplete_feature
-
+def test_detect_multiple_features_raises_when_incomplete_exist(tmp_path: Path):
+    """Test that multiple features (even with incomplete ones) raises MultipleFeaturesError."""
     # Create repo with multiple features
-    repo_root = tmp_path / "repo"
-    kitty_specs = repo_root / "kitty-specs"
-    kitty_specs.mkdir(parents=True)
-
-    # Feature 001 - complete
-    feature_001 = kitty_specs / "001-feature-a"
-    tasks_001 = feature_001 / "tasks"
-    tasks_001.mkdir(parents=True)
-    (tasks_001 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: done\n---\n"
-    )
-
-    # Feature 002 - incomplete
-    feature_002 = kitty_specs / "002-feature-b"
-    tasks_002 = feature_002 / "tasks"
-    tasks_002.mkdir(parents=True)
-    (tasks_002 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: doing\n---\n"
-    )
-
-    # Feature 003 - incomplete (should be selected as latest)
-    feature_003 = kitty_specs / "003-feature-c"
-    tasks_003 = feature_003 / "tasks"
-    tasks_003.mkdir(parents=True)
-    (tasks_003 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: planned\n---\n"
-    )
-
-    latest = find_latest_incomplete_feature(repo_root)
-    assert latest == "003-feature-c"
-
-
-def test_find_latest_incomplete_all_complete(tmp_path: Path):
-    """Test find_latest_incomplete_feature when all features are complete."""
-    from specify_cli.core.feature_detection import find_latest_incomplete_feature
-
-    repo_root = tmp_path / "repo"
-    kitty_specs = repo_root / "kitty-specs"
-    kitty_specs.mkdir(parents=True)
-
-    # Both features complete
-    for slug in ["001-feature-a", "002-feature-b"]:
-        feature_dir = kitty_specs / slug
-        tasks_dir = feature_dir / "tasks"
-        tasks_dir.mkdir(parents=True)
-        (tasks_dir / "WP01.md").write_text(
-            "---\nwork_package_id: WP01\ntitle: Test\nlane: done\n---\n"
-        )
-
-    latest = find_latest_incomplete_feature(repo_root)
-    assert latest is None
-
-
-def test_find_latest_incomplete_no_features(tmp_path: Path):
-    """Test find_latest_incomplete_feature when no features exist."""
-    from specify_cli.core.feature_detection import find_latest_incomplete_feature
-
-    repo_root = tmp_path / "repo"
-    kitty_specs = repo_root / "kitty-specs"
-    kitty_specs.mkdir(parents=True)
-
-    latest = find_latest_incomplete_feature(repo_root)
-    assert latest is None
-
-
-def test_detect_fallback_to_latest_incomplete(tmp_path: Path):
-    """Test Priority 6: fallback to latest incomplete feature."""
-    # Create repo with multiple features
-    repo_root = tmp_path / "repo"
-    kitty_specs = repo_root / "kitty-specs"
-    kitty_specs.mkdir(parents=True)
-
-    # Feature 020 - complete
-    feature_020 = kitty_specs / "020-feature-a"
-    tasks_020 = feature_020 / "tasks"
-    tasks_020.mkdir(parents=True)
-    (tasks_020 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: done\n---\n"
-    )
-
-    # Feature 025 - incomplete (should be auto-selected)
-    feature_025 = kitty_specs / "025-feature-b"
-    tasks_025 = feature_025 / "tasks"
-    tasks_025.mkdir(parents=True)
-    (tasks_025 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: doing\n---\n"
-    )
-
-    # Mock git to fail (force fallback)
-    with patch("subprocess.run") as mock_run:
-        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
-
-        ctx = detect_feature(repo_root, cwd=repo_root, mode="strict")
-
-        assert ctx is not None
-        assert ctx.slug == "025-feature-b"
-        assert ctx.detection_method == "fallback_latest_incomplete"
-
-
-def test_detect_fallback_respects_explicit_feature(tmp_path: Path):
-    """Test fallback does NOT activate when explicit feature is provided."""
-    repo_root = tmp_path / "repo"
-    kitty_specs = repo_root / "kitty-specs"
-    kitty_specs.mkdir(parents=True)
-
-    # Create complete and incomplete features
-    feature_020 = kitty_specs / "020-complete"
-    tasks_020 = feature_020 / "tasks"
-    tasks_020.mkdir(parents=True)
-    (tasks_020 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: done\n---\n"
-    )
-
-    feature_025 = kitty_specs / "025-incomplete"
-    tasks_025 = feature_025 / "tasks"
-    tasks_025.mkdir(parents=True)
-    (tasks_025 / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\ntitle: Test\nlane: doing\n---\n"
-    )
-
-    # Explicit feature should win (Priority 1), not fallback (Priority 6)
-    ctx = detect_feature(repo_root, explicit_feature="020-complete")
-
-    assert ctx.slug == "020-complete"
-    assert ctx.detection_method == "explicit"
-
-
-def test_detect_fallback_disabled_by_allow_latest_incomplete_fallback(tmp_path: Path):
-    """Test that allow_latest_incomplete_fallback=False suppresses Priority 6 fallback."""
-    # Same setup as test_detect_fallback_to_latest_incomplete
     repo_root = tmp_path / "repo"
     kitty_specs = repo_root / "kitty-specs"
     kitty_specs.mkdir(parents=True)
@@ -860,23 +728,44 @@ def test_detect_fallback_disabled_by_allow_latest_incomplete_fallback(tmp_path: 
         "---\nwork_package_id: WP01\ntitle: Test\nlane: doing\n---\n"
     )
 
-    # Mock git to fail (force past priorities 3-4)
+    # Mock git to fail (force auto-detect path)
     with patch("subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")
 
-        # With fallback disabled, should raise MultipleFeaturesError instead of
-        # silently picking 025-feature-b
         with pytest.raises(MultipleFeaturesError) as exc_info:
-            detect_feature(
-                repo_root,
-                cwd=repo_root,
-                mode="strict",
-                allow_latest_incomplete_fallback=False,
-            )
+            detect_feature(repo_root, cwd=repo_root, mode="strict")
 
         error_msg = str(exc_info.value)
         assert "Multiple features found" in error_msg
         assert "--feature" in error_msg
+
+
+def test_detect_explicit_feature_wins_over_multiple(tmp_path: Path):
+    """Test explicit feature wins when multiple features exist."""
+    repo_root = tmp_path / "repo"
+    kitty_specs = repo_root / "kitty-specs"
+    kitty_specs.mkdir(parents=True)
+
+    # Create complete and incomplete features
+    feature_020 = kitty_specs / "020-complete"
+    tasks_020 = feature_020 / "tasks"
+    tasks_020.mkdir(parents=True)
+    (tasks_020 / "WP01.md").write_text(
+        "---\nwork_package_id: WP01\ntitle: Test\nlane: done\n---\n"
+    )
+
+    feature_025 = kitty_specs / "025-incomplete"
+    tasks_025 = feature_025 / "tasks"
+    tasks_025.mkdir(parents=True)
+    (tasks_025 / "WP01.md").write_text(
+        "---\nwork_package_id: WP01\ntitle: Test\nlane: doing\n---\n"
+    )
+
+    # Explicit feature should win (Priority 1)
+    ctx = detect_feature(repo_root, explicit_feature="020-complete")
+
+    assert ctx.slug == "020-complete"
+    assert ctx.detection_method == "explicit"
 
 
 def test_detect_fallback_error_when_all_complete(tmp_path: Path):
@@ -906,8 +795,8 @@ def test_detect_fallback_error_when_all_complete(tmp_path: Path):
         assert "spec-kitty specify" in error_msg
 
 
-def test_detect_fallback_respects_priority_order(tmp_path: Path):
-    """Test fallback (Priority 6) is lower than cwd detection (Priority 4)."""
+def test_detect_cwd_wins_over_error_with_multiple_features(tmp_path: Path):
+    """Test cwd detection (Priority 4) wins when multiple features exist."""
     repo_root = tmp_path / "repo"
     kitty_specs = repo_root / "kitty-specs"
     kitty_specs.mkdir(parents=True)

--- a/tests/specify_cli/test_cli/test_agent_feature.py
+++ b/tests/specify_cli/test_cli/test_agent_feature.py
@@ -418,7 +418,6 @@ class TestFinalizeTasksCommand:
         assert args[0] == tmp_path
         assert isinstance(args[1], Path)
         assert kwargs["explicit_feature"] == "001-test"
-        assert kwargs["allow_latest_incomplete_fallback"] is False
 
     @patch("specify_cli.cli.commands.agent.feature.locate_project_root")
     @patch("specify_cli.cli.commands.agent.feature._find_feature_directory")
@@ -792,27 +791,25 @@ class TestFindFeatureDirectory:
         assert result == kitty_specs / "001-test-feature"
 
     @patch("specify_cli.cli.commands.agent.feature.is_worktree_context")
-    def test_finds_latest_feature_in_main_repo(
+    def test_raises_error_with_multiple_features_in_main_repo(
         self, mock_is_worktree: Mock, tmp_path: Path
     ):
-        """Should find highest numbered feature in main repo."""
+        """Should raise error when multiple features exist (no auto-selection)."""
         # Setup
         from specify_cli.cli.commands.agent.feature import _find_feature_directory
 
         mock_is_worktree.return_value = False
 
-        # Create main repo structure
+        # Create main repo structure with multiple features
         kitty_specs = tmp_path / "kitty-specs"
         kitty_specs.mkdir()
         (kitty_specs / "001-feature").mkdir()
         (kitty_specs / "003-feature").mkdir()
         (kitty_specs / "002-feature").mkdir()
 
-        # Execute
-        result = _find_feature_directory(tmp_path, tmp_path)
-
-        # Verify
-        assert result == kitty_specs / "003-feature"
+        # Execute & Verify - should raise because multiple features and no context
+        with pytest.raises(ValueError, match="Multiple features found"):
+            _find_feature_directory(tmp_path, tmp_path)
 
     @patch("specify_cli.cli.commands.agent.feature.is_worktree_context")
     def test_raises_error_when_no_features_in_main_repo(

--- a/tests/specify_cli/test_cli/test_commands.py
+++ b/tests/specify_cli/test_cli/test_commands.py
@@ -172,7 +172,7 @@ def test_accept_checklist_json_output(monkeypatch, tmp_path: Path) -> None:
     assert data["feature"] == "001-demo-feature"
 
 
-def test_accept_json_suppresses_fallback_announcement(monkeypatch, tmp_path: Path) -> None:
+def test_accept_json_auto_detect_feature(monkeypatch, tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
 
@@ -188,16 +188,8 @@ def test_accept_json_suppresses_fallback_announcement(monkeypatch, tmp_path: Pat
         def to_dict(self) -> dict[str, object]:
             return {"feature": self.feature, "lanes": self.lanes}
 
-    captured: dict[str, object] = {}
-
-    def fake_detect(_repo_root, *, announce_fallback=True):
-        captured["announce_fallback"] = announce_fallback
-        if announce_fallback:
-            print("ℹ️  Auto-selected latest incomplete: 002-auto-feature")
-        return "002-auto-feature"
-
     monkeypatch.setattr(accept_module, "find_repo_root", lambda: repo_root)
-    monkeypatch.setattr(accept_module, "detect_feature_slug", fake_detect)
+    monkeypatch.setattr(accept_module, "detect_feature_slug", lambda _repo_root: "002-auto-feature")
     monkeypatch.setattr(accept_module, "choose_mode", lambda mode, _repo_root: mode)
     monkeypatch.setattr(accept_module, "collect_feature_summary", lambda *args, **kwargs: DummySummary())
 
@@ -207,7 +199,6 @@ def test_accept_json_suppresses_fallback_announcement(monkeypatch, tmp_path: Pat
     )
 
     assert result.exit_code == 0
-    assert captured["announce_fallback"] is False
     assert result.stdout.lstrip().startswith("{")
     data = json.loads(result.stdout)
     assert data["feature"] == "002-auto-feature"

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -82,7 +82,7 @@ def test_resolve_active_feature_uses_core_detector(tmp_path, monkeypatch):
             number="010",
             name="new-feature",
             directory=tmp_path / "kitty-specs" / "010-new-feature",
-            detection_method="fallback_latest_incomplete",
+            detection_method="single_auto",
         )
 
     monkeypatch.setattr(scanner, "detect_feature", _fake_detect_feature)


### PR DESCRIPTION
## Summary

Fixes #295 — removes the dangerous "Priority 6" fallback that silently picked the highest-numbered incomplete feature from the entire monorepo when no feature context could be detected.

**What was removed:**
- `find_latest_incomplete_feature()` function — deleted entirely
- `allow_latest_incomplete_fallback` parameter — removed from `detect_feature()` and all callers
- `announce_fallback` parameter — removed from `detect_feature()` and all callers
- The entire Priority 6 fallback code path — when multiple features exist and no context resolves which one, the CLI now **always** errors with `--feature` guidance

**Files changed (12):**
- `feature_detection.py` — core: deleted function + fallback block
- `workflow.py`, `tasks.py`, `context.py`, `feature.py` — agent commands: cleaned up removed parameters
- `acceptance.py`, `accept.py` — acceptance flow: removed `announce_fallback`
- `scanner.py` — dashboard: removed `announce_fallback`
- 4 test files — updated to expect errors instead of silent wrong-feature selection

## Root Cause

`detect_feature()` had a "Priority 6" fallback that scanned ALL features in `kitty-specs/` and returned the highest-numbered incomplete one. This was fundamentally a guess, and guesses that silently modify work packages are dangerous. The fallback fired whenever no `--feature` flag, env var, git branch, or cwd context could identify the feature — common when running from the repo root on `main`.

## Test plan

- [x] 92 tests pass on main (feature detection + agent feature + dashboard + commands)
- [x] Zero references to removed code remain in src/ and tests/
- [ ] Manual: `spec-kitty agent workflow implement WP01` from repo root with multiple features → errors with `--feature` guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)