### PR TITLE
Prepare 2.0.10 release and harden upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [2.0.10] - 2026-03-20
+
+### ✅ Added
+
+- **Project-level `auto_commit` setting (`#321`)**: repos can now configure automatic commit behavior directly in project config.
+- **Sync queue resilience and diagnostics (`#320`)**: offline queue now supports FIFO eviction, coalescing, configurable caps, and sync doctor coverage for failure recovery.
+
+### 🐛 Fixed
+
+- **Merge target resolution (`#272`)**: merge target branch is now resolved from feature `meta.json`, preventing merges from targeting the wrong branch.
+- **Acceptance and state persistence hardening (`#319`)**: state writes are now centralized around canonical metadata/state handling to reduce drift across acceptance, mission, and status flows.
+- **Feature context fallback restored**: ambiguous agent/task resolution now falls back to the latest incomplete feature instead of stopping on a stale explicit-selection error.
+- **Upgrade downgrade protection**: `spec-kitty upgrade` now refuses older targets instead of silently rewriting project metadata backwards.
+- **Migration discovery fail-fast**: broken `m_*.py` modules now fail discovery immediately instead of being skipped with a stderr warning.
+- **Upgrade metadata durability**: successful and failed migration records are now persisted immediately so retries can resume from an accurate state after mid-run failures.
+- **Safe auto-commit stash isolation**: `safe_commit()` now restores only the stash entry it created, preventing unrelated user stashes from being popped during upgrade/status auto-commits.
+- **Embedded task script compatibility**: copied `.kittify/scripts/tasks` helpers now fall back cleanly when the host `specify_cli` install is older than the copied templates.
+
+### 🔧 Changed
+
+- **State architecture cleanup phase 2 (`#319`)**: consolidated atomic-write and state-contract handling across runtime, acceptance, and feature metadata paths.
+- **Test and quality isolation follow-ups**: retained the refactors that separated policy/test churn from release-critical behavior on the 2.x line.
+
 ## [2.0.9] - 2026-03-15
 
 ### ✅ Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "2.0.9"
+version = "2.0.10"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scripts/tasks/acceptance_support.py
+++ b/scripts/tasks/acceptance_support.py
@@ -7,6 +7,7 @@ the public API for backwards compatibility with standalone scripts.
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -26,19 +27,31 @@ for _ in range(6):
             sys.path.insert(0, str(_src))
         break
 
-from specify_cli.acceptance import (  # noqa: E402
-    AcceptanceError,
-    AcceptanceMode,
-    AcceptanceResult,
-    AcceptanceSummary,
-    ArtifactEncodingError,
-    WorkPackageState,
-    choose_mode,
-    collect_feature_summary,
-    detect_feature_slug,
-    normalize_feature_encoding,
-    perform_acceptance,
+_EXPORT_NAMES = (
+    "AcceptanceError",
+    "AcceptanceMode",
+    "AcceptanceResult",
+    "AcceptanceSummary",
+    "ArtifactEncodingError",
+    "WorkPackageState",
+    "choose_mode",
+    "collect_feature_summary",
+    "detect_feature_slug",
+    "normalize_feature_encoding",
+    "perform_acceptance",
 )
+
+
+def _load_acceptance_api():
+    core = importlib.import_module("specify_cli.acceptance")
+    if all(hasattr(core, name) for name in _EXPORT_NAMES):
+        return {name: getattr(core, name) for name in _EXPORT_NAMES}
+
+    legacy = importlib.import_module("specify_cli.scripts.tasks.acceptance_support")
+    return {name: getattr(legacy, name) for name in _EXPORT_NAMES}
+
+
+globals().update(_load_acceptance_api())
 
 # Re-export task_helpers utilities that callers historically accessed
 # through this module (e.g. acc.run_git in tests).

--- a/scripts/tasks/tasks_cli.py
+++ b/scripts/tasks/tasks_cli.py
@@ -673,18 +673,23 @@ def merge_command(args: argparse.Namespace) -> None:
         run_git(["rev-parse", "--show-toplevel"], cwd=Path.cwd()).stdout.strip()
     )
     repo_root = local_root
-    feature = _resolve_feature(find_repo_root(), args.feature)
+    current_branch = run_git(
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        check=True,
+    ).stdout.strip()
+
+    if args.feature:
+        feature = args.feature
+    elif current_branch and current_branch != "HEAD":
+        feature = current_branch
+    else:
+        feature = detect_feature_slug(find_repo_root(), cwd=repo_root)
 
     # Resolve target branch dynamically if not specified
     if args.target is None:
         from specify_cli.core.git_ops import resolve_primary_branch
         args.target = resolve_primary_branch(repo_root)
-
-    current_branch = run_git([
-        "rev-parse",
-        "--abbrev-ref",
-        "HEAD",
-    ], cwd=repo_root, check=True).stdout.strip()
 
     if current_branch == args.target:
         raise TaskCliError(

--- a/src/specify_cli/acceptance.py
+++ b/src/specify_cli/acceptance.py
@@ -22,7 +22,6 @@ from .tasks_support import (
     run_git,
     split_frontmatter,
 )
-from specify_cli.status.reducer import materialize
 from specify_cli.status.store import EVENTS_FILENAME, StoreError
 from specify_cli.feature_metadata import load_meta, record_acceptance, write_meta
 from specify_cli.mission import MissionError, get_mission_for_feature
@@ -434,7 +433,8 @@ def collect_feature_summary(
     except TaskCliError:
         primary_repo_root = repo_root
 
-    # Capture git cleanliness BEFORE materialize() writes status.json
+    # Capture git cleanliness before any status inspection. Query paths must
+    # not rewrite derived files like status.json.
     try:
         git_dirty = git_status_lines(repo_root)
     except TaskCliError:
@@ -447,7 +447,7 @@ def collect_feature_summary(
 
     use_legacy = is_legacy_format(feature_dir)
 
-    # ── Canonical state validation via materialize() ──────────────────────
+    # ── Canonical state validation via reducer-only snapshot ──────────────
     events_path = feature_dir / EVENTS_FILENAME
     if not events_path.exists():
         activity_issues.append(
@@ -458,7 +458,10 @@ def collect_feature_summary(
         snapshot_wps: Dict[str, dict] = {}
     else:
         try:
-            snapshot = materialize(feature_dir)
+            from specify_cli.status.reducer import reduce
+            from specify_cli.status.store import read_events
+
+            snapshot = reduce(read_events(feature_dir))
         except StoreError as exc:
             raise AcceptanceError(f"Status event log is corrupted for feature '{feature}': {exc}") from exc
         snapshot_wps = snapshot.work_packages

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -164,7 +164,7 @@ def upgrade(  # noqa: C901
     # Import upgrade system (lazy to avoid circular imports)
     from specify_cli.upgrade.detector import VersionDetector
     from specify_cli.upgrade.registry import MigrationRegistry
-    from specify_cli.upgrade.runner import MigrationRunner
+    from specify_cli.upgrade.runner import MigrationRunner, validate_upgrade_target
 
     # Import migrations to register them
     from specify_cli.upgrade import migrations  # noqa: F401
@@ -180,6 +180,27 @@ def upgrade(  # noqa: C901
         target_version = __version__
     else:
         target_version = target
+
+    validation_error = validate_upgrade_target(current_version, target_version)
+    if validation_error:
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "status": "failed",
+                        "current_version": current_version,
+                        "target_version": target_version,
+                        "success": False,
+                        "errors": [validation_error],
+                        "warnings": [],
+                        "auto_committed": False,
+                        "auto_commit_paths": [],
+                    }
+                )
+            )
+        else:
+            console.print(f"[red]Error:[/red] {validation_error}")
+        raise typer.Exit(1)
 
     if not json_output:
         console.print(f"[cyan]Current version:[/cyan] {current_version}")

--- a/src/specify_cli/core/feature_detection.py
+++ b/src/specify_cli/core/feature_detection.py
@@ -244,7 +244,7 @@ def _detect_from_cwd(cwd: Path, repo_root: Path) -> Optional[str]:
     # Walk up directory tree
     for parent in [cwd, *cwd.parents]:
         # Stop at repo root
-        if parent == repo_root or parent.parent == repo_root:
+        if parent == repo_root:
             break
 
         # Check for .worktrees/###-feature-name pattern
@@ -444,15 +444,13 @@ def detect_feature(
             detected_slug = all_features[0]
             detection_method = "single_auto"
         elif len(all_features) > 1:
-            # Multiple features: require explicit selection
             main_repo_root = _get_main_repo_root(repo_root)
             kitty_specs_dir = main_repo_root / "kitty-specs"
-            all_complete = all(
-                is_feature_complete(kitty_specs_dir / slug)
-                for slug in all_features
-            )
+            incomplete_features = [
+                slug for slug in all_features if not is_feature_complete(kitty_specs_dir / slug)
+            ]
 
-            if all_complete:
+            if not incomplete_features:
                 error_msg = (
                     f"All features are complete ({len(all_features)} features).\n\n"
                     + "Please specify explicitly using:\n"
@@ -462,20 +460,12 @@ def detect_feature(
                     + "  spec-kitty specify\n"
                     + "  /spec-kitty.specify  (in agent workflow)"
                 )
+                if mode == "strict":
+                    raise MultipleFeaturesError(all_features, error_msg)
+                return None
             else:
-                error_msg = (
-                    f"Multiple features found ({len(all_features)}), cannot auto-detect:\n"
-                    + "\n".join(f"  - {f}" for f in all_features[:10])
-                    + ("\n  ... and more" if len(all_features) > 10 else "")
-                    + "\n\nPlease specify explicitly using:\n"
-                    + "  --feature <feature-slug>  (e.g., --feature 020-my-feature)\n"
-                    + "  SPECIFY_FEATURE=<feature-slug>  (environment variable)\n"
-                    + "  Or run from inside a feature directory or worktree"
-                )
-
-            if mode == "strict":
-                raise MultipleFeaturesError(all_features, error_msg)
-            return None
+                detected_slug = incomplete_features[-1]
+                detection_method = "latest_incomplete"
         else:
             # No features found
             error_msg = (

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -7,7 +7,32 @@ capturing unrelated staged changes.
 from __future__ import annotations
 
 import subprocess
+import uuid
 from pathlib import Path
+
+
+def _find_stash_ref(repo_path: Path, stash_message: str) -> str | None:
+    """Return the stash ref for a unique stash message, if present."""
+    result = subprocess.run(
+        ["git", "stash", "list", "--format=%gd\t%s"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        if "\t" not in line:
+            continue
+        ref, message = line.split("\t", 1)
+        if message == stash_message or message.endswith(f": {stash_message}"):
+            return ref
+
+    return None
 
 
 def safe_commit(
@@ -58,9 +83,11 @@ def safe_commit(
                 pass
         normalized_files.append(str(file))
 
+    stash_message = f"spec-kitty-safe-commit:{uuid.uuid4()}"
+
     # Save current staging area (only staged changes, not working tree)
     stash_result = subprocess.run(
-        ["git", "stash", "push", "--staged", "--quiet"],
+        ["git", "stash", "push", "--staged", "--quiet", "-m", stash_message],
         cwd=repo_path,
         capture_output=True,
         text=True,
@@ -69,8 +96,10 @@ def safe_commit(
         check=False,
     )
 
-    # Track if we stashed anything (needed for cleanup)
-    stashed_something = stash_result.returncode == 0
+    # Track whether we created a stash entry so we only restore our own stash.
+    created_stash = stash_result.returncode == 0 and _find_stash_ref(repo_path, stash_message) is not None
+    restore_failed = False
+    commit_success = False
 
     try:
         # Stage only the intended files
@@ -88,35 +117,12 @@ def safe_commit(
             )
             if add_result.returncode != 0:
                 # Failed to stage file
-                return False
-
-        # Commit the staged files
-        commit_result = subprocess.run(
-            ["git", "commit", "-m", commit_message],
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-        )
-
-        # Check for success
-        if commit_result.returncode == 0:
-            return True
-
-        # Check if it was "nothing to commit" scenario
-        if "nothing to commit" in commit_result.stdout or "nothing to commit" in commit_result.stderr:
-            return allow_empty
-
-        # Other error occurred
-        return False
-
-    finally:
-        # Restore original staging area if we stashed anything
-        if stashed_something:
-            subprocess.run(
-                ["git", "stash", "pop", "--index", "--quiet"],
+                commit_success = False
+                break
+        else:
+            # Commit the staged files
+            commit_result = subprocess.run(
+                ["git", "commit", "-m", commit_message],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
@@ -124,3 +130,37 @@ def safe_commit(
                 errors="replace",
                 check=False,
             )
+
+            # Check for success
+            if commit_result.returncode == 0:
+                commit_success = True
+            # Check if it was "nothing to commit" scenario
+            elif "nothing to commit" in commit_result.stdout or "nothing to commit" in commit_result.stderr:
+                commit_success = allow_empty
+            else:
+                # Other error occurred
+                commit_success = False
+
+    finally:
+        # Restore original staging area if we created a stash entry.
+        if created_stash:
+            stash_ref = _find_stash_ref(repo_path, stash_message)
+            if stash_ref is None:
+                restore_failed = True
+            else:
+                restore_result = subprocess.run(
+                    ["git", "stash", "pop", "--index", "--quiet", stash_ref],
+                    cwd=repo_path,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=False,
+                )
+                if restore_result.returncode != 0:
+                    restore_failed = True
+
+        if restore_failed:
+            commit_success = False
+
+    return commit_success

--- a/src/specify_cli/scripts/tasks/acceptance_support.py
+++ b/src/specify_cli/scripts/tasks/acceptance_support.py
@@ -6,6 +6,7 @@ the public API for backwards compatibility with standalone scripts.
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -25,19 +26,31 @@ for _ in range(6):
             sys.path.insert(0, str(_src))
         break
 
-from specify_cli.acceptance import (  # noqa: E402
-    AcceptanceError,
-    AcceptanceMode,
-    AcceptanceResult,
-    AcceptanceSummary,
-    ArtifactEncodingError,
-    WorkPackageState,
-    choose_mode,
-    collect_feature_summary,
-    detect_feature_slug,
-    normalize_feature_encoding,
-    perform_acceptance,
+_EXPORT_NAMES = (
+    "AcceptanceError",
+    "AcceptanceMode",
+    "AcceptanceResult",
+    "AcceptanceSummary",
+    "ArtifactEncodingError",
+    "WorkPackageState",
+    "choose_mode",
+    "collect_feature_summary",
+    "detect_feature_slug",
+    "normalize_feature_encoding",
+    "perform_acceptance",
 )
+
+
+def _load_acceptance_api():
+    core = importlib.import_module("specify_cli.acceptance")
+    if all(hasattr(core, name) for name in _EXPORT_NAMES):
+        return {name: getattr(core, name) for name in _EXPORT_NAMES}
+
+    legacy = importlib.import_module("specify_cli.scripts.tasks.acceptance_support")
+    return {name: getattr(legacy, name) for name in _EXPORT_NAMES}
+
+
+globals().update(_load_acceptance_api())
 
 __all__ = [
     "AcceptanceError",

--- a/src/specify_cli/scripts/tasks/tasks_cli.py
+++ b/src/specify_cli/scripts/tasks/tasks_cli.py
@@ -590,18 +590,23 @@ def merge_command(args: argparse.Namespace) -> None:
         run_git(["rev-parse", "--show-toplevel"], cwd=Path.cwd()).stdout.strip()
     )
     repo_root = local_root
-    feature = _resolve_feature(find_repo_root(), args.feature)
+    current_branch = run_git(
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        check=True,
+    ).stdout.strip()
+
+    if args.feature:
+        feature = args.feature
+    elif current_branch and current_branch != "HEAD":
+        feature = current_branch
+    else:
+        feature = detect_feature_slug(find_repo_root(), cwd=repo_root)
 
     # Resolve target branch dynamically if not specified
     if args.target is None:
         from specify_cli.core.git_ops import resolve_primary_branch
         args.target = resolve_primary_branch(repo_root)
-
-    current_branch = run_git([
-        "rev-parse",
-        "--abbrev-ref",
-        "HEAD",
-    ], cwd=repo_root, check=True).stdout.strip()
 
     if current_branch == args.target:
         raise TaskCliError(

--- a/src/specify_cli/upgrade/migrations/__init__.py
+++ b/src/specify_cli/upgrade/migrations/__init__.py
@@ -11,6 +11,10 @@ import pkgutil
 from pathlib import Path
 
 
+class MigrationDiscoveryError(RuntimeError):
+    """Raised when a migration module cannot be imported cleanly."""
+
+
 def auto_discover_migrations() -> None:
     """
     Auto-discover and import all migration modules.
@@ -26,6 +30,8 @@ def auto_discover_migrations() -> None:
     by reloading already-imported modules (only if they're not already registered).
     """
     import sys
+
+    failures: list[str] = []
 
     # Get the migrations package directory
     migrations_dir = Path(__file__).parent
@@ -72,15 +78,15 @@ def auto_discover_migrations() -> None:
                     # Fresh import
                     importlib.import_module(f".{module_name}", package=__name__)
             except Exception as e:
-                # Log but don't fail - let the migration registry validation catch it
-                print(
-                    f"Warning: Failed to import migration module {module_name}: {e}",
-                    file=sys.stderr,
-                )
+                failures.append(f"{module_name}: {e}")
+
+    if failures:
+        joined = "; ".join(failures)
+        raise MigrationDiscoveryError(f"Failed to import migration module(s): {joined}")
 
 
 # Auto-discover all migrations on module import
 auto_discover_migrations()
 
 # Export the auto_discover function for testing
-__all__ = ["auto_discover_migrations"]
+__all__ = ["MigrationDiscoveryError", "auto_discover_migrations"]

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from packaging.version import InvalidVersion, Version
 from rich.console import Console
 
 from specify_cli.core.constants import KITTIFY_DIR, WORKTREES_DIR
@@ -31,6 +32,20 @@ class UpgradeResult:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     dry_run: bool = False
+
+
+def validate_upgrade_target(from_version: str, target_version: str) -> str | None:
+    """Return an error message when the requested target would downgrade state."""
+    if from_version == "unknown":
+        return None
+
+    try:
+        if Version(target_version) < Version(from_version):
+            return f"Refusing to downgrade project metadata from {from_version} to {target_version}"
+    except InvalidVersion:
+        return None
+
+    return None
 
 
 class MigrationRunner:
@@ -75,8 +90,19 @@ class MigrationRunner:
             dry_run=dry_run,
         )
 
+        validation_error = validate_upgrade_target(from_version, target_version)
+        if validation_error:
+            result.success = False
+            result.errors.append(validation_error)
+            return result
+
         # Get applicable migrations
-        migrations = MigrationRegistry.get_applicable(from_version, target_version, project_path=self.project_path)
+        version_for_migration = "0.0.0" if from_version == "unknown" else from_version
+        migrations = MigrationRegistry.get_applicable(
+            version_for_migration,
+            target_version,
+            project_path=self.project_path,
+        )
 
         if not migrations:
             # Still update version stamp even when no migrations needed
@@ -157,7 +183,13 @@ class MigrationRunner:
         if not migration.detect(self.project_path):
             # Migration not needed - project doesn't have old state
             if not dry_run:
-                metadata.record_migration(migration.migration_id, "skipped", "Not applicable")
+                self._record_migration_result(
+                    metadata,
+                    self.kittify_dir,
+                    migration.migration_id,
+                    "skipped",
+                    "Not applicable",
+                )
             return (MigrationResult(
                 success=True,
                 warnings=[f"Migration {migration.migration_id} not needed (project already in target state)"],),
@@ -180,7 +212,9 @@ class MigrationRunner:
 
         # Record in metadata
         if not dry_run:
-            metadata.record_migration(
+            self._record_migration_result(
+                metadata,
+                self.kittify_dir,
                 migration.migration_id,
                 "success" if result.success else "failed",
                 "; ".join(result.changes_made) if result.changes_made else None,
@@ -234,7 +268,13 @@ class MigrationRunner:
 
                 if not migration.detect(worktree):
                     if not dry_run:
-                        wt_metadata.record_migration(migration.migration_id, "skipped", "Not applicable")
+                        self._record_migration_result(
+                            wt_metadata,
+                            wt_kittify,
+                            migration.migration_id,
+                            "skipped",
+                            "Not applicable",
+                        )
                     continue
 
                 can_apply, reason = migration.can_apply(worktree)
@@ -248,13 +288,23 @@ class MigrationRunner:
 
                 if migration_result.success:
                     if not dry_run:
-                        wt_metadata.record_migration(
+                        self._record_migration_result(
+                            wt_metadata,
+                            wt_kittify,
                             migration.migration_id,
                             "success",
                             "; ".join(migration_result.changes_made) if migration_result.changes_made else None,
                         )
                     result["warnings"].extend([f"Worktree {worktree.name}: {w}" for w in migration_result.warnings])
                 else:
+                    if not dry_run:
+                        self._record_migration_result(
+                            wt_metadata,
+                            wt_kittify,
+                            migration.migration_id,
+                            "failed",
+                            "; ".join(migration_result.errors) if migration_result.errors else None,
+                        )
                     result["errors"].extend([f"Worktree {worktree.name}: {e}" for e in migration_result.errors])
 
             # Save worktree metadata
@@ -281,3 +331,15 @@ class MigrationRunner:
             platform=sys.platform,
             platform_version=platform.platform(),
         )
+
+    def _record_migration_result(
+        self,
+        metadata: ProjectMetadata,
+        metadata_dir: Path,
+        migration_id: str,
+        result: str,
+        notes: str | None = None,
+    ) -> None:
+        """Persist each migration record immediately for crash/failure recovery."""
+        metadata.record_migration(migration_id, result, notes)
+        metadata.save(metadata_dir)

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -1009,10 +1009,10 @@ class TestFindFeatureDirectory:
         assert result == kitty_specs / "001-test-feature"
 
     @patch("specify_cli.cli.commands.agent.feature.is_worktree_context")
-    def test_multiple_features_requires_explicit_selection(
+    def test_multiple_features_fall_back_to_latest_incomplete(
         self, mock_is_worktree: Mock, tmp_path: Path
     ):
-        """Should raise error when multiple features exist and none specified."""
+        """Should use centralized latest-incomplete fallback when no feature is specified."""
         from specify_cli.cli.commands.agent.feature import _find_feature_directory
 
         mock_is_worktree.return_value = False
@@ -1020,15 +1020,22 @@ class TestFindFeatureDirectory:
         # Create main repo structure with multiple features
         kitty_specs = tmp_path / "kitty-specs"
         kitty_specs.mkdir()
-        for slug in ("001-feature", "002-feature", "003-feature"):
+        for slug, lane in (
+            ("001-feature", "done"),
+            ("002-feature", "done"),
+            ("003-feature", "planned"),
+        ):
             feature_dir = kitty_specs / slug
             tasks_dir = feature_dir / "tasks"
             tasks_dir.mkdir(parents=True)
-            (tasks_dir / "WP01-test.md").write_text("# WP01\n")
+            (tasks_dir / "WP01.md").write_text(
+                f"---\nwork_package_id: WP01\ntitle: Test\nlane: {lane}\n---\n",
+                encoding="utf-8",
+            )
 
-        # Multiple features without explicit selection should error
-        with pytest.raises(ValueError, match="Multiple features found"):
-            _find_feature_directory(tmp_path, tmp_path)
+        result = _find_feature_directory(tmp_path, tmp_path)
+
+        assert result == kitty_specs / "003-feature"
 
     @patch("specify_cli.cli.commands.agent.feature.is_worktree_context")
     def test_raises_error_when_no_features_in_main_repo(

--- a/tests/cross_cutting/misc/test_gitignore_manager_simple.py
+++ b/tests/cross_cutting/misc/test_gitignore_manager_simple.py
@@ -14,6 +14,7 @@ import gitignore_manager
 
 GitignoreManager = gitignore_manager.GitignoreManager
 ProtectionResult = gitignore_manager.ProtectionResult
+TOTAL_PROTECTED_ENTRIES = len(gitignore_manager.AGENT_DIRECTORIES) + len(gitignore_manager.RUNTIME_PROTECTED_ENTRIES)
 
 
 def run_tests():
@@ -59,7 +60,9 @@ def test_basic_functionality():
         result = manager.protect_all_agents()
         assert result.success, "protect_all_agents failed"
         assert result.modified, "File should be modified on first run"
-        assert len(result.entries_added) == 24, f"Expected 24 entries, got {len(result.entries_added)}"
+        assert len(result.entries_added) == TOTAL_PROTECTED_ENTRIES, (
+            f"Expected {TOTAL_PROTECTED_ENTRIES} entries, got {len(result.entries_added)}"
+        )
 
         # Verify file created
         assert manager.gitignore_path.exists(), ".gitignore not created"
@@ -105,12 +108,16 @@ def test_duplicate_detection():
         # First run
         result1 = manager.protect_all_agents()
         assert result1.modified, "First run should modify file"
-        assert len(result1.entries_added) == 24, "Should add 24 entries"
+        assert len(result1.entries_added) == TOTAL_PROTECTED_ENTRIES, (
+            f"Should add {TOTAL_PROTECTED_ENTRIES} entries"
+        )
 
         # Second run
         result2 = manager.protect_all_agents()
         assert not result2.modified, "Second run should not modify file"
-        assert len(result2.entries_skipped) == 24, "Should skip 24 entries"
+        assert len(result2.entries_skipped) == TOTAL_PROTECTED_ENTRIES, (
+            f"Should skip {TOTAL_PROTECTED_ENTRIES} entries"
+        )
         assert len(result2.entries_added) == 0, "Should add 0 new entries"
 
 

--- a/tests/git_ops/test_safe_commit_helper_integration.py
+++ b/tests/git_ops/test_safe_commit_helper_integration.py
@@ -312,3 +312,47 @@ def test_safe_commit_fails_gracefully_on_invalid_file(git_repo: Path):
     )
 
     assert result is False, "Should return False when file doesn't exist"
+
+
+def test_safe_commit_does_not_pop_unrelated_existing_stash(git_repo: Path):
+    """safe_commit must restore only its own temporary stash entry."""
+    staged_file = git_repo / "staged.txt"
+    staged_file.write_text("already staged\n", encoding="utf-8")
+    subprocess.run(["git", "add", "staged.txt"], cwd=git_repo, check=True)
+    subprocess.run(
+        ["git", "stash", "push", "--staged", "-m", "preexisting-stash"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    before = subprocess.run(
+        ["git", "stash", "list"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "preexisting-stash" in before.stdout
+
+    wp_file = git_repo / "WP07.md"
+    wp_file.write_text("---\nlane: planned\n---\n", encoding="utf-8")
+
+    result = safe_commit(
+        repo_path=git_repo,
+        files_to_commit=[wp_file],
+        commit_message="Commit WP07 only",
+        allow_empty=False,
+    )
+
+    after = subprocess.run(
+        ["git", "stash", "list"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result is True
+    assert "preexisting-stash" in after.stdout

--- a/tests/init/test_feature_detection.py
+++ b/tests/init/test_feature_detection.py
@@ -261,6 +261,21 @@ def test_detect_cwd_path_inside_worktree(repo_with_features: Path):
         assert ctx.detection_method == "cwd_path"
 
 
+def test_detect_cwd_path_at_worktree_root(repo_with_features: Path):
+    """Worktree root itself should still resolve via cwd detection."""
+    worktree_dir = repo_with_features / ".worktrees" / "020-feature-a-WP01"
+    worktree_dir.mkdir(parents=True)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        ctx = detect_feature(repo_with_features, cwd=worktree_dir)
+
+        assert ctx is not None
+        assert ctx.slug == "020-feature-a"
+        assert ctx.detection_method == "cwd_path"
+
+
 def test_detect_single_feature_auto(repo_with_single_feature: Path):
     """Test single feature auto-detect (only one feature exists)."""
     # Mock git to fail (force auto-detect)
@@ -706,8 +721,8 @@ def test_is_feature_complete_parse_error(tmp_path: Path):
     assert is_feature_complete(feature_dir) is False
 
 
-def test_detect_multiple_features_requires_explicit(tmp_path: Path):
-    """Multiple features with no context raises MultipleFeaturesError."""
+def test_detect_multiple_features_falls_back_to_latest_incomplete(tmp_path: Path):
+    """Multiple features with no context pick the latest incomplete feature."""
     repo_root = tmp_path / "repo"
     kitty_specs = repo_root / "kitty-specs"
     kitty_specs.mkdir(parents=True)
@@ -732,12 +747,11 @@ def test_detect_multiple_features_requires_explicit(tmp_path: Path):
     with patch("subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")
 
-        with pytest.raises(MultipleFeaturesError) as exc_info:
-            detect_feature(repo_root, cwd=repo_root, mode="strict")
+        ctx = detect_feature(repo_root, cwd=repo_root, mode="strict")
 
-        error_msg = str(exc_info.value)
-        assert "Multiple features found" in error_msg
-        assert "--feature" in error_msg
+        assert ctx is not None
+        assert ctx.slug == "025-feature-b"
+        assert ctx.detection_method == "latest_incomplete"
 
 
 def test_detect_explicit_feature_wins_over_ambiguity(tmp_path: Path):

--- a/tests/init/test_feature_detection_integration.py
+++ b/tests/init/test_feature_detection_integration.py
@@ -221,7 +221,7 @@ def test_error_messages_mention_feature_flag(repo_root: Path):
     # Check for helpful error messages
     assert "--feature" in content, "Error messages should mention --feature flag"
     assert "SPECIFY_FEATURE" in content, "Error messages should mention SPECIFY_FEATURE env var"
-    assert "Multiple features found" in content, "Should handle multiple features case"
+    assert "All features are complete" in content, "Should handle completed feature ambiguity"
 
 
 def test_error_messages_list_available_features(repo_root: Path):

--- a/tests/init/test_init_flow_integration.py
+++ b/tests/init/test_init_flow_integration.py
@@ -20,6 +20,7 @@ import pytest
 pytestmark = pytest.mark.git_repo
 
 GitignoreManager = gitignore_manager.GitignoreManager
+TOTAL_PROTECTED_ENTRIES = len(gitignore_manager.AGENT_DIRECTORIES) + len(gitignore_manager.RUNTIME_PROTECTED_ENTRIES)
 
 def test_init_flow_fresh_project():
     """Test init flow with a fresh project (no .gitignore)."""
@@ -33,7 +34,7 @@ def test_init_flow_fresh_project():
         # Verify success
         assert result.success, "Init flow should succeed"
         assert result.modified, "Should create new .gitignore"
-        assert len(result.entries_added) == 24, "Should add all 13 agents + 11 runtime paths"
+        assert len(result.entries_added) == TOTAL_PROTECTED_ENTRIES, "Should add all protected agent/runtime paths"
 
         # Verify file exists and has correct content
         gitignore_path = project_path / ".gitignore"
@@ -70,7 +71,7 @@ dist/
         # Verify success
         assert result.success, "Init flow should succeed"
         assert result.modified, "Should modify existing .gitignore"
-        assert len(result.entries_added) == 24, "Should add all 13 agents + 11 runtime paths"
+        assert len(result.entries_added) == TOTAL_PROTECTED_ENTRIES, "Should add all protected agent/runtime paths"
 
         # Verify existing content is preserved
         content = gitignore_path.read_text()
@@ -95,14 +96,14 @@ def test_init_flow_idempotency():
         result1 = manager1.protect_all_agents()
         assert result1.success
         assert result1.modified
-        assert len(result1.entries_added) == 24
+        assert len(result1.entries_added) == TOTAL_PROTECTED_ENTRIES
 
         # Second init (should do nothing)
         manager2 = GitignoreManager(project_path)
         result2 = manager2.protect_all_agents()
         assert result2.success
         assert not result2.modified, "Should not modify on second run"
-        assert len(result2.entries_skipped) == 24
+        assert len(result2.entries_skipped) == TOTAL_PROTECTED_ENTRIES
         assert len(result2.entries_added) == 0
 
         # Third init (still should do nothing)
@@ -146,8 +147,8 @@ node_modules/
         assert ".claude/" in result.entries_skipped
         assert ".gemini/" in result.entries_skipped
 
-        # Check that new ones were added (should be 21 - 24 total minus 3 existing)
-        assert len(result.entries_added) == 21
+        expected_new_entries = TOTAL_PROTECTED_ENTRIES - 3
+        assert len(result.entries_added) == expected_new_entries
         assert ".cursor/" in result.entries_added
 
         # Verify no duplicates in file

--- a/tests/upgrade/test_auto_discovery.py
+++ b/tests/upgrade/test_auto_discovery.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-from specify_cli.upgrade.migrations import auto_discover_migrations
+from specify_cli.upgrade.migrations import MigrationDiscoveryError, auto_discover_migrations
 from specify_cli.upgrade.registry import MigrationRegistry
 
 pytestmark = pytest.mark.fast
@@ -64,8 +64,8 @@ class TestAutoDiscovery:
         assert "__init__" not in migration_ids
         assert "test_" not in " ".join(migration_ids)
 
-    def test_auto_discover_handles_import_errors_gracefully(self, capsys):
-        """Import errors are logged but don't crash discovery."""
+    def test_auto_discover_raises_on_import_errors(self):
+        """Import errors fail fast so broken migrations cannot be skipped silently."""
         MigrationRegistry.clear()
 
         # Mock pkgutil to return a fake module that will fail import
@@ -74,15 +74,10 @@ class TestAutoDiscovery:
             class FakeModuleInfo:
                 name = "m_fake_broken"
 
-            # Return our fake module plus one real one
             mock_iter.return_value = [FakeModuleInfo()]
 
-            # This should log a warning but not crash
-            auto_discover_migrations()
-
-            # Check stderr for warning
-            captured = capsys.readouterr()
-            assert "Warning" in captured.err or "Failed to import" in captured.err
+            with pytest.raises(MigrationDiscoveryError, match="m_fake_broken"):
+                auto_discover_migrations()
 
     def test_auto_discover_imports_base_module(self):
         """The base.py module is also imported (needed for BaseMigration)."""

--- a/tests/upgrade/test_runner_status_classification.py
+++ b/tests/upgrade/test_runner_status_classification.py
@@ -42,6 +42,21 @@ class _AppliedMigration(BaseMigration):
         return MigrationResult(success=True, changes_made=["updated file"])
 
 
+class _FailingMigration(BaseMigration):
+    migration_id = "10.0.0_failed"
+    description = "Failing migration for metadata persistence tests"
+    target_version = "10.0.0"
+
+    def detect(self, project_path: Path) -> bool:  # noqa: ARG002
+        return True
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:  # noqa: ARG002
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:  # noqa: ARG002
+        return MigrationResult(success=False, errors=["boom"])
+
+
 def _setup_project(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -123,3 +138,41 @@ def test_upgrade_creates_worktree_metadata_when_only_kitty_specs_exists(
 
     assert result.success is True
     assert (worktree / ".kittify" / "metadata.yaml").exists()
+
+
+def test_upgrade_rejects_downgrade_target(monkeypatch, tmp_path: Path) -> None:
+    project_path = _setup_project(tmp_path)
+    runner = MigrationRunner(project_path)
+
+    monkeypatch.setattr(runner.detector, "detect_version", lambda: "2.0.9")
+
+    result = runner.upgrade("1.0.0", include_worktrees=False)
+
+    assert result.success is False
+    assert result.errors == ["Refusing to downgrade project metadata from 2.0.9 to 1.0.0"]
+
+
+def test_upgrade_persists_successful_migrations_before_later_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    project_path = _setup_project(tmp_path)
+    runner = MigrationRunner(project_path)
+    first = _AppliedMigration()
+    second = _FailingMigration()
+
+    monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+    monkeypatch.setattr(
+        "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+        lambda _from, _to, project_path=None: [first, second],  # noqa: ARG005
+    )
+
+    result = runner.upgrade("10.0.0", include_worktrees=False)
+    metadata = ProjectMetadata.load(project_path / ".kittify")
+
+    assert result.success is False
+    assert result.migrations_applied == [first.migration_id]
+    assert result.errors == ["boom"]
+    assert metadata is not None
+    assert metadata.has_migration(first.migration_id)
+    assert any(record.id == second.migration_id and record.result == "failed" for record in metadata.applied_migrations)

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -7,6 +7,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+import typer
 
 import specify_cli.cli.commands.upgrade as upgrade_cmd
 
@@ -549,3 +551,30 @@ def test_upgrade_no_migrations_safe_commit_failure_shows_warning(
     assert data["auto_committed"] is False
     assert len(data["warnings"]) == 1
     assert "review and commit manually" in data["warnings"][0]
+
+
+def test_upgrade_rejects_downgrade_target_in_json_mode(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Downgrade targets should fail before metadata is rewritten."""
+    project_path = _setup_upgrade_project(tmp_path)
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+
+    with pytest.raises(typer.Exit) as exc:
+        upgrade_cmd.upgrade(
+            dry_run=False,
+            force=True,
+            target="0.9.0",
+            json_output=True,
+            verbose=False,
+            no_worktrees=True,
+        )
+
+    data = json.loads(capsys.readouterr().out.strip())
+    assert exc.value.exit_code == 1
+    assert data["status"] == "failed"
+    assert data["success"] is False
+    assert data["errors"] == ["Refusing to downgrade project metadata from 1.0.0a1 to 0.9.0"]


### PR DESCRIPTION
## Summary
- bump the 2.x line to 2.0.10 and refresh the release notes
- harden upgrade execution against downgrades, broken migration discovery, and stash corruption
- fix release-prep regressions in feature detection, embedded task scripts, and init/task tests

## Validation
- python3 scripts/release/validate_release.py --mode branch --tag-pattern 'v2.*.*' --pyproject pyproject.toml --changelog CHANGELOG.md
- python3 scripts/release/validate_release.py --mode tag --tag v2.0.10 --tag-pattern 'v2.*.*' --pyproject pyproject.toml --changelog CHANGELOG.md
- python3 -m build --sdist --wheel --outdir /tmp/spec-kitty-release-20260320-175717/build-2.0.10
- pytest -q tests/cross_cutting/misc/test_tasks_cli_commands.py
- pytest -q tests/git_ops/test_safe_commit_helper_integration.py tests/upgrade/test_auto_discovery.py tests/upgrade/test_runner_status_classification.py tests/upgrade/test_upgrade_auto_commit_unit.py tests/init/test_feature_detection.py tests/init/test_feature_detection_integration.py tests/agent/test_agent_feature.py -k "FindFeatureDirectory or context_resolve or downgrade or stash or discovery or persists or latest_incomplete"
- pytest -q --maxfail=1 (interrupted cleanly at 3214 passed, 9 skipped, 25 xfailed, 56%)
