### PR TITLE
chore(release): prepare 3.0.1

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -103,10 +103,10 @@ jobs:
         run: |
           if [[ -n "${{ inputs.tag }}" ]]; then
             echo "Running validation in tag mode for dry run: ${{ inputs.tag }}"
-            python scripts/release/validate_release.py --mode tag --tag "${{ inputs.tag }}" --tag-pattern "v2.*.*"
+            python scripts/release/validate_release.py --mode tag --tag "${{ inputs.tag }}" --tag-pattern "v*.*.*"
           else
             echo "Running validation in branch mode"
-            python scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
+            python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
           fi
 
       - name: Test packaging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   push:
     tags:
-      - 'v[0-9]+.*.*'
+      - 'v*.*.*'
 
 permissions:
   contents: write
@@ -75,7 +75,7 @@ jobs:
           exit ${PIPESTATUS[0]}
 
       - name: Validate release metadata
-        run: python scripts/release/validate_release.py --mode tag --tag "${GITHUB_REF_NAME}" --tag-pattern "v2.*.*"
+        run: python scripts/release/validate_release.py --mode tag --tag "${GITHUB_REF_NAME}" --tag-pattern "v*.*.*"
 
       - name: Build distributions
         run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [3.0.1] - 2026-03-31
+
+### Fixed
+
+- **Canonical status hard cutover completed.** Work-package lane state is now consistently sourced from `status.events.jsonl` across active CLI commands, packaged task tooling, templates, docs, and standalone helpers. Frontmatter lane fallbacks and `lane=` body-log writes are removed from active 3.0 flows.
+- **Canonical bootstrap and hard-fail behavior hardened.** `finalize-tasks` now seeds canonical `planned` state for generated WPs, while runtime commands fail explicitly when canonical status is missing instead of silently reconstructing it from abandoned frontmatter state.
+- **Release automation updated for 3.x.** GitHub release validation, maintainer docs, and workflow tag handling now use semantic `vX.Y.Z` tags generically, so `v3.0.1` publishes correctly to GitHub Releases and PyPI.
+
 ## [3.0.0] - 2026-03-30
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -96,18 +96,17 @@ graph LR
 
 </div>
 
-**Current stable release line:** `v2.1.1` (`main`, GitHub Releases, and PyPI)
+**Current stable release line:** `v3.0.1` (`main`, GitHub Releases, and PyPI)
 
-**2.1.1 highlights:**
-- Hotfix for PyPI wheels to bundle the canonical doctrine skill pack correctly
-- Upgrade repair migration for `2.1.0` projects that missed the managed skill pack
-- Release guardrails now fail if a wheel omits doctrine files or bundled skills
+**3.0.1 highlights:**
+- Canonical status hard cutover completed: active runtime paths no longer fall back to WP frontmatter lane state
+- `finalize-tasks` bootstraps canonical `planned` state for generated work packages
+- Release automation and maintainer tooling now accept semantic `vX.Y.Z` tags for 3.x publishing
 
-**2.1.0 highlights:**
-- Agent Skills Pack with bundled skills, installer/verification flow, and upgrade migration coverage
-- Structured requirement mapping from requirements into work-package planning
-- Deterministic branch intent injection in planning templates
-- `1.x` is now deprecated and retained only as `1.x-maintenance` for critical fixes
+**3.0.0 highlights:**
+- Event log is now the sole authority for mutable work-package status
+- Explicit feature targeting, MissionContext identity, and ownership manifests land on the 3.x stable line
+- Sparse checkout is removed in favor of in-repo planning artifacts and standard worktrees
 
 **Jump to:**
 [Getting Started](#-getting-started-complete-workflow) •
@@ -121,16 +120,16 @@ graph LR
 
 ## 📌 Release Track
 
-Spec Kitty now uses `main` as the stable `2.x` release line.
+Spec Kitty now uses `main` as the stable `3.x` release line.
 The former `1.x` line is deprecated and moves to `1.x-maintenance` for maintenance-only fixes.
 
 | Branch | Version | Status | Install |
 |--------|---------|--------|---------|
-| **main** | **2.1.x** | Current stable line | `pip install spec-kitty-cli` |
+| **main** | **3.0.x** | Current stable line | `pip install spec-kitty-cli` |
 | **1.x-maintenance** | **1.x** | Deprecated, maintenance-only | Install from a pinned maintenance tag or source checkout |
 
 **For users:** install the stable line from PyPI with `pip install spec-kitty-cli`.
-**For existing 1.x users:** migrate to `2.1.x` where possible; `1.x-maintenance` is only for critical maintenance and will no longer publish new PyPI releases.
+**For existing 1.x or 2.x users:** migrate to `3.0.x` where possible; `1.x-maintenance` is only for critical maintenance and will no longer publish new PyPI releases.
 
 ---
 
@@ -1148,10 +1147,10 @@ cat .kittify/metadata.yaml
 If you encounter issues with an agent, please open an issue so we can refine the integration.
 
 <details>
-<summary><h2>🚀 Releasing 2.x on GitHub and PyPI (Maintainers)</h2></summary>
+<summary><h2>🚀 Releasing Stable Versions on GitHub and PyPI (Maintainers)</h2></summary>
 
-The stable `2.x` line now lives on `main` and publishes from semantic tags in the form `v2.<minor>.<patch>`.
-Starting with `2.1.0`, the release workflow publishes both GitHub release artifacts and the PyPI package.
+The stable `3.x` line now lives on `main` and publishes from semantic tags in the form `vX.Y.Z`.
+The release workflow publishes both GitHub release artifacts and the PyPI package.
 
 ### 0. One-Time Setup
 
@@ -1172,7 +1171,7 @@ git checkout -b release/vX.Y.Z
 ### 2. Validate Locally
 
 ```bash
-python scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
+python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
 python -m pytest
 python -m build
 twine check dist/*
@@ -1209,8 +1208,8 @@ python -m pip index versions spec-kitty-cli
 
 ### Guardrails
 
-- `release-readiness.yml`: runs on PRs to `main` (and `2.x` during the cutover window) to validate version/changelog/tests.
-- `release.yml`: runs on `v2.*.*` tags and performs:
+- `release-readiness.yml`: runs on PRs to `main` (and `2.x` if the maintenance branch is still active) to validate version/changelog/tests.
+- `release.yml`: runs on `v*.*.*` tags and performs:
   - test execution
   - release metadata validation
   - artifact build and checksums
@@ -1220,7 +1219,7 @@ python -m pip index versions spec-kitty-cli
 ### Troubleshooting
 
 **Validation fails**: "Version does not advance beyond latest tag"
-- Check latest tag: `git tag --list 'v2.*.*' --sort=-version:refname | head -1`
+- Check latest tag: `git tag --list 'v*.*.*' --sort=-version:refname | head -1`
 - Bump `pyproject.toml` to a higher semantic version
 
 **Validation fails**: "CHANGELOG.md lacks a populated section"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,10 +1,10 @@
 # Release Checklist
 
-Use this checklist for stable `2.x` releases from `main`.
+Use this checklist for stable releases from `main`.
 
-> `main` is the primary `2.x` line and publishes both GitHub releases and PyPI packages.
+> `main` is the primary stable release line and publishes both GitHub releases and PyPI packages.
 > `1.x-maintenance` is deprecated overall, reserved for critical maintenance only, and should not receive new PyPI releases.
-> For the branch rename/cutover itself, see `docs/how-to/2-1-main-cutover-checklist.md`.
+> Historical 2.x release notes remain in Git tags and changelog history; new stable releases ship from `main`.
 
 ## Pre-Release Preparation
 
@@ -38,7 +38,7 @@ Use this checklist for stable `2.x` releases from `main`.
   ```
 - [ ] Run release validation in branch mode:
   ```bash
-  python scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
+  python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
   ```
 - [ ] Run linting and formatting checks appropriate for changed files:
   ```bash
@@ -56,7 +56,7 @@ Use this checklist for stable `2.x` releases from `main`.
 - [ ] Bump `version` in `pyproject.toml`.
 - [ ] Add a populated `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`.
 - [ ] Review `README.md` release-track messaging:
-  - `main` should be described as the stable `2.x` line.
+  - `main` should be described as the stable `3.x` line.
   - `1.x-maintenance` should be described as deprecated maintenance-only.
 - [ ] Review installation docs if distribution channels changed.
 - [ ] If new ADRs were added, verify they are filed under the correct versioned architecture path.
@@ -163,7 +163,7 @@ git push origin vX.Y.Z
 
 - [ ] If this is a minor or major release, publish release notes and migration guidance.
 - [ ] If release-track policy changed, call it out explicitly:
-  - `main` is the stable `2.x` line
+  - `main` is the stable `3.x` line
   - `1.x-maintenance` is deprecated maintenance-only
   - no new `1.x` PyPI releases are planned
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.0.0"
+version = "3.0.1"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,14 +1,14 @@
 # Release Scripts
 
 This directory contains helper scripts that keep local release checks aligned with the
-automated GitHub-only release pipeline for the `2.x` branch.
+automated release pipeline for stable releases from `main`.
 
-## 2.x Release Scope
+## Stable Release Scope
 
-- Branch: `2.x`
+- Branch: `main`
 - Versioning: semantic versions (`X.Y.Z`) in `pyproject.toml`
-- Tags: `v2.<minor>.<patch>`
-- Publication target: GitHub Releases only (no PyPI publish from `2.x`)
+- Tags: `vX.Y.Z`
+- Publication targets: GitHub Releases and PyPI
 
 ## Scripts
 
@@ -21,10 +21,10 @@ version progression relative to existing tags.
 
 ```bash
 # Branch mode (for PRs and local development)
-python scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
+python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
 
 # Tag mode (for release workflow)
-python scripts/release/validate_release.py --mode tag --tag v2.0.0 --tag-pattern "v2.*.*"
+python scripts/release/validate_release.py --mode tag --tag v3.0.1 --tag-pattern "v*.*.*"
 ```
 
 #### What it validates
@@ -32,7 +32,7 @@ python scripts/release/validate_release.py --mode tag --tag v2.0.0 --tag-pattern
 - `pyproject.toml` version is valid semantic version (`X.Y.Z`)
 - `CHANGELOG.md` contains populated section for that version
 - Version advances beyond latest existing release tag
-- In tag mode: tag matches version (for example `v2.0.0` <-> `2.0.0`)
+- In tag mode: tag matches version (for example `v3.0.1` <-> `3.0.1`)
 
 ### `extract_changelog.py`
 
@@ -44,8 +44,8 @@ python scripts/release/extract_changelog.py 2.0.0
 
 ## Workflow Integration
 
-- PR checks: `.github/workflows/release-readiness.yml` (targets `2.x`)
-- Tag releases: `.github/workflows/release.yml` (triggers on `v2.*.*`)
+- PR checks: `.github/workflows/release-readiness.yml`
+- Tag releases: `.github/workflows/release.yml` (triggers on `v*.*.*`)
 
 Release workflow sequence:
 
@@ -59,11 +59,11 @@ Release workflow sequence:
 
 ```bash
 # 1) prepare version + changelog
-vim pyproject.toml   # version = "2.0.0"
-vim CHANGELOG.md     # add ## [2.0.0] - YYYY-MM-DD
+vim pyproject.toml   # version = "3.0.1"
+vim CHANGELOG.md     # add ## [3.0.1] - YYYY-MM-DD
 
 # 2) validate
-python scripts/release/validate_release.py --mode branch --tag-pattern "v2.*.*"
+python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
 python -m pytest
 python -m build
 twine check dist/*
@@ -71,9 +71,9 @@ twine check dist/*
 # 3) clean build artifacts
 rm -rf dist/ build/
 
-# 4) merge to 2.x, then tag
-git tag v2.0.0 -m "Release 2.0.0"
-git push origin v2.0.0
+# 4) merge to main, then tag
+git tag v3.0.1 -m "Release 3.0.1"
+git push origin v3.0.1
 ```
 
 ## Troubleshooting
@@ -81,7 +81,7 @@ git push origin v2.0.0
 ### Version does not advance
 
 ```bash
-git tag --list 'v2.*.*' --sort=-version:refname | head -1
+git tag --list 'v*.*.*' --sort=-version:refname | head -1
 ```
 
 Then bump `pyproject.toml` to a higher semantic version.
@@ -91,7 +91,7 @@ Then bump `pyproject.toml` to a higher semantic version.
 Add:
 
 ```markdown
-## [2.0.0] - 2026-02-22
+## [3.0.1] - 2026-03-31
 ```
 
 with non-empty notes below the heading.
@@ -101,10 +101,10 @@ with non-empty notes below the heading.
 If tag and `pyproject.toml` do not match:
 
 ```bash
-git tag -d v2.0.0
-git push origin :refs/tags/v2.0.0
-git tag v2.0.0 -m "Release 2.0.0"
-git push origin v2.0.0
+git tag -d v3.0.1
+git push origin :refs/tags/v3.0.1
+git tag v3.0.1 -m "Release 3.0.1"
+git push origin v3.0.1
 ```
 
 ## Testing

--- a/scripts/release/validate_release.py
+++ b/scripts/release/validate_release.py
@@ -195,7 +195,11 @@ def discover_semver_tags(
 ) -> list[str]:
     output = git("tag", "--list", tag_pattern, cwd=repo_root)
     tags = [line.strip() for line in output.splitlines() if line.strip()]
-    filtered = [tag for tag in tags if tag != exclude]
+    filtered = [
+        tag
+        for tag in tags
+        if tag != exclude and SEMVER_RE.match(tag.lstrip("v"))
+    ]
     filtered.sort(key=lambda tag: parse_semver(tag.lstrip("v")), reverse=True)
     return filtered
 

--- a/tests/release/test_validate_release.py
+++ b/tests/release/test_validate_release.py
@@ -241,3 +241,30 @@ def test_branch_mode_honors_tag_pattern_scope(tmp_path: Path) -> None:
     result_unscoped = run_validator(tmp_path, "--mode", "branch")
     assert result_unscoped.returncode == 1
     assert "does not advance beyond latest tag v3.0.0" in result_unscoped.stderr
+
+
+def test_branch_mode_ignores_prerelease_tags_for_progression(tmp_path: Path) -> None:
+    init_repo(tmp_path)
+    write_release_files(
+        tmp_path,
+        "1.0.0",
+        changelog_for_versions(("1.0.0", "- Initial stable release")),
+    )
+    stage_and_commit(tmp_path, "chore: bootstrap 1.0.0")
+    tag(tmp_path, "v1.0.0")
+
+    write_release_files(
+        tmp_path,
+        "1.0.1",
+        changelog_for_versions(
+            ("1.0.1", "- Stable patch release"),
+            ("1.0.0", "- Initial stable release"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: prep 1.0.1")
+    tag(tmp_path, "v1.0.0a1")
+
+    result = run_validator(tmp_path, "--mode", "branch", "--tag-pattern", "v*.*.*")
+
+    assert result.returncode == 0, result.stderr
+    assert "All required checks passed." in result.stdout


### PR DESCRIPTION
## Summary

- bump `spec-kitty-cli` to `3.0.1`
- add the `3.0.1` changelog entry
- fix release automation and maintainer docs for stable `vX.Y.Z` tags on `main`
- make release validation ignore prerelease tags when comparing stable version progression

## Validation

- `python3 scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"`
- `pytest -q tests/release/test_validate_release.py`
- `python3 -m build`
- `twine check dist/*`