### PR TITLE
fix: address Sonar readiness and parser findings

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -117,6 +117,8 @@ jobs:
             core_misc:
               - 'src/kernel/**'
               - 'src/doctrine/**'
+              - 'src/specify_cli/core/**'
+              - 'src/specify_cli/saas/**'
               - 'tests/kernel/**'
               - 'tests/doctrine/**'
               - 'tests/policy/**'
@@ -1759,6 +1761,7 @@ jobs:
       - integration-tests-dashboard
       - integration-tests-upgrade
       - integration-tests-cli
+      - fast-tests-core-misc
     if: always() && github.event_name == 'pull_request'
 
     steps:

--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -39,9 +39,9 @@ import re
 # Section splitter
 # ---------------------------------------------------------------------------
 
-_WP_SECTION_HEADER = re.compile(
-    r"(?m)^(?:##\s+|###\s+)(?:(?:Work Package\s+)?(?P<wp_id>WP\d{2})(?:\b|:)|Work Package\s+(?P<wp_number>\d{1,2})(?:\b|\s*[—:-]|$))"
-)
+_WP_SECTION_HEADER = re.compile(r"(?m)^(?:##|###)\s+(?P<title>.+)$")
+_WP_ID_TITLE = re.compile(r"^(?:Work Package\s+)?(?P<wp_id>WP\d{2})(?:\b|:)")
+_WP_NUMBER_TITLE = re.compile(r"^Work Package\s+(?P<wp_number>\d{1,2})(?:\b|\s*[—:-]|$)")
 
 # Matches any top-level ## heading (exactly two #s).  Used by _split_wp_sections
 # to find the stop boundary for the final WP section.  Sub-headings (### or
@@ -49,17 +49,13 @@ _WP_SECTION_HEADER = re.compile(
 _ANY_H2_HEADER = re.compile(r"^## ", re.MULTILINE)
 
 
-def _normalize_wp_section_id(match: re.Match[str]) -> str:
-    """Return canonical ``WP##`` for a parsed section header match."""
-    wp_id = match.group("wp_id")
-    if wp_id:
-        return wp_id
-
-    wp_number = match.group("wp_number")
-    if wp_number is None:
-        raise ValueError("WP section header match did not capture a work package identifier")
-
-    return f"WP{int(wp_number):02d}"
+def _match_wp_section_id(title: str) -> str | None:
+    """Return canonical ``WP##`` when ``title`` is a work-package heading."""
+    if explicit_id_match := _WP_ID_TITLE.match(title):
+        return explicit_id_match.group("wp_id")
+    if numeric_match := _WP_NUMBER_TITLE.match(title):
+        return f"WP{int(numeric_match.group('wp_number')):02d}"
+    return None
 
 
 def _split_wp_sections(tasks_content: str) -> dict[str, str]:
@@ -74,14 +70,17 @@ def _split_wp_sections(tasks_content: str) -> dict[str, str]:
         WP section header (or end of file).
     """
     sections: dict[str, str] = {}
-    matches = list(_WP_SECTION_HEADER.finditer(tasks_content))
+    matches: list[tuple[str, re.Match[str]]] = []
+    for match in _WP_SECTION_HEADER.finditer(tasks_content):
+        wp_id = _match_wp_section_id(match.group("title"))
+        if wp_id is not None:
+            matches.append((wp_id, match))
 
-    for idx, match in enumerate(matches):
-        wp_id = _normalize_wp_section_id(match)
+    for idx, (wp_id, match) in enumerate(matches):
         start = match.end()
         if idx + 1 < len(matches):
             # There is a next WP header — use it as the end (existing behaviour).
-            end = matches[idx + 1].start()
+            end = matches[idx + 1][1].start()
         else:
             # Final WP: stop at the first non-WP, non-Dependencies ## heading
             # after this WP header, or at EOF if no such heading exists.  This
@@ -97,12 +96,12 @@ def _split_wp_sections(tasks_content: str) -> dict[str, str]:
             for h2_match in _ANY_H2_HEADER.finditer(tasks_content, match.end()):
                 # Skip WP ID headings — those would start the next WP section
                 # (shouldn't happen in the final-WP branch, but be safe).
-                if _WP_SECTION_HEADER.match(tasks_content, h2_match.start()):
+                line_end = tasks_content.find("\n", h2_match.start())
+                heading_line = tasks_content[h2_match.start():line_end if line_end != -1 else None]
+                if _match_wp_section_id(heading_line[3:].strip()) is not None:
                     continue
                 # Skip "## Dependencies" headings — those are Pattern 3
                 # dependency-declaration headers and belong to this WP.
-                line_end = tasks_content.find("\n", h2_match.start())
-                heading_line = tasks_content[h2_match.start():line_end if line_end != -1 else None]
                 if _DEPS_HEADING.match(heading_line.strip()):
                     continue
                 # Non-WP, non-Dependencies ## heading — this is a stop boundary.

--- a/src/specify_cli/saas/readiness.py
+++ b/src/specify_cli/saas/readiness.py
@@ -188,8 +188,8 @@ def _probe_reachability(server_url: str, timeout_s: float = 2.0) -> bool:
         return False
 
 
-def _probe_mission_binding(repo_root: Path, feature_slug: str | None) -> bool:
-    """Return True iff a tracker binding exists for ``feature_slug`` in ``repo_root``.
+def _probe_mission_binding(repo_root: Path) -> bool:
+    """Return True iff a tracker binding exists in ``repo_root``.
 
     Delegates to ``specify_cli.tracker.config.load_tracker_config`` — the
     same path used by tracker CLI commands.  Returns ``False`` if no binding
@@ -267,7 +267,7 @@ def evaluate_readiness(
             return _build_result(ReadinessState.HOST_UNREACHABLE, server_url=server_url)
 
         # Step 5: mission binding (optional)
-        if require_mission_binding and not _probe_mission_binding(repo_root, feature_slug):
+        if require_mission_binding and not _probe_mission_binding(repo_root):
             return _build_result(
                 ReadinessState.MISSING_MISSION_BINDING,
                 feature_slug=feature_slug or "",

--- a/tests/core/test_dependency_parser.py
+++ b/tests/core/test_dependency_parser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+import specify_cli.core.dependency_parser as dependency_parser
 from specify_cli.core.dependency_parser import parse_dependencies_from_tasks_md
 
 
@@ -231,6 +232,12 @@ class TestSectionHeaderVariants:
         content = "### WP01\n\nNo deps.\n\n### WP02\n\nDepends on WP01.\n"
         result = parse_dependencies_from_tasks_md(content)
         assert result["WP02"] == ["WP01"]
+
+    def test_non_wp_headings_are_ignored_by_section_matcher(self) -> None:
+        assert dependency_parser._match_wp_section_id("Notes") is None
+
+    def test_numeric_heading_without_suffix_normalizes(self) -> None:
+        assert dependency_parser._match_wp_section_id("Work Package 7") == "WP07"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/release/test_diff_coverage_policy.py
+++ b/tests/release/test_diff_coverage_policy.py
@@ -320,6 +320,11 @@ def test_tighten_workflow_passes_large_pr_sample() -> None:
         "diff-coverage must depend on fast-tests-charter; otherwise charter-only "
         "changes can race artifact upload and produce timing-dependent results."
     )
+    assert re.search(r"diff-coverage:\s*\n(?:.*\n)*?\s+needs:\s*\n(?:.*\n)*?\s+- fast-tests-core-misc", workflow_text), (
+        "diff-coverage must depend on fast-tests-core-misc; otherwise uncategorized "
+        "core/specify_cli changes can race coverage upload and fail before their "
+        "artifact exists."
+    )
 
     # ------------------------------------------------------------------
     # 6. quality-gate is the aggregate signal and must fail when

--- a/tests/saas/test_readiness_unit.py
+++ b/tests/saas/test_readiness_unit.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import specify_cli.saas.readiness as readiness
 from specify_cli.saas.readiness import ReadinessState, evaluate_readiness
 
 # ---------------------------------------------------------------------------
@@ -372,3 +373,59 @@ def test_non_exception_result_has_empty_details(
 
     assert result.state is ReadinessState.MISSING_AUTH
     assert result.details == {}
+
+
+def test_probe_host_config_returns_none_on_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ConfigurationError from auth config resolves to an absent host URL."""
+
+    class FakeConfigurationError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        "specify_cli.auth.config.get_saas_base_url",
+        lambda: (_ for _ in ()).throw(FakeConfigurationError("missing")),
+    )
+    monkeypatch.setattr("specify_cli.auth.errors.ConfigurationError", FakeConfigurationError)
+
+    assert readiness._probe_host_config() is None
+
+
+def test_probe_host_config_returns_none_on_unexpected_import_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any unexpected import/runtime failure should keep the helper no-raise."""
+
+    def raise_import_error() -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("specify_cli.auth.config.get_saas_base_url", raise_import_error)
+
+    assert readiness._probe_host_config() is None
+
+
+def test_probe_reachability_returns_false_on_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Network exceptions must collapse to False."""
+
+    def raise_url_error(*_args: object, **_kwargs: object) -> object:
+        raise OSError("offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", raise_url_error)
+
+    assert readiness._probe_reachability("https://example.invalid") is False
+
+
+def test_probe_mission_binding_ignores_loader_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tracker config loader failures should return False, not raise."""
+
+    def raise_loader_error(_repo_root: Path) -> object:
+        raise RuntimeError("no tracker config")
+
+    monkeypatch.setattr("specify_cli.tracker.config.load_tracker_config", raise_loader_error)
+
+    assert readiness._probe_mission_binding(_REPO) is False


### PR DESCRIPTION
## Summary
- remove the unused mission-binding probe parameter in hosted readiness
- simplify work-package header parsing to eliminate the regex-complexity hit in the shared dependency parser
- add focused helper coverage for both modules to lift the Sonar-affected files into the mid-90s locally

## Validation
- `PYTHONPATH=/tmp/spec-kitty-pydeps:src python3 -m pytest tests/saas/test_readiness_unit.py tests/saas/test_readiness_integration.py tests/core/test_dependency_parser.py --cov=specify_cli.saas.readiness --cov=specify_cli.core.dependency_parser --cov-report=term-missing`

## Notes
- GitHub code-scanning alerts: none open
- GitHub Dependabot alerts: none open
- SonarCloud nightly `main` quality gate was failing on `new_coverage` and `new_security_hotspots_reviewed`.
- The remaining Sonar hotspots are legacy review items around intentional localhost/http loopback and dashboard resources; this PR focuses on the actionable code-side issues from the nightly run rather than suppressing or papering over those findings.
