### PR TITLE
fix(dashboard): validate bootstrap before reuse

### DIFF
--- a/src/specify_cli/dashboard/handlers/api.py
+++ b/src/specify_cli/dashboard/handlers/api.py
@@ -9,10 +9,9 @@ from pathlib import Path
 
 from ..charter_path import resolve_project_charter_path
 from ..diagnostics import run_diagnostics
-from ..scanner import format_path_for_display, resolve_active_feature, scan_all_features
+from ..scanner import format_path_for_display
 from ..templates import get_dashboard_html
 from .base import DashboardHandler
-from specify_cli.mission import MissionError, get_mission_by_name
 from specify_cli.sync.daemon import ensure_sync_daemon_running, get_sync_daemon_status
 
 __all__ = ["APIHandler"]
@@ -23,42 +22,10 @@ class APIHandler(DashboardHandler):
 
     def handle_root(self) -> None:
         """Return the rendered dashboard HTML shell."""
-        project_path = Path(self.project_dir).resolve()
-
-        # Derive active mission from the most active feature (per-feature mission model)
-        mission_context = {
-            'name': 'No active feature',
-            'domain': 'unknown',
-            'version': '',
-            'slug': '',
-            'description': '',
-            'path': '',
-        }
-
-        try:
-            features = scan_all_features(project_path)
-
-            active_feature = resolve_active_feature(project_path, features)
-
-            if active_feature:
-                feature_mission_key = active_feature.get('meta', {}).get('mission', 'software-dev')
-                kittify_dir = project_path / ".kittify"
-                mission = get_mission_by_name(feature_mission_key, kittify_dir)
-                mission_context = {
-                    'name': mission.name,
-                    'domain': mission.config.domain,
-                    'version': mission.config.version,
-                    'slug': mission.path.name,
-                    'description': mission.config.description or '',
-                    'path': format_path_for_display(str(mission.path)),
-                }
-        except (MissionError, Exception):
-            pass  # Keep default "No active feature" context
-
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
         self.end_headers()
-        self.wfile.write(get_dashboard_html(mission_context=mission_context).encode())
+        self.wfile.write(get_dashboard_html().encode())
 
     def handle_health(self) -> None:
         """Return project health metadata."""

--- a/src/specify_cli/dashboard/lifecycle.py
+++ b/src/specify_cli/dashboard/lifecycle.py
@@ -160,14 +160,14 @@ def _is_spec_kitty_dashboard(port: int, timeout: float = 0.3) -> bool:
         True if confirmed to be a spec-kitty dashboard, False otherwise
     """
     health_url = f"http://127.0.0.1:{port}/api/health"
-    data = _fetch_dashboard_health_payload(health_url, timeout=timeout)
+    data = _fetch_dashboard_json_payload(health_url, timeout=timeout)
     return bool(data and 'project_path' in data and 'status' in data)
 
 
-def _fetch_dashboard_health_payload(health_url: str, timeout: float = 0.5) -> dict | None:
-    """Fetch and decode dashboard health payload, returning None on failure."""
+def _fetch_dashboard_json_payload(url: str, timeout: float = 0.5) -> dict | None:
+    """Fetch and decode a JSON dashboard payload, returning None on failure."""
     try:
-        with urllib.request.urlopen(health_url, timeout=timeout) as response:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
             if response.status != 200:
                 return None
             payload = response.read()
@@ -182,6 +182,33 @@ def _fetch_dashboard_health_payload(health_url: str, timeout: float = 0.5) -> di
         return None
 
     return data if isinstance(data, dict) else None
+
+
+def _fetch_dashboard_features_payload(port: int, timeout: float = 0.5) -> dict | None:
+    """Fetch dashboard bootstrap data and ensure it matches the UI contract."""
+    url = f"http://127.0.0.1:{port}/api/features"
+    data = _fetch_dashboard_json_payload(url, timeout=timeout)
+    if data is None:
+        return None
+
+    features = data.get('features')
+    if not isinstance(features, list):
+        return None
+
+    return data
+
+
+def _check_dashboard_bootstrap(
+    port: int,
+    project_dir: Path,
+    expected_token: Optional[str],
+    timeout: float = 0.5,
+) -> bool:
+    """Verify that the dashboard can satisfy the browser bootstrap contract."""
+    if not _check_dashboard_health(port, project_dir, expected_token, timeout=timeout):
+        return False
+
+    return _fetch_dashboard_features_payload(port, timeout=timeout) is not None
 
 
 def _cleanup_orphaned_dashboards_in_range(start_port: int = 9237, port_count: int = 100) -> int:
@@ -252,7 +279,7 @@ def _check_dashboard_health(
 ) -> bool:
     """Verify that the dashboard on the port belongs to the provided project."""
     health_url = f"http://127.0.0.1:{port}/api/health"
-    data = _fetch_dashboard_health_payload(health_url, timeout=timeout)
+    data = _fetch_dashboard_json_payload(health_url, timeout=timeout)
     if data is None:
         return False
 
@@ -292,7 +319,7 @@ def get_dashboard_status(project_dir: Path, timeout: float = 0.5) -> DashboardSt
         return DashboardStatus(healthy=False, url=url, token=token, pid=pid)
 
     health_url = f"http://127.0.0.1:{port}/api/health"
-    data = _fetch_dashboard_health_payload(health_url, timeout=timeout)
+    data = _fetch_dashboard_json_payload(health_url, timeout=timeout)
     if data is None:
         return DashboardStatus(
             healthy=False,
@@ -371,8 +398,10 @@ def ensure_dashboard_running(
     if dashboard_file.exists():
         existing_url, existing_port, existing_token, existing_pid = _parse_dashboard_file(dashboard_file)
 
-        # First, try health check - if dashboard is healthy, reuse it
-        if existing_port is not None and _check_dashboard_health(existing_port, project_dir_resolved, existing_token):
+        # Only reuse a running daemon when the UI bootstrap endpoint is valid.
+        if existing_port is not None and _check_dashboard_bootstrap(
+            existing_port, project_dir_resolved, existing_token
+        ):
             url = existing_url or f"http://127.0.0.1:{existing_port}"
             return url, existing_port, False
 

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.css
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.css
@@ -48,21 +48,6 @@ body {
     gap: 16px;
 }
 
-.mission-display {
-    font-size: 0.9em;
-    color: var(--medium-text);
-}
-
-.mission-label {
-    color: #6b7280;
-    margin-right: 6px;
-}
-
-.mission-name {
-    font-weight: 600;
-    color: var(--dark-text);
-}
-
 .docs-site-link {
     display: inline-flex;
     align-items: center;

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -7,18 +7,6 @@ let projectPathDisplay = 'Loading…';
 let activeWorktreeDisplay = 'detecting…';
 let featureSelectActive = false;
 let featureSelectIdleTimer = null;
-let activeMission = {
-    name: 'Loading…',
-    domain: '',
-    version: '',
-    slug: '',
-    path: '',
-    description: ''
-};
-
-if (typeof window !== 'undefined' && window.__INITIAL_MISSION__) {
-    activeMission = window.__INITIAL_MISSION__;
-}
 
 /**
  * Intercept clicks on links within rendered markdown content.
@@ -100,17 +88,6 @@ function interceptMarkdownLinks(container, basePath = '') {
             link.title = `View ${fullPath} in dashboard`;
         }
     });
-}
-
-function updateMissionDisplay(mission) {
-    const nameEl = document.getElementById('mission-name');
-    if (!nameEl) return;
-
-    if (mission) {
-        activeMission = mission;
-    }
-
-    nameEl.textContent = activeMission.name || 'Unknown mission';
 }
 
 // Cookie-based state persistence
@@ -1289,10 +1266,6 @@ function fetchData(isInitialLoad = false) {
                 activeWorktreeDisplay = '';
             }
 
-            if (data.active_mission) {
-                updateMissionDisplay(data.active_mission);
-            }
-
             const currentFeatureObj = allFeatures.find(f => f.id === currentFeature);
             computeFeatureWorktreeStatus(currentFeatureObj || null);
             updateTreeInfo();
@@ -1493,7 +1466,6 @@ function refreshDiagnostics() {
     loadDiagnostics();
 }
 
-updateMissionDisplay();
 updateTreeInfo();
 fetchData(true);  // Pass true for initial load
 

--- a/src/specify_cli/dashboard/templates/index.html
+++ b/src/specify_cli/dashboard/templates/index.html
@@ -30,10 +30,6 @@
             <div id="single-feature-name" style="display: none; font-size: 1.2em; color: var(--grassy-green); font-weight: 600;"></div>
         </div>
         <div class="header-right">
-            <div class="mission-display" id="mission-display">
-                <span class="mission-label">Mission:</span>
-                <span class="mission-name" id="mission-name">Loading…</span>
-            </div>
             <a class="docs-site-link" href="https://docs.spec-kitty.ai/" target="_blank" rel="noopener noreferrer">
                 📚 Docs ↗
             </a>

--- a/tests/cross_cutting/dashboard/test_dashboard_cli_accuracy.py
+++ b/tests/cross_cutting/dashboard/test_dashboard_cli_accuracy.py
@@ -42,7 +42,11 @@ def is_dashboard_accessible(port: int, timeout: float = 2.0) -> bool:
     """
     try:
         with urlopen(f"http://127.0.0.1:{port}/api/features", timeout=timeout) as response:
-            return response.status == 200
+            if response.status != 200:
+                return False
+
+            payload = json.loads(response.read().decode())
+            return isinstance(payload, dict) and isinstance(payload.get("features"), list)
     except (URLError, OSError, Exception):
         return False
 

--- a/tests/test_dashboard/test_lifecycle.py
+++ b/tests/test_dashboard/test_lifecycle.py
@@ -5,6 +5,8 @@ import pytest
 
 from specify_cli.dashboard import lifecycle
 
+pytestmark = pytest.mark.fast
+
 
 def test_parse_and_write_dashboard_file_roundtrip(tmp_path):
     dashboard_file = tmp_path / ".kittify" / ".dashboard"
@@ -154,3 +156,49 @@ def test_get_dashboard_status_reads_sync_metadata(monkeypatch, tmp_path):
     assert status.last_sync == "2026-04-04T12:00:00+00:00"
     assert status.consecutive_failures == 2
     assert status.websocket_status == "Connected"
+
+
+def test_ensure_dashboard_running_restarts_stale_reused_daemon(monkeypatch, tmp_path):
+    project_dir = tmp_path
+    dashboard_meta = project_dir / ".kittify" / ".dashboard"
+    dashboard_meta.parent.mkdir(parents=True)
+    lifecycle._write_dashboard_file(
+        dashboard_meta,
+        "http://127.0.0.1:9238",
+        9238,
+        "staletoken",
+        pid=4242,
+    )
+
+    killed = {"count": 0}
+
+    class FakeProc:
+        def kill(self):
+            killed["count"] += 1
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_check_dashboard_bootstrap",
+        lambda port, proj_dir, token: False,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_check_dashboard_health",
+        lambda port, proj_dir, token: token == "fresh-token",
+    )
+    monkeypatch.setattr(lifecycle, "_is_process_alive", lambda pid: pid == 4242)
+    monkeypatch.setattr(lifecycle.psutil, "Process", lambda pid: FakeProc())
+    monkeypatch.setattr(lifecycle, "start_dashboard", lambda *args, **kwargs: (9345, 5151))
+    monkeypatch.setattr(lifecycle.secrets, "token_hex", lambda _size: "fresh-token")
+
+    url, port, started = lifecycle.ensure_dashboard_running(project_dir, background_process=False)
+
+    assert started is True
+    assert port == 9345
+    assert url == "http://127.0.0.1:9345"
+    assert killed["count"] == 1
+
+    _, stored_port, stored_token, stored_pid = lifecycle._parse_dashboard_file(dashboard_meta)
+    assert stored_port == 9345
+    assert stored_token == "fresh-token"
+    assert stored_pid == 5151

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -6,12 +6,20 @@ import pytest
 
 from specify_cli.dashboard.templates import get_dashboard_html
 
+pytestmark = pytest.mark.fast
+
 
 def test_dashboard_template_references_static_assets():
     html = get_dashboard_html()
     assert '<link rel="stylesheet" href="/static/dashboard/dashboard.css">' in html
     assert '<script src="/static/dashboard/dashboard.js"></script>' in html
     assert '<link rel="icon" type="image/png" href="/static/spec-kitty.png">' in html
+
+
+def test_dashboard_template_omits_mission_badge():
+    html = get_dashboard_html()
+    assert 'mission-display' not in html
+    assert 'Mission:' not in html
 
 
 def test_static_assets_exist():
@@ -27,7 +35,6 @@ def test_static_assets_exist():
         assert asset.stat().st_size > 0, f"{asset} should not be empty"
 
 
-@pytest.mark.fast
 def test_dashboard_javascript_has_valid_syntax():
     if shutil.which("node") is None:
         pytest.skip("node is required for dashboard.js syntax validation")


### PR DESCRIPTION
## Summary
- remove the stale mission badge/bootstrap wiring from the dashboard shell
- only reuse an existing dashboard daemon when `/api/features` returns a valid bootstrap payload
- add regression coverage for stale daemon restart and the dashboard bootstrap contract

## Verification
- `uv run --extra test pytest tests/test_dashboard/test_lifecycle.py tests/test_dashboard/test_static.py tests/cross_cutting/dashboard/test_dashboard_cli_accuracy.py`