### PR TITLE
fix(implement): preserve actionable --json errors

### DIFF
--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -7,6 +7,7 @@ import json
 import re
 import subprocess
 from datetime import datetime, timezone
+from io import StringIO
 from pathlib import Path
 
 import typer
@@ -51,8 +52,12 @@ def _json_safe_output(func):
     def wrapper(*args, **kwargs):
         json_output = bool(kwargs.get("json_output", False))
         previous_quiet = console.quiet
+        previous_file = console.file
+        capture_buffer: StringIO | None = None
         if json_output:
-            console.quiet = True
+            capture_buffer = StringIO()
+            console.file = capture_buffer
+            console.quiet = False
 
         wp_id = kwargs.get("wp_id")
         if wp_id is None and args:
@@ -62,7 +67,13 @@ def _json_safe_output(func):
             return func(*args, **kwargs)
         except typer.Exit as exc:
             if json_output and getattr(exc, "exit_code", 1):
-                payload = {"status": "error", "error": "implement command failed"}
+                lines = [
+                    line.rstrip()
+                    for line in (capture_buffer.getvalue() if capture_buffer else "").splitlines()
+                    if line.strip()
+                ]
+                summary = "\n".join(lines[-20:]).strip() if lines else "implement command failed"
+                payload = {"status": "error", "error": summary or "implement command failed"}
                 if wp_id:
                     payload["wp_id"] = str(wp_id)
                 print(json.dumps(payload))
@@ -76,6 +87,7 @@ def _json_safe_output(func):
             raise typer.Exit(1)
         finally:
             console.quiet = previous_quiet
+            console.file = previous_file
 
     return wrapper
 

--- a/tests/agent/test_implement_command.py
+++ b/tests/agent/test_implement_command.py
@@ -159,6 +159,31 @@ class TestImplementCommand:
         assert payload["branch"] == "kitty/mission-010-feature-lane-a"
         assert payload["lane_id"] == "lane-a"
 
+    def test_implement_json_error_output_is_clean(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "010-feature"
+        create_meta_json(feature_dir)
+        wp_file = feature_dir / "tasks" / "WP01-setup.md"
+        wp_file.parent.mkdir(parents=True)
+        wp_file.write_text("---\nwork_package_id: WP01\ndependencies: []\n---\n# WP01")
+
+        with patch("specify_cli.cli.commands.implement.find_repo_root", return_value=tmp_path), patch(
+            "specify_cli.cli.commands.implement.detect_feature_context",
+            return_value=("010", "010-feature"),
+        ), patch(
+            "specify_cli.cli.commands.implement.resolve_feature_target_branch",
+            return_value="main",
+        ), patch(
+            "specify_cli.cli.commands.implement._ensure_planning_artifacts_committed_git",
+        ):
+            with pytest.raises(typer.Exit):
+                implement("WP01", feature="010-feature", json_output=True)
+
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["status"] == "error"
+        assert payload["wp_id"] == "WP01"
+        assert payload["error"] != "implement command failed"
+        assert "lanes.json is required" in payload["error"]
+
     def test_implement_creates_lane_workspace(self, tmp_path: Path) -> None:
         feature_dir = tmp_path / "kitty-specs" / "010-feature"
         create_meta_json(feature_dir)


### PR DESCRIPTION
## Summary
- keep `spec-kitty implement --json` machine-readable without collapsing every failure into the same opaque error string
- capture the recent console output for `typer.Exit` failures and return that text in the JSON envelope
- add a regression test proving lane-validation failures surface actionable text

## Why
External orchestrators and wrappers need an actionable failure message from `--json` mode. Returning only `implement command failed` forces callers to scrape human output or rerun the command interactively.

## Scope
- `src/specify_cli/cli/commands/implement.py`
- `tests/agent/test_implement_command.py`

## Validation
- `python3 -m pytest tests/agent/test_implement_command.py -q`

## Notes
This restacks the original PR after `#342` landed and intentionally drops the stale orchestrator docs/API claims that no longer matched current `main`.