### PR TITLE
fix: use resolved branch in tasks README examples

### DIFF
--- a/src/specify_cli/core/feature_creation.py
+++ b/src/specify_cli/core/feature_creation.py
@@ -46,7 +46,7 @@ class FeatureCreationResult:
 
 KEBAB_CASE_PATTERN = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 
-TASKS_README_CONTENT = """\
+TASKS_README_TEMPLATE = """\
 # Tasks Directory
 
 This directory contains work package (WP) prompt files.
@@ -72,9 +72,9 @@ Each WP file **MUST** use YAML frontmatter:
 work_package_id: "WP01"
 title: "Work Package Title"
 dependencies: []
-planning_base_branch: "2.x"
-merge_target_branch: "2.x"
-branch_strategy: "Planning artifacts were generated on 2.x; completed changes must merge back into 2.x."
+planning_base_branch: "{planning_branch}"
+merge_target_branch: "{planning_branch}"
+branch_strategy: "Planning artifacts were generated on {planning_branch}; completed changes must merge back into {planning_branch}."
 subtasks:
   - "T001"
   - "T002"
@@ -112,6 +112,11 @@ spec-kitty agent tasks move-task WP01 --to doing
 - Format: `WP01-kebab-case-slug.md`
 - Examples: `WP01-setup-infrastructure.md`, `WP02-user-auth.md`
 """
+
+
+def render_tasks_readme_content(planning_branch: str) -> str:
+    """Render tasks/README.md with branch-aware example frontmatter."""
+    return TASKS_README_TEMPLATE.format(planning_branch=planning_branch)
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +266,10 @@ def create_feature_core(
 
     # Tasks README
     tasks_readme = tasks_dir / "README.md"
-    tasks_readme.write_text(TASKS_README_CONTENT, encoding="utf-8")
+    tasks_readme.write_text(
+        render_tasks_readme_content(planning_branch),
+        encoding="utf-8",
+    )
 
     # ------------------------------------------------------------------
     # 5. Spec template

--- a/tests/specify_cli/core/test_feature_creation.py
+++ b/tests/specify_cli/core/test_feature_creation.py
@@ -224,6 +224,12 @@ def test_explicit_target_branch(tmp_path: Path) -> None:
     )
     assert meta["target_branch"] == "2.x"
 
+    tasks_readme = (result.feature_dir / "tasks" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert 'planning_base_branch: "2.x"' in tasks_readme
+    assert 'merge_target_branch: "2.x"' in tasks_readme
+
 
 def test_target_branch_defaults_to_current(tmp_path: Path) -> None:
     """When no target_branch provided, uses the current branch."""
@@ -245,6 +251,12 @@ def test_target_branch_defaults_to_current(tmp_path: Path) -> None:
         (result.feature_dir / "meta.json").read_text(encoding="utf-8")
     )
     assert meta["target_branch"] == "develop"
+
+    tasks_readme = (result.feature_dir / "tasks" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert 'planning_base_branch: "develop"' in tasks_readme
+    assert 'merge_target_branch: "develop"' in tasks_readme
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #418

The tasks README template had hardcoded `2.x` values in the YAML example, which made new features show the wrong branch strategy on projects using `main` or another branch. This now renders the example using the resolved planning branch from feature creation.

I also added assertions in feature creation tests to make sure the generated README branch fields follow `target_branch`.

Greetings, saschabuehrle