### PR TITLE
fix: reduce Sonar nightly findings

### DIFF
--- a/src/specify_cli/auth/http/transport.py
+++ b/src/specify_cli/auth/http/transport.py
@@ -30,7 +30,6 @@ from specify_cli.auth import get_token_manager
 from specify_cli.auth.errors import (
     NetworkError,
     NotAuthenticatedError,
-    TokenRefreshError,
 )
 
 # Default timeout for all HTTP operations (per WP08 spec).
@@ -99,11 +98,7 @@ class OAuthHttpClient:
         tm = get_token_manager()
 
         # First attempt: inject the current access token (auto-refresh if near expiry).
-        try:
-            access_token = await tm.get_access_token()
-        except (NotAuthenticatedError, TokenRefreshError):
-            # Propagate auth errors unchanged — callers differentiate these.
-            raise
+        access_token = await tm.get_access_token()
 
         response = await self._send(method, url, access_token, kwargs)
 

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -41,6 +41,7 @@ from specify_cli.tasks_support import (
 from specify_cli.workspace_context import resolve_workspace_for_wp
 
 _REVIEW_FEEDBACK_SENTINELS = frozenset({"force-override", "action-review-claim"})
+_REVIEW_CYCLE_SCHEME = "review-cycle://"
 
 
 def _write_prompt_to_file(
@@ -106,8 +107,8 @@ def _resolve_review_feedback_pointer(repo_root: Path, pointer: str) -> Path | No
     if not value or value in _REVIEW_FEEDBACK_SENTINELS:
         return None
 
-    if value.startswith("review-cycle://"):
-        relative = value[len("review-cycle://") :]
+    if value.startswith(_REVIEW_CYCLE_SCHEME):
+        relative = value.removeprefix(_REVIEW_CYCLE_SCHEME)
         parts = [p for p in relative.split("/") if p]
         if len(parts) != 3:
             return None
@@ -699,7 +700,11 @@ def implement(
                 from specify_cli.review.fix_prompt import generate_fix_prompt as _generate_fix_prompt
 
                 _sub_artifact_dir = feature_dir / "tasks" / wp_slug
-                if review_feedback_ref and review_feedback_ref.startswith("review-cycle://") and review_feedback_file is not None:
+                if (
+                    review_feedback_ref
+                    and review_feedback_ref.startswith(_REVIEW_CYCLE_SCHEME)
+                    and review_feedback_file is not None
+                ):
                     _latest_artifact = _ReviewCycleArtifact.from_file(review_feedback_file)
                 else:
                     _latest_artifact = _ReviewCycleArtifact.latest(_sub_artifact_dir)

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -916,6 +916,10 @@ def doctor() -> None:
     server_url = config.get_server_url()
     table.add_row("Server URL", server_url)
 
+    token_labels = {
+        "access": "Access token",
+        "refresh": "Refresh token",
+    }
     tm = get_token_manager()
     session = tm.get_current_session()
     if session is None:
@@ -935,27 +939,30 @@ def doctor() -> None:
 
         if access_ok:
             table.add_row(
-                "Access token",
+                token_labels["access"],
                 f"[green]Valid[/green] (expires {access_exp_dt.isoformat()})",
             )
         elif access_exp_dt is not None:
             table.add_row(
-                "Access token",
+                token_labels["access"],
                 f"[red]Expired[/red] ({access_exp_dt.isoformat()})",
             )
         else:
-            table.add_row("Access token", "[red]Missing[/red]")
+            table.add_row(token_labels["access"], "[red]Missing[/red]")
 
         if refresh_exp_dt is None:
-            table.add_row("Refresh token", "[green]Valid[/green] (no expiry stored)")
+            table.add_row(
+                token_labels["refresh"],
+                "[green]Valid[/green] (no expiry stored)",
+            )
         elif refresh_ok:
             table.add_row(
-                "Refresh token",
+                token_labels["refresh"],
                 f"[green]Valid[/green] (expires {refresh_exp_dt.isoformat()})",
             )
         else:
             table.add_row(
-                "Refresh token",
+                token_labels["refresh"],
                 f"[red]Expired[/red] ({refresh_exp_dt.isoformat()})",
             )
 

--- a/src/specify_cli/tracker/saas_client.py
+++ b/src/specify_cli/tracker/saas_client.py
@@ -30,6 +30,10 @@ from specify_cli.auth.errors import (
 from specify_cli.sync.config import SyncConfig
 from specify_cli.core.contract_gate import validate_outbound_payload
 
+_SESSION_EXPIRED_MESSAGE = (
+    "Session expired. Run `spec-kitty auth login` to re-authenticate."
+)
+
 
 class SaaSTrackerClientError(RuntimeError):
     """Raised when a SaaS tracker API call fails.
@@ -308,14 +312,14 @@ class SaaSTrackerClient:
                 _force_refresh_sync()
             except AuthenticationError as exc:
                 raise SaaSTrackerClientError(
-                    "Session expired. Run `spec-kitty auth login` to re-authenticate.",
+                    _SESSION_EXPIRED_MESSAGE,
                     error_code="session_expired",
                     status_code=401,
                     user_action_required=True,
                 ) from exc
             except Exception as exc:
                 raise SaaSTrackerClientError(
-                    "Session expired. Run `spec-kitty auth login` to re-authenticate.",
+                    _SESSION_EXPIRED_MESSAGE,
                     error_code="session_expired",
                     status_code=401,
                     user_action_required=True,
@@ -326,7 +330,7 @@ class SaaSTrackerClient:
             )
             if response.status_code == 401:
                 raise SaaSTrackerClientError(
-                    "Session expired. Run `spec-kitty auth login` to re-authenticate.",
+                    _SESSION_EXPIRED_MESSAGE,
                     error_code="session_expired",
                     status_code=401,
                     user_action_required=True,


### PR DESCRIPTION
## Summary
- replace changelog frontmatter regex parsing with line-based parsing to remove the two regex hotspot candidates on main
- deduplicate repeated Sonar-flagged auth/sync literals in tracker, sync doctor, and agent workflow paths
- simplify OAuth transport token retrieval so the 401 retry flow keeps behavior without the redundant re-raise block

## Validation
- UV_CACHE_DIR=/tmp/spec-kitty-uv-cache UV_PYTHON_INSTALL_DIR=/tmp/spec-kitty-uv-python uv run --extra test --python 3.14 pytest tests/release/test_release_prep.py tests/auth/test_http_transport.py tests/sync/test_sync_doctor.py tests/review/test_artifacts.py tests/sync/tracker/test_saas_client.py tests/sync/tracker/test_saas_client_origin.py -q

## Context
- GitHub security alerts: no open code-scanning alerts, no open Dependabot alerts at run time
- Latest scheduled main run: https://github.com/Priivacy-ai/spec-kitty/actions/runs/24274673744
- No suppressions added in this patch