### PR TITLE
chore(release): prepare 2.1.0 cutover

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -3,6 +3,7 @@ name: CI Quality
 on:
   pull_request:
     branches:
+      - main
       - develop
       - 2.x
   push:

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -3,6 +3,7 @@ name: Release Readiness Check
 on:
   pull_request:
     branches:
+      - main
       - 2.x
     paths:
       - pyproject.toml
@@ -142,7 +143,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "See the validation output above for specific errors." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "📖 **Reference**: [Release Checklist](https://github.com/${{ github.repository }}/blob/2.x/RELEASE_CHECKLIST.md)" >> $GITHUB_STEP_SUMMARY
+            echo "📖 **Reference**: [Release Checklist](https://github.com/${{ github.repository }}/blob/main/RELEASE_CHECKLIST.md)" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Fail if validation failed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish 2.x GitHub Release
+name: Publish 2.x Release
 
 on:
   push:
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  build-release:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -158,3 +158,24 @@ jobs:
             dist/
             SHA256SUMS.txt
           retention-days: 30
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/spec-kitty-cli/
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-distributions
+          path: .
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [2.1.0] - 2026-03-21
+
+### ✅ Added
+
+- **Agent Skills Pack (`#330`)**: added canonical bundled skills, registry/installer/verification flow, manifest support, and upgrade migration `m_2_0_11_install_skills`.
+- **Structured requirement mapping (`#329`)**: added requirement-to-work-package mapping support with CLI integration for tracing delivery intent into execution planning.
+
+### 🔧 Changed
+
+- **Deterministic planning branch intent (`#328`)**: `specify` and `plan` commands now inject explicit target-branch metadata into templates to reduce ambiguity in downstream execution.
+- **Primary release line promotion**: `2.x` becomes the stable `main` line, with GitHub Releases and PyPI publication starting at `2.1.0`.
+
+### ⚠️ Deprecated
+
+- **`1.x` overall**: the former `1.x` line is now deprecated and moves to `1.x-maintenance` for critical fixes only. No new `1.x` PyPI releases are planned.
+
+### 🗑️ Removed
+
+- **Public `/spec-kitty.clarify` slash command (`#322`)**: removed the legacy clarify command, template, and migration path in favor of the current planning/discovery flow.
+
 ## [2.0.11] - 2026-03-20
 
 ### 📄 Documentation

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 ---
 
-## 🚀 What You Get in 0.15.x
+## 🚀 What You Get in 2.1.x
 
 | Capability | What Spec Kitty provides |
 |------------|--------------------------|
@@ -96,12 +96,13 @@ graph LR
 
 </div>
 
-**Current 2.x release line:** `v2.0.11` (GitHub releases)
+**Current stable release line:** `v2.1.0` (`main`, GitHub Releases, and PyPI)
 
-**2.x highlights:**
-- Primary branch detection now works with `main`, `master`, `develop`, and custom defaults
-- Branch routing and merge-base calculation are centralized for more predictable behavior
-- Worktree isolation and lane transitions have stronger guardrails and test coverage
+**2.1.0 highlights:**
+- Agent Skills Pack with bundled skills, installer/verification flow, and upgrade migration coverage
+- Structured requirement mapping from requirements into work-package planning
+- Deterministic branch intent injection in planning templates
+- `1.x` is now deprecated and retained only as `1.x-maintenance` for critical fixes
 
 **Jump to:**
 [Getting Started](#-getting-started-complete-workflow) •
@@ -115,15 +116,16 @@ graph LR
 
 ## 📌 Release Track
 
-Spec Kitty now runs split release tracks: `main` for the 1.0 PyPI stream and `2.x` for GitHub-only next-generation releases.
+Spec Kitty now uses `main` as the stable `2.x` release line.
+The former `1.x` line is deprecated and moves to `1.x-maintenance` for maintenance-only fixes.
 
 | Branch | Version | Status | Install |
 |--------|---------|--------|---------|
-| **main** | **1.0.0rc** | Release-candidate/stable PyPI stream | `pip install --pre spec-kitty-cli` |
-| **2.x** | **2.x** | GitHub-only semantic releases | Install from source or GitHub release artifacts |
+| **main** | **2.1.x** | Current stable line | `pip install spec-kitty-cli` |
+| **1.x-maintenance** | **1.x** | Deprecated, maintenance-only | Install from a pinned maintenance tag or source checkout |
 
-**For users:** install stable from PyPI (`pip install spec-kitty-cli`) or opt into RC (`pip install --pre spec-kitty-cli`).
-**For 2.x contributors/testers:** follow `v2.*.*` GitHub releases and install from source or release artifacts.
+**For users:** install the stable line from PyPI with `pip install spec-kitty-cli`.
+**For existing 1.x users:** migrate to `2.1.x` where possible; `1.x-maintenance` is only for critical maintenance and will no longer publish new PyPI releases.
 
 ---
 
@@ -1141,20 +1143,25 @@ cat .kittify/metadata.yaml
 If you encounter issues with an agent, please open an issue so we can refine the integration.
 
 <details>
-<summary><h2>🚀 Releasing 2.x on GitHub (Maintainers)</h2></summary>
+<summary><h2>🚀 Releasing 2.x on GitHub and PyPI (Maintainers)</h2></summary>
 
-`2.x` now uses GitHub-only releases with semantic tags in the form `v2.<minor>.<patch>`.
-The `2.x` release workflow does not publish to PyPI.
+The stable `2.x` line now lives on `main` and publishes from semantic tags in the form `v2.<minor>.<patch>`.
+Starting with `2.1.0`, the release workflow publishes both GitHub release artifacts and the PyPI package.
+
+### 0. One-Time Setup
+
+- Configure PyPI Trusted Publishing for `spec-kitty-cli` against `.github/workflows/release.yml`.
+- Keep `1.x-maintenance` maintenance-only; do not use it for new PyPI releases.
 
 ### 1. Prepare Release Branch
 
 ```bash
-git checkout 2.x
-git pull origin 2.x
-git checkout -b release/v2.0.0
+git checkout main
+git pull origin main
+git checkout -b release/vX.Y.Z
 
-# Update pyproject.toml to a semantic version (example: 2.0.0)
-# Add CHANGELOG.md entry under: ## [2.0.0] - YYYY-MM-DD
+# Update pyproject.toml to a semantic version (example: X.Y.Z)
+# Add CHANGELOG.md entry under: ## [X.Y.Z] - YYYY-MM-DD
 ```
 
 ### 2. Validate Locally
@@ -1167,40 +1174,42 @@ twine check dist/*
 rm -rf dist/ build/
 ```
 
-### 3. Open and Merge PR to `2.x`
+### 3. Open and Merge PR to `main`
 
 ```bash
 git add pyproject.toml CHANGELOG.md
-git commit -m "chore(release): prepare 2.0.0"
-git push origin release/v2.0.0
+git commit -m "chore(release): prepare X.Y.Z"
+git push origin release/vX.Y.Z
 ```
 
-After review, merge into `2.x`.
+After review, merge into `main` with a linear-history strategy (`rebase`).
 
 ### 4. Tag and Push
 
 ```bash
-git checkout 2.x
-git pull origin 2.x
-git tag v2.0.0 -m "Release 2.0.0"
-git push origin v2.0.0
+git checkout main
+git pull origin main
+git tag vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
 This triggers `.github/workflows/release.yml`.
 
-### 5. Verify GitHub Release
+### 5. Verify GitHub Release and PyPI Publication
 
 ```bash
-gh release view v2.0.0
+gh release view vX.Y.Z
+python -m pip index versions spec-kitty-cli
 ```
 
 ### Guardrails
 
-- `release-readiness.yml`: runs on PRs to `2.x` to validate version/changelog/tests.
+- `release-readiness.yml`: runs on PRs to `main` (and `2.x` during the cutover window) to validate version/changelog/tests.
 - `release.yml`: runs on `v2.*.*` tags and performs:
   - test execution
   - release metadata validation
   - artifact build and checksums
+  - PyPI publication via Trusted Publishing
   - GitHub Release creation with changelog notes
 
 ### Troubleshooting
@@ -1214,15 +1223,16 @@ gh release view v2.0.0
 
 **Tag already exists**:
 ```bash
-git tag -d v2.0.0
-git push origin :refs/tags/v2.0.0
-git tag v2.0.0 -m "Release 2.0.0"
-git push origin v2.0.0
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+git tag vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
 ### References
 
 - `RELEASE_CHECKLIST.md`
+- `docs/how-to/2-1-main-cutover-checklist.md`
 - `scripts/release/README.md`
 - `.github/workflows/release.yml`
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,227 +1,140 @@
 # Release Checklist
 
-Use this checklist to ensure consistent, high-quality releases of spec-kitty.
+Use this checklist for stable `2.x` releases from `main`.
 
-> For the `2.x` branch, releases are GitHub-only. Use semantic tags in the form `v2.<minor>.<patch>` and skip any PyPI publication steps.
+> `main` is the primary `2.x` line and publishes both GitHub releases and PyPI packages.
+> `1.x-maintenance` is deprecated overall, reserved for critical maintenance only, and should not receive new PyPI releases.
+> For the branch rename/cutover itself, see `docs/how-to/2-1-main-cutover-checklist.md`.
 
 ## Pre-Release Preparation
 
 ### Version Planning
 
-- [ ] Determine version number using [Semantic Versioning](https://semver.org/):
-  - **Patch** (X.Y.Z): Bug fixes, small improvements
-  - **Minor** (X.Y.0): New features, backward compatible
-  - **Major** (X.0.0): Breaking changes
+- [ ] Choose the version with [Semantic Versioning](https://semver.org/):
+  - Patch (`X.Y.Z`): bug fixes and small improvements
+  - Minor (`X.Y.0`): new features, backward-compatible platform changes
+  - Major (`X.0.0`): breaking changes
+- [ ] Confirm the release is intended for `main`, not `1.x-maintenance`.
+- [ ] If the release also changes branch policy, docs, or distribution channels, include that in `CHANGELOG.md`.
+
+### Release-Line Sanity
+
+- [ ] Confirm the default branch is `main`.
+- [ ] Confirm `1.x-maintenance` exists and is marked maintenance-only.
+- [ ] Confirm open PRs are targeted intentionally:
+  - New product work should target `main`.
+  - Maintenance-only fixes should target `1.x-maintenance`.
+- [ ] Confirm PyPI Trusted Publishing is configured for `spec-kitty-cli` against `.github/workflows/release.yml`.
 
 ### Code Quality
 
-- [ ] Run full test suite: `pytest tests/ -v`
-  - All tests passing
-  - No unexpected failures
-  - Check for XPASS (unexpectedly passing tests that should be reviewed)
-
-- [ ] **CRITICAL: Verify all migrations are registered**:
+- [ ] Run the full test suite:
   ```bash
-  pytest tests/specify_cli/upgrade/test_migration_robustness.py::TestMigrationRegistryCompleteness -v
+  pytest tests/ -v
   ```
-  - **Why**: Prevents release blocker bug (0.13.2) where migrations existed but weren't imported
-  - **Impact**: If this test fails, migrations won't run during `spec-kitty upgrade`
-  - **Fix**: Add missing imports to `src/specify_cli/upgrade/migrations/__init__.py`
-
-- [ ] Run linting and formatting checks:
+- [ ] Verify migration registry completeness:
+  ```bash
+  pytest tests/upgrade/test_migration_robustness.py::TestMigrationRegistryCompleteness -v
+  ```
+- [ ] Run release validation in branch mode:
+  ```bash
+  python scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
+  ```
+- [ ] Run linting and formatting checks appropriate for changed files:
   ```bash
   ruff check .
   ruff format --check .
   ```
-
-- [ ] Verify test coverage for new features:
+- [ ] Build the package and verify metadata:
   ```bash
-  pytest tests/ --cov=src/specify_cli --cov-report=term-missing
+  python -m build
+  twine check dist/*
   ```
 
-### Documentation Updates
+### Documentation and Metadata
 
-- [ ] Update `CHANGELOG.md`:
-  - Add new version section with date
-  - List all changes under appropriate categories:
-    - **Added**: New features
-    - **Fixed**: Bug fixes
-    - **Changed**: Breaking changes or major updates
-    - **Deprecated**: Features marked for removal
-    - **Removed**: Removed features
-    - **Security**: Security fixes
-  - Reference relevant issues/PRs
-  - Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format
+- [ ] Bump `version` in `pyproject.toml`.
+- [ ] Add a populated `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`.
+- [ ] Review `README.md` release-track messaging:
+  - `main` should be described as the stable `2.x` line.
+  - `1.x-maintenance` should be described as deprecated maintenance-only.
+- [ ] Review installation docs if distribution channels changed.
+- [ ] If new ADRs were added, verify they are filed under the correct versioned architecture path.
 
-- [ ] Update `pyproject.toml`:
-  - Bump `version` field to new version number
-  - Verify dependencies are up to date
-  - Check Python version requirements
+### Upgrade and Migration Checks
 
-- [ ] Review README.md:
-  - Ensure installation instructions are current
-  - Update version badges if present
-  - Verify examples still work
-
-- [ ] Check ADRs (Architecture Decision Records):
-  - If new ADR added, verify it's in `architecture/1.x/adr/` or `architecture/2.x/adr/` as appropriate
-  - Ensure ADR is linked from relevant docs
-
-### Migration Testing (if migrations included)
-
-- [ ] Test migrations on sample projects:
+- [ ] Test upgrade on a representative existing project:
   ```bash
-  # Create test project with old version
-  spec-kitty init test-project
-  cd test-project
-
-  # Upgrade to new version
-  spec-kitty upgrade --dry-run  # Preview changes
-  spec-kitty upgrade             # Apply migrations
+  spec-kitty upgrade --dry-run
+  spec-kitty upgrade
   ```
-
-- [ ] Verify migration idempotency:
+- [ ] Verify idempotency:
   ```bash
-  spec-kitty upgrade  # Run again
-  # Should report "No migrations needed"
+  spec-kitty upgrade
   ```
-
-- [ ] Test migration rollback (if applicable):
-  - Verify projects can downgrade safely
-  - Check for data loss scenarios
-
-### Agent Compatibility (if agent templates changed)
-
-- [ ] Verify all 12 agents updated:
-  - [ ] Claude Code (`.claude/commands/`)
-  - [ ] GitHub Copilot (`.github/prompts/`)
-  - [ ] GitHub Codex (`.codex/prompts/`)
-  - [ ] OpenCode (`.opencode/command/`)
-  - [ ] Google Gemini (`.gemini/commands/`)
-  - [ ] Cursor (`.cursor/commands/`)
-  - [ ] Windsurf (`.windsurf/workflows/`)
-  - [ ] Qwen Code (`.qwen/commands/`)
-  - [ ] Kilocode (`.kilocode/workflows/`)
-  - [ ] Augment Code (`.augment/commands/`)
-  - [ ] Roo Cline (`.roo/commands/`)
-  - [ ] Amazon Q (`.amazonq/prompts/`)
-
-- [ ] Test slash commands with at least 2 different agents:
-  ```bash
-  # In a test project with agent configured
-  /spec-kitty.specify
-  /spec-kitty.plan
-  /spec-kitty.tasks
-  /spec-kitty.implement
-  /spec-kitty.review
-  ```
-
-### Breaking Changes Review
-
-If this is a major or minor version with breaking changes:
-
-- [ ] Document breaking changes in CHANGELOG.md "Changed" section
-- [ ] Create migration guide if needed (e.g., `docs/upgrading-to-X.Y.0.md`)
-- [ ] Add deprecation warnings for features to be removed in next major version
-- [ ] Update examples in documentation to reflect breaking changes
+- [ ] If migrations changed agent assets or templates, smoke-test at least two agent integrations.
 
 ## Release Process
 
-### 1. Create Release Branch
+### 1. Create the Release Branch
 
 ```bash
+git checkout main
+git pull origin main
 git checkout -b release/X.Y.Z
 ```
 
-### 2. Commit Version Bump
+### 2. Commit Release Metadata
 
 ```bash
-git add pyproject.toml CHANGELOG.md
-git commit -m "chore: Bump version to X.Y.Z"
+git add pyproject.toml CHANGELOG.md README.md RELEASE_CHECKLIST.md
+git commit -m "chore(release): prepare X.Y.Z"
 ```
 
-### 3. Push and Create Pull Request
+### 3. Push and Open the Release PR
 
 ```bash
 git push origin release/X.Y.Z
-gh pr create --title "Release X.Y.Z: [Brief description]" \
-             --body "$(cat <<'EOF'
-## Release X.Y.Z
-
-### Summary
-[Brief description of what's in this release]
-
-### Checklist
-- [x] Version bumped in pyproject.toml
-- [x] CHANGELOG.md updated
-- [x] All tests passing
-- [x] Migrations tested
-- [x] Documentation updated
-
-### Testing
-- Tested on: [Python versions]
-- Tested agents: [List agents tested]
-- Tested migrations: [Yes/No]
-
-### Breaking Changes
-[List any breaking changes or "None"]
-EOF
-)" \
-             --base 2.x
+gh pr create --base main --title "Release X.Y.Z" --fill
 ```
 
 ### 4. Wait for CI and Review
 
-- [ ] GitHub Actions "Release Readiness Check" passes:
-  - Version properly bumped
-  - CHANGELOG.md has entry for new version
-  - Tests pass
-  - Package builds successfully
+- [ ] `Release Readiness Check` passes.
+- [ ] `CI Quality` passes or has explicitly accepted non-blocking failures.
+- [ ] Maintainer approval is recorded.
+- [ ] Any release-note or install-doc feedback is resolved.
 
-- [ ] Get approval from maintainer
-- [ ] Address any review feedback
+### 5. Merge the Release PR
 
-### 5. Merge Release PR
-
-- [ ] Use "Merge commit" strategy (NOT squash)
-  - Preserves commit history
-  - Important for changelog generation
+- [ ] Use a linear-history merge strategy that matches branch protection (`rebase` if available).
 
 ```bash
-# After approval, merge via GitHub UI or:
-gh pr merge --merge --delete-branch
+gh pr merge --rebase --delete-branch
 ```
 
-### 6. Create and Push Release Tag
+### 6. Tag the Release from `main`
 
 ```bash
-git checkout 2.x
-git pull origin 2.x
-git tag -a vX.Y.Z -m "Release vX.Y.Z
-
-[Brief description of what's in this release]
-
-Key changes:
-- [Feature 1]
-- [Feature 2]
-- [Bug fix 1]
-"
+git checkout main
+git pull origin main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
 ### 7. Monitor Automated Publishing
 
-- [ ] Watch GitHub Actions workflow: `.github/workflows/release.yml`
+- [ ] Watch `.github/workflows/release.yml`:
   ```bash
   gh run watch
   ```
-
-- [ ] Verify workflow completes successfully:
-  - Tests pass
-  - Package builds
-  - GitHub release created (with artifacts)
-
-- [ ] Verify GitHub release payload:
+- [ ] Verify the workflow:
+  - runs tests
+  - validates release metadata
+  - builds distributions
+  - publishes to PyPI
+  - creates the GitHub release
+- [ ] Verify the GitHub release payload:
   ```bash
   gh release view vX.Y.Z
   gh release download vX.Y.Z --dir /tmp/spec-kitty-release-check
@@ -229,259 +142,56 @@ git push origin vX.Y.Z
 
 ## Post-Release Verification
 
-### Installation Testing
+### Package Availability
 
-- [ ] Test fresh installation:
+- [ ] Verify PyPI shows the new version:
   ```bash
-  gh release download vX.Y.Z --dir /tmp/spec-kitty-release-check
-  python -m pip install --force-reinstall /tmp/spec-kitty-release-check/spec_kitty_cli-X.Y.Z-py3-none-any.whl
+  python -m pip index versions spec-kitty-cli
+  ```
+- [ ] Verify the GitHub release is public and includes the wheel, sdist, and checksums.
+
+### Installation and Upgrade
+
+- [ ] Test a fresh install:
+  ```bash
+  python -m pip install --force-reinstall spec-kitty-cli==X.Y.Z
   spec-kitty --version
-  spec-kitty init test-project
-  cd test-project
-  spec-kitty --help
   ```
+- [ ] Test upgrade from the previous stable release on a sample project.
 
-- [ ] Test upgrade from previous version:
-  ```bash
-  gh release download vX.Y.[Z-1] --dir /tmp/spec-kitty-prev-check
-  python -m pip install --force-reinstall /tmp/spec-kitty-prev-check/spec_kitty_cli-X.Y.[Z-1]-py3-none-any.whl
-  spec-kitty init old-project
-  gh release download vX.Y.Z --dir /tmp/spec-kitty-release-check
-  python -m pip install --force-reinstall /tmp/spec-kitty-release-check/spec_kitty_cli-X.Y.Z-py3-none-any.whl
-  cd old-project
-  spec-kitty upgrade
-  ```
+### Communication
 
-### Documentation
+- [ ] If this is a minor or major release, publish release notes and migration guidance.
+- [ ] If release-track policy changed, call it out explicitly:
+  - `main` is the stable `2.x` line
+  - `1.x-maintenance` is deprecated maintenance-only
+  - no new `1.x` PyPI releases are planned
 
-- [ ] Update any external documentation sites
-- [ ] Post release announcement (if major/minor version):
-  - GitHub Discussions
-  - Project website
-  - Social media (if applicable)
+## Maintenance-Line Policy
 
-### Issue Cleanup
+- [ ] Only cut `1.x-maintenance` releases for critical fixes.
+- [ ] Do not publish new `1.x` releases to PyPI.
+- [ ] If a `1.x-maintenance` release is needed, use GitHub tags/releases only and state clearly that the line is deprecated.
 
-- [ ] Close resolved issues with release version:
-  ```
-  Fixed in vX.Y.Z
-  ```
+## Rollback Procedure
 
-- [ ] Update project board / milestones:
-  - Move completed issues to "Done"
-  - Create next milestone if needed
+If a critical issue is discovered after release:
 
-## Rollback Procedure (if needed)
-
-If critical issues discovered after release:
-
-### Option 1: Hot Fix Release
-
-1. Create hotfix branch from tag:
-   ```bash
-   git checkout -b hotfix/X.Y.Z+1 vX.Y.Z
-   ```
-
-2. Fix issue, commit, test
-
-3. Follow release process for X.Y.Z+1
-
-### Option 2: Retire GitHub Release
-
-**Only for critical security issues or broken installations before hotfix is ready**
-
-```bash
-# Mark the release as retired in GitHub and point users to the hotfix
-gh release edit vX.Y.Z --draft
-# Or delete if policy allows:
-# gh release delete vX.Y.Z --cleanup-tag --yes
-```
-
-**Note:** Prefer hotfix releases over deleting tags/releases.
-
-## Version-Specific Checklists
-
-### For Research Mission Changes (0.13.0+)
-
-- [ ] Test CSV schema validation:
-  - evidence-log.csv schema enforcement
-  - source-register.csv schema enforcement
-  - Detection migration informational output
-
-- [ ] Verify agent templates updated:
-  - Research CSV Schemas section present
-  - Canonical schemas documented
-  - Append-only examples included
-
-### For Agent Management Changes (0.12.0+)
-
-- [ ] Test config-driven behavior:
-  ```bash
-  spec-kitty agent config list
-  spec-kitty agent config add claude
-  spec-kitty agent config remove codex
-  spec-kitty agent config status
-  spec-kitty agent config sync
-  ```
-
-- [ ] Verify migrations respect agent config
-- [ ] Test with projects with/without config.yaml
-
-### For Workspace-per-WP Changes (0.11.0+)
-
-- [ ] Test workspace creation per work package
-- [ ] Test dependency graph handling
-- [ ] Test parallel WP execution
-- [ ] Test merge workflow with multiple WPs
+1. Cut a hotfix from `vX.Y.Z` and release `X.Y.(Z+1)` as soon as practical.
+2. If the PyPI artifact is broken and no hotfix is ready yet, yank the PyPI release and update the GitHub release notes with the replacement plan.
+3. Prefer forward fixes over deleting published tags.
 
 ## Common Gotchas
 
-### Migration Issues
-
-- **Migration not detected**: Ensure migration is registered with `@MigrationRegistry.register`
-- **Migration runs multiple times**: Check idempotency, should be safe to run repeatedly
-- **Migration breaks existing projects**: Always test on sample projects before release
-
-### Version Mismatch
-
-- **PyPI shows old version**: Wait 5-10 minutes for PyPI to update indexes
-- **Local installation wrong version**: Clear pip cache: `pip cache purge`
-
-### CI Failures
-
-- **Tests timeout**: Check for infinite loops in new code
-- **Import errors**: Verify package structure in `pyproject.toml`
-- **Release workflow fails**: Check `PYPI_API_TOKEN` secret is set
-
-### Test Environment Differences (Lessons from v0.13.6)
-
-**Problem**: Tests pass locally but fail in CI with git command errors.
-
-**Common Causes:**
-
-1. **Git Default Branch Name Mismatch**
-   ```
-   Error: Command '['git', 'branch', 'feature-branch', 'main']' returned non-zero exit status 128
-   ```
-   - **Cause**: `git init` creates different default branch names in different environments
-     - Local (macOS with git 2.30+): Creates "main"
-     - CI (Ubuntu with older git): Creates "master"
-     - User's machine: Depends on `init.defaultBranch` config
-
-   - **Fix**: Always use `git init -b main` to explicitly set branch name
-     ```python
-     # ❌ BAD (environment-dependent)
-     subprocess.run(["git", "init"], cwd=repo, check=True)
-
-     # ✅ GOOD (explicit)
-     subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True)
-     ```
-
-   - **Files affected in v0.13.6**:
-     - `tests/unit/test_multi_parent_merge_empty_branches.py`
-     - `tests/unit/test_move_task_git_validation.py`
-
-2. **Rich Console Formatting Differences**
-   ```
-   AssertionError: assert 'exists but is not a valid worktree' in output
-   # Output has double spaces: 'exists but is not  a valid worktree'
-   ```
-   - **Cause**: Rich console adds ANSI color codes; `capsys.readouterr()` strips them but leaves spacing artifacts
-   - **Fix**: Normalize whitespace before assertions
-     ```python
-     import re
-     output = re.sub(r'\s+', ' ', captured.out)  # Normalize all whitespace
-     assert "expected text" in output
-     ```
-
-   - **File affected in v0.13.6**:
-     - `tests/specify_cli/test_implement_validation.py`
-
-3. **"PYPI_API_TOKEN not configured" Error (Misleading)**
-   - **What it looks like**: GitHub Actions shows "PYPI_API_TOKEN secret is not configured"
-   - **What it actually means**: Generic error message from failure handler
-   - **Real cause**: Usually test failures or validation errors earlier in workflow
-   - **Fix**: Check actual step that failed (tests, validation, build) before assuming it's a token issue
-   - **v0.13.6 experience**: Message appeared 3 times, but real issue was git test failures
-
-**Debugging Strategy:**
-
-1. **Add Test Output Capture** (Added in v0.13.6):
-   ```yaml
-   - name: Run tests
-     run: |
-       python -m pytest -v --tb=short 2>&1 | tee pytest-output.txt
-       exit ${PIPESTATUS[0]}
-
-   - name: Upload test output
-     uses: actions/upload-artifact@v4
-     if: always()
-     with:
-       name: pytest-output
-       path: pytest-output.txt
-       retention-days: 7
-   ```
-
-2. **Check System Reminder Messages**: When workflow fails, CI output may include system reminders with actual error details
-
-3. **Test Locally with CI-like Environment**:
-   ```bash
-   # Simulate CI Python version
-   python3.11 -m pytest
-
-   # Simulate CI git version
-   git --version
-   # If different from local, test with docker:
-   docker run -v $(pwd):/code -w /code python:3.11 python -m pytest
-   ```
-
-**Preventive Measures:**
-
-- [ ] Always use `git init -b main` in test fixtures
-- [ ] Normalize whitespace when testing console output
-- [ ] Don't assume default git config matches local environment
-- [ ] Test with pytest (not just `PYTHONPATH=src pytest`) to match CI
-- [ ] Review system reminder messages in CI output for real errors
-
-## Checklist Summary
-
-Quick reference for minimum release steps:
-
-1. ✅ All tests pass
-2. ✅ Version bumped in `pyproject.toml`
-3. ✅ CHANGELOG.md updated
-4. ✅ Release PR created and approved
-5. ✅ Release PR merged (merge commit, not squash)
-6. ✅ Tag created and pushed
-7. ✅ GitHub Actions workflow completes
-8. ✅ PyPI installation verified
+- **Validation fails with "Version does not advance beyond latest tag"**:
+  bump `pyproject.toml` to a higher semantic version.
+- **Validation fails with "CHANGELOG.md lacks a populated section"**:
+  add `## [X.Y.Z]` with real release notes before tagging.
+- **PyPI publish fails**:
+  check PyPI Trusted Publishing configuration for the workflow and repository, not a legacy token secret.
+- **Fresh install still shows the old version**:
+  wait a few minutes for package indexes to refresh, then retry with `pip cache purge` if needed.
 
 ---
 
-**Last Updated**: 2026-01-27 (for version 0.13.6)
-**Next Review**: After each major or minor release
-
-## Release History Notes
-
-### v0.13.6 (2026-01-27) - Lessons Learned
-
-**Issues Encountered:**
-1. Tests passed locally (1733/1733) but failed in CI (5 failed, 5 errors)
-2. Git default branch mismatch (local: "main", CI: "master")
-3. Rich console formatting created double-space artifacts in assertions
-4. Misleading "PYPI_API_TOKEN not configured" error (actual cause: test failures)
-
-**Resolution:**
-- Fixed git fixtures: `git init` → `git init -b main`
-- Normalized whitespace in assertions: `re.sub(r'\s+', ' ', output)`
-- Added pytest output artifact capture for debugging
-- Total release attempts: 4
-- Time to resolution: ~30 minutes
-
-**Improvements Made:**
-- Enhanced release workflow with test output artifacts
-- Documented CI environment gotchas
-- Added git fixture best practices
-- Clarified misleading error messages
-
-**Key Learning**: Always test that new test fixtures work in CI environments with different git/console configurations, not just locally.
+**Last Updated**: 2026-03-21

--- a/docs/1x/index.md
+++ b/docs/1x/index.md
@@ -1,6 +1,7 @@
 # 1.x Documentation (Legacy Track)
 
-`1.x` is the stable local-first workflow track.
+`1.x` is deprecated overall and now retained only as `1.x-maintenance` for critical maintenance work.
+No new `1.x` PyPI releases are planned.
 
 ## What 1.x Covers
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -55,7 +55,7 @@
       "_disableContribution": false,
       "_gitContribute": {
         "repo": "https://github.com/Priivacy-ai/spec-kitty",
-        "branch": "2.x"
+        "branch": "main"
       },
       "_appLogoPath": "assets/images/logo_small.webp",
       "_appFaviconPath": "assets/images/logo_small.webp"

--- a/docs/how-to/2-1-main-cutover-checklist.md
+++ b/docs/how-to/2-1-main-cutover-checklist.md
@@ -1,0 +1,117 @@
+# 2.1 Main-Branch Cutover Checklist
+
+Use this checklist to promote the `2.x` line to `main`, park the old line as `1.x-maintenance`, and ship `2.1.0` as the first stable PyPI release on the promoted line.
+
+## Desired End State
+
+- `main` points at the former `2.x` history and is the stable `2.x` line.
+- `1.x-maintenance` points at the former `main` history and is clearly deprecated.
+- `2.1.0` publishes both GitHub release artifacts and the PyPI package.
+- Install and docs messaging consistently describe `1.x-maintenance` as maintenance-only.
+
+## Phase 0: Freeze and Confirm
+
+- [ ] Freeze non-release merges during the cutover window.
+- [ ] Confirm the cutover is a branch rename/cutover, not a merge.
+- [ ] Confirm the intended open-PR outcome:
+  - PRs targeting `2.x` should land on the future `main`.
+  - PRs targeting current `main` should either stay on `1.x-maintenance` or be explicitly rebased.
+- [ ] Confirm the release version is `2.1.0`.
+
+## Phase 1: Repo and Distribution Prep
+
+- [ ] Merge the release-preparation changes for `2.1.0`:
+  - version bump
+  - changelog entry
+  - README/docs release-track update
+  - release workflow with PyPI publish
+  - release-readiness targeting `main` (and temporarily `2.x`)
+- [ ] Configure PyPI Trusted Publishing for `spec-kitty-cli`:
+  - owner/repo: `Priivacy-ai/spec-kitty`
+  - workflow: `.github/workflows/release.yml`
+  - environment: `pypi`
+- [ ] Verify GitHub environment settings for `pypi` if environment protection rules are used.
+- [ ] Confirm branch protections are defined for both current `main` and `2.x` before rename.
+
+## Phase 2: Pre-Cutover Verification
+
+- [ ] Confirm latest `2.x` HEAD is the intended release candidate.
+- [ ] Confirm `CI Quality` is green on that commit.
+- [ ] Confirm `Release Readiness Check` passes for the `2.1.0` PR.
+- [ ] Confirm `gh pr list` shows the expected open PRs and bases.
+- [ ] Confirm docs and metadata now describe:
+  - `main` as stable `2.x`
+  - `1.x-maintenance` as deprecated maintenance-only
+  - PyPI publication starting with `2.1.0`
+
+## Phase 3: Branch Cutover on GitHub
+
+Do these steps in GitHub settings/UI during the freeze window.
+
+1. [ ] Temporarily change the default branch from current `main` to `2.x`.
+2. [ ] Rename current `main` to `1.x-maintenance`.
+3. [ ] Rename current `2.x` to `main`.
+4. [ ] Set `main` back as the default branch.
+5. [ ] Verify branch protection rules carried over correctly after rename.
+6. [ ] Verify open PR retargeting:
+   - current `2.x` PRs should now target `main`
+   - current `main` PRs should now target `1.x-maintenance`
+
+## Phase 4: Post-Cutover Repository Checks
+
+- [ ] Verify the repository homepage and default-branch badge point at the new `main`.
+- [ ] Verify raw `main` asset URLs still resolve as expected.
+- [ ] Verify docs contribution/edit links point at `main`.
+- [ ] Verify workflows trigger on the right branches after the rename.
+- [ ] Verify `README.md` on GitHub clearly marks `1.x-maintenance` as deprecated.
+- [ ] Add a short deprecation note or pinned issue for `1.x-maintenance` if desired.
+
+## Phase 5: Release `2.1.0`
+
+1. [ ] Check out the new `main` locally and pull latest.
+2. [ ] Confirm `pyproject.toml` and `CHANGELOG.md` still show `2.1.0`.
+3. [ ] Tag the release:
+   ```bash
+   git checkout main
+   git pull origin main
+   git tag -a v2.1.0 -m "Release v2.1.0"
+   git push origin v2.1.0
+   ```
+4. [ ] Watch `.github/workflows/release.yml`.
+5. [ ] Verify:
+   - tests passed
+   - distributions built
+   - PyPI publish succeeded
+   - GitHub release was created with artifacts and notes
+
+## Phase 6: Release Verification
+
+- [ ] Verify GitHub release `v2.1.0` exists.
+- [ ] Verify PyPI shows `2.1.0` as the latest version.
+- [ ] Verify `pip install spec-kitty-cli` installs `2.1.0`.
+- [ ] Smoke-test `spec-kitty --version` and `spec-kitty init` from the PyPI install.
+- [ ] Verify upgrade behavior on a representative existing project.
+
+## Phase 7: Follow-Through
+
+- [ ] Announce `2.1.0` as the new stable line.
+- [ ] State clearly that `1.x-maintenance` is deprecated and maintenance-only.
+- [ ] Update any external docs or pinned install instructions that still mention the old split-track model.
+- [ ] Close or retarget any stale PRs/issues that still refer to the old branch setup.
+
+## Current PRs to Check During Cutover
+
+At the time this checklist was prepared:
+
+- `#305` targets `2.x` and should end up on the new `main`.
+- `#277` targets `2.x` and should end up on the new `main`.
+- `#265` targets current `main` and should end up on `1.x-maintenance` unless intentionally rebased.
+
+## Rollback Plan
+
+If the branch rename causes unexpected automation or protection issues:
+
+1. Pause tagging and PyPI publication.
+2. Fix branch protection and workflow targeting on GitHub first.
+3. Re-verify PR bases and default branch behavior.
+4. Only tag `v2.1.0` after the branch model is stable.

--- a/docs/how-to/install-and-upgrade.md
+++ b/docs/how-to/install-and-upgrade.md
@@ -4,6 +4,9 @@ Use this guide to install the Spec Kitty CLI and upgrade existing projects.
 
 ## Install from PyPI
 
+The stable PyPI package now tracks the `2.x` line from `main`.
+The old `1.x` line is deprecated and remains available only from pinned maintenance tags or source checkouts if you cannot migrate yet.
+
 ```bash
 pip install spec-kitty-cli
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ This site is versioned by product line.
 
 | Track | Use when | Entry point |
 |---|---|---|
-| `1.x` | You are maintaining or operating legacy local-first workflows. | [Open 1.x docs](1x/index.md) |
-| `2.x` | You are building on current doctrine, glossary, constitution, and runtime architecture. | [Open 2.x docs](2x/index.md) |
+| `1.x` | You are maintaining a deprecated legacy workflow that is now maintenance-only. | [Open 1.x docs](1x/index.md) |
+| `2.x` | You are building on the current stable line published from `main` and PyPI. | [Open 2.x docs](2x/index.md) |
 
 ## Documentation Scope for This Release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "2.0.11"
+version = "2.1.0"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- bump the release line to 2.1.0
- switch docs and release policy to main-as-2.x with 1.x-maintenance deprecated
- add PyPI publishing to the v2 release workflow and document the branch cutover checklist

## Validation
- python3 scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
- python3 scripts/release/extract_changelog.py 2.1.0
- python3 -m build --wheel
- python3 YAML parse of edited workflow files
- git diff --check