### PR TITLE
fix(orchestrator-api): add verdict requirement for review transitions

### DIFF
--- a/.agents/skills/spec-kitty-runtime-review/SKILL.md
+++ b/.agents/skills/spec-kitty-runtime-review/SKILL.md
@@ -67,6 +67,22 @@ from this skill.
 
 ## Step 4: Issue Verdict
 
+**CRITICAL: Before running any command, emit an explicit verdict line:**
+
+For approval:
+```
+VERDICT: APPROVED
+```
+
+For rejection:
+```
+VERDICT: REJECTED
+```
+
+**This verdict line is REQUIRED.** Without it, the review cycle will be rejected.
+
+---
+
 Take exactly one action — never "approve with conditions".
 
 ### Approve (all acceptance criteria met)

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -442,14 +442,15 @@ Perform an explicit single lane transition on a work package.
 Usage: spec-kitty orchestrator-api transition [OPTIONS]
 
 Options:
-  --feature     TEXT  Feature slug [required]
-  --wp          TEXT  Work package ID [required]
-  --to          TEXT  Target lane [required]
-  --actor       TEXT  Actor identity [required]
-  --note        TEXT  Reason/note for the transition
-  --policy      TEXT  Policy metadata JSON (required for run-affecting lanes)
-  --force             Force the transition
-  --review-ref  TEXT  Review reference
+  --feature          TEXT  Feature slug [required]
+  --wp               TEXT  Work package ID [required]
+  --to               TEXT  Target lane [required]
+  --actor            TEXT  Actor identity [required]
+  --note             TEXT  Reason/note for the transition
+  --policy           TEXT  Policy metadata JSON (required for run-affecting lanes)
+  --force                  Force the transition
+  --review-ref       TEXT  Review reference
+  --evidence-json    TEXT  Evidence JSON (required for done transitions)
 ```
 
 **Flags:**
@@ -464,6 +465,10 @@ Options:
 | `--policy` | TEXT | Conditional | none | JSON policy metadata (required for run-affecting lanes) |
 | `--force` | FLAG | No | off | Override guard checks (recovery only) |
 | `--review-ref` | TEXT | No | none | Review artifact reference |
+| `--evidence-json` | TEXT | Conditional¹ | none | JSON payload recorded with the transition |
+
+**Notes:**
+1. `--evidence-json` is **required** for `done` transitions. Must include `review.verdict` field with value `"approved"` or `"changes_requested"`.
 
 **Valid target lanes and policy requirement:**
 
@@ -498,6 +503,40 @@ Options:
 - Use `--force` only for recovery from known-bad state, never in normal flow.
 - Use `--note` to record reasoning in the audit trail.
 - Use `--review-ref` when transitioning from `for_review` or `approved` back to `in_progress` or `planned` (review rollback guard).
+- Use `--evidence-json` for `done` transitions. Example:
+  ```bash
+  spec-kitty orchestrator-api transition \
+    --feature my-feature --wp WP01 --to done --actor reviewer-bot \
+    --evidence-json '{"review": {"reviewer": "reviewer-bot", "verdict": "approved", "reference": "PR#42"}}'
+  ```
+
+**Example: Review approved transition**
+```bash
+spec-kitty orchestrator-api transition \
+  --feature 042-test-feature --wp WP01 --to done \
+  --actor reviewer-bot \
+  --evidence-json '{"review":{"reviewer":"reviewer-bot","verdict":"approved","reference":"PR#42"}}'
+```
+
+Response:
+```json
+{
+  "contract_version": "1.0.0",
+  "command": "transition",
+  "timestamp": "2026-03-28T15:00:00+00:00",
+  "correlation_id": "corr-abc123",
+  "success": true,
+  "error_code": null,
+  "data": {
+    "feature_slug": "042-test-feature",
+    "wp_id": "WP01",
+    "from_lane": "for_review",
+    "to_lane": "done",
+    "policy_metadata_recorded": false,
+    "evidence_recorded": true
+  }
+}
+```
 
 ---
 

--- a/src/doctrine/templates/command-templates/review.md
+++ b/src/doctrine/templates/command-templates/review.md
@@ -454,6 +454,24 @@ This is intentional - worktrees provide isolation for parallel feature developme
 
    **Default stance: REJECT.** Only approve when you've actively tried to find problems and found none. "Looks good" is not good enough - you must prove it's good.
 
+### 4.13 EMIT EXPLICIT VERDICT (CRITICAL)
+
+**BEFORE running any command, you MUST emit an explicit verdict line:**
+
+For approval:
+```
+VERDICT: APPROVED
+```
+
+For rejection:
+```
+VERDICT: REJECTED
+```
+
+**This verdict line is REQUIRED.** Without it, the review cycle will be rejected as invalid.
+
+After emitting the verdict, proceed with the appropriate command below.
+
 5. Decide outcome:
 
 - **Needs changes**:

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -635,6 +635,7 @@ def transition(
     policy: str = typer.Option(None, "--policy", help="Policy metadata JSON (required for run-affecting lanes)"),
     force: bool = typer.Option(False, "--force", help="Force the transition"),
     review_ref: str = typer.Option(None, "--review-ref", help="Review reference"),
+    evidence_json: str = typer.Option(None, "--evidence-json", help="Evidence JSON (required for done transitions)"),
 ) -> None:
     """Emit a single lane transition for a WP."""
     cmd = "transition"
@@ -668,6 +669,22 @@ def transition(
             _fail(cmd, "POLICY_VALIDATION_FAILED", str(exc))
             return
 
+    # Evidence JSON required for done transitions
+    evidence_dict: dict | None = None
+    if to_lane == "done":
+        if not evidence_json:
+            _fail(
+                cmd,
+                "EVIDENCE_REQUIRED",
+                "--evidence-json is required for done transitions (must include review.verdict)",
+            )
+            return
+        try:
+            evidence_dict = json.loads(evidence_json)
+        except json.JSONDecodeError as exc:
+            _fail(cmd, "EVIDENCE_INVALID", f"Invalid JSON in --evidence-json: {exc}")
+            return
+
     main_repo_root = _get_main_repo_root()
     feature_dir = _resolve_feature_dir(main_repo_root, feature)
     if feature_dir is None:
@@ -698,6 +715,7 @@ def transition(
             review_ref=review_ref,
             execution_mode="worktree",
             policy_metadata=policy_dict,
+            evidence=evidence_dict,
         )
     except TransitionError as exc:
         _fail(cmd, "TRANSITION_REJECTED", str(exc))
@@ -712,6 +730,7 @@ def transition(
             "from_lane": from_lane,
             "to_lane": to_lane,
             "policy_metadata_recorded": policy_dict is not None,
+            "evidence_recorded": evidence_dict is not None,
         },
     )
     _emit(envelope)


### PR DESCRIPTION
- Add --evidence-json parameter to orchestrator-api transition command
  - Required for 'done' transitions with review.verdict field
  - Validates JSON format and rejects invalid evidence
  - Returns EVIDENCE_REQUIRED or EVIDENCE_INVALID error codes

- Add VERDICT instruction to review prompt template
  - Reviewers must emit 'VERDICT: APPROVED' or 'VERDICT: REJECTED'
  - Instruction added to doctrine review template
  - Instruction added to runtime-review skill

- Update orchestrator-api documentation
  - Document --evidence-json parameter
  - Add example showing done transition with verdict
  - Update usage notes

Fixes issue where external orchestrators could not complete review transitions because the verdict was not being captured.