### PR TITLE
fix(release): use PyPI runtime dependency for 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "packaging>=23.0",
     "psutil>=5.9.0",  # Cross-platform process management for dashboard
     "spec-kitty-events==2.3.1",
-    "spec-kitty-runtime @ git+https://github.com/Priivacy-ai/spec-kitty-runtime.git@v0.2.0a0",
+    "spec-kitty-runtime==0.2.0a0",
     "websockets>=12.0",  # WebSocket client for sync protocol
     "toml>=0.10.2",  # Config file parsing
     "filelock>=3.13.0",  # Credential storage locking


### PR DESCRIPTION
## Summary
- replace the direct git runtime dependency with the published PyPI package pin
- keep 2.1.0 behavior aligned with the validated runtime tag v0.2.0a0
- unblock PyPI publication for the existing 2.1.0 release

## Verification
- python3 -m build --wheel
- inspected wheel METADATA to confirm spec-kitty-runtime==0.2.0a0
