### PR TITLE
fix: preserve canonical review feedback handoff

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -40,6 +40,8 @@ from specify_cli.tasks_support import (
 )
 from specify_cli.workspace_context import resolve_workspace_for_wp
 
+_REVIEW_FEEDBACK_SENTINELS = frozenset({"force-override", "action-review-claim"})
+
 
 def _write_prompt_to_file(
     command_type: str,
@@ -96,11 +98,12 @@ def _resolve_review_feedback_pointer(repo_root: Path, pointer: str) -> Path | No
       → ``.git/spec-kitty/feedback/<mission_slug>/<task_id>/<filename>``
 
     Also handles legacy absolute-path strings.
-    Returns None for the sentinel string ``"force-override"`` or any
+    Returns None for sentinel values such as ``"force-override"`` and
+    ``"action-review-claim"``, or any
     unrecognised / non-existent pointer.
     """
     value = pointer.strip()
-    if not value or value == "force-override":
+    if not value or value in _REVIEW_FEEDBACK_SENTINELS:
         return None
 
     if value.startswith("review-cycle://"):
@@ -127,6 +130,60 @@ def _resolve_review_feedback_pointer(repo_root: Path, pointer: str) -> Path | No
     if candidate.exists() and candidate.is_file():
         return candidate
     return None
+
+
+def _read_wp_events(feature_dir: Path, wp_id: str):
+    """Return canonical status events for a single work package."""
+    try:
+        from specify_cli.status.store import read_events as _read_status_events
+
+        return [event for event in _read_status_events(feature_dir) if event.wp_id == wp_id]
+    except Exception:
+        return []
+
+
+def _latest_review_feedback_reference(
+    feature_dir: Path,
+    repo_root: Path,
+    wp_id: str,
+) -> tuple[str | None, Path | None, int | None]:
+    """Return the newest canonical review feedback reference for *wp_id*.
+
+    Operational sentinels like ``action-review-claim`` are intentionally
+    skipped so implement/fix handoff uses the persisted review artifact
+    instead of the transient reviewer claim marker.
+    """
+    wp_events = _read_wp_events(feature_dir, wp_id)
+    for index in range(len(wp_events) - 1, -1, -1):
+        event = wp_events[index]
+        if event.review_ref is None:
+            continue
+        review_ref = event.review_ref.strip()
+        if not review_ref or review_ref in _REVIEW_FEEDBACK_SENTINELS:
+            continue
+        return review_ref, _resolve_review_feedback_pointer(repo_root, review_ref), index
+    return None, None, None
+
+
+def _resolve_review_feedback_context(
+    feature_dir: Path,
+    repo_root: Path,
+    wp_id: str,
+    wp_frontmatter: str,
+) -> tuple[bool, str | None, Path | None]:
+    """Resolve review-feedback presence and the canonical readable artifact."""
+    review_feedback_ref, review_feedback_file, _ = _latest_review_feedback_reference(feature_dir, repo_root, wp_id)
+    if review_feedback_ref is not None:
+        return True, review_feedback_ref, review_feedback_file
+
+    fm_review_status = extract_scalar(wp_frontmatter, "review_status")
+    fm_review_feedback = extract_scalar(wp_frontmatter, "review_feedback")
+    if fm_review_status and str(fm_review_status) == "has_feedback":
+        ref = str(fm_review_feedback).strip() if fm_review_feedback else None
+        path = _resolve_review_feedback_pointer(repo_root, ref) if ref else None
+        return True, ref, path
+
+    return False, None, None
 
 
 def _render_charter_context(repo_root: Path, action: str) -> str:
@@ -185,12 +242,11 @@ def _has_prior_rejection(
 ) -> bool:
     """Check if a WP has review-cycle artifacts from a prior rejection.
 
-    Both conditions must be true:
+    A prior rejection is active when:
     1. Review-cycle artifact files exist in the sub-artifact directory.
-    2. The latest event for this WP is a rejection (from_lane=for_review).
-
-    This prevents false positives when artifacts exist from a cycle that was
-    already resolved (last event is not a rejection).
+    2. The newest canonical review feedback reference for this WP resolves to a
+       readable artifact.
+    3. The WP has not since resolved to an approved/done terminal state.
 
     Args:
         feature_dir: Path to kitty-specs/<mission>/ in the main repo.
@@ -206,19 +262,24 @@ def _has_prior_rejection(
     if not list(sub_artifact_dir.glob("review-cycle-*.md")):
         return False
 
-    # Check that the latest event for this WP is a rejection transition
-    try:
-        from specify_cli.status.store import read_events as _read_status_events
+    wp_events = _read_wp_events(feature_dir, normalized_wp_id)
+    if not wp_events:
+        return False
 
-        _events = _read_status_events(feature_dir)
-        for _ev in reversed(_events):
-            if _ev.wp_id == normalized_wp_id:
-                # Latest event for this WP found — check if it came from for_review
-                return _ev.from_lane == Lane.FOR_REVIEW
-    except Exception:
-        pass
+    repo_root = feature_dir.parent.parent
+    review_feedback_ref, review_feedback_file, review_feedback_index = _latest_review_feedback_reference(
+        feature_dir,
+        repo_root,
+        normalized_wp_id,
+    )
+    if review_feedback_ref is None or review_feedback_file is None or review_feedback_index is None:
+        return False
 
-    return False
+    if any(event.to_lane in {Lane.APPROVED, Lane.DONE} for event in wp_events[review_feedback_index + 1 :]):
+        return False
+
+    latest_event = wp_events[-1]
+    return latest_event.to_lane not in {Lane.APPROVED, Lane.DONE}
 
 
 def _ensure_target_branch_checked_out(repo_root: Path, mission_slug: str) -> tuple[Path, str]:
@@ -484,6 +545,25 @@ def implement(
             raise RuntimeError(_missing_canonical_status_message(normalized_wp_id, mission_slug))
         current_lane = _wf_get_wp_lane(_wf_feature_dir, normalized_wp_id)
         needs_agent_assignment = _wp_agent_assignment.tool == "unknown"
+        feature_dir = main_repo_root / "kitty-specs" / mission_slug
+        wp_slug = wp.path.stem
+        has_feedback, review_feedback_ref, review_feedback_file = _resolve_review_feedback_context(
+            feature_dir=feature_dir,
+            repo_root=main_repo_root,
+            wp_id=normalized_wp_id,
+            wp_frontmatter=wp.frontmatter,
+        )
+        fix_mode_active = _has_prior_rejection(feature_dir, wp_slug, normalized_wp_id)
+
+        if has_feedback and review_feedback_ref is None:
+            print(f"Error: {normalized_wp_id} has review feedback but no readable review reference.")
+            print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
+            raise typer.Exit(1)
+
+        if has_feedback and review_feedback_file is None:
+            print(f"Error: {normalized_wp_id} review feedback artifact is missing or unreadable: {review_feedback_ref}")
+            print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
+            raise typer.Exit(1)
 
         if current_lane != Lane.IN_PROGRESS or needs_agent_assignment:
             # Require --agent parameter to track who is working
@@ -614,49 +694,20 @@ def implement(
         else:
             print(f"⚠️  {normalized_wp_id} is already in lane: {current_lane}. Action implement will not move it to in_progress.")
 
-        # Check review feedback from canonical event log (review_ref stored in events)
-        # Also check frontmatter review_feedback/review_status as fallback
-        feature_dir = repo_root / "kitty-specs" / mission_slug
-        has_feedback = False
-        review_feedback_ref = None
-        review_feedback_file = None
-        try:
-            from specify_cli.status.store import read_events as _read_status_events
-
-            _events = _read_status_events(feature_dir)
-            # Find the most recent rejection event for this WP (for_review -> planned/in_progress with review_ref)
-            for _ev in reversed(_events):
-                if _ev.wp_id == normalized_wp_id and _ev.from_lane == Lane.FOR_REVIEW and _ev.review_ref is not None:
-                    has_feedback = True
-                    review_feedback_ref = _ev.review_ref
-                    break
-        except Exception:
-            pass
-
-        # Fallback: check frontmatter review metadata (handles transition period)
-        if not has_feedback:
-            fm_review_status = extract_scalar(wp.frontmatter, "review_status")
-            fm_review_feedback = extract_scalar(wp.frontmatter, "review_feedback")
-            if fm_review_status and str(fm_review_status) == "has_feedback":
-                has_feedback = True
-                if fm_review_feedback and str(fm_review_feedback).startswith("feedback://"):
-                    review_feedback_ref = str(fm_review_feedback)
-
-        if review_feedback_ref:
-            review_feedback_file = _resolve_review_feedback_pointer(main_repo_root, review_feedback_ref)
-
         # Fix-mode detection: if the WP was rejected and has review-cycle artifacts,
         # generate a focused fix-mode prompt instead of the full WP prompt.
         # The fix-prompt completely replaces the full WP prompt (not appended to it).
-        _wp_slug = wp.path.stem  # e.g. "WP01-some-title"
-        if _has_prior_rejection(feature_dir, _wp_slug, normalized_wp_id):
+        if fix_mode_active:
             try:
                 from rich.console import Console as _RichConsole
                 from specify_cli.review.artifacts import ReviewCycleArtifact as _ReviewCycleArtifact
                 from specify_cli.review.fix_prompt import generate_fix_prompt as _generate_fix_prompt
 
-                _sub_artifact_dir = feature_dir / "tasks" / _wp_slug
-                _latest_artifact = _ReviewCycleArtifact.latest(_sub_artifact_dir)
+                _sub_artifact_dir = feature_dir / "tasks" / wp_slug
+                if review_feedback_ref and review_feedback_ref.startswith("review-cycle://") and review_feedback_file is not None:
+                    _latest_artifact = _ReviewCycleArtifact.from_file(review_feedback_file)
+                else:
+                    _latest_artifact = _ReviewCycleArtifact.latest(_sub_artifact_dir)
                 if _latest_artifact is not None:
                     _console = _RichConsole()
                     _console.print(

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -170,20 +170,20 @@ def _resolve_review_feedback_context(
     repo_root: Path,
     wp_id: str,
     wp_frontmatter: str,
-) -> tuple[bool, str | None, Path | None]:
+) -> tuple[bool, str | None, Path | None, str | None]:
     """Resolve review-feedback presence and the canonical readable artifact."""
     review_feedback_ref, review_feedback_file, _ = _latest_review_feedback_reference(feature_dir, repo_root, wp_id)
     if review_feedback_ref is not None:
-        return True, review_feedback_ref, review_feedback_file
+        return True, review_feedback_ref, review_feedback_file, "canonical"
 
     fm_review_status = extract_scalar(wp_frontmatter, "review_status")
     fm_review_feedback = extract_scalar(wp_frontmatter, "review_feedback")
     if fm_review_status and str(fm_review_status) == "has_feedback":
         ref = str(fm_review_feedback).strip() if fm_review_feedback else None
         path = _resolve_review_feedback_pointer(repo_root, ref) if ref else None
-        return True, ref, path
+        return True, ref, path, "frontmatter"
 
-    return False, None, None
+    return False, None, None, None
 
 
 def _render_charter_context(repo_root: Path, action: str) -> str:
@@ -547,7 +547,7 @@ def implement(
         needs_agent_assignment = _wp_agent_assignment.tool == "unknown"
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
         wp_slug = wp.path.stem
-        has_feedback, review_feedback_ref, review_feedback_file = _resolve_review_feedback_context(
+        has_feedback, review_feedback_ref, review_feedback_file, review_feedback_source = _resolve_review_feedback_context(
             feature_dir=feature_dir,
             repo_root=main_repo_root,
             wp_id=normalized_wp_id,
@@ -555,12 +555,7 @@ def implement(
         )
         fix_mode_active = _has_prior_rejection(feature_dir, wp_slug, normalized_wp_id)
 
-        if has_feedback and review_feedback_ref is None:
-            print(f"Error: {normalized_wp_id} has review feedback but no readable review reference.")
-            print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
-            raise typer.Exit(1)
-
-        if has_feedback and review_feedback_file is None:
+        if review_feedback_source == "canonical" and review_feedback_file is None:
             print(f"Error: {normalized_wp_id} review feedback artifact is missing or unreadable: {review_feedback_ref}")
             print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
             raise typer.Exit(1)

--- a/tests/agent/test_workflow_feedback_pointer_2x_unit.py
+++ b/tests/agent/test_workflow_feedback_pointer_2x_unit.py
@@ -211,9 +211,11 @@ def test_implement_prompt_warns_when_feedback_pointer_artifact_is_missing(workfl
     runner = CliRunner()
     result = runner.invoke(workflow.app, ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"])
 
-    assert result.exit_code == 1, result.stdout
-    assert "review feedback artifact is missing or unreadable" in result.stdout
-    assert "Re-run move-task with --review-feedback-file" in result.stdout
+    assert result.exit_code == 0, result.stdout
+    prompt_file = Path(tempfile.gettempdir()) / "spec-kitty-implement-WP01.md"
+    prompt_content = prompt_file.read_text(encoding="utf-8")
+    assert "WARNING: review feedback reference is set, but the artifact is missing/unreadable." in prompt_content
+    assert "Ask reviewer to re-run move-task with --review-feedback-file." in prompt_content
 
 
 def test_implement_prompt_warns_when_review_status_has_feedback_without_reference(
@@ -230,9 +232,13 @@ def test_implement_prompt_warns_when_review_status_has_feedback_without_referenc
     runner = CliRunner()
     result = runner.invoke(workflow.app, ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"])
 
-    assert result.exit_code == 1, result.stdout
-    assert "has review feedback but no readable review reference" in result.stdout
-    assert "Re-run move-task with --review-feedback-file" in result.stdout
+    assert result.exit_code == 0, result.stdout
+    assert "Has review feedback - but no review_feedback reference is set" in result.stdout
+
+    prompt_file = Path(tempfile.gettempdir()) / "spec-kitty-implement-WP01.md"
+    prompt_content = prompt_file.read_text(encoding="utf-8")
+    assert "WARNING: review_status=has_feedback but no review_feedback reference is set." in prompt_content
+    assert "Ask reviewer to re-run move-task with --review-feedback-file." in prompt_content
 
 
 def test_implement_fix_cycle_prefers_review_cycle_artifact_over_review_claim_token(

--- a/tests/agent/test_workflow_feedback_pointer_2x_unit.py
+++ b/tests/agent/test_workflow_feedback_pointer_2x_unit.py
@@ -13,6 +13,9 @@ from typer.testing import CliRunner
 from tests.branch_contract import IS_2X_BRANCH
 from specify_cli.cli.commands.agent import workflow
 from specify_cli.frontmatter import write_frontmatter
+from specify_cli.review.artifacts import AffectedFile, ReviewCycleArtifact
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.store import append_event
 
 pytestmark = [
     pytest.mark.skipif(not IS_2X_BRANCH, reason="2.x-only review feedback pointer contract"),
@@ -71,6 +74,31 @@ def _write_wp(
     }
     wp_body = f"# WP01 Prompt\n\n## Activity Log\n- 2026-01-01T00:00:00Z – system – lane={lane} – Prompt created.\n"
     write_frontmatter(wp_path, wp_frontmatter, wp_body)
+
+
+def _append_event(
+    feature_dir: Path,
+    *,
+    event_id: str,
+    from_lane: Lane,
+    to_lane: Lane,
+    review_ref: str | None = None,
+) -> None:
+    append_event(
+        feature_dir,
+        StatusEvent(
+            event_id=event_id,
+            mission_slug="001-test-feature",
+            wp_id="WP01",
+            from_lane=from_lane,
+            to_lane=to_lane,
+            at="2026-01-01T00:00:00Z",
+            actor="tester",
+            force=False,
+            execution_mode="worktree",
+            review_ref=review_ref,
+        ),
+    )
 
 
 @pytest.fixture()
@@ -183,11 +211,9 @@ def test_implement_prompt_warns_when_feedback_pointer_artifact_is_missing(workfl
     runner = CliRunner()
     result = runner.invoke(workflow.app, ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"])
 
-    assert result.exit_code == 0, result.stdout
-    prompt_file = Path(tempfile.gettempdir()) / "spec-kitty-implement-WP01.md"
-    prompt_content = prompt_file.read_text(encoding="utf-8")
-    assert "WARNING: review feedback reference is set, but the artifact is missing/unreadable." in prompt_content
-    assert "Ask reviewer to re-run move-task with --review-feedback-file." in prompt_content
+    assert result.exit_code == 1, result.stdout
+    assert "review feedback artifact is missing or unreadable" in result.stdout
+    assert "Re-run move-task with --review-feedback-file" in result.stdout
 
 
 def test_implement_prompt_warns_when_review_status_has_feedback_without_reference(
@@ -204,13 +230,63 @@ def test_implement_prompt_warns_when_review_status_has_feedback_without_referenc
     runner = CliRunner()
     result = runner.invoke(workflow.app, ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"])
 
-    assert result.exit_code == 0, result.stdout
-    assert "Has review feedback - but no review_feedback reference is set" in result.stdout
+    assert result.exit_code == 1, result.stdout
+    assert "has review feedback but no readable review reference" in result.stdout
+    assert "Re-run move-task with --review-feedback-file" in result.stdout
 
+
+def test_implement_fix_cycle_prefers_review_cycle_artifact_over_review_claim_token(
+    workflow_repo: tuple[Path, str, Path],
+):
+    repo, _feedback_pointer, _feedback_file = workflow_repo
+    feature_dir = repo / "kitty-specs" / "001-test-feature"
+    review_cycle_dir = feature_dir / "tasks" / "WP01-test-task"
+    review_cycle_path = review_cycle_dir / "review-cycle-2.md"
+    review_cycle_ref = "review-cycle://001-test-feature/WP01-test-task/review-cycle-2.md"
+    ReviewCycleArtifact(
+        cycle_number=2,
+        wp_id="WP01",
+        mission_slug="001-test-feature",
+        reviewer_agent="codex",
+        verdict="rejected",
+        reviewed_at="2026-04-10T06:36:14Z",
+        affected_files=[AffectedFile(path="apps/cli_auth/views_authorization.py", line_range="51-88")],
+        reproduction_command="pytest tests/agent -q",
+        body="**Issue 1**: Persist the validated GET request server-side.\n",
+    ).write(review_cycle_path)
+
+    _append_event(feature_dir, event_id="01AAA000000000000000000001", from_lane=Lane.PLANNED, to_lane=Lane.CLAIMED)
+    _append_event(feature_dir, event_id="01AAA000000000000000000002", from_lane=Lane.CLAIMED, to_lane=Lane.IN_PROGRESS)
+    _append_event(feature_dir, event_id="01AAA000000000000000000003", from_lane=Lane.IN_PROGRESS, to_lane=Lane.FOR_REVIEW)
+    _append_event(
+        feature_dir,
+        event_id="01AAA000000000000000000004",
+        from_lane=Lane.FOR_REVIEW,
+        to_lane=Lane.IN_PROGRESS,
+        review_ref="action-review-claim",
+    )
+    _append_event(
+        feature_dir,
+        event_id="01AAA000000000000000000005",
+        from_lane=Lane.IN_PROGRESS,
+        to_lane=Lane.PLANNED,
+        review_ref=review_cycle_ref,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        workflow.app,
+        ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Fix mode" in result.stdout
+    assert "Cycle 2" in result.stdout
     prompt_file = Path(tempfile.gettempdir()) / "spec-kitty-implement-WP01.md"
     prompt_content = prompt_file.read_text(encoding="utf-8")
-    assert "WARNING: review_status=has_feedback but no review_feedback reference is set." in prompt_content
-    assert "Ask reviewer to re-run move-task with --review-feedback-file." in prompt_content
+    assert "## Review Findings" in prompt_content
+    assert "Persist the validated GET request server-side." in prompt_content
+    assert "action-review-claim" not in prompt_content
 
 
 def test_review_prompt_mentions_shared_git_common_dir_feedback_storage(workflow_repo: tuple[Path, str, Path]):

--- a/tests/integration/test_rejection_cycle.py
+++ b/tests/integration/test_rejection_cycle.py
@@ -511,3 +511,31 @@ class TestImplementReviewFeedbackHandoff:
         assert "## Review Findings" in prompt_content
         assert "Use the canonical review artifact instead of the claim token." in prompt_content
         assert "action-review-claim" not in prompt_content
+
+    def test_implement_fails_when_canonical_review_artifact_is_unreadable(
+        self,
+        workflow_cli_repo: tuple[Path, Path],
+    ) -> None:
+        _repo, feature_dir = workflow_cli_repo
+        review_cycle_ref = "review-cycle://001-test-feature/WP01-test-task/review-cycle-9.md"
+
+        append_event(feature_dir, _make_event(event_id="01BBB000000000000000000001"))
+        append_event(
+            feature_dir,
+            _make_event(
+                event_id="01BBB000000000000000000002",
+                from_lane=Lane.IN_PROGRESS,
+                to_lane=Lane.PLANNED,
+                review_ref=review_cycle_ref,
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow.app,
+            ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        assert "review feedback artifact is missing or unreadable" in result.stdout
+        assert review_cycle_ref in result.stdout

--- a/tests/integration/test_rejection_cycle.py
+++ b/tests/integration/test_rejection_cycle.py
@@ -9,10 +9,17 @@ Tests the interaction between:
 from __future__ import annotations
 
 import json
+import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from specify_cli.cli.commands.agent import workflow
+from specify_cli.frontmatter import write_frontmatter
+from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.lanes.persistence import write_lanes_json
 from specify_cli.review.artifacts import AffectedFile, ReviewCycleArtifact
 from specify_cli.status.models import Lane, StatusEvent
 from specify_cli.status.store import append_event
@@ -85,6 +92,27 @@ def _write_wp_file(
     return wp_file
 
 
+def _write_cli_wp(wp_path: Path) -> None:
+    write_frontmatter(
+        wp_path,
+        {
+            "work_package_id": "WP01",
+            "subtasks": ["T001"],
+            "title": "Test Task",
+            "phase": "Phase 1",
+            "lane": "planned",
+            "dependencies": [],
+            "assignee": "",
+            "agent": "unknown",
+            "shell_pid": "",
+            "review_status": "none",
+            "review_feedback": "",
+            "history": [],
+        },
+        "# WP01 Prompt\n",
+    )
+
+
 # ---------------------------------------------------------------------------
 # T009: _has_prior_rejection helper tests
 # ---------------------------------------------------------------------------
@@ -119,12 +147,12 @@ class TestHasPriorRejection:
         feature_dir = tmp_path / "kitty-specs" / "066-test-mission"
         _make_artifact(tmp_path, "WP01-some-title")
 
-        # Emit a rejection event: for_review -> in_progress
+        # Emit a rejection event with a canonical review-cycle artifact reference.
         rejection_event = _make_event(
             event_id="01AAAA0000000000000000001A",
             wp_id="WP01",
-            from_lane=Lane.FOR_REVIEW,
-            to_lane=Lane.IN_PROGRESS,
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.PLANNED,
             review_ref="review-cycle://066-test-mission/WP01-some-title/review-cycle-1.md",
         )
         append_event(feature_dir, rejection_event)
@@ -143,8 +171,9 @@ class TestHasPriorRejection:
         append_event(feature_dir, _make_event(
             event_id="01AAAA0000000000000000001A",
             wp_id="WP01",
-            from_lane=Lane.FOR_REVIEW,
-            to_lane=Lane.IN_PROGRESS,
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.PLANNED,
+            review_ref="review-cycle://066-test-mission/WP01-some-title/review-cycle-1.md",
         ))
         # Then: approval (for_review -> approved)
         append_event(feature_dir, _make_event(
@@ -204,14 +233,46 @@ class TestHasPriorRejection:
         append_event(feature_dir, _make_event(
             event_id="01AAAA0000000000000000001A",
             wp_id="WP01",
-            from_lane=Lane.FOR_REVIEW,
-            to_lane=Lane.IN_PROGRESS,
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.PLANNED,
+            review_ref="review-cycle://066-test-mission/WP01-some-title/review-cycle-1.md",
         ))
         # Second rejection (latest)
         append_event(feature_dir, _make_event(
             event_id="01BBBB0000000000000000002B",
             wp_id="WP01",
-            from_lane=Lane.FOR_REVIEW,
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.PLANNED,
+            review_ref="review-cycle://066-test-mission/WP01-some-title/review-cycle-2.md",
+        ))
+
+        result = _has_prior_rejection(feature_dir, "WP01-some-title", "WP01")
+        assert result is True
+
+    def test_reentry_after_rejection_still_returns_true(self, tmp_path: Path) -> None:
+        """Claim/in-progress events after a rejection should not clear fix mode."""
+        from specify_cli.cli.commands.agent.workflow import _has_prior_rejection
+
+        feature_dir = tmp_path / "kitty-specs" / "066-test-mission"
+        _make_artifact(tmp_path, "WP01-some-title", cycle=1)
+
+        append_event(feature_dir, _make_event(
+            event_id="01AAAA0000000000000000001A",
+            wp_id="WP01",
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.PLANNED,
+            review_ref="review-cycle://066-test-mission/WP01-some-title/review-cycle-1.md",
+        ))
+        append_event(feature_dir, _make_event(
+            event_id="01BBBB0000000000000000002B",
+            wp_id="WP01",
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.CLAIMED,
+        ))
+        append_event(feature_dir, _make_event(
+            event_id="01CCCC0000000000000000003C",
+            wp_id="WP01",
+            from_lane=Lane.CLAIMED,
             to_lane=Lane.IN_PROGRESS,
         ))
 
@@ -329,3 +390,124 @@ class TestModeSwitchFallsThroughOnResolved:
 
         result = _has_prior_rejection(feature_dir, "WP01-some-title", "WP01")
         assert result is False
+
+
+@pytest.fixture()
+def workflow_cli_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True, capture_output=True)
+
+    (repo / ".kittify").mkdir()
+
+    mission_slug = "001-test-feature"
+    feature_dir = repo / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "feature_number": "001",
+                "mission_slug": mission_slug,
+                "created_at": "2026-01-17T00:00:00Z",
+                "friendly_name": mission_slug,
+                "mission": "software-dev",
+                "slug": mission_slug,
+                "target_branch": "main",
+                "vcs": "git",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    write_lanes_json(
+        feature_dir,
+        LanesManifest(
+            version=1,
+            mission_slug=mission_slug,
+            mission_id=f"mission-{mission_slug}",
+            mission_branch=f"kitty/mission-{mission_slug}",
+            target_branch="main",
+            lanes=[
+                ExecutionLane(
+                    lane_id="lane-a",
+                    wp_ids=("WP01",),
+                    write_scope=("src/**",),
+                    predicted_surfaces=("core",),
+                    depends_on_lanes=(),
+                    parallel_group=0,
+                )
+            ],
+            computed_at="2026-04-04T10:00:00Z",
+            computed_from="test",
+        ),
+    )
+    (feature_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
+    _write_cli_wp(tasks_dir / "WP01-test-task.md")
+
+    workspace = repo / ".worktrees" / f"{mission_slug}-lane-a"
+    workspace.mkdir(parents=True)
+
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "seed workflow fixture"], cwd=repo, check=True, capture_output=True)
+
+    monkeypatch.chdir(repo)
+    return repo, feature_dir
+
+
+class TestImplementReviewFeedbackHandoff:
+    def test_implement_uses_review_cycle_artifact_after_review_claim(
+        self,
+        workflow_cli_repo: tuple[Path, Path],
+    ) -> None:
+        repo, feature_dir = workflow_cli_repo
+        review_cycle_ref = "review-cycle://001-test-feature/WP01-test-task/review-cycle-2.md"
+        ReviewCycleArtifact(
+            cycle_number=2,
+            wp_id="WP01",
+            mission_slug="001-test-feature",
+            reviewer_agent="codex",
+            verdict="rejected",
+            reviewed_at="2026-04-10T06:36:14Z",
+            affected_files=[AffectedFile(path="src/example.py", line_range="1-5")],
+            reproduction_command="pytest tests/integration/test_rejection_cycle.py -q",
+            body="**Issue 1**: Use the canonical review artifact instead of the claim token.\n",
+        ).write(feature_dir / "tasks" / "WP01-test-task" / "review-cycle-2.md")
+
+        append_event(feature_dir, _make_event(event_id="01AAA000000000000000000001"))
+        append_event(feature_dir, _make_event(event_id="01AAA000000000000000000002", from_lane=Lane.CLAIMED, to_lane=Lane.IN_PROGRESS))
+        append_event(feature_dir, _make_event(event_id="01AAA000000000000000000003", from_lane=Lane.IN_PROGRESS, to_lane=Lane.FOR_REVIEW))
+        append_event(
+            feature_dir,
+            _make_event(
+                event_id="01AAA000000000000000000004",
+                from_lane=Lane.FOR_REVIEW,
+                to_lane=Lane.IN_PROGRESS,
+                review_ref="action-review-claim",
+            ),
+        )
+        append_event(
+            feature_dir,
+            _make_event(
+                event_id="01AAA000000000000000000005",
+                from_lane=Lane.IN_PROGRESS,
+                to_lane=Lane.PLANNED,
+                review_ref=review_cycle_ref,
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow.app,
+            ["implement", "WP01", "--feature", "001-test-feature", "--agent", "test-agent"],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert "Fix mode" in result.stdout
+        prompt_file = Path(tempfile.gettempdir()) / "spec-kitty-implement-WP01.md"
+        prompt_content = prompt_file.read_text(encoding="utf-8")
+        assert "## Review Findings" in prompt_content
+        assert "Use the canonical review artifact instead of the claim token." in prompt_content
+        assert "action-review-claim" not in prompt_content


### PR DESCRIPTION
## Summary

Fix implement/fix-cycle review feedback handoff so sub-agents use the latest canonical review artifact instead of the transient `action-review-claim` token.

## What changed

- ignore non-canonical review refs like `action-review-claim` and `force-override` when resolving implement feedback context
- resolve the newest readable review artifact for a WP from canonical status events before prompting the implementer
- preserve fix-mode across re-entry after a rejection, while suppressing it once a later approval/done event resolves that review cycle
- fail implement early when feedback is declared but the canonical review artifact is missing or unreadable
- add regression coverage for rejection re-entry and the direct implement handoff path

## Verification

- `pytest -q tests/integration/test_rejection_cycle.py`

Fixes #579.
