### PR TITLE
Fix release-blocking canonical status tests

### DIFF
--- a/scripts/tasks/task_helpers.py
+++ b/scripts/tasks/task_helpers.py
@@ -450,9 +450,13 @@ def get_lane_from_frontmatter(wp_path: Path, warn_on_missing: bool = True) -> st
     del warn_on_missing
 
     feature_dir = wp_path.parent.parent
-    stem = wp_path.stem
-    wp_id_match = re.match(r"^(WP\d+)", stem, re.IGNORECASE)
-    wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
+    text = wp_path.read_text(encoding="utf-8-sig")
+    frontmatter, _body, _padding = split_frontmatter(text)
+    wp_id = extract_scalar(frontmatter, "work_package_id")
+    if not wp_id:
+        stem = wp_path.stem
+        wp_id_match = re.match(r"^(WP\d+)(?=$|[-_.])", stem, re.IGNORECASE)
+        wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
 
     try:
         from specify_cli.status.lane_reader import get_wp_lane

--- a/src/specify_cli/cli/commands/agent/feature.py
+++ b/src/specify_cli/cli/commands/agent/feature.py
@@ -1685,7 +1685,7 @@ def finalize_tasks(
         wp_files = list(tasks_dir.glob("WP*.md"))
         wp_ids: list[str] = []
         for wp_file in wp_files:
-            wp_id_match = re.match(r"(WP\d{2})", wp_file.name)
+            wp_id_match = re.match(r"^(WP\d{2})(?=$|[-_.])", wp_file.name)
             if wp_id_match:
                 wp_ids.append(wp_id_match.group(1))
 
@@ -1753,7 +1753,7 @@ def finalize_tasks(
 
         for wp_file in wp_files:
             # Extract WP ID from filename
-            wp_id_match = re.match(r"(WP\d{2})", wp_file.name)
+            wp_id_match = re.match(r"^(WP\d{2})(?=$|[-_.])", wp_file.name)
             if not wp_id_match:
                 continue
 
@@ -1842,7 +1842,7 @@ def finalize_tasks(
         # Validate ownership manifests across all WPs (hard errors block finalization)
         wp_manifests: dict[str, object] = {}
         for wp_file in wp_files:
-            wp_id_match = re.match(r"(WP\d{2})", wp_file.name)
+            wp_id_match = re.match(r"^(WP\d{2})(?=$|[-_.])", wp_file.name)
             if not wp_id_match:
                 continue
             wp_id = wp_id_match.group(1)
@@ -2145,7 +2145,7 @@ def _parse_requirement_refs_from_wp_files(wp_files: list[Path]) -> dict[str, lis
 
     parsed: dict[str, list[str]] = {}
     for wp_file in wp_files:
-        wp_id_match = re.match(r"(WP\d{2})", wp_file.name)
+        wp_id_match = re.match(r"^(WP\d{2})(?=$|[-_.])", wp_file.name)
         if not wp_id_match:
             continue
         wp_id = wp_id_match.group(1)

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -431,9 +431,7 @@ def _process_wp_file(
     wp_id = frontmatter.get("work_package_id", prompt_file.stem)
     # Derive feature_dir: WP files live at kitty-specs/<slug>/tasks/WP01.md
     feature_dir = prompt_file.parent.parent
-    stem = prompt_file.stem
-    wp_id_match = re.match(r"^(WP\d+)", stem, re.IGNORECASE)
-    canonical_wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
+    canonical_wp_id = str(wp_id).strip() or prompt_file.stem
     from specify_cli.status.lane_reader import get_wp_lane
     lane = get_wp_lane(feature_dir, canonical_wp_id)
 

--- a/src/specify_cli/mission_v1/guards.py
+++ b/src/specify_cli/mission_v1/guards.py
@@ -270,10 +270,19 @@ def _read_lane_from_frontmatter(file_path: Path) -> str | None:
     Raises ``CanonicalStatusNotFoundError`` when no event log exists.
     Returns ``"uninitialized"`` when the event log has no events for this WP.
     """
-    wp_id_match = re.match(r"(WP\d+)", file_path.stem)
-    if wp_id_match is None:
-        return None
-    wp_id = wp_id_match.group(1)
+    from specify_cli.frontmatter import FrontmatterError, read_frontmatter
+
+    try:
+        frontmatter, _body = read_frontmatter(file_path)
+    except (FrontmatterError, OSError):
+        frontmatter = {}
+
+    wp_id = frontmatter.get("work_package_id")
+    if not isinstance(wp_id, str) or not wp_id.strip():
+        wp_id_match = re.match(r"^(WP\d+)(?=$|[-_.])", file_path.stem)
+        if wp_id_match is None:
+            return None
+        wp_id = wp_id_match.group(1)
     feature_dir = file_path.parent.parent  # tasks/ -> feature_dir
 
     from specify_cli.status.lane_reader import get_wp_lane

--- a/src/specify_cli/scripts/tasks/task_helpers.py
+++ b/src/specify_cli/scripts/tasks/task_helpers.py
@@ -435,9 +435,13 @@ def get_lane_from_frontmatter(wp_path: Path, warn_on_missing: bool = True) -> st
     del warn_on_missing
 
     feature_dir = wp_path.parent.parent
-    stem = wp_path.stem
-    wp_id_match = re.match(r"^(WP\d+)", stem, re.IGNORECASE)
-    wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
+    text = wp_path.read_text(encoding="utf-8-sig")
+    frontmatter, _body, _padding = split_frontmatter(text)
+    wp_id = extract_scalar(frontmatter, "work_package_id")
+    if not wp_id:
+        stem = wp_path.stem
+        wp_id_match = re.match(r"^(WP\d+)(?=$|[-_.])", stem, re.IGNORECASE)
+        wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
 
     try:
         from specify_cli.status.lane_reader import get_wp_lane

--- a/src/specify_cli/tasks_support.py
+++ b/src/specify_cli/tasks_support.py
@@ -391,10 +391,13 @@ def get_lane_from_frontmatter(wp_path: Path, warn_on_missing: bool = True) -> st
     # Derive feature_dir: WP files live at kitty-specs/<slug>/tasks/WP01.md
     feature_dir = wp_path.parent.parent
 
-    # Extract wp_id from filename (e.g. WP01.md -> WP01, WP04-something.md -> WP04)
-    stem = wp_path.stem
-    wp_id_match = re.match(r"^(WP\d+)", stem, re.IGNORECASE)
-    wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
+    text = wp_path.read_text(encoding="utf-8-sig")
+    frontmatter, _body, _padding = split_frontmatter(text)
+    wp_id = extract_scalar(frontmatter, "work_package_id")
+    if not wp_id:
+        stem = wp_path.stem
+        wp_id_match = re.match(r"^(WP\d+)(?=$|[-_.])", stem, re.IGNORECASE)
+        wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
 
     from specify_cli.status.lane_reader import get_wp_lane
     return get_wp_lane(feature_dir, wp_id)

--- a/tests/cross_cutting/misc/test_task_helpers.py
+++ b/tests/cross_cutting/misc/test_task_helpers.py
@@ -25,14 +25,14 @@ def test_split_frontmatter_handles_padding() -> None:
 
 
 def test_append_activity_log_creates_section() -> None:
-    entry = "- 2025-01-01T00:00:00Z – system – shell_pid=1 – lane=planned – Created"
+    entry = "- 2025-01-01T00:00:00Z – system – shell_pid=1 – Created"
     body = th.append_activity_log("", entry)
     assert "## Activity Log" in body
     assert entry in body
 
-    second = th.append_activity_log(body, "- 2025-01-02T00:00:00Z – agent – shell_pid=2 – lane=doing – Moved")
+    second = th.append_activity_log(body, "- 2025-01-02T00:00:00Z – agent – shell_pid=2 – Moved")
     assert second.count("Activity Log") == 1
-    assert "lane=doing" in second
+    assert "shell_pid=2" in second
 
 
 def test_detect_conflicting_wp_status() -> None:

--- a/tests/cross_cutting/misc/test_tasks_cli_commands.py
+++ b/tests/cross_cutting/misc/test_tasks_cli_commands.py
@@ -23,8 +23,8 @@ def test_update_and_rollback(feature_repo: Path, feature_slug: str) -> None:
     run(["git", "commit", "-am", "Update to doing"], cwd=feature_repo)
 
     updated_wp = locate_work_package(feature_repo, feature_slug, "WP01")
-    assert updated_wp.current_lane == "doing"
-    assert 'lane: "doing"' in updated_wp.frontmatter
+    assert updated_wp.current_lane == "in_progress"
+    assert "lane:" not in updated_wp.frontmatter
 
     # File should still be in same location (flat tasks/)
     assert updated_wp.path.parent.name == "tasks", "WP file should stay in tasks/ directory"
@@ -36,8 +36,8 @@ def test_update_and_rollback(feature_repo: Path, feature_slug: str) -> None:
     assert rolled_wp.current_lane == "planned"
 
 
-def test_update_modifies_frontmatter_only(feature_repo: Path, feature_slug: str) -> None:
-    """Test that update only modifies frontmatter, not file location."""
+def test_update_modifies_metadata_only(feature_repo: Path, feature_slug: str) -> None:
+    """Test that update preserves file location and custom content."""
     wp_path = feature_repo / "kitty-specs" / feature_slug / "tasks" / "WP01.md"
     original_text = wp_path.read_text(encoding="utf-8")
     wp_path.write_text(original_text + "\n<!-- reviewer note -->\n", encoding="utf-8")
@@ -50,7 +50,7 @@ def test_update_modifies_frontmatter_only(feature_repo: Path, feature_slug: str)
 
     content = wp_path.read_text(encoding="utf-8")
     assert "<!-- reviewer note -->" in content, "Custom content should be preserved"
-    assert 'lane: "doing"' in content, "Lane should be updated in frontmatter"
+    assert "lane:" not in content, "Lane should not be written into frontmatter"
 
 
 def test_list_command_output(feature_repo: Path, feature_slug: str) -> None:
@@ -282,9 +282,9 @@ def test_exact_wp_id_matching_not_prefix(feature_repo: Path, feature_slug: str) 
     result = run_tasks_cli(["update", feature_slug, "WP04", "doing", "--force"], cwd=feature_repo)
     assert_success(result)
 
-    # Verify WP04 is now "doing"
+    # Verify WP04 is now canonically in progress
     wp04 = locate_work_package(feature_repo, feature_slug, "WP04")
-    assert wp04.current_lane == "doing", "WP04 should be in doing"
+    assert wp04.current_lane == "in_progress", "WP04 should be in progress"
 
     # Verify WP04b is still "planned"
     wp04b = locate_work_package(feature_repo, feature_slug, "WP04b")
@@ -316,7 +316,7 @@ def test_exact_wp_id_matching_with_slug(feature_repo: Path, feature_slug: str) -
 
     # Verify via frontmatter
     wp04 = locate_work_package(feature_repo, feature_slug, "WP04")
-    assert wp04.current_lane == "doing", "WP04-feature-name.md should be in doing"
+    assert wp04.current_lane == "in_progress", "WP04-feature-name.md should be in progress"
 
     wp04b = locate_work_package(feature_repo, feature_slug, "WP04b")
     assert wp04b.current_lane == "planned", "WP04b should still be in planned"
@@ -371,7 +371,7 @@ def test_update_ignores_other_wp_modifications(feature_repo: Path, feature_slug:
 
     # Verify WP01 updated
     wp01 = locate_work_package(feature_repo, feature_slug, "WP01")
-    assert wp01.current_lane == "doing", "WP01 should have updated to doing"
+    assert wp01.current_lane == "in_progress", "WP01 should have updated to in_progress"
 
     # Verify WP02 still has its modifications
     wp02_content = wp02_path.read_text(encoding="utf-8")
@@ -402,7 +402,7 @@ def test_update_with_staged_other_wp_changes(feature_repo: Path, feature_slug: s
 
     # Verify WP01 updated
     wp01 = locate_work_package(feature_repo, feature_slug, "WP01")
-    assert wp01.current_lane == "doing", "WP01 should have updated to doing"
+    assert wp01.current_lane == "in_progress", "WP01 should have updated to in_progress"
 
 
 def test_sequential_updates_by_different_agents(feature_repo: Path, feature_slug: str) -> None:
@@ -428,5 +428,5 @@ def test_sequential_updates_by_different_agents(feature_repo: Path, feature_slug
     # Both should be in doing now
     wp01 = locate_work_package(feature_repo, feature_slug, "WP01")
     wp02 = locate_work_package(feature_repo, feature_slug, "WP02")
-    assert wp01.current_lane == "doing", "WP01 should be in doing"
-    assert wp02.current_lane == "doing", "WP02 should be in doing"
+    assert wp01.current_lane == "in_progress", "WP01 should be in progress"
+    assert wp02.current_lane == "in_progress", "WP02 should be in progress"

--- a/tests/specify_cli/test_canonical_acceptance.py
+++ b/tests/specify_cli/test_canonical_acceptance.py
@@ -14,8 +14,11 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from specify_cli.acceptance import collect_feature_summary
 from specify_cli.feature_metadata import load_meta, record_acceptance
+from specify_cli.status.lane_reader import CanonicalStatusNotFoundError
 from specify_cli.status.models import Lane, StatusEvent
 from specify_cli.status.store import append_event
 
@@ -323,21 +326,12 @@ class TestCanonicalStateAuthority:
         with patch("specify_cli.acceptance.run_git") as mock_git, \
              patch("specify_cli.acceptance.git_status_lines", return_value=[]):
             mock_git.return_value.stdout = "main\n"
-            summary = collect_feature_summary(
-                tmp_path,
-                "099-test-feature",
-                strict_metadata=False,
-            )
-
-        # Should have explicit error about missing canonical state
-        assert any(
-            "status.events.jsonl" in issue
-            for issue in summary.activity_issues
-        ), f"Expected missing event log error, got: {summary.activity_issues}"
-        assert any(
-            "canonical state" in issue.lower() or "No canonical state" in issue
-            for issue in summary.activity_issues
-        ), f"Expected actionable error message, got: {summary.activity_issues}"
+            with pytest.raises(CanonicalStatusNotFoundError, match="Canonical status not found"):
+                collect_feature_summary(
+                    tmp_path,
+                    "099-test-feature",
+                    strict_metadata=False,
+                )
 
     def test_wp_with_no_events_reports_no_canonical_state(self, tmp_path: Path) -> None:
         """WP exists in task files but has no events in the log."""

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -3,18 +3,38 @@ from pathlib import Path
 
 from specify_cli.dashboard import scanner
 from specify_cli.dashboard.constitution_path import resolve_project_constitution_path
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.reducer import materialize
+from specify_cli.status.store import append_event
 
 
-def _create_feature(tmp_path: Path, slug: str = "001-demo-feature") -> Path:
+def _set_wp_lane(feature_dir: Path, wp_id: str, lane: str) -> None:
+    append_event(
+        feature_dir,
+        StatusEvent(
+            event_id=f"TEST{wp_id}{lane.upper()}0000000000000000"[:26],
+            feature_slug=feature_dir.name,
+            wp_id=wp_id,
+            from_lane=Lane.PLANNED,
+            to_lane=Lane(lane),
+            at="2026-03-31T09:00:00+00:00",
+            actor="test",
+            force=True,
+            execution_mode="direct_repo",
+        ),
+    )
+    materialize(feature_dir)
+
+
+def _create_feature(tmp_path: Path, slug: str = "001-demo-feature", *, lane: str = "planned") -> Path:
     feature_dir = tmp_path / "kitty-specs" / slug
-    (feature_dir / "tasks" / "planned").mkdir(parents=True)
+    (feature_dir / "tasks").mkdir(parents=True)
     (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
     (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
     (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
 
     prompt = """---
 work_package_id: WP01
-lane: planned
 subtasks: ["T1"]
 agent: codex
 ---
@@ -22,7 +42,8 @@ agent: codex
 
 Body
 """
-    (feature_dir / "tasks" / "planned" / "WP01-demo.md").write_text(prompt, encoding="utf-8")
+    (feature_dir / "tasks" / "WP01-demo.md").write_text(prompt, encoding="utf-8")
+    _set_wp_lane(feature_dir, "WP01", lane)
     return feature_dir
 
 
@@ -136,13 +157,8 @@ def test_new_path_preferred_when_both_exist(tmp_path):
 
 
 def test_scan_feature_kanban_approved_lane(tmp_path):
-    """WPs with lane: approved should land in the approved column, not planned."""
-    feature_dir = tmp_path / "kitty-specs" / "001-demo"
-    (feature_dir / "tasks").mkdir(parents=True)
-    (feature_dir / "tasks" / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\nlane: approved\n---\n# Work Package Prompt: WP01\n",
-        encoding="utf-8",
-    )
+    """WPs with canonical lane approved should land in the approved column."""
+    feature_dir = _create_feature(tmp_path, "001-demo", lane="approved")
     lanes = scanner.scan_feature_kanban(tmp_path, "001-demo")
     assert len(lanes["approved"]) == 1
     assert len(lanes["planned"]) == 0
@@ -155,9 +171,10 @@ def test_scan_feature_kanban_lane_mapping(tmp_path):
     (feature_dir / "tasks").mkdir(parents=True)
     for wp_id, lane in [("WP01", "claimed"), ("WP02", "in_progress")]:
         (feature_dir / "tasks" / f"{wp_id}.md").write_text(
-            f"---\nwork_package_id: {wp_id}\nlane: {lane}\n---\n# Work Package Prompt: {wp_id}\n",
+            f"---\nwork_package_id: {wp_id}\n---\n# Work Package Prompt: {wp_id}\n",
             encoding="utf-8",
         )
+        _set_wp_lane(feature_dir, wp_id, lane)
     lanes = scanner.scan_feature_kanban(tmp_path, "001-demo")
     assert len(lanes["planned"]) == 1  # claimed -> planned
     assert len(lanes["doing"]) == 1  # in_progress -> doing

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,6 +36,54 @@ def run_tasks_cli(args: list[str], *, cwd: Path, env: dict[str, str] | None = No
     return run_python_script(TASKS_DIR / "tasks_cli.py", args, cwd=cwd, env=env)
 
 
+def _canonical_lane(lane: str) -> str:
+    return {"doing": "in_progress"}.get(lane, lane)
+
+
+def _event_timestamp(timestamp: str) -> str:
+    return timestamp[:-1] + "+00:00" if timestamp.endswith("Z") else timestamp
+
+
+def _seed_canonical_wp_state(
+    repo_root: Path,
+    feature: str,
+    wp_id: str,
+    lane: str,
+    *,
+    actor: str,
+    timestamp: str,
+) -> None:
+    from specify_cli.status.models import Lane, StatusEvent
+    from specify_cli.status.reducer import materialize, reduce
+    from specify_cli.status.store import append_event, read_events
+
+    feature_dir = repo_root / "kitty-specs" / feature
+    canonical_target = _canonical_lane(lane)
+    existing_events = read_events(feature_dir)
+    snapshot = reduce(existing_events)
+    current_lane = snapshot.work_packages.get(wp_id, {}).get("lane")
+
+    if current_lane == canonical_target:
+        if existing_events and not (feature_dir / "status.json").exists():
+            materialize(feature_dir)
+        return
+
+    event = StatusEvent(
+        event_id=f"TEST{wp_id}{len(existing_events) + 1:020d}",
+        feature_slug=feature,
+        wp_id=wp_id,
+        from_lane=Lane(current_lane or "planned"),
+        to_lane=Lane(canonical_target),
+        at=_event_timestamp(timestamp),
+        actor=actor,
+        force=True,
+        execution_mode="direct_repo",
+        reason="test fixture bootstrap",
+    )
+    append_event(feature_dir, event)
+    materialize(feature_dir)
+
+
 def write_wp(
     repo_root: Path,
     feature: str,
@@ -48,6 +96,7 @@ def write_wp(
     note: str = "Created",
     timestamp: str = "2025-01-01T00:00:00Z",
     legacy: bool = False,
+    seed_canonical: bool = True,
 ) -> Path:
     """Create a work package file for testing.
 
@@ -68,27 +117,38 @@ def write_wp(
         tasks_dir.mkdir(parents=True, exist_ok=True)
         path = tasks_dir / f"{wp_id}.md"
 
-    frontmatter = "\n".join(
+    frontmatter_lines = [f'work_package_id: "{wp_id}"']
+    if legacy:
+        frontmatter_lines.append(f'lane: "{lane}"')
+    frontmatter_lines.extend(
         [
-            f'work_package_id: "{wp_id}"',
-            f'lane: "{lane}"',
             f'agent: "{agent}"',
             f'assignee: "{assignee}"',
             f'shell_pid: "{shell_pid}"',
         ]
     )
+    frontmatter = "\n".join(frontmatter_lines)
     document = build_document(frontmatter, "", "\n")
     path.write_text(document, encoding="utf-8")
 
     front, body, padding = split_frontmatter(path.read_text(encoding="utf-8"))
     updated_body = append_activity_log(
         body,
-        f"- {timestamp} – {agent} – shell_pid={shell_pid} – lane={lane} – {note}",
+        f"- {timestamp} – {agent} – shell_pid={shell_pid} – {note}",
     )
-    updated_front = set_scalar(
-        set_scalar(set_scalar(set_scalar(front, "lane", lane), "agent", agent), "assignee", assignee),
-        "shell_pid",
-        shell_pid,
-    )
+    updated_front = front
+    if legacy:
+        updated_front = set_scalar(updated_front, "lane", lane)
+    updated_front = set_scalar(set_scalar(updated_front, "agent", agent), "assignee", assignee)
+    updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
     path.write_text(build_document(updated_front, updated_body, padding), encoding="utf-8")
+    if seed_canonical and not legacy:
+        _seed_canonical_wp_state(
+            repo_root,
+            feature,
+            wp_id,
+            lane,
+            actor=agent,
+            timestamp=timestamp,
+        )
     return path


### PR DESCRIPTION
## Summary
- seed canonical status in shared non-legacy test fixtures instead of relying on removed frontmatter fallback
- update cross-cutting/dashboard/canonical acceptance tests to assert the 3.0 event-log model
- tighten WP id extraction so WP04 does not alias WP04b when reading canonical status

## Verification
- pytest -q tests/cross_cutting/misc/test_task_helpers.py tests/cross_cutting/misc/test_tasks_cli_commands.py tests/cross_cutting/misc/test_acceptance_support.py tests/specify_cli/test_canonical_acceptance.py tests/test_dashboard/test_scanner.py
- pytest -q tests/specify_cli/test_standalone_tasks_cli_canonical.py tests/missions/test_mission_v1_guards_unit.py tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py