### PR TITLE
Fix 2.0.10 release CI regressions

### DIFF
--- a/src/specify_cli/core/execution_context.py
+++ b/src/specify_cli/core/execution_context.py
@@ -79,6 +79,7 @@ def _resolve_feature_context(
             cwd=cwd,
             env=env,
             mode="strict",
+            allow_latest_incomplete=True,
         )
     except Exception as exc:
         raise ActionContextError("FEATURE_CONTEXT_UNRESOLVED", str(exc)) from exc

--- a/src/specify_cli/core/feature_detection.py
+++ b/src/specify_cli/core/feature_detection.py
@@ -18,7 +18,7 @@ Priority order:
 3. Git branch name (strips -WP## suffix for worktree branches)
 4. Current directory path (walk up looking for ###-feature-name)
 5. Single feature auto-detect (only if exactly one feature exists)
-6. Fallback to latest incomplete feature (auto-selects if no explicit context)
+6. Optional fallback to latest incomplete feature (opt-in only)
 7. Error with clear guidance (if all features complete or ambiguous)
 """
 
@@ -353,6 +353,7 @@ def detect_feature(
     env: Mapping[str, str] | None = None,
     mode: Literal["strict", "lenient"] = "strict",
     allow_single_auto: bool = True,
+    allow_latest_incomplete: bool = False,
 ) -> FeatureContext | None:
     """
     Unified feature detection with configurable behavior.
@@ -363,6 +364,7 @@ def detect_feature(
     3. Git branch name (strips -WP## suffix)
     4. Current directory path (walks up to find ###-feature-name)
     5. Single feature auto-detect (if allow_single_auto=True)
+    6. Optional latest-incomplete fallback (if allow_latest_incomplete=True)
     6. Error (strict mode) or None (lenient mode)
 
     Args:
@@ -372,6 +374,8 @@ def detect_feature(
         env: Environment variables (defaults to os.environ)
         mode: "strict" raises error if ambiguous, "lenient" returns None
         allow_single_auto: Auto-detect if exactly one feature exists
+        allow_latest_incomplete: Auto-select the latest incomplete feature
+            when multiple features exist and no other context is available.
 
     Returns:
         FeatureContext with detection details, or None in lenient mode
@@ -463,9 +467,24 @@ def detect_feature(
                 if mode == "strict":
                     raise MultipleFeaturesError(all_features, error_msg)
                 return None
-            else:
+            elif allow_latest_incomplete:
                 detected_slug = incomplete_features[-1]
                 detection_method = "latest_incomplete"
+            else:
+                error_msg = (
+                    f"Multiple features found ({len(all_features)} total, "
+                    f"{len(incomplete_features)} incomplete).\n\n"
+                    "Please specify explicitly using:\n"
+                    "  --feature <feature-slug>  (e.g., --feature 020-my-feature)\n"
+                    "  SPECIFY_FEATURE=<feature-slug>  (environment variable)\n"
+                    "\nAvailable features:\n"
+                    + "\n".join(f"  - {slug}" for slug in all_features[:20])
+                )
+                if len(all_features) > 20:
+                    error_msg += f"\n  ... and {len(all_features) - 20} more"
+                if mode == "strict":
+                    raise MultipleFeaturesError(all_features, error_msg)
+                return None
         else:
             # No features found
             error_msg = (

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -1009,10 +1009,10 @@ class TestFindFeatureDirectory:
         assert result == kitty_specs / "001-test-feature"
 
     @patch("specify_cli.cli.commands.agent.feature.is_worktree_context")
-    def test_multiple_features_fall_back_to_latest_incomplete(
+    def test_multiple_features_require_explicit_selection(
         self, mock_is_worktree: Mock, tmp_path: Path
     ):
-        """Should use centralized latest-incomplete fallback when no feature is specified."""
+        """Mutating feature commands should not auto-select among multiple features."""
         from specify_cli.cli.commands.agent.feature import _find_feature_directory
 
         mock_is_worktree.return_value = False
@@ -1033,9 +1033,8 @@ class TestFindFeatureDirectory:
                 encoding="utf-8",
             )
 
-        result = _find_feature_directory(tmp_path, tmp_path)
-
-        assert result == kitty_specs / "003-feature"
+        with pytest.raises(ValueError, match="Please specify explicitly"):
+            _find_feature_directory(tmp_path, tmp_path)
 
     @patch("specify_cli.cli.commands.agent.feature.is_worktree_context")
     def test_raises_error_when_no_features_in_main_repo(

--- a/tests/cross_cutting/test_gitignore_isolation_integration.py
+++ b/tests/cross_cutting/test_gitignore_isolation_integration.py
@@ -6,12 +6,47 @@ instead of mutating versioned .gitignore files.
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+from tests.utils import REPO_ROOT
 
 pytestmark = pytest.mark.git_repo
+
+
+def _write_valid_meta(feature_dir: Path, slug: str) -> None:
+    feature_dir.joinpath("meta.json").write_text(
+        json.dumps(
+            {
+                "feature_number": slug.split("-", 1)[0],
+                "slug": slug,
+                "feature_slug": slug,
+                "friendly_name": "Test Feature",
+                "mission": "software-dev",
+                "target_branch": "main",
+                "created_at": "2026-03-20T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_checkout_cli(project_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    src_root = str(REPO_ROOT / "src")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_root if not existing else f"{src_root}:{existing}"
+    return subprocess.run(
+        [sys.executable, "-m", "specify_cli.__init__", *args],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
 def test_worktree_creation_does_not_modify_gitignore(tmp_path: Path):
     """Test that worktree creation doesn't modify tracked .gitignore file.
@@ -43,9 +78,7 @@ def test_worktree_creation_does_not_modify_gitignore(tmp_path: Path):
     feature_dir = tmp_path / "kitty-specs" / "001-test-feature"
     feature_dir.mkdir(parents=True)
 
-    # Create meta.json
-    meta_path = feature_dir / "meta.json"
-    meta_path.write_text('{"feature_slug": "001-test-feature", "target_branch": "main"}')
+    _write_valid_meta(feature_dir, "001-test-feature")
 
     # Create WP task file
     tasks_dir = feature_dir / "tasks"
@@ -78,12 +111,7 @@ dependencies: []
     initial_gitignore = gitignore_path.read_text()
 
     # Run spec-kitty implement to create worktree
-    result = subprocess.run(
-        ["spec-kitty", "implement", "WP01"],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_checkout_cli(tmp_path, "implement", "WP01")
 
     # Verify command succeeded
     assert result.returncode == 0, f"implement failed: {result.stderr}"
@@ -159,9 +187,7 @@ def test_worktree_merge_has_no_gitignore_pollution(tmp_path: Path):
     feature_dir = tmp_path / "kitty-specs" / "001-test-feature"
     feature_dir.mkdir(parents=True)
 
-    # Create meta.json
-    meta_path = feature_dir / "meta.json"
-    meta_path.write_text('{"feature_slug": "001-test-feature", "target_branch": "main"}')
+    _write_valid_meta(feature_dir, "001-test-feature")
 
     # Create WP task file
     tasks_dir = feature_dir / "tasks"
@@ -199,12 +225,7 @@ dependencies: []
     ).stdout.strip()
 
     # Create worktree
-    result = subprocess.run(
-        ["spec-kitty", "implement", "WP01"],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_checkout_cli(tmp_path, "implement", "WP01")
     assert result.returncode == 0, f"implement failed: {result.stderr}"
 
     # In worktree, create a test file and commit
@@ -289,9 +310,7 @@ def test_git_info_exclude_contains_exclusion_patterns(tmp_path: Path):
     feature_dir = tmp_path / "kitty-specs" / "001-test-feature"
     feature_dir.mkdir(parents=True)
 
-    # Create meta.json
-    meta_path = feature_dir / "meta.json"
-    meta_path.write_text('{"feature_slug": "001-test-feature", "target_branch": "main"}')
+    _write_valid_meta(feature_dir, "001-test-feature")
 
     # Create WP task file
     tasks_dir = feature_dir / "tasks"
@@ -317,12 +336,7 @@ dependencies: []
     )
 
     # Create worktree
-    result = subprocess.run(
-        ["spec-kitty", "implement", "WP01"],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_checkout_cli(tmp_path, "implement", "WP01")
     assert result.returncode == 0, f"implement failed: {result.stderr}"
 
     # Check that .git/info/exclude exists (in git directory, not worktree)

--- a/tests/init/test_feature_detection.py
+++ b/tests/init/test_feature_detection.py
@@ -722,7 +722,7 @@ def test_is_feature_complete_parse_error(tmp_path: Path):
 
 
 def test_detect_multiple_features_falls_back_to_latest_incomplete(tmp_path: Path):
-    """Multiple features with no context pick the latest incomplete feature."""
+    """Latest-incomplete fallback is available when callers opt in."""
     repo_root = tmp_path / "repo"
     kitty_specs = repo_root / "kitty-specs"
     kitty_specs.mkdir(parents=True)
@@ -747,7 +747,12 @@ def test_detect_multiple_features_falls_back_to_latest_incomplete(tmp_path: Path
     with patch("subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")
 
-        ctx = detect_feature(repo_root, cwd=repo_root, mode="strict")
+        ctx = detect_feature(
+            repo_root,
+            cwd=repo_root,
+            mode="strict",
+            allow_latest_incomplete=True,
+        )
 
         assert ctx is not None
         assert ctx.slug == "025-feature-b"

--- a/tests/research/test_research_workflow_integration.py
+++ b/tests/research/test_research_workflow_integration.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import subprocess
+import json
 from pathlib import Path
 
 import pytest
@@ -120,8 +121,27 @@ def test_full_research_workflow_via_cli(tmp_path: Path, run_cli) -> None:
     subprocess.run(["git", "add", "."], cwd=project_dir, check=True, capture_output=True)
     subprocess.run(["git", "commit", "-m", "Init"], cwd=project_dir, check=True, capture_output=True)
 
-    # Verify research mission active
-    result = run_cli(project_dir, "mission", "current")
+    # Create a feature so mission current has explicit feature context.
+    feature_slug = "001-research-test"
+    feature_dir = project_dir / "kitty-specs" / feature_slug
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "feature_number": "001",
+                "slug": feature_slug,
+                "feature_slug": feature_slug,
+                "friendly_name": "Research Test",
+                "mission": "research",
+                "target_branch": "main",
+                "created_at": "2026-03-20T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Verify research mission active for the explicit feature.
+    result = run_cli(project_dir, "mission", "current", "--feature", feature_slug)
     assert result.returncode == 0
     assert "research" in result.stdout.lower()
 

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -160,22 +160,6 @@ def test_collect_feature_summary_does_not_dirty_repo(tmp_path: Path) -> None:
     summary = collect_feature_summary(repo_root, _FEATURE_SLUG)
     assert summary.git_dirty == [], f"First call dirtied the repo: {summary.git_dirty}"
 
-    # Commit any status.json changes from the first call so the repo is clean
-    # again.  materialize() always rewrites status.json with a fresh timestamp,
-    # so it will be modified after each call.  The regression fix ensures the
-    # git-cleanliness check runs BEFORE materialize -- so each individual call
-    # sees a clean repo *at the point of checking*.
-    subprocess.run(
-        ["git", "-C", str(repo_root), "add", "-A"],
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(repo_root), "commit", "-m", "post-materialize"],
-        check=True,
-        capture_output=True,
-    )
-
     # Call a second time -- must still report clean (no cumulative drift)
     summary2 = collect_feature_summary(repo_root, _FEATURE_SLUG)
     assert summary2.git_dirty == [], f"Second call dirtied the repo: {summary2.git_dirty}"

--- a/tests/sync/test_edge_cases.py
+++ b/tests/sync/test_edge_cases.py
@@ -113,7 +113,7 @@ class TestQueueOverflow:
     """Test queue behavior at 10K limit."""
 
     def test_queue_rejects_at_max(self, tmp_path: Path):
-        """Queue returns False when at MAX_QUEUE_SIZE (SC-006 edge case)."""
+        """Queue evicts the oldest event when it reaches MAX_QUEUE_SIZE."""
         queue = OfflineQueue(db_path=tmp_path / "overflow.db")
 
         # Fill to capacity
@@ -129,7 +129,7 @@ class TestQueueOverflow:
 
         assert queue.size() == OfflineQueue.MAX_QUEUE_SIZE
 
-        # Next event should be rejected
+        # Next event should succeed by evicting the oldest row
         result = queue.queue_event(
             {
                 "event_id": "overflow_event_00000000000000",
@@ -137,13 +137,15 @@ class TestQueueOverflow:
                 "payload": {},
             }
         )
-        assert result is False
+        assert result is True
         assert queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        events = queue.drain_queue(limit=1)
+        assert events[0]["event_id"] != "evt0000000000000000000000"
 
     def test_emitter_handles_full_queue(self, tmp_path: Path):
-        """EventEmitter handles full queue gracefully (non-blocking)."""
+        """EventEmitter handles queue persistence gracefully (non-blocking)."""
         queue = MagicMock(spec=OfflineQueue)
-        queue.queue_event.return_value = False  # Queue full
+        queue.queue_event.return_value = True
 
         clock = LamportClock(value=0, node_id="test", _storage_path=tmp_path / "c.json")
         auth = MagicMock()
@@ -154,7 +156,7 @@ class TestQueueOverflow:
         em = EventEmitter(clock=clock, config=config, queue=queue, _auth=auth, ws_client=None)
         # Should not raise even though queue is full
         event = em.emit_wp_status_changed("WP01", "planned", "in_progress")
-        # Event is still returned (it was valid), but queue rejected it
+        # Event is still returned when it can be persisted.
         assert event is not None
 
 

--- a/tests/sync/test_offline_queue.py
+++ b/tests/sync/test_offline_queue.py
@@ -134,7 +134,7 @@ class TestOfflineQueueSizeLimit:
     """Test queue size limit enforcement"""
 
     def test_queue_size_limit_enforced(self, temp_queue):
-        """Test queue rejects events when at capacity"""
+        """Test queue evicts oldest events when at capacity."""
         # Queue up to the limit
         for i in range(OfflineQueue.MAX_QUEUE_SIZE):
             event = {"event_id": f"evt-{i}", "event_type": "Test", "payload": {}}
@@ -144,11 +144,13 @@ class TestOfflineQueueSizeLimit:
 
         assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
 
-        # One more should fail
+        # One more should succeed by evicting the oldest row
         overflow_event = {"event_id": "evt-overflow", "event_type": "Test", "payload": {}}
         result = temp_queue.queue_event(overflow_event)
-        assert result is False
+        assert result is True
         assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        events = temp_queue.drain_queue(limit=1)
+        assert events[0]["event_id"] == "evt-1"
 
     def test_queue_accepts_after_drain_and_sync(self, temp_queue):
         """Test queue accepts events after making room"""

--- a/tests/sync/test_offline_replay.py
+++ b/tests/sync/test_offline_replay.py
@@ -310,7 +310,7 @@ class TestQueueSizeLimit:
     """Test T133: Queue size limit warning"""
 
     def test_queue_size_limit_enforced(self, temp_queue):
-        """Queue should reject events at MAX_QUEUE_SIZE (10,000)"""
+        """Queue should evict the oldest event at MAX_QUEUE_SIZE."""
         # Fill queue to limit
         for i in range(OfflineQueue.MAX_QUEUE_SIZE):
             result = temp_queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
@@ -318,10 +318,12 @@ class TestQueueSizeLimit:
 
         assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
 
-        # 10,001st event should fail
+        # 10,001st event should succeed and evict the oldest row
         result = temp_queue.queue_event({"event_id": "evt-overflow", "event_type": "Test", "payload": {}})
-        assert result is False
+        assert result is True
         assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        events = temp_queue.drain_queue(limit=1)
+        assert events[0]["event_id"] == "evt-1"
 
     def test_queue_accepts_after_sync(self, temp_queue):
         """Queue accepts new events after sync makes room"""


### PR DESCRIPTION
## Summary
- restore strict feature ambiguity handling for mutating commands and keep latest-incomplete fallback opt-in for action context resolution
- update stale integration tests to use valid feature metadata and run the checkout under test instead of a globally installed CLI
- align sync queue limit expectations with the current FIFO eviction behavior and remove the stale acceptance regression assumption

## Validation
- pytest -q tests/tasks/test_planning_workflow_integration.py -k 'ambiguous_context_returns_candidates' tests/agent/test_context_resolve_unit.py::test_context_resolve_tasks_uses_latest_incomplete tests/agent/test_agent_feature.py::TestFindFeatureDirectory::test_multiple_features_require_explicit_selection tests/init/test_feature_detection.py::test_detect_multiple_features_falls_back_to_latest_incomplete
- pytest -q tests/cross_cutting/test_gitignore_isolation_integration.py tests/research/test_research_workflow_integration.py::test_full_research_workflow_via_cli tests/specify_cli/test_acceptance_regressions.py::test_collect_feature_summary_does_not_dirty_repo
- pytest -q tests/sync/test_edge_cases.py::TestQueueOverflow::test_queue_rejects_at_max tests/sync/test_offline_queue.py::TestOfflineQueueSizeLimit::test_queue_size_limit_enforced tests/sync/test_offline_replay.py::TestQueueSizeLimit::test_queue_size_limit_enforced
- python3 scripts/release/validate_release.py --mode branch --tag-pattern 'v2.*.*'
- python3 scripts/release/validate_release.py --mode tag --tag v2.0.10 --tag-pattern 'v2.*.*'
- python3 -m build --wheel --sdist