### PR TITLE
chore(release): bump version to 3.1.0a3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.1.0a2"
+version = "3.1.0a3"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump `version` in `pyproject.toml` from `3.1.0a2` to `3.1.0a3`

Post-release version bump missed after tagging `v3.1.0a2`. Without this, `check-readiness` fails on every PR with:

> Version 3.1.0a2 does not advance beyond latest tag v3.1.0a2.

Closes #408

## Test plan
- [ ] `check-readiness` passes on this PR and subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)