### PR TITLE
docs: define mission terminology boundary and rollout plan

### DIFF
--- a/architecture/2.x/adr/2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md
+++ b/architecture/2.x/adr/2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md
@@ -1,0 +1,254 @@
+# Mission Type, Mission, and Mission Run Terminology Boundary
+
+| Field | Value |
+|---|---|
+| Filename | `2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md` |
+| Status | Accepted |
+| Date | 2026-04-04 |
+| Deciders | Robert Douglass, Spec Kitty Architecture Team |
+| Technical Story | Nomenclature consolidation after PR #348 and Doctrine Runtime Activation epic #364 |
+
+---
+
+## Context and Problem Statement
+
+Spec Kitty currently carries multiple conflicting ontologies for the same set of
+objects.
+
+The main collisions are:
+
+1. `Mission` sometimes means the reusable workflow blueprint (`software-dev`,
+   `research`, `documentation`).
+2. `Mission` sometimes means the concrete tracked item under
+   `kitty-specs/<slug>/`.
+3. `Mission Run` already exists in runtime/state code as the persisted
+   execution/session instance under `.kittify/runtime/`, but parts of the
+   ongoing rename effort also use `mission run` to mean the tracked item.
+4. `Feature` is still the dominant tracked-item term in large parts of the
+   CLI, API, dashboard, docs, tutorials, skills, and website language even
+   though that noun only fits software delivery naturally.
+5. `Workflow`, `phase`, `action`, `step contract`, and `procedure` are used
+   interchangeably in places where they should describe different layers.
+
+Issue [#241](https://github.com/Priivacy-ai/spec-kitty/issues/241) surfaced the
+first concrete collision: `--feature` was proposed to become `--mission`, but
+`--mission` already meant mission blueprint/type selection.
+
+PR [#348](https://github.com/Priivacy-ai/spec-kitty/pull/348) moved the system
+toward `mission type` and `mission run`, but the branch still leaves one
+critical ambiguity unresolved: `mission run` is already a runtime/session term
+in the codebase.
+
+Epic [#364](https://github.com/Priivacy-ai/spec-kitty/issues/364) and design
+spike [#367](https://github.com/Priivacy-ai/spec-kitty/issues/367) make the
+deeper architectural requirement explicit: Spec Kitty needs one noun per layer,
+not a rotating set of aliases.
+
+## Decision Drivers
+
+* **One noun, one layer** — each canonical term must name exactly one object
+  in the domain model.
+* **Support all mission types** — the core tracked-item term must work for
+  software development, research, documentation, and future mission types.
+* **Preserve runtime clarity** — runtime/session identity must remain distinct
+  from planning/delivery identity.
+* **Migration tractability** — existing `feature` and `mission-run`
+  compatibility surfaces must be migratable without breaking every script at
+  once.
+* **API and event safety** — persisted fields and command flags must not reuse
+  the same noun for different entities.
+
+## Considered Options
+
+* **Option 1:** Keep `Feature` as the canonical tracked item, use
+  `Mission Type` for the blueprint, and reserve `Mission Run` for runtime.
+* **Option 2:** Generalize `Mission` to the canonical tracked item, use
+  `Mission Type` for the blueprint, reserve `Mission Run` for runtime/session
+  instances, and keep `Feature` only as a compatibility alias for
+  software-dev missions.
+* **Option 3:** Use `Mission Run` as the canonical tracked item and rename the
+  runtime/session concept to something else.
+
+## Decision Outcome
+
+**Chosen option: Option 2**, because it gives Spec Kitty one portable tracked
+item noun across all mission types while preserving `mission run` for the
+runtime/session layer where it already exists.
+
+### Core Terminology Model
+
+| Canonical term | Layer | Definition |
+|---|---|---|
+| `Mission Type` | Reusable blueprint | A reusable workflow definition that specifies lifecycle actions, guards, templates, artifacts, action indices, and default doctrine bindings. |
+| `Mission` | Concrete tracked item | The concrete thing being planned, executed, reviewed, and integrated in a repository. Stored under `kitty-specs/<mission-slug>/`. |
+| `Mission Run` | Runtime/session instance | One persisted runtime execution instance for a mission. Stored under `.kittify/runtime/` and identified by `mission_run_id`. |
+| `Work Package` | Planning/review slice | One decomposed slice of work inside a mission. |
+| `Mission Action` | Outer lifecycle node | A public lifecycle action such as `specify`, `plan`, `implement`, or `review`. |
+| `Step Contract` | Action contract | A structured contract that decomposes one mission action into internal steps and delegation hooks. |
+| `Procedure` | Reusable subworkflow | A doctrine-level reusable playbook that a step contract may delegate to. |
+| `Tactic` | Technique | A smaller reusable technique applied within a procedure or step contract. |
+| `Directive` | Constraint | A rule or policy that constrains behavior. |
+
+### Specific Naming Rules
+
+1. `Mission Type` is the only canonical name for the reusable blueprint layer.
+   Use `mission type`, not plain `mission`, when the subject is
+   `software-dev`, `research`, `documentation`, or another reusable template.
+2. `Mission` is the only canonical name for the concrete tracked item currently
+   represented by `kitty-specs/<slug>/`, `meta.json`, `tasks.md`, work package
+   status, acceptance, and integration.
+3. `Mission Run` is reserved exclusively for the runtime/session instance.
+   It MUST NOT be used to name the tracked item, directory slug, or top-level
+   planning scope.
+4. `Feature` is not a canonical architecture noun anymore. It remains an
+   allowed compatibility alias for a `Mission` whose `mission_type` is
+   `software-dev`.
+5. `Workflow` is an umbrella prose term only. It is not a primary tracked
+   object. When precision matters, use `mission type`, `mission action`,
+   `step contract`, or `procedure`.
+6. `Phase` is allowed as explanatory prose for high-level lifecycle discussion,
+   but technical contracts, APIs, events, docs, and help text should prefer
+   `mission action` or `step` when referring to concrete runtime nodes.
+
+### Command, API, and State Naming Rules
+
+1. `--mission-type` is the canonical selector for the reusable blueprint.
+2. `--mission` is the canonical selector for the concrete tracked mission.
+3. `--mission-run` is reserved for runtime/session selectors only.
+4. `--feature` is a compatibility alias for `--mission` on software-dev
+   legacy surfaces during migration.
+5. `feature_slug` is a compatibility field name only. The canonical tracked
+   item identifier is `mission_slug`.
+6. `mission_run_id` is the canonical runtime/session identifier and must never
+   alias a tracked mission slug.
+
+### Compatibility and Migration Policy
+
+1. Existing user-facing and machine-facing surfaces may dual-read and dual-write
+   legacy names during migration.
+2. Canonical docs, glossary entries, architecture docs, and new APIs MUST use
+   the terminology in this ADR immediately.
+3. Compatibility aliases must be explicitly labeled as aliases or deprecated
+   surfaces. They must not be presented as co-equal canonical terms.
+4. `Feature` may remain in examples, tutorials, and public marketing copy only
+   when the text is specifically about software delivery outcomes, not when
+   describing the generic product model.
+
+### Decision on Step Contracts and Procedures
+
+1. `Mission Type` defines the outer lifecycle and the available mission
+   actions.
+2. `Step Contract` is the executable action contract for one mission action.
+3. `Procedure` is a reusable doctrine playbook used by a step contract to
+   supply structured guidance for part of an action.
+4. A procedure is not a mission, not a mission action, and not a mission run.
+
+### Decision on Existing Technical Artifact Names
+
+`mission-runtime.yaml` remains an established technical filename for the
+mission-type runtime DAG. It is not a `Mission Run` artifact and must not be
+described that way in docs or code comments.
+
+## Consequences
+
+### Positive
+
+* The tracked-item noun now works across software, research, documentation, and
+  future mission types.
+* Runtime/session identity stays cleanly separate from planning/delivery
+  identity.
+* Step contract and procedure language can be defined without overloading
+  `workflow`.
+* Public docs can explain the system without forcing every non-software use
+  case into the word `feature`.
+
+### Negative
+
+* Some of PR #348's `mission-run` tracked-item naming will need to be reversed
+  or deprecated.
+* CLI, API, dashboard, tutorial, and website copy will all require coordinated
+  updates.
+* Event/API compatibility fields such as `feature_slug` will need a deprecation
+  plan instead of an ad-hoc drift.
+
+### Neutral
+
+* Existing legacy files, commands, and docs may temporarily preserve old names
+  as compatibility wrappers while the migration runs.
+* Public marketing copy may still use ordinary English words like `feature`
+  when describing software outcomes, so long as it does not redefine the
+  product model.
+
+### Confirmation
+
+This decision is validated when all of the following are true:
+
+1. No canonical doc or glossary entry uses `mission run` to mean the tracked
+   mission under `kitty-specs/<slug>/`.
+2. No canonical CLI help text or API contract uses `--mission-run` to select a
+   tracked mission slug.
+3. Runtime/state code uses `mission_run_id` only for execution/session identity.
+4. The generic product model in docs and website copy says
+   `Mission Type -> Mission -> Mission Run`, with `Feature` clearly marked as a
+   software-dev compatibility alias.
+5. `Step Contract` and `Procedure` are described consistently across doctrine,
+   runtime, docs, skills, and public explanations.
+
+## Pros and Cons of the Options
+
+### Option 1: Keep `Feature` as the canonical tracked item
+
+**Pros:**
+
+* Lowest short-term migration cost.
+* Matches current 2.x filesystem and many existing docs.
+
+**Cons:**
+
+* Makes research and documentation missions sound like software features.
+* Keeps the product model biased toward one mission type.
+* Leaves the broader terminology problem only partially solved.
+
+### Option 2: Generalize `Mission` as the canonical tracked item
+
+**Pros:**
+
+* Gives one generic tracked-item noun across all mission types.
+* Preserves `Mission Run` for runtime/session identity where it already exists.
+* Makes issue #367's outer-lifecycle model easier to explain cleanly.
+
+**Cons:**
+
+* Requires a larger rename and compatibility program.
+* Forces explicit migration rules for `feature` and `mission-run` legacy
+  surfaces.
+
+### Option 3: Use `Mission Run` as the canonical tracked item
+
+**Pros:**
+
+* Avoids renaming the tracked item back away from some of PR #348's current
+  help text.
+
+**Cons:**
+
+* Directly collides with the existing runtime/session use of `mission run`.
+* Forces a second rename for `mission_run_id`, runtime state, and run-index
+  files.
+* Makes the domain model less precise, not more.
+
+## More Information
+
+**Related Issues:**
+- [#241](https://github.com/Priivacy-ai/spec-kitty/issues/241)
+- [#364](https://github.com/Priivacy-ai/spec-kitty/issues/364)
+- [#367](https://github.com/Priivacy-ai/spec-kitty/issues/367)
+
+**Related Pull Request:**
+- [#348](https://github.com/Priivacy-ai/spec-kitty/pull/348)
+
+**Related ADRs:**
+- `2026-02-17-1-canonical-next-command-runtime-loop.md`
+- `2026-02-17-2-runtime-owned-mission-discovery-loading.md`
+- `2026-04-03-1-execution-lanes-own-worktrees-and-mission-branches.md`
+- `2026-04-03-3-feature-acceptance-runs-on-the-integrated-mission-branch.md`

--- a/architecture/2.x/initiatives/2026-04-mission-nomenclature-reconciliation/README.md
+++ b/architecture/2.x/initiatives/2026-04-mission-nomenclature-reconciliation/README.md
@@ -1,0 +1,356 @@
+# Initiative: Mission Nomenclature Reconciliation
+
+This initiative operationalizes ADR
+`2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md`.
+
+The goal is not a blind search/replace. The goal is to make every first-party
+Spec Kitty surface describe the same model:
+
+`Mission Type -> Mission -> Mission Run`
+
+with:
+
+- `Feature` retained only as a software-dev compatibility alias
+- `Workflow` demoted to umbrella prose
+- `Step Contract` and `Procedure` kept as distinct doctrine/runtime layers
+
+## Success Criteria
+
+1. Canonical docs, glossary entries, architecture docs, and public website copy
+   describe the same terminology model.
+2. Tracked-item selectors use `mission`, blueprint selectors use
+   `mission-type`, and runtime/session selectors use `mission-run`.
+3. `mission_run_id` is used only for runtime/session identity.
+4. `feature_slug` is either removed, dual-written as a compatibility alias, or
+   explicitly marked deprecated wherever it remains.
+5. `Step Contract` and `Procedure` mean the same thing in doctrine docs, CLI
+   help text, prompt templates, and UI copy.
+
+## Canonical Target Vocabulary
+
+| Term | Canonical meaning | Notes |
+|---|---|---|
+| `Mission Type` | Reusable workflow blueprint | Examples: `software-dev`, `research`, `documentation` |
+| `Mission` | Concrete tracked item under `kitty-specs/<slug>/` | Generic tracked-item noun across all mission types |
+| `Mission Run` | Runtime/session instance | Runtime-only; never a synonym for the tracked mission |
+| `Work Package` | Planning/review slice inside a mission | `WPxx` artifacts and status |
+| `Mission Action` | Outer lifecycle action | `specify`, `plan`, `implement`, `review`, etc. |
+| `Step Contract` | Structured contract for one mission action | Internal decomposition of an action |
+| `Procedure` | Reusable doctrine subworkflow | Delegated to by a step contract |
+| `Feature` | Compatibility alias for a software-dev mission | Not canonical product language |
+| `Workflow` | Umbrella prose only | Replace with specific nouns in technical surfaces |
+
+## Scope by Property
+
+This initiative covers all first-party Spec Kitty properties in the current
+workspace that either expose product language or consume CLI/API/runtime
+contracts.
+
+| Property | Primary surface types | Required outcome |
+|---|---|---|
+| `spec-kitty` | Core CLI, runtime, events, dashboard, docs, glossary, skills | Canonical source rollout |
+| `Spec-Kitty-Website` | Public website, marketing copy, docs entrypoints | Public model matches ADR |
+| `spec-kitty-saas` | SaaS onboarding, UI labels, dashboards, API consumers | UI and product text align with core |
+| `spec-kitty-hub` | Shared UI and integration surfaces | Shared terminology model |
+| `spec-kitty-tracker` | Tracker-facing UX and status copy | Mission terminology, compat where needed |
+| `spec-kitty-orchestrator` | Provider-side orchestration UX and API usage | Contract names/versioning aligned |
+| `spec-kitty-runtime` | Runtime library and typed models | `mission run` reserved for runtime |
+| `spec-kitty-events` | Event schemas, projections, event docs | Canonical field naming and alias strategy |
+| `spec-kitty-mobile*` | Mobile onboarding/help surfaces | Public language matches core |
+| `spec-kitty-end-to-end-testing`, `spec-kitty-plain-english-tests` | Fixtures, transcripts, golden outputs | Regression coverage updated |
+
+## Workstreams
+
+### 1. Policy and Glossary Lock
+
+Goal: make the ADR and glossary the uncontested source of truth before any code
+rename proceeds.
+
+Tasks:
+- Update `glossary/contexts/orchestration.md` to match the ADR exactly.
+- Update `glossary/historical-terms.md` so `Feature` is marked as a
+  compatibility alias, not a co-equal current term.
+- Add or update glossary entries for `Mission Type`, `Mission Action`,
+  `Step Contract`, and `Procedure` where needed.
+- Add one short glossary note that `workflow` is generic prose, not a primary
+  domain object.
+- Update architecture and explanation docs that currently mix
+  `Mission`, `Feature`, and `Mission Run`.
+
+Representative files:
+- `glossary/contexts/orchestration.md`
+- `glossary/contexts/doctrine.md`
+- `glossary/contexts/identity.md`
+- `glossary/historical-terms.md`
+- `docs/2x/runtime-and-missions.md`
+- `docs/explanation/mission-system.md`
+
+Acceptance gate:
+- No glossary entry defines `Mission Run` as the tracked item.
+- No canonical doc uses `Mission` to mean reusable blueprint without the word
+  `Type`.
+
+### 2. Core CLI Taxonomy
+
+Goal: make flags, command groups, help text, error messages, and examples obey
+the ADR.
+
+Canonical selector policy:
+- `--mission-type` = reusable blueprint selector
+- `--mission` = tracked mission selector
+- `--mission-run` = runtime/session selector only
+- `--feature` = compatibility alias for `--mission` on software-dev legacy
+  surfaces
+
+Tasks:
+- Audit command groups that currently use `mission-run` for tracked missions.
+- Introduce canonical tracked-mission help text and examples.
+- Mark legacy `feature` wrappers and legacy `mission-run` tracked-item wrappers
+  as compatibility surfaces.
+- Update autogenerated or hand-authored CLI docs to stop teaching the wrong
+  nouns.
+- Decide whether `agent workflow` remains a command name as compatibility
+  veneer or is replaced by a more precise surface such as `agent mission`.
+
+Representative files:
+- `src/specify_cli/cli/commands/agent/mission_run.py`
+- `src/specify_cli/cli/commands/agent/feature.py`
+- `src/specify_cli/cli/commands/agent/workflow.py`
+- `src/specify_cli/cli/commands/mission_type.py`
+- `src/specify_cli/cli/commands/implement.py`
+- `docs/reference/cli-commands.md`
+- `docs/reference/agent-subcommands.md`
+
+Acceptance gate:
+- No canonical help text says `--mission-run` selects `kitty-specs/<slug>/`.
+- `--mission-type` is the documented primary selector for blueprint choice.
+
+### 3. Runtime, Events, and API Contracts
+
+Goal: separate tracked mission identity from runtime/session identity in every
+machine-facing contract.
+
+Tasks:
+- Inventory every public JSON field carrying tracked-item identity.
+- Introduce `mission_slug` as the canonical tracked-item field where absent.
+- Dual-write `feature_slug` only where needed for compatibility.
+- Reserve `mission_run_id` for runtime/session state only.
+- Decide whether orchestrator API commands and payloads need versioned aliases
+  (`mission-state`, `accept-mission`, `merge-mission`) or a staged
+  deprecation layer.
+- Update event-envelope and state-contract docs to explain the alias window.
+
+Representative files:
+- `src/specify_cli/next/runtime_bridge.py`
+- `src/specify_cli/context/models.py`
+- `src/specify_cli/state_contract.py`
+- `src/specify_cli/orchestrator_api/commands.py`
+- `docs/reference/orchestrator-api.md`
+- `docs/reference/event-envelope.md`
+- `docs/status-model.md`
+
+Acceptance gate:
+- `mission_run_id` never aliases a mission slug.
+- Every public payload that identifies a tracked mission documents
+  `mission_slug` as canonical.
+
+### 4. Dashboard and Product UI Surfaces
+
+Goal: make user-visible UI labels, navigation, badges, filters, empty states,
+and notifications use the canonical terminology.
+
+Tasks:
+- Audit dashboard labels such as `currentFeature`, feature tabs, accept/merge
+  flows, and activity log strings.
+- Update mission-type selectors in onboarding and creation flows.
+- Ensure software-dev specific surfaces can still say `feature` where that is
+  domain-natural, but only as a subtype/example of mission.
+- Review screenshots, onboarding callouts, and empty-state guidance so public
+  language matches the model.
+
+Representative surfaces:
+- `src/specify_cli/dashboard/static/dashboard/dashboard.js`
+- SaaS dashboards and onboarding in `spec-kitty-saas`
+- Tracker and hub surfaces in `spec-kitty-tracker` and `spec-kitty-hub`
+
+Acceptance gate:
+- Generic UI copy says `Mission` unless the context is explicitly
+  software-delivery-specific.
+- No dashboard label uses `Mission Run` for the tracked item.
+
+### 5. Docs, Skills, Prompt Templates, and Tutorials
+
+Goal: fix the highest-volume repetition surfaces that currently teach the wrong
+model back to users and agents.
+
+Tasks:
+- Update all docs that explain the hierarchy.
+- Update skills under `.agents/`, `.claude/`, and `src/doctrine/skills/`.
+- Update command templates under `src/doctrine/missions/*/command-templates/`.
+- Update public tutorials, how-to guides, and quickstart snippets.
+- Add a terminology migration note to the docs site so users understand what is
+  canonical vs compatibility.
+
+Representative files:
+- `src/doctrine/skills/spec-kitty-mission-system/SKILL.md`
+- `src/doctrine/skills/spec-kitty-runtime-next/SKILL.md`
+- `src/doctrine/skills/spec-kitty-constitution-doctrine/SKILL.md`
+- `docs/reference/missions.md`
+- `docs/explanation/runtime-loop.md`
+- `docs/tutorials/*`
+- `.agents/skills/**`
+- `.claude/skills/**`
+
+Acceptance gate:
+- Mission-system docs, runtime docs, and glossary all describe the same
+  hierarchy.
+- No tutorial teaches `mission run` as the tracked item.
+
+### 6. Public Website and Marketing Language
+
+Goal: make the public story match the product model without sacrificing plain
+English clarity.
+
+Rules:
+- Use `Mission` as the generic product noun.
+- Use `Mission Type` when describing reusable workflows.
+- Use `Feature` only as an example outcome within `software-dev`.
+- Avoid `Mission Run` in marketing except where explaining runtime/session
+  internals for technical audiences.
+
+Tasks:
+- Update homepage/product pages/feature lists.
+- Update diagrams, screenshots, captions, alt text, and hero copy.
+- Update docs entry copy and SEO meta descriptions where terminology currently
+  implies `Feature` is the generic tracked item.
+
+Primary property:
+- `Spec-Kitty-Website`
+
+Acceptance gate:
+- A new reader can understand the model from the website without reading the
+  glossary.
+
+### 7. Sister Repo Reconciliation
+
+Goal: align non-core repositories that parse, render, or echo Spec Kitty terms.
+
+Tasks by repo category:
+- `spec-kitty-runtime`, `spec-kitty-events`: field names, schema comments,
+  event docs, generated clients.
+- `spec-kitty-orchestrator`: provider-side command invocation, contract docs,
+  CLI examples, dashboard strings.
+- `spec-kitty-saas`, `spec-kitty-hub`, `spec-kitty-tracker`: onboarding,
+  workflow copy, labels, filters, analytics dimensions.
+- `spec-kitty-mobile*`: mobile help text, onboarding, and glossary snippets.
+- Test repos: golden transcripts, plain-English expectations, fixture slugs,
+  and E2E assertions.
+
+Acceptance gate:
+- No first-party property teaches a contradictory hierarchy.
+
+### 8. Compatibility, Deprecation, and Release Management
+
+Goal: sequence the migration without causing silent breakage.
+
+Tasks:
+- Publish an explicit compatibility matrix for flags, fields, and command
+  groups.
+- Add deprecation warnings where legacy selectors remain accepted.
+- Define removal criteria for `feature` primary surfaces and
+  `mission-run` tracked-item selectors.
+- Version public API changes where payload field names change.
+- Add regression tests for legacy aliases during the deprecation window.
+
+Acceptance gate:
+- Users can follow canonical docs immediately.
+- Legacy automation receives explicit warnings, not silent behavior changes.
+
+## Rollout Sequence
+
+### Phase 0: Freeze the Lexicon
+
+Deliverables:
+- ADR accepted
+- Initiative published
+- Search inventory captured
+
+No code/API renames should proceed before this phase is merged.
+
+### Phase 1: Canonical Docs and Glossary
+
+Deliverables:
+- Glossary and architecture docs updated
+- `spec-kitty` docs site updated
+- Skills and doctrine docs updated
+
+This phase changes the language people read first.
+
+### Phase 2: Core CLI and Runtime Contracts
+
+Deliverables:
+- Canonical selectors and help text updated
+- Runtime/session naming separated from tracked-item naming
+- Event/API alias strategy implemented
+
+This phase changes what developers and automation call.
+
+### Phase 3: UI and Dashboard Surfaces
+
+Deliverables:
+- Core dashboard copy updated
+- SaaS/hub/tracker product UIs updated
+- Screenshots and support text refreshed
+
+This phase changes what users see while operating the product.
+
+### Phase 4: External Properties and Public Website
+
+Deliverables:
+- Public website copy updated
+- Marketing diagrams updated
+- Orchestrator/provider docs updated
+
+This phase changes what prospects and integrators learn.
+
+### Phase 5: Deprecation Burn-Down
+
+Deliverables:
+- Legacy aliases reduced to a documented allowlist
+- Removal plan published
+- Metrics collected on legacy command/field usage
+
+This phase retires the old language safely.
+
+## Search and Audit Checklist
+
+Use this checklist in every property before editing:
+
+- Search for `mission run` used to mean tracked item.
+- Search for `--mission-run` used to select `kitty-specs/<slug>/`.
+- Search for `--mission` used to mean mission type without a compatibility note.
+- Search for `feature_slug` in public payloads and docs.
+- Search for `feature-state`, `accept-feature`, `merge-feature`, and related
+  command docs.
+- Search for `workflow` where a more specific term should be used.
+- Search for hierarchy diagrams that still say `Mission -> Feature` or
+  `Mission -> Mission Run` incorrectly.
+
+Suggested starting commands in each repo:
+
+```bash
+rg -n "mission run|mission-run|feature_slug|feature-state|accept-feature|merge-feature|--feature\\b|--mission\\b|--mission-run\\b|workflow"
+```
+
+## Done Definition
+
+This initiative is complete when:
+
+1. The glossary, ADRs, docs, and website all teach the same model.
+2. The core CLI and APIs use canonical selectors/field names with explicit
+   compatibility aliases.
+3. No first-party property uses `Mission Run` to mean the tracked mission.
+4. `Feature` appears only in software-dev-specific or explicitly deprecated
+   contexts.
+5. The remaining compatibility exceptions are documented in one allowlist with
+   owners and removal dates.

--- a/architecture/2.x/initiatives/README.md
+++ b/architecture/2.x/initiatives/README.md
@@ -11,3 +11,5 @@ Canonical decisions must land in `architecture/2.x/adr/` once accepted.
    - Brainstorm lineage, exploratory user journeys, dialectics, and structure proposals
 2. `next-mission-mappings/`
    - Open tracking items for `spec-kitty next` mission mapping/template parity
+3. `2026-04-mission-nomenclature-reconciliation/`
+   - ADR-driven rollout plan for `Mission Type -> Mission -> Mission Run`


### PR DESCRIPTION
## Summary
- add an ADR that fixes the canonical Mission Type -> Mission -> Mission Run model
- add an initiative plan for reconciling terminology across CLI, APIs, docs, skills, dashboards, and website surfaces
- register the initiative in the 2.x initiatives index

## Validation
- git diff --check