### PR TITLE
Fix finalize-tasks lane generation and artifact commits

### DIFF
--- a/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
@@ -556,8 +556,8 @@ WP01 (approved) --> WP02 (approved) --> WP03 (approved) --> merge --> all done
 ```
 
 1. Implement WP01, review, approve
-2. THEN implement WP02 (`--base WP01`), review, approve
-3. THEN implement WP03 (`--base WP02`), review, approve
+2. THEN implement WP02, review, approve. The implementation workspace base is inferred automatically from the approved dependency graph.
+3. THEN implement WP03, review, approve. The implementation workspace base is inferred automatically from the approved dependency graph.
 4. `spec-kitty merge --mission <slug>`
 
 ### Parallel Opportunities (Independent WPs)

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -60,6 +60,42 @@ app = typer.Typer(name="mission", help="Mission lifecycle commands for AI agents
 console = Console()
 
 
+def _extract_wp_ids_from_task_files(wp_files: list[Path]) -> list[str]:
+    """Return canonical WP IDs discovered from task filenames."""
+    wp_ids: set[str] = set()
+    for wp_file in wp_files:
+        wp_id_match = re.match(r"^(WP\d{2})(?:[-_.]|$)", wp_file.name)
+        if wp_id_match:
+            wp_ids.add(wp_id_match.group(1))
+    return sorted(wp_ids)
+
+
+def _collect_finalize_artifacts(
+    feature_dir: Path,
+    tasks_dir: Path,
+    mission_slug: str,
+    lanes_path: Path | None = None,
+) -> list[Path]:
+    """Return all deterministic artifacts finalize-tasks may need to commit."""
+    candidates: list[Path] = [
+        feature_dir / "status.events.jsonl",
+        feature_dir / "status.json",
+        feature_dir / "tasks.md",
+        feature_dir / ".kittify" / "dossiers" / mission_slug / "snapshot-latest.json",
+    ]
+    candidates.extend(sorted(path for path in tasks_dir.iterdir() if path.is_file()))
+    if lanes_path is not None:
+        candidates.append(lanes_path)
+
+    seen: set[Path] = set()
+    artifacts: list[Path] = []
+    for candidate in candidates:
+        if candidate.exists() and candidate not in seen:
+            artifacts.append(candidate)
+            seen.add(candidate)
+    return artifacts
+
+
 def _with_cli_version(payload: dict[str, object]) -> dict[str, object]:
     """Attach CLI version metadata to JSON payloads for log observability."""
     if "spec_kitty_version" in payload:
@@ -1312,6 +1348,7 @@ def finalize_tasks(
                 console.print(f"[red]Error:[/red] {error_msg}")
             raise typer.Exit(1)
         wp_files = list(tasks_dir.glob("WP*.md"))
+        expected_wp_ids = _extract_wp_ids_from_task_files(wp_files)
 
         spec_md = feature_dir / "spec.md"
         if not spec_md.exists():
@@ -1363,6 +1400,30 @@ def finalize_tasks(
             from specify_cli.core.dependency_parser import parse_dependencies_from_tasks_md as _shared_parse_deps
 
             wp_dependencies = _shared_parse_deps(tasks_content)
+            missing_wp_sections = [wp_id for wp_id in expected_wp_ids if wp_id not in wp_dependencies]
+            extra_wp_sections = sorted(set(wp_dependencies) - set(expected_wp_ids))
+            if missing_wp_sections or extra_wp_sections:
+                error_msg = (
+                    "tasks.md work package coverage is incomplete. "
+                    "finalize-tasks could not match all WP files to parsed sections, "
+                    "so dependency lanes would be unreliable."
+                )
+                payload = {
+                    "error": error_msg,
+                    "missing_wp_sections": missing_wp_sections,
+                    "extra_wp_sections": extra_wp_sections,
+                    "hint": "Use supported section headers such as '## WP01', '## Work Package WP01', or '## Work Package 1 — Title'.",
+                }
+                if json_output:
+                    _emit_json(payload)
+                else:
+                    console.print(f"[red]Error:[/red] {error_msg}")
+                    if missing_wp_sections:
+                        console.print(f"  Missing WP sections: {', '.join(missing_wp_sections)}")
+                    if extra_wp_sections:
+                        console.print(f"  Extra WP sections: {', '.join(extra_wp_sections)}")
+                    console.print(f"  {payload['hint']}")
+                raise typer.Exit(1)
 
             # FALLBACK: tasks.md text (backward compat for pre-API projects)
             tasks_md_refs = _parse_requirement_refs_from_tasks_md(tasks_content)
@@ -1399,11 +1460,7 @@ def finalize_tasks(
 
         # Update each WP file's frontmatter with dependencies + requirement refs
         wp_files = list(tasks_dir.glob("WP*.md"))
-        wp_ids: list[str] = []
-        for wp_file in wp_files:
-            wp_id_match = re.match(r"^(WP\d{2})(?:[-_.]|$)", wp_file.name)
-            if wp_id_match:
-                wp_ids.append(wp_id_match.group(1))
+        wp_ids = _extract_wp_ids_from_task_files(wp_files)
 
         missing_requirement_refs_wps: list[str] = []
         unknown_requirement_refs: dict[str, list[str]] = {}
@@ -1834,7 +1891,10 @@ def finalize_tasks(
                         for c in pr.import_coupling[:3]:
                             console.print(f"    coupling: {c}")
             if risk_report.exceeds_threshold and _policy.risk.mode == "block":
-                error_msg = f"Parallelization risk {risk_report.overall_score:.2f} exceeds threshold {risk_report.threshold:.2f}. Use --force to override."
+                error_msg = (
+                    f"Parallelization risk {risk_report.overall_score:.2f} exceeds threshold "
+                    f"{risk_report.threshold:.2f}. Adjust the risk policy to proceed."
+                )
                 if json_output:
                     _emit_json(
                         {
@@ -1849,32 +1909,28 @@ def finalize_tasks(
                     console.print(f"[red]Error:[/red] {error_msg}")
                 raise typer.Exit(1)
 
+        # Run dossier sync before the commit so its deterministic snapshot lands
+        # atomically with the rest of the planning artifacts.
+        with contextlib.suppress(Exception):
+            from specify_cli.sync.dossier_pipeline import (
+                trigger_feature_dossier_sync_if_enabled,
+            )
+
+            trigger_feature_dossier_sync_if_enabled(
+                feature_dir,
+                mission_slug,
+                repo_root,
+            )
+
         try:
-            # Build list of all files to commit via safe_commit
-            files_to_commit = []
-            files_to_commit_rel = []
-
-            # Include tasks.md (if present)
-            if tasks_md.exists():
-                files_to_commit.append(tasks_md)
-                rel_path = str(tasks_md.relative_to(repo_root))
-                files_to_commit_rel.append(rel_path)
-                files_committed.append(rel_path)
-
-            # Include all files in tasks_dir
-            for f in tasks_dir.iterdir():
-                if f.is_file():
-                    files_to_commit.append(f)
-                    rel_path = str(f.relative_to(repo_root))
-                    files_to_commit_rel.append(rel_path)
-                    files_committed.append(rel_path)
-
-            # Include lanes.json if computed
-            if lanes_path and lanes_path.exists():
-                files_to_commit.append(lanes_path)
-                rel_path = str(lanes_path.relative_to(repo_root))
-                files_to_commit_rel.append(rel_path)
-                files_committed.append(rel_path)
+            files_to_commit = _collect_finalize_artifacts(
+                feature_dir,
+                tasks_dir,
+                mission_slug,
+                lanes_path=lanes_path,
+            )
+            files_to_commit_rel = [str(path.relative_to(repo_root)) for path in files_to_commit]
+            files_committed = list(files_to_commit_rel)
 
             # Detect changes only within finalize-tasks outputs.
             # This avoids treating unrelated dirty files as commit failures.
@@ -1948,18 +2004,6 @@ def finalize_tasks(
                 )
             except Exception as exc:
                 console.print(f"[yellow]Warning:[/yellow] WPCreated emission failed for {wp['id']}: {exc}")
-
-        # Dossier sync (fire-and-forget)
-        with contextlib.suppress(Exception):
-            from specify_cli.sync.dossier_pipeline import (
-                trigger_feature_dossier_sync_if_enabled,
-            )
-
-            trigger_feature_dossier_sync_if_enabled(
-                feature_dir,
-                mission_slug,
-                repo_root,
-            )
 
         if json_output:
             _emit_json(

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -1895,12 +1895,22 @@ def finalize_tasks(
         from specify_cli.core.dependency_parser import parse_dependencies_from_tasks_md as _shared_parse_deps
 
         dependencies_map: dict[str, list[str]] = _shared_parse_deps(tasks_content)
-
-        # Ensure all WP files in tasks/ dir are in the map (with empty deps if not mentioned)
-        for wp_file in tasks_dir.glob("WP*.md"):
-            wp_id_stem = wp_file.stem.split("-")[0]  # Extract WP## from WP##-title.md
-            if re.match(r"^WP\d{2}$", wp_id_stem) and wp_id_stem not in dependencies_map:
-                dependencies_map[wp_id_stem] = []
+        expected_wp_ids = sorted(
+            wp_file.stem.split("-")[0]
+            for wp_file in tasks_dir.glob("WP*.md")
+            if re.match(r"^WP\d{2}$", wp_file.stem.split("-")[0])
+        )
+        missing_wp_sections = [wp_id for wp_id in expected_wp_ids if wp_id not in dependencies_map]
+        extra_wp_sections = sorted(set(dependencies_map) - set(expected_wp_ids))
+        if missing_wp_sections or extra_wp_sections:
+            _output_error(
+                json_output,
+                (
+                    "tasks.md work package coverage is incomplete. finalize-tasks could not match "
+                    "all WP files to parsed sections, so dependency lanes would be unreliable."
+                ),
+            )
+            raise typer.Exit(1)
 
         # Validate dependency graph for cycles
         from specify_cli.core.dependency_graph import detect_cycles

--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -40,13 +40,26 @@ import re
 # ---------------------------------------------------------------------------
 
 _WP_SECTION_HEADER = re.compile(
-    r"(?m)^(?:##\s+(?:Work Package\s+)?|###\s+)(WP\d{2})(?:\b|:)"
+    r"(?m)^(?:##\s+|###\s+)(?:(?:Work Package\s+)?(?P<wp_id>WP\d{2})(?:\b|:)|Work Package\s+(?P<wp_number>\d{1,2})(?:\b|\s*[—:-]|$))"
 )
 
 # Matches any top-level ## heading (exactly two #s).  Used by _split_wp_sections
 # to find the stop boundary for the final WP section.  Sub-headings (### or
 # deeper) are intentionally NOT matched — they must not trigger a stop.
 _ANY_H2_HEADER = re.compile(r"^## ", re.MULTILINE)
+
+
+def _normalize_wp_section_id(match: re.Match[str]) -> str:
+    """Return canonical ``WP##`` for a parsed section header match."""
+    wp_id = match.group("wp_id")
+    if wp_id:
+        return wp_id
+
+    wp_number = match.group("wp_number")
+    if wp_number is None:
+        raise ValueError("WP section header match did not capture a work package identifier")
+
+    return f"WP{int(wp_number):02d}"
 
 
 def _split_wp_sections(tasks_content: str) -> dict[str, str]:
@@ -64,7 +77,7 @@ def _split_wp_sections(tasks_content: str) -> dict[str, str]:
     matches = list(_WP_SECTION_HEADER.finditer(tasks_content))
 
     for idx, match in enumerate(matches):
-        wp_id = match.group(1)
+        wp_id = _normalize_wp_section_id(match)
         start = match.end()
         if idx + 1 < len(matches):
             # There is a next WP header — use it as the end (existing behaviour).

--- a/tests/core/test_dependency_parser.py
+++ b/tests/core/test_dependency_parser.py
@@ -218,6 +218,15 @@ class TestSectionHeaderVariants:
         assert result["WP01"] == []
         assert result["WP02"] == ["WP01"]
 
+    def test_numeric_work_package_headers_normalize_to_wp_ids(self) -> None:
+        content = (
+            "## Work Package 1 — Foundation\n\nNo deps.\n\n"
+            "## Work Package 2: Follow Up\n\nDepends on WP01.\n"
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP01"] == []
+        assert result["WP02"] == ["WP01"]
+
     def test_hash_hash_hash_header_style(self) -> None:
         content = "### WP01\n\nNo deps.\n\n### WP02\n\nDepends on WP01.\n"
         result = parse_dependencies_from_tasks_md(content)

--- a/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
+++ b/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
@@ -532,6 +532,112 @@ class TestWP01Regressions:
                 continue
         pytest.fail("No JSON output with 'result': 'success' found")
 
+    def test_finalize_rejects_incomplete_tasks_md_wp_coverage(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Fail loudly when tasks.md headings do not cover all WP files."""
+        mission_slug = "060-test-feature"
+        feature_dir = _setup_feature(tmp_path, mission_slug)
+        (feature_dir / "tasks.md").write_text(
+            "# Tasks\n\n## Package 1\n\nNo dependencies.\n\n## Package 2\n\nDepends on WP01.\n",
+            encoding="utf-8",
+        )
+
+        patches = _common_patches(tmp_path, mission_slug)
+        mock_bootstrap = MagicMock(return_value=_make_bootstrap_result())
+        patches[f"{MODULE}.bootstrap_canonical_state"] = mock_bootstrap
+
+        from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+        ctx_patches = {k: patch(k, v) for k, v in patches.items()}
+        for p in ctx_patches.values():
+            p.start()
+
+        try:
+            with pytest.raises(typer.Exit):
+                finalize_tasks(
+                    feature=mission_slug,
+                    json_output=True,
+                    validate_only=False,
+                )
+        finally:
+            for p in ctx_patches.values():
+                p.stop()
+
+        mock_bootstrap.assert_not_called()
+        captured = capsys.readouterr()
+        for line in captured.out.strip().splitlines():
+            try:
+                data = json.loads(line)
+                assert data["missing_wp_sections"] == ["WP01", "WP02"]
+                assert "coverage is incomplete" in data["error"]
+                return
+            except json.JSONDecodeError:
+                continue
+        pytest.fail("No JSON error payload found for incomplete WP coverage")
+
+    def test_finalize_commits_status_and_snapshot_artifacts(self, tmp_path: Path) -> None:
+        """Commit set must include bootstrap status artifacts and dossier snapshot."""
+        mission_slug = "060-test-feature"
+        feature_dir = _setup_feature(tmp_path, mission_slug)
+        captured_files: list[Path] = []
+
+        def _bootstrap_side_effect(feature_path: Path, slug: str, dry_run: bool) -> BootstrapResult:
+            assert feature_path == feature_dir
+            assert slug == mission_slug
+            assert dry_run is False
+            (feature_path / "status.events.jsonl").write_text('{"event":"seeded"}\n', encoding="utf-8")
+            (feature_path / "status.json").write_text("{}", encoding="utf-8")
+            return _make_bootstrap_result()
+
+        def _safe_commit_spy(**kwargs: object) -> bool:
+            nonlocal captured_files
+            captured_files = list(kwargs["files_to_commit"])  # type: ignore[index]
+            return True
+
+        def _write_snapshot(feature_path: Path, slug: str, repo_root: Path) -> None:
+            assert feature_path == feature_dir
+            assert slug == mission_slug
+            assert repo_root == tmp_path
+            snapshot_path = feature_path / ".kittify" / "dossiers" / slug / "snapshot-latest.json"
+            snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_path.write_text("{}", encoding="utf-8")
+
+        patches = _common_patches(tmp_path, mission_slug)
+        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(side_effect=_bootstrap_side_effect)
+        patches[f"{MODULE}.safe_commit"] = _safe_commit_spy
+
+        from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+        ctx_patches = {k: patch(k, v) for k, v in patches.items()}
+        extra_patch = patch(
+            "specify_cli.sync.dossier_pipeline.trigger_feature_dossier_sync_if_enabled",
+            side_effect=_write_snapshot,
+        )
+        for p in ctx_patches.values():
+            p.start()
+        extra_patch.start()
+
+        try:
+            finalize_tasks(
+                feature=mission_slug,
+                json_output=True,
+                validate_only=False,
+            )
+        except (typer.Exit, SystemExit):
+            pass
+        finally:
+            extra_patch.stop()
+            for p in ctx_patches.values():
+                p.stop()
+
+        committed_paths = {path.relative_to(tmp_path).as_posix() for path in captured_files}
+        assert "kitty-specs/060-test-feature/status.events.jsonl" in committed_paths
+        assert "kitty-specs/060-test-feature/status.json" in committed_paths
+        assert "kitty-specs/060-test-feature/.kittify/dossiers/060-test-feature/snapshot-latest.json" in committed_paths
+
 
 class TestValidateOnlyUsesInMemoryOwnership:
     """Regression test for validate-only ownership inference and manifest reuse."""


### PR DESCRIPTION
## Summary
- accept `## Work Package N — ...` task headings in the shared dependency parser
- fail loudly when finalize-tasks cannot match WP files to parsed tasks.md sections
- commit canonical status artifacts and dossier snapshots atomically with finalize-tasks output
- remove stale `--force` guidance from the risk gate and stop the implement-review skill from recommending unsupported `--base WP01` usage

## Repro fixed
Historical mission repro from `033-canonical-baseline-and-repository-boundary` previously did this:
1. `agent mission finalize-tasks` returned success but parsed no WP sections and wrote no `lanes.json`
2. `implement WP01 --json` auto-committed `status.events.jsonl` / `status.json`
3. `implement` still failed with `lanes.json is required`

With this patch, the same mission now:
- parses the real `Work Package N — ...` headings correctly
- writes and commits `lanes.json`, `status.events.jsonl`, `status.json`, and dossier `snapshot-latest.json` in one finalize commit
- proceeds through `implement WP01 --json` without the planning-artifact or missing-lanes failures

## Validation
- `pytest -q tests/core/test_dependency_parser.py tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py`
- `pytest -q tests/agent/cli/commands/test_tasks_helpers.py tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py`
- real CLI repro using the patched clone against the historical `033-canonical-baseline-and-repository-boundary` repo state
