### PR TITLE
fix: remove changelog parser regex hotspots

### DIFF
--- a/src/specify_cli/release/changelog.py
+++ b/src/specify_cli/release/changelog.py
@@ -7,7 +7,6 @@ Zero network calls (FR-014).
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 from pathlib import Path
 
@@ -96,10 +95,10 @@ def _parse_wp_frontmatter_status(wp_file: Path) -> str | None:
     if end == -1:
         return None
     fm_block = content[3:end]
-    # Simple regex extraction — avoids YAML parser dependency
-    match = re.search(r"^\s*status\s*:\s*(.+)$", fm_block, re.MULTILINE)
-    if match:
-        return match.group(1).strip().strip("'\"")
+    for raw_line in fm_block.splitlines():
+        key, separator, value = raw_line.partition(":")
+        if separator and key.strip() == "status":
+            return value.strip().strip("'\"")
     return None
 
 
@@ -112,8 +111,7 @@ def _parse_wp_title(wp_file: Path) -> str:
     for line in content.splitlines():
         stripped = line.strip()
         if stripped.startswith("## ") or stripped.startswith("# "):
-            # Remove leading #s and whitespace
-            return re.sub(r"^#+\s*", "", stripped)
+            return stripped.lstrip("#").strip()
     return wp_file.stem
 
 
@@ -127,11 +125,10 @@ def _parse_wp_id(wp_file: Path) -> str:
         end = content.find("\n---", 3)
         if end != -1:
             fm_block = content[3:end]
-            match = re.search(
-                r"^\s*work_package_id\s*:\s*(.+)$", fm_block, re.MULTILINE
-            )
-            if match:
-                return match.group(1).strip().strip("'\"")
+            for raw_line in fm_block.splitlines():
+                key, separator, value = raw_line.partition(":")
+                if separator and key.strip() == "work_package_id":
+                    return value.strip().strip("'\"")
     return wp_file.stem
 
 

--- a/tests/release/test_release_prep.py
+++ b/tests/release/test_release_prep.py
@@ -19,7 +19,12 @@ import pytest
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.agent.release import app
-from specify_cli.release.changelog import build_changelog_block
+from specify_cli.release.changelog import (
+    _parse_wp_frontmatter_status,
+    _parse_wp_id,
+    _parse_wp_title,
+    build_changelog_block,
+)
 from specify_cli.release.payload import ReleasePrepPayload, build_release_prep_payload
 from specify_cli.release.version import propose_version
 
@@ -194,6 +199,63 @@ def test_changelog_accepts_since_tag_none(tmp_path: Path) -> None:
     changelog, slugs = build_changelog_block(tmp_path, since_tag=None)
     assert isinstance(changelog, str)
     assert isinstance(slugs, list)
+
+
+def test_wp_frontmatter_status_parses_quoted_values_without_regex(tmp_path: Path) -> None:
+    wp_file = tmp_path / "WP01-test.md"
+    wp_file.write_text(
+        dedent(
+            """\
+            ---
+            work_package_id: "WP01"
+            status: 'done'
+            ---
+
+            ## WP01
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    assert _parse_wp_frontmatter_status(wp_file) == "done"
+
+
+def test_wp_id_parses_values_containing_colons(tmp_path: Path) -> None:
+    wp_file = tmp_path / "custom-name.md"
+    wp_file.write_text(
+        dedent(
+            """\
+            ---
+            work_package_id: "WP:01"
+            status: done
+            ---
+
+            ## WP01
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    assert _parse_wp_id(wp_file) == "WP:01"
+
+
+def test_wp_title_strips_heading_markers_without_regex(tmp_path: Path) -> None:
+    wp_file = tmp_path / "WP01-title.md"
+    wp_file.write_text(
+        dedent(
+            """\
+            ---
+            work_package_id: WP01
+            status: done
+            ---
+
+            ##   Release Prep Title
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    assert _parse_wp_title(wp_file) == "Release Prep Title"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace regex-based frontmatter parsing in release changelog helpers with bounded string parsing
- replace heading cleanup regex with direct heading marker stripping
- add targeted release tests for quoted frontmatter values and heading normalization

## Validation
- PYTHONPATH=/tmp/spec-kitty-pydeps:src python3 -m pytest tests/release/test_release_prep.py -q
- PYTHONPATH=/tmp/spec-kitty-pydeps:src python3 -m pytest tests/release/test_release_payload_draft.py -q

## Notes
- This addresses the actionable SonarCloud hotspot in `src/specify_cli/release/changelog.py` without suppressing the warning.
- I did not change unrelated Sonar backlog items or UI-only hotspot review state in this PR.