### PR TITLE
Globalize managed doctrine skills

### DIFF
--- a/src/doctrine/skills/spec-kitty-setup-doctor/references/agent-path-matrix.md
+++ b/src/doctrine/skills/spec-kitty-setup-doctor/references/agent-path-matrix.md
@@ -4,21 +4,26 @@ Reference: Framework capability matrix for Spec Kitty 2.0.11+
 
 ## Skill Roots and Wrapper Roots by Agent
 
-| Agent | Key | Installation Class | Skill Root(s) | Wrapper Root |
-|-------|-----|-------------------|---------------|--------------|
-| Claude Code | `claude` | native-root-required | `.claude/skills/` | `.claude/commands/` |
-| GitHub Copilot | `copilot` | shared-root-capable | `.agents/skills/`, `.github/skills/` | `.github/prompts/` |
-| Gemini CLI | `gemini` | shared-root-capable | `.agents/skills/`, `.gemini/skills/` | `.gemini/commands/` |
-| Cursor | `cursor` | shared-root-capable | `.agents/skills/`, `.cursor/skills/` | `.cursor/commands/` |
-| Qwen Code | `qwen` | native-root-required | `.qwen/skills/` | `.qwen/commands/` |
-| opencode | `opencode` | shared-root-capable | `.agents/skills/`, `.opencode/skills/` | `.opencode/command/` |
-| Windsurf | `windsurf` | shared-root-capable | `.agents/skills/`, `.windsurf/skills/` | `.windsurf/workflows/` |
-| Codex CLI | `codex` | shared-root-capable | `.agents/skills/` | `.codex/prompts/` |
-| Kilo Code | `kilocode` | native-root-required | `.kilocode/skills/` | `.kilocode/workflows/` |
-| Auggie CLI | `auggie` | shared-root-capable | `.agents/skills/`, `.augment/skills/` | `.augment/commands/` |
-| Roo Code | `roo` | shared-root-capable | `.agents/skills/`, `.roo/skills/` | `.roo/commands/` |
-| Amazon Q Developer CLI | `q` | wrapper-only | _(none)_ | `.amazonq/prompts/` |
-| Google Antigravity | `antigravity` | shared-root-capable | `.agents/skills/`, `.agent/skills/` | `.agent/workflows/` |
+Canonical Spec Kitty doctrine skills are now managed in the user's home
+directory and projected into project roots as needed. That means a CLI upgrade
+refreshes the canonical pack once under the user home; projects should not need
+fresh per-repo snapshots of `spec-kitty-*` skills.
+
+| Agent | Key | Installation Class | Canonical User Root | Project Skill Root(s) | Wrapper Root |
+|-------|-----|-------------------|---------------------|-----------------------|--------------|
+| Claude Code | `claude` | native-root-required | `~/.claude/skills/` | `.claude/skills/` | `.claude/commands/` |
+| GitHub Copilot | `copilot` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.github/skills/` | `.github/prompts/` |
+| Gemini CLI | `gemini` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.gemini/skills/` | `.gemini/commands/` |
+| Cursor | `cursor` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.cursor/skills/` | `.cursor/commands/` |
+| Qwen Code | `qwen` | native-root-required | `~/.qwen/skills/` | `.qwen/skills/` | `.qwen/commands/` |
+| opencode | `opencode` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.opencode/skills/` | `.opencode/command/` |
+| Windsurf | `windsurf` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.windsurf/skills/` | `.windsurf/workflows/` |
+| Codex CLI | `codex` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/` | `.codex/prompts/` |
+| Kilo Code | `kilocode` | native-root-required | `~/.kilocode/skills/` | `.kilocode/skills/` | `.kilocode/workflows/` |
+| Auggie CLI | `auggie` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.augment/skills/` | `.augment/commands/` |
+| Roo Code | `roo` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.roo/skills/` | `.roo/commands/` |
+| Amazon Q Developer CLI | `q` | wrapper-only | _(none)_ | _(none)_ | `.amazonq/prompts/` |
+| Google Antigravity | `antigravity` | shared-root-capable | `~/.agents/skills/` | `.agents/skills/`, `.agent/skills/` | `.agent/workflows/` |
 
 ## Installation Classes
 
@@ -48,7 +53,10 @@ exclusively through wrapper slash commands in the wrapper root.
 ## Notes
 
 - The shared root `.agents/skills/` is created once and symlinked or referenced
-  by all shared-root-capable agents. This avoids duplicating skill content.
+  by all shared-root-capable agents. The canonical managed copy lives in
+  `~/.agents/skills/`; project roots should project to it rather than snapshot it.
+- Managed canonical files under the user home are read-only. If a project replaces
+  one of its projected files locally, that is treated as drift and can be repaired.
 - Wrapper roots contain slash-command files (e.g., `spec-kitty.implement.md`)
   that agents use for `/spec-kitty.implement` style invocation.
 - When verifying an installation, check the skill root(s) first, then the

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -98,9 +98,11 @@ def main_callback(
 
     # FR-002: Ensure global runtime (~/.kittify/) is populated and current.
     # Must run BEFORE check_version_pin() so global assets are available.
+    from specify_cli.runtime.agent_skills import ensure_global_agent_skills
     from specify_cli.runtime.bootstrap import check_version_pin, ensure_runtime
 
     ensure_runtime()
+    ensure_global_agent_skills()
 
     # F-Pin-001 / 1A-16: Warn on runtime.pin_version for all project invocations.
     project_root = locate_project_root()

--- a/src/specify_cli/runtime/agent_skills.py
+++ b/src/specify_cli/runtime/agent_skills.py
@@ -1,0 +1,107 @@
+"""Bootstrap user-global canonical doctrine skills."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from specify_cli.runtime.bootstrap import _get_cli_version, _lock_exclusive
+from specify_cli.runtime.home import get_kittify_home
+from specify_cli.skills.paths import get_primary_global_skill_root, iter_installable_agents
+from specify_cli.skills.registry import SkillRegistry
+from specify_cli.template import get_local_repo_root
+
+logger = logging.getLogger(__name__)
+
+_VERSION_FILENAME = "agent-skills.lock"
+_LOCK_FILENAME = ".agent-skills.lock"
+
+
+def _discover_registry() -> SkillRegistry | None:
+    """Resolve the canonical bundled skill registry."""
+    try:
+        registry = SkillRegistry.from_package()
+        if registry.discover_skills():
+            return registry
+    except Exception:
+        logger.debug("Package skill registry unavailable", exc_info=True)
+
+    local_repo = get_local_repo_root()
+    if local_repo is not None:
+        registry = SkillRegistry.from_local_repo(local_repo)
+        if registry.discover_skills():
+            return registry
+
+    return None
+
+
+def _unique_global_roots() -> list[Path]:
+    roots: list[Path] = []
+    seen: set[Path] = set()
+
+    for agent_key in iter_installable_agents():
+        root = get_primary_global_skill_root(agent_key)
+        if root is None or root in seen:
+            continue
+        seen.add(root)
+        roots.append(root)
+
+    return roots
+
+
+def _sync_skill_root(root: Path, registry: SkillRegistry) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    skills = registry.discover_skills()
+    canonical_names = {skill.name for skill in skills}
+
+    for existing in root.iterdir():
+        if existing.name.startswith("spec-kitty-") and existing.name not in canonical_names:
+            if existing.is_symlink() or existing.is_file():
+                existing.unlink()
+            elif existing.is_dir():
+                shutil.rmtree(existing)
+
+    for skill in skills:
+        dest = root / skill.name
+        if dest.exists() or dest.is_symlink():
+            if dest.is_symlink() or dest.is_file():
+                dest.unlink()
+            else:
+                shutil.rmtree(dest)
+        shutil.copytree(skill.skill_dir, dest)
+        for file_path in dest.rglob("*"):
+            if not file_path.is_file():
+                continue
+            mode = file_path.stat().st_mode
+            file_path.chmod(mode & ~0o222)
+
+
+def ensure_global_agent_skills() -> None:
+    """Ensure user-global canonical skill roots are populated for this CLI version."""
+    registry = _discover_registry()
+    if registry is None:
+        return
+
+    kittify_home = get_kittify_home()
+    kittify_home.mkdir(parents=True, exist_ok=True)
+    cache_dir = kittify_home / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    version_file = cache_dir / _VERSION_FILENAME
+    cli_version = _get_cli_version()
+    if version_file.exists() and version_file.read_text().strip() == cli_version:
+        return
+
+    lock_path = cache_dir / _LOCK_FILENAME
+    lock_fd = open(lock_path, "w")  # noqa: SIM115
+    try:
+        _lock_exclusive(lock_fd)
+        if version_file.exists() and version_file.read_text().strip() == cli_version:
+            return
+
+        for root in _unique_global_roots():
+            _sync_skill_root(root, registry)
+        version_file.write_text(cli_version)
+    finally:
+        lock_fd.close()

--- a/src/specify_cli/skills/installer.py
+++ b/src/specify_cli/skills/installer.py
@@ -1,4 +1,4 @@
-"""Skill installer: copies canonical skills to agent-specific skill roots."""
+"""Skill installer: project skills are projected from user-global canonical roots."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from specify_cli.core.config import (
     AGENT_SKILL_CONFIG,
-    SKILL_CLASS_NATIVE,
     SKILL_CLASS_SHARED,
     SKILL_CLASS_WRAPPER,
 )
@@ -17,26 +16,118 @@ from specify_cli.skills.manifest import (
     ManagedSkillManifest,
     compute_content_hash,
 )
+from specify_cli.skills.paths import (
+    get_primary_global_skill_root,
+    get_primary_project_skill_root,
+)
 from specify_cli.skills.registry import CanonicalSkill, SkillRegistry
 
+DELIVERY_COPY = "copy"
+DELIVERY_SYMLINK = "symlink"
 
-def _install_skill_files(
+
+def _make_tree_read_only(root: Path) -> None:
+    """Remove write bits from all files in a managed canonical skill tree."""
+    for file_path in root.rglob("*"):
+        if not file_path.is_file():
+            continue
+        mode = file_path.stat().st_mode
+        file_path.chmod(mode & ~0o222)
+
+
+def _sync_global_skill(skill: CanonicalSkill, target_root: Path) -> Path:
+    """Install one canonical skill into the user-global root."""
+    target_root.mkdir(parents=True, exist_ok=True)
+    dest_dir = target_root / skill.name
+    if dest_dir.exists() or dest_dir.is_symlink():
+        if dest_dir.is_symlink() or dest_dir.is_file():
+            dest_dir.unlink()
+        else:
+            shutil.rmtree(dest_dir)
+    shutil.copytree(skill.skill_dir, dest_dir)
+    _make_tree_read_only(dest_dir)
+    return dest_dir
+
+
+def _ensure_backup_root(project_path: Path, backup_root: Path | None) -> Path:
+    if backup_root is not None:
+        return backup_root
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    root = project_path / ".kittify" / ".migration-backup" / "agent-skills" / timestamp
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _archive_existing_path(dest: Path, project_path: Path, backup_root: Path | None) -> Path:
+    """Move an existing project-local skill file out of the way."""
+    backup_root = _ensure_backup_root(project_path, backup_root)
+    backup_path = backup_root / dest.relative_to(project_path)
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(dest), str(backup_path))
+    return backup_root
+
+
+def _project_skill_file(
+    source_file: Path,
+    dest: Path,
+    project_path: Path,
+    *,
+    backup_root: Path | None = None,
+) -> tuple[str, Path | None]:
+    """Project a global canonical skill file into the project.
+
+    Prefers a symlink so future CLI upgrades only need to refresh the
+    global canonical roots. Falls back to a copy when symlinks are unavailable.
+    """
+    if dest.is_symlink():
+        try:
+            if dest.resolve() == source_file.resolve():
+                return DELIVERY_SYMLINK, backup_root
+        except OSError:
+            pass
+        dest.unlink()
+    elif dest.exists():
+        try:
+            if dest.is_file() and compute_content_hash(dest) == compute_content_hash(source_file):
+                dest.unlink()
+            else:
+                backup_root = _archive_existing_path(dest, project_path, backup_root)
+        except OSError:
+            backup_root = _archive_existing_path(dest, project_path, backup_root)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        dest.symlink_to(source_file)
+        return DELIVERY_SYMLINK, backup_root
+    except OSError:
+        shutil.copy2(source_file, dest)
+        return DELIVERY_COPY, backup_root
+
+
+def _project_skill_files(
     skill: CanonicalSkill,
     target_skill_dir: Path,
+    global_skill_dir: Path,
     project_path: Path,
     installation_class: str,
     agent_key: str,
 ) -> list[ManagedFileEntry]:
-    """Copy all files for one skill to *target_skill_dir* and return manifest entries."""
+    """Project all files for one skill into the project and return manifest entries."""
     entries: list[ManagedFileEntry] = []
     now = datetime.now(timezone.utc).isoformat()
+    backup_root: Path | None = None
 
     for source_file in skill.all_files:
         rel_within_skill = source_file.relative_to(skill.skill_dir)
+        global_file = global_skill_dir / rel_within_skill
         dest = target_skill_dir / rel_within_skill
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_file, dest)
-
+        delivery_mode, backup_root = _project_skill_file(
+            global_file,
+            dest,
+            project_path,
+            backup_root=backup_root,
+        )
         entries.append(
             ManagedFileEntry(
                 skill_name=skill.name,
@@ -46,6 +137,7 @@ def _install_skill_files(
                 agent_key=agent_key,
                 content_hash=compute_content_hash(dest),
                 installed_at=now,
+                delivery_mode=delivery_mode,
             )
         )
 
@@ -59,7 +151,7 @@ def _make_entries_for_existing(
     installation_class: str,
     agent_key: str,
 ) -> list[ManagedFileEntry]:
-    """Create manifest entries pointing to already-installed shared files (no copy)."""
+    """Create manifest entries pointing to already-projected files."""
     entries: list[ManagedFileEntry] = []
     now = datetime.now(timezone.utc).isoformat()
 
@@ -76,6 +168,7 @@ def _make_entries_for_existing(
                 agent_key=agent_key,
                 content_hash=compute_content_hash(dest),
                 installed_at=now,
+                delivery_mode=DELIVERY_SYMLINK if dest.is_symlink() else DELIVERY_COPY,
             )
         )
 
@@ -89,54 +182,50 @@ def install_skills_for_agent(
     *,
     shared_root_installed: set[str] | None = None,
 ) -> list[ManagedFileEntry]:
-    """Install skills for one agent. Returns manifest entries created.
-
-    Args:
-        project_path: Project root directory.
-        agent_key: Agent identifier (e.g., "claude").
-        skills: List of canonical skills to install.
-        shared_root_installed: Set of skill names already installed to shared root.
-            Pass a mutable set to enable deduplication across agents.
-
-    Returns:
-        List of ManagedFileEntry for each installed file.
-    """
+    """Install skills for one agent. Returns manifest entries created."""
     config = AGENT_SKILL_CONFIG.get(agent_key)
     if config is None:
         raise ValueError(f"Unknown agent key: {agent_key!r}")
 
     installation_class: str = config["class"]  # type: ignore[assignment]
-
-    # wrapper-only agents get no skill files
     if installation_class == SKILL_CLASS_WRAPPER:
         return []
 
-    skill_roots: list[str] = config["skill_roots"]  # type: ignore[assignment]
-    root = skill_roots[0]  # Use the first (primary) root
+    project_root = get_primary_project_skill_root(agent_key)
+    global_root = get_primary_global_skill_root(agent_key)
+    if project_root is None or global_root is None:
+        raise ValueError(f"Agent {agent_key!r} has no installable skill root")
 
     all_entries: list[ManagedFileEntry] = []
 
     for skill in skills:
-        target_skill_dir = project_path / root / skill.name
+        global_skill_dir = _sync_global_skill(skill, global_root)
+        target_skill_dir = project_path / project_root / skill.name
 
         if installation_class == SKILL_CLASS_SHARED:
-            # Shared-root deduplication
             if shared_root_installed is not None and skill.name in shared_root_installed:
-                # Files already on disk -- just create manifest entries
                 entries = _make_entries_for_existing(
                     skill, target_skill_dir, project_path, installation_class, agent_key
                 )
             else:
-                # First shared-root agent to need this skill: copy files
-                entries = _install_skill_files(
-                    skill, target_skill_dir, project_path, installation_class, agent_key
+                entries = _project_skill_files(
+                    skill,
+                    target_skill_dir,
+                    global_skill_dir,
+                    project_path,
+                    installation_class,
+                    agent_key,
                 )
                 if shared_root_installed is not None:
                     shared_root_installed.add(skill.name)
         else:
-            # native-root-required: always copy
-            entries = _install_skill_files(
-                skill, target_skill_dir, project_path, installation_class, agent_key
+            entries = _project_skill_files(
+                skill,
+                target_skill_dir,
+                global_skill_dir,
+                project_path,
+                installation_class,
+                agent_key,
             )
 
         all_entries.extend(entries)
@@ -149,16 +238,7 @@ def install_all_skills(
     agent_keys: list[str],
     registry: SkillRegistry,
 ) -> ManagedSkillManifest:
-    """Install skills for all agents. Returns populated manifest.
-
-    Args:
-        project_path: Project root directory.
-        agent_keys: List of agent identifiers to install skills for.
-        registry: SkillRegistry used to discover canonical skills.
-
-    Returns:
-        Populated ManagedSkillManifest with entries for all installed files.
-    """
+    """Install skills for all agents. Returns populated manifest."""
     skills = registry.discover_skills()
     now = datetime.now(timezone.utc).isoformat()
 
@@ -177,9 +257,6 @@ def install_all_skills(
             skills,
             shared_root_installed=shared_root_installed,
         )
-        # Append directly: shared-root agents legitimately produce entries
-        # with the same installed_path but different agent_key.  Using
-        # add_entry() would replace the earlier agent's entry.
         manifest.entries.extend(entries)
 
     return manifest

--- a/src/specify_cli/skills/manifest.py
+++ b/src/specify_cli/skills/manifest.py
@@ -27,6 +27,7 @@ class ManagedFileEntry:
     agent_key: str  # "claude", "codex", etc.
     content_hash: str  # "sha256:<hex>"
     installed_at: str  # ISO 8601 UTC
+    delivery_mode: str = "copy"  # "copy" or "symlink"
 
 
 @dataclass
@@ -90,7 +91,12 @@ def load_manifest(project_path: Path) -> ManagedSkillManifest | None:
     try:
         raw = target.read_text(encoding="utf-8")
         data = json.loads(raw)
-        entries = [ManagedFileEntry(**e) for e in data.get("entries", [])]
+        entries = []
+        for entry_data in data.get("entries", []):
+            if "delivery_mode" not in entry_data:
+                entry_data = dict(entry_data)
+                entry_data["delivery_mode"] = "copy"
+            entries.append(ManagedFileEntry(**entry_data))
         return ManagedSkillManifest(
             version=data.get("version", 1),
             created_at=data.get("created_at", ""),

--- a/src/specify_cli/skills/paths.py
+++ b/src/specify_cli/skills/paths.py
@@ -1,0 +1,50 @@
+"""Helpers for mapping canonical skill roots between project and user scopes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specify_cli.core.config import AGENT_SKILL_CONFIG, SKILL_CLASS_WRAPPER
+
+
+def get_primary_project_skill_root(agent_key: str) -> str | None:
+    """Return the primary project-local skill root for an agent."""
+    config = AGENT_SKILL_CONFIG.get(agent_key)
+    if config is None or config["class"] == SKILL_CLASS_WRAPPER:
+        return None
+
+    roots = config["skill_roots"]
+    if not isinstance(roots, list) or not roots:
+        return None
+
+    return roots[0]
+
+
+def get_primary_global_skill_root(agent_key: str) -> Path | None:
+    """Return the user-global canonical skill root for an agent.
+
+    The global root mirrors the project-local root beneath the user's home
+    directory, for example:
+
+    - ``.claude/skills`` -> ``~/.claude/skills``
+    - ``.agents/skills`` -> ``~/.agents/skills``
+    """
+    root = get_primary_project_skill_root(agent_key)
+    if root is None:
+        return None
+
+    normalized = root.strip("/")
+    return Path.home() / normalized
+
+
+def iter_installable_agents() -> list[str]:
+    """Return all agents that support a skill root."""
+    installable: list[str] = []
+
+    for agent_key, config in AGENT_SKILL_CONFIG.items():
+        if config["class"] == SKILL_CLASS_WRAPPER:
+            continue
+        installable.append(agent_key)
+
+    return installable
+

--- a/src/specify_cli/skills/verifier.py
+++ b/src/specify_cli/skills/verifier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,7 +15,9 @@ from specify_cli.skills.manifest import (
     load_manifest,
     save_manifest,
 )
+from specify_cli.skills.paths import get_primary_global_skill_root
 from specify_cli.skills.registry import SkillRegistry
+from specify_cli.template import get_local_repo_root
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +50,10 @@ def verify_installed_skills(project_path: Path) -> VerifyResult:
     missing: list[ManagedFileEntry] = []
     drifted: list[tuple[ManagedFileEntry, str]] = []
     errors: list[str] = []
+    registry = _discover_registry()
 
     for entry in manifest.entries:
-        installed = (project_path / entry.installed_path).resolve()
+        installed = _project_managed_path(project_path, entry.installed_path)
         # Guard against path traversal — installed path must stay within project
         if not installed.is_relative_to(project_path.resolve()):
             errors.append(f"Unsafe path {entry.installed_path}: escapes project root")
@@ -62,7 +66,8 @@ def verify_installed_skills(project_path: Path) -> VerifyResult:
         except OSError as exc:
             errors.append(f"Cannot read {entry.installed_path}: {exc}")
             continue
-        if actual_hash != entry.content_hash:
+        expected_hash = _expected_hash(entry, registry) or entry.content_hash
+        if actual_hash != expected_hash:
             drifted.append((entry, actual_hash))
 
     ok = len(missing) == 0 and len(drifted) == 0 and len(errors) == 0
@@ -90,7 +95,7 @@ def repair_skills(
 
     for entry in entries_to_repair:
         # Guard against path traversal in installed_path
-        dest = (project_path / entry.installed_path).resolve()
+        dest = _project_managed_path(project_path, entry.installed_path)
         if not dest.is_relative_to(project_path.resolve()):
             logger.warning("Unsafe path %s: escapes project root", entry.installed_path)
             failed += 1
@@ -119,7 +124,26 @@ def repair_skills(
             continue
         try:
             dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source_path, dest)
+            delivery_mode = entry.delivery_mode
+            if entry.delivery_mode == "symlink":
+                global_root = get_primary_global_skill_root(entry.agent_key)
+                if global_root is None:
+                    raise OSError(f"No global skill root configured for agent {entry.agent_key}")
+                global_source = global_root / entry.skill_name / entry.source_file
+                if not global_source.exists():
+                    _sync_skill_to_global_root(skill, global_root)
+                if dest.exists() or dest.is_symlink():
+                    if dest.is_symlink() or dest.is_file():
+                        dest.unlink()
+                    else:
+                        shutil.rmtree(dest)
+                try:
+                    dest.symlink_to(global_source)
+                except OSError:
+                    shutil.copy2(source_path, dest)
+                    delivery_mode = "copy"
+            else:
+                shutil.copy2(source_path, dest)
             new_hash = compute_content_hash(dest)
             # Update the manifest entry with the new hash
             manifest.add_entry(
@@ -131,6 +155,7 @@ def repair_skills(
                     agent_key=entry.agent_key,
                     content_hash=new_hash,
                     installed_at=entry.installed_at,
+                    delivery_mode=delivery_mode,
                 )
             )
             repaired += 1
@@ -158,3 +183,64 @@ def _find_source_file(skill_dir: Path, source_file: str) -> Path | None:
     if candidate.is_file():
         return candidate
     return None
+
+
+def _discover_registry() -> SkillRegistry | None:
+    """Resolve the canonical skill registry for dynamic drift detection."""
+    try:
+        registry = SkillRegistry.from_package()
+        if registry.discover_skills():
+            return registry
+    except Exception:
+        logger.debug("Package skill registry unavailable", exc_info=True)
+
+    local_repo = get_local_repo_root()
+    if local_repo is not None:
+        registry = SkillRegistry.from_local_repo(local_repo)
+        if registry.discover_skills():
+            return registry
+
+    return None
+
+
+def _expected_hash(entry: ManagedFileEntry, registry: SkillRegistry | None) -> str | None:
+    """Return the current canonical hash for an entry when available."""
+    if entry.delivery_mode == "symlink":
+        global_root = get_primary_global_skill_root(entry.agent_key)
+        if global_root is not None:
+            global_source = global_root / entry.skill_name / entry.source_file
+            if global_source.is_file():
+                return compute_content_hash(global_source)
+
+    if registry is None:
+        return None
+
+    skill = registry.get_skill(entry.skill_name)
+    if skill is None:
+        return None
+
+    source_path = _find_source_file(skill.skill_dir, entry.source_file)
+    if source_path is None:
+        return None
+
+    return compute_content_hash(source_path)
+
+
+def _sync_skill_to_global_root(skill, global_root: Path) -> None:
+    """Refresh one global canonical skill directory before relinking a project file."""
+    dest_dir = global_root / skill.name
+    dest_dir.parent.mkdir(parents=True, exist_ok=True)
+    if dest_dir.exists() or dest_dir.is_symlink():
+        if dest_dir.is_symlink() or dest_dir.is_file():
+            dest_dir.unlink()
+        else:
+            shutil.rmtree(dest_dir)
+    shutil.copytree(skill.skill_dir, dest_dir)
+
+
+def _project_managed_path(project_path: Path, installed_path: str) -> Path:
+    """Normalize a managed project path without resolving symlink targets."""
+    normalized = Path(os.path.normpath(str(project_path / installed_path)))
+    if not normalized.is_absolute():
+        normalized = (project_path / normalized).absolute()
+    return normalized

--- a/src/specify_cli/upgrade/migrations/m_3_0_3_globalize_skill_pack.py
+++ b/src/specify_cli/upgrade/migrations/m_3_0_3_globalize_skill_pack.py
@@ -1,0 +1,149 @@
+"""Migration: relink canonical doctrine skills to user-global roots."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+
+
+def _discover_registry():
+    """Resolve the canonical bundled skill registry."""
+    from specify_cli.skills.registry import SkillRegistry
+    from specify_cli.template import get_local_repo_root
+
+    try:
+        registry = SkillRegistry.from_package()
+        if registry.discover_skills():
+            return registry
+    except Exception:
+        pass
+
+    local_repo = get_local_repo_root()
+    if local_repo is not None:
+        registry = SkillRegistry.from_local_repo(local_repo)
+        if registry.discover_skills():
+            return registry
+
+    return None
+
+
+def _installable_agents(project_path: Path) -> list[str]:
+    from specify_cli.core.agent_config import load_agent_config
+    from specify_cli.core.config import AGENT_SKILL_CONFIG, SKILL_CLASS_WRAPPER
+
+    installable: list[str] = []
+    for agent_key in load_agent_config(project_path).available:
+        config = AGENT_SKILL_CONFIG.get(agent_key)
+        if config is None or config["class"] == SKILL_CLASS_WRAPPER:
+            continue
+        installable.append(agent_key)
+    return installable
+
+
+@MigrationRegistry.register
+class GlobalizeSkillPackMigration(BaseMigration):
+    """Relink canonical doctrine skills so future CLI upgrades are global-only."""
+
+    migration_id = "3.0.3_globalize_skill_pack"
+    description = "Relink canonical doctrine skills to user-global roots"
+    target_version = "3.0.3"
+
+    def detect(self, project_path: Path) -> bool:
+        from specify_cli.skills.manifest import load_manifest
+        from specify_cli.skills.paths import get_primary_project_skill_root
+
+        if not (project_path / ".kittify").is_dir():
+            return False
+
+        registry = _discover_registry()
+        if registry is None:
+            return False
+
+        skills = registry.discover_skills()
+        if not skills:
+            return False
+
+        agents = _installable_agents(project_path)
+        if not agents:
+            return False
+
+        manifest = load_manifest(project_path)
+        if manifest is not None:
+            for entry in manifest.entries:
+                if entry.skill_name.startswith("spec-kitty-") and entry.delivery_mode != "symlink":
+                    return True
+
+        for agent_key in agents:
+            root = get_primary_project_skill_root(agent_key)
+            if root is None:
+                continue
+            for skill in skills:
+                skill_file = project_path / root / skill.name / "SKILL.md"
+                if not skill_file.exists():
+                    return True
+                if not skill_file.is_symlink():
+                    return True
+
+        return False
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        if not (project_path / ".kittify").is_dir():
+            return False, ".kittify/ directory does not exist (not initialized)"
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        from specify_cli.skills.installer import install_all_skills
+        from specify_cli.skills.manifest import load_manifest, save_manifest
+
+        changes: list[str] = []
+        warnings: list[str] = []
+        errors: list[str] = []
+
+        registry = _discover_registry()
+        if registry is None:
+            errors.append("No canonical skills discovered for relinking")
+            return MigrationResult(success=False, changes_made=changes, errors=errors)
+
+        skills = registry.discover_skills()
+        if not skills:
+            errors.append("No canonical skills discovered for relinking")
+            return MigrationResult(success=False, changes_made=changes, errors=errors)
+
+        agents = _installable_agents(project_path)
+        if not agents:
+            warnings.append("No skill-installing agents configured; skipping relink")
+            return MigrationResult(success=True, changes_made=changes, warnings=warnings)
+
+        if dry_run:
+            changes.append(
+                f"Would relink {len(skills)} canonical skill(s) for {len(agents)} agent(s)"
+            )
+            return MigrationResult(success=True, changes_made=changes)
+
+        manifest = install_all_skills(project_path, agents, registry)
+        existing = load_manifest(project_path)
+        preserved: list = []
+        if existing is not None:
+            canonical_names = {skill.name for skill in skills}
+            preserved = [
+                entry
+                for entry in existing.entries
+                if entry.skill_name not in canonical_names or entry.agent_key not in agents
+            ]
+            manifest.entries.extend(preserved)
+
+        if not manifest.entries and not preserved:
+            errors.append("No managed skill files were linked for any configured agent")
+            return MigrationResult(success=False, changes_made=changes, errors=errors)
+
+        manifest.spec_kitty_version = "3.0.3"
+        save_manifest(manifest, project_path)
+
+        changes.append(
+            f"Relinked {len(skills)} canonical skill(s) for {len(agents)} agent(s) "
+            f"({len(manifest.entries)} managed files)"
+        )
+        changes.append("Updated .kittify/skills-manifest.json for global canonical skill links")
+        return MigrationResult(success=True, changes_made=changes, warnings=warnings)

--- a/tests/runtime/test_agent_skills.py
+++ b/tests/runtime/test_agent_skills.py
@@ -1,0 +1,47 @@
+"""Tests for the global managed agent-skill bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specify_cli.runtime.agent_skills import ensure_global_agent_skills
+from specify_cli.skills.registry import SkillRegistry
+
+
+def _create_skill(root: Path, name: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: test\n---\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def test_global_bootstrap_preserves_non_spec_kitty_user_skills(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(home / ".kittify"))
+
+    skills_root = tmp_path / "doctrine_skills"
+    _create_skill(skills_root, "spec-kitty-test-skill")
+    registry = SkillRegistry(skills_root)
+
+    custom_skill = home / ".claude" / "skills" / "custom-skill" / "SKILL.md"
+    custom_skill.parent.mkdir(parents=True, exist_ok=True)
+    custom_skill.write_text("# custom\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "specify_cli.runtime.agent_skills._discover_registry",
+        lambda: registry,
+    )
+
+    ensure_global_agent_skills()
+
+    managed_skill = home / ".claude" / "skills" / "spec-kitty-test-skill" / "SKILL.md"
+    assert managed_skill.is_file()
+    assert custom_skill.is_file()
+    assert custom_skill.read_text(encoding="utf-8") == "# custom\n"
+
+    mode = managed_skill.stat().st_mode
+    assert mode & 0o200 == 0
+

--- a/tests/specify_cli/skills/test_e2e.py
+++ b/tests/specify_cli/skills/test_e2e.py
@@ -231,7 +231,8 @@ def test_drift_detection_and_repair(tmp_path: Path) -> None:
     original_hash = compute_content_hash(installed_file)
     assert entries[0].content_hash == original_hash
 
-    # Modify the installed file (simulate user edit / drift)
+    # Replace the project projection (simulate a local override / drift)
+    installed_file.unlink()
     installed_file.write_text("User modified this content!", encoding="utf-8")
     modified_hash = compute_content_hash(installed_file)
     assert modified_hash != original_hash

--- a/tests/upgrade/migrations/test_m_3_0_3_globalize_skill_pack.py
+++ b/tests/upgrade/migrations/test_m_3_0_3_globalize_skill_pack.py
@@ -1,0 +1,101 @@
+"""Tests for the 3.0.3 globalize-skill-pack migration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.skills.manifest import ManagedFileEntry, ManagedSkillManifest, save_manifest
+from specify_cli.skills.registry import SkillRegistry
+from specify_cli.upgrade.migrations.m_3_0_3_globalize_skill_pack import (
+    GlobalizeSkillPackMigration,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def _setup_project(tmp_path: Path, agents: list[str]) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    kittify = project / ".kittify"
+    kittify.mkdir()
+
+    config_content = "agents:\n  available:\n"
+    for agent_key in agents:
+        config_content += f"    - {agent_key}\n"
+    (kittify / "config.yaml").write_text(config_content, encoding="utf-8")
+    return project
+
+
+def _setup_skills(tmp_path: Path) -> Path:
+    skills_root = tmp_path / "doctrine_skills"
+    skill_dir = skills_root / "spec-kitty-test-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: spec-kitty-test-skill\ndescription: test\n---\n# Test\n",
+        encoding="utf-8",
+    )
+    return skills_root
+
+
+def test_detects_project_local_snapshot_copy(tmp_path: Path) -> None:
+    project = _setup_project(tmp_path, ["claude"])
+    skills_root = _setup_skills(tmp_path)
+
+    copied_skill = project / ".claude" / "skills" / "spec-kitty-test-skill" / "SKILL.md"
+    copied_skill.parent.mkdir(parents=True, exist_ok=True)
+    copied_skill.write_text("# stale copy\n", encoding="utf-8")
+    save_manifest(
+        ManagedSkillManifest(
+            entries=[
+                ManagedFileEntry(
+                    skill_name="spec-kitty-test-skill",
+                    source_file="SKILL.md",
+                    installed_path=".claude/skills/spec-kitty-test-skill/SKILL.md",
+                    installation_class="native-root-required",
+                    agent_key="claude",
+                    content_hash="sha256:stale",
+                    installed_at="2026-01-01T00:00:00+00:00",
+                )
+            ]
+        ),
+        project,
+    )
+
+    with patch(
+        "specify_cli.upgrade.migrations.m_3_0_3_globalize_skill_pack._discover_registry",
+        return_value=SkillRegistry(skills_root),
+    ):
+        assert GlobalizeSkillPackMigration().detect(project) is True
+
+
+def test_apply_relinks_project_to_global_skill_home(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(home / ".kittify"))
+
+    project = _setup_project(tmp_path, ["claude"])
+    skills_root = _setup_skills(tmp_path)
+
+    copied_skill = project / ".claude" / "skills" / "spec-kitty-test-skill" / "SKILL.md"
+    copied_skill.parent.mkdir(parents=True, exist_ok=True)
+    copied_skill.write_text("# stale copy\n", encoding="utf-8")
+
+    with patch(
+        "specify_cli.upgrade.migrations.m_3_0_3_globalize_skill_pack._discover_registry",
+        return_value=SkillRegistry(skills_root),
+    ):
+        result = GlobalizeSkillPackMigration().apply(project)
+
+    assert result.success is True
+
+    installed = project / ".claude" / "skills" / "spec-kitty-test-skill" / "SKILL.md"
+    assert installed.is_file()
+
+    manifest_path = project / ".kittify" / "skills-manifest.json"
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert data["spec_kitty_version"] == "3.0.3"
+    assert data["entries"][0]["delivery_mode"] in {"symlink", "copy"}


### PR DESCRIPTION
## Summary
- bootstrap canonical `spec-kitty-*` skills into user-global agent roots on every CLI startup
- project those managed files into project skill roots instead of re-snapshotting doctrine skills per repo
- add a current-version migration that relinks stale local snapshots to the global canonical pack and updates the managed-skill manifest
- make verifier/repair treat projected canonical files correctly across future CLI upgrades and document the new path model

## Validation
- `pytest -q tests/specify_cli/skills/test_installer.py tests/specify_cli/skills/test_verifier.py tests/specify_cli/skills/test_e2e.py tests/upgrade/migrations/test_m_2_0_11_install_skills.py tests/upgrade/migrations/test_m_2_1_1_repair_skill_pack.py tests/upgrade/migrations/test_m_3_0_3_globalize_skill_pack.py tests/runtime/test_agent_skills.py tests/init/test_init_minimal_integration.py tests/adversarial/test_distribution.py tests/specify_cli/core/test_skill_config.py`
- fresh temp-home repro: `spec-kitty init` now creates user-global canonical skills plus project projections for Claude/Codex
- fresh temp-home repro: `spec-kitty upgrade --force --json` on a stale local snapshot applies `3.0.3_globalize_skill_pack` and restores a projected canonical skill
