### PR TITLE
fix: address actionable sonar maintenance issues

### DIFF
--- a/src/specify_cli/auth/device_flow/poller.py
+++ b/src/specify_cli/auth/device_flow/poller.py
@@ -86,6 +86,55 @@ class DeviceFlowPoller:
         """Return the wrapped :class:`DeviceFlowState`."""
         return self._state
 
+    def _raise_if_expired(self) -> None:
+        """Stop polling once the local device-flow state has expired."""
+        if self._state.is_expired():
+            raise DeviceFlowExpired(
+                f"Device authorization expired after {self._state.expires_in} seconds. "
+                "Run `spec-kitty auth login --headless` again."
+            )
+
+    @staticmethod
+    def _raise_terminal_error(error: str, response: dict[str, Any]) -> None:
+        """Raise the terminal exception for a non-retriable OAuth error."""
+        if error == "access_denied":
+            raise DeviceFlowDenied(
+                "User denied the authorization request. "
+                "Run `spec-kitty auth login --headless` to try again."
+            )
+
+        if error == "expired_token":
+            raise DeviceFlowExpired(
+                "Device code expired before approval. "
+                "Run `spec-kitty auth login --headless` to try again."
+            )
+
+        desc = response.get("error_description", error)
+        raise DeviceFlowDenied(f"Unexpected device flow error: {desc}")
+
+    def _handle_response(
+        self,
+        response: dict[str, Any],
+        *,
+        interval: int,
+        on_pending: Callable[[DeviceFlowState], None] | None,
+    ) -> tuple[dict[str, Any] | None, int]:
+        """Classify a token response and return the next loop state."""
+        error = response.get("error")
+        if error is None:
+            return response, interval
+
+        if error == "authorization_pending":
+            if on_pending is not None:
+                on_pending(self._state)
+            return None, interval
+
+        if error == "slow_down":
+            next_interval = min(interval + _SLOW_DOWN_BACKOFF, _MAX_INTERVAL_SECONDS)
+            return None, next_interval
+
+        self._raise_terminal_error(error, response)
+
     async def poll(
         self,
         token_request: Callable[[str], Awaitable[dict[str, Any]]],
@@ -131,11 +180,7 @@ class DeviceFlowPoller:
         interval = min(self._state.interval, _MAX_INTERVAL_SECONDS)
 
         while True:
-            if self._state.is_expired():
-                raise DeviceFlowExpired(
-                    f"Device authorization expired after {self._state.expires_in} seconds. "
-                    "Run `spec-kitty auth login --headless` again."
-                )
+            self._raise_if_expired()
 
             # Sleep BEFORE the first poll too -- gives the user time to open
             # the browser and approve. This is intentional UX, not a bug.
@@ -150,33 +195,10 @@ class DeviceFlowPoller:
                 log.warning("Network error during device flow poll: %s", exc)
                 continue
 
-            error = response.get("error")
-            if error is None:
-                # Success: response contains access_token, refresh_token, etc.
-                return response
-
-            if error == "authorization_pending":
-                if on_pending is not None:
-                    on_pending(self._state)
-                continue
-
-            if error == "slow_down":
-                # RFC 8628 §3.5: bump interval, but still cap at 10s (FR-018).
-                interval = min(interval + _SLOW_DOWN_BACKOFF, _MAX_INTERVAL_SECONDS)
-                continue
-
-            if error == "access_denied":
-                raise DeviceFlowDenied(
-                    "User denied the authorization request. "
-                    "Run `spec-kitty auth login --headless` to try again."
-                )
-
-            if error == "expired_token":
-                raise DeviceFlowExpired(
-                    "Device code expired before approval. "
-                    "Run `spec-kitty auth login --headless` to try again."
-                )
-
-            # Unknown error -- propagate with whatever description SaaS gave us.
-            desc = response.get("error_description", error)
-            raise DeviceFlowDenied(f"Unexpected device flow error: {desc}")
+            handled_response, interval = self._handle_response(
+                response,
+                interval=interval,
+                on_pending=on_pending,
+            )
+            if handled_response is not None:
+                return handled_response

--- a/src/specify_cli/auth/device_flow/poller.py
+++ b/src/specify_cli/auth/device_flow/poller.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, NoReturn
 from collections.abc import Awaitable, Callable
 
 from ..errors import DeviceFlowDenied, DeviceFlowExpired, NetworkError
@@ -95,7 +95,7 @@ class DeviceFlowPoller:
             )
 
     @staticmethod
-    def _raise_terminal_error(error: str, response: dict[str, Any]) -> None:
+    def _raise_terminal_error(error: str, response: dict[str, Any]) -> NoReturn:
         """Raise the terminal exception for a non-retriable OAuth error."""
         if error == "access_denied":
             raise DeviceFlowDenied(

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -36,6 +36,10 @@ from specify_cli.sync.feature_flags import (
 
 console = Console()
 
+_STATUS_ACCESS_TOKEN_LABEL = "Access token"
+_STATUS_REFRESH_TOKEN_LABEL = "Refresh token"
+_STATUS_LAST_SYNC_LABEL = "Last Sync"
+
 
 def humanize_timedelta(td: "timedelta") -> str:
     """Convert a timedelta into a concise human-readable string.
@@ -726,11 +730,14 @@ def status(
     if daemon_status.last_sync:
         try:
             parsed_sync_time = datetime.fromisoformat(daemon_status.last_sync)
-            table.add_row("Last Sync", parsed_sync_time.strftime("%Y-%m-%d %H:%M:%S UTC"))
+            table.add_row(
+                _STATUS_LAST_SYNC_LABEL,
+                parsed_sync_time.strftime("%Y-%m-%d %H:%M:%S UTC"),
+            )
         except ValueError:
-            table.add_row("Last Sync", daemon_status.last_sync)
+            table.add_row(_STATUS_LAST_SYNC_LABEL, daemon_status.last_sync)
     else:
-        table.add_row("Last Sync", "[dim]Never[/dim]")
+        table.add_row(_STATUS_LAST_SYNC_LABEL, "[dim]Never[/dim]")
 
     if daemon_status.consecutive_failures > 0:
         table.add_row("Failures", f"[yellow]{daemon_status.consecutive_failures} consecutive[/yellow]")
@@ -935,27 +942,30 @@ def doctor() -> None:
 
         if access_ok:
             table.add_row(
-                "Access token",
+                _STATUS_ACCESS_TOKEN_LABEL,
                 f"[green]Valid[/green] (expires {access_exp_dt.isoformat()})",
             )
         elif access_exp_dt is not None:
             table.add_row(
-                "Access token",
+                _STATUS_ACCESS_TOKEN_LABEL,
                 f"[red]Expired[/red] ({access_exp_dt.isoformat()})",
             )
         else:
-            table.add_row("Access token", "[red]Missing[/red]")
+            table.add_row(_STATUS_ACCESS_TOKEN_LABEL, "[red]Missing[/red]")
 
         if refresh_exp_dt is None:
-            table.add_row("Refresh token", "[green]Valid[/green] (no expiry stored)")
+            table.add_row(
+                _STATUS_REFRESH_TOKEN_LABEL,
+                "[green]Valid[/green] (no expiry stored)",
+            )
         elif refresh_ok:
             table.add_row(
-                "Refresh token",
+                _STATUS_REFRESH_TOKEN_LABEL,
                 f"[green]Valid[/green] (expires {refresh_exp_dt.isoformat()})",
             )
         else:
             table.add_row(
-                "Refresh token",
+                _STATUS_REFRESH_TOKEN_LABEL,
                 f"[red]Expired[/red] ({refresh_exp_dt.isoformat()})",
             )
 

--- a/src/specify_cli/tracker/saas_client.py
+++ b/src/specify_cli/tracker/saas_client.py
@@ -30,6 +30,10 @@ from specify_cli.auth.errors import (
 from specify_cli.sync.config import SyncConfig
 from specify_cli.core.contract_gate import validate_outbound_payload
 
+_SESSION_EXPIRED_MESSAGE = (
+    "Session expired. Run `spec-kitty auth login` to re-authenticate."
+)
+
 
 class SaaSTrackerClientError(RuntimeError):
     """Raised when a SaaS tracker API call fails.
@@ -308,14 +312,14 @@ class SaaSTrackerClient:
                 _force_refresh_sync()
             except AuthenticationError as exc:
                 raise SaaSTrackerClientError(
-                    "Session expired. Run `spec-kitty auth login` to re-authenticate.",
+                    _SESSION_EXPIRED_MESSAGE,
                     error_code="session_expired",
                     status_code=401,
                     user_action_required=True,
                 ) from exc
             except Exception as exc:
                 raise SaaSTrackerClientError(
-                    "Session expired. Run `spec-kitty auth login` to re-authenticate.",
+                    _SESSION_EXPIRED_MESSAGE,
                     error_code="session_expired",
                     status_code=401,
                     user_action_required=True,
@@ -326,7 +330,7 @@ class SaaSTrackerClient:
             )
             if response.status_code == 401:
                 raise SaaSTrackerClientError(
-                    "Session expired. Run `spec-kitty auth login` to re-authenticate.",
+                    _SESSION_EXPIRED_MESSAGE,
                     error_code="session_expired",
                     status_code=401,
                     user_action_required=True,


### PR DESCRIPTION
## Summary
- remove the unused readiness probe parameter flagged by Sonar on `src/specify_cli/saas/readiness.py`
- deduplicate repeated Sonar literals in sync status output and SaaS tracker session-expiry handling
- reduce device-flow poller cognitive complexity by extracting response classification helpers without changing behavior

## Findings reviewed
- Open GitHub code-scanning alerts: none
- Open Dependabot alerts: none
- Secret scanning: disabled on this repository
- SonarCloud `main` quality gate is currently failing on `new_coverage` and `new_security_hotspots_reviewed`
- This PR addresses the actionable code-side Sonar issues from the recent readiness/sync/auth surfaces; it does not claim to resolve the repo-wide `new_coverage` debt or Sonar hotspot review-state metrics, which are tracked outside this patch

## Validation
- `PYTHONPATH=/tmp/spec-kitty-pydeps311:src python3.11 -m pytest tests/auth/test_device_flow_poller.py tests/saas/test_readiness_unit.py tests/sync/test_sync_status_command.py tests/sync/tracker/test_saas_client.py -q`
