### PR TITLE
fix: expose review handoff evidence in orchestrator-api transition

### DIFF
--- a/docs/explanation/kanban-workflow.md
+++ b/docs/explanation/kanban-workflow.md
@@ -429,7 +429,7 @@ Users can override lane transitions when needed:
 spec-kitty agent tasks move-task WP01 --to planned --force --note "Reopening after hotfix"
 ```
 
-External orchestrators should request equivalent transitions through `spec-kitty orchestrator-api transition ...` so host validation and audit history stay consistent.
+External orchestrators should request equivalent transitions through `spec-kitty orchestrator-api transition ...`, including review-handoff evidence such as `--subtasks-complete`, `--implementation-evidence-present`, `--review-ref`, and `--evidence-json`, so host validation and audit history stay consistent.
 
 ## Rules and Constraints
 

--- a/docs/how-to/build-custom-orchestrator.md
+++ b/docs/how-to/build-custom-orchestrator.md
@@ -51,11 +51,14 @@ Use returned `workspace_path` and `prompt_path` to run your agent process.
 # implementation complete
 spec-kitty orchestrator-api transition \
   --feature <slug> --wp WP01 --to for_review \
-  --actor my-orchestrator --policy '<json>'
+  --actor my-orchestrator --policy '<json>' \
+  --subtasks-complete --implementation-evidence-present
 # review approved
 spec-kitty orchestrator-api transition \
   --feature <slug> --wp WP01 --to done \
-  --actor reviewer-bot
+  --actor reviewer-bot \
+  --review-ref review/WP01/attempt-1 \
+  --evidence-json '{"review":{"reviewer":"reviewer-bot","verdict":"approved","reference":"review/WP01/attempt-1"}}'
 # review rejected -> rework
 spec-kitty orchestrator-api start-review \
   --feature <slug> --wp WP01 --actor my-orchestrator \

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -450,6 +450,9 @@ Options:
   --policy      TEXT  Policy metadata JSON (required for run-affecting lanes)
   --force             Force the transition
   --review-ref  TEXT  Review reference
+  --evidence-json  TEXT  JSON string with done evidence
+  --subtasks-complete  BOOLEAN  Whether required subtasks are complete for in_progress->for_review
+  --implementation-evidence-present  BOOLEAN  Whether implementation evidence exists for in_progress->for_review
 ```
 
 **Flags:**
@@ -464,6 +467,9 @@ Options:
 | `--policy` | TEXT | Conditional | none | JSON policy metadata (required for run-affecting lanes) |
 | `--force` | FLAG | No | off | Override guard checks (recovery only) |
 | `--review-ref` | TEXT | No | none | Review artifact reference |
+| `--evidence-json` | TEXT | No | none | JSON object recorded as done evidence |
+| `--subtasks-complete` | FLAG | No | off | Satisfy the `in_progress` -> `for_review` subtask completion guard |
+| `--implementation-evidence-present` | FLAG | No | off | Satisfy the `in_progress` -> `for_review` implementation evidence guard |
 
 **Valid target lanes and policy requirement:**
 
@@ -498,6 +504,8 @@ Options:
 - Use `--force` only for recovery from known-bad state, never in normal flow.
 - Use `--note` to record reasoning in the audit trail.
 - Use `--review-ref` when transitioning from `for_review` or `approved` back to `in_progress` or `planned` (review rollback guard).
+- Use `--subtasks-complete` and `--implementation-evidence-present` when an external orchestrator submits completed implementation for review.
+- Use `--review-ref` together with `--evidence-json` when an external orchestrator records `done` after review approval.
 
 ---
 

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -635,6 +635,9 @@ def transition(
     policy: str = typer.Option(None, "--policy", help="Policy metadata JSON (required for run-affecting lanes)"),
     force: bool = typer.Option(False, "--force", help="Force the transition"),
     review_ref: str = typer.Option(None, "--review-ref", help="Review reference"),
+    evidence_json: str = typer.Option(None, "--evidence-json", help="JSON string with done evidence"),
+    subtasks_complete: bool = typer.Option(None, "--subtasks-complete", help="Whether required subtasks are complete for in_progress->for_review"),
+    implementation_evidence_present: bool = typer.Option(None, "--implementation-evidence-present", help="Whether implementation evidence exists for in_progress->for_review"),
 ) -> None:
     """Emit a single lane transition for a WP."""
     cmd = "transition"
@@ -668,6 +671,18 @@ def transition(
             _fail(cmd, "POLICY_VALIDATION_FAILED", str(exc))
             return
 
+    evidence: dict | None = None
+    if evidence_json is not None:
+        try:
+            parsed_evidence = json.loads(evidence_json)
+        except json.JSONDecodeError as exc:
+            _fail(cmd, "USAGE_ERROR", f"Invalid JSON in --evidence-json: {exc}")
+            return
+        if not isinstance(parsed_evidence, dict):
+            _fail(cmd, "USAGE_ERROR", "--evidence-json must decode to a JSON object")
+            return
+        evidence = parsed_evidence
+
     main_repo_root = _get_main_repo_root()
     feature_dir = _resolve_feature_dir(main_repo_root, feature)
     if feature_dir is None:
@@ -695,7 +710,10 @@ def transition(
             actor,
             reason=note,
             force=force,
+            evidence=evidence,
             review_ref=review_ref,
+            subtasks_complete=subtasks_complete,
+            implementation_evidence_present=implementation_evidence_present,
             execution_mode="worktree",
             policy_metadata=policy_dict,
         )

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -463,6 +463,97 @@ class TestTransition:
         data = json.loads(result.output)
         assert data["error_code"] == "POLICY_METADATA_REQUIRED"
 
+    def test_transition_passes_review_handoff_flags_to_status_emit(self, tmp_path):
+        repo_root, _ = _make_feature(tmp_path, "099-test-feature")
+        feature_slug = "099-test-feature"
+
+        emit_mock = MagicMock()
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ), patch(
+            "specify_cli.status.emit.emit_status_transition",
+            emit_mock,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "transition",
+                    "--feature", feature_slug,
+                    "--wp", "WP01",
+                    "--to", "for_review",
+                    "--actor", "claude",
+                    "--policy", _valid_policy_json(),
+                    "--subtasks-complete",
+                    "--implementation-evidence-present",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = emit_mock.call_args.kwargs
+        assert kwargs["subtasks_complete"] is True
+        assert kwargs["implementation_evidence_present"] is True
+
+    def test_transition_passes_done_evidence_to_status_emit(self, tmp_path):
+        repo_root, _ = _make_feature(tmp_path, "099-test-feature")
+        feature_slug = "099-test-feature"
+
+        emit_mock = MagicMock()
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ), patch(
+            "specify_cli.status.emit.emit_status_transition",
+            emit_mock,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "transition",
+                    "--feature", feature_slug,
+                    "--wp", "WP01",
+                    "--to", "done",
+                    "--actor", "reviewer",
+                    "--review-ref", "review-001",
+                    "--evidence-json", '{"review":{"reviewer":"reviewer","verdict":"approved","reference":"review-001"}}',
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = emit_mock.call_args.kwargs
+        assert kwargs["review_ref"] == "review-001"
+        assert kwargs["evidence"] == {
+            "review": {
+                "reviewer": "reviewer",
+                "verdict": "approved",
+                "reference": "review-001",
+            }
+        }
+
+    def test_transition_rejects_invalid_evidence_json(self, tmp_path):
+        repo_root, _ = _make_feature(tmp_path, "099-test-feature")
+        feature_slug = "099-test-feature"
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "transition",
+                    "--feature", feature_slug,
+                    "--wp", "WP01",
+                    "--to", "done",
+                    "--actor", "reviewer",
+                    "--evidence-json", '{"review":',
+                ],
+            )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["error_code"] == "USAGE_ERROR"
+
 # ── append-history ────────────────────────────────────────────────
 
 class TestAppendHistory:


### PR DESCRIPTION
## Summary
- extend `spec-kitty orchestrator-api transition` with `--evidence-json`, `--subtasks-complete`, and `--implementation-evidence-present`
- pass those inputs through to the canonical status emitter instead of requiring external orchestrators to mix command surfaces
- update the external orchestrator docs and integration coverage for the completed contract

## Why
External orchestrators were documented to use `orchestrator-api transition`, but current releases still required `agent status emit` for evidence-backed `for_review` and `done` transitions. This PR closes that gap and restores a complete public contract for outside automation.

## Validation
- `python3 -m py_compile src/specify_cli/orchestrator_api/commands.py tests/agent/test_orchestrator_commands_integration.py`
- `pytest tests/agent/test_orchestrator_commands_integration.py -q`
