### PR TITLE
Align tracker origin client with SaaS contract

### DIFF
--- a/src/specify_cli/tracker/origin.py
+++ b/src/specify_cli/tracker/origin.py
@@ -246,6 +246,7 @@ def bind_mission_origin(
             external_issue_key=candidate.external_issue_key,
             external_issue_url=candidate.url,
             title=candidate.title,
+            external_status=candidate.status,
         )
     except SaaSTrackerClientError as exc:
         raise OriginBindingError(str(exc)) from exc

--- a/src/specify_cli/tracker/saas_client.py
+++ b/src/specify_cli/tracker/saas_client.py
@@ -98,8 +98,8 @@ class SaaSTrackerClient:
     _PUSH_PATH = "/api/v1/tracker/push/"
     _RUN_PATH = "/api/v1/tracker/run/"
     _OPERATIONS_PATH = "/api/v1/tracker/operations/{operation_id}/"
-    _SEARCH_ISSUES_PATH = "/api/v1/tracker/issues/search/"
-    _BIND_ORIGIN_PATH = "/api/v1/tracker/origin/bind/"
+    _SEARCH_ISSUES_PATH = "/api/v1/tracker/issue-search/"
+    _BIND_ORIGIN_PATH = "/api/v1/tracker/mission-origin/bind/"
 
     # ----- low-level request helpers -----
 
@@ -354,6 +354,7 @@ class SaaSTrackerClient:
         external_issue_key: str,
         external_issue_url: str,
         title: str,
+        external_status: str = "",
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """POST bind endpoint — create MissionOriginLink on SaaS.
@@ -370,7 +371,8 @@ class SaaSTrackerClient:
             "external_issue_id": external_issue_id,
             "external_issue_key": external_issue_key,
             "external_issue_url": external_issue_url,
-            "title": title,
+            "external_title": title,
+            "external_status": external_status,
         }
         response = self._request_with_retry(
             "POST",

--- a/tests/sync/tracker/test_saas_client_origin.py
+++ b/tests/sync/tracker/test_saas_client_origin.py
@@ -274,7 +274,7 @@ class TestSearchIssues:
 
         args, _ = mock_http.request.call_args
         assert args[0] == "POST"
-        assert args[1].endswith("/api/v1/tracker/issues/search/")
+        assert args[1].endswith("/api/v1/tracker/issue-search/")
 
 
 # ---------------------------------------------------------------------------
@@ -433,7 +433,7 @@ class TestBindMissionOrigin:
 
         args, _ = mock_http.request.call_args
         assert args[0] == "POST"
-        assert args[1].endswith("/api/v1/tracker/origin/bind/")
+        assert args[1].endswith("/api/v1/tracker/mission-origin/bind/")
 
     @patch("specify_cli.tracker.saas_client.httpx.Client")
     def test_payload_contains_all_fields(
@@ -456,4 +456,5 @@ class TestBindMissionOrigin:
         assert payload["external_issue_id"] == "12345"
         assert payload["external_issue_key"] == "PROJ-42"
         assert payload["external_issue_url"] == "https://jira.example.com/browse/PROJ-42"
-        assert payload["title"] == "Fix login bug"
+        assert payload["external_title"] == "Fix login bug"
+        assert payload["external_status"] == ""


### PR DESCRIPTION
## Summary
- align the issue-search and mission-origin bind client paths with the SaaS control-plane contract
- send external title/status fields during bind and propagate the candidate status from the origin service
- update the SaaS client tests to match the contract

## Testing
- uv run pytest -q tests/sync/tracker/test_origin.py tests/sync/tracker/test_origin_integration.py tests/sync/tracker/test_saas_client_origin.py
- uv run ruff check src/specify_cli/tracker/origin.py src/specify_cli/tracker/saas_client.py tests/sync/tracker/test_saas_client_origin.py