### PR TITLE
docs(arch): align lane transition docs with 9-lane model (mission 065)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 | Capability | What Spec Kitty provides |
 |------------|--------------------------|
 | **Spec-driven artifacts** | Generates and maintains `spec.md`, `plan.md`, `wps.yaml`, and `tasks.md` in `kitty-specs/<mission>/` |
-| **Work package execution** | Uses canonical lifecycle lanes (`planned`, `claimed`, `in_progress`, `for_review`, `approved`, `done`, `blocked`, `canceled`) with `doing` as UI alias for `in_progress` |
+| **Work package execution** | Uses canonical lifecycle lanes (`planned`, `claimed`, `in_progress`, `for_review`, `in_review`, `approved`, `done`, `blocked`, `canceled`) with `doing` as UI alias for `in_progress` |
 | **Parallel implementation model** | Creates isolated git worktrees under `.worktrees/`; every mission executes through lane-based worktrees, with exactly one worktree per computed execution lane |
 | **Live project visibility** | Local dashboard for kanban and mission progress (`spec-kitty dashboard`) |
 | **Review resilience** | Persisted versioned review artifacts, focused fix prompts, dirty-state classification, and arbiter checklists |

--- a/architecture/2.x/adr/2026-02-09-2-wp-lifecycle-state-machine.md
+++ b/architecture/2.x/adr/2026-02-09-2-wp-lifecycle-state-machine.md
@@ -10,10 +10,14 @@
 
 ---
 
-> Superseded by `2026-04-03-2-review-approval-and-integration-completion-are-distinct.md`.
-> This ADR encoded `for_review -> done` as reviewer approval. The current
-> lifecycle model separates reviewer approval (`approved`) from integrated
-> completion (`done`).
+> Superseded by `2026-04-03-2-review-approval-and-integration-completion-are-distinct.md`,
+> which is itself partially superseded by `2026-04-06-1-wp-state-pattern-for-lane-behavior.md`.
+> `2026-04-06-1` is the current authority for the full 9-lane state machine.
+>
+> This ADR encoded a 7-lane model with `for_review -> done` as reviewer approval.
+> The current lifecycle separates reviewer approval (`approved`) from integrated
+> completion (`done`), promotes `in_review` to a first-class 9th lane, and
+> encapsulates all lane behavior in the `WPState` ABC.
 
 ## Context and Problem Statement
 

--- a/architecture/2.x/adr/2026-04-03-2-review-approval-and-integration-completion-are-distinct.md
+++ b/architecture/2.x/adr/2026-04-03-2-review-approval-and-integration-completion-are-distinct.md
@@ -3,10 +3,12 @@
 | Field | Value |
 |---|---|
 | Filename | `2026-04-03-2-review-approval-and-integration-completion-are-distinct.md` |
-| Status | Accepted |
+| Status | Partially superseded |
 | Date | 2026-04-03 |
 | Deciders | Spec Kitty Architecture Team |
 | Technical Story | Reliability remediation after Feature 028 — align lifecycle semantics with integrated shipping reality |
+
+> **Partial supersession (2026-04-06):** The core decision of this ADR — adding an explicit `approved` lane and separating reviewer approval from integration-complete — remains in force. However, the `in_review` lane promotion section is superseded by `2026-04-06-1-wp-state-pattern-for-lane-behavior.md`, which promotes `in_review` from an alias for `for_review` to a first-class 9th lane with its own concrete `WPState` class and conflict-detection guard. The transition model in the *Decision Outcome* section below reflects the pre-`in_review`-promotion design; see `2026-04-06-1` for the current canonical transition set.
 
 ---
 
@@ -178,6 +180,9 @@ Use a distinct lane for reviewer approval before final integrated completion.
 **Supersedes:**
 - `2026-02-09-2-wp-lifecycle-state-machine.md`
 - `2026-02-09-4-cross-repo-evidence-completion.md`
+
+**Partially superseded by:**
+- `2026-04-06-1-wp-state-pattern-for-lane-behavior.md` — supersedes the `in_review`-as-alias approach; `in_review` is now a first-class lane
 
 **Interprets alongside:**
 - `2026-02-09-3-event-log-merge-semantics.md` — rollback-aware merge semantics


### PR DESCRIPTION
Three stale references identified during post-065 review:

- README.md capability table: add `in_review` to the canonical lane list (was listing 8 lanes, omitting the first-class 9th lane introduced in 065)

- ADR 2026-04-03-2: mark as Partially superseded; core approved/done separation decision remains, but the in_review-as-alias approach is superseded by 2026-04-06-1 which promotes in_review to a first-class lane

- ADR 2026-02-09-2: update supersession chain to reference 2026-04-06-1 as the current authority; was pointing only to 2026-04-03-2 which is itself now partially superseded