### PR TITLE
fix: preserve explicit WP args in workflow prompts

### DIFF
--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -84,7 +84,7 @@ Syntax format in this reference:
 
 ## /spec-kitty.implement
 
-**Syntax**: `/spec-kitty.implement [WP_ID]`
+**Syntax**: `/spec-kitty.implement [WP_ID] [--base WP_ID]`
 
 **Purpose**: Create a worktree and start implementation for a specific work package.
 
@@ -93,6 +93,7 @@ Syntax format in this reference:
 - Run from main repository for the workflow prompt; worktree is created by CLI.
 
 **What it does**:
+- If explicit slash-command args are provided, forwards the WP/base selection into the resolver-first workflow.
 - Step 1: `spec-kitty agent workflow implement WP## --agent <agent>` to show the prompt and move the WP to `doing`.
 - Step 2: `spec-kitty implement WP## [--base WP##]` to create the worktree.
 - Implementation happens inside the created worktree.
@@ -107,7 +108,7 @@ Syntax format in this reference:
 
 ## /spec-kitty.review
 
-**Syntax**: `/spec-kitty.review [WP_ID or prompt path]`
+**Syntax**: `/spec-kitty.review [WP_ID]`
 
 **Purpose**: Review a completed work package and update its lane status.
 
@@ -116,6 +117,7 @@ Syntax format in this reference:
 - WP must be in `lane: "for_review"`.
 
 **What it does**:
+- If `WP_ID` is provided, forwards it to the resolver-first workflow as an explicit `--wp-id`.
 - Loads the WP prompt, supporting artifacts, and code changes.
 - Performs structured review and records feedback via `--review-feedback-file`.
 - Persists feedback in shared git common-dir and writes frontmatter `review_feedback` pointer (`feedback://...`) in the WP file.

--- a/spec-driven.md
+++ b/spec-driven.md
@@ -196,7 +196,7 @@ After a plan is created **and Phase 0 research is complete**, this command analy
 
 Provides a structured hand-off gate for work packages with `lane: "for_review"`:
 
-1. **Selection**: Auto-detects first WP with `lane: "for_review"` (or accepts explicit WP ID).
+1. **Selection**: Auto-detects first WP with `lane: "for_review"` (or accepts an explicit WP ID passed through the slash command).
 2. **Auto-move to doing**: Moves WP to `lane: "doing"` and displays full prompt with review instructions.
 3. **Deep Review**: Agent reviews prompt, supporting docs, and code changes before rendering findings.
 4. **Decision Flow**: Agent uses workflow commands to update `lane` to "done" (approved) or "planned" (changes requested), which updates frontmatter and activity logs with agent + PID data.

--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -43,7 +43,24 @@ If a file/path is uncertain, verify first with `ls` or `test -f` before reading 
 
 **You MUST scroll to the BOTTOM** to see the completion command!
 
-Resolve canonical action context first:
+Resolve canonical action context first.
+
+Explicit slash-command argument from the caller (may be empty, and may include `--base WP##`):
+
+{ARGS}
+
+If the explicit caller argument above is non-empty:
+
+- Treat it as the canonical slash-command input for this run.
+- Forward the explicit WP selector to `spec-kitty agent context resolve` via `--wp-id`.
+- If a `--base WP##` flag is present, pass it through to the resolver too.
+- Do not run the default resolver command below unchanged when explicit args are present.
+- Do not rely on raw argument text appended elsewhere in the prompt for correctness.
+- Example with explicit WP and base: `spec-kitty agent context resolve --action implement --agent <your-name> --wp-id WP03 --base WP01 --json`
+- Example with explicit WP only: `spec-kitty agent context resolve --action implement --agent <your-name> --wp-id WP03 --json`
+- Example without explicit args: `spec-kitty agent context resolve --action implement --agent <your-name> --json`
+
+Default resolver command:
 
 ```bash
 spec-kitty agent context resolve --action implement --agent <your-name> --json

--- a/src/specify_cli/missions/software-dev/command-templates/review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/review.md
@@ -16,7 +16,23 @@ Use JSON `text` as governance context. On first load (`mode=bootstrap`), follow 
 
 **You MUST scroll to the BOTTOM** to see the completion commands!
 
-Resolve canonical action context first:
+Resolve canonical action context first.
+
+Explicit slash-command argument from the caller (may be empty; only explicit WP IDs are supported here):
+
+{ARGS}
+
+If the explicit caller argument above is non-empty:
+
+- Treat it as the required work package id for this review run.
+- Forward it to `spec-kitty agent context resolve` as `--wp-id <value>`.
+- Do not run the default resolver command below unchanged when an explicit WP is present.
+- Do not interpret it as a prompt path in resolver-first review prompts.
+- Do not rely on raw argument text appended elsewhere in the prompt for correctness.
+- Example with explicit WP: `spec-kitty agent context resolve --action review --agent <your-name> --wp-id WP02 --json`
+- Example without explicit WP: `spec-kitty agent context resolve --action review --agent <your-name> --json`
+
+Default resolver command:
 
 ```bash
 spec-kitty agent context resolve --action review --agent <your-name> --json

--- a/tests/init/test_central_templates.py
+++ b/tests/init/test_central_templates.py
@@ -8,6 +8,8 @@ from pathlib import Path
 pytestmark = pytest.mark.fast
 
 TEMPLATE_DIR = Path("src/specify_cli/templates/command-templates")
+MISSION_TEMPLATE_DIR = Path("src/specify_cli/missions/software-dev/command-templates")
+SLASH_COMMAND_DOC = Path("docs/reference/slash-commands.md")
 EXPECTED_TEMPLATES = {
     "accept.md",
     "analyze.md",
@@ -123,3 +125,25 @@ def test_central_review_template_dependency_checks() -> None:
     content_lower = content.lower()
     assert "dependencies" in content_lower, "review.md should mention dependencies"
     assert "rebase" in content_lower, "review.md should mention rebase warnings"
+
+
+def test_central_workflow_templates_preserve_explicit_argument_slots() -> None:
+    """Software-dev overrides must surface caller args for resolver-first flows."""
+    implement_content = (MISSION_TEMPLATE_DIR / "implement.md").read_text(encoding="utf-8")
+    review_content = (MISSION_TEMPLATE_DIR / "review.md").read_text(encoding="utf-8")
+
+    assert "{ARGS}" in implement_content, "implement.md should preserve explicit caller args"
+    assert "{ARGS}" in review_content, "review.md should preserve explicit caller args"
+    assert "--base WP01" in implement_content, "implement.md should document forwarding explicit base args"
+    assert "only explicit WP IDs are supported here" in review_content, (
+        "review.md should make the explicit WP-only contract clear"
+    )
+
+
+def test_slash_command_reference_matches_resolver_first_contract() -> None:
+    """Public slash-command docs must match the resolver-first implement/review contract."""
+    content = SLASH_COMMAND_DOC.read_text(encoding="utf-8")
+
+    assert "**Syntax**: `/spec-kitty.implement [WP_ID] [--base WP_ID]`" in content
+    assert "**Syntax**: `/spec-kitty.review [WP_ID]`" in content
+    assert "prompt path" not in content.lower()

--- a/tests/test_template/test_asset_generator.py
+++ b/tests/test_template/test_asset_generator.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from specify_cli.template.asset_generator import (
     generate_agent_assets,
     prepare_command_templates,
     render_command_template,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOFTWARE_DEV_TEMPLATE_DIR = REPO_ROOT / "src" / "specify_cli" / "missions" / "software-dev" / "command-templates"
 
 
 def _write_template(path: Path, with_agent_script: bool = True) -> None:
@@ -106,6 +111,69 @@ spec-kitty agent workflow implement WP01 --agent __AGENT__
     )
 
     assert "spec-kitty agent workflow implement WP01 --agent codex" in output
+
+
+@pytest.mark.parametrize(
+    ("agent_key", "arg_format", "extension", "expected_placeholder"),
+    [
+        ("claude", "$ARGUMENTS", "md", "$ARGUMENTS"),
+        ("codex", "$ARGUMENTS", "md", "$ARGUMENTS"),
+        ("opencode", "$ARGUMENTS", "md", "$ARGUMENTS"),
+        ("gemini", "{{args}}", "toml", "{{args}}"),
+        ("qwen", "{{args}}", "toml", "{{args}}"),
+    ],
+)
+def test_implement_template_preserves_explicit_argument_placeholder(
+    agent_key: str,
+    arg_format: str,
+    extension: str,
+    expected_placeholder: str,
+) -> None:
+    template_path = SOFTWARE_DEV_TEMPLATE_DIR / "implement.md"
+
+    output = render_command_template(
+        template_path,
+        script_type="sh",
+        agent_key=agent_key,
+        arg_format=arg_format,
+        extension=extension,
+    )
+
+    assert "Explicit slash-command argument from the caller" in output
+    assert expected_placeholder in output
+    assert "--wp-id WP03 --base WP01" in output
+
+
+@pytest.mark.parametrize(
+    ("agent_key", "arg_format", "extension", "expected_placeholder"),
+    [
+        ("claude", "$ARGUMENTS", "md", "$ARGUMENTS"),
+        ("codex", "$ARGUMENTS", "md", "$ARGUMENTS"),
+        ("opencode", "$ARGUMENTS", "md", "$ARGUMENTS"),
+        ("gemini", "{{args}}", "toml", "{{args}}"),
+        ("qwen", "{{args}}", "toml", "{{args}}"),
+    ],
+)
+def test_review_template_preserves_explicit_argument_placeholder(
+    agent_key: str,
+    arg_format: str,
+    extension: str,
+    expected_placeholder: str,
+) -> None:
+    template_path = SOFTWARE_DEV_TEMPLATE_DIR / "review.md"
+
+    output = render_command_template(
+        template_path,
+        script_type="sh",
+        agent_key=agent_key,
+        arg_format=arg_format,
+        extension=extension,
+    )
+
+    assert "Explicit slash-command argument from the caller" in output
+    assert "only explicit WP IDs are supported here" in output
+    assert "Do not interpret it as a prompt path" in output
+    assert expected_placeholder in output
 
 
 def test_prepare_command_templates_overlays_mission(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve explicit slash-command args in the software-dev `implement` and `review` prompts so agents forward them into the resolver-first flow instead of relying on runtime-specific argument appending
- align the public slash-command contract so `/spec-kitty.review` is WP-only and `/spec-kitty.implement` documents explicit `--base` support
- add regression tests across Markdown and TOML agent formats to ensure the argument placeholder survives rendering for supported runtimes

## Testing
- `uv run pytest tests/test_template/test_asset_generator.py tests/init/test_central_templates.py`

## Linear
- Primary: PRI-26, PRI-29
- Related follow-up: PRI-28, PRI-18