### PR TITLE
Add prerelease publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,17 @@ jobs:
       - name: Validate release metadata
         run: python scripts/release/validate_release.py --mode tag --tag "${GITHUB_REF_NAME}" --tag-pattern "v*.*.*"
 
+      - name: Classify release channel
+        id: release_channel
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc|alpha|beta)[0-9]*$ ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
       - name: Build distributions
         run: python -m build
 
@@ -174,7 +185,7 @@ jobs:
             dist/*.tar.gz
             SHA256SUMS.txt
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.release_channel.outputs.is_prerelease }}
 
       - name: Upload test output
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Prerelease publishing is now first-class** — tag-mode release validation accepts matching prerelease tags such as `v3.1.0a0`, GitHub Releases are marked as prereleases automatically for those tags, and maintainer docs now document the end-to-end prerelease PyPI/GitHub publish path.
+
 ## [3.1.0a0] - 2026-04-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,7 @@ If you encounter issues with an agent, please open an issue so we can refine the
 <summary><h2>🚀 Releasing Stable Versions on GitHub and PyPI (Maintainers)</h2></summary>
 
 The stable `3.x` line now lives on `main` and publishes from semantic tags in the form `vX.Y.Z`.
+Prerelease testing builds can also publish from `main` using tags such as `vX.Y.ZaN`.
 The release workflow publishes both GitHub release artifacts and the PyPI package.
 
 ### 0. One-Time Setup
@@ -1175,8 +1176,8 @@ git checkout main
 git pull origin main
 git checkout -b release/vX.Y.Z
 
-# Update pyproject.toml to a semantic version (example: X.Y.Z)
-# Add CHANGELOG.md entry under: ## [X.Y.Z] - YYYY-MM-DD
+# Update pyproject.toml to a release version (example: X.Y.Z or X.Y.ZaN)
+# Add CHANGELOG.md entry under: ## [X.Y.Z] - YYYY-MM-DD (or prerelease ## [X.Y.ZaN] - YYYY-MM-DD)
 ```
 
 ### 2. Validate Locally
@@ -1208,6 +1209,13 @@ git tag vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
+For prereleases, use the exact prerelease tag instead:
+
+```bash
+git tag vX.Y.ZaN -m "Release vX.Y.ZaN"
+git push origin vX.Y.ZaN
+```
+
 This triggers `.github/workflows/release.yml`.
 
 ### 5. Verify GitHub Release and PyPI Publication
@@ -1220,12 +1228,12 @@ python -m pip index versions spec-kitty-cli
 ### Guardrails
 
 - `release-readiness.yml`: runs on PRs to `main` (and `2.x` if the maintenance branch is still active) to validate version/changelog/tests.
-- `release.yml`: runs on `v*.*.*` tags and performs:
+- `release.yml`: runs on stable and prerelease `v*.*.*` tags and performs:
   - test execution
   - release metadata validation
   - artifact build and checksums
   - PyPI publication via Trusted Publishing
-  - GitHub Release creation with changelog notes
+  - GitHub Release creation with changelog notes, marked as prerelease when the tag is a prerelease
 
 ### Troubleshooting
 
@@ -1243,6 +1251,10 @@ git push origin :refs/tags/vX.Y.Z
 git tag vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
+
+**Installing a prerelease from PyPI**:
+- `python -m pip install --upgrade --pre spec-kitty-cli`
+- `python -m pip install --upgrade "spec-kitty-cli==X.Y.ZaN"`
 
 ### References
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,10 +1,10 @@
 # Release Checklist
 
-Use this checklist for stable releases from `main`.
+Use this checklist for releases from `main`.
 
-> `main` is the primary stable release line and publishes both GitHub releases and PyPI packages.
+> `main` is the primary release line and publishes both GitHub releases and PyPI packages.
 > `1.x-maintenance` is deprecated overall, reserved for critical maintenance only, and should not receive new PyPI releases.
-> Historical 2.x release notes remain in Git tags and changelog history; new stable releases ship from `main`.
+> Historical 2.x release notes remain in Git tags and changelog history; new stable and prerelease 3.x releases ship from `main`.
 
 ## Pre-Release Preparation
 
@@ -14,6 +14,7 @@ Use this checklist for stable releases from `main`.
   - Patch (`X.Y.Z`): bug fixes and small improvements
   - Minor (`X.Y.0`): new features, backward-compatible platform changes
   - Major (`X.0.0`): breaking changes
+- [ ] If cutting a prerelease, use a Python-compatible prerelease suffix (`X.Y.ZaN`, `X.Y.ZbN`, or `X.Y.ZrcN`) and plan to publish the final stable cut later as `X.Y.Z`.
 - [ ] Confirm the release is intended for `main`, not `1.x-maintenance`.
 - [ ] If the release also changes branch policy, docs, or distribution channels, include that in `CHANGELOG.md`.
 
@@ -55,6 +56,7 @@ Use this checklist for stable releases from `main`.
 
 - [ ] Bump `version` in `pyproject.toml`.
 - [ ] Add a populated `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`.
+- [ ] For prereleases, use the exact prerelease heading (`## [X.Y.ZaN] - YYYY-MM-DD`, etc.).
 - [ ] Review `README.md` release-track messaging:
   - `main` should be described as the stable `3.x` line.
   - `1.x-maintenance` should be described as deprecated maintenance-only.
@@ -122,6 +124,13 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
+For prereleases, use the exact prerelease tag instead:
+
+```bash
+git tag -a vX.Y.ZaN -m "Release vX.Y.ZaN"
+git push origin vX.Y.ZaN
+```
+
 ### 7. Monitor Automated Publishing
 
 - [ ] Watch `.github/workflows/release.yml`:
@@ -134,6 +143,7 @@ git push origin vX.Y.Z
   - builds distributions
   - publishes to PyPI
   - creates the GitHub release
+- [ ] If this is a prerelease, confirm GitHub marks the release as `Pre-release`.
 - [ ] Verify the GitHub release payload:
   ```bash
   gh release view vX.Y.Z
@@ -149,6 +159,10 @@ git push origin vX.Y.Z
   python -m pip index versions spec-kitty-cli
   ```
 - [ ] Verify the GitHub release is public and includes the wheel, sdist, and checksums.
+- [ ] If this is a prerelease, verify installation with:
+  ```bash
+  python -m pip install --upgrade --pre "spec-kitty-cli==X.Y.ZaN"
+  ```
 
 ### Installation and Upgrade
 
@@ -191,6 +205,8 @@ If a critical issue is discovered after release:
   check PyPI Trusted Publishing configuration for the workflow and repository, not a legacy token secret.
 - **Fresh install still shows the old version**:
   wait a few minutes for package indexes to refresh, then retry with `pip cache purge` if needed.
+- **Prerelease install does not resolve**:
+  use `pip install --pre spec-kitty-cli` or pin the exact prerelease version.
 
 ---
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,7 +1,7 @@
 # Release Scripts
 
 This directory contains helper scripts that keep local release checks aligned with the
-automated release pipeline for stable releases from `main`.
+automated release pipeline for stable and prerelease releases from `main`.
 
 ## Stable Release Scope
 
@@ -10,14 +10,17 @@ automated release pipeline for stable releases from `main`.
 - Tags: `vX.Y.Z`
 - Publication targets: GitHub Releases and PyPI
 
-## Testing Prereleases
+## Prerelease Publish Scope
 
-Branch-mode readiness checks also accept testing prerelease versions such as
-`3.1.0a0`, `3.1.0b1`, or `3.1.0rc1` in `pyproject.toml`. This is for
-pre-release validation on PRs and `main` before the final stable cut.
+- Branch: `main`
+- Versioning: prereleases use `X.Y.ZaN`, `X.Y.ZbN`, or `X.Y.ZrcN`
+- Tags: `vX.Y.ZaN`, `vX.Y.ZbN`, or `vX.Y.ZrcN`
+- Publication targets: GitHub Releases and PyPI
+- Installer behavior: users must pass `--pre` (or pin the exact prerelease) to `pip`
 
-Tagged releases remain stable-only. To publish, convert the prerelease to the
-final `X.Y.Z` version and tag that exact commit as `vX.Y.Z`.
+Branch-mode readiness checks accept both stable and prerelease versions.
+Tag-mode publish checks now accept matching prerelease tags as well, and GitHub
+marks those releases as prereleases automatically.
 
 ## Scripts
 
@@ -38,10 +41,10 @@ python scripts/release/validate_release.py --mode tag --tag v3.0.1 --tag-pattern
 
 #### What it validates
 
-- `pyproject.toml` version is valid stable or testing release version
+- `pyproject.toml` version is a valid stable or prerelease version
 - `CHANGELOG.md` contains populated section for that version
 - Version advances beyond latest existing release tag
-- In tag mode: version must be stable and tag matches version (for example `v3.0.1` <-> `3.0.1`)
+- In tag mode: tag matches version (for example `v3.0.1` <-> `3.0.1`, `v3.1.0a0` <-> `3.1.0a0`)
 
 ### `extract_changelog.py`
 
@@ -54,7 +57,7 @@ python scripts/release/extract_changelog.py 2.0.0
 ## Workflow Integration
 
 - PR checks: `.github/workflows/release-readiness.yml`
-- Tag releases: `.github/workflows/release.yml` (triggers on `v*.*.*`)
+- Tag releases: `.github/workflows/release.yml` (triggers on stable and prerelease `v*.*.*` tags)
 
 Release workflow sequence:
 
@@ -68,7 +71,7 @@ Release workflow sequence:
 
 ```bash
 # 1) prepare version + changelog
-vim pyproject.toml   # version = "3.1.0a0" for testing, "3.1.0" for release
+vim pyproject.toml   # version = "3.1.0a0" for prerelease, "3.1.0" for stable
 vim CHANGELOG.md     # add ## [3.1.0a0] - YYYY-MM-DD (or final ## [3.1.0])
 
 # 2) validate
@@ -80,8 +83,12 @@ twine check dist/*
 # 3) clean build artifacts
 rm -rf dist/ build/
 
-# 4) merge to main, then convert to final and tag
-#    Edit pyproject.toml to "3.1.0" and rename the changelog heading to [3.1.0]
+# 4a) prerelease publish from main
+git tag v3.1.0a0 -m "Release 3.1.0a0"
+git push origin v3.1.0a0
+
+# 4b) stable publish from main
+#     Edit pyproject.toml to "3.1.0" and rename the changelog heading to [3.1.0]
 git tag v3.1.0 -m "Release 3.1.0"
 git push origin v3.1.0
 ```
@@ -115,6 +122,14 @@ git tag -d v3.0.1
 git push origin :refs/tags/v3.0.1
 git tag v3.0.1 -m "Release 3.0.1"
 git push origin v3.0.1
+```
+
+### Installing a prerelease from PyPI
+
+```bash
+python -m pip install --upgrade --pre spec-kitty-cli
+# or pin an exact build
+python -m pip install --upgrade "spec-kitty-cli==3.1.0a0"
 ```
 
 ## Testing

--- a/scripts/release/validate_release.py
+++ b/scripts/release/validate_release.py
@@ -9,9 +9,10 @@ testing cut:
 3. Version progression is monotonic relative to existing git tags and, in tag
    mode, matches the release tag that triggered the workflow.
 
-Branch mode accepts stable versions (``X.Y.Z``) and testing prereleases such as
-``X.Y.ZaN``. Tag mode remains stable-only because GitHub Releases and PyPI
-publishing are reserved for final ``vX.Y.Z`` tags.
+Both validation modes accept stable versions (``X.Y.Z``) and prerelease
+versions such as ``X.Y.ZaN``. Tagged prereleases publish through the same
+release workflow, but GitHub marks them as prereleases and installers must opt
+into them explicitly.
 
 It is intentionally dependency-light so it can run both locally and in CI
 without additional bootstrapping beyond Python 3.11.
@@ -34,7 +35,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreter
     import tomli as tomllib  # type: ignore
 
 
-FINAL_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 RELEASE_VERSION_RE = re.compile(
     r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
     r"(?:(?P<stage>a|b|rc|alpha|beta)(?P<stage_num>\d*))?$",
@@ -99,12 +99,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=("branch", "tag"),
         default="branch",
         help="Validation mode. 'branch' expects a version bump without a tag. "
-        "'tag' enforces tag-version parity and monotonic progression.",
+        "'tag' enforces tag-version parity and monotonic progression for stable "
+        "or prerelease publish tags.",
     )
     parser.add_argument(
         "--tag",
-        help="Explicit tag (e.g., v1.2.3). Defaults to the detected GITHUB_REF or "
-        "GITHUB_REF_NAME in tag mode.",
+        help="Explicit tag (e.g., v1.2.3 or v1.3.0a0). Defaults to the detected "
+        "GITHUB_REF or GITHUB_REF_NAME in tag mode.",
     )
     parser.add_argument(
         "--pyproject",
@@ -198,8 +199,7 @@ def git(*args: str, cwd: Path | None = None) -> str:
         ["git", *args],
         cwd=cwd,
         check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     if result.returncode != 0:
@@ -220,7 +220,7 @@ def find_repo_root(start: Path) -> Path:
     return Path(output)
 
 
-def discover_semver_tags(
+def discover_release_tags(
     repo_root: Path, tag_pattern: str, exclude: str | None = None
 ) -> list[str]:
     output = git("tag", "--list", tag_pattern, cwd=repo_root)
@@ -228,19 +228,12 @@ def discover_semver_tags(
     filtered = [
         tag
         for tag in tags
-        if tag != exclude and FINAL_SEMVER_RE.match(tag.lstrip("v"))
+        if tag != exclude
+        and tag.startswith("v")
+        and RELEASE_VERSION_RE.match(tag.lstrip("v"))
     ]
-    filtered.sort(key=lambda tag: parse_semver(tag.lstrip("v")), reverse=True)
+    filtered.sort(key=lambda tag: parse_release_version(tag.lstrip("v")), reverse=True)
     return filtered
-
-
-def parse_semver(value: str) -> tuple[int, int, int]:
-    match = FINAL_SEMVER_RE.match(value)
-    if not match:
-        raise ReleaseValidatorError(
-            f"Value '{value}' is not a valid semantic version (expected X.Y.Z)."
-        )
-    return tuple(int(part) for part in match.groups())
 
 
 def parse_release_version(value: str) -> tuple[int, int, int, int, int]:
@@ -286,7 +279,7 @@ def validate_version_progression(
     if not existing_tags:
         return None
     current_tuple = parse_release_version(current_version)
-    latest_tuple = parse_semver(existing_tags[0].lstrip("v"))
+    latest_tuple = parse_release_version(existing_tags[0].lstrip("v"))
     if current_tuple <= latest_tuple:
         return ValidationIssue(
             message=f"Version {current_version} does not advance beyond latest tag {existing_tags[0]}.",
@@ -343,19 +336,12 @@ def run_validation(args: argparse.Namespace) -> ValidationResult:
         )
 
     if args.mode == "tag":
-        if is_prerelease_version(version):
-            issues.append(
-                ValidationIssue(
-                    message=f"Tag mode does not allow prerelease version {version}.",
-                    hint="Use a stable X.Y.Z version for tagged releases, or validate prereleases in branch mode.",
-                )
-            )
         tag = args.tag or detect_tag_from_env()
         if not tag:
             issues.append(
                 ValidationIssue(
                     message="No tag supplied and none detected from environment.",
-                    hint="Use --tag vX.Y.Z or set GITHUB_REF_NAME when running in CI.",
+                    hint="Use --tag vX.Y.Z or vX.Y.ZaN, or set GITHUB_REF_NAME when running in CI.",
                 )
             )
         else:
@@ -363,14 +349,14 @@ def run_validation(args: argparse.Namespace) -> ValidationResult:
             if mismatch:
                 issues.append(mismatch)
 
-        existing_tags = discover_semver_tags(
+        existing_tags = discover_release_tags(
             repo_root, tag_pattern=args.tag_pattern, exclude=tag
         )
         progression_issue = validate_version_progression(version, existing_tags)
         if progression_issue:
             issues.append(progression_issue)
     else:
-        existing_tags = discover_semver_tags(repo_root, tag_pattern=args.tag_pattern)
+        existing_tags = discover_release_tags(repo_root, tag_pattern=args.tag_pattern)
         progression_issue = validate_version_progression(version, existing_tags)
         if progression_issue:
             issues.append(progression_issue)

--- a/tests/release/test_validate_release.py
+++ b/tests/release/test_validate_release.py
@@ -229,7 +229,7 @@ def test_tag_mode_fails_on_regression(tmp_path: Path) -> None:
     assert "does not advance beyond latest tag v0.2.3" in result.stderr
 
 
-def test_tag_mode_rejects_prerelease_versions(tmp_path: Path) -> None:
+def test_tag_mode_accepts_prerelease_versions(tmp_path: Path) -> None:
     init_repo(tmp_path)
     write_release_files(
         tmp_path,
@@ -251,8 +251,8 @@ def test_tag_mode_rejects_prerelease_versions(tmp_path: Path) -> None:
 
     result = run_validator(tmp_path, "--mode", "tag", "--tag", "v0.3.0a0")
 
-    assert result.returncode == 1
-    assert "Tag mode does not allow prerelease version 0.3.0a0" in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert "Tag: v0.3.0a0" in result.stdout
 
 
 def test_branch_mode_honors_tag_pattern_scope(tmp_path: Path) -> None:
@@ -295,7 +295,7 @@ def test_branch_mode_honors_tag_pattern_scope(tmp_path: Path) -> None:
     assert "does not advance beyond latest tag v3.0.0" in result_unscoped.stderr
 
 
-def test_branch_mode_ignores_prerelease_tags_for_progression(tmp_path: Path) -> None:
+def test_tag_mode_rejects_prerelease_regression(tmp_path: Path) -> None:
     init_repo(tmp_path)
     write_release_files(
         tmp_path,
@@ -307,14 +307,63 @@ def test_branch_mode_ignores_prerelease_tags_for_progression(tmp_path: Path) -> 
 
     write_release_files(
         tmp_path,
+        "1.0.1a1",
+        changelog_for_versions(
+            ("1.0.1a1", "- Later prerelease"),
+            ("1.0.0", "- Initial stable release"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: prep 1.0.1a1")
+    tag(tmp_path, "v1.0.1a1")
+
+    write_release_files(
+        tmp_path,
+        "1.0.1a0",
+        changelog_for_versions(
+            ("1.0.1a0", "- Earlier prerelease"),
+            ("1.0.1a1", "- Later prerelease"),
+            ("1.0.0", "- Initial stable release"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: regress to 1.0.1a0")
+
+    result = run_validator(tmp_path, "--mode", "tag", "--tag", "v1.0.1a0")
+
+    assert result.returncode == 1
+    assert "does not advance beyond latest tag v1.0.1a1" in result.stderr
+
+
+def test_branch_mode_accepts_final_release_after_prerelease_tag(tmp_path: Path) -> None:
+    init_repo(tmp_path)
+    write_release_files(
+        tmp_path,
+        "1.0.0",
+        changelog_for_versions(("1.0.0", "- Initial stable release")),
+    )
+    stage_and_commit(tmp_path, "chore: bootstrap 1.0.0")
+    tag(tmp_path, "v1.0.0")
+
+    write_release_files(
+        tmp_path,
+        "1.0.1a1",
+        changelog_for_versions(
+            ("1.0.1a1", "- Release candidate"),
+            ("1.0.0", "- Initial stable release"),
+        ),
+    )
+    stage_and_commit(tmp_path, "chore: prep 1.0.1a1")
+    tag(tmp_path, "v1.0.1a1")
+
+    write_release_files(
+        tmp_path,
         "1.0.1",
         changelog_for_versions(
             ("1.0.1", "- Stable patch release"),
+            ("1.0.1a1", "- Release candidate"),
             ("1.0.0", "- Initial stable release"),
         ),
     )
     stage_and_commit(tmp_path, "chore: prep 1.0.1")
-    tag(tmp_path, "v1.0.0a1")
 
     result = run_validator(tmp_path, "--mode", "branch", "--tag-pattern", "v*.*.*")
 


### PR DESCRIPTION
## Summary
- allow release tag validation for matching prerelease tags like `v3.1.0a0`
- mark GitHub releases as prereleases automatically when the tag is a prerelease
- document and test the prerelease publish/install flow

## Testing
- source .venv312/bin/activate && pytest -q tests/release/test_validate_release.py
- source .venv312/bin/activate && pytest -q tests/cross_cutting/versioning
- source .venv312/bin/activate && python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- source .venv312/bin/activate && python scripts/release/validate_release.py --mode tag --tag v3.1.0a0 --tag-pattern 'v*.*.*'
- source .venv312/bin/activate && ruff check scripts/release/validate_release.py tests/release/test_validate_release.py
