### PR TITLE
test: speed up fast sync tests

### DIFF
--- a/tests/agent/test_commands.py
+++ b/tests/agent/test_commands.py
@@ -58,12 +58,17 @@ def test_cli_help_simple_mode_avoids_rich_tables(monkeypatch) -> None:
     assert "╭" not in result.stdout
 
 
-def test_verify_setup_command_runs() -> None:
-    """Test that verify-setup command works (replaces deprecated check command)."""
-    # verify-setup requires being in a project or exits with code 1
-    # This is expected behavior - when not in a project, it shows helpful error
+def test_verify_setup_command_runs(monkeypatch, tmp_path: Path) -> None:
+    """Test that verify-setup renders the tool-checking section."""
+    monkeypatch.setattr(verify_module, "check_tool_for_tracker", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(verify_module, "find_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(verify_module, "get_project_root_or_exit", lambda repo_root: repo_root)
+    monkeypatch.setattr(verify_module, "check_version_compatibility", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(verify_module, "run_enhanced_verify", lambda **_kwargs: {})
+
     result = runner.invoke(cli_app, ["verify-setup"])
-    # Should show tool checking results even when not in a project
+
+    assert result.exit_code == 0
     assert "Check Available Tools" in result.stdout or "Checking for installed tools" in result.stdout
 
 

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -338,13 +338,15 @@ class TestBatchSyncLimit:
 
 
 class TestBatchSync1000Events:
-    """Test batch sync with 1000 events as per spec requirement"""
+    """Test batch sync with a representative large batch."""
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_1000_events(self, mock_post, temp_queue):
-        """Test batch sync handles 1000 events (spec requirement)"""
-        # Queue 1000 events
-        for i in range(1000):
+        """Test batch sync handles a large compressed payload."""
+        event_count = 200
+
+        # Queue a representative large batch
+        for i in range(event_count):
             temp_queue.queue_event(
                 {
                     "event_id": f"evt-{i:04d}",
@@ -356,31 +358,35 @@ class TestBatchSync1000Events:
                 }
             )
 
-        assert temp_queue.size() == 1000
+        assert temp_queue.size() == event_count
 
-        # Mock successful response for all 1000
+        # Mock successful response for all queued events
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(1000)]
+            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(event_count)]
         }
         mock_post.return_value = mock_response
 
         result = batch_sync(
-            queue=temp_queue, auth_token="token", server_url="http://localhost:8000", limit=1000, show_progress=False
+            queue=temp_queue,
+            auth_token="token",
+            server_url="http://localhost:8000",
+            limit=event_count,
+            show_progress=False,
         )
 
-        assert result.total_events == 1000
-        assert result.synced_count == 1000
+        assert result.total_events == event_count
+        assert result.synced_count == event_count
         assert result.error_count == 0
         assert temp_queue.size() == 0  # Queue should be empty
 
-        # Verify gzip payload contains all 1000 events
+        # Verify gzip payload contains all queued events
         call_args = mock_post.call_args
         compressed_data = call_args.kwargs["data"]
         decompressed = gzip.decompress(compressed_data)
         payload = json.loads(decompressed)
-        assert len(payload["events"]) == 1000
+        assert len(payload["events"]) == event_count
 
 
 class TestSyncAllQueuedEvents:

--- a/tests/sync/test_edge_cases.py
+++ b/tests/sync/test_edge_cases.py
@@ -114,10 +114,11 @@ class TestQueueOverflow:
 
     def test_queue_rejects_at_max(self, tmp_path: Path):
         """Queue evicts the oldest event when it reaches MAX_QUEUE_SIZE."""
-        queue = OfflineQueue(db_path=tmp_path / "overflow.db")
+        max_queue_size = 8
+        queue = OfflineQueue(db_path=tmp_path / "overflow.db", max_queue_size=max_queue_size)
 
         # Fill to capacity
-        for i in range(OfflineQueue.MAX_QUEUE_SIZE):
+        for i in range(max_queue_size):
             result = queue.queue_event(
                 {
                     "event_id": f"evt{i:06d}00000000000000000000",
@@ -127,7 +128,7 @@ class TestQueueOverflow:
             )
             assert result is True
 
-        assert queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        assert queue.size() == max_queue_size
 
         # Next event should succeed by evicting the oldest row
         result = queue.queue_event(
@@ -138,7 +139,7 @@ class TestQueueOverflow:
             }
         )
         assert result is True
-        assert queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        assert queue.size() == max_queue_size
         events = queue.drain_queue(limit=1)
         assert events[0]["event_id"] != "evt0000000000000000000000"
 

--- a/tests/sync/test_offline_queue.py
+++ b/tests/sync/test_offline_queue.py
@@ -133,40 +133,46 @@ class TestOfflineQueue:
 class TestOfflineQueueSizeLimit:
     """Test queue size limit enforcement"""
 
-    def test_queue_size_limit_enforced(self, temp_queue):
+    def test_queue_size_limit_enforced(self, tmp_path: Path):
         """Test queue evicts oldest events when at capacity."""
-        # Queue up to the limit
-        for i in range(OfflineQueue.MAX_QUEUE_SIZE):
-            event = {"event_id": f"evt-{i}", "event_type": "Test", "payload": {}}
-            result = temp_queue.queue_event(event)
-            if i < OfflineQueue.MAX_QUEUE_SIZE:
-                assert result is True
+        max_queue_size = 8
+        queue = OfflineQueue(tmp_path / "queue_size_limit.db", max_queue_size=max_queue_size)
 
-        assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        # Queue up to the limit
+        for i in range(max_queue_size):
+            event = {"event_id": f"evt-{i}", "event_type": "Test", "payload": {}}
+            result = queue.queue_event(event)
+            assert result is True
+
+        assert queue.size() == max_queue_size
 
         # One more should succeed by evicting the oldest row
         overflow_event = {"event_id": "evt-overflow", "event_type": "Test", "payload": {}}
-        result = temp_queue.queue_event(overflow_event)
+        result = queue.queue_event(overflow_event)
         assert result is True
-        assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
-        events = temp_queue.drain_queue(limit=1)
+        assert queue.size() == max_queue_size
+        events = queue.drain_queue(limit=1)
         assert events[0]["event_id"] == "evt-1"
 
-    def test_queue_accepts_after_drain_and_sync(self, temp_queue):
+    def test_queue_accepts_after_drain_and_sync(self, tmp_path: Path):
         """Test queue accepts events after making room"""
+        max_queue_size = 32
+        drain_count = 10
+        queue = OfflineQueue(tmp_path / "queue_accepts_after_drain.db", max_queue_size=max_queue_size)
+
         # Fill to limit
-        for i in range(OfflineQueue.MAX_QUEUE_SIZE):
-            temp_queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
+        for i in range(max_queue_size):
+            queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
 
         # Remove some events
-        events = temp_queue.drain_queue(limit=100)
+        events = queue.drain_queue(limit=drain_count)
         event_ids = [e["event_id"] for e in events]
-        temp_queue.mark_synced(event_ids)
+        queue.mark_synced(event_ids)
 
-        assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE - 100
+        assert queue.size() == max_queue_size - drain_count
 
         # Should accept new events now
-        result = temp_queue.queue_event({"event_id": "evt-new", "event_type": "Test", "payload": {}})
+        result = queue.queue_event({"event_id": "evt-new", "event_type": "Test", "payload": {}})
         assert result is True
 
 

--- a/tests/sync/test_offline_replay.py
+++ b/tests/sync/test_offline_replay.py
@@ -167,37 +167,43 @@ class TestReconnectionTriggersBatchSync:
 
 
 class TestBatchSyncThroughput:
-    """Test T131: Batch sync <30s for 1000 events"""
+    """Test T131: Batch sync throughput on representative large batches."""
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_throughput_1000_events(self, mock_post, temp_queue):
-        """1000 events should sync in <30s (mocked network)"""
-        # Queue 1000 events
-        for i in range(1000):
+        """A representative large batch should sync quickly (mocked network)."""
+        event_count = 200
+
+        # Queue a representative large batch
+        for i in range(event_count):
             temp_queue.queue_event(create_test_event(i))
 
-        assert temp_queue.size() == 1000
+        assert temp_queue.size() == event_count
 
         # Mock successful response for all events
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "results": [{"event_id": f"evt-{i:06d}", "status": "success"} for i in range(1000)]
+            "results": [{"event_id": f"evt-{i:06d}", "status": "success"} for i in range(event_count)]
         }
         mock_post.return_value = mock_response
 
         # Measure sync time
         start = time.time()
         result = batch_sync(
-            queue=temp_queue, auth_token="token", server_url="http://localhost:8000", limit=1000, show_progress=False
+            queue=temp_queue,
+            auth_token="token",
+            server_url="http://localhost:8000",
+            limit=event_count,
+            show_progress=False,
         )
         duration = time.time() - start
 
         # Verify throughput
-        assert result.total_events == 1000
-        assert result.synced_count == 1000
+        assert result.total_events == event_count
+        assert result.synced_count == event_count
         assert temp_queue.size() == 0
-        assert duration < 30, f"Batch sync took {duration:.2f}s, expected <30s"
+        assert duration < 5, f"Batch sync took {duration:.2f}s, expected <5s"
 
         # Verify gzip compression was used
         call_args = mock_post.call_args
@@ -206,9 +212,12 @@ class TestBatchSyncThroughput:
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_throughput_multiple_batches(self, mock_post, temp_queue):
-        """Sync 2500 events in multiple batches <30s"""
-        # Queue 2500 events
-        for i in range(2500):
+        """Sync multiple batches quickly while preserving batch boundaries."""
+        event_count = 240
+        batch_size = 100
+
+        # Queue enough events to force multiple batches
+        for i in range(event_count):
             temp_queue.queue_event(create_test_event(i))
 
         def mock_batch_response(*args, **kwargs):
@@ -231,16 +240,16 @@ class TestBatchSyncThroughput:
             queue=temp_queue,
             auth_token="token",
             server_url="http://localhost:8000",
-            batch_size=1000,
+            batch_size=batch_size,
             show_progress=False,
         )
         duration = time.time() - start
 
-        assert result.total_events == 2500
-        assert result.synced_count == 2500
+        assert result.total_events == event_count
+        assert result.synced_count == event_count
         assert temp_queue.size() == 0
-        assert duration < 30, f"Multi-batch sync took {duration:.2f}s, expected <30s"
-        assert mock_post.call_count == 3  # 1000 + 1000 + 500
+        assert duration < 5, f"Multi-batch sync took {duration:.2f}s, expected <5s"
+        assert mock_post.call_count == 3  # 100 + 100 + 40
 
 
 class TestIdempotency:
@@ -309,36 +318,43 @@ class TestIdempotency:
 class TestQueueSizeLimit:
     """Test T133: Queue size limit warning"""
 
-    def test_queue_size_limit_enforced(self, temp_queue):
+    def test_queue_size_limit_enforced(self, tmp_path: Path):
         """Queue should evict the oldest event at MAX_QUEUE_SIZE."""
+        max_queue_size = 8
+        queue = OfflineQueue(tmp_path / "queue_size_limit.db", max_queue_size=max_queue_size)
+
         # Fill queue to limit
-        for i in range(OfflineQueue.MAX_QUEUE_SIZE):
-            result = temp_queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
+        for i in range(max_queue_size):
+            result = queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
             assert result is True
 
-        assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
+        assert queue.size() == max_queue_size
 
         # 10,001st event should succeed and evict the oldest row
-        result = temp_queue.queue_event({"event_id": "evt-overflow", "event_type": "Test", "payload": {}})
+        result = queue.queue_event({"event_id": "evt-overflow", "event_type": "Test", "payload": {}})
         assert result is True
-        assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE
-        events = temp_queue.drain_queue(limit=1)
+        assert queue.size() == max_queue_size
+        events = queue.drain_queue(limit=1)
         assert events[0]["event_id"] == "evt-1"
 
-    def test_queue_accepts_after_sync(self, temp_queue):
+    def test_queue_accepts_after_sync(self, tmp_path: Path):
         """Queue accepts new events after sync makes room"""
+        max_queue_size = 32
+        drain_count = 10
+        queue = OfflineQueue(tmp_path / "queue_accepts_after_sync.db", max_queue_size=max_queue_size)
+
         # Fill to limit
-        for i in range(OfflineQueue.MAX_QUEUE_SIZE):
-            temp_queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
+        for i in range(max_queue_size):
+            queue.queue_event({"event_id": f"evt-{i}", "event_type": "Test", "payload": {}})
 
         # Drain some events (simulating sync)
-        events = temp_queue.drain_queue(limit=1000)
-        temp_queue.mark_synced([e["event_id"] for e in events])
+        events = queue.drain_queue(limit=drain_count)
+        queue.mark_synced([e["event_id"] for e in events])
 
-        assert temp_queue.size() == OfflineQueue.MAX_QUEUE_SIZE - 1000
+        assert queue.size() == max_queue_size - drain_count
 
         # Should accept new events now
-        result = temp_queue.queue_event({"event_id": "evt-new", "event_type": "Test", "payload": {}})
+        result = queue.queue_event({"event_id": "evt-new", "event_type": "Test", "payload": {}})
         assert result is True
 
 
@@ -347,12 +363,14 @@ class TestEventRecovery:
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_100_percent_event_recovery(self, mock_post, temp_queue):
-        """Queue 500 events, verify all 500 recovered after sync"""
-        # Queue 500 events
-        for i in range(500):
+        """Queue a representative set of events and verify all are recovered."""
+        event_count = 120
+
+        # Queue events
+        for i in range(event_count):
             temp_queue.queue_event(create_test_event(i, node_id="recovery-test"))
 
-        assert temp_queue.size() == 500
+        assert temp_queue.size() == event_count
 
         # Track which events were sent
         sent_event_ids = set()
@@ -377,17 +395,21 @@ class TestEventRecovery:
         mock_post.side_effect = mock_batch_response
 
         result = batch_sync(
-            queue=temp_queue, auth_token="token", server_url="http://localhost:8000", limit=1000, show_progress=False
+            queue=temp_queue,
+            auth_token="token",
+            server_url="http://localhost:8000",
+            limit=event_count,
+            show_progress=False,
         )
 
         # Verify 100% recovery
-        assert result.synced_count == 500
+        assert result.synced_count == event_count
         assert result.error_count == 0
         assert temp_queue.size() == 0
-        assert len(sent_event_ids) == 500
+        assert len(sent_event_ids) == event_count
 
         # Verify all event IDs were sent
-        expected_ids = {f"evt-{i:06d}" for i in range(500)}
+        expected_ids = {f"evt-{i:06d}" for i in range(event_count)}
         assert sent_event_ids == expected_ids
 
     @patch("specify_cli.sync.batch.requests.post")


### PR DESCRIPTION
## Summary

Speed up the fast test lane by removing synthetic high-volume work from a small set of sync tests and by mocking the expensive tool scan in the `verify-setup` smoke test.

## What changed

- Replace production-scale queue capacity fills in fast tests with small per-test `max_queue_size` values while keeping the same eviction and acceptance semantics.
- Reduce representative large-batch sync tests from 1000/2500/500 event payloads to smaller batches that still cover gzip payload handling, multi-batch behavior, and recovery behavior.
- Mock `verify-setup` tool checks in the command smoke test so it verifies rendering, not actual environment probing.

## Files

- `tests/sync/test_offline_replay.py`
- `tests/sync/test_offline_queue.py`
- `tests/sync/test_edge_cases.py`
- `tests/sync/test_batch_sync.py`
- `tests/agent/test_commands.py`

## Verification

Targeted changed-file run:
- `pytest tests/sync/test_offline_replay.py tests/sync/test_batch_sync.py tests/sync/test_offline_queue.py tests/sync/test_edge_cases.py tests/agent/test_commands.py -q --durations=30`
- Result: `97 passed in 4.55s`

Observed local improvements:
- `tests/sync/test_offline_replay.py`: `5.07s -> 2.32s`
- `tests/sync/test_batch_sync.py`: `2.64s -> 2.32s`
- `tests/agent/test_commands.py::test_verify_setup_command_runs`: `0.68s -> 0.05s`
- full `-m fast` local runtime: `35.10s -> 26.60s`, then `28.41s` on the branch run due unrelated existing failures outside this PR

## Notes

The current fast suite still has unrelated failing tests on this branch and on the full local run:
- `tests/agent/test_implement_command.py`
- `tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py`

Those failures are not touched by this PR.
