### PR TITLE
fix: make merge gate dependency check read-only

### DIFF
--- a/src/specify_cli/policy/merge_gates.py
+++ b/src/specify_cli/policy/merge_gates.py
@@ -216,10 +216,13 @@ def _evaluate_dependency_gate(
     """Check that all WP dependencies are in done lane."""
     try:
         from specify_cli.core.dependency_graph import build_dependency_graph
-        from specify_cli.status.reducer import materialize
+        from specify_cli.status.reducer import reduce
+        from specify_cli.status.store import read_events
 
         graph = build_dependency_graph(feature_dir)
-        snapshot = materialize(feature_dir)
+        # Merge gate evaluation must remain read-only. Writing status.json here
+        # dirties the repo and can block repeated merge attempts.
+        snapshot = reduce(read_events(feature_dir))
 
         wp_lanes: dict[str, str] = {}
         if snapshot and hasattr(snapshot, "work_packages"):

--- a/tests/policy/test_merge_gates.py
+++ b/tests/policy/test_merge_gates.py
@@ -1,6 +1,7 @@
 """Tests for merge gate evaluation engine."""
 
 import json
+import subprocess
 
 import pytest
 
@@ -130,3 +131,63 @@ class TestOverallEvaluation:
         assert "overall_pass" in d
         assert "gates" in d
         assert "warnings" in d
+
+
+class TestDependencyGateReadOnly:
+    def test_evaluate_merge_gates_does_not_create_status_json(self, tmp_path):
+        feature_dir = _setup_feature(
+            tmp_path, ["WP01"], wp_lanes={"WP01": "approved"},
+        )
+
+        result = evaluate_merge_gates(
+            feature_dir, "010-feat", ["WP01"],
+            MergeGateConfig(mode="block"), tmp_path,
+        )
+
+        dependency_gate = next(g for g in result.gates if g.gate_name == "dependency")
+        assert dependency_gate.verdict == GateVerdict.PASS
+        assert not (feature_dir / "status.json").exists()
+
+    def test_evaluate_merge_gates_does_not_dirty_tracked_status_json(self, tmp_path):
+        feature_dir = _setup_feature(
+            tmp_path, ["WP01"], wp_lanes={"WP01": "approved"},
+        )
+        repo_root = tmp_path
+
+        subprocess.run(["git", "init", str(repo_root)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo_root), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_root), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+
+        from specify_cli.status.reducer import materialize
+
+        materialize(feature_dir)
+        subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+
+        result = evaluate_merge_gates(
+            feature_dir, "010-feat", ["WP01"],
+            MergeGateConfig(mode="block"), tmp_path,
+        )
+
+        dependency_gate = next(g for g in result.gates if g.gate_name == "dependency")
+        assert dependency_gate.verdict == GateVerdict.PASS
+
+        git_status = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert git_status == ""


### PR DESCRIPTION
## Summary
- stop the dependency merge gate from calling `materialize()` during merge evaluation
- compute the snapshot in memory with `read_events()` + `reduce()` so merge gate evaluation stays read-only
- add regression tests proving merge gate evaluation neither creates `status.json` nor dirties a tracked snapshot on rerun

## Root cause
The lane-based merge path evaluates merge gates before merging. The dependency gate called `materialize(feature_dir)`, which always rewrote `kitty-specs/<feature>/status.json` with a fresh `materialized_at` timestamp. That made merge evaluation itself mutate the working tree, so retries re-dirtied `status.json` every time.

## Testing
- `python3 -m pytest tests/policy/test_merge_gates.py`
- manual lane-based merge repro: verified `git status --porcelain` stays clean before and after `_run_lane_based_merge(...)`
