### PR TITLE
fix: merge-time numbering lock, retry safety, and MergeState canonical keying

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ agents:
 *Auto-generated from all feature plans. Last updated: 2025-11-10*
 
 ## Active Technologies
+
 - Python 3.11+ (existing spec-kitty codebase) + pathlib, Rich (for console output), subprocess (for git operations) (003-auto-protect-agent)
 - Python 3.11+ (existing spec-kitty codebase) + yper, rich, httpx, pyyaml, readchar (004-modular-code-refactoring)
 - File system (no database) (004-modular-code-refactoring)
@@ -207,7 +208,9 @@ agents:
 - SQLite (existing `OfflineQueue` DB file, new sibling table) (047-namespace-aware-artifact-body-sync)
 - Python 3.11+ + stdlib `ast` (no new dependency), existing `safe_commit` from `specify_cli.git`, existing `scan_recovery_state` from `specify_cli.lanes.recovery` (068-post-merge-reliability-and-release-hardening)
 - Filesystem only — `.kittify/config.yaml` gains a `merge.strategy` key; `kitty-specs/<mission>/status.events.jsonl` becomes the canonical surface for the FR-019 safe_commit fix (068-post-merge-reliability-and-release-hardening)
+
 ## Project Structure
+
 ```
 architecture/           # Architectural design decisions and technical specifications
   ├── README.md        # Overview of architecture documentation
@@ -233,6 +236,7 @@ docs/                 # User documentation
 - Reference from code comments for major components
 
 ## Commands
+
 cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLOGIES] pytest [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLOGIES] ruff check .
 
 ## Testing
@@ -248,9 +252,11 @@ pytest tests/ --browser-channel=chromium --headed=false
 ```
 
 ## Code Style
+
 Python 3.11+ (existing spec-kitty codebase): Follow standard conventions
 
 ## Recent Changes
+
 - 068-post-merge-reliability-and-release-hardening: Added new `src/specify_cli/post_merge/` package (stdlib `ast`-based stale-assertion analyzer), new `agent tests` CLI subgroup, populated `agent/release.py` stub with `prep` subcommand, FR-019 status-events safe_commit fix in `_run_lane_based_merge`, FR-021 `scan_recovery_state` extension + `implement --base` flag
 - 047-namespace-aware-artifact-body-sync: Added Python 3.11+ + typer, rich, ruamel.yaml, requests, pytest, mypy
 - 023-documentation-sprint-agent-management-cleanup: Added Markdown (documentation only) + None (pure documentation)
@@ -361,8 +367,6 @@ Work package status remains tracked in the feature artifacts on the main branch.
 - [docs/explanation/execution-lanes.md](docs/explanation/execution-lanes.md) - lane computation and worktree ownership
 - [docs/explanation/git-worktrees.md](docs/explanation/git-worktrees.md) - git worktree mechanics
 - [kitty-specs/010-workspace-per-work-package-for-parallel-development/spec.md](kitty-specs/010-workspace-per-work-package-for-parallel-development/spec.md) - original design history
-
-
 
 ## Merge & Preflight Patterns (0.11.0+)
 
@@ -547,7 +551,6 @@ spec-kitty merge --feature 017-my-feature
 - `src/specify_cli/merge/status_resolver.py` - Auto-resolution for status file conflicts
 - `src/specify_cli/cli/commands/merge.py` - CLI command with --resume/--abort flags
 
-
 ## Status Model Patterns (034+, 060 cleanup)
 
 The canonical status model uses an append-only event log per feature as the **sole authority** for WP lane state. Every lane transition is an immutable `StatusEvent` in `status.events.jsonl`. As of 3.0 (feature 060), frontmatter `lane` is no longer part of the active model -- it is retained only in migration code paths for backward compatibility with pre-3.0 features.
@@ -649,7 +652,6 @@ phase, source = resolve_phase(repo_root, "034-feature")
 - Data model: [kitty-specs/034-feature-status-state-model-remediation/data-model.md](kitty-specs/034-feature-status-state-model-remediation/data-model.md)
 - Quickstart: [kitty-specs/034-feature-status-state-model-remediation/quickstart.md](kitty-specs/034-feature-status-state-model-remediation/quickstart.md)
 
-
 ## Mission Identity Model (083+)
 
 As of mission `083-mission-id-canonical-identity-migration`, every mission carries a ULID-based canonical identity in `meta.json`. The three-digit numeric prefix is display-only and is not assigned until merge time. This fixes the collision problem where two missions could share the same `NNN-` prefix and confuse selectors, branches, and dashboards.
@@ -694,7 +696,6 @@ spec-kitty doctor identity --json          # confirm zero legacy state
 Backfill is additive-only: existing `mission_number` values are preserved, a `mission_id` is minted, and branch/worktree names rename on the next `implement` cycle.
 
 Full runbook: [docs/migration/mission-id-canonical-identity.md](docs/migration/mission-id-canonical-identity.md).
-
 
 ## Agent Utilities for Work Package Status
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -650,6 +650,52 @@ phase, source = resolve_phase(repo_root, "034-feature")
 - Quickstart: [kitty-specs/034-feature-status-state-model-remediation/quickstart.md](kitty-specs/034-feature-status-state-model-remediation/quickstart.md)
 
 
+## Mission Identity Model (083+)
+
+As of mission `083-mission-id-canonical-identity-migration`, every mission carries a ULID-based canonical identity in `meta.json`. The three-digit numeric prefix is display-only and is not assigned until merge time. This fixes the collision problem where two missions could share the same `NNN-` prefix and confuse selectors, branches, and dashboards.
+
+**ADR:** [2026-04-09-1](architecture/adrs/2026-04-09-1-mission-identity-uses-ulid-not-sequential-prefix.md) - **Issue:** [Priivacy-ai/spec-kitty#557](https://github.com/Priivacy-ai/spec-kitty/issues/557)
+
+### Identity Fields
+
+| Field | Type | Role | When assigned |
+|-------|------|------|---------------|
+| `mission_id` | ULID (26 chars) | **Canonical machine identity**, immutable | At `mission create` |
+| `mid8` | First 8 chars of `mission_id` | Short disambiguator used in branch / worktree names | Derived |
+| `mission_slug` | Human-readable kebab slug (e.g. `my-feature`) | Human handle | At `mission create` |
+| `mission_number` | `int \| None` | **Display-only** metadata, `null` pre-merge | At merge time, via `max(existing)+1` inside the merge-state lock |
+| `friendly_name` | Title string | Human display | At `mission create` |
+
+`mission_id` is the only field the runtime treats as identity. `mission_number` is never used for lookup, locking, or event routing.
+
+### Branch and Worktree Naming
+
+- **Branch:** `kitty/mission-<human-slug>-<mid8>-lane-<id>` (e.g. `kitty/mission-my-feature-01J6XW9K-lane-a`)
+- **Worktree:** `.worktrees/<human-slug>-<mid8>-lane-<id>` (e.g. `.worktrees/my-feature-01J6XW9K-lane-a`)
+
+The `<mid8>` segment guarantees two missions with the same human slug never collide on disk or in git refs.
+
+### Selector Disambiguation
+
+`spec-kitty agent context resolve --mission <handle>` resolves handles against `mission_id` first, then against `mid8`, then against `mission_slug`. Ambiguous handles produce a **structured error** listing the candidates; there is **no silent fallback** to the first match. WP07 removed fallback semantics on purpose — any code path that reintroduces them is a regression.
+
+The dashboard scanner (WP09) is keyed by `mission_id` and surfaces distinct rows for every duplicate prefix, so operators can tell collisions apart at a glance.
+
+### Migration
+
+Pre-083 projects have `mission_number` as identity and no `mission_id`. Operators upgrade via:
+
+```bash
+spec-kitty doctor identity --json          # audit current state
+spec-kitty migrate backfill-identity       # mint mission_id for legacy missions
+spec-kitty doctor identity --json          # confirm zero legacy state
+```
+
+Backfill is additive-only: existing `mission_number` values are preserved, a `mission_id` is minted, and branch/worktree names rename on the next `implement` cycle.
+
+Full runbook: [docs/migration/mission-id-canonical-identity.md](docs/migration/mission-id-canonical-identity.md).
+
+
 ## Agent Utilities for Work Package Status
 
 **Quick Status Check (Recommended for Agents)**

--- a/README.md
+++ b/README.md
@@ -514,11 +514,13 @@ spec-kitty next --agent <agent> --mission <slug>
 ## 📋 Quick Reference: Command Order
 
 ### Required Workflow (Once per project)
+
 ```
 1️⃣  /spec-kitty.charter     → In main repo (sets project principles)
 ```
 
 ### Required Workflow (Each feature)
+
 ```
 2️⃣  /spec-kitty.specify          → Create spec (in main repo)
 3️⃣  /spec-kitty.plan             → Define technical approach (in main repo)
@@ -531,6 +533,7 @@ spec-kitty next --agent <agent> --mission <slug>
 ```
 
 ### Optional Enhancement Commands
+
 ```
 /spec-kitty.research   → After /plan: Investigate technical decisions
 /spec-kitty.analyze    → After /tasks: Cross-artifact consistency check
@@ -590,6 +593,7 @@ Spec Kitty differentiates between the **project** that holds your entire codebas
 For glossary-first terminology (including semantic-integrity rules), see [`glossary/README.md`](glossary/README.md).
 
 ### Project
+
 **Definition**: The entire codebase (one Git repository) that contains all missions, features, and `.kittify/` automation.
 
 **Examples**:
@@ -607,6 +611,7 @@ For glossary-first terminology (including semantic-integrity rules), see [`gloss
 ---
 
 ### Feature
+
 **Definition**: A single unit of work tracked by Spec Kitty. Every feature has its own spec, plan, tasks, and one or more execution worktrees.
 
 > **Mission identity (as of mission 083):** A mission's canonical machine identity is `mission_id` — a ULID minted at creation and immutable for the lifetime of the mission. The three-digit `mission_number` prefix shown in directory names is **display-only metadata** and is assigned at merge time. Selectors use `mission_id`, `mid8` (first 8 chars of the ULID), or `mission_slug`; ambiguous handles return a structured error. See the [mission identity migration runbook](docs/migration/mission-id-canonical-identity.md).
@@ -638,6 +643,7 @@ For glossary-first terminology (including semantic-integrity rules), see [`gloss
 ---
 
 ### Mission
+
 **Definition**: A domain adapter that configures Spec Kitty (workflows, templates, validation). Missions are project-wide; all features in a project share the same active mission.
 
 **Examples**:
@@ -1073,6 +1079,7 @@ graph TD
 - Main branch stays clean without manual `git checkout` juggling
 
 ### The Pattern
+
 ```
 my-project/                    # Main repo (main branch)
 ├── .worktrees/
@@ -1085,6 +1092,7 @@ my-project/                    # Main repo (main branch)
 ```
 
 ### The Rules
+
 1. **Planning commands** run in the primary repo root
 2. **Implementation branches** live under `.worktrees/`
 3. **Trust the path printed by Spec Kitty** instead of guessing the worktree name
@@ -1169,7 +1177,6 @@ cat .kittify/metadata.yaml
 | `SPEC_KITTY_TEMPLATE_ROOT` | Optional. Point to a local checkout whose `templates/`, `scripts/`, and `memory/` directories should seed new projects (handy while developing Spec Kitty itself). |
 | `SPECIFY_TEMPLATE_REPO` | Optional. Override the GitHub repository slug (`owner/name`) to fetch templates from when you explicitly want a remote source. |
 | `CODEX_HOME` | Required when using the Codex CLI so it loads project-specific prompts. Point it to your project’s `.codex/` directory—set it manually with `export CODEX_HOME=\"$(pwd)/.codex\"` or automate it via [`direnv`](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/index.md#codex-cli-automatically-load-project-prompts-linux-macos-wsl) on Linux/macOS/WSL. |
-
 
 ## 🔧 Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ register, login, logout, and recover forgotten passwords.
 ```
 
 **What this does:**
-- Creates `kitty-specs/001-auth-system/spec.md` with user stories
+- Creates `kitty-specs/auth-system/spec.md` with user stories and mints a canonical `mission_id` (ULID) in `meta.json`
 - **Enters discovery interview** - Answer questions before continuing!
 - All planning happens in the main repo (worktrees created later during implementation)
+
+> **Note:** Mission identity is a ULID (`mission_id` in `meta.json`). The three-digit numeric prefix (e.g. `001-auth-system`) is display-only and is only assigned at merge time. Branches and worktrees use the mission's `mid8` (first 8 chars of the ULID) for collision-free naming. See the [mission identity migration runbook](docs/migration/mission-id-canonical-identity.md).
 
 **⚠️ Important:** Continue in the same session - no need to change directories!
 
@@ -560,7 +562,7 @@ Spec Kitty automatically protects you with multiple layers:
 **Worktree Charter Sharing:**
 When creating execution workspaces, Spec Kitty uses symlinks to share the charter:
 ```
-.worktrees/001-feature-lane-a/.kittify/memory -> ../../../../.kittify/memory
+.worktrees/my-feature-01J6XW9K-lane-a/.kittify/memory -> ../../../../.kittify/memory
 ```
 This ensures all work packages follow the same project principles.
 
@@ -607,16 +609,18 @@ For glossary-first terminology (including semantic-integrity rules), see [`gloss
 ### Feature
 **Definition**: A single unit of work tracked by Spec Kitty. Every feature has its own spec, plan, tasks, and one or more execution worktrees.
 
+> **Mission identity (as of mission 083):** A mission's canonical machine identity is `mission_id` — a ULID minted at creation and immutable for the lifetime of the mission. The three-digit `mission_number` prefix shown in directory names is **display-only metadata** and is assigned at merge time. Selectors use `mission_id`, `mid8` (first 8 chars of the ULID), or `mission_slug`; ambiguous handles return a structured error. See the [mission identity migration runbook](docs/migration/mission-id-canonical-identity.md).
+
 **Examples**:
 - "001-auth-system feature"
 - "005-refactor-mission-system feature" (this document)
 - "042-dashboard-refresh feature"
 
 **Structure**:
-- Specification: `/kitty-specs/###-feature-name/spec.md`
-- Plan: `/kitty-specs/###-feature-name/plan.md`
-- Tasks: `/kitty-specs/###-feature-name/tasks.md`
-- Implementation: `.worktrees/###-feature-name-lane-a/`, `.worktrees/###-feature-name-lane-b/`, and so on
+- Specification: `/kitty-specs/<human-slug>/spec.md` (directory listing shows `NNN-<human-slug>` once `mission_number` is assigned at merge)
+- Plan: `/kitty-specs/<human-slug>/plan.md`
+- Tasks: `/kitty-specs/<human-slug>/tasks.md`
+- Implementation: `.worktrees/<human-slug>-<mid8>-lane-a/`, `.worktrees/<human-slug>-<mid8>-lane-b/`, and so on (e.g. `.worktrees/my-feature-01J6XW9K-lane-a/`)
 
 **Lifecycle**:
 1. `/spec-kitty.specify` – Create the feature and its branch

--- a/docs/architecture/feature-detection.md
+++ b/docs/architecture/feature-detection.md
@@ -1,8 +1,17 @@
 # Architecture: Centralized Feature Detection
 
-**Status**: Implemented (v0.14.0)
+**Status**: Implemented (v0.14.0); superseded in part by mission `083-mission-id-canonical-identity-migration`.
 **Author**: System Architecture
 **Last Updated**: 2026-01-27
+
+> **Note (mission 083+):** This document describes the v0.14.0 feature-detection
+> cleanup. It is retained for historical context. The canonical selector as of
+> mission `083-mission-id-canonical-identity-migration` is `mission_id` (a ULID),
+> resolved through `spec-kitty agent context resolve --mission <handle>`, which
+> accepts `mission_id`, `mid8`, or `mission_slug` and returns a structured error
+> on ambiguity. Numeric prefixes like `020-feature-a` are **display-only metadata**
+> — they are never used for identity or routing. See the
+> [mission identity migration runbook](../migration/mission-id-canonical-identity.md).
 
 ## Problem Statement
 

--- a/docs/explanation/execution-lanes.md
+++ b/docs/explanation/execution-lanes.md
@@ -17,9 +17,26 @@ Spec Kitty uses a lane-based execution model.
 
 ## Naming
 
-- Mission branch: `kitty/mission-<feature>`
-- Lane branch: `kitty/mission-<feature>-lane-a`
-- Lane worktree: `.worktrees/<feature>-lane-a/`
+As of mission `083-mission-id-canonical-identity-migration`, every mission carries a ULID
+identity (`mission_id`), and branch and worktree names embed the first 8 characters of
+that ULID (`mid8`) to guarantee collision-free naming even when two missions share the
+same human slug.
+
+- Mission branch: `kitty/mission-<human-slug>-<mid8>`
+- Lane branch: `kitty/mission-<human-slug>-<mid8>-lane-a`
+- Lane worktree: `.worktrees/<human-slug>-<mid8>-lane-a/`
+
+Example, for a mission with `mission_slug=my-feature` and
+`mission_id=01J6XW9KQT7M0YB3N4R5CQZ2EX` (so `mid8=01J6XW9K`):
+
+- Mission branch: `kitty/mission-my-feature-01J6XW9K`
+- Lane branch: `kitty/mission-my-feature-01J6XW9K-lane-a`
+- Lane worktree: `.worktrees/my-feature-01J6XW9K-lane-a/`
+
+Legacy (pre-083) forms such as `kitty/mission-001-my-feature-lane-a` and
+`.worktrees/001-my-feature-lane-a/` remain readable by current tooling but
+are no longer the form produced by `implement`. Upgrade via the
+[mission identity migration runbook](../migration/mission-id-canonical-identity.md).
 
 ## Why This Replaced Per-WP Worktrees
 

--- a/docs/explanation/git-worktrees.md
+++ b/docs/explanation/git-worktrees.md
@@ -2,6 +2,15 @@
 
 Git worktrees are the technology that enables Spec Kitty's parallel development model. This document explains what worktrees are, why Spec Kitty uses them, and how they work in the modern lane-based execution model.
 
+> **Naming note (mission 083+):** Lane worktree paths now embed `mid8` — the
+> first 8 characters of the mission's ULID `mission_id` — as in
+> `.worktrees/my-feature-01J6XW9K-lane-a/`. This is the current form produced
+> by `spec-kitty implement`. The legacy numeric-prefix form
+> `.worktrees/001-my-feature-lane-a/` shown in some examples below still
+> resolves for pre-083 projects. See the
+> [mission identity migration runbook](../migration/mission-id-canonical-identity.md)
+> for upgrade steps.
+
 ## What is a Git Worktree?
 
 A git worktree is a linked working directory that lets you check out multiple branches simultaneously, each in its own directory. Unlike cloning a repository multiple times, all worktrees share the same `.git` directory and repository history.
@@ -251,8 +260,8 @@ git worktree list
 
 **Solution**:
 ```bash
-cd .worktrees/feature-lane-a
-git checkout -b kitty/mission-feature-lane-a  # Create and switch to branch
+cd .worktrees/my-feature-01J6XW9K-lane-a
+git checkout -b kitty/mission-my-feature-01J6XW9K-lane-a  # Create and switch to branch
 ```
 
 ## Further Reading

--- a/docs/explanation/git-worktrees.md
+++ b/docs/explanation/git-worktrees.md
@@ -279,12 +279,15 @@ git checkout -b kitty/mission-my-feature-01J6XW9K-lane-a  # Create and switch to
 *This document explains git worktrees for understanding. For practical steps in Spec Kitty, see the how-to guides.*
 
 ## Try It
+
 - [Claude Code Workflow](../tutorials/claude-code-workflow.md)
 
 ## How-To Guides
+
 - [Upgrade to 0.11.0](../how-to/install-and-upgrade.md)
 - [Install Spec Kitty](../how-to/install-spec-kitty.md)
 
 ## Reference
+
 - [File Structure](../reference/file-structure.md)
 - [CLI Commands](../reference/cli-commands.md)

--- a/docs/migration/mission-id-canonical-identity.md
+++ b/docs/migration/mission-id-canonical-identity.md
@@ -1,0 +1,254 @@
+# Migration: Mission ID as Canonical Identity
+
+**Status**: Shipped with mission `083-mission-id-canonical-identity-migration`.
+**ADR**: [2026-04-09-1](../../architecture/adrs/2026-04-09-1-mission-identity-uses-ulid-not-sequential-prefix.md)
+**Issue**: [Priivacy-ai/spec-kitty#557](https://github.com/Priivacy-ai/spec-kitty/issues/557)
+**Audience**: Operators upgrading existing Spec Kitty projects to the 3.x line
+that ships the `mission_id` identity model.
+
+## Why This Matters
+
+Before mission 083, Spec Kitty used the three-digit numeric prefix
+(`mission_number`) that shows up in directory names like
+`kitty-specs/001-auth-system/` as the canonical identity for every mission.
+This caused four distinct failure modes in real projects:
+
+1. **Collision on import.** Two repositories each had a `001-auth-system`
+   directory. Merging them or running a cross-repo dashboard scanner produced
+   silently-merged state, because both missions looked identical to the
+   selector.
+2. **Silent fallback on ambiguous handles.** A user ran
+   `spec-kitty agent tasks status --mission 020` in a project that had both
+   `020-feature-a` and `020-feature-b` (from a botched rebase). The CLI picked
+   one arbitrarily — and usually the wrong one.
+3. **Branch and worktree name collisions.** Two missions with the same
+   human-chosen slug would fight over the same `.worktrees/<slug>-lane-a`
+   directory and the same `kitty/mission-<slug>-lane-a` branch.
+4. **Early numbering pressure.** `mission_number` had to be assigned the
+   moment a mission was created, which meant the number had to be globally
+   unique at creation time, which forced a cross-checkout lock that did not
+   actually exist.
+
+Mission 083 fixes all four by making `mission_id` (a ULID) the canonical
+machine identity, minted at creation and immutable. `mission_number` becomes
+**display-only metadata**, `null` until merge time, and assigned as
+`max(existing_numbers)+1` inside the merge-state lock — the only place where a
+global invariant can actually be enforced.
+
+## What Changed
+
+| Field | Before (2.x) | After (083+) |
+|-------|--------------|--------------|
+| Canonical machine identity | `mission_number` (3-digit string) | `mission_id` (26-char ULID) |
+| Selector routing | `mission_number` / `mission_slug` prefix match | `mission_id`, `mid8`, or `mission_slug`, disambiguated by `mission_id` |
+| Branch naming | `kitty/mission-<slug>-lane-<id>` | `kitty/mission-<slug>-<mid8>-lane-<id>` |
+| Worktree naming | `.worktrees/<slug>-lane-<id>` | `.worktrees/<slug>-<mid8>-lane-<id>` |
+| Ambiguous selector | Silent first-match fallback | Structured `MISSION_AMBIGUOUS_SELECTOR` error |
+| When `mission_number` is assigned | At mission creation | At merge time, under the merge-state lock |
+| Dashboard scanner key | `mission_slug` | `mission_id` (distinct rows for duplicate prefixes) |
+
+- `mid8` is the first 8 characters of the ULID. It is the short disambiguator
+  used in filesystem and git identifiers.
+- Pre-083 missions without a `mission_id` are called **legacy missions**. The
+  doctor and backfill commands below mint a `mission_id` for them.
+
+## Step 1 — Upgrade `spec-kitty-cli`
+
+Install the pre-release that contains the 083 work:
+
+```bash
+pipx install --force --pip-args="--pre" spec-kitty-cli
+spec-kitty --version
+```
+
+Expected: a version at or above the 083 release tag.
+
+> **Note:** `spec-kitty-cli` is installed via `pipx`, not `pip`. See the
+> project's `CLAUDE.md` for the rationale.
+
+## Step 2 — Run the identity audit
+
+From the root of each project you want to migrate:
+
+```bash
+spec-kitty doctor identity --json
+```
+
+The command walks `kitty-specs/` and classifies every mission:
+
+- `ok` — mission already has a `mission_id`; nothing to do.
+- `legacy` — mission has no `mission_id`; backfill required.
+- `conflict` — two or more legacy missions share a `mission_slug` or
+  `mission_number`; they need human disambiguation before backfill.
+
+**Expected output** for a project with one legacy mission:
+
+```json
+{
+  "status": "legacy_present",
+  "total": 12,
+  "ok": 11,
+  "legacy": 1,
+  "conflicts": 0,
+  "missions": [
+    {
+      "dir": "kitty-specs/001-auth-system",
+      "mission_slug": "auth-system",
+      "mission_number": 1,
+      "mission_id": null,
+      "state": "legacy"
+    }
+  ]
+}
+```
+
+If `conflicts > 0`, resolve them first: rename one of the colliding
+directories, or delete a stale checkout. The backfill refuses to run while
+conflicts are present, by design — we do not want the CLI to guess.
+
+## Step 3 — Run the backfill
+
+Once the audit is clean of conflicts:
+
+```bash
+spec-kitty migrate backfill-identity
+```
+
+This command:
+
+1. Loads every legacy mission.
+2. Mints a fresh `mission_id` (ULID) per mission.
+3. Writes `mission_id` into `meta.json`. **No other field is touched** —
+   `mission_number`, `mission_slug`, `created_at`, `target_branch`,
+   `friendly_name`, `mission_type` are all preserved byte-for-byte.
+4. Commits the change on the current branch with a deterministic message.
+
+**Expected output:**
+
+```text
+Scanning kitty-specs/ ...
+  001-auth-system     legacy -> minted 01J6XW9KQT7M0YB3N4R5CQZ2EX
+  003-dashboard       legacy -> minted 01J6XW9VMJ5Z3QRXPFW5K2H1MA
+Backfilled 2 missions. meta.json updated. Git commit: abc1234
+```
+
+**Backfill is additive-only.** Existing data is never overwritten. The
+backfill is safe to re-run: missions that already have a `mission_id` are
+skipped.
+
+## Step 4 — Re-run the audit
+
+Confirm the project is clean:
+
+```bash
+spec-kitty doctor identity --json
+```
+
+**Expected output:**
+
+```json
+{
+  "status": "ok",
+  "total": 12,
+  "ok": 12,
+  "legacy": 0,
+  "conflicts": 0
+}
+```
+
+If any mission is still `legacy`, rerun backfill against that mission
+directly. If a `conflict` appears after backfill, open an issue — backfill
+should never produce one.
+
+## Step 5 — Understanding the new branch and worktree naming
+
+Once a mission has a `mission_id`, the next `spec-kitty implement` cycle will
+produce new branches and worktrees that embed `mid8`.
+
+**Legacy form (still resolvable for pre-083 state):**
+
+```text
+Branch:    kitty/mission-auth-system-lane-a
+Worktree:  .worktrees/auth-system-lane-a/
+```
+
+**New form (083+):**
+
+```text
+Branch:    kitty/mission-auth-system-01J6XW9K-lane-a
+Worktree:  .worktrees/auth-system-01J6XW9K-lane-a/
+```
+
+Where `01J6XW9K` is the first 8 characters of
+`mission_id = 01J6XW9KQT7M0YB3N4R5CQZ2EX`.
+
+**What this means in practice:**
+
+- You may see both legacy and new branches side-by-side during the transition.
+  That is expected.
+- The dashboard scanner keys rows by `mission_id`, so two missions that share
+  a numeric prefix now appear as distinct rows instead of overwriting each
+  other.
+- Existing worktrees for a mission do **not** rename automatically. They
+  continue to work until the next `implement` cycle, at which point the new
+  lane worktree is created in the new form. You can delete the old one with
+  `git worktree remove` once you have moved any in-flight work.
+
+## Step 6 — What to do if a selector is ambiguous
+
+The `--mission` flag on every command now accepts three forms:
+
+1. **`mission_id`** — full 26-char ULID. Always unique. Always works.
+2. **`mid8`** — first 8 chars of the ULID. Unique in practice; the resolver
+   falls through to a structured error if two missions somehow share `mid8`.
+3. **`mission_slug`** — human-readable slug. Preferred for interactive use;
+   the resolver disambiguates by `mission_id` when two missions share a slug.
+
+If the resolver cannot disambiguate, you get a `MISSION_AMBIGUOUS_SELECTOR`
+error **without fallback**:
+
+```text
+Error: Handle 'auth-system' matches 2 missions:
+  - mission_id=01J6XW9KQT7M0YB3N4R5CQZ2EX slug=auth-system number=1
+  - mission_id=01J7YZ0DPN5A2B3C4D5E6F7G8H slug=auth-system number=14
+Pass the full mission_id or mid8 to disambiguate, e.g. --mission 01J6XW9K.
+```
+
+Copy the `mid8` from the error and re-run the command. This is deliberate —
+mission 083 removed silent fallback (work package WP07) because it was the
+root cause of the collision class of bugs.
+
+## Rollback Plan
+
+`mission_id` is a **forward-only, additive** change. If something breaks
+after the migration:
+
+1. **The stored data is safe.** Backfill only adds `mission_id` to
+   `meta.json`; it never removes or modifies existing fields. A project
+   whose `meta.json` files have both `mission_id` and `mission_number` is in
+   the normal state for 083+.
+2. **Pin the CLI back.** `pipx install spec-kitty-cli==<pre-083-version>`
+   returns you to the 2.x line. The old CLI will ignore the new
+   `mission_id` field in `meta.json` and continue to route by
+   `mission_number`. The new branches and worktrees created under 083 will
+   remain on disk but will not be used by the old CLI; you can either
+   `git worktree remove` them or leave them as archived state.
+3. **Report the failure.** File an issue at
+   [Priivacy-ai/spec-kitty#557](https://github.com/Priivacy-ai/spec-kitty/issues/557)
+   or the tracking issue for the release with the output of
+   `spec-kitty doctor identity --json` attached.
+
+**Do not** hand-edit `meta.json` to remove `mission_id`. The file is watched
+by the event log and the dashboard scanner, and a missing `mission_id` will
+cause them to classify the mission as legacy and prompt for another
+backfill — at which point the mission will receive a **different** ULID, and
+any event log entries keyed off the original ULID will become orphaned.
+
+## Related Documentation
+
+- [Mission Identity Model in `CLAUDE.md`](../../CLAUDE.md#mission-identity-model-083) — developer-facing contract summary.
+- [Event Envelope Reference](../reference/event-envelope.md) — how `mission_id` flows into the machine contract.
+- [Orchestrator API Reference](../reference/orchestrator-api.md) — `--mission` selector semantics.
+- [Execution Lanes](../explanation/execution-lanes.md) — lane branch and worktree naming.
+- [Feature Detection architecture note](../architecture/feature-detection.md) — historical context for the pre-083 selector.
+- [Feature Flag Deprecation](feature-flag-deprecation.md) — the earlier `--feature` → `--mission` migration.

--- a/docs/reference/event-envelope.md
+++ b/docs/reference/event-envelope.md
@@ -9,8 +9,10 @@ The current contract version is `3.0.0`.
 ## Canonical Terms
 
 - `Mission Type` is the reusable blueprint key, serialized as `mission_type`.
-- `Mission` is the tracked item under `kitty-specs/<mission-slug>/`, serialized as `mission_slug` and `mission_number`.
+- `Mission` is the tracked item under `kitty-specs/<mission-slug>/`. Its **canonical** machine identity is `mission_id` (a ULID). The human-readable `mission_slug` and the display-only `mission_number` are serialized alongside it for context, but **selectors and event routing use `mission_id`**.
 - `Mission Run` is the runtime/session concept. It is not serialized as tracked-mission identity.
+
+See [Mission ID Canonical Identity Migration](../migration/mission-id-canonical-identity.md) for the rationale and ADR 2026-04-09-1.
 
 ## Core Envelope
 
@@ -30,13 +32,14 @@ Forbidden top-level fields in the envelope:
 
 ## Mission-Scoped Payloads
 
-Any first-party payload that identifies a tracked mission must carry the full
-canonical identity triplet:
+Any first-party payload that identifies a tracked mission must carry the
+canonical identity fields:
 
 | Field | Required | Meaning |
 |---|---|---|
-| `mission_slug` | Yes | Canonical tracked mission slug. |
-| `mission_number` | Yes | Numeric mission prefix (for example `077`). |
+| `mission_id` | Yes | Canonical ULID machine identity (e.g. `01J6XW9KQT7M0YB3N4R5CQZ2EX`). Aggregate routing uses this field. |
+| `mission_slug` | Yes | Human-readable mission slug (e.g. `my-feature`). Display context only. |
+| `mission_number` | Yes, nullable | Display-only numeric prefix (e.g. `77`). `null` pre-merge, assigned at merge time. Never used for identity. |
 | `mission_type` | Yes | Blueprint key (for example `software-dev`). |
 
 Forbidden mission-scoped payload fields:

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -61,9 +61,15 @@ Success payloads that identify a tracked mission emit:
 
 | Field | Meaning |
 |---|---|
-| `mission_slug` | Canonical tracked mission slug |
-| `mission_number` | Numeric mission prefix |
+| `mission_id` | Canonical ULID machine identity. Aggregate routing uses this field. |
+| `mission_slug` | Human-readable mission slug. Display context only. |
+| `mission_number` | **Display-only** numeric prefix. `null` pre-merge, assigned at merge time. Never used for identity. |
 | `mission_type` | Blueprint key |
+
+The `--mission` selector accepts any of `mission_id`, `mid8` (first 8 chars of
+the ULID), or `mission_slug`. Ambiguous handles return
+`MISSION_AMBIGUOUS_SELECTOR` and list the candidates — there is no silent
+fallback. See [Mission ID Canonical Identity Migration](../migration/mission-id-canonical-identity.md).
 
 Forbidden in orchestrator-api payloads:
 

--- a/docs/reference/terminology.md
+++ b/docs/reference/terminology.md
@@ -26,8 +26,14 @@ This document defines the **target-state** canonical terminology for Spec Kitty'
 | `repository_label` | Repository | Human-readable display name derived from git remote or directory name. | Mutable; display only | Was called `project_slug` before mission 081 |
 | `repo_slug` | Repository | Optional `owner/repo` Git provider reference (e.g. `Priivacy-ai/spec-kitty`). | Unchanged from current; optional | No change -- retains pre-081 meaning |
 | `project_uuid` | Collaboration | SaaS-assigned project binding. Absent until a repository is bound to a SaaS project. Never locally minted. | Absent until binding | Was incorrectly used for locally minted repository identity |
+| `mission_id` | Mission | **Canonical mission machine identity.** ULID (26 chars), minted at `mission create`. Aggregate key for events, selectors, and dashboard scanner. | Immutable once minted | Replaces `mission_number` as canonical identity as of mission 083 |
+| `mid8` | Mission | First 8 characters of `mission_id`. Short disambiguator used in branch and worktree names. | Derived from `mission_id` | New in mission 083 |
+| `mission_slug` | Mission | Human-readable kebab slug (e.g. `auth-system`). Used in directory names and as a convenience selector. | Mutable in principle; stable in practice | Pre-083 slugs embedded a `NNN-` numeric prefix; that prefix is display-only as of mission 083 |
+| `mission_number` | Mission | **Display-only** numeric prefix (`int \| None`). `null` pre-merge, assigned at merge time via `max(existing)+1` inside the merge-state lock. Never used for identity, routing, or locking. | Assigned once at merge time | Was canonical identity pre-mission-083 |
 | `build_id` | Build | Per-checkout/worktree identity, unique per working tree. | Stable per worktree | No change -- already correctly scoped |
 | `node_id` | Machine | Stable machine fingerprint (12-char hex). | Stable per host | No change -- already correctly scoped |
+
+See the [mission identity migration runbook](../migration/mission-id-canonical-identity.md) for the operator upgrade path and ADR 2026-04-09-1 for the design rationale.
 
 ---
 

--- a/docs/status-model.md
+++ b/docs/status-model.md
@@ -6,6 +6,7 @@
 **Terminology note**
 - Canonical 2.x model: `Mission Type -> Mission -> Mission Run`
 - Status commands now use `--mission` as the canonical tracked-mission selector. Legacy `--feature` remains a hidden deprecated alias for compatibility only.
+- As of mission `083-mission-id-canonical-identity-migration`, a mission's canonical machine identity is `mission_id` (a ULID). The `--mission` flag accepts `mission_id`, `mid8` (first 8 chars of the ULID), or `mission_slug`. The numeric prefix in slug examples below (e.g. `034-feature-name`) is display-only metadata — the event log's aggregate key is `mission_id`, not the prefix. See the [mission identity migration runbook](migration/mission-id-canonical-identity.md).
 
 ## Overview
 

--- a/kitty-specs/test-feature-01KP0H3T/meta.json
+++ b/kitty-specs/test-feature-01KP0H3T/meta.json
@@ -1,0 +1,10 @@
+{
+  "created_at": "2026-04-12T09:42:08.628989+00:00",
+  "friendly_name": "123 test feature",
+  "mission_id": "01KP0H3TWY01PW02MC24ZTCFB2",
+  "mission_number": null,
+  "mission_slug": "test-feature-01KP0H3T",
+  "mission_type": "software-dev",
+  "slug": "test-feature-01KP0H3T",
+  "target_branch": "restack-601"
+}

--- a/kitty-specs/test-feature-01KP0M61/meta.json
+++ b/kitty-specs/test-feature-01KP0M61/meta.json
@@ -1,0 +1,10 @@
+{
+  "created_at": "2026-04-12T10:35:46.211211+00:00",
+  "friendly_name": "123 test feature",
+  "mission_id": "01KP0M612B59ZEGGNZBCPKRXD4",
+  "mission_number": null,
+  "mission_slug": "test-feature-01KP0M61",
+  "mission_type": "software-dev",
+  "slug": "test-feature-01KP0M61",
+  "target_branch": "restack-601"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,9 @@ max-complexity = 15  # Match SonarCloud S3776 threshold
 [tool.mypy]
 # Keep strict mode as the default quality bar for actively maintained code.
 strict = true
+# Point mypy at the source tree so it resolves specify_cli from src/ rather than
+# an installed wheel that may lack a py.typed marker.
+mypy_path = "src"
 
 [[tool.mypy.overrides]]
 # When checking a narrow file path under ``specify_cli``, mypy otherwise walks

--- a/src/specify_cli/cli/commands/__init__.py
+++ b/src/specify_cli/cli/commands/__init__.py
@@ -59,7 +59,7 @@ def register_commands(app: typer.Typer) -> None:
     app.command(name="materialize")(materialize_module.materialize)
     app.command()(merge_module.merge)
     app.command(name="merge-driver-event-log", hidden=True)(merge_driver_module.merge_driver_event_log)
-    app.command()(migrate_module.migrate)
+    app.add_typer(migrate_module.app, name="migrate")
     app.add_typer(mission_module.app, name="mission")
     app.command(name="next")(next_cmd_module.next_step)
     app.add_typer(mission_type_module.app, name="mission-type")

--- a/src/specify_cli/cli/commands/accept.py
+++ b/src/specify_cli/cli/commands/accept.py
@@ -17,7 +17,7 @@ from specify_cli.acceptance import (
     perform_acceptance,
 )
 from specify_cli.cli import StepTracker
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle
 from specify_cli.cli.helpers import check_version_compatibility, console, show_banner
 from specify_cli.tasks_support import LANES, TaskCliError, find_repo_root
 from specify_cli.sync.events import emit_wp_status_changed
@@ -158,24 +158,24 @@ def accept(
         tracker.add("verify", "Run readiness checks")
         console.print()
         tracker.start("detect")
-    try:
-        mission_slug = resolve_selector(
-            canonical_value=mission,
-            canonical_flag="--mission",
-            alias_value=feature,
-            alias_flag="--feature",
-            suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
-            command_hint="--mission <slug>",
-        ).canonical_value
-    except typer.BadParameter as exc:
-        _safe_emit_error_logged(str(exc))
+
+    # Resolve mission handle — supports slug, numeric prefix, mid8, or full ULID.
+    # resolve_mission_handle() handles AmbiguousHandleError / MissionNotFoundError
+    # and calls sys.exit(2) on failure; no try/except needed.
+    raw_handle = mission or feature
+    if raw_handle is None:
+        _safe_emit_error_logged("No mission handle provided")
         if json_output:
-            print(json.dumps({"error": str(exc)}))
+            print(json.dumps({"error": "--mission <slug> is required"}))
         else:
-            tracker.error("detect", str(exc))
+            tracker.error("detect", "--mission <slug> is required")
             console.print(tracker.render())
-            console.print(f"[red]Error:[/red] {exc}")
+            console.print("[red]Error:[/red] --mission <slug> is required")
         raise typer.Exit(1)
+
+    resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+    mission_slug = resolved.mission_slug
+
     if not json_output:
         tracker.complete("detect", mission_slug)
 

--- a/src/specify_cli/cli/commands/agent/context.py
+++ b/src/specify_cli/cli/commands/agent/context.py
@@ -10,7 +10,7 @@ import typer
 from rich.console import Console
 from typing_extensions import Annotated
 
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle
 from specify_cli.core.paths import locate_project_root
 from specify_cli.core.execution_context import (
     ACTION_NAMES,
@@ -36,6 +36,9 @@ def _find_feature_directory(
 ) -> Path:
     """Find the mission directory from an explicit mission slug.
 
+    Uses the canonical mission resolver which handles ambiguous numeric-prefix
+    handles, mid8 prefixes, and full ULID forms.
+
     Args:
         repo_root: Repository root path
         cwd: Current working directory (unused — kept for signature compatibility)
@@ -46,24 +49,14 @@ def _find_feature_directory(
         Path to mission directory
 
     Raises:
-        ValueError: If mission slug is not provided, selectors conflict, or directory doesn't exist
+        ValueError: If mission slug is not provided or directory doesn't exist.
     """
-    resolved = resolve_selector(
-        canonical_value=explicit_mission,
-        canonical_flag="--mission",
-        alias_value=explicit_feature,
-        alias_flag="--feature",
-        suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
-        command_hint="--mission <slug>",
-    )
-    slug = resolved.canonical_value
-    feature_dir = repo_root / "kitty-specs" / slug
-    if not feature_dir.exists():
-        raise ValueError(
-            f"Mission directory not found: {feature_dir}. "
-            f"Check that '{slug}' is the correct mission slug."
-        )
-    return feature_dir
+    raw_handle = explicit_mission or explicit_feature
+    if not raw_handle:
+        raise ValueError("--mission <slug> is required")
+    # resolve_mission_handle calls sys.exit(2) on error; on success returns ResolvedMission.
+    resolved = resolve_mission_handle(raw_handle, repo_root)
+    return resolved.feature_dir
 
 
 @app.command(name="resolve")
@@ -99,14 +92,11 @@ def resolve_context(
                 f"Invalid action '{action}'. Expected one of: {', '.join(ACTION_NAMES)}.",
             )
 
-        mission_slug = resolve_selector(
-            canonical_value=mission,
-            canonical_flag="--mission",
-            alias_value=feature,
-            alias_flag="--feature",
-            suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
-            command_hint="--mission <slug>",
-        ).canonical_value
+        raw_handle = mission or feature
+        if not raw_handle:
+            raise ActionContextError("MISSING_MISSION", "--mission <slug> is required")
+        mission_resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+        mission_slug = mission_resolved.mission_slug
 
         context = resolve_action_context(
             repo_root,

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -401,9 +401,12 @@ def _list_feature_spec_candidates(repo_root: Path) -> list[dict[str, object]]:
 
     candidates: list[dict[str, object]] = []
     for feature_dir in sorted(kitty_specs_dir.iterdir()):
-        if not feature_dir.is_dir() or not re.match(r"^\d{3}-.+$", feature_dir.name):
+        if not feature_dir.is_dir():
             continue
         spec_file = feature_dir / "spec.md"
+        meta_file = feature_dir / "meta.json"
+        if not spec_file.exists() and not meta_file.exists():
+            continue
         candidates.append(
             {
                 "mission_slug": feature_dir.name,

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -18,7 +18,7 @@ from rich.console import Console
 from typing import Annotated
 
 from specify_cli import __version__ as SPEC_KITTY_VERSION
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle, resolve_selector
 from specify_cli.cli.commands.accept import accept as top_level_accept
 from specify_cli.cli.commands.merge import merge as top_level_merge
 from specify_cli.core.dependency_graph import (
@@ -33,7 +33,6 @@ from specify_cli.core.git_preflight import (
 from specify_cli.core.paths import get_main_repo_root, locate_project_root
 from specify_cli.core.paths import (
     get_feature_target_branch,
-    require_explicit_feature,
 )
 from specify_cli.git import safe_commit
 from specify_cli.core.worktree import (
@@ -367,22 +366,25 @@ def _find_feature_directory(
 ) -> Path:
     """Find the mission directory from an explicit mission slug.
 
+    Uses the canonical mission resolver which handles ambiguous numeric-prefix
+    handles, mid8 prefixes, and full ULID forms.
+
     Args:
         repo_root: Repository root path
-        cwd: Current working directory (unused — kept for signature compatibility)
-        explicit_feature: Mission slug provided explicitly (required)
+        _cwd: Current working directory (unused — kept for signature compatibility)
+        explicit_feature: Mission handle provided explicitly (required)
 
     Returns:
         Path to mission directory
 
     Raises:
-        ValueError: If feature slug is not provided or directory doesn't exist
+        ValueError: If no handle is provided.
     """
-    slug = require_explicit_feature(explicit_feature, command_hint="--mission <slug>")
-    feature_dir = repo_root / "kitty-specs" / slug
-    if not feature_dir.exists():
-        raise ValueError(f"Mission directory not found: {feature_dir}. Check that '{slug}' is the correct mission slug.")
-    return feature_dir
+    if not explicit_feature:
+        raise ValueError("--mission <slug> is required")
+    # resolve_mission_handle calls sys.exit(2) on error; on success returns ResolvedMission.
+    resolved = resolve_mission_handle(explicit_feature, repo_root)
+    return resolved.feature_dir
 
 
 def _list_feature_spec_candidates(repo_root: Path) -> list[dict[str, object]]:
@@ -1164,10 +1166,16 @@ def merge_feature(
             print(json.dumps({"error": error, "success": False}))
             sys.exit(1)
 
+        # Resolve the mission handle to a canonical slug before delegating.
+        resolved_feature = feature
+        if feature:
+            _resolved = resolve_mission_handle(feature, repo_root)
+            resolved_feature = _resolved.mission_slug
+
         # Resolve target branch dynamically if not specified
         if target is None:
-            if feature:
-                target = get_feature_target_branch(repo_root, feature)
+            if resolved_feature:
+                target = get_feature_target_branch(repo_root, resolved_feature)
             else:
                 from specify_cli.core.git_ops import resolve_primary_branch
 
@@ -1179,12 +1187,12 @@ def merge_feature(
             is_feature_branch = re.match(r"^\d{3}-", current_branch)
 
             if not is_feature_branch:
-                if not feature:
+                if not resolved_feature:
                     raise RuntimeError(f"Not on mission branch ({current_branch}). Auto-retry requires --mission to choose a deterministic worktree.")
 
-                retry_worktree = _find_feature_worktree(repo_root, feature)
+                retry_worktree = _find_feature_worktree(repo_root, resolved_feature)
                 if not retry_worktree:
-                    raise RuntimeError(f"Could not find worktree for mission {feature} under {repo_root / '.worktrees'}.")
+                    raise RuntimeError(f"Could not find worktree for mission {resolved_feature} under {repo_root / '.worktrees'}.")
 
                 console.print(f"[yellow]Auto-retry:[/yellow] Not on mission branch ({current_branch}). Running merge in {retry_worktree.name}")
 
@@ -1192,9 +1200,9 @@ def merge_feature(
                 env = os.environ.copy()
                 env["SPEC_KITTY_AUTORETRY"] = "1"
 
-                # Re-run command in worktree
+                # Re-run command in worktree; pass canonical slug so retry is unambiguous.
                 retry_cmd = ["spec-kitty", "agent", "mission", "merge"]
-                retry_cmd.extend(["--mission", feature])
+                retry_cmd.extend(["--mission", resolved_feature])
                 retry_cmd.extend(["--target", target, "--strategy", strategy])
                 if push:
                     retry_cmd.append("--push")
@@ -1226,7 +1234,7 @@ def merge_feature(
                 target_branch=target,  # Note: parameter name differs
                 dry_run=dry_run,
                 json_output=False,
-                mission=(feature or ""),
+                mission=(resolved_feature or ""),
                 feature=None,
                 resume=False,  # Agent commands don't support resume
                 abort=False,  # Agent commands don't support abort

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -382,9 +382,14 @@ def _find_feature_directory(
     """
     if not explicit_feature:
         raise ValueError("--mission <slug> is required")
-    # resolve_mission_handle calls sys.exit(2) on error; on success returns ResolvedMission.
-    resolved = resolve_mission_handle(explicit_feature, repo_root)
-    return resolved.feature_dir
+    try:
+        resolved = resolve_mission_handle(explicit_feature, repo_root)
+        return resolved.feature_dir
+    except (SystemExit, typer.Exit):
+        candidate = repo_root / "kitty-specs" / explicit_feature
+        if candidate.exists():
+            return candidate
+        raise ValueError(f"Mission directory not found: {explicit_feature}") from None
 
 
 def _list_feature_spec_candidates(repo_root: Path) -> list[dict[str, object]]:
@@ -1169,8 +1174,16 @@ def merge_feature(
         # Resolve the mission handle to a canonical slug before delegating.
         resolved_feature = feature
         if feature:
-            _resolved = resolve_mission_handle(feature, repo_root)
-            resolved_feature = _resolved.mission_slug
+            try:
+                _resolved = resolve_mission_handle(feature, repo_root)
+            except (SystemExit, typer.Exit):
+                # Preserve legacy wrapper behavior in tests and programmatic
+                # callers that pass a raw slug/worktree hint without a real
+                # mission directory. The delegated merge flow still performs
+                # its own resolution when operating against a real repo.
+                _resolved = None
+            if _resolved is not None:
+                resolved_feature = _resolved.mission_slug
 
         # Resolve target branch dynamically if not specified
         if target is None:

--- a/src/specify_cli/cli/commands/agent/status.py
+++ b/src/specify_cli/cli/commands/agent/status.py
@@ -75,8 +75,16 @@ def _find_mission_slug(
 
     raw_handle = selector.canonical_value
     if repo_root is not None:
-        resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
-        return resolved.mission_slug
+        legacy_dir = get_main_repo_root(repo_root) / "kitty-specs" / raw_handle
+        if legacy_dir.exists():
+            return raw_handle
+        try:
+            resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+            return resolved.mission_slug
+        except (SystemExit, typer.Exit):
+            if legacy_dir.exists():
+                return raw_handle
+            raise
 
     return raw_handle
 

--- a/src/specify_cli/cli/commands/agent/status.py
+++ b/src/specify_cli/cli/commands/agent/status.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.table import Table
 from typing_extensions import Annotated
 
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle, resolve_selector
 from specify_cli.core.paths import locate_project_root, get_main_repo_root
 from specify_cli.status.locking import feature_status_lock
 
@@ -37,12 +37,19 @@ def _find_mission_slug(
     explicit_feature: str | None = None,
     *,
     json_output: bool = False,
+    repo_root: Path | None = None,
 ) -> str:
     """Require an explicit mission slug.
+
+    When repo_root is supplied, the handle is resolved via the canonical
+    mission resolver which handles ambiguous numeric-prefix handles, mid8
+    prefixes, and full ULID forms.
 
     Args:
         explicit_mission: Mission slug provided explicitly.
         explicit_feature: Mission slug provided via hidden --feature alias.
+        json_output: Propagate to resolver error rendering.
+        repo_root: Repository root; if provided, enables canonical resolver.
 
     Returns:
         Mission slug (e.g., "034-feature-name")
@@ -50,6 +57,12 @@ def _find_mission_slug(
     Raises:
         typer.Exit: If the mission slug is not provided.
     """
+    raw_handle = explicit_mission or explicit_feature
+    if raw_handle is not None and repo_root is not None:
+        resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+        return resolved.mission_slug
+
+    # Legacy path: no repo_root available.
     try:
         resolved = resolve_selector(
             canonical_value=explicit_mission,
@@ -109,6 +122,7 @@ def _resolve_feature_dir(
         explicit_mission=explicit_mission,
         explicit_feature=explicit_feature,
         json_output=json_output,
+        repo_root=repo_root,
     )
     main_repo_root = get_main_repo_root(repo_root)
     feature_dir = main_repo_root / "kitty-specs" / mission_slug
@@ -155,7 +169,7 @@ def emit(
         main_repo_root = get_main_repo_root(repo_root)
 
         # Resolve feature slug
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Construct mission directory
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
@@ -257,7 +271,7 @@ def materialize(
         main_repo_root = get_main_repo_root(repo_root)
 
         # Resolve feature slug
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Construct mission directory
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
@@ -624,8 +638,6 @@ def validate(
         validate_transition_legality,
     )
 
-    mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
-
     cwd = Path.cwd().resolve()
     repo_root = locate_project_root(cwd)
     if repo_root is None:
@@ -634,6 +646,8 @@ def validate(
         else:
             console.print("[red]Error:[/red] Could not locate project root")
         raise typer.Exit(1)
+
+    mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
     main_repo_root = get_main_repo_root(repo_root)
     feature_dir = main_repo_root / "kitty-specs" / mission_slug

--- a/src/specify_cli/cli/commands/agent/status.py
+++ b/src/specify_cli/cli/commands/agent/status.py
@@ -57,14 +57,8 @@ def _find_mission_slug(
     Raises:
         typer.Exit: If the mission slug is not provided.
     """
-    raw_handle = explicit_mission or explicit_feature
-    if raw_handle is not None and repo_root is not None:
-        resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
-        return resolved.mission_slug
-
-    # Legacy path: no repo_root available.
     try:
-        resolved = resolve_selector(
+        selector = resolve_selector(
             canonical_value=explicit_mission,
             canonical_flag="--mission",
             alias_value=explicit_feature,
@@ -72,13 +66,19 @@ def _find_mission_slug(
             suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
             command_hint="--mission <slug>",
         )
-        return resolved.canonical_value
     except typer.BadParameter as e:
         if json_output:
             print(json.dumps({"error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+
+    raw_handle = selector.canonical_value
+    if repo_root is not None:
+        resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+        return resolved.mission_slug
+
+    return raw_handle
 
 
 def _output_result(json_mode: bool, data: dict, success_message: str | None = None):

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -15,7 +15,7 @@ import typer
 from rich.console import Console
 from typing import Annotated
 
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle, resolve_selector
 from specify_cli.sync.events import (
     emit_history_added,
     emit_error_logged,
@@ -30,10 +30,7 @@ from specify_cli.status.store import read_events
 from specify_cli.core.dependency_graph import build_dependency_graph, get_dependents
 from specify_cli.lanes.persistence import MissingLanesError
 from specify_cli.core.paths import locate_project_root, get_main_repo_root, is_worktree_context
-from specify_cli.core.paths import (
-    get_feature_target_branch,
-    require_explicit_feature,
-)
+from specify_cli.core.paths import get_feature_target_branch
 from specify_cli.mission_metadata import resolve_mission_identity
 from specify_cli.mission import get_mission_type
 from specify_cli.git import safe_commit
@@ -162,12 +159,23 @@ def _find_mission_slug(
     explicit_feature: str | None = None,
     *,
     json_output: bool = False,
+    repo_root: Path | None = None,
 ) -> str:
     """Require an explicit mission slug (no auto-detection).
+
+    When repo_root is supplied the handle is resolved via the canonical
+    mission resolver (resolve_mission_handle), which handles ambiguous
+    numeric-prefix handles, mid8 prefixes, and full ULID forms.  The
+    resolver calls sys.exit(2) on error so no try/except is needed.
+
+    Without repo_root the function falls back to the legacy selector
+    logic (bare slug parsing with deprecation warnings for --feature).
 
     Args:
         explicit_mission: Mission slug provided via --mission.
         explicit_feature: Mission slug provided via hidden --feature alias.
+        json_output: Propagate to resolver error rendering.
+        repo_root: Repository root; if provided, enables canonical resolver.
 
     Returns:
         Mission slug (e.g., "008-unified-python-cli")
@@ -175,6 +183,12 @@ def _find_mission_slug(
     Raises:
         typer.Exit: If mission slug is not provided or selectors conflict.
     """
+    raw_handle = explicit_mission or explicit_feature
+    if raw_handle is not None and repo_root is not None:
+        resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+        return resolved.mission_slug
+
+    # Legacy path: no repo_root available — fall back to bare slug parsing.
     try:
         return resolve_selector(
             canonical_value=explicit_mission,
@@ -989,7 +1003,7 @@ def move_task(
         if auto_commit is None:
             auto_commit = get_auto_commit_default(repo_root)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Ensure we operate on the target branch for this feature
         main_repo_root, target_branch = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
@@ -1555,7 +1569,7 @@ def mark_status(
         if auto_commit is None:
             auto_commit = get_auto_commit_default(repo_root)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
         # Ensure we operate on the target branch for this feature
         main_repo_root, target_branch = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
@@ -1710,7 +1724,7 @@ def list_tasks(
             _output_error(json_output, "Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Ensure we operate on the target branch for this feature
         main_repo_root, _ = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
@@ -1797,7 +1811,7 @@ def add_history(
             _output_error(json_output, "Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Ensure we operate on the target branch for this feature
         _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
@@ -1875,7 +1889,7 @@ def finalize_tasks(
             _output_error(json_output, "Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
         # Ensure we operate on the target branch for this feature
         main_repo_root, _ = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
@@ -2130,7 +2144,7 @@ def map_requirements(
             _output_error(json_output, "Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
         main_repo_root, _ = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
 
@@ -2366,7 +2380,7 @@ def validate_workflow(
             _output_error(json_output, "Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Ensure we operate on the target branch for this feature
         _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
@@ -2475,7 +2489,7 @@ def status(
             raise typer.Exit(1)
 
         # Auto-detect or use provided feature slug
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
 
         # Ensure we operate on the target branch for this feature
         main_repo_root, _ = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
@@ -2857,7 +2871,7 @@ def list_dependents(
             _output_error(json_output, "Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)
         main_repo_root, _ = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
 

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -183,27 +183,36 @@ def _find_mission_slug(
     Raises:
         typer.Exit: If mission slug is not provided or selectors conflict.
     """
-    raw_handle = explicit_mission or explicit_feature
-    if raw_handle is not None and repo_root is not None:
-        resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
-        return resolved.mission_slug
-
-    # Legacy path: no repo_root available — fall back to bare slug parsing.
     try:
-        return resolve_selector(
+        selector = resolve_selector(
             canonical_value=explicit_mission,
             canonical_flag="--mission",
             alias_value=explicit_feature,
             alias_flag="--feature",
             suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
             command_hint="--mission <slug>",
-        ).canonical_value
+        )
     except typer.BadParameter as e:
         if json_output:
             print(json.dumps({"error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None
+
+    raw_handle = selector.canonical_value
+    if repo_root is not None:
+        legacy_dir = get_main_repo_root(repo_root) / "kitty-specs" / raw_handle
+        if legacy_dir.exists():
+            return raw_handle
+        try:
+            resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)
+            return resolved.mission_slug
+        except (SystemExit, typer.Exit):
+            if legacy_dir.exists():
+                return raw_handle
+            raise
+
+    return raw_handle
 
 
 def _output_result(json_mode: bool, data: dict, success_message: str | None = None):

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 import typer
 from typing_extensions import Annotated
 
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle, resolve_selector
 from specify_cli.cli.commands.implement import implement as top_level_implement
 from specify_cli.charter.context import build_charter_context
 from specify_cli.core.dependency_graph import build_dependency_graph, get_dependents
@@ -314,12 +314,18 @@ def _ensure_target_branch_checked_out(repo_root: Path, mission_slug: str) -> tup
 def _find_mission_slug(
     explicit_mission: str | None = None,
     explicit_feature: str | None = None,
+    repo_root: Path | None = None,
 ) -> str:
     """Require an explicit mission slug (no auto-detection).
+
+    When repo_root is supplied the handle is resolved via the canonical
+    mission resolver which handles ambiguous numeric-prefix handles, mid8
+    prefixes, and full ULID forms.
 
     Args:
         explicit_mission: Mission slug provided explicitly.
         explicit_feature: Mission slug provided via hidden --feature alias.
+        repo_root: Repository root; if provided, enables canonical resolver.
 
     Returns:
         Mission slug (e.g., "008-unified-python-cli")
@@ -327,6 +333,12 @@ def _find_mission_slug(
     Raises:
         typer.Exit: If mission slug is not provided or selectors conflict.
     """
+    raw_handle = explicit_mission or explicit_feature
+    if raw_handle is not None and repo_root is not None:
+        resolved = resolve_mission_handle(raw_handle, repo_root)
+        return resolved.mission_slug
+
+    # Legacy path: no repo_root available.
     try:
         resolved = resolve_selector(
             canonical_value=explicit_mission,
@@ -457,7 +469,7 @@ def implement(
             print("Error: Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, repo_root=repo_root)
 
         # Ensure planning repo is on the target branch before we start
         # (needed for auto-commits and status tracking inside this command)
@@ -1218,7 +1230,7 @@ def review(
             print("Error: Could not locate project root")
             raise typer.Exit(1)
 
-        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature)
+        mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, repo_root=repo_root)
 
         # Ensure planning repo is on the target branch before we start
         # (needed for auto-commits and status tracking inside this command)

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -333,14 +333,8 @@ def _find_mission_slug(
     Raises:
         typer.Exit: If mission slug is not provided or selectors conflict.
     """
-    raw_handle = explicit_mission or explicit_feature
-    if raw_handle is not None and repo_root is not None:
-        resolved = resolve_mission_handle(raw_handle, repo_root)
-        return resolved.mission_slug
-
-    # Legacy path: no repo_root available.
     try:
-        resolved = resolve_selector(
+        selector = resolve_selector(
             canonical_value=explicit_mission,
             canonical_flag="--mission",
             alias_value=explicit_feature,
@@ -348,10 +342,24 @@ def _find_mission_slug(
             suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
             command_hint="--mission <slug>",
         )
-        return resolved.canonical_value
     except typer.BadParameter as e:
         print(f"Error: {e}")
         raise typer.Exit(1)
+
+    raw_handle = selector.canonical_value
+    if raw_handle is not None and repo_root is not None:
+        legacy_dir = get_main_repo_root(repo_root) / "kitty-specs" / raw_handle
+        if legacy_dir.exists():
+            return raw_handle
+        try:
+            resolved = resolve_mission_handle(raw_handle, repo_root)
+            return resolved.mission_slug
+        except (SystemExit, typer.Exit):
+            if legacy_dir.exists():
+                return raw_handle
+            raise
+
+    return raw_handle
 
 
 def _normalize_wp_id(wp_arg: str) -> str:

--- a/src/specify_cli/cli/commands/dashboard.py
+++ b/src/specify_cli/cli/commands/dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import webbrowser
 
 import typer
@@ -26,10 +27,31 @@ def dashboard(
         "--open",
         help="Open dashboard URL in your default browser (disabled by default).",
     ),
+    emit_json: bool = typer.Option(
+        False,
+        "--json",
+        help=(
+            "Print the mission registry as JSON (keyed by mission_id) and exit. "
+            "Does not start the dashboard server."
+        ),
+    ),
 ) -> None:
     """Open or stop the Spec Kitty dashboard."""
     project_root = get_project_root_or_exit()
     check_version_compatibility(project_root, "dashboard")
+
+    # --json: emit mission registry keyed by mission_id and exit early.
+    if emit_json:
+        from specify_cli.dashboard.scanner import build_mission_registry, sort_missions_for_display
+
+        registry = build_mission_registry(project_root)
+        display_order = sort_missions_for_display(registry)
+        payload = {
+            "missions": registry,
+            "display_order": display_order,
+        }
+        console.print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
 
     console.print()
 

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from rich.console import Console
 from rich.table import Table
-from typing import Annotated
 
 from specify_cli.core.paths import locate_project_root
+
+if TYPE_CHECKING:
+    from specify_cli.status.identity_audit import IdentityState
 
 app = typer.Typer(name="doctor", help="Project health diagnostics")
 console = Console()
@@ -184,3 +189,216 @@ def state_roots(
 
     console.print()
     raise typer.Exit(0 if report.healthy else 1)
+
+
+def _scope_to_mission(
+    repo_root: Path,
+    all_states: list[IdentityState],
+    mission: str,
+) -> list[IdentityState]:
+    """Filter states to a single mission slug (or classify it directly)."""
+    from specify_cli.status.identity_audit import classify_mission
+
+    filtered = [s for s in all_states if s.slug == mission]
+    if filtered:
+        return filtered
+    target_dir = repo_root / "kitty-specs" / mission
+    if target_dir.is_dir():
+        return [classify_mission(target_dir)]
+    return []
+
+
+def _scope_prefixes(
+    duplicate_prefixes: dict[str, list[IdentityState]],
+    mission: str,
+) -> dict[str, list[IdentityState]]:
+    """Narrow duplicate_prefixes to the prefix of the scoped mission."""
+    import re as _re
+
+    m = _re.match(r"^(\d{3})-", mission)
+    if not m:
+        return {}
+    prefix = m.group(1)
+    return {prefix: duplicate_prefixes[prefix]} if prefix in duplicate_prefixes else {}
+
+
+def _print_dup_and_ambig(
+    duplicate_prefixes: dict[str, list[IdentityState]],
+    ambiguous_selectors: dict[str, list[IdentityState]],
+) -> None:
+    """Print duplicate-prefix and ambiguous-selector sections."""
+    if duplicate_prefixes:
+        console.print("[bold yellow]Duplicate Prefixes[/bold yellow]")
+        for prefix, items in sorted(duplicate_prefixes.items()):
+            console.print(f"  [yellow]{prefix}[/yellow] — {len(items)} collision(s):")
+            for s in items:
+                mid = s.mission_id or "[dim]no mission_id[/dim]"
+                console.print(f"    {s.slug}  mission_id={mid}  state={s.state}")
+        console.print()
+
+    if ambiguous_selectors:
+        console.print("[bold yellow]Ambiguous Selectors[/bold yellow]")
+        for handle, items in sorted(ambiguous_selectors.items()):
+            console.print(f"  [yellow]{handle!r}[/yellow] → {len(items)} candidate(s):")
+            for s in items:
+                console.print(f"    {s.slug}")
+        console.print()
+
+    if not duplicate_prefixes and not ambiguous_selectors:
+        console.print("[green]No duplicate prefixes or ambiguous selectors.[/green]\n")
+
+
+def _print_identity_human(
+    all_states: list[IdentityState],
+    duplicate_prefixes: dict[str, list[IdentityState]],
+    ambiguous_selectors: dict[str, list[IdentityState]],
+    summary: dict[str, object],
+    fail_on_states: set[str],
+    fail_on_triggered: bool,
+    fail_on: str | None,
+) -> None:
+    """Render the human-readable identity report to the console."""
+    counts_dict: dict[str, int] = summary["counts"]  # type: ignore[assignment]
+    total = len(all_states)
+    console.print(f"\n[bold]Mission Identity Audit[/bold] — {total} mission(s)\n")
+
+    summary_table = Table(box=None, padding=(0, 2), show_edge=False)
+    summary_table.add_column("State", style="cyan", min_width=10)
+    summary_table.add_column("Count", justify="right", min_width=6)
+    _state_styles = {"assigned": "[green]", "pending": "[yellow]", "legacy": "[red]", "orphan": "[red]"}
+    for state_name in ("assigned", "pending", "legacy", "orphan"):
+        count = counts_dict.get(state_name, 0)
+        styled = f"{_state_styles.get(state_name, '')}{state_name}[/]"
+        summary_table.add_row(styled, str(count))
+    console.print(summary_table)
+    console.print()
+
+    _print_dup_and_ambig(duplicate_prefixes, ambiguous_selectors)
+
+    legacy_paths: list[str] = summary["legacy_paths"]  # type: ignore[assignment]
+    orphan_paths: list[str] = summary["orphan_paths"]  # type: ignore[assignment]
+    if legacy_paths:
+        console.print("[bold red]Legacy missions (need backfill):[/bold red]")
+        for p in legacy_paths:
+            console.print(f"  {p}")
+        console.print()
+    if orphan_paths:
+        console.print("[bold red]Orphan missions (need triage):[/bold red]")
+        for p in orphan_paths:
+            console.print(f"  {p}")
+        console.print()
+
+    if fail_on_triggered:
+        console.print(
+            f"[bold red]FAIL:[/bold red] --fail-on {fail_on!r} triggered "
+            f"(one or more missions in: {', '.join(sorted(fail_on_states))})"
+        )
+
+
+@app.command(name="identity")
+def identity(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit structured JSON output (suitable for CI)"),
+    ] = False,
+    mission: Annotated[
+        str | None,
+        typer.Option("--mission", help="Scope report to a single mission slug"),
+    ] = None,
+    fail_on: Annotated[
+        str | None,
+        typer.Option(
+            "--fail-on",
+            help=(
+                "Exit non-zero if any mission is in the given state(s). "
+                "Comma-separated list of: assigned, pending, legacy, orphan."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Report mission-identity health across kitty-specs/.
+
+    Classifies every mission into one of four states (FR-045):
+
+    \\b
+    - assigned: mission_id present AND mission_number non-null (fully migrated)
+    - pending:  mission_id present AND mission_number null (pre-merge)
+    - legacy:   mission_id missing AND mission_number present (needs backfill)
+    - orphan:   both fields missing or meta.json unreadable (needs triage)
+
+    Also reports duplicate numeric prefixes (FR-011) and ambiguous selectors
+    that would resolve to multiple missions (FR-012).
+
+    Examples:
+        spec-kitty doctor identity
+        spec-kitty doctor identity --json
+        spec-kitty doctor identity --mission 083-foo
+        spec-kitty doctor identity --fail-on legacy,orphan
+    """
+    from specify_cli.status.identity_audit import (
+        audit_repo,
+        find_ambiguous_selectors,
+        find_duplicate_prefixes,
+        summarize,
+    )
+
+    try:
+        repo_root = locate_project_root()
+    except Exception as exc:
+        console.print("[red]Error:[/red] Not in a spec-kitty project")
+        raise typer.Exit(1) from exc
+
+    if repo_root is None:
+        console.print("[red]Error:[/red] Not in a spec-kitty project")
+        raise typer.Exit(1)
+
+    all_states = audit_repo(repo_root)
+
+    if mission is not None:
+        scoped = _scope_to_mission(repo_root, all_states, mission)
+        if not scoped:
+            console.print(f"[red]Error:[/red] Mission not found: {mission!r}")
+            raise typer.Exit(1)
+        all_states = scoped
+
+    _summary = summarize(all_states)
+    dup_prefixes = find_duplicate_prefixes(repo_root)
+    if mission is not None:
+        dup_prefixes = _scope_prefixes(dup_prefixes, mission)
+    ambig_selectors = find_ambiguous_selectors(all_states)
+
+    fail_on_states: set[str] = (
+        {s.strip() for s in fail_on.split(",") if s.strip()} if fail_on else set()
+    )
+    fail_on_triggered = bool(
+        fail_on_states and any(s.state in fail_on_states for s in all_states)
+    )
+
+    if json_output:
+        report = {
+            "summary": _summary["counts"],
+            "missions": [s.to_dict() for s in all_states],
+            "duplicate_prefixes": {
+                prefix: [s.to_dict() for s in items]
+                for prefix, items in dup_prefixes.items()
+            },
+            "ambiguous_selectors": {
+                handle: [s.to_dict() for s in items]
+                for handle, items in ambig_selectors.items()
+            },
+            "fail_on_triggered": fail_on_triggered,
+        }
+        sys.stdout.write(json.dumps(report, indent=2) + "\n")
+        sys.stdout.flush()
+        raise typer.Exit(1 if fail_on_triggered else 0)
+
+    _print_identity_human(
+        all_states,
+        dup_prefixes,
+        ambig_selectors,
+        _summary,
+        fail_on_states,
+        fail_on_triggered,
+        fail_on,
+    )
+    raise typer.Exit(1 if fail_on_triggered else 0)

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -101,8 +101,8 @@ def detect_feature_context(
     mission_flag: str | None = None,
     feature_flag: str | None = None,
     repo_root: Path | None = None,
-) -> tuple[str, str]:
-    """Require an explicit mission slug and return (number, slug).
+) -> tuple[str | None, str]:
+    """Require an explicit mission slug and return ``(mission_number, slug)``.
 
     Uses the canonical mission resolver (resolve_mission_handle) when
     repo_root is supplied, falling back to bare slug parsing otherwise.
@@ -124,11 +124,7 @@ def detect_feature_context(
         slug = raw_handle
 
     match = _re.match(r"^(\d{3})-", slug)
-    if not match:
-        console.print(f"[red]Error:[/red] Invalid feature slug format: {slug}\nExpected format: ###-feature-name (for example, 010-lane-only-runtime)")
-        raise typer.Exit(1)
-
-    return match.group(1), slug
+    return (match.group(1) if match else None), slug
 
 
 def find_wp_file(repo_root: Path, mission_slug: str, wp_id: str) -> Path:

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 from rich.console import Console
 
 from specify_cli.cli import StepTracker
-from specify_cli.cli.selector_resolution import resolve_selector
+from specify_cli.cli.selector_resolution import resolve_mission_handle
 from specify_cli.core.context_validation import require_main_repo
 from specify_cli.core.vcs import VCSBackend
 from specify_cli.mission_metadata import resolve_mission_identity, set_vcs_lock
@@ -100,23 +100,28 @@ def _json_safe_output(func):
 def detect_feature_context(
     mission_flag: str | None = None,
     feature_flag: str | None = None,
+    repo_root: Path | None = None,
 ) -> tuple[str, str]:
-    """Require an explicit mission slug and return (number, slug)."""
+    """Require an explicit mission slug and return (number, slug).
+
+    Uses the canonical mission resolver (resolve_mission_handle) when
+    repo_root is supplied, falling back to bare slug parsing otherwise.
+    The repo_root is always available in the callers that matter.
+    """
     import re as _re
 
-    try:
-        resolved = resolve_selector(
-            canonical_value=mission_flag,
-            canonical_flag="--mission",
-            alias_value=feature_flag,
-            alias_flag="--feature",
-            suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
-            command_hint="--mission <slug>",
-        )
-        slug = resolved.canonical_value
-    except typer.BadParameter as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1) from exc
+    raw_handle = mission_flag or feature_flag
+    if raw_handle is None:
+        console.print("[red]Error:[/red] --mission <slug> is required")
+        raise typer.Exit(1)
+
+    if repo_root is not None:
+        # Use canonical resolver — handles ambiguity, mid8, full ULID, etc.
+        resolved = resolve_mission_handle(raw_handle, repo_root)
+        slug = resolved.mission_slug
+    else:
+        # Bare-slug fallback for callers without a repo_root (e.g., unit tests).
+        slug = raw_handle
 
     match = _re.match(r"^(\d{3})-", slug)
     if not match:
@@ -305,7 +310,7 @@ def _run_recover_mode(
 
     try:
         repo_root = find_repo_root()
-        _feature_number, mission_slug = detect_feature_context(mission, feature)
+        _feature_number, mission_slug = detect_feature_context(mission, feature, repo_root=repo_root)
     except (TaskCliError, typer.Exit) as exc:
         if json_output:
             print(json.dumps({"status": "error", "error": str(exc)}))
@@ -440,7 +445,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         repo_root = find_repo_root()
         if auto_commit is None:
             auto_commit = get_auto_commit_default(repo_root)
-        _feature_number, mission_slug = detect_feature_context(mission, feature)
+        _feature_number, mission_slug = detect_feature_context(mission, feature, repo_root=repo_root)
         feature_dir = repo_root / "kitty-specs" / mission_slug
         wp_file = find_wp_file(repo_root, mission_slug, wp_id)
         declared_deps = parse_wp_dependencies(wp_file)

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -262,6 +262,32 @@ def _bake_mission_number_into_mission_branch(
     import subprocess as _subprocess
     import tempfile as _tempfile
 
+    def _is_git_repo(path: Path) -> bool:
+        probe = _subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+        )
+        return probe.returncode == 0 and probe.stdout.strip() == "true"
+
+    def _has_branch_ref(path: Path, ref_name: str) -> bool:
+        probe = _subprocess.run(
+            ["git", "rev-parse", "--verify", f"{ref_name}^{{commit}}"],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+        )
+        return probe.returncode == 0
+
+    if not _is_git_repo(main_repo):
+        logger.warning(
+            "Skipping mission_number bake for %s: %s is not a git repository",
+            mission_slug,
+            main_repo,
+        )
+        return None
+
     # -- Step 1: Check the TARGET branch's meta.json for this mission.
     # If the target already has an integer mission_number for this mission,
     # it was assigned in a prior successful merge — true no-op.
@@ -321,6 +347,14 @@ def _bake_mission_number_into_mission_branch(
     mission_tmp_dir = _tempfile.mkdtemp(prefix="kitty-numwrite-")
     mission_tmp_path = Path(mission_tmp_dir)
     try:
+        if not _has_branch_ref(main_repo, mission_branch):
+            logger.warning(
+                "Skipping mission_number bake for %s: branch %s does not exist",
+                mission_slug,
+                mission_branch,
+            )
+            return None
+
         result = _subprocess.run(
             ["git", "worktree", "add", "--detach", str(mission_tmp_path), mission_branch],
             cwd=str(main_repo),
@@ -328,10 +362,13 @@ def _bake_mission_number_into_mission_branch(
             text=True,
         )
         if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to create mission-branch worktree for mission_number write: "
-                f"{result.stderr.strip()}"
+            logger.warning(
+                "Skipping mission_number bake for %s: could not create mission worktree for %s (%s)",
+                mission_slug,
+                mission_branch,
+                result.stderr.strip(),
             )
+            return None
 
         meta_path = mission_tmp_path / "kitty-specs" / mission_slug / "meta.json"
         if not meta_path.exists():

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -44,7 +44,7 @@ from specify_cli.merge.state import (
     release_merge_lock,
     save_state,
 )
-from specify_cli.mission_metadata import resolve_mission_identity
+from specify_cli.mission_metadata import resolve_mission_identity, write_meta
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace
 from specify_cli.post_merge.stale_assertions import StaleAssertionReport, run_check
 from specify_cli.status.wp_metadata import read_wp_frontmatter
@@ -389,8 +389,10 @@ def _bake_mission_number_into_mission_branch(
             return None
 
         meta_data["mission_number"] = next_number
-        new_content = _json.dumps(meta_data, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-        meta_path.write_text(new_content, encoding="utf-8")
+        # Route all meta.json mutations through the canonical writer API.
+        # Use validate=False to preserve merge-time tolerance for legacy/partial
+        # mission metadata while still enforcing atomic writes + standard format.
+        write_meta(meta_path.parent, meta_data, validate=False)
 
         # Stage and commit the change on the mission branch.
         rel_meta = meta_path.relative_to(mission_tmp_path)

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -35,12 +35,16 @@ from specify_cli.lanes.persistence import CorruptLanesError, MissingLanesError, 
 from specify_cli.merge.config import MergeStrategy, load_merge_config
 from specify_cli.merge.ordering import assign_next_mission_number
 from specify_cli.merge.state import (
+    MergeLockError,
     MergeState,
+    acquire_merge_lock,
     clear_state,
     load_state,
     needs_number_assignment,
+    release_merge_lock,
     save_state,
 )
+from specify_cli.mission_metadata import resolve_mission_identity
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace
 from specify_cli.post_merge.stale_assertions import StaleAssertionReport, run_check
 from specify_cli.status.wp_metadata import read_wp_frontmatter
@@ -231,36 +235,38 @@ def _bake_mission_number_into_mission_branch(
 
     Implements WP10 / FR-044 / T053:
 
-    1. If the mission's ``meta.json`` already has an integer ``mission_number``
-       (legacy or previously-merged), this is a no-op and returns ``None``.
-    2. Otherwise, scan the target branch's ``kitty-specs/`` view for the next
-       available integer (``max + 1``, or ``1`` if empty).
+    1. Scan the target branch's ``kitty-specs/`` view for the next available
+       integer (``max + 1``, or ``1`` if empty).
+    2. Check the mission branch's ``meta.json`` — if it already has an integer
+       ``mission_number`` that matches the freshly-computed value or is already
+       present on the target branch, this is a no-op (idempotent on retry).
     3. In dry-run mode, log the value but do not write or commit.
     4. Otherwise, create a detached worktree at the mission branch tip, update
        ``meta.json`` in place, commit the change, and fast-forward the mission
        branch ref so the integer lands in the eventual mission→target merge.
 
-    The caller MUST hold the per-mission merge-state lock for the duration of
-    this call.  See WP10/T055.
+    The caller MUST hold the global merge lock
+    (``acquire_merge_lock("__global_merge__", ...)``) for the duration.
+
+    **Retry safety**: The assignment always re-derives from the target branch
+    tip.  If a prior run assigned a number from a stale target and the push
+    failed, re-running after ``git fetch`` will see the updated target and
+    compute the correct next value — the stale number in the mission branch's
+    ``meta.json`` is overwritten.
 
     Returns:
         The assigned integer if a new number was written; ``None`` if the
-        mission already had a number (no-op) or in dry-run mode.
+        target branch's ``meta.json`` already has the number or in dry-run mode.
     """
     import json as _json
     import subprocess as _subprocess
     import tempfile as _tempfile
 
-    feature_dir = main_repo / "kitty-specs" / mission_slug
-
-    if not needs_number_assignment(feature_dir):
-        logger.debug("Mission %s already has an integer mission_number; skipping assignment", mission_slug)
-        return None
-
-    # Compute against the target branch's view of kitty-specs/.  We use a
-    # short-lived detached worktree at the target tip so the scan reflects
-    # the most recent committed state of `target_branch`, NOT the current
-    # mission branch (which is what we are about to update).
+    # -- Step 1: Check the TARGET branch's meta.json for this mission.
+    # If the target already has an integer mission_number for this mission,
+    # it was assigned in a prior successful merge — true no-op.
+    # We do NOT check the mission branch's copy, because a stale assignment
+    # from a failed push must be re-derivable on retry.
     tmp_dir = _tempfile.mkdtemp(prefix="kitty-numassign-")
     tmp_path = Path(tmp_dir)
     next_number: int
@@ -277,11 +283,26 @@ def _bake_mission_number_into_mission_branch(
                 result.stderr.strip(),
             )
             # Fall back to scanning main_repo's working tree.  Best effort.
-            next_number = assign_next_mission_number(
-                main_repo, main_repo / "kitty-specs"
-            )
+            scan_root = main_repo
+            scan_specs = main_repo / "kitty-specs"
         else:
-            next_number = assign_next_mission_number(tmp_path, tmp_path / "kitty-specs")
+            scan_root = tmp_path
+            scan_specs = tmp_path / "kitty-specs"
+
+        # Check if the target branch already has this mission with a number
+        target_meta_path = scan_specs / mission_slug / "meta.json"
+        if target_meta_path.exists():
+            target_meta = _json.loads(target_meta_path.read_text(encoding="utf-8"))
+            existing_on_target = target_meta.get("mission_number") if isinstance(target_meta, dict) else None
+            if isinstance(existing_on_target, int) and not isinstance(existing_on_target, bool):
+                logger.debug(
+                    "Mission %s already has mission_number=%d on target branch %s; no-op",
+                    mission_slug, existing_on_target, target_branch,
+                )
+                return None
+
+        # Compute next number from the target branch's kitty-specs/ view
+        next_number = assign_next_mission_number(scan_root, scan_specs)
     finally:
         _subprocess.run(
             ["git", "worktree", "remove", str(tmp_path), "--force"],
@@ -295,8 +316,8 @@ def _bake_mission_number_into_mission_branch(
         )
         return None
 
-    # Write the integer into meta.json on the mission branch via a detached
-    # worktree at the mission branch tip, then update the ref.
+    # -- Step 2: Write the integer into meta.json on the mission branch.
+    # Always write (overwrite a stale value from a prior failed attempt).
     mission_tmp_dir = _tempfile.mkdtemp(prefix="kitty-numwrite-")
     mission_tmp_path = Path(mission_tmp_dir)
     try:
@@ -328,15 +349,6 @@ def _bake_mission_number_into_mission_branch(
                 "meta.json for %s is not a JSON object; cannot bake mission_number",
                 mission_slug,
             )
-            return None
-
-        # Idempotency guard at the write boundary: if some other concurrent
-        # writer already filled it in (shouldn't happen under the lock, but
-        # belt-and-braces), respect that and return.
-        existing = meta_data.get("mission_number")
-        if isinstance(existing, int) and not isinstance(existing, bool):
-            return None
-        if isinstance(existing, str) and existing.strip():
             return None
 
         meta_data["mission_number"] = next_number
@@ -526,28 +538,71 @@ def _run_lane_based_merge(
         strategy: Merge strategy for the mission→target step (FR-005, FR-006).
             Lane→mission step always uses merge commits regardless of this value.
     """
-    from specify_cli.lanes.branch_naming import lane_branch_name
-    from specify_cli.lanes.compute import PLANNING_LANE_ID
-    from specify_cli.lanes.merge import merge_lane_to_mission, merge_mission_to_target
-    from specify_cli.policy.config import load_policy_config
-    from specify_cli.policy.merge_gates import evaluate_merge_gates
-
     main_repo = get_main_repo_root(repo_root)
     feature_dir = main_repo / "kitty-specs" / mission_slug
     lanes_manifest = require_lanes_json(feature_dir)
     if target_override:
         lanes_manifest.target_branch = target_override
 
+    # -- Resolve canonical mission_id from meta.json (P2 fix: use ULID, not slug) --
+    identity = resolve_mission_identity(feature_dir)
+    canonical_id = identity.mission_id or mission_slug  # fallback for legacy missions without ULID
+
+    # -- Acquire global merge lock to serialize concurrent merges --
+    # The lock is keyed by a well-known sentinel so that merges of DIFFERENT
+    # missions also serialize against each other.  This is required because
+    # mission_number assignment (WP10) computes max(existing)+1 from the
+    # target branch — two concurrent merges scanning the same target tip
+    # would compute the same next number.
+    _GLOBAL_MERGE_LOCK_ID = "__global_merge__"
+    if not acquire_merge_lock(_GLOBAL_MERGE_LOCK_ID, main_repo):
+        raise MergeLockError(_GLOBAL_MERGE_LOCK_ID, main_repo / ".kittify" / "runtime" / "merge" / _GLOBAL_MERGE_LOCK_ID / "lock")
+
+    try:
+        _run_lane_based_merge_locked(
+            main_repo=main_repo,
+            mission_slug=mission_slug,
+            canonical_id=canonical_id,
+            feature_dir=feature_dir,
+            lanes_manifest=lanes_manifest,
+            push=push,
+            delete_branch=delete_branch,
+            remove_worktree=remove_worktree,
+            strategy=strategy,
+        )
+    finally:
+        release_merge_lock(_GLOBAL_MERGE_LOCK_ID, main_repo)
+
+
+def _run_lane_based_merge_locked(
+    main_repo: Path,
+    mission_slug: str,
+    canonical_id: str,
+    feature_dir: Path,
+    lanes_manifest: object,  # LanesManifest
+    *,
+    push: bool,
+    delete_branch: bool,
+    remove_worktree: bool,
+    strategy: MergeStrategy = MergeStrategy.SQUASH,
+) -> None:
+    """Inner merge flow, called with the global merge lock held."""
+    from specify_cli.lanes.branch_naming import lane_branch_name
+    from specify_cli.lanes.compute import PLANNING_LANE_ID
+    from specify_cli.lanes.merge import merge_lane_to_mission, merge_mission_to_target
+    from specify_cli.policy.config import load_policy_config
+    from specify_cli.policy.merge_gates import evaluate_merge_gates
+
     # -- T001: MergeState lifecycle: load or create --
     all_wp_ids = [wp for lane in lanes_manifest.lanes for wp in lane.wp_ids]
-    state = load_state(main_repo, mission_slug)
+    state = load_state(main_repo, canonical_id)
     is_resume = False
     if state is not None and state.completed_wps:
         is_resume = True
         console.print(f"[bold cyan]Resuming[/bold cyan] merge for {mission_slug} ({len(state.completed_wps)}/{len(state.wp_order)} WPs already done)")
     else:
         state = MergeState(
-            mission_id=mission_slug,
+            mission_id=canonical_id,
             mission_slug=mission_slug,
             target_branch=lanes_manifest.target_branch,
             wp_order=all_wp_ids,
@@ -605,16 +660,9 @@ def _run_lane_based_merge(
     merge_base_sha = merge_base_sha.strip() if _ret == 0 else "HEAD~1"
 
     # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
-    # Inside merge-state lock (single-writer): safe to compute max + 1.
-    # We are running in the per-mission merge flow that owns the merge-state
-    # entry under .kittify/runtime/merge/<mission_slug>/, which serializes
-    # concurrent merges of the same mission. Concurrent merges of *different*
-    # missions still serialize against the target branch's kitty-specs/ scan
-    # because each computes max+1 from the same target snapshot and the second
-    # merger picks up the first merger's commit only after that commit lands
-    # in the target ref via mission→target — so the natural cascade gives
-    # distinct integers as long as each mission's assignment is computed from
-    # the most recent target tip at the moment of mission→target.
+    # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
+    # which serializes ALL merge operations — same-mission and cross-mission.
+    # This guarantees the max+1 scan sees the most recent target state.
     _bake_mission_number_into_mission_branch(
         main_repo=main_repo,
         mission_slug=mission_slug,
@@ -757,8 +805,8 @@ def _run_lane_based_merge(
         console.print(f"  Cleaned up {len(lanes_manifest.lanes)} lane branch(es) + mission branch")
 
     # -- T002: Cleanup workspace (preserves state.json) then clear state --
-    cleanup_merge_workspace(mission_slug, main_repo)
-    clear_state(main_repo, mission_slug)
+    cleanup_merge_workspace(canonical_id, main_repo)
+    clear_state(main_repo, canonical_id)
 
     # -- T013: Render stale-assertion findings in the merge summary --
     console.print("\n[bold]Stale assertion findings:[/bold]")

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -33,7 +33,14 @@ from specify_cli.core.paths import get_feature_target_branch, get_main_repo_root
 from specify_cli.git import safe_commit
 from specify_cli.lanes.persistence import CorruptLanesError, MissingLanesError, require_lanes_json
 from specify_cli.merge.config import MergeStrategy, load_merge_config
-from specify_cli.merge.state import MergeState, clear_state, load_state, save_state
+from specify_cli.merge.ordering import assign_next_mission_number
+from specify_cli.merge.state import (
+    MergeState,
+    clear_state,
+    load_state,
+    needs_number_assignment,
+    save_state,
+)
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace
 from specify_cli.post_merge.stale_assertions import StaleAssertionReport, run_check
 from specify_cli.status.wp_metadata import read_wp_frontmatter
@@ -212,6 +219,181 @@ def _assert_merged_wps_reached_done(
         raise typer.Exit(1)
 
 
+def _bake_mission_number_into_mission_branch(
+    main_repo: Path,
+    mission_slug: str,
+    mission_branch: str,
+    target_branch: str,
+    *,
+    dry_run: bool = False,
+) -> int | None:
+    """Assign and persist a dense integer ``mission_number`` for a pre-merge mission.
+
+    Implements WP10 / FR-044 / T053:
+
+    1. If the mission's ``meta.json`` already has an integer ``mission_number``
+       (legacy or previously-merged), this is a no-op and returns ``None``.
+    2. Otherwise, scan the target branch's ``kitty-specs/`` view for the next
+       available integer (``max + 1``, or ``1`` if empty).
+    3. In dry-run mode, log the value but do not write or commit.
+    4. Otherwise, create a detached worktree at the mission branch tip, update
+       ``meta.json`` in place, commit the change, and fast-forward the mission
+       branch ref so the integer lands in the eventual mission→target merge.
+
+    The caller MUST hold the per-mission merge-state lock for the duration of
+    this call.  See WP10/T055.
+
+    Returns:
+        The assigned integer if a new number was written; ``None`` if the
+        mission already had a number (no-op) or in dry-run mode.
+    """
+    import json as _json
+    import subprocess as _subprocess
+    import tempfile as _tempfile
+
+    feature_dir = main_repo / "kitty-specs" / mission_slug
+
+    if not needs_number_assignment(feature_dir):
+        logger.debug("Mission %s already has an integer mission_number; skipping assignment", mission_slug)
+        return None
+
+    # Compute against the target branch's view of kitty-specs/.  We use a
+    # short-lived detached worktree at the target tip so the scan reflects
+    # the most recent committed state of `target_branch`, NOT the current
+    # mission branch (which is what we are about to update).
+    tmp_dir = _tempfile.mkdtemp(prefix="kitty-numassign-")
+    tmp_path = Path(tmp_dir)
+    next_number: int
+    try:
+        result = _subprocess.run(
+            ["git", "worktree", "add", "--detach", str(tmp_path), target_branch],
+            cwd=str(main_repo),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "Could not create scan worktree for mission_number assignment: %s",
+                result.stderr.strip(),
+            )
+            # Fall back to scanning main_repo's working tree.  Best effort.
+            next_number = assign_next_mission_number(
+                main_repo, main_repo / "kitty-specs"
+            )
+        else:
+            next_number = assign_next_mission_number(tmp_path, tmp_path / "kitty-specs")
+    finally:
+        _subprocess.run(
+            ["git", "worktree", "remove", str(tmp_path), "--force"],
+            cwd=str(main_repo),
+            capture_output=True,
+        )
+
+    if dry_run:
+        console.print(
+            f"[cyan]would assign[/cyan] mission_number={next_number} to mission {mission_slug}"
+        )
+        return None
+
+    # Write the integer into meta.json on the mission branch via a detached
+    # worktree at the mission branch tip, then update the ref.
+    mission_tmp_dir = _tempfile.mkdtemp(prefix="kitty-numwrite-")
+    mission_tmp_path = Path(mission_tmp_dir)
+    try:
+        result = _subprocess.run(
+            ["git", "worktree", "add", "--detach", str(mission_tmp_path), mission_branch],
+            cwd=str(main_repo),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to create mission-branch worktree for mission_number write: "
+                f"{result.stderr.strip()}"
+            )
+
+        meta_path = mission_tmp_path / "kitty-specs" / mission_slug / "meta.json"
+        if not meta_path.exists():
+            logger.warning(
+                "meta.json missing on mission branch %s for %s; cannot bake mission_number",
+                mission_branch,
+                mission_slug,
+            )
+            return None
+
+        # Read, mutate, write preserving sort_keys + 2-space indent + trailing newline.
+        meta_data = _json.loads(meta_path.read_text(encoding="utf-8"))
+        if not isinstance(meta_data, dict):
+            logger.warning(
+                "meta.json for %s is not a JSON object; cannot bake mission_number",
+                mission_slug,
+            )
+            return None
+
+        # Idempotency guard at the write boundary: if some other concurrent
+        # writer already filled it in (shouldn't happen under the lock, but
+        # belt-and-braces), respect that and return.
+        existing = meta_data.get("mission_number")
+        if isinstance(existing, int) and not isinstance(existing, bool):
+            return None
+        if isinstance(existing, str) and existing.strip():
+            return None
+
+        meta_data["mission_number"] = next_number
+        new_content = _json.dumps(meta_data, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+        meta_path.write_text(new_content, encoding="utf-8")
+
+        # Stage and commit the change on the mission branch.
+        rel_meta = meta_path.relative_to(mission_tmp_path)
+        _subprocess.run(
+            ["git", "add", str(rel_meta)],
+            cwd=str(mission_tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        commit_msg = f"chore({mission_slug}): assign mission_number={next_number}"
+        _subprocess.run(
+            [
+                "git",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                commit_msg,
+            ],
+            cwd=str(mission_tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        # Get the new commit and fast-forward the mission branch ref.
+        new_sha = _subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(mission_tmp_path),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        _subprocess.run(
+            ["git", "update-ref", f"refs/heads/{mission_branch}", new_sha],
+            cwd=str(main_repo),
+            capture_output=True,
+            check=True,
+        )
+    finally:
+        _subprocess.run(
+            ["git", "worktree", "remove", str(mission_tmp_path), "--force"],
+            cwd=str(main_repo),
+            capture_output=True,
+        )
+
+    console.print(
+        f"[green]Assigned[/green] mission_number={next_number} to mission {mission_slug}"
+    )
+    logger.info("Assigned mission_number=%d to mission %s", next_number, mission_slug)
+    return next_number
+
+
 def _enforce_git_preflight(repo_root: Path, *, json_output: bool) -> None:
     """Run git preflight checks and stop early with deterministic remediation."""
     if not (repo_root / ".git").exists():
@@ -239,7 +421,8 @@ def _extract_mission_slug(branch_name: str) -> str | None:
 
     parsed = parse_mission_slug_from_branch(branch_name)
     if parsed:
-        return parsed
+        # BranchParseResult(slug, mid8_token, lane_id) — return the slug portion
+        return parsed.slug
 
     match = re.match(r"^(\d{3}-[a-z0-9][a-z0-9-]*?)(?:-(?:lane-[a-z]))?$", branch_name)
     if match:
@@ -420,6 +603,25 @@ def _run_lane_based_merge(
         cwd=main_repo,
     )
     merge_base_sha = merge_base_sha.strip() if _ret == 0 else "HEAD~1"
+
+    # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
+    # Inside merge-state lock (single-writer): safe to compute max + 1.
+    # We are running in the per-mission merge flow that owns the merge-state
+    # entry under .kittify/runtime/merge/<mission_slug>/, which serializes
+    # concurrent merges of the same mission. Concurrent merges of *different*
+    # missions still serialize against the target branch's kitty-specs/ scan
+    # because each computes max+1 from the same target snapshot and the second
+    # merger picks up the first merger's commit only after that commit lands
+    # in the target ref via mission→target — so the natural cascade gives
+    # distinct integers as long as each mission's assignment is computed from
+    # the most recent target tip at the moment of mission→target.
+    _bake_mission_number_into_mission_branch(
+        main_repo=main_repo,
+        mission_slug=mission_slug,
+        mission_branch=lanes_manifest.mission_branch,
+        target_branch=lanes_manifest.target_branch,
+        dry_run=False,
+    )
 
     # -- Mission-to-target merge (T010: honor strategy for this step only) --
     mission_result = merge_mission_to_target(main_repo, mission_slug, lanes_manifest, strategy=strategy)
@@ -690,6 +892,21 @@ def merge(
                 console.print(f"[red]Error:[/red] {error_msg}")
             raise typer.Exit(1) from exc
 
+        # WP10/T053: dry-run preview of merge-time mission_number assignment.
+        feature_dir_for_preview = (
+            get_main_repo_root(repo_root) / "kitty-specs" / resolved_feature
+        )
+        would_assign_number: int | None = None
+        if needs_number_assignment(feature_dir_for_preview):
+            try:
+                would_assign_number = assign_next_mission_number(
+                    get_main_repo_root(repo_root),
+                    get_main_repo_root(repo_root) / "kitty-specs",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("dry-run mission_number scan failed: %s", exc)
+                would_assign_number = None
+
         payload: dict[str, object] = {
             "spec_kitty_version": SPEC_KITTY_VERSION,
             "mission_slug": resolved_feature,
@@ -700,7 +917,12 @@ def merge(
             "push": push,
             "mission_branch": lanes_manifest.mission_branch,
             "lanes": [lane.to_dict() for lane in lanes_manifest.lanes],
+            "would_assign_mission_number": would_assign_number,
         }
+        if would_assign_number is not None and not json_output:
+            console.print(
+                f"[cyan]would assign[/cyan] mission_number={would_assign_number} to mission {resolved_feature}"
+            )
         if json_output:
             print(json.dumps(payload))
         else:
@@ -736,6 +958,7 @@ __all__ = [
     "_run_lane_based_merge",
     "_is_linear_history_rejection",
     "_emit_remediation_hint",
+    "_bake_mission_number_into_mission_branch",
     "LINEAR_HISTORY_REJECTION_TOKENS",
     "merge",
 ]

--- a/src/specify_cli/cli/commands/migrate_cmd.py
+++ b/src/specify_cli/cli/commands/migrate_cmd.py
@@ -1,24 +1,22 @@
-"""CLI command for migrating per-project .kittify/ to centralized model.
+"""CLI commands for runtime migration and identity backfill.
 
-Usage:
-    spec-kitty migrate              # Migrate with confirmation
-    spec-kitty migrate --dry-run    # Preview changes without modifying
-    spec-kitty migrate --force      # Skip confirmation prompt
-    spec-kitty migrate --verbose    # Show file-by-file detail
+Subcommands:
 
-The migrate command performs two operations:
+- ``spec-kitty migrate`` — Migrate project .kittify/ to centralized model.
+- ``spec-kitty migrate backfill-identity`` — Write ULID ``mission_id`` into
+  any ``meta.json`` that lacks one.  Idempotent and non-destructive.
 
-1. **Global runtime install** -- ensures ``~/.kittify/`` is populated with
-   up-to-date package assets (idempotent; uses ``ensure_runtime()``).
-2. **Per-project cleanup** -- classifies per-project ``.kittify/`` files as
-   identical (removed), customized (moved to overrides/), or project-specific
-   (kept).
+Usage examples::
 
-After a successful migration, legacy-tier warnings are fully suppressed
-during normal template resolution.
+    spec-kitty migrate --dry-run
+    spec-kitty migrate backfill-identity --dry-run --json
+    spec-kitty migrate backfill-identity --mission 083-foo-bar
 """
 
 from __future__ import annotations
+
+import json
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -27,10 +25,21 @@ from specify_cli.core.paths import locate_project_root
 from specify_cli.runtime.bootstrap import ensure_runtime
 from specify_cli.runtime.migrate import execute_migration
 
+app = typer.Typer(
+    name="migrate",
+    help=(
+        "Migration commands: update .kittify/ layout and backfill identity fields "
+        "in legacy missions."
+    ),
+    no_args_is_help=False,
+    invoke_without_command=True,
+)
 console = Console()
 
 
-def migrate(
+@app.callback(invoke_without_command=True)
+def migrate(  # noqa: C901
+    ctx: typer.Context,
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would change without modifying the filesystem"
     ),
@@ -55,6 +64,10 @@ def migrate(
         spec-kitty migrate --dry-run    # Preview
         spec-kitty migrate --force      # Apply without confirmation
     """
+    # If a subcommand was invoked, don't run the migrate callback body.
+    if ctx.invoked_subcommand is not None:
+        return
+
     project_dir = locate_project_root()
     if project_dir is None:
         console.print(
@@ -132,3 +145,138 @@ def migrate(
     # This is a security boundary decision -- credentials have a different
     # lifecycle and permission model from runtime assets.  Documented here
     # per WP08 acceptance criteria.
+
+
+@app.command(name="backfill-identity")
+def backfill_identity(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit per-mission result list as structured JSON"),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help=(
+                "Report what would change without writing any files. "
+                "The JSON shape is identical to a live run."
+            ),
+        ),
+    ] = False,
+    mission: Annotated[
+        str | None,
+        typer.Option(
+            "--mission",
+            help="Scope to a single mission slug (e.g. 083-foo-bar). Omit to process all.",
+            metavar="SLUG",
+        ),
+    ] = None,
+) -> None:
+    """Write a ULID mission_id into any meta.json that lacks one.
+
+    This command is **idempotent** — running it twice produces identical
+    state.  Existing ``mission_id`` values are never overwritten.  The
+    command also coerces legacy string-typed ``mission_number`` values
+    (e.g. ``"042"`` → ``42``) while walking each mission.
+
+    After writing, the dossier parity hash is recomputed for every mission
+    that was modified.  Individual dossier failures are logged as warnings
+    and do not abort the run.
+
+    **When to run:**
+
+    - After upgrading from a spec-kitty version that predates ``mission_id``
+    - After pulling a clone that has legacy missions (no ``mission_id``)
+    - As part of CI checks on legacy repositories
+
+    Exit codes:
+
+    - ``0`` — all results are ``wrote`` or ``skip``
+    - ``1`` — one or more ``error`` results (corrupt JSON, sentinel strings, …)
+
+    Examples:
+
+        spec-kitty migrate backfill-identity --dry-run --json
+
+        spec-kitty migrate backfill-identity --mission 083-foo-bar
+
+        spec-kitty migrate backfill-identity
+    """
+    from specify_cli.migration.backfill_identity import backfill_repo
+
+    repo_root = locate_project_root()
+    if repo_root is None:
+        _error("Could not locate project root. No .kittify/ directory found in any parent directory.")
+        raise typer.Exit(1)
+
+    results = backfill_repo(repo_root, dry_run=dry_run, mission_slug=mission)
+
+    wrote = [r for r in results if r.action == "wrote"]
+    skipped = [r for r in results if r.action == "skip"]
+    errored = [r for r in results if r.action == "error"]
+    coerced = [r for r in results if r.number_coerced]
+    warned = [r for r in results if r.dossier_warning]
+
+    if json_output:
+        payload = {
+            "dry_run": dry_run,
+            "summary": {
+                "total": len(results),
+                "wrote": len(wrote),
+                "skip": len(skipped),
+                "error": len(errored),
+                "number_coerced": len(coerced),
+                "dossier_warnings": len(warned),
+            },
+            "results": [
+                {
+                    "slug": r.slug,
+                    "action": r.action,
+                    "mission_id": r.mission_id,
+                    "number_coerced": r.number_coerced,
+                    "reason": r.reason,
+                    "dossier_warning": r.dossier_warning,
+                }
+                for r in results
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        prefix = "[dim](dry-run)[/dim] " if dry_run else ""
+        console.print(f"\n{prefix}[bold]backfill-identity summary[/bold]")
+        console.print(f"  Total missions scanned : {len(results)}")
+        console.print(f"  Written (mission_id)   : {len(wrote)}")
+        console.print(f"  Skipped (already set)  : {len(skipped)}")
+        console.print(f"  Errors                 : {len(errored)}")
+        console.print(f"  Number coerced         : {len(coerced)}")
+        if warned:
+            console.print(f"  [yellow]Dossier warnings       : {len(warned)}[/yellow]")
+
+        if errored:
+            console.print("\n[red]Errors:[/red]")
+            for r in errored:
+                console.print(f"  [red]{r.slug}:[/red] {r.reason}")
+
+        if dry_run:
+            console.print("\n[dim]Dry run — no files were modified.[/dim]")
+        elif wrote:
+            console.print(
+                f"\n[green]Done.[/green] {len(wrote)} mission(s) received a "
+                f"``mission_id``."
+            )
+        else:
+            console.print("\n[green]Done.[/green] All missions already have a ``mission_id``.")
+
+    if errored:
+        raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _error(message: str) -> None:
+    """Print an error message to stderr via Rich console."""
+    err_console = Console(stderr=True)
+    err_console.print(f"[red]Error:[/red] {message}")

--- a/src/specify_cli/cli/selector_resolution.py
+++ b/src/specify_cli/cli/selector_resolution.py
@@ -1,15 +1,41 @@
-"""Helpers for canonical selector resolution and deprecated aliases."""
+"""Helpers for canonical selector resolution and deprecated aliases.
+
+Mission handle resolution
+-------------------------
+``resolve_mission_handle`` wraps :func:`~specify_cli.context.mission_resolver.resolve_mission`
+and translates resolver exceptions into user-facing error messages.  Call it
+after obtaining a raw ``--mission`` / ``--feature`` flag value and before
+performing any kitty-specs directory access.
+
+Example::
+
+    from specify_cli.cli.selector_resolution import resolve_mission_handle
+
+    resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=False)
+    feature_dir = resolved.feature_dir
+    mission_slug = resolved.mission_slug
+"""
 
 from __future__ import annotations
 
+import json as _json
 import os
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import click
 import typer
 from rich.console import Console
 
+from specify_cli.context.errors import MissingIdentityError
+from specify_cli.context.mission_resolver import (
+    AmbiguousHandleError,
+    MissionNotFoundError,
+    ResolvedMission,
+    resolve_mission,
+)
 from specify_cli.core.paths import require_explicit_feature
 
 _err_console = Console(stderr=True)
@@ -149,3 +175,75 @@ def resolve_selector(
         alias_flag=alias_flag,
         warning_emitted=warning_emitted,
     )
+
+
+# ---------------------------------------------------------------------------
+# Mission handle resolver (T036 / T037 / T038)
+# ---------------------------------------------------------------------------
+
+
+def resolve_mission_handle(
+    handle: str,
+    repo_root: Path,
+    *,
+    json_mode: bool = False,
+) -> ResolvedMission:
+    """Resolve a user-supplied mission handle to a canonical :class:`~specify_cli.context.mission_resolver.ResolvedMission`.
+
+    Accepted input forms (priority order):
+
+    1. Full 26-char ULID ``mission_id``
+    2. 8-char ``mid8`` prefix
+    3. Full slug with numeric prefix (e.g. ``"083-foo-bar"``)
+    4. Human slug without prefix (e.g. ``"foo-bar"``)
+    5. Numeric prefix alone (e.g. ``"083"``)
+
+    On success the :class:`~specify_cli.context.mission_resolver.ResolvedMission`
+    is returned.  On failure the appropriate error message is printed to *stderr*
+    and :func:`sys.exit` is called with exit code 2.
+
+    Args:
+        handle: Raw flag value from ``--mission`` or ``--feature``.
+        repo_root: Absolute path to the repository root.
+        json_mode: When ``True``, error payloads are emitted as JSON (for
+            callers that pass ``--json``).
+
+    Returns:
+        The uniquely resolved mission.
+
+    Raises:
+        SystemExit(2): On ``AmbiguousHandleError``, ``MissionNotFoundError``, or
+            ``MissingIdentityError``.
+    """
+    try:
+        return resolve_mission(handle, repo_root)
+    except AmbiguousHandleError as exc:
+        if json_mode:
+            _err_console.print_json(_json.dumps(exc.to_dict()))
+        else:
+            _err_console.print(str(exc))
+        sys.exit(2)
+    except MissionNotFoundError as exc:
+        if json_mode:
+            payload = {"error": "mission_not_found", "handle": exc.handle}
+            _err_console.print_json(_json.dumps(payload))
+        else:
+            _err_console.print(
+                f'[red]Error:[/red] No mission found for handle "{exc.handle}". '
+                f"Check that the handle is correct and that the mission exists in kitty-specs/."
+            )
+        sys.exit(2)
+    except MissingIdentityError as exc:
+        if json_mode:
+            payload = {
+                "error": "missing_mission_id",
+                "detail": str(exc),
+                "remediation": "spec-kitty migrate backfill-identity",
+            }
+            _err_console.print_json(_json.dumps(payload))
+        else:
+            _err_console.print(
+                f"[red]Error:[/red] {exc}\n"
+                f"[yellow]Remediation:[/yellow] Run `spec-kitty migrate backfill-identity` to fix."
+            )
+        sys.exit(2)

--- a/src/specify_cli/context/mission_resolver.py
+++ b/src/specify_cli/context/mission_resolver.py
@@ -1,0 +1,272 @@
+"""Mission handle resolver: maps user-supplied handles to canonical mission identity.
+
+Resolution priority (most-specific → least-specific):
+
+1. **Full mission_id** (26-char ULID): exact match on ``meta.json.mission_id``
+2. **mid8 prefix** (8 chars): match on ``mission_id[:8]``
+3. **Full slug with numeric prefix** (e.g. ``"083-foo-bar"``): directory name match
+4. **Human slug without prefix** (e.g. ``"foo-bar"``): stripped slug match
+5. **Numeric prefix alone** (e.g. ``"083"``): directory prefix match
+
+If a handle unambiguously identifies one mission at any priority level, it is
+returned immediately.  If it matches multiple missions, ``AmbiguousHandleError``
+is raised with the full candidate list.  If it matches zero missions at any
+level, the resolver falls through to the next level; if all levels are
+exhausted without a match, ``MissionNotFoundError`` is raised.
+
+Missions whose ``meta.json`` lacks a ``mission_id`` are silently skipped during
+index construction (they cannot be resolved by identity).  To fix such missions,
+run ``spec-kitty migrate backfill-identity``.
+
+Implementation note: ``kitty-specs/`` is walked once per ``resolve_mission``
+call.  The resulting in-memory index is not cached across calls because the
+resolver is used in short-lived CLI commands; caching can be added later if
+profiling shows it is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from specify_cli.lanes.branch_naming import strip_numeric_prefix
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ULID_RE = re.compile(r"^[0-9A-Z]{26}$")
+_MID8_RE = re.compile(r"^[0-9A-Z]{8}$")
+_PREFIX_RE = re.compile(r"^(\d{3})-")
+
+# ---------------------------------------------------------------------------
+# Public data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolvedMission:
+    """Canonical resolved identity for a single mission.
+
+    Attributes:
+        mission_id: Full 26-character ULID string from ``meta.json``.
+        mission_slug: Directory name in ``kitty-specs/`` (e.g. ``"083-foo-bar"``).
+        feature_dir: Absolute path to the mission directory.
+        mid8: First 8 characters of ``mission_id`` (short disambiguator).
+    """
+
+    mission_id: str
+    mission_slug: str
+    feature_dir: Path
+    mid8: str
+
+
+class AmbiguousHandleError(Exception):
+    """Raised when a handle matches more than one mission.
+
+    Attributes:
+        handle: The user-supplied handle that was ambiguous.
+        candidates: All missions matched by the handle.
+    """
+
+    def __init__(self, handle: str, candidates: list[ResolvedMission]) -> None:
+        self.handle = handle
+        self.candidates = candidates
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        lines = [
+            f'Error: mission handle "{self.handle}" matches multiple missions.',
+            "",
+            "Candidates:",
+        ]
+        for c in self.candidates:
+            lines.append(f"  {c.mission_slug} (mission_id {c.mission_id}, mid8 {c.mid8})")
+        lines.append("")
+        lines.append("Re-run with a more specific handle:")
+        for c in self.candidates:
+            lines.append(f"  spec-kitty <command> --mission {c.mid8}")
+            lines.append(f"  spec-kitty <command> --mission {c.mission_slug}")
+        lines.append("")
+        lines.append("For JSON output of all candidates:")
+        lines.append(f'  spec-kitty doctor identity --mission {self.handle} --json')
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable error payload for ``--json`` callers."""
+        return {
+            "error": "ambiguous_mission_handle",
+            "handle": self.handle,
+            "candidates": [
+                {
+                    "mission_id": c.mission_id,
+                    "mid8": c.mid8,
+                    "slug": c.mission_slug,
+                    "feature_dir": str(c.feature_dir),
+                }
+                for c in self.candidates
+            ],
+        }
+
+
+class MissionNotFoundError(Exception):
+    """Raised when no mission matches the supplied handle.
+
+    Attributes:
+        handle: The user-supplied handle that matched nothing.
+    """
+
+    def __init__(self, handle: str) -> None:
+        self.handle = handle
+        super().__init__(f'No mission found for handle "{handle}".')
+
+
+# ---------------------------------------------------------------------------
+# Internal: index construction
+# ---------------------------------------------------------------------------
+
+
+def _build_index(repo_root: Path) -> list[ResolvedMission]:
+    """Walk ``kitty-specs/`` and return a list of indexable missions.
+
+    Missions whose ``meta.json`` lacks a ``mission_id`` are silently skipped.
+    Non-directory entries (e.g. ``README.md``) are also skipped.
+    """
+    specs_dir = repo_root / "kitty-specs"
+    if not specs_dir.exists():
+        return []
+
+    missions: list[ResolvedMission] = []
+    for entry in sorted(specs_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        meta_path = entry / "meta.json"
+        if not meta_path.exists():
+            continue
+        try:
+            data = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        mission_id: str | None = data.get("mission_id") or None
+        if not mission_id:
+            # Legacy mission without mission_id — cannot be resolved by identity.
+            # Operator must run `spec-kitty migrate backfill-identity`.
+            continue
+        missions.append(
+            ResolvedMission(
+                mission_id=mission_id,
+                mission_slug=entry.name,
+                feature_dir=entry,
+                mid8=mission_id[:8],
+            )
+        )
+    return missions
+
+
+# ---------------------------------------------------------------------------
+# Internal: form classifiers
+# ---------------------------------------------------------------------------
+
+
+def _is_full_ulid(handle: str) -> bool:
+    """Return True if the handle looks like a full 26-char ULID."""
+    return bool(_ULID_RE.match(handle))
+
+
+def _is_mid8(handle: str) -> bool:
+    """Return True if the handle looks like a mid8 (8 uppercase alphanumeric chars)."""
+    return bool(_MID8_RE.match(handle))
+
+
+def _is_numeric_prefix(handle: str) -> bool:
+    """Return True if the handle is a pure digit string (e.g. '083')."""
+    return handle.isdigit()
+
+
+# ---------------------------------------------------------------------------
+# Public resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_mission(handle: str, repo_root: Path) -> ResolvedMission:
+    """Resolve a user-supplied handle to a canonical mission.
+
+    Resolution priority (see module docstring):
+    1. Full mission_id (26-char ULID)
+    2. mid8 prefix (8 chars of upper alphanumeric)
+    3. Full slug with numeric prefix (directory name)
+    4. Human slug without prefix
+    5. Numeric prefix alone (all-digits handle)
+
+    Args:
+        handle: A mission handle in any supported form.
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        The uniquely resolved :class:`ResolvedMission`.
+
+    Raises:
+        AmbiguousHandleError: The handle matches more than one mission.
+        MissionNotFoundError: The handle matches no mission.
+    """
+    missions = _build_index(repo_root)
+
+    # ------------------------------------------------------------------
+    # Priority 1: Full mission_id (exact 26-char ULID)
+    # ------------------------------------------------------------------
+    if _is_full_ulid(handle):
+        matches = [m for m in missions if m.mission_id == handle]
+        return _resolve_or_raise(handle, matches)
+
+    # ------------------------------------------------------------------
+    # Priority 2: mid8 prefix (8 uppercase alphanum chars)
+    # Note: also catches shorter unique prefixes (partial mid8) via startswith.
+    # ------------------------------------------------------------------
+    if _is_mid8(handle):
+        matches = [m for m in missions if m.mission_id.startswith(handle)]
+        return _resolve_or_raise(handle, matches)
+
+    # ------------------------------------------------------------------
+    # Priority 3: Full slug with numeric prefix (e.g. "083-foo-bar")
+    # ------------------------------------------------------------------
+    matches = [m for m in missions if m.mission_slug == handle]
+    if matches:
+        return _resolve_or_raise(handle, matches)
+
+    # ------------------------------------------------------------------
+    # Priority 4: Human slug without numeric prefix (e.g. "foo-bar")
+    # ------------------------------------------------------------------
+    if not _is_numeric_prefix(handle):
+        human_matches = [
+            m for m in missions if strip_numeric_prefix(m.mission_slug) == handle
+        ]
+        if human_matches:
+            return _resolve_or_raise(handle, human_matches)
+
+    # ------------------------------------------------------------------
+    # Priority 5: Numeric prefix (all-digits string, e.g. "083")
+    # ------------------------------------------------------------------
+    if _is_numeric_prefix(handle):
+        prefix_matches = [
+            m for m in missions if _PREFIX_RE.match(m.mission_slug) and
+            _PREFIX_RE.match(m.mission_slug).group(1) == handle  # type: ignore[union-attr]
+        ]
+        return _resolve_or_raise(handle, prefix_matches)
+
+    raise MissionNotFoundError(handle)
+
+
+# ---------------------------------------------------------------------------
+# Internal: resolve-or-raise helper
+# ---------------------------------------------------------------------------
+
+
+def _resolve_or_raise(handle: str, matches: list[ResolvedMission]) -> ResolvedMission:
+    """Return the single match, raise on zero or multiple matches."""
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise AmbiguousHandleError(handle, matches)
+    raise MissionNotFoundError(handle)

--- a/src/specify_cli/context/resolver.py
+++ b/src/specify_cli/context/resolver.py
@@ -54,7 +54,13 @@ def _read_project_uuid(repo_root: Path) -> str:
 
 
 def _read_meta_json(feature_dir: Path) -> dict[str, str]:
-    """Read mission_id and target_branch from meta.json."""
+    """Read mission identity and target_branch from meta.json.
+
+    Legacy missions authored before the identity backfill may lack
+    ``mission_id``. In that case, fall back to ``feature_dir.name`` so
+    context-bound commands can still operate deterministically on a
+    single explicit mission directory.
+    """
     meta_path = feature_dir / "meta.json"
     if not meta_path.exists():
         msg = f"meta.json not found at {meta_path}."
@@ -62,13 +68,7 @@ def _read_meta_json(feature_dir: Path) -> dict[str, str]:
 
     data = json.loads(meta_path.read_text(encoding="utf-8"))
 
-    mission_id = data.get("mission_id")
-    if not mission_id:
-        raise MissingIdentityError(
-            f"meta.json at {meta_path} is missing mission_id. "
-            f"This mission was authored before the mission_id migration landed. "
-            f"Run `spec-kitty migrate backfill-identity` to fix."
-        )
+    mission_id = data.get("mission_id") or feature_dir.name
     target_branch = data.get("target_branch", "main")
 
     identity = mission_identity_fields(

--- a/src/specify_cli/context/resolver.py
+++ b/src/specify_cli/context/resolver.py
@@ -62,14 +62,14 @@ def _read_meta_json(feature_dir: Path) -> dict[str, str]:
 
     data = json.loads(meta_path.read_text(encoding="utf-8"))
 
-    # mission_id may not exist yet in current metadata;
-    # fall back to mission_slug as the identifier during transition
-    mission_id = data.get("mission_id", data.get("mission_slug", ""))
-    target_branch = data.get("target_branch", "main")
-
+    mission_id = data.get("mission_id")
     if not mission_id:
-        msg = f"Neither mission_id nor mission_slug found in {meta_path}. The feature metadata is incomplete."
-        raise MissingIdentityError(msg)
+        raise MissingIdentityError(
+            f"meta.json at {meta_path} is missing mission_id. "
+            f"This mission was authored before the mission_id migration landed. "
+            f"Run `spec-kitty migrate backfill-identity` to fix."
+        )
+    target_branch = data.get("target_branch", "main")
 
     identity = mission_identity_fields(
         str(data.get("mission_slug") or data.get("slug") or feature_dir.name),

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -344,7 +344,7 @@ def create_mission_core(
     with contextlib.suppress(Exception):
         emit_mission_created(
             mission_slug=mission_slug_formatted,
-            mission_number="",  # no number pre-merge (FR-044)
+            mission_number=None,  # no number pre-merge (FR-044)
             target_branch=planning_branch,
             wp_count=0,
             mission_id=meta.get("mission_id"),

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -20,8 +20,8 @@ from ulid import ULID
 
 from specify_cli.core.git_ops import get_current_branch, is_git_repo
 from specify_cli.core.paths import is_worktree_context, locate_project_root
-from specify_cli.core.worktree import get_next_feature_number
 from specify_cli.git import safe_commit
+from specify_cli.lanes.branch_naming import mid8, strip_numeric_prefix
 from specify_cli.sync.events import emit_mission_created
 
 
@@ -35,7 +35,7 @@ class MissionCreationResult:
 
     feature_dir: Path
     mission_slug: str
-    mission_number: str
+    mission_number: int | None  # None for pre-merge missions (FR-044)
     meta: dict[str, Any]
     target_branch: str
     current_branch: str
@@ -241,10 +241,16 @@ def create_mission_core(
     planning_branch = target_branch if target_branch else current_branch
 
     # ------------------------------------------------------------------
-    # 4. Feature number allocation + directory creation
+    # 4. Directory creation — human-slug + mid8 format (FR-032, FR-044)
+    #
+    # Pre-merge missions are identified by mission_id (ULID) only.
+    # No feature_number is allocated here; mission_number stays None
+    # until merge time (single-writer context on main).
     # ------------------------------------------------------------------
-    feature_number = get_next_feature_number(resolved_root)
-    mission_slug_formatted = f"{feature_number:03d}-{mission_slug}"
+    # Mint the ULID first so we can derive mid8 for the directory name.
+    mission_id = str(ULID())
+    human_slug = strip_numeric_prefix(mission_slug)
+    mission_slug_formatted = f"{human_slug}-{mid8(mission_id)}"
 
     feature_dir = resolved_root / "kitty-specs" / mission_slug_formatted
     feature_dir.mkdir(parents=True, exist_ok=True)
@@ -295,10 +301,12 @@ def create_mission_core(
         with contextlib.suppress(json.JSONDecodeError, OSError):
             meta = json.loads(meta_file.read_text(encoding="utf-8"))
 
-    # Mint canonical machine-facing identity. The ULID is immutable after creation.
-    # mission_number (the numeric prefix) is display-only; see ADR b85116ed.
-    meta.setdefault("mission_id", str(ULID()))
-    meta.setdefault("mission_number", f"{feature_number:03d}")
+    # Mint canonical machine-facing identity. The ULID was already generated
+    # above (needed for mid8 directory naming). The ULID is immutable after creation.
+    # mission_number is null pre-merge; a dense display number is assigned only
+    # at merge time (single-writer context on main). See FR-044.
+    meta.setdefault("mission_id", mission_id)
+    meta.setdefault("mission_number", None)  # JSON null — pre-merge missions have no number
     meta.setdefault("slug", mission_slug_formatted)
     meta.setdefault("mission_slug", mission_slug_formatted)
     meta.setdefault("friendly_name", mission_slug.replace("-", " ").strip())
@@ -336,7 +344,7 @@ def create_mission_core(
     with contextlib.suppress(Exception):
         emit_mission_created(
             mission_slug=mission_slug_formatted,
-            mission_number=f"{feature_number:03d}",
+            mission_number="",  # no number pre-merge (FR-044)
             target_branch=planning_branch,
             wp_count=0,
             mission_id=meta.get("mission_id"),
@@ -362,7 +370,7 @@ def create_mission_core(
     return MissionCreationResult(
         feature_dir=feature_dir,
         mission_slug=mission_slug_formatted,
-        mission_number=f"{feature_number:03d}",
+        mission_number=None,  # pre-merge: no display number assigned (FR-044)
         meta=meta,
         target_branch=planning_branch,
         current_branch=current_branch,

--- a/src/specify_cli/core/worktree.py
+++ b/src/specify_cli/core/worktree.py
@@ -128,12 +128,13 @@ def create_wp_workspace(
         mode = ExecutionMode.CODE_CHANGE
 
     if mode == ExecutionMode.PLANNING_ARTIFACT:
-        return create_planning_workspace(
+        result_path = create_planning_workspace(
             mission_slug=mission_slug,
             wp_code=wp_code,
             owned_files=list(owned_files_raw) if isinstance(owned_files_raw, (list, tuple)) else [],
             repo_root=repo_root,
         )
+        return Path(result_path)
 
     # code_change: create a standard git worktree (full checkout)
     workspace_path.parent.mkdir(parents=True, exist_ok=True)
@@ -160,91 +161,55 @@ def create_wp_workspace(
     return workspace_path
 
 
-def get_next_feature_number(repo_root: Path) -> int:
-    """Determine next sequential feature number.
-
-    Scans both kitty-specs/ and .worktrees/ directories for existing features
-    (###-name format) and returns next number in sequence. This prevents number
-    reuse when features exist only in worktrees.
-
-    .. note::
-        **Display-only**: This function computes a human-friendly sequential
-        display number for a mission. It MUST NOT be used as the canonical
-        machine-facing identity. The canonical identity is the ``mission_id``
-        (ULID) in ``meta.json``. See FR-204.
-
-    Args:
-        repo_root: Repository root path
-
-    Returns:
-        Next feature number (e.g., 9 if highest existing is 008)
-
-    Examples:
-        >>> repo_root = Path("/path/to/repo")
-        >>> next_num = get_next_feature_number(repo_root)
-        >>> assert next_num > 0
-    """
-    max_number = 0
-
-    # Scan kitty-specs/ for feature numbers
-    specs_dir = repo_root / KITTY_SPECS_DIR
-    if specs_dir.exists():
-        for item in sorted(specs_dir.iterdir(), key=lambda p: p.name):
-            if item.is_dir() and len(item.name) >= 3 and item.name[:3].isdigit():
-                try:
-                    number = int(item.name[:3])
-                    max_number = max(max_number, number)
-                except ValueError:
-                    # Not a valid number, skip
-                    continue
-
-    # Also scan .worktrees/ for feature numbers
-    worktrees_dir = repo_root / WORKTREES_DIR
-    if worktrees_dir.exists():
-        for item in sorted(worktrees_dir.iterdir(), key=lambda p: p.name):
-            if item.is_dir() and len(item.name) >= 3 and item.name[:3].isdigit():
-                try:
-                    number = int(item.name[:3])
-                    max_number = max(max_number, number)
-                except ValueError:
-                    # Not a valid number, skip
-                    continue
-
-    return max_number + 1
-
-
-def create_feature_worktree(repo_root: Path, mission_slug: str, feature_number: int | None = None) -> tuple[Path, Path]:
+def create_feature_worktree(
+    repo_root: Path,
+    mission_slug: str,
+    mission_id: str | None = None,
+) -> tuple[Path, Path]:
     """Create workspace (git worktree) for feature development.
 
     Creates a new workspace with a feature branch and sets up the
     feature directory structure. Uses VCS abstraction.
 
+    The worktree is named ``<human-slug>-<mid8>[-lane-<id>]`` using the new
+    identity-stable format (FR-033).  The ``mission_id`` is required; if it
+    is missing, the call fails with a clear error pointing at the backfill
+    command (FR-052 edge case).
+
     Args:
         repo_root: Repository root path
-        mission_slug: Feature identifier (e.g., "test-feature")
-        feature_number: Optional feature number (auto-detected if None)
+        mission_slug: Feature identifier (e.g., "083-foo-bar" or "foo-bar").
+        mission_id: ULID from ``meta.json``.  Required.  Must be present for
+            new and backfilled legacy missions; raise on missing (FR-052).
 
     Returns:
         Tuple of (worktree_path, feature_dir)
 
     Raises:
-        RuntimeError: If workspace creation fails
-        FileExistsError: If worktree path already exists
+        RuntimeError: If workspace creation fails or ``mission_id`` is missing.
+        FileExistsError: If worktree path already exists.
 
     Examples:
         >>> repo_root = Path("/path/to/repo")
-        >>> worktree, feature_dir = create_feature_worktree(repo_root, "new-feature")
+        >>> worktree, feature_dir = create_feature_worktree(
+        ...     repo_root, "new-feature", mission_id="01KNXQS9ATWWFXS3K5ZJ9E5008"
+        ... )
         >>> assert worktree.exists()
         >>> assert feature_dir.exists()
     """
-    # Auto-detect feature number if not provided
-    if feature_number is None:
-        feature_number = get_next_feature_number(repo_root)
+    if not mission_id:
+        raise RuntimeError(
+            "create_feature_worktree requires mission_id from meta.json. "
+            "For legacy missions that pre-date mission_id, run "
+            "`spec-kitty migrate backfill-identity` first."
+        )
 
-    # Format: 001-test-feature
-    branch_name = f"{feature_number:03d}-{mission_slug}"
+    from specify_cli.lanes.branch_naming import mid8, strip_numeric_prefix
 
-    # Create worktree at .worktrees/001-test-feature
+    human_slug = strip_numeric_prefix(mission_slug)
+    branch_name = f"{human_slug}-{mid8(mission_id)}"
+
+    # Create worktree at .worktrees/<human-slug>-<mid8>
     worktree_path = repo_root / WORKTREES_DIR / branch_name
 
     # Ensure .worktrees directory exists

--- a/src/specify_cli/dashboard/api_types.py
+++ b/src/specify_cli/dashboard/api_types.py
@@ -147,6 +147,44 @@ class ResearchResponse(TypedDict):
 
 
 # ---------------------------------------------------------------------------
+# Mission registry types (T048, WP09)
+# ---------------------------------------------------------------------------
+
+
+class MissionRecord(TypedDict, total=False):
+    """Single mission record from :func:`scanner.build_mission_registry`.
+
+    This is the canonical wire shape for per-mission data keyed by
+    ``mission_id`` (a ULID) or a pseudo-key (``legacy:<slug>`` or
+    ``orphan:<path.name>``).
+
+    Fields
+    ------
+    mission_id
+        The registry key itself.  For assigned/pending missions this is the
+        ULID from ``meta.json``.  For legacy missions it is ``legacy:<slug>``;
+        for orphan missions it is ``orphan:<dir-name>``.
+    mission_slug
+        Directory name (e.g. ``"080-foo"``).  Used for display and URL routing.
+    display_number
+        Integer numeric prefix (e.g. ``80`` for ``080-foo``), or ``None`` for
+        pre-merge missions.  This is a *display* metadata field — it is NOT
+        the identity key.
+    mid8
+        First 8 characters of the ULID ``mission_id``, precomputed for compact
+        display.  ``None`` for pseudo-key (legacy/orphan) records.
+    feature_dir
+        Absolute path to the mission directory as a string.
+    """
+
+    mission_id: str  # ULID or pseudo-key
+    mission_slug: str  # directory name
+    display_number: int | None  # numeric prefix for display sort; None = pre-merge
+    mid8: str | None  # first 8 chars of mission_id; None for pseudo-keys
+    feature_dir: str  # absolute path as string
+
+
+# ---------------------------------------------------------------------------
 # Features-list endpoint (the largest shape)
 # ---------------------------------------------------------------------------
 
@@ -341,6 +379,7 @@ __all__ = [
     "KanbanStats",
     "KanbanTaskData",
     "MissionContext",
+    "MissionRecord",
     "ResearchArtifact",
     "ResearchResponse",
     "SyncInfo",

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -35,6 +35,7 @@ _KANBAN_COLUMN_FOR_LANE: dict[Lane, str] = {
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "build_mission_registry",
     "format_path_for_display",
     "gather_feature_paths",
     "get_feature_artifacts",
@@ -44,6 +45,7 @@ __all__ = [
     "resolve_active_feature",
     "scan_all_features",
     "scan_feature_kanban",
+    "sort_missions_for_display",
 ]
 
 
@@ -272,6 +274,114 @@ def gather_feature_paths(project_dir: Path) -> dict[str, Path]:
                 feature_paths[feature_dir.name] = feature_dir
 
     return feature_paths
+
+
+def _read_mission_identity(feature_dir: Path) -> tuple[str | None, int | None]:
+    """Return (mission_id, mission_number) from meta.json, or (None, None) if unreadable.
+
+    Returns empty strings coerced to None for mission_id.
+    """
+    meta_path = feature_dir / "meta.json"
+    if not meta_path.exists():
+        return None, None
+    try:
+        raw = json.loads(meta_path.read_text(encoding="utf-8-sig"))
+        if not isinstance(raw, dict):
+            return None, None
+        mission_id: str | None = raw.get("mission_id") or None  # "" -> None
+        raw_number = raw.get("mission_number")
+        mission_number: int | None = None
+        if isinstance(raw_number, int):
+            mission_number = raw_number
+        elif isinstance(raw_number, str) and raw_number.isdigit():
+            mission_number = int(raw_number)
+    except (json.JSONDecodeError, OSError, ValueError):
+        return None, None
+    return mission_id, mission_number
+
+
+def _mission_record_key(feature_dir: Path, mission_id: str | None, mission_number: int | None) -> str:
+    """Compute the canonical registry key for a mission.
+
+    - Assigned (mission_id present, mission_number present): use mission_id
+    - Pending (mission_id present, mission_number absent): use mission_id
+    - Legacy (mission_id absent, mission_number present): use ``legacy:<slug>``
+    - Orphan (both absent): use ``orphan:<path.name>``
+    """
+    if mission_id is not None:
+        return mission_id
+    slug = feature_dir.name
+    if mission_number is not None:
+        return f"legacy:{slug}"
+    return f"orphan:{slug}"
+
+
+def build_mission_registry(project_dir: Path) -> dict[str, dict[str, Any]]:
+    """Return a dict keyed by ``mission_id`` (or pseudo-key) mapping to mission records.
+
+    Each record is a minimal dict with at least:
+    - ``mission_id``: str — the ULID (or the pseudo-key for legacy/orphan)
+    - ``mission_slug``: str — the directory name
+    - ``display_number``: int | None — the numeric prefix for display sorting
+    - ``mid8``: str | None — first 8 chars of mission_id (None for pseudo-keys)
+
+    Duplicate numeric prefixes produce DISTINCT records because each gets its own
+    ``mission_id`` key.  The three ``080-*`` missions on a real repo each appear
+    as a separate entry.
+
+    Args:
+        project_dir: Repository root containing ``kitty-specs/``.
+
+    Returns:
+        ``{mission_id_or_pseudo_key: record}`` dict.
+    """
+    registry: dict[str, dict[str, Any]] = {}
+    feature_paths = gather_feature_paths(project_dir)
+
+    for _feature_id, feature_dir in feature_paths.items():
+        mission_id, mission_number = _read_mission_identity(feature_dir)
+        key = _mission_record_key(feature_dir, mission_id, mission_number)
+
+        # mid8 is meaningful only when key is an actual mission_id (ULID).
+        is_pseudo = key.startswith(("legacy:", "orphan:"))
+        mid8: str | None = None if is_pseudo else (mission_id[:8] if mission_id else None)
+
+        registry[key] = {
+            "mission_id": key,  # canonical key, may be pseudo
+            "mission_slug": feature_dir.name,
+            "display_number": mission_number,
+            "mid8": mid8,
+            "feature_dir": str(feature_dir),
+        }
+
+    return registry
+
+
+def sort_missions_for_display(registry: dict[str, dict[str, Any]]) -> list[str]:
+    """Return an ordered list of registry keys suitable for display.
+
+    Sort order:
+    1. ``display_number`` ascending (missions with a numeric prefix come first)
+    2. ``None`` display_number last (pre-merge / pending missions)
+    3. Secondary: ``mission_slug`` ascending (stable tie-break among same-prefix missions)
+
+    Args:
+        registry: Output of :func:`build_mission_registry`.
+
+    Returns:
+        Ordered list of mission_id strings (or pseudo-keys).
+    """
+
+    def _sort_key(key: str) -> tuple[int, int, str]:
+        record = registry[key]
+        number = record.get("display_number")
+        slug = record.get("mission_slug", key)
+        # None sorts last: use (1, 0, slug) vs (0, number, slug)
+        if number is None:
+            return (1, 0, slug)
+        return (0, number, slug)
+
+    return sorted(registry.keys(), key=_sort_key)
 
 
 def resolve_feature_dir(project_dir: Path, feature_id: str) -> Path | None:

--- a/src/specify_cli/lanes/branch_naming.py
+++ b/src/specify_cli/lanes/branch_naming.py
@@ -1,27 +1,130 @@
 """Branch naming conventions for mission and lane branches.
 
-Mission branch: kitty/mission-{mission_slug}
-Lane branch:    kitty/mission-{mission_slug}-{lane_id}
+Branch name grammar (two forms, both accepted by parse_mission_slug_from_branch):
 
-Both use the kitty/ namespace prefix for visual grouping in git.
-Branch names use mission_slug (human-readable) rather than mission_id
-(ULID) because branches are a human-facing surface.
+  Legacy form (pre-WP02):
+    kitty/mission-<NNN>-<slug>[-lane-<id>]
+    where <NNN> is a 3-digit zero-padded numeric prefix
+
+  New form (WP02+, FR-032, FR-033):
+    kitty/mission-<human-slug>-<mid8>[-lane-<id>]
+    where <human-slug> is the mission slug with any leading NNN- prefix stripped,
+    and <mid8> is the first 8 characters of the mission's ULID.
+
+Example for this mission:
+  083-mission-id-canonical-identity-migration with ULID 01KNXQS9ATWWFXS3K5ZJ9E5008
+  -> human-slug: mission-id-canonical-identity-migration
+  -> mid8: 01KNXQS9
+  -> branch: kitty/mission-mission-id-canonical-identity-migration-01KNXQS9-lane-a
+
+Rationale: pre-merge branches must not carry dead numbering semantics, because
+there is no mission_number until merge time (FR-044). The mid8 token ensures
+two concurrent missions with identical human slugs produce distinct branch names
+(FR-032), eliminating the partition-unsafe collision that led to the 080-* triple.
+
+Both forms are accepted at read time so existing worktrees keep working (FR-052).
 """
 
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 _MISSION_PREFIX = "kitty/mission-"
-_MISSION_RE = re.compile(r"^kitty/mission-(.+)$")
-_LANE_RE = re.compile(r"^kitty/mission-(.+)-(lane-[a-z])$")
+
+# Legacy regex: NNN-slug (3 digits + hyphen prefix)
+_LEGACY_MISSION_RE = re.compile(r"^kitty/mission-(\d{3}-.+)$")
+_LEGACY_LANE_RE = re.compile(r"^kitty/mission-(\d{3}-.+)-(lane-[a-z])$")
+
+# New regex: <human-slug>-<mid8>[-lane-<id>]
+# Mid8 = exactly 8 uppercase alphanumeric characters (ULID character set)
+_MID8_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{8}$")  # Crockford base32, exactly 8 chars
+_NEW_LANE_RE = re.compile(r"^kitty/mission-(.+)-([0-9A-HJKMNP-TV-Z]{8})-(lane-[a-z])$")
+_NEW_MISSION_RE = re.compile(r"^kitty/mission-(.+)-([0-9A-HJKMNP-TV-Z]{8})$")
+
+# Numeric prefix pattern: exactly 3 digits + hyphen
+_NUMERIC_PREFIX_RE = re.compile(r"^\d{3}-(.+)$")
 
 
-def mission_branch_name(mission_slug: str) -> str:
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def strip_numeric_prefix(slug: str) -> str:
+    """Strip a leading NNN- numeric prefix from a mission slug.
+
+    Strips exactly 3 digits followed by a hyphen from the start of the slug.
+    If the slug has no such prefix, it is returned unchanged. The remainder
+    after stripping must be non-empty; if it would be empty, the original slug
+    is returned unchanged.
+
+    Rule: strip exactly ``r"^\\d{3}-"``. Do not strip 2-digit, 4-digit, or
+    longer prefixes. This matches the allocator's historical output format.
+
+    Examples:
+        "083-foo"       -> "foo"
+        "001-bar-baz"   -> "bar-baz"
+        "foo"           -> "foo"      (no prefix)
+        "08-foo"        -> "08-foo"   (only 2 digits, not stripped)
+        "1234-foo"      -> "1234-foo" (4 digits, not stripped)
+        "083-"          -> "083-"     (empty remainder, not stripped)
+    """
+    if not slug:
+        return slug
+    match = _NUMERIC_PREFIX_RE.match(slug)
+    if match:
+        remainder = match.group(1)
+        if remainder:  # only strip if remainder is non-empty
+            return remainder
+    return slug
+
+
+def mid8(mission_id: str) -> str:
+    """Return the first 8 characters of a ULID (the ``mid8`` alias).
+
+    Args:
+        mission_id: A ULID string (26 characters, Crockford base32).
+
+    Returns:
+        The first 8 characters.
+
+    Raises:
+        ValueError: If ``mission_id`` is shorter than 8 characters — this is a
+            programming error (mission_id from meta.json is always a full ULID).
+    """
+    if len(mission_id) < 8:
+        raise ValueError(
+            f"mission_id must be at least 8 characters to derive mid8, got {len(mission_id)!r}: {mission_id!r}"
+        )
+    return mission_id[:8]
+
+
+# ---------------------------------------------------------------------------
+# Branch name constructors
+# ---------------------------------------------------------------------------
+
+
+def mission_branch_name(mission_slug: str, *, mission_id: str | None = None) -> str:
     """Return the mission integration branch name.
 
-    Example: mission_branch_name("057-my-feature") -> "kitty/mission-057-my-feature"
+    When ``mission_id`` is provided, uses the new ``<human-slug>-<mid8>`` format
+    (FR-032).  When ``mission_id`` is ``None``, falls back to the legacy format
+    for backward compatibility with pre-WP02 callers.
+
+    New form:  ``kitty/mission-<human-slug>-<mid8>``
+    Legacy:    ``kitty/mission-<slug>``
+
+    Examples:
+        mission_branch_name("083-my-feature", mission_id="01KNXQS9ATWWFXS3K5ZJ9E5008")
+          -> "kitty/mission-my-feature-01KNXQS9"
+        mission_branch_name("057-my-feature")  # legacy, no mission_id
+          -> "kitty/mission-057-my-feature"
     """
+    if mission_id is not None:
+        human_slug = strip_numeric_prefix(mission_slug)
+        return f"{_MISSION_PREFIX}{human_slug}-{mid8(mission_id)}"
+    # Legacy form: no mission_id supplied (pre-WP02 callers, must still work)
     return f"{_MISSION_PREFIX}{mission_slug}"
 
 
@@ -29,6 +132,8 @@ def lane_branch_name(
     mission_slug: str,
     lane_id: str,
     planning_base_branch: str | None = None,
+    *,
+    mission_id: str | None = None,
 ) -> str:
     """Return a lane branch name.
 
@@ -36,52 +141,154 @@ def lane_branch_name(
     rather than a ``kitty/mission-…`` branch name, because planning-artifact WPs
     live in the main repository checkout on the target branch (typically ``main``).
 
+    When ``mission_id`` is provided, uses the new ``<human-slug>-<mid8>`` format
+    (FR-032).  When ``mission_id`` is ``None``, falls back to the legacy format.
+
     Args:
-        mission_slug: Feature slug (e.g. ``"057-my-feature"``).
+        mission_slug: Feature slug (e.g. ``"083-my-feature"``).
         lane_id: Lane identifier (e.g. ``"lane-a"`` or ``"lane-planning"``).
         planning_base_branch: The branch that planning-artifact work targets
             (typically the value of ``target_branch`` from ``meta.json``).
             Defaults to ``"main"`` when ``lane_id == "lane-planning"`` and this
             argument is omitted.  Ignored for all other lane IDs.
+        mission_id: Optional ULID. When present, the new ``<human-slug>-<mid8>``
+            naming format is used. When ``None``, the legacy format is preserved.
 
     Examples:
-        lane_branch_name("057-my-feature", "lane-a") -> "kitty/mission-057-my-feature-lane-a"
-        lane_branch_name("057-my-feature", "lane-planning") -> "main"
-        lane_branch_name("057-my-feature", "lane-planning", planning_base_branch="release/3.x") -> "release/3.x"
+        lane_branch_name("083-my-feature", "lane-a", mission_id="01KNXQS9ATWWFXS3K5ZJ9E5008")
+          -> "kitty/mission-my-feature-01KNXQS9-lane-a"
+        lane_branch_name("057-my-feature", "lane-a")  # legacy
+          -> "kitty/mission-057-my-feature-lane-a"
+        lane_branch_name("083-my-feature", "lane-planning")
+          -> "main"
+        lane_branch_name("083-my-feature", "lane-planning", planning_base_branch="release/3.x")
+          -> "release/3.x"
     """
     if lane_id == "lane-planning":
         return planning_base_branch if planning_base_branch is not None else "main"
+    if mission_id is not None:
+        human_slug = strip_numeric_prefix(mission_slug)
+        return f"{_MISSION_PREFIX}{human_slug}-{mid8(mission_id)}-{lane_id}"
+    # Legacy form
     return f"{_MISSION_PREFIX}{mission_slug}-{lane_id}"
 
 
-def is_mission_branch(branch_name: str) -> bool:
-    """Return True if branch matches the mission branch pattern.
+# ---------------------------------------------------------------------------
+# Predicates
+# ---------------------------------------------------------------------------
 
-    A mission branch matches kitty/mission-{slug} but NOT
-    kitty/mission-{slug}-lane-{x} (which is a lane branch).
+
+def is_mission_branch(branch_name: str) -> bool:
+    """Return True if branch matches either mission branch pattern (legacy or new).
+
+    A mission branch matches ``kitty/mission-<body>`` but NOT a lane branch
+    (which ends in ``-lane-<id>``).
     """
     if not branch_name.startswith(_MISSION_PREFIX):
         return False
-    # Must match mission pattern but NOT lane pattern
-    return _MISSION_RE.match(branch_name) is not None and _LANE_RE.match(branch_name) is None
+    # Must not be a lane branch
+    if is_lane_branch(branch_name):
+        return False
+    body = branch_name[len(_MISSION_PREFIX):]
+    return bool(body)
 
 
 def is_lane_branch(branch_name: str) -> bool:
-    """Return True if branch matches a lane branch pattern."""
-    return _LANE_RE.match(branch_name) is not None
+    """Return True if branch matches a lane branch pattern (legacy or new)."""
+    return (
+        _LEGACY_LANE_RE.match(branch_name) is not None
+        or _NEW_LANE_RE.match(branch_name) is not None
+    )
 
 
-def parse_mission_slug_from_branch(branch_name: str) -> str | None:
-    """Extract mission_slug from a mission or lane branch name.
+def is_legacy_branch(branch_name: str) -> bool:
+    """Return True if branch uses the legacy NNN-slug naming form.
 
-    Returns None if the branch doesn't match either pattern.
+    Legacy form: ``kitty/mission-NNN-slug[-lane-X]``
+    New form:    ``kitty/mission-<human-slug>-<mid8>[-lane-X]``
+
+    Returns False for non-mission branches.
     """
-    lane_match = _LANE_RE.match(branch_name)
-    if lane_match:
-        return lane_match.group(1)
-    mission_match = _MISSION_RE.match(branch_name)
-    if mission_match:
-        return mission_match.group(1)
+    if not branch_name.startswith(_MISSION_PREFIX):
+        return False
+    return (
+        _LEGACY_LANE_RE.match(branch_name) is not None
+        or _LEGACY_MISSION_RE.match(branch_name) is not None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parse result type
+# ---------------------------------------------------------------------------
+
+
+class BranchParseResult(NamedTuple):
+    """Structured result from ``parse_mission_slug_from_branch``.
+
+    Attributes:
+        slug: The human slug extracted from the branch name.
+            - Legacy: the full ``NNN-slug`` portion.
+            - New: just the ``<human-slug>`` (NNN prefix already stripped).
+        mid8_token: The 8-character ULID prefix for new-form branches;
+            ``None`` for legacy branches.
+        lane_id: The lane identifier (e.g. ``"lane-a"``) when present;
+            ``None`` for mission branches without a lane.
+    """
+
+    slug: str
+    mid8_token: str | None
+    lane_id: str | None
+
+
+# ---------------------------------------------------------------------------
+# Branch parser
+# ---------------------------------------------------------------------------
+
+
+def parse_mission_slug_from_branch(branch_name: str) -> BranchParseResult | None:
+    """Extract mission identity tokens from a mission or lane branch name.
+
+    Accepts both legacy (``NNN-slug``) and new (``<human-slug>-<mid8>``) forms,
+    for backward compatibility with worktrees created before WP02 (FR-052).
+
+    Grammar (in priority order):
+      1. New lane:     ``kitty/mission-<human-slug>-<mid8>-lane-<id>``
+      2. New mission:  ``kitty/mission-<human-slug>-<mid8>``
+      3. Legacy lane:  ``kitty/mission-NNN-slug-lane-<id>``
+      4. Legacy miss.: ``kitty/mission-NNN-slug``
+
+    The parser distinguishes new from legacy by checking whether the penultimate
+    token (before the optional lane suffix) is an 8-char ULID-alphabet token.
+    Parsing is anchored from the *right* so slugs with embedded hyphens are
+    handled correctly.
+
+    Returns:
+        A :class:`BranchParseResult` triple ``(slug, mid8_token, lane_id)`` or
+        ``None`` if the branch doesn't match any known mission pattern.
+    """
+    if not branch_name.startswith(_MISSION_PREFIX):
+        return None
+
+    # Try new lane form first (most specific)
+    m = _NEW_LANE_RE.match(branch_name)
+    if m:
+        return BranchParseResult(slug=m.group(1), mid8_token=m.group(2), lane_id=m.group(3))
+
+    # Try new mission form (no lane suffix)
+    m = _NEW_MISSION_RE.match(branch_name)
+    if m:
+        return BranchParseResult(slug=m.group(1), mid8_token=m.group(2), lane_id=None)
+
+    # Try legacy lane form
+    m = _LEGACY_LANE_RE.match(branch_name)
+    if m:
+        return BranchParseResult(slug=m.group(1), mid8_token=None, lane_id=m.group(2))
+
+    # Try legacy mission form
+    m = _LEGACY_MISSION_RE.match(branch_name)
+    if m:
+        return BranchParseResult(slug=m.group(1), mid8_token=None, lane_id=None)
+
     return None
 
 
@@ -90,7 +297,12 @@ def parse_lane_id_from_branch(branch_name: str) -> str | None:
 
     Returns None if the branch is not a lane branch.
     """
-    lane_match = _LANE_RE.match(branch_name)
-    if lane_match:
-        return lane_match.group(2)
+    # New form
+    m = _NEW_LANE_RE.match(branch_name)
+    if m:
+        return m.group(3)
+    # Legacy form
+    m = _LEGACY_LANE_RE.match(branch_name)
+    if m:
+        return m.group(2)
     return None

--- a/src/specify_cli/lanes/branch_naming.py
+++ b/src/specify_cli/lanes/branch_naming.py
@@ -35,6 +35,8 @@ _MISSION_PREFIX = "kitty/mission-"
 # Legacy regex: NNN-slug (3 digits + hyphen prefix)
 _LEGACY_MISSION_RE = re.compile(r"^kitty/mission-(\d{3}-.+)$")
 _LEGACY_LANE_RE = re.compile(r"^kitty/mission-(\d{3}-.+)-(lane-[a-z])$")
+_PLAIN_LEGACY_MISSION_RE = re.compile(r"^kitty/mission-(.+)$")
+_PLAIN_LEGACY_LANE_RE = re.compile(r"^kitty/mission-(.+)-(lane-[a-z])$")
 
 # New regex: <human-slug>-<mid8>[-lane-<id>]
 # Mid8 = exactly 8 uppercase alphanumeric characters (ULID character set)
@@ -214,6 +216,8 @@ def is_legacy_branch(branch_name: str) -> bool:
     return (
         _LEGACY_LANE_RE.match(branch_name) is not None
         or _LEGACY_MISSION_RE.match(branch_name) is not None
+        or _PLAIN_LEGACY_LANE_RE.match(branch_name) is not None
+        or _PLAIN_LEGACY_MISSION_RE.match(branch_name) is not None
     )
 
 
@@ -289,6 +293,16 @@ def parse_mission_slug_from_branch(branch_name: str) -> BranchParseResult | None
     if m:
         return BranchParseResult(slug=m.group(1), mid8_token=None, lane_id=None)
 
+    # Try compatibility legacy lane form without numeric prefix.
+    m = _PLAIN_LEGACY_LANE_RE.match(branch_name)
+    if m:
+        return BranchParseResult(slug=m.group(1), mid8_token=None, lane_id=m.group(2))
+
+    # Try compatibility legacy mission form without numeric prefix.
+    m = _PLAIN_LEGACY_MISSION_RE.match(branch_name)
+    if m:
+        return BranchParseResult(slug=m.group(1), mid8_token=None, lane_id=None)
+
     return None
 
 
@@ -303,6 +317,10 @@ def parse_lane_id_from_branch(branch_name: str) -> str | None:
         return m.group(3)
     # Legacy form
     m = _LEGACY_LANE_RE.match(branch_name)
+    if m:
+        return m.group(2)
+    # Compatibility legacy form without numeric prefix
+    m = _PLAIN_LEGACY_LANE_RE.match(branch_name)
     if m:
         return m.group(2)
     return None

--- a/src/specify_cli/lanes/branch_naming.py
+++ b/src/specify_cli/lanes/branch_naming.py
@@ -213,12 +213,8 @@ def is_legacy_branch(branch_name: str) -> bool:
     """
     if not branch_name.startswith(_MISSION_PREFIX):
         return False
-    return (
-        _LEGACY_LANE_RE.match(branch_name) is not None
-        or _LEGACY_MISSION_RE.match(branch_name) is not None
-        or _PLAIN_LEGACY_LANE_RE.match(branch_name) is not None
-        or _PLAIN_LEGACY_MISSION_RE.match(branch_name) is not None
-    )
+    parsed = parse_mission_slug_from_branch(branch_name)
+    return parsed is not None and parsed.mid8_token is None
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/merge/__init__.py
+++ b/src/specify_cli/merge/__init__.py
@@ -14,7 +14,12 @@ from specify_cli.merge.conflict_resolver import (
     classify_conflict,
     resolve_owned_conflicts,
 )
-from specify_cli.merge.ordering import MergeOrderError, get_merge_order, has_dependency_info
+from specify_cli.merge.ordering import (
+    MergeOrderError,
+    assign_next_mission_number,
+    get_merge_order,
+    has_dependency_info,
+)
 from specify_cli.merge.state import (
     MergeState,
     acquire_merge_lock,
@@ -22,6 +27,7 @@ from specify_cli.merge.state import (
     has_active_merge,
     is_merge_locked,
     load_state,
+    needs_number_assignment,
     release_merge_lock,
     save_state,
 )
@@ -47,6 +53,7 @@ __all__ = [
     "get_merge_order",
     "MergeOrderError",
     "has_dependency_info",
+    "assign_next_mission_number",
     # State persistence
     "MergeState",
     "save_state",
@@ -56,6 +63,7 @@ __all__ = [
     "acquire_merge_lock",
     "release_merge_lock",
     "is_merge_locked",
+    "needs_number_assignment",
     # Workspace
     "create_merge_workspace",
     "cleanup_merge_workspace",

--- a/src/specify_cli/merge/ordering.py
+++ b/src/specify_cli/merge/ordering.py
@@ -15,7 +15,13 @@ from specify_cli.core.dependency_graph import (
     topological_sort,
 )
 
-__all__ = ["get_merge_order", "MergeOrderError", "has_dependency_info", "display_merge_order"]
+__all__ = [
+    "get_merge_order",
+    "MergeOrderError",
+    "has_dependency_info",
+    "display_merge_order",
+    "assign_next_mission_number",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +111,75 @@ def get_merge_order(
             result.append(wp_map[wp_id])
 
     return result
+
+
+def assign_next_mission_number(target_branch_path: Path, kitty_specs_dir: Path) -> int:
+    """Compute the next dense integer ``mission_number`` for the target branch.
+
+    Walks ``kitty_specs_dir`` (which should reflect the checked-out target
+    branch's ``kitty-specs/`` view), reads every mission's ``meta.json`` via
+    the canonical metadata loader, collects all non-null integer
+    ``mission_number`` values, and returns ``max(collected) + 1`` -- or ``1``
+    if no missions on the target branch have an integer assigned yet.
+
+    **Locking invariant (FR-044, WP10/T052/T055):** This helper does **not**
+    acquire any lock.  It assumes the caller is already holding the
+    merge-state lock for the mission being merged, which provides
+    single-writer semantics against the target branch.  Calling this without
+    the lock is a race-condition bug.
+
+    Args:
+        target_branch_path: Path to the checked-out target branch worktree
+            (e.g. the merge worktree at
+            ``.kittify/runtime/merge/<mission_id>/workspace/``). Currently
+            unused for I/O -- present in the signature so callers explicitly
+            document which branch's view they are reading.  ``kitty_specs_dir``
+            must be a child of (or otherwise consistent with) this path.
+        kitty_specs_dir: Path to the ``kitty-specs/`` directory on the
+            target branch worktree.  Each immediate subdirectory containing a
+            ``meta.json`` is treated as a mission.
+
+    Returns:
+        The next available integer ``mission_number`` (>= 1).
+
+    Notes:
+        - Pre-merge missions (``mission_number: null``) are excluded from the
+          max computation by virtue of being ``None`` after coercion.
+        - Legacy string forms (``"042"``) are coerced to ``int`` by
+          :func:`specify_cli.mission_metadata.resolve_mission_identity` and
+          participate in the max.
+        - Missions whose ``meta.json`` is missing or unreadable are skipped.
+    """
+    # Lazy import to keep merge.ordering import-cheap and avoid any
+    # mission_metadata <-> merge cycles.
+    from specify_cli.mission_metadata import resolve_mission_identity
+
+    del target_branch_path  # Documentation only -- see docstring.
+
+    if not kitty_specs_dir.exists() or not kitty_specs_dir.is_dir():
+        return 1
+
+    collected: list[int] = []
+    for child in sorted(kitty_specs_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if not (child / "meta.json").exists():
+            continue
+        try:
+            identity = resolve_mission_identity(child)
+        except (ValueError, TypeError):
+            # Malformed mission_number — skip rather than crash the merge.
+            logger.warning(
+                "Skipping mission %s during number assignment scan: malformed mission_number",
+                child.name,
+            )
+            continue
+        if identity.mission_number is not None:
+            collected.append(identity.mission_number)
+
+    if not collected:
+        return 1
+    return max(collected) + 1
 
 
 def display_merge_order(

--- a/src/specify_cli/merge/state.py
+++ b/src/specify_cli/merge/state.py
@@ -30,6 +30,7 @@ __all__ = [
     "is_merge_locked",
     "detect_git_merge_state",
     "abort_git_merge",
+    "needs_number_assignment",
 ]
 
 _STATE_FILE = "state.json"
@@ -306,6 +307,35 @@ def is_merge_locked(mission_id: str, repo_root: Path) -> bool:
 # ---------------------------------------------------------------------------
 # Git merge state helpers (unchanged from original)
 # ---------------------------------------------------------------------------
+
+def needs_number_assignment(feature_dir: Path) -> bool:
+    """Return True if the mission's ``meta.json`` lacks an integer ``mission_number``.
+
+    The merge-time number-assignment gate (FR-044, WP10/T051): a mission needs
+    a number assigned when its ``meta.json`` carries ``mission_number: null``.
+    Any non-null value -- including legacy string forms like ``"042"`` -- is
+    treated as already assigned because the mission_metadata loader coerces
+    string forms to ``int`` at read time.
+
+    Args:
+        feature_dir: Path to the mission's ``kitty-specs/<slug>/`` directory.
+
+    Returns:
+        ``True`` if ``mission_number`` resolves to ``None``; ``False`` if it
+        resolves to any integer (including ``0``).  Returns ``False`` if the
+        ``meta.json`` file is missing -- there is nothing to assign into.
+    """
+    # Imported lazily to avoid a circular import (mission_metadata may import
+    # nothing in this module today, but the merge package wires into many
+    # higher-level subsystems and we want to keep the import surface tight).
+    from specify_cli.mission_metadata import resolve_mission_identity
+
+    if not (feature_dir / "meta.json").exists():
+        return False
+
+    identity = resolve_mission_identity(feature_dir)
+    return identity.mission_number is None
+
 
 def detect_git_merge_state(repo_root: Path) -> bool:
     """Check if git has an active merge in progress via MERGE_HEAD."""

--- a/src/specify_cli/migration/backfill_identity.py
+++ b/src/specify_cli/migration/backfill_identity.py
@@ -1,6 +1,6 @@
 """Assign immutable identity fields to all entities in a legacy project.
 
-Three entry points:
+Three legacy entry points (preserved for backward compatibility):
 
 - :func:`backfill_project_uuid` – write ``spec_kitty.project_uuid`` to
   ``.kittify/metadata.yaml``.
@@ -9,7 +9,14 @@ Three entry points:
 - :func:`backfill_wp_ids` – write ``work_package_id``, ``wp_code``, and
   ``mission_id`` to each WP frontmatter file under ``tasks/``.
 
-All three functions are *idempotent*: if an ID already exists it is never
+WP04 additions (FR-013, FR-014, FR-050, FR-051):
+
+- :class:`BackfillResult` – per-mission result dataclass.
+- :func:`backfill_mission` – idempotent ULID write for a single mission.
+- :func:`backfill_repo` – walk ``kitty-specs/`` and call
+  :func:`backfill_mission` on each, then trigger dossier rehash.
+
+All functions are *idempotent*: if an ID already exists it is never
 overwritten.
 """
 
@@ -18,11 +25,14 @@ from __future__ import annotations
 import json
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import ulid as _ulid_mod
 from ruamel.yaml import YAML
+
+from specify_cli.mission_metadata import _coerce_mission_number
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +54,254 @@ def _make_yaml() -> YAML:
     y.width = 4096
     y.indent(mapping=2, sequence=2, offset=0)
     return y
+
+
+# ---------------------------------------------------------------------------
+# WP04: BackfillResult dataclass
+# ---------------------------------------------------------------------------
+
+BackfillAction = Literal["wrote", "skip", "error"]
+
+
+@dataclass
+class BackfillResult:
+    """Per-mission result from :func:`backfill_mission`.
+
+    Attributes:
+        feature_dir: Absolute path to the mission directory.
+        slug: Directory name used as mission slug.
+        action: ``"wrote"`` – ULID minted and written; ``"skip"`` – field
+            already present; ``"error"`` – unrecoverable per-mission error.
+        mission_id: Newly minted ULID when *action* is ``"wrote"``, existing
+            ULID when *action* is ``"skip"``, ``None`` on error.
+        number_coerced: ``True`` when ``mission_number`` was rewritten from
+            a string (e.g. ``"042"``) to an integer (``42``).
+        reason: Human-readable explanation (populated on ``"skip"`` and
+            ``"error"``).
+        dossier_warning: Non-empty string when the dossier rehash step
+            logged a recoverable warning.
+    """
+
+    feature_dir: Path
+    slug: str
+    action: BackfillAction
+    mission_id: str | None = None
+    number_coerced: bool = False
+    reason: str | None = None
+    dossier_warning: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# WP04: idempotent single-mission backfill
+# ---------------------------------------------------------------------------
+
+
+def backfill_mission(feature_dir: Path, *, dry_run: bool = False) -> BackfillResult:
+    """Idempotently write ``mission_id`` into ``<feature_dir>/meta.json``.
+
+    If ``mission_id`` is already present and non-empty the call is a no-op
+    (returns ``action="skip"``).  If missing or empty a fresh ULID is minted
+    and written atomically.
+
+    Also applies legacy ``mission_number`` type coercion (T020): a string
+    value that parses as a positive integer (e.g. ``"042"``) is rewritten as
+    the integer ``42``.  Sentinel strings such as ``"pending"`` raise
+    :class:`ValueError` immediately — they are never silently discarded.
+
+    Args:
+        feature_dir: Absolute path to a single mission directory containing
+            ``meta.json``.
+        dry_run: When ``True``, compute the result without writing to disk.
+
+    Returns:
+        A :class:`BackfillResult` describing what happened.
+    """
+    slug = feature_dir.name
+    meta_path = feature_dir / "meta.json"
+
+    # --- missing meta.json ---------------------------------------------------
+    if not meta_path.exists():
+        logger.debug("Skipping %s (no meta.json)", slug)
+        return BackfillResult(
+            feature_dir=feature_dir,
+            slug=slug,
+            action="skip",
+            reason="meta.json not found",
+        )
+
+    # --- read ----------------------------------------------------------------
+    try:
+        raw_text = meta_path.read_text(encoding="utf-8")
+        meta: dict[str, Any] = json.loads(raw_text)
+        if not isinstance(meta, dict):
+            raise ValueError(f"Expected JSON object, got {type(meta).__name__}")
+    except (json.JSONDecodeError, OSError, ValueError) as exc:
+        logger.warning("Corrupt meta.json in %s: %s", slug, exc)
+        return BackfillResult(
+            feature_dir=feature_dir,
+            slug=slug,
+            action="error",
+            reason=f"corrupt json: {exc}",
+        )
+
+    changed = False
+
+    # --- mission_id ----------------------------------------------------------
+    existing_id: str | None = meta.get("mission_id") or None  # treat "" as None
+    if existing_id is not None:
+        skip_id = True
+        new_id = existing_id
+    else:
+        skip_id = False
+        new_id = _generate_ulid()
+        meta["mission_id"] = new_id
+        changed = True
+
+    # --- mission_number coercion (T020) --------------------------------------
+    number_coerced = False
+    raw_number = meta.get("mission_number")
+    if isinstance(raw_number, str) and raw_number.strip():
+        try:
+            coerced = _coerce_mission_number(raw_number)
+        except (TypeError, ValueError) as exc:
+            # Sentinel strings like "pending" — raise loudly, do not guess.
+            raise ValueError(
+                f"Cannot coerce mission_number {raw_number!r} in {slug}: {exc}"
+            ) from exc
+        if coerced != raw_number:
+            meta["mission_number"] = coerced
+            number_coerced = True
+            changed = True
+
+    # --- write (sorted keys, standard format matching write_meta) ---------------
+    if changed and not dry_run:
+        content = json.dumps(meta, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+        meta_path.write_text(content, encoding="utf-8")
+
+    if skip_id and not number_coerced:
+        return BackfillResult(
+            feature_dir=feature_dir,
+            slug=slug,
+            action="skip",
+            mission_id=existing_id,
+            number_coerced=False,
+            reason="mission_id already present",
+        )
+
+    action: BackfillAction = "skip" if dry_run and skip_id else "wrote" if not skip_id else "skip"
+    # If mission_id was already present but number was coerced, report "wrote"
+    if number_coerced and not dry_run:
+        action = "wrote"
+    if dry_run and not skip_id:
+        action = "wrote"  # dry-run would-write
+    return BackfillResult(
+        feature_dir=feature_dir,
+        slug=slug,
+        action=action,
+        mission_id=new_id,
+        number_coerced=number_coerced,
+    )
+
+
+# ---------------------------------------------------------------------------
+# WP04: repo-level walk
+# ---------------------------------------------------------------------------
+
+
+def backfill_repo(
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+    mission_slug: str | None = None,
+) -> list[BackfillResult]:
+    """Walk ``kitty-specs/`` and idempotently backfill every mission.
+
+    After the write pass completes, triggers a dossier rehash (via
+    :func:`~specify_cli.sync.dossier_pipeline.trigger_feature_dossier_sync_if_enabled`)
+    for every mission that was modified (``action="wrote"`` or
+    ``number_coerced=True``).  Individual dossier failures are captured as
+    warnings and do not abort the overall run.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        dry_run: When ``True``, compute results without writing any files.
+        mission_slug: When provided, scope the walk to a single mission
+            directory (optional).
+
+    Returns:
+        List of :class:`BackfillResult`, one per mission directory visited.
+    """
+    kitty_specs = repo_root / "kitty-specs"
+    results: list[BackfillResult] = []
+
+    if not kitty_specs.is_dir():
+        logger.warning("kitty-specs/ not found at %s", repo_root)
+        return results
+
+    if mission_slug is not None:
+        # Scope to a single mission directory.
+        candidates: list[Path] = []
+        for entry in kitty_specs.iterdir():
+            if entry.is_dir() and entry.name == mission_slug:
+                candidates.append(entry)
+        if not candidates:
+            logger.warning("No mission directory found for slug %r", mission_slug)
+            return results
+    else:
+        candidates = sorted(
+            entry for entry in kitty_specs.iterdir() if entry.is_dir()
+        )
+
+    for feature_dir in candidates:
+        result = backfill_mission(feature_dir, dry_run=dry_run)
+        results.append(result)
+
+    # --- dossier rehash (T021) -----------------------------------------------
+    if not dry_run:
+        _rehash_modified_missions(results, repo_root)
+
+    return results
+
+
+def trigger_feature_dossier_sync_if_enabled(
+    feature_dir: Path,
+    mission_slug: str,
+    repo_root: Path,
+) -> None:
+    """Thin wrapper around the dossier pipeline for patching in tests."""
+    from specify_cli.sync.dossier_pipeline import (
+        trigger_feature_dossier_sync_if_enabled as _real_fn,
+    )
+    _real_fn(
+        feature_dir=feature_dir,
+        mission_slug=mission_slug,
+        repo_root=repo_root,
+    )
+
+
+def _rehash_modified_missions(results: list[BackfillResult], repo_root: Path) -> None:
+    """Trigger dossier rehash for every mission that was modified.
+
+    Failures are captured as :attr:`BackfillResult.dossier_warning` on the
+    corresponding result entry and do not propagate exceptions.
+    """
+    modified = [r for r in results if r.action == "wrote" or r.number_coerced]
+    for result in modified:
+        try:
+            trigger_feature_dossier_sync_if_enabled(
+                feature_dir=result.feature_dir,
+                mission_slug=result.slug,
+                repo_root=repo_root,
+            )
+        except Exception as exc:
+            warning = f"dossier rehash failed: {exc}"
+            logger.warning("Dossier rehash warning for %s: %s", result.slug, exc)
+            result.dossier_warning = warning
+
+
+# ---------------------------------------------------------------------------
+# Legacy entry points (preserved for backward compatibility)
+# ---------------------------------------------------------------------------
 
 
 def backfill_project_uuid(repo_root: Path) -> str:

--- a/src/specify_cli/mission_metadata.py
+++ b/src/specify_cli/mission_metadata.py
@@ -31,9 +31,13 @@ from specify_cli.core.atomic import atomic_write
 
 
 class MissionMetaRequired(TypedDict):
-    """Required fields -- always present in a valid meta.json."""
+    """Required fields -- always present in a valid meta.json.
 
-    mission_number: str
+    Note: ``mission_number`` is stored as ``int | null`` in meta.json
+    (per FR-044).  This TypedDict uses ``str`` for backward-compatibility
+    documentation only; the actual runtime type is ``int | None``.
+    """
+
     slug: str
     mission_slug: str
     friendly_name: str
@@ -77,10 +81,19 @@ _MISSION_NUMBER_PATTERN = re.compile(r"^(?P<number>\d+)-")
 
 @dataclass(frozen=True, slots=True)
 class MissionIdentity:
-    """Canonical machine-facing mission identity fields."""
+    """Canonical machine-facing mission identity fields.
+
+    ``mission_number`` is ``int | None``:
+    - ``None``  — pre-merge mission (no number assigned yet; FR-044)
+    - ``int``   — post-merge mission (dense display number assigned at merge)
+
+    Legacy missions stored as strings (``"042"``) are coerced to ``int`` by
+    the reader (``resolve_mission_identity``).  The write path always emits
+    ``null`` or an integer, never a string sentinel (FR-044, T008).
+    """
 
     mission_slug: str
-    mission_number: str
+    mission_number: int | None
     mission_type: str
     mission_id: str | None = None  # Canonical identity per ADR b85116ed. None only for pre-3.1.1 missions.
 
@@ -95,22 +108,92 @@ def _now_iso() -> str:
     return _dt.datetime.now(_dt.UTC).isoformat()
 
 
-def mission_number_from_slug(mission_slug: str) -> str:
-    """Extract the numeric mission prefix from a mission slug when present."""
+def mission_number_from_slug(mission_slug: str) -> int | None:
+    """Extract the numeric mission prefix from a mission slug when present.
+
+    Returns the prefix as an ``int`` if the slug starts with ``NNN-``,
+    or ``None`` if no numeric prefix is found.
+
+    Examples:
+        "083-foo-bar" -> 83
+        "foo-bar"     -> None
+    """
     match = _MISSION_NUMBER_PATTERN.match(str(mission_slug).strip())
     if match is None:
-        return ""
-    return match.group("number")
+        return None
+    raw = match.group("number")
+    try:
+        return int(raw.lstrip("0") or "0") or int(raw)
+    except ValueError:
+        return None
+
+
+def _coerce_mission_number(raw: object) -> int | None:
+    """Coerce a raw meta.json ``mission_number`` value to ``int | None``.
+
+    Canonical coercion matrix (T008 / FR-044):
+
+    - ``None``, ``""`` (missing or empty)   → ``None``
+    - ``int``                                → pass through
+    - ``str`` that parses as positive int    → ``int`` (leading zeros stripped)
+    - ``str`` "pending", "unassigned", "TBD" → ``ValueError``
+    - ``str`` not parseable as int           → ``ValueError``
+    - ``float``, ``list``, etc.              → ``TypeError``
+    """
+    _SENTINEL_STRINGS = frozenset({"pending", "unassigned", "TBD"})
+
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        # bool is a subclass of int, but a bool mission_number is a bug
+        raise TypeError(
+            f"meta.json mission_number must be int or null, got bool {raw!r}."
+        )
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        if not raw.strip():
+            # empty or whitespace-only string → None
+            return None
+        if raw.strip() in _SENTINEL_STRINGS:
+            raise ValueError(
+                f"meta.json mission_number must be int or null, got {raw!r}. "
+                "Run `spec-kitty migrate backfill-identity` to migrate."
+            )
+        try:
+            stripped = raw.strip().lstrip("0")
+            return int(stripped) if stripped else 0
+        except ValueError:
+            raise ValueError(
+                f"meta.json mission_number must be int or null, got {raw!r}. "
+                "Run `spec-kitty migrate backfill-identity` to migrate."
+            ) from None
+    raise TypeError(
+        f"meta.json mission_number must be int, str, or null, got {type(raw).__name__!r}."
+    )
 
 
 def mission_identity_fields(
     mission_slug: str,
-    mission_number: str | None = None,
+    mission_number: int | str | None = None,
     mission_type: str | None = None,
 ) -> dict[str, str]:
-    """Normalize canonical mission identity fields for machine-facing payloads."""
+    """Normalize canonical mission identity fields for machine-facing payloads.
+
+    Converts ``mission_number`` to a display string at the payload boundary.
+    ``None`` becomes ``""``; integers are formatted as their decimal string
+    representation (no leading-zero padding — that is display-layer choice).
+    """
     resolved_slug = str(mission_slug).strip()
-    resolved_number = str(mission_number or "").strip() or mission_number_from_slug(resolved_slug)
+    # Stringify mission_number at the display boundary
+    if isinstance(mission_number, int):
+        resolved_number: str = str(mission_number)
+    else:
+        resolved_number = str(mission_number or "").strip()
+    # Fall back to slug-derived prefix if no number provided
+    if not resolved_number:
+        slug_number = mission_number_from_slug(resolved_slug)
+        resolved_number = str(slug_number) if slug_number is not None else ""
     resolved_type = str(mission_type or "").strip() or "software-dev"
     return {
         "mission_slug": resolved_slug,
@@ -120,15 +203,27 @@ def mission_identity_fields(
 
 
 def resolve_mission_identity(feature_dir: Path) -> MissionIdentity:
-    """Resolve canonical mission identity fields from a mission directory."""
+    """Resolve canonical mission identity fields from a mission directory.
+
+    Reads ``meta.json`` and coerces ``mission_number`` to ``int | None``
+    using the legacy coercion rule (T008):
+
+    - Stored as JSON null   → ``None``
+    - Stored as JSON int    → ``int``
+    - Stored as string "042" → ``42`` (leading zeros stripped)
+    - Stored as "pending" / sentinel → raises ``ValueError``
+    """
     meta = load_meta(feature_dir) or {}
-    fields = mission_identity_fields(
-        str(meta.get("mission_slug") or meta.get("slug") or feature_dir.name),
-        str(meta.get("mission_number") or "").strip() or None,
-        str(meta.get("mission_type") or meta.get("mission") or "").strip() or None,
-    )
+    raw_number = meta.get("mission_number")
+    mission_number: int | None = _coerce_mission_number(raw_number)
+
+    resolved_slug = str(meta.get("mission_slug") or meta.get("slug") or feature_dir.name)
+    resolved_type = str(meta.get("mission_type") or meta.get("mission") or "").strip() or "software-dev"
+
     return MissionIdentity(
-        **fields,
+        mission_slug=resolved_slug,
+        mission_number=mission_number,
+        mission_type=resolved_type,
         mission_id=meta.get("mission_id"),  # None if not present (legacy mission)
     )
 

--- a/src/specify_cli/missions/software-dev/command-templates/analyze.md
+++ b/src/specify_cli/missions/software-dev/command-templates/analyze.md
@@ -9,7 +9,7 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## Goal
 

--- a/src/specify_cli/missions/software-dev/command-templates/charter.md
+++ b/src/specify_cli/missions/software-dev/command-templates/charter.md
@@ -11,7 +11,7 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## Command Contract
 

--- a/src/specify_cli/missions/software-dev/command-templates/checklist.md
+++ b/src/specify_cli/missions/software-dev/command-templates/checklist.md
@@ -20,7 +20,7 @@ description: Generate a requirements-quality checklist
 
 **Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 

--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -19,7 +19,7 @@ guardrails for bulk operations.
 allocated by `spec-kitty agent action implement WPxx --agent <name>`. Do NOT modify files outside
 your `owned_files` boundaries.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 

--- a/src/specify_cli/missions/software-dev/command-templates/plan.md
+++ b/src/specify_cli/missions/software-dev/command-templates/plan.md
@@ -14,14 +14,15 @@ description: Create an implementation plan
 # You should already be here if you just ran /spec-kitty.specify
 
 # Creates:
-# - kitty-specs/###-feature/plan.md → In project root checkout
+# - kitty-specs/<mission_slug>/plan.md → In project root checkout
+#   (the NNN- prefix in the directory listing is display-only metadata)
 # - Commits to target branch
 # - NO worktrees created
 ```
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -60,7 +61,7 @@ This command runs in the **project root checkout**, not in a worktree.
   - Run `spec-kitty agent mission setup-plan --mission <mission-slug> --json`
   - Use `current_branch`, `target_branch` / `base_branch`, and `planning_base_branch` / `merge_target_branch` (plus uppercase aliases) from that payload
   - Use `branch_matches_target` from that payload to detect branch mismatch; do not probe branch state manually inside the prompt
-- Planning artifacts live in `kitty-specs/###-mission/`
+- Planning artifacts live in `kitty-specs/<mission_slug>/` (the `NNN-` prefix is display-only metadata)
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
@@ -123,11 +124,14 @@ Planning requirements (scale to complexity):
 
    **Example**:
    ```bash
-   # If detected feature is 020-my-feature:
-   spec-kitty agent mission setup-plan --mission 020-my-feature --json
+   # Resolve the active mission handle, then pass it to setup-plan.
+   # The --mission flag accepts mission_id (ULID), mid8 (first 8 chars), or mission_slug.
+   # The resolver disambiguates by mission_id; ambiguous handles become structured errors.
+   spec-kitty agent context resolve --mission <handle> --json
+   spec-kitty agent mission setup-plan --mission <handle> --json
    ```
 
-   **Error handling**: If the command fails with "Cannot detect feature" or "Multiple features found", verify your feature detection logic in step 2 and ensure you're passing the correct feature slug.
+   **Error handling**: If the command fails with "Cannot detect mission", "Multiple missions found", or `MISSION_AMBIGUOUS_SELECTOR`, pass an unambiguous handle — the `mission_id` or its 8-char prefix `mid8` always disambiguates.
 
 4. **Load context**: Read `spec_file` from setup-plan JSON output and `.kittify/charter/charter.md` if it exists. If the charter file is missing, skip Charter Check and note that it is absent. Load IMPL_PLAN template (already copied).
 

--- a/src/specify_cli/missions/software-dev/command-templates/research.md
+++ b/src/specify_cli/missions/software-dev/command-templates/research.md
@@ -3,7 +3,7 @@ description: Generate research documents for the current mission
 ---
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<feature>/tasks/`). Never refer to a folder by name alone.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## Location Pre-flight Check
 
@@ -16,7 +16,7 @@ git branch --show-current
 
 **Expected output:**
 - `pwd`: Should end with your project root directory path
-- Branch: Should show your feature branch name like `001-feature-name` (NOT `main`)
+- Branch: Should show your mission branch (e.g. `kitty/mission-<slug>-<mid8>` or a legacy `NNN-feature-name` form), NOT `main`
 
 **If you see the main branch or the wrong directory path:**
 

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -246,10 +246,10 @@ Given that feature description, do this:
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
     - For any remaining ambiguity:
-      * Ask the user a focused follow-up question immediately and halt work until they answer
-      * Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
-      * Record any interim assumption in the Assumptions section
-      * Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
+      - Ask the user a focused follow-up question immediately and halt work until they answer
+      - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
+      - Record any interim assumption in the Assumptions section
+      - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -14,14 +14,16 @@ description: Create a mission specification
 cd /path/to/project/root  # Your project root checkout
 
 # All planning artifacts are created in the project root and committed:
-# - kitty-specs/###-feature/spec.md → Created in project root
+# - kitty-specs/<mission_slug>/spec.md → Created in project root
+#   (use the mission_slug returned by `mission create`; the numeric NNN- prefix
+#    is display-only and is assigned at merge time)
 # - Committed to target branch (from create JSON: target_branch/base_branch)
 # - NO worktrees created
 ```
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -141,16 +143,16 @@ Store the final mission selection in your notes and include it in the spec outpu
 
 **Planning happens in the project root checkout - NO worktree created!**
 
-1. Creates `kitty-specs/###-mission/spec.md` directly in project root
+1. Creates `kitty-specs/<mission_slug>/spec.md` directly in project root (the optional `NNN-` prefix is display-only metadata assigned at merge time)
 2. Automatically commits to target branch
 3. No worktree created during specify
 
-**Worktrees created later**: After `/spec-kitty.tasks` finishes, run: `spec-kitty next --agent <agent> --mission <slug>`. Your agent will call `spec-kitty agent action implement WP## --agent <name>` for each WP. Each lane gets exactly one worktree, for example `.worktrees/###-feature-lane-a`.
+**Worktrees created later**: After `/spec-kitty.tasks` finishes, run: `spec-kitty next --agent <agent> --mission <handle>`. The `--mission` handle can be the mission's `mission_id` (ULID), `mid8` (first 8 chars), or `mission_slug`; the resolver disambiguates by `mission_id` and returns a structured error on ambiguity (no silent fallback). Your agent will call `spec-kitty agent action implement WP## --agent <name>` for each WP. Each lane gets exactly one worktree, for example `.worktrees/<human-slug>-<mid8>-lane-a/` (e.g. `.worktrees/my-feature-01J6XW9K-lane-a/`).
 
 ## Location
 
 - Work in: **Project root checkout** (not a worktree)
-- Creates: `kitty-specs/###-feature/spec.md`
+- Creates: `kitty-specs/<mission_slug>/spec.md` (the `NNN-` prefix is display-only and assigned at merge time)
 - Commits to: target branch (from `create --json` → `target_branch`)
 
 ## Outline
@@ -183,8 +185,9 @@ Given that feature description, do this:
 
    The command returns JSON with:
    - `result`: "success" or error message
-   - `mission_slug`: Mission number and slug (e.g., "014-checkout-upsell-flow")
-   - `mission_number`: Mission number (e.g., "014")
+   - `mission_id`: Canonical ULID machine identity (e.g., `01J6XW9KQT7M0YB3N4R5CQZ2EX`). Immutable.
+   - `mission_slug`: Human-readable mission slug (e.g., `checkout-upsell-flow`)
+   - `mission_number`: **Display-only** numeric prefix, `null` pre-merge. Assigned at merge time. **Never** use this as a selector or identity.
    - `mission_type`: Mission type key (for example `software-dev`)
    - `slug`: Unnumbered mission slug (e.g., `checkout-upsell-flow`)
    - `feature_dir`: Absolute path to the feature directory inside the main repo
@@ -210,7 +213,7 @@ Given that feature description, do this:
    **Do NOT try to read a template file.** The spec structure is defined in this prompt (see sections below). The `create` command scaffolds an initial `spec.md` — read it, then update it following the structure in this prompt.
 
 5. Update `<feature_dir>/meta.json` only when needed:
-   - Keep identity fields from `create` unchanged (`mission_number`, `slug`, `mission_slug`, `created_at`, `target_branch`).
+   - **Never** modify identity fields from `create` (`mission_id`, `slug`, `mission_slug`, `created_at`, `target_branch`). `mission_id` is the canonical ULID and is immutable. `mission_number` is display-only and is `null` pre-merge — do not set it by hand.
    - Keep `target_branch` aligned to the value from `create --json` output. Never hardcode `main`.
    - Ensure `friendly_name` matches the confirmed title.
    - Ensure `mission_type` is correct.
@@ -220,9 +223,10 @@ Given that feature description, do this:
    Example `meta.json` schema (identity fields that must be present explicitly):
    ```json
    {
-     "mission_number": "042",
+     "mission_id": "01J6XW9KQT7M0YB3N4R5CQZ2EX",
+     "mission_number": null,
      "slug": "my-feature",
-     "mission_slug": "042-my-feature",
+     "mission_slug": "my-feature",
      "friendly_name": "My Mission",
      "mission_type": "software-dev",
      "target_branch": "main",
@@ -230,6 +234,10 @@ Given that feature description, do this:
      "created_at": "2026-01-01T00:00:00+00:00"
    }
    ```
+
+   `mission_number` becomes a concrete integer only at merge time, assigned as
+   `max(existing_numbers)+1` inside the merge-state lock. Selectors disambiguate
+   by `mission_id` (or its 8-char prefix `mid8`), never by `mission_number`.
 
    **Do not regenerate timestamps or directory paths via shell commands.**
 

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-outline.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-outline.md
@@ -33,7 +33,7 @@ break work into clear pieces, and write detailed guidance.
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
@@ -19,7 +19,7 @@ This step assumes `wps.yaml` already exists with complete WP definitions.
 
 **IMPORTANT**: This step works in the project root checkout. NO worktrees created.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 

--- a/src/specify_cli/missions/software-dev/command-templates/tasks.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks.md
@@ -635,4 +635,3 @@ A rushed job with vague, oversized WPs causes:
 - Implementation taking 2-3x longer
 - Rework and review cycles
 - Feature failure
-

--- a/src/specify_cli/missions/software-dev/command-templates/tasks.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks.md
@@ -32,17 +32,18 @@ description: Break a plan into work packages
 # You should already be here if you just ran /spec-kitty.plan
 
 # Creates:
-# - kitty-specs/###-feature/tasks/WP01-*.md → In project root checkout
-# - kitty-specs/###-feature/tasks/WP02-*.md → In project root checkout
+# - kitty-specs/<mission_slug>/tasks/WP01-*.md → In project root checkout
+# - kitty-specs/<mission_slug>/tasks/WP02-*.md → In project root checkout
+#   (the NNN- prefix in directory listings is display-only metadata)
 # - Commits ALL to target branch
 # - NO worktrees created
 ```
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**Worktrees created later**: After tasks are finalized, run your agent loop: `spec-kitty next --agent <agent> --mission <slug>`. Your agent will call `spec-kitty agent action implement WP## --agent <name>` for each WP. `finalize_tasks` computes the execution lanes, and each lane gets exactly one worktree.
+**Worktrees created later**: After tasks are finalized, run your agent loop: `spec-kitty next --agent <agent> --mission <handle>`. Your agent will call `spec-kitty agent action implement WP## --agent <name>` for each WP. `finalize_tasks` computes the execution lanes, and each lane gets exactly one worktree.
 
-**In repos with multiple missions, always pass `--mission <slug>` to every spec-kitty command.**
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 

--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -53,6 +53,24 @@ logger = logging.getLogger(__name__)
 _LEGACY_LANE_FIELD = "lane"
 
 
+def _load_mission_id(feature_dir: Path) -> str | None:
+    """Load the canonical mission_id (ULID) from meta.json.
+
+    Returns None when meta.json is absent or does not contain
+    a ``mission_id`` key (legacy missions pre-dating 3.1.1).
+    Never raises — missing/corrupt meta is a silent degradation.
+    """
+    try:
+        meta = load_meta(feature_dir)
+    except ValueError:
+        logger.debug("Malformed meta.json in %s; mission_id will be None", feature_dir)
+        return None
+    if not isinstance(meta, dict):
+        return None
+    raw_id = meta.get("mission_id")
+    return str(raw_id) if raw_id else None
+
+
 class TransitionError(Exception):
     """Raised when a status transition is invalid."""
 
@@ -293,6 +311,10 @@ def emit_status_transition(
     if feature_dir is None or mission_slug is None or wp_id is None or to_lane is None or actor is None:
         raise TypeError("emit_status_transition requires feature_dir/mission_dir, mission_slug, wp_id, to_lane, and actor")
 
+    # T023: Load mission_id (ULID) from meta.json to use as the canonical
+    # machine-facing identity for new events.  None for legacy/pre-3.1.1 missions.
+    mission_id = _load_mission_id(feature_dir)
+
     raw_to_lane = to_lane.strip().lower()
 
     # Step 1: Resolve alias
@@ -332,6 +354,7 @@ def emit_status_transition(
             review_ref=review_ref,
             evidence=None,
             policy_metadata=policy_metadata,
+            mission_id=mission_id,
         )
 
     # Step 3: Validate the transition
@@ -356,7 +379,11 @@ def emit_status_transition(
     if not ok:
         raise TransitionError(error_msg)
 
-    # Step 4: Create StatusEvent with ULID event_id
+    # Step 4: Create StatusEvent with ULID event_id.
+    # mission_id is the canonical machine-facing identity (ULID from meta.json).
+    # T023: New events carry mission_id alongside mission_slug.
+    # T025: to_dict() emits legacy_aggregate_id=mission_slug as a drift-window
+    # compatibility shim for downstream SaaS consumers (removable after WP12).
     event = StatusEvent(
         event_id=_generate_ulid(),
         mission_slug=mission_slug,
@@ -371,6 +398,7 @@ def emit_status_transition(
         review_ref=review_ref,
         evidence=done_evidence,
         policy_metadata=policy_metadata,
+        mission_id=mission_id,
     )
 
     # Step 5: Persist event to JSONL log

--- a/src/specify_cli/status/identity_audit.py
+++ b/src/specify_cli/status/identity_audit.py
@@ -1,0 +1,326 @@
+"""Mission-identity health audit (FR-010, FR-011, FR-012, FR-045, NFR-002).
+
+Four-state classifier
+---------------------
+Every mission in ``kitty-specs/`` is classified into one of four derived states
+based on the presence / absence of ``mission_id`` and ``mission_number`` in
+``meta.json`` (FR-045):
+
+``assigned``
+    ``mission_id`` is present AND ``mission_number`` is non-null.
+    Fully migrated / post-merge.
+
+``pending``
+    ``mission_id`` is present AND ``mission_number`` is null.
+    Pre-merge, waiting for merge-to-main number assignment.
+
+``legacy``
+    ``mission_id`` is missing AND ``mission_number`` is present.
+    Pre-migration artifact; requires backfill.
+
+``orphan``
+    Both fields missing (or meta.json unreadable).
+    Requires manual triage.
+
+Duplicate-prefix report (FR-011)
+---------------------------------
+:func:`find_duplicate_prefixes` walks ``kitty-specs/`` and groups mission
+directories by their 3-digit leading numeric prefix.  Any group with ≥ 2
+members is reported.
+
+Selector-ambiguity report (FR-012)
+------------------------------------
+:func:`find_ambiguous_selectors` computes every handle form for each mission
+(full slug, numeric prefix, human slug) and flags handles that map to ≥ 2
+missions.
+
+Performance: the full audit over 200 missions must complete in < 3 s (NFR-002).
+All I/O is synchronous file reads; no subprocesses are spawned.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from specify_cli.lanes.branch_naming import strip_numeric_prefix
+from specify_cli.mission_metadata import _coerce_mission_number
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+IdentityStateLabel = Literal["assigned", "pending", "legacy", "orphan"]
+
+# Regex to extract exactly 3-digit leading prefix from a directory name.
+_PREFIX_RE = re.compile(r"^(\d{3})-")
+
+
+@dataclass
+class IdentityState:
+    """Audit result for a single mission directory.
+
+    Attributes:
+        path: Absolute path to the mission directory (e.g. ``kitty-specs/083-foo``).
+        slug: Directory name used as the mission slug.
+        mission_id: ULID string from ``meta.json``, or ``None`` if missing.
+        mission_number: Integer from ``meta.json`` (after coercion), or ``None``.
+        state: Four-state label per FR-045.
+        error: Non-empty when ``meta.json`` could not be read / parsed.
+    """
+
+    path: Path
+    slug: str
+    mission_id: str | None
+    mission_number: int | None
+    state: IdentityStateLabel
+    error: str | None = field(default=None)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "path": str(self.path),
+            "slug": self.slug,
+            "mission_id": self.mission_id,
+            "mission_number": self.mission_number,
+            "state": self.state,
+            "error": self.error,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_mission(feature_dir: Path) -> IdentityState:
+    """Classify a single mission directory into one of the four identity states.
+
+    Reads ``meta.json`` from *feature_dir*.  A corrupt or unreadable
+    ``meta.json`` is classified as ``orphan`` with the ``error`` field
+    populated — it does **not** propagate an exception.
+
+    Args:
+        feature_dir: Absolute path to a mission directory (must contain
+            ``meta.json`` or be classifiable as an orphan without one).
+
+    Returns:
+        An :class:`IdentityState` for the mission.
+    """
+    slug = feature_dir.name
+    meta_path = feature_dir / "meta.json"
+
+    # --- Try to read meta.json -------------------------------------------------
+    if not meta_path.exists():
+        return IdentityState(
+            path=feature_dir,
+            slug=slug,
+            mission_id=None,
+            mission_number=None,
+            state="orphan",
+            error="meta.json not found",
+        )
+
+    try:
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError(f"Expected JSON object, got {type(raw).__name__}")
+    except (json.JSONDecodeError, OSError, ValueError) as exc:
+        return IdentityState(
+            path=feature_dir,
+            slug=slug,
+            mission_id=None,
+            mission_number=None,
+            state="orphan",
+            error=str(exc),
+        )
+
+    # --- Extract fields --------------------------------------------------------
+    mission_id: str | None = raw.get("mission_id") or None  # treat "" as None
+    raw_number = raw.get("mission_number")
+    try:
+        mission_number: int | None = _coerce_mission_number(raw_number)
+    except (TypeError, ValueError) as exc:
+        # Sentinel string like "pending" or bad type — treat as None for classification.
+        logger.debug("mission_number coercion error for %s: %s", feature_dir, exc)
+        mission_number = None
+
+    # --- Four-state matrix (FR-045) -------------------------------------------
+    if mission_id is not None and mission_number is not None:
+        state: IdentityStateLabel = "assigned"
+    elif mission_id is not None and mission_number is None:
+        state = "pending"
+    elif mission_id is None and mission_number is not None:
+        state = "legacy"
+    else:
+        state = "orphan"
+
+    return IdentityState(
+        path=feature_dir,
+        slug=slug,
+        mission_id=mission_id,
+        mission_number=mission_number,
+        state=state,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repo-level audit
+# ---------------------------------------------------------------------------
+
+
+def audit_repo(repo_root: Path) -> list[IdentityState]:
+    """Walk ``kitty-specs/`` and classify every mission directory.
+
+    Directories without a ``meta.json`` are classified as ``orphan``.
+    Entries that are not directories (e.g. ``README.md``) are silently skipped.
+    An empty or absent ``kitty-specs/`` directory returns an empty list.
+
+    Args:
+        repo_root: Path to the repository root (contains ``kitty-specs/``).
+
+    Returns:
+        Sorted list of :class:`IdentityState` objects, one per mission directory.
+    """
+    specs_dir = repo_root / "kitty-specs"
+    if not specs_dir.exists():
+        return []
+
+    states: list[IdentityState] = []
+    for entry in sorted(specs_dir.iterdir()):
+        if not entry.is_dir():
+            continue  # skip README.md, templates, etc.
+        states.append(classify_mission(entry))
+
+    return states
+
+
+# ---------------------------------------------------------------------------
+# Summarise
+# ---------------------------------------------------------------------------
+
+
+def summarize(states: list[IdentityState]) -> dict[str, object]:
+    """Aggregate a list of :class:`IdentityState` objects into a summary dict.
+
+    Returns a dict with:
+    - ``counts``: ``{state: int}`` for all four states (zero-filled)
+    - ``legacy_paths``: list of ``str`` paths for legacy missions
+    - ``orphan_paths``: list of ``str`` paths for orphan missions
+
+    Args:
+        states: Flat list from :func:`audit_repo`.
+    """
+    counts: dict[str, int] = {"assigned": 0, "pending": 0, "legacy": 0, "orphan": 0}
+    legacy_paths: list[str] = []
+    orphan_paths: list[str] = []
+
+    for s in states:
+        counts[s.state] += 1
+        if s.state == "legacy":
+            legacy_paths.append(str(s.path))
+        elif s.state == "orphan":
+            orphan_paths.append(str(s.path))
+
+    return {
+        "counts": counts,
+        "legacy_paths": legacy_paths,
+        "orphan_paths": orphan_paths,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-prefix report (FR-011)
+# ---------------------------------------------------------------------------
+
+
+def find_duplicate_prefixes(repo_root: Path) -> dict[str, list[IdentityState]]:
+    """Report every 3-digit numeric prefix shared by ≥ 2 mission directories.
+
+    Walks ``kitty-specs/`` and groups directories by their leading ``NNN-``
+    prefix (regex ``^(\\d{3})-``).  Only groups with size ≥ 2 are returned.
+
+    Directories without a leading numeric prefix are silently skipped.
+
+    Args:
+        repo_root: Path to the repository root.
+
+    Returns:
+        ``{"NNN": [<IdentityState>, ...]}`` for every duplicated prefix.
+        Empty dict when no duplicates exist.
+    """
+    specs_dir = repo_root / "kitty-specs"
+    if not specs_dir.exists():
+        return {}
+
+    groups: dict[str, list[IdentityState]] = {}
+    for entry in sorted(specs_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        m = _PREFIX_RE.match(entry.name)
+        if not m:
+            continue
+        prefix = m.group(1)
+        state = classify_mission(entry)
+        groups.setdefault(prefix, []).append(state)
+
+    return {prefix: items for prefix, items in groups.items() if len(items) >= 2}
+
+
+# ---------------------------------------------------------------------------
+# Selector-ambiguity report (FR-012)
+# ---------------------------------------------------------------------------
+
+
+def find_ambiguous_selectors(
+    states: list[IdentityState],
+) -> dict[str, list[IdentityState]]:
+    """Report every selector handle that would resolve to ≥ 2 missions.
+
+    For each mission, three handle forms are computed:
+    - **Full slug** — the directory name (e.g. ``"083-foo-bar"``)
+    - **Numeric prefix** — the leading 3-digit token (e.g. ``"083"``)
+    - **Human slug** — the slug with its numeric prefix stripped (e.g. ``"foo-bar"``)
+
+    Any handle that maps to ≥ 2 distinct missions is an ambiguity.
+
+    A handle is an *exact* match — the handle ``"foo"`` does not ambiguate
+    with ``"foobar"`` unless ``"foobar"`` is itself used as a full-slug
+    handle (which it is not, since full-slug is the directory name).
+
+    Args:
+        states: Flat list from :func:`audit_repo`.
+
+    Returns:
+        ``{"handle": [<IdentityState>, ...]}`` for every ambiguous handle.
+        Empty dict when every handle resolves to exactly one mission.
+    """
+    handle_map: dict[str, list[IdentityState]] = {}
+
+    for state in states:
+        slug = state.slug
+        handles: set[str] = set()
+
+        # Full slug handle
+        handles.add(slug)
+
+        # Numeric prefix handle
+        m = _PREFIX_RE.match(slug)
+        if m:
+            handles.add(m.group(1))
+
+        # Human slug handle (strip exactly NNN- prefix)
+        human = strip_numeric_prefix(slug)
+        if human != slug:
+            handles.add(human)
+
+        for handle in handles:
+            handle_map.setdefault(handle, []).append(state)
+
+    return {h: items for h, items in handle_map.items() if len(items) >= 2}

--- a/src/specify_cli/status/models.py
+++ b/src/specify_cli/status/models.py
@@ -171,6 +171,15 @@ class StatusEvent:
     """Immutable record of a single lane transition.
 
     Each event is one line in status.events.jsonl.
+
+    Wire-format evolution (FR-023, ADR 2026-04-09-1):
+    - Legacy events: carry only ``mission_slug`` for mission identity.
+    - New events (post-WP05): carry both ``mission_slug`` AND ``mission_id``
+      (the ULID from meta.json).  ``mission_id`` becomes the canonical
+      machine-facing identity; ``mission_slug`` is retained for human
+      readability and backward compatibility.
+    - ``legacy_aggregate_id``: drift-window compat field, equals ``mission_slug``
+      on new writes, absent on legacy events.  Readers ignore it.
     """
 
     event_id: str  # ULID
@@ -186,6 +195,9 @@ class StatusEvent:
     review_ref: str | None = None
     evidence: DoneEvidence | None = None
     policy_metadata: dict[str, Any] | None = None
+    # mission_id (ULID) added in WP05; None for legacy events read from disk
+    # before the migration, or for missions that pre-date mission_id minting.
+    mission_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -203,6 +215,12 @@ class StatusEvent:
             "evidence": self.evidence.to_dict() if self.evidence else None,
             "policy_metadata": self.policy_metadata,
         }
+        if self.mission_id is not None:
+            d["mission_id"] = self.mission_id
+            # Drift-window shim (T025): legacy_aggregate_id carries mission_slug
+            # so downstream SaaS consumers that index by slug can still find events.
+            # Remove after SaaS side migrates to mission_id (tracked in WP12).
+            d["legacy_aggregate_id"] = self.mission_slug
         return d
 
     # Legacy lane name aliases from older event log formats.
@@ -231,6 +249,7 @@ class StatusEvent:
             review_ref=data.get("review_ref"),
             evidence=DoneEvidence.from_dict(evidence_data) if evidence_data else None,
             policy_metadata=data.get("policy_metadata"),
+            mission_id=data.get("mission_id"),  # None for legacy events
         )
 
 

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -3,17 +3,36 @@
 Provides append-only persistence of StatusEvent records to a JSONL file
 (status.events.jsonl). Each line is a JSON object with deterministic
 (sorted) key ordering.
+
+Back-compat reader (T024, FR-023):
+    Events written before WP05 carry only ``mission_slug`` for mission
+    identity. Events written after WP05 carry both ``mission_slug`` AND
+    ``mission_id`` (a ULID from meta.json).
+
+    The :func:`read_events` reader tolerates both shapes and resolves the
+    ``mission_id`` for legacy events by reading the corresponding
+    ``meta.json`` file. The slug→mission_id mapping is cached per call
+    inside ``_SlugResolver`` to avoid repeated disk reads.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import re
 from pathlib import Path
 from typing import Any
 
 from .models import StatusEvent
 
+logger = logging.getLogger(__name__)
+
 EVENTS_FILENAME = "status.events.jsonl"
+
+# Regex patterns for identity classification (T024)
+_ULID_PATTERN = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+_MISSION_SLUG_PATTERN = re.compile(r"^\d{3}-[a-z0-9-]+$")
+_WP_ID_PATTERN = re.compile(r"^WP\d+$")
 
 
 class StoreError(Exception):
@@ -23,6 +42,96 @@ class StoreError(Exception):
 def _events_path(feature_dir: Path) -> Path:
     """Return the canonical path to the events JSONL file."""
     return feature_dir / EVENTS_FILENAME
+
+
+class _SlugResolver:
+    """Cache-backed slug → mission_id resolver.
+
+    Reads ``meta.json`` from the kitty-specs directory alongside the
+    event log to resolve a legacy ``mission_slug`` to its canonical
+    ``mission_id`` (ULID).  Results are cached in memory to avoid
+    repeated disk reads within a single :func:`read_events` call.
+
+    Orphaned slugs (whose meta.json does not exist or does not contain
+    a ``mission_id``) are logged as a warning and return ``None``.
+    """
+
+    def __init__(self, feature_dir: Path) -> None:
+        # feature_dir is the directory that owns status.events.jsonl.
+        # The slug→dir mapping uses sibling kitty-specs directories.
+        self._feature_dir = feature_dir
+        self._kitty_specs_root: Path | None = self._find_kitty_specs_root()
+        self._cache: dict[str, str | None] = {}
+
+    def _find_kitty_specs_root(self) -> Path | None:
+        """Walk up from feature_dir to find the kitty-specs root."""
+        candidate = self._feature_dir.parent
+        # feature_dir is typically kitty-specs/<slug>/ — so parent is kitty-specs/
+        if candidate.name == "kitty-specs":
+            return candidate
+        # In case we're already inside a deeper structure, try two levels up
+        two_up = candidate.parent
+        if two_up.name == "kitty-specs":
+            return two_up
+        # Otherwise, fall back to the parent (best effort)
+        return candidate
+
+    def resolve(self, mission_slug: str) -> str | None:
+        """Return the mission_id for *mission_slug*, or None if unresolvable.
+
+        Reads ``<kitty_specs_root>/<mission_slug>/meta.json`` and extracts
+        the ``mission_id`` field.  Returns None if the file is missing,
+        the field is absent, or JSON is malformed (logs a warning).
+        """
+        if mission_slug in self._cache:
+            return self._cache[mission_slug]
+
+        mission_id: str | None = None
+        if self._kitty_specs_root is not None:
+            meta_path = self._kitty_specs_root / mission_slug / "meta.json"
+            if meta_path.exists():
+                try:
+                    data = json.loads(meta_path.read_text(encoding="utf-8"))
+                    mission_id = data.get("mission_id") or None
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning(
+                        "Could not read meta.json for slug %r: %s",
+                        mission_slug,
+                        exc,
+                    )
+            else:
+                logger.warning(
+                    "No meta.json found for mission_slug %r (orphaned event); "
+                    "mission_id will be None for these events",
+                    mission_slug,
+                )
+
+        self._cache[mission_slug] = mission_id
+        return mission_id
+
+
+def _resolve_mission_id_from_dict(
+    raw: dict[str, Any],
+    resolver: _SlugResolver,
+) -> str | None:
+    """Resolve the canonical mission_id from a raw event dict.
+
+    Strategy (T024):
+    1. If the event already carries ``mission_id`` (new-format), use it.
+    2. If ``aggregate_id`` looks like a ULID, treat it as ``mission_id``.
+    3. If ``mission_slug`` / ``feature_slug`` is present, resolve via meta.json.
+    4. Return None for unresolvable events (caller logs/skips as appropriate).
+    """
+    # New-format event: mission_id field present directly
+    if raw.get("mission_id"):
+        return str(raw["mission_id"])
+
+    # Legacy path: try to resolve from mission_slug
+    slug = raw.get("mission_slug") or raw.get("feature_slug") or ""
+    if slug:
+        return resolver.resolve(slug)
+
+    return None
 
 
 def append_event(feature_dir: Path, event: StatusEvent) -> None:
@@ -67,6 +176,11 @@ def read_events_raw(feature_dir: Path) -> list[dict[str, Any]]:
 def read_events(feature_dir: Path) -> list[StatusEvent]:
     """Read and deserialize StatusEvent objects from the events file.
 
+    Handles both legacy events (``mission_slug`` only) and new events
+    (``mission_slug`` + ``mission_id``).  For legacy events, the
+    ``mission_id`` is resolved from the corresponding ``meta.json`` via
+    the slug resolver (cached per call).
+
     Returns an empty list when the file does not exist.
     Blank lines are silently skipped.
     Raises :class:`StoreError` on invalid JSON **or** invalid event
@@ -76,6 +190,7 @@ def read_events(feature_dir: Path) -> list[StatusEvent]:
     if not path.exists():
         return []
 
+    resolver = _SlugResolver(feature_dir)
     results: list[StatusEvent] = []
     with path.open("r", encoding="utf-8") as fh:
         for line_number, raw_line in enumerate(fh, start=1):
@@ -87,6 +202,12 @@ def read_events(feature_dir: Path) -> list[StatusEvent]:
             except json.JSONDecodeError as exc:
                 raise StoreError(f"Invalid JSON on line {line_number}: {exc}") from exc
             try:
+                # Resolve mission_id from the raw dict before parsing,
+                # so that from_dict() receives it even for legacy events.
+                resolved_mission_id = _resolve_mission_id_from_dict(obj, resolver)
+                if resolved_mission_id is not None and "mission_id" not in obj:
+                    # Inject resolved value so from_dict() populates the field
+                    obj = {**obj, "mission_id": resolved_mission_id}
                 event = StatusEvent.from_dict(obj)
             except (KeyError, ValueError, TypeError) as exc:
                 raise StoreError(f"Invalid event structure on line {line_number}: {exc}") from exc

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -121,7 +121,7 @@ _ULID_PATTERN = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")  # kept for test compat
 # Broader ID validation via normalize_event_id (accepts ULID + UUID)
 from specify_cli.spec_kitty_events import normalize_event_id as _normalize_event_id
 _WP_ID_PATTERN = re.compile(r"^WP\d{2}$")
-_FEATURE_SLUG_PATTERN = re.compile(r"^\d{3}-[a-z0-9-]+$")
+_FEATURE_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$")
 _FEATURE_NUMBER_PATTERN = re.compile(r"^\d{3}$")
 
 

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -1,4 +1,26 @@
-"""EventEmitter: core event creation and dispatch for CLI sync."""
+"""EventEmitter: core event creation and dispatch for CLI sync.
+
+Outbound SaaS payload contract (FR-024, ADR 2026-04-09-1, WP06):
+  All mission-lifecycle events (MissionCreated, MissionClosed,
+  MissionOriginBound) use ``aggregate_id = mission_id`` (a ULID) as
+  the canonical machine-facing identity.  The human-readable slug and
+  numeric identifier survive as display-metadata fields in the payload:
+
+    ``aggregate_id``   — mission_id (ULID) — primary join key for SaaS
+    ``payload.mission_id``     — same ULID, for payload-level consumers
+    ``payload.mission_slug``   — human slug (display / backward compat)
+    ``payload.mission_number`` — int | None (None for pre-merge missions)
+
+  WP-level event emitters (WPStatusChanged, WPCreated, WPAssigned,
+  DependencyResolved, HistoryAdded) are NOT affected; they use
+  ``aggregate_id = wp_id``.
+
+  Error events use ``aggregate_id = wp_id`` or ``"error"``; also
+  NOT affected.
+
+  The SaaS-side schema update is tracked in spec-kitty-saas#47 (WP12).
+  Remove ``mission_slug`` display fields after that PR lands.
+"""
 
 from __future__ import annotations
 
@@ -150,10 +172,12 @@ _PAYLOAD_RULES: dict[str, dict[str, Any]] = {
         },
     },
     "MissionCreated": {
+        # mission_number is int | None (FR-044, WP02): None for pre-merge,
+        # int for post-merge.  mission_id (ULID) is the aggregate identity.
         "required": {"mission_slug", "mission_number", "target_branch", "wp_count"},
         "validators": {
             "mission_slug": lambda v: isinstance(v, str) and bool(_FEATURE_SLUG_PATTERN.match(v)),
-            "mission_number": lambda v: isinstance(v, str) and bool(_FEATURE_NUMBER_PATTERN.match(v)),
+            "mission_number": lambda v: v is None or (isinstance(v, int) and v >= 0),
             "target_branch": lambda v: isinstance(v, str) and len(v) >= 1,
             "wp_count": lambda v: isinstance(v, int) and v >= 0,
             "created_at": lambda v: _is_datetime_string(v),
@@ -442,14 +466,24 @@ class EventEmitter:
     def emit_mission_created(
         self,
         mission_slug: str,
-        mission_number: str,
+        mission_number: int | None,
         target_branch: str,
         wp_count: int,
         created_at: str | None = None,
         causation_id: str | None = None,
         mission_id: str | None = None,
     ) -> dict[str, Any] | None:
-        """Emit MissionCreated event (FR-011)."""
+        """Emit MissionCreated event (FR-011, FR-024).
+
+        ``mission_id`` is the canonical aggregate identity (ULID from meta.json).
+        ``aggregate_id`` is set to ``mission_id`` when provided, enabling the SaaS
+        side to join events without relying on mutable slug strings (ADR 2026-04-09-1).
+
+        Payload always includes:
+          - ``mission_id``     — ULID primary key (equals aggregate_id when present)
+          - ``mission_slug``   — human display string (never used as join key)
+          - ``mission_number`` — int | None (None for pre-merge, int for post-merge)
+        """
         payload: dict[str, Any] = {
             "mission_slug": mission_slug,
             "mission_number": mission_number,
@@ -458,11 +492,18 @@ class EventEmitter:
         }
         if created_at is not None:
             payload["created_at"] = created_at
+        # mission_id is the aggregate identity (FR-024).  Always include in
+        # payload when present so SaaS consumers see both the join key and
+        # display slug.  aggregate_id switches from mission_slug → mission_id
+        # when mission_id is available; legacy call sites that omit mission_id
+        # fall back to mission_slug for backward compat during the drift window.
+        effective_aggregate_id = mission_slug
         if mission_id is not None:
             payload["mission_id"] = mission_id
+            effective_aggregate_id = mission_id
         return self._emit(
             event_type="MissionCreated",
-            aggregate_id=mission_slug,
+            aggregate_id=effective_aggregate_id,
             aggregate_type="Mission",
             payload=payload,
             causation_id=causation_id,
@@ -475,8 +516,17 @@ class EventEmitter:
         completed_at: str | None = None,
         total_duration: str | None = None,
         causation_id: str | None = None,
+        mission_id: str | None = None,
     ) -> dict[str, Any] | None:
-        """Emit MissionClosed event (FR-012)."""
+        """Emit MissionClosed event (FR-012, FR-024).
+
+        ``mission_id`` is the canonical aggregate identity (ULID from meta.json).
+        ``aggregate_id`` is set to ``mission_id`` when provided (ADR 2026-04-09-1).
+
+        Payload always includes:
+          - ``mission_id``   — ULID primary key (when present)
+          - ``mission_slug`` — human display string (backward compat)
+        """
         payload: dict[str, Any] = {
             "mission_slug": mission_slug,
             "total_wps": total_wps,
@@ -485,9 +535,14 @@ class EventEmitter:
             payload["completed_at"] = completed_at
         if total_duration is not None:
             payload["total_duration"] = total_duration
+        # mission_id is the aggregate identity (FR-024).
+        effective_aggregate_id = mission_slug
+        if mission_id is not None:
+            payload["mission_id"] = mission_id
+            effective_aggregate_id = mission_id
         return self._emit(
             event_type="MissionClosed",
-            aggregate_id=mission_slug,
+            aggregate_id=effective_aggregate_id,
             aggregate_type="Mission",
             payload=payload,
             causation_id=causation_id,
@@ -577,8 +632,17 @@ class EventEmitter:
         external_issue_url: str,
         title: str,
         causation_id: str | None = None,
+        mission_id: str | None = None,
     ) -> dict[str, Any] | None:
-        """Emit MissionOriginBound event (observational telemetry only)."""
+        """Emit MissionOriginBound event (observational telemetry, FR-024).
+
+        ``mission_id`` is the canonical aggregate identity (ULID from meta.json).
+        ``aggregate_id`` is set to ``mission_id`` when provided (ADR 2026-04-09-1).
+
+        Payload always includes:
+          - ``mission_id``   — ULID primary key (when present)
+          - ``mission_slug`` — human display string (backward compat)
+        """
         payload: dict[str, Any] = {
             "mission_slug": mission_slug,
             "provider": provider,
@@ -587,9 +651,14 @@ class EventEmitter:
             "external_issue_url": external_issue_url,
             "title": title,
         }
+        # mission_id is the aggregate identity (FR-024).
+        effective_aggregate_id = mission_slug
+        if mission_id is not None:
+            payload["mission_id"] = mission_id
+            effective_aggregate_id = mission_id
         return self._emit(
             event_type="MissionOriginBound",
-            aggregate_id=mission_slug,
+            aggregate_id=effective_aggregate_id,
             aggregate_type="Mission",
             payload=payload,
             causation_id=causation_id,

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -121,7 +121,9 @@ _ULID_PATTERN = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")  # kept for test compat
 # Broader ID validation via normalize_event_id (accepts ULID + UUID)
 from specify_cli.spec_kitty_events import normalize_event_id as _normalize_event_id
 _WP_ID_PATTERN = re.compile(r"^WP\d{2}$")
-_FEATURE_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$")
+_FEATURE_SLUG_PATTERN = re.compile(
+    r"^(?:\d{3}-[a-z0-9-]+|[a-z0-9]+(?:-[a-z0-9]+)*-[0-9A-HJKMNP-TV-Z]{8})$"
+)
 _FEATURE_NUMBER_PATTERN = re.compile(r"^\d{3}$")
 
 

--- a/src/specify_cli/sync/events.py
+++ b/src/specify_cli/sync/events.py
@@ -247,7 +247,7 @@ def emit_wp_assigned(
 
 def emit_mission_created(
     mission_slug: str,
-    mission_number: str,
+    mission_number: int | None,
     target_branch: str,
     wp_count: int,
     created_at: str | None = None,

--- a/src/specify_cli/upgrade/migrations/m_3_1_1_normalize_status_json.py
+++ b/src/specify_cli/upgrade/migrations/m_3_1_1_normalize_status_json.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from specify_cli.mission_metadata import resolve_mission_identity
-from specify_cli.status.reducer import SNAPSHOT_FILENAME, materialize, materialize_to_json, reduce
+from specify_cli.status.reducer import SNAPSHOT_FILENAME, reduce
 from specify_cli.status.store import read_events
 
 from ..registry import MigrationRegistry
@@ -37,7 +36,7 @@ def _iter_feature_dirs(project_path: Path) -> list[Path]:
 
 
 def _needs_normalisation(feature_dir: Path) -> bool:
-    """Return True when status.json differs from the canonical reduced snapshot.
+    """Return True when status.json has a stale ``materialized_at`` value.
 
     This check must stay read-only. Calling ``materialize()`` here would rewrite
     ``status.json`` during detect()/dry_run evaluation and hide stale files from
@@ -47,13 +46,10 @@ def _needs_normalisation(feature_dir: Path) -> bool:
     if not status_path.exists():
         return False
     try:
+        actual = json.loads(status_path.read_text(encoding="utf-8"))
         snapshot = reduce(read_events(feature_dir))
-        identity = resolve_mission_identity(feature_dir)
-        snapshot.mission_number = identity.mission_number
-        snapshot.mission_type = identity.mission_type
-        expected = materialize_to_json(snapshot)
-        actual = status_path.read_text(encoding="utf-8")
-        return actual != expected
+        expected_materialized_at = snapshot.materialized_at
+        return actual.get("materialized_at") != expected_materialized_at
     except Exception:
         return False
 
@@ -88,10 +84,14 @@ class NormalizeStatusJsonMigration(BaseMigration):
                     if _needs_normalisation(feature_dir):
                         changes.append(f"{feature_dir.name}: would normalise status.json")
                 else:
-                    before = status_path.read_text(encoding="utf-8")
-                    materialize(feature_dir)
-                    after = status_path.read_text(encoding="utf-8")
-                    if before != after:
+                    if _needs_normalisation(feature_dir):
+                        current = json.loads(status_path.read_text(encoding="utf-8"))
+                        snapshot = reduce(read_events(feature_dir))
+                        current["materialized_at"] = snapshot.materialized_at
+                        status_path.write_text(
+                            json.dumps(current, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
+                            encoding="utf-8",
+                        )
                         changes.append(f"{feature_dir.name}: normalised status.json")
             except Exception as exc:
                 errors.append(f"{feature_dir.name}: {exc}")

--- a/tests/agent/cli/commands/test_status_validate.py
+++ b/tests/agent/cli/commands/test_status_validate.py
@@ -60,6 +60,23 @@ def _make_event(
     return event
 
 
+def _extract_json(output: str) -> dict:
+    """Extract the first JSON object from mixed stdout output."""
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        pass
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise ValueError(f"No valid JSON found in output:\n{output}")
+
+
 def _setup_feature(
     tmp_path: Path,
     mission_slug: str = "034-test-feature",
@@ -238,7 +255,7 @@ class TestValidateCommand:
         )
         assert result.exit_code == 0
 
-        data = json.loads(result.output)
+        data = _extract_json(result.output)
         assert data["mission_slug"] == mission_slug
         assert "passed" in data
         assert isinstance(data["errors"], list)
@@ -278,7 +295,7 @@ class TestValidateCommand:
         )
         assert result.exit_code == 1
 
-        data = json.loads(result.output)
+        data = _extract_json(result.output)
         assert data["passed"] is False
         assert data["error_count"] > 0
         assert len(data["errors"]) > 0
@@ -330,6 +347,6 @@ class TestValidateCommand:
             app, ["validate", "--mission", mission_slug, "--json"]
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = _extract_json(result.output)
         assert data["passed"] is True
         assert data["error_count"] == 0

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -8,12 +8,15 @@ from unittest.mock import Mock, patch
 
 import pytest
 from typer.testing import CliRunner
+from ulid import ULID
 
 from specify_cli.cli.commands.agent.mission import app
 
 pytestmark = pytest.mark.fast
 
 runner = CliRunner()
+TEST_MISSION_ID = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+TEST_MISSION_MID8 = TEST_MISSION_ID[:8]
 
 
 class TestBranchContextCommand:
@@ -60,9 +63,8 @@ class TestCreateFeatureCommand:
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.core.mission_creation.is_git_repo", return_value=True)
     @patch("specify_cli.core.mission_creation.get_current_branch")
-    @patch("specify_cli.core.mission_creation.get_next_feature_number")
     def test_creates_feature_with_json_output(
-        self, mock_get_number: Mock, mock_branch: Mock,
+        self, mock_branch: Mock,
         mock_is_git: Mock, mock_locate: Mock, mock_is_wt: Mock,
         mock_commit: Mock, mock_emit: Mock, tmp_path: Path
     ):
@@ -70,7 +72,6 @@ class TestCreateFeatureCommand:
         # Setup
         mock_locate.return_value = tmp_path
         mock_branch.return_value = "main"
-        mock_get_number.return_value = 1
 
         # Create necessary directories
         (tmp_path / ".kittify" / "templates").mkdir(parents=True)
@@ -78,13 +79,14 @@ class TestCreateFeatureCommand:
         (tmp_path / "kitty-specs").mkdir(exist_ok=True)
 
         # Execute
-        result = runner.invoke(app, ["create", "test-feature", "--json"])
+        with patch("specify_cli.core.mission_creation.ULID", return_value=ULID.from_str(TEST_MISSION_ID)):
+            result = runner.invoke(app, ["create", "test-feature", "--json"])
 
         # Verify
         assert result.exit_code == 0, f"Command failed: {result.output}"
         output = json.loads(result.stdout)
         assert output["result"] == "success"
-        assert output["mission_slug"] == "001-test-feature"
+        assert output["mission_slug"] == f"test-feature-{TEST_MISSION_MID8}"
         assert "feature_dir" in output
         assert output["current_branch"] == "main"
         assert output["target_branch"] == "main"
@@ -97,7 +99,7 @@ class TestCreateFeatureCommand:
         assert output["BASE_BRANCH"] == "main"
 
         # Verify feature directory was created
-        feature_dir = tmp_path / "kitty-specs" / "001-test-feature"
+        feature_dir = tmp_path / "kitty-specs" / f"test-feature-{TEST_MISSION_MID8}"
         assert feature_dir.exists()
         assert (feature_dir / "spec.md").exists()
 
@@ -105,9 +107,10 @@ class TestCreateFeatureCommand:
         meta_path = feature_dir / "meta.json"
         assert meta_path.exists()
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        assert meta["mission_number"] == "001"
-        assert meta["slug"] == "001-test-feature"
-        assert meta["mission_slug"] == "001-test-feature"
+        assert meta["mission_id"] == TEST_MISSION_ID
+        assert meta["mission_number"] is None
+        assert meta["slug"] == f"test-feature-{TEST_MISSION_MID8}"
+        assert meta["mission_slug"] == f"test-feature-{TEST_MISSION_MID8}"
         assert meta["mission_type"] == "software-dev"
         assert meta["target_branch"] == "main"
 
@@ -117,9 +120,8 @@ class TestCreateFeatureCommand:
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.core.mission_creation.is_git_repo", return_value=True)
     @patch("specify_cli.core.mission_creation.get_current_branch")
-    @patch("specify_cli.core.mission_creation.get_next_feature_number")
     def test_creates_feature_with_human_output(
-        self, mock_get_number: Mock, mock_branch: Mock,
+        self, mock_branch: Mock,
         mock_is_git: Mock, mock_locate: Mock, mock_is_wt: Mock,
         mock_commit: Mock, mock_emit: Mock, tmp_path: Path
     ):
@@ -127,7 +129,6 @@ class TestCreateFeatureCommand:
         # Setup
         mock_locate.return_value = tmp_path
         mock_branch.return_value = "main"
-        mock_get_number.return_value = 1
 
         # Create necessary directories
         (tmp_path / ".kittify" / "templates").mkdir(parents=True)
@@ -135,11 +136,12 @@ class TestCreateFeatureCommand:
         (tmp_path / "kitty-specs").mkdir(exist_ok=True)
 
         # Execute
-        result = runner.invoke(app, ["create", "test-feature"])
+        with patch("specify_cli.core.mission_creation.ULID", return_value=ULID.from_str(TEST_MISSION_ID)):
+            result = runner.invoke(app, ["create", "test-feature"])
 
         # Verify
         assert result.exit_code == 0, f"Command failed: {result.output}"
-        assert "Mission created: 001-test-feature" in result.stdout
+        assert f"Mission created: test-feature-{TEST_MISSION_MID8}" in result.stdout
         assert "Directory:" in result.stdout
 
     @patch("specify_cli.core.mission_creation.is_worktree_context", return_value=False)
@@ -257,9 +259,8 @@ class TestCreateFeatureCommand:
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.core.mission_creation.is_git_repo", return_value=True)
     @patch("specify_cli.core.mission_creation.get_current_branch")
-    @patch("specify_cli.core.mission_creation.get_next_feature_number")
     def test_allows_feature_creation_from_any_branch(
-        self, mock_get_number: Mock, mock_branch: Mock,
+        self, mock_branch: Mock,
         mock_is_git: Mock, mock_locate: Mock, mock_is_wt: Mock,
         mock_commit: Mock, mock_emit: Mock, tmp_path: Path
     ):
@@ -267,7 +268,6 @@ class TestCreateFeatureCommand:
         # Setup: On non-main branch — should succeed (not block)
         mock_locate.return_value = tmp_path
         mock_branch.return_value = "develop"
-        mock_get_number.return_value = 1
 
         # Create necessary directories
         (tmp_path / ".kittify" / "templates").mkdir(parents=True)
@@ -275,7 +275,8 @@ class TestCreateFeatureCommand:
         (tmp_path / "kitty-specs").mkdir(exist_ok=True)
 
         # Execute
-        result = runner.invoke(app, ["create", "test-feature", "--json"])
+        with patch("specify_cli.core.mission_creation.ULID", return_value=ULID.from_str(TEST_MISSION_ID)):
+            result = runner.invoke(app, ["create", "test-feature", "--json"])
 
         # Verify — should succeed, recording "develop" as target_branch
         assert result.exit_code == 0, f"Command failed: {result.output}"
@@ -289,9 +290,8 @@ class TestCreateFeatureCommand:
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.core.mission_creation.is_git_repo", return_value=True)
     @patch("specify_cli.core.mission_creation.get_current_branch")
-    @patch("specify_cli.core.mission_creation.get_next_feature_number")
     def test_creates_feature_on_primary_branch(
-        self, mock_get_number: Mock, mock_branch: Mock,
+        self, mock_branch: Mock,
         mock_is_git: Mock, mock_locate: Mock, mock_is_wt: Mock,
         mock_commit: Mock, mock_emit: Mock, tmp_path: Path
     ):
@@ -299,7 +299,6 @@ class TestCreateFeatureCommand:
         # Setup: On primary branch
         mock_locate.return_value = tmp_path
         mock_branch.return_value = "main"
-        mock_get_number.return_value = 1
 
         # Create necessary directories
         (tmp_path / ".kittify" / "templates").mkdir(parents=True)
@@ -307,7 +306,8 @@ class TestCreateFeatureCommand:
         (tmp_path / "kitty-specs").mkdir(exist_ok=True)
 
         # Execute
-        result = runner.invoke(app, ["create", "test-feature", "--json"])
+        with patch("specify_cli.core.mission_creation.ULID", return_value=ULID.from_str(TEST_MISSION_ID)):
+            result = runner.invoke(app, ["create", "test-feature", "--json"])
 
         # Verify
         assert result.exit_code == 0, f"Command failed: {result.output}"

--- a/tests/agent/test_commands.py
+++ b/tests/agent/test_commands.py
@@ -161,6 +161,23 @@ def test_research_creates_artifacts(monkeypatch, tmp_path: Path) -> None:
 def test_accept_checklist_json_output(monkeypatch, tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
+    feature_dir = repo_root / "kitty-specs" / "001-demo-feature"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_id": "01KNXQS9ATWWFXS3K5ZJ9E5008",
+                "mission_slug": "001-demo-feature",
+                "slug": "001-demo-feature",
+                "friendly_name": "Demo Feature",
+                "mission_type": "software-dev",
+                "target_branch": "main",
+                "created_at": "2026-04-12T00:00:00+00:00",
+                "mission_number": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     class DummySummary:
         ok = True

--- a/tests/agent/test_context_resolve_unit.py
+++ b/tests/agent/test_context_resolve_unit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -44,12 +45,21 @@ def _write_wp(path: Path, wp_id: str, lane: str, dependencies: str = "[]") -> No
 
 
 def _make_feature(repo_root: Path, slug: str, *, target_branch: str = "main") -> Path:
+    config_path = repo_root / ".kittify" / "config.yaml"
+    if not config_path.exists():
+        config_path.write_text(
+            "project:\n  uuid: 00000000-0000-0000-0000-000000000001\n",
+            encoding="utf-8",
+        )
+
+    mission_id = "01" + hashlib.sha1(slug.encode("utf-8")).hexdigest().upper()[:24]
     feature_dir = repo_root / "kitty-specs" / slug
     feature_dir.mkdir(parents=True)
     (feature_dir / "meta.json").write_text(
         json.dumps(
             {
-                "mission_number": slug.split("-", 1)[0],
+                "mission_id": mission_id,
+                "mission_number": None,
                 "mission_slug": slug,
                 "mission_type": "software-dev",
                 "target_branch": target_branch,

--- a/tests/agent/test_create_feature_branch_unit.py
+++ b/tests/agent/test_create_feature_branch_unit.py
@@ -40,7 +40,6 @@ def _run_create_feature(
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value=current_branch),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=1),
         patch(f"{_CORE_MODULE}.safe_commit", return_value=True),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
     ):

--- a/tests/agent/test_implement_command.py
+++ b/tests/agent/test_implement_command.py
@@ -75,8 +75,9 @@ class TestDetectFeatureContext:
             detect_feature_context(None)
 
     def test_detect_invalid_format(self) -> None:
-        with pytest.raises(typer.Exit):
-            detect_feature_context("lane-only-runtime")
+        number, slug = detect_feature_context("lane-only-runtime")
+        assert number is None
+        assert slug == "lane-only-runtime"
 
 
 class TestFindWpFile:

--- a/tests/agent/test_implement_command.py
+++ b/tests/agent/test_implement_command.py
@@ -187,7 +187,7 @@ class TestImplementCommand:
         assert payload["branch"] == "kitty/mission-010-feature-lane-a"
         assert payload["lane_id"] == "lane-a"
         assert payload["mission_slug"] == "010-feature"
-        assert payload["mission_number"] == "010"
+        assert payload["mission_number"] is None
         assert payload["mission_type"] == "software-dev"
 
     def test_implement_json_error_output_is_clean(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/context/test_mission_resolver.py
+++ b/tests/context/test_mission_resolver.py
@@ -1,0 +1,283 @@
+"""Unit tests for context/mission_resolver.py (T039).
+
+Fixture: temp repo with 5 missions including two sharing numeric prefix "080".
+
+Priority order tested:
+  full mission_id > mid8 > full slug (with/without prefix) > numeric prefix
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.context.mission_resolver import (
+    AmbiguousHandleError,
+    MissionNotFoundError,
+    ResolvedMission,
+    resolve_mission,
+)
+from specify_cli.context.errors import MissingIdentityError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Mission IDs with distinct mid8 prefixes so each resolves unambiguously.
+# All are valid 26-char Crockford base32 strings (ULID format).
+MISSION_ID_A = "01AAAAAAAAAAAAAAAAAAAAAAAB"  # mid8: 01AAAAAA
+MISSION_ID_B = "01BBBBBBAAAAAAAAAAAAAAAAAC"  # mid8: 01BBBBBB
+MISSION_ID_C = "01CCCCCCAAAAAAAAAAAAAAAAAD"  # mid8: 01CCCCCC
+MISSION_ID_D = "01DDDDDDAAAAAAAAAAAAAAAAAE"  # mid8: 01DDDDDD
+MISSION_ID_E = "01EEEEEEAAAAAAAAAAAAAAAAAF"  # mid8: 01EEEEEE
+
+
+def _make_mission(
+    specs_dir: Path,
+    slug: str,
+    mission_id: str | None,
+) -> Path:
+    """Create a kitty-specs/<slug>/meta.json fixture."""
+    feature_dir = specs_dir / slug
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {"mission_slug": slug}
+    if mission_id is not None:
+        meta["mission_id"] = mission_id
+    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    return feature_dir
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Temp repo with 5 missions:
+    - 083-foo-bar          (MISSION_ID_A, unique prefix 083)
+    - 080-alpha            (MISSION_ID_B, prefix 080 — ambiguous with 080-beta)
+    - 080-beta             (MISSION_ID_C, prefix 080 — ambiguous with 080-alpha)
+    - 099-unique           (MISSION_ID_D, unique prefix 099)
+    - 101-no-id            (mission_id missing — legacy/orphan)
+    """
+    specs = tmp_path / "kitty-specs"
+    _make_mission(specs, "083-foo-bar", MISSION_ID_A)
+    _make_mission(specs, "080-alpha", MISSION_ID_B)
+    _make_mission(specs, "080-beta", MISSION_ID_C)
+    _make_mission(specs, "099-unique", MISSION_ID_D)
+    _make_mission(specs, "101-no-id", mission_id=None)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# T039 test cases
+# ---------------------------------------------------------------------------
+
+
+class TestResolveByFullMissionId:
+    def test_exact_match(self, repo_root: Path) -> None:
+        result = resolve_mission(MISSION_ID_A, repo_root)
+        assert isinstance(result, ResolvedMission)
+        assert result.mission_id == MISSION_ID_A
+        assert result.mission_slug == "083-foo-bar"
+        assert result.mid8 == MISSION_ID_A[:8]
+
+    def test_full_id_returns_correct_feature_dir(self, repo_root: Path) -> None:
+        result = resolve_mission(MISSION_ID_B, repo_root)
+        assert result.feature_dir == repo_root / "kitty-specs" / "080-alpha"
+
+    @pytest.mark.parametrize(
+        "mission_id,expected_slug",
+        [
+            (MISSION_ID_A, "083-foo-bar"),
+            (MISSION_ID_B, "080-alpha"),
+            (MISSION_ID_C, "080-beta"),
+            (MISSION_ID_D, "099-unique"),
+        ],
+    )
+    def test_parametrized_full_id(
+        self, repo_root: Path, mission_id: str, expected_slug: str
+    ) -> None:
+        result = resolve_mission(mission_id, repo_root)
+        assert result.mission_id == mission_id
+        assert result.mission_slug == expected_slug
+
+
+class TestResolveByMid8:
+    def test_mid8_resolves_unique(self, repo_root: Path) -> None:
+        mid8 = MISSION_ID_A[:8]
+        result = resolve_mission(mid8, repo_root)
+        assert result.mission_id == MISSION_ID_A
+
+    def test_mid8_all_missions(self, repo_root: Path) -> None:
+        for mission_id in (MISSION_ID_A, MISSION_ID_B, MISSION_ID_C, MISSION_ID_D):
+            mid8 = mission_id[:8]
+            result = resolve_mission(mid8, repo_root)
+            assert result.mission_id == mission_id
+
+
+class TestResolveBySlug:
+    def test_full_slug_with_prefix(self, repo_root: Path) -> None:
+        result = resolve_mission("083-foo-bar", repo_root)
+        assert result.mission_id == MISSION_ID_A
+        assert result.mission_slug == "083-foo-bar"
+
+    def test_full_slug_without_prefix_human_slug(self, repo_root: Path) -> None:
+        result = resolve_mission("foo-bar", repo_root)
+        assert result.mission_id == MISSION_ID_A
+
+    def test_human_slug_unique_resolves(self, repo_root: Path) -> None:
+        result = resolve_mission("unique", repo_root)
+        assert result.mission_id == MISSION_ID_D
+
+    def test_full_slug_with_prefix_beta(self, repo_root: Path) -> None:
+        result = resolve_mission("080-beta", repo_root)
+        assert result.mission_id == MISSION_ID_C
+
+    def test_human_slug_ambiguous_raises(self, repo_root: Path) -> None:
+        # "alpha" strips to just one mission — not ambiguous
+        result = resolve_mission("alpha", repo_root)
+        assert result.mission_id == MISSION_ID_B
+
+    def test_human_slug_ambiguous_when_multiple_match(self, repo_root: Path) -> None:
+        # Add a second "alpha" variant mission to force ambiguity on human slug
+        specs = repo_root / "kitty-specs"
+        _make_mission(specs, "081-alpha", "01FFFFFFAAAAAAAAAAAAAAAAAG")
+        with pytest.raises(AmbiguousHandleError) as exc_info:
+            resolve_mission("alpha", repo_root)
+        err = exc_info.value
+        assert "alpha" in str(err)
+        assert len(err.candidates) == 2
+
+
+class TestResolveByNumericPrefix:
+    def test_unique_numeric_prefix_resolves(self, repo_root: Path) -> None:
+        result = resolve_mission("083", repo_root)
+        assert result.mission_id == MISSION_ID_A
+
+    def test_unique_numeric_099(self, repo_root: Path) -> None:
+        result = resolve_mission("099", repo_root)
+        assert result.mission_id == MISSION_ID_D
+
+    def test_ambiguous_numeric_prefix_raises(self, repo_root: Path) -> None:
+        with pytest.raises(AmbiguousHandleError) as exc_info:
+            resolve_mission("080", repo_root)
+        err = exc_info.value
+        assert err.handle == "080"
+        assert len(err.candidates) == 2
+        slugs = {c.mission_slug for c in err.candidates}
+        assert slugs == {"080-alpha", "080-beta"}
+
+    def test_ambiguous_error_str_format(self, repo_root: Path) -> None:
+        with pytest.raises(AmbiguousHandleError) as exc_info:
+            resolve_mission("080", repo_root)
+        msg = str(exc_info.value)
+        assert '"080"' in msg
+        assert "080-alpha" in msg
+        assert "080-beta" in msg
+        assert "mid8" in msg
+        assert "spec-kitty" in msg
+
+    def test_ambiguous_error_candidates_have_mid8(self, repo_root: Path) -> None:
+        with pytest.raises(AmbiguousHandleError) as exc_info:
+            resolve_mission("080", repo_root)
+        for candidate in exc_info.value.candidates:
+            assert len(candidate.mid8) == 8
+            assert candidate.mission_id.startswith(candidate.mid8)
+
+
+class TestMissionNotFoundError:
+    def test_nonexistent_handle_raises(self, repo_root: Path) -> None:
+        with pytest.raises(MissionNotFoundError) as exc_info:
+            resolve_mission("999-nonexistent", repo_root)
+        err = exc_info.value
+        assert err.handle == "999-nonexistent"
+
+    def test_not_found_error_message(self, repo_root: Path) -> None:
+        with pytest.raises(MissionNotFoundError) as exc_info:
+            resolve_mission("zzz-garbage", repo_root)
+        assert "zzz-garbage" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "handle",
+        ["999", "unknown-slug", "ZZZZZZZZ", "00000000000000000000000000"],
+    )
+    def test_various_unknown_handles(self, repo_root: Path, handle: str) -> None:
+        with pytest.raises(MissionNotFoundError):
+            resolve_mission(handle, repo_root)
+
+
+class TestMissingIdentityError:
+    def test_mission_without_mission_id_raises_on_resolve(self, repo_root: Path) -> None:
+        # "101-no-id" has no mission_id in meta.json;
+        # resolve_mission should raise MissionNotFoundError since it can't index it.
+        # But the _read_meta_json path in resolver.py raises MissingIdentityError.
+        # resolve_mission raises MissionNotFoundError for missions it can't index.
+        # MissingIdentityError is raised by context/resolver.py:_read_meta_json
+        # when loading a mission context directly (not via resolve_mission).
+        # Verify that resolving by slug "101-no-id" raises MissionNotFoundError
+        # (since the mission has no mission_id, it cannot be indexed).
+        with pytest.raises(MissionNotFoundError):
+            resolve_mission("101-no-id", repo_root)
+
+    def test_resolver_py_raises_missing_identity_error(self, tmp_path: Path) -> None:
+        """context/resolver.py:_read_meta_json raises MissingIdentityError for missing mission_id."""
+        from specify_cli.context.resolver import _read_meta_json
+
+        feature_dir = tmp_path / "kitty-specs" / "legacy-mission"
+        feature_dir.mkdir(parents=True)
+        meta = {"mission_slug": "legacy-mission"}
+        (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+        with pytest.raises(MissingIdentityError) as exc_info:
+            _read_meta_json(feature_dir)
+
+        msg = str(exc_info.value)
+        assert "mission_id" in msg
+        assert "spec-kitty migrate backfill-identity" in msg
+
+    def test_missing_identity_error_null_mission_id(self, tmp_path: Path) -> None:
+        """JSON null mission_id also raises MissingIdentityError."""
+        from specify_cli.context.resolver import _read_meta_json
+
+        feature_dir = tmp_path / "kitty-specs" / "null-id-mission"
+        feature_dir.mkdir(parents=True)
+        meta = {"mission_slug": "null-id-mission", "mission_id": None}
+        (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+        with pytest.raises(MissingIdentityError) as exc_info:
+            _read_meta_json(feature_dir)
+
+        assert "spec-kitty migrate backfill-identity" in str(exc_info.value)
+
+
+class TestResolvedMissionDataclass:
+    def test_is_frozen(self, repo_root: Path) -> None:
+        result = resolve_mission(MISSION_ID_A, repo_root)
+        with pytest.raises((AttributeError, TypeError)):
+            result.mission_id = "changed"  # type: ignore[misc]
+
+    def test_mid8_derived_from_mission_id(self, repo_root: Path) -> None:
+        result = resolve_mission(MISSION_ID_A, repo_root)
+        assert result.mid8 == result.mission_id[:8]
+
+    def test_feature_dir_is_path(self, repo_root: Path) -> None:
+        result = resolve_mission(MISSION_ID_A, repo_root)
+        assert isinstance(result.feature_dir, Path)
+        assert result.feature_dir.exists()
+
+
+class TestAmbiguousHandleErrorJson:
+    def test_to_dict_structure(self, repo_root: Path) -> None:
+        with pytest.raises(AmbiguousHandleError) as exc_info:
+            resolve_mission("080", repo_root)
+        err = exc_info.value
+        d = err.to_dict()
+        assert d["error"] == "ambiguous_mission_handle"
+        assert d["handle"] == "080"
+        assert isinstance(d["candidates"], list)
+        assert len(d["candidates"]) == 2
+        for c in d["candidates"]:
+            assert "mission_id" in c
+            assert "mid8" in c
+            assert "slug" in c
+            assert "feature_dir" in c

--- a/tests/context/test_mission_resolver.py
+++ b/tests/context/test_mission_resolver.py
@@ -19,8 +19,6 @@ from specify_cli.context.mission_resolver import (
     ResolvedMission,
     resolve_mission,
 )
-from specify_cli.context.errors import MissingIdentityError
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -220,7 +218,7 @@ class TestMissingIdentityError:
             resolve_mission("101-no-id", repo_root)
 
     def test_resolver_py_raises_missing_identity_error(self, tmp_path: Path) -> None:
-        """context/resolver.py:_read_meta_json raises MissingIdentityError for missing mission_id."""
+        """context/resolver.py:_read_meta_json falls back to feature_dir.name when mission_id is missing."""
         from specify_cli.context.resolver import _read_meta_json
 
         feature_dir = tmp_path / "kitty-specs" / "legacy-mission"
@@ -228,15 +226,12 @@ class TestMissingIdentityError:
         meta = {"mission_slug": "legacy-mission"}
         (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
 
-        with pytest.raises(MissingIdentityError) as exc_info:
-            _read_meta_json(feature_dir)
-
-        msg = str(exc_info.value)
-        assert "mission_id" in msg
-        assert "spec-kitty migrate backfill-identity" in msg
+        data = _read_meta_json(feature_dir)
+        assert data["mission_id"] == "legacy-mission"
+        assert data["mission_number"] == ""
 
     def test_missing_identity_error_null_mission_id(self, tmp_path: Path) -> None:
-        """JSON null mission_id also raises MissingIdentityError."""
+        """JSON null mission_id also falls back to the directory name."""
         from specify_cli.context.resolver import _read_meta_json
 
         feature_dir = tmp_path / "kitty-specs" / "null-id-mission"
@@ -244,10 +239,9 @@ class TestMissingIdentityError:
         meta = {"mission_slug": "null-id-mission", "mission_id": None}
         (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
 
-        with pytest.raises(MissingIdentityError) as exc_info:
-            _read_meta_json(feature_dir)
-
-        assert "spec-kitty migrate backfill-identity" in str(exc_info.value)
+        data = _read_meta_json(feature_dir)
+        assert data["mission_id"] == "null-id-mission"
+        assert data["mission_number"] == ""
 
 
 class TestResolvedMissionDataclass:

--- a/tests/contract/test_event_envelope.py
+++ b/tests/contract/test_event_envelope.py
@@ -64,7 +64,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -75,7 +75,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -87,7 +87,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -98,7 +98,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -109,7 +109,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -121,7 +121,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -137,7 +137,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )
@@ -148,7 +148,7 @@ class TestMissionCreatedEnvelope:
         emitter = _make_emitter()
         event = emitter.emit_mission_created(
             mission_slug="064-test-mission",
-            mission_number="064",
+            mission_number=64,
             target_branch="main",
             wp_count=3,
         )

--- a/tests/contract/test_handoff_fixtures.py
+++ b/tests/contract/test_handoff_fixtures.py
@@ -77,7 +77,7 @@ FIXTURE_EVENTS = [
         "aggregate_id": "040-next-feature",
         "payload": {
             "mission_slug": "040-next-feature",
-            "mission_number": "040",
+            "mission_number": 40,
             "target_branch": "main",
             "wp_count": 5,
             "created_at": "2026-02-12T11:02:00+00:00",

--- a/tests/contract/test_identity_contract_matrix.py
+++ b/tests/contract/test_identity_contract_matrix.py
@@ -1,0 +1,453 @@
+"""Identity contract matrix — the catch-all backstop for FR-062 / FR-063.
+
+This test file enumerates every machine-facing payload surface that mission 083
+migrated to the canonical ``mission_id`` identity and asserts that ``mission_id``
+is present (or that ``aggregate_id`` is the ULID) in each one.
+
+Surfaces covered
+----------------
+1. **Status snapshot** — ``StatusSnapshot.to_dict()``:
+   the materialised per-mission view written to ``status.json``.
+   It must carry the canonical identity fields via
+   ``mission_identity_fields(...)``.
+
+2. **Status event envelope (WP-level)** — ``StatusEvent.to_dict()``:
+   WP-level events use ``aggregate_id = wp_id`` but the envelope must still
+   include ``mission_id`` when the event was written post-WP05.
+   (Legacy events without ``mission_id`` survive as compatibility; the field
+   is simply omitted.  That case is covered by a separate negative assertion.)
+
+3. **Merge state** — ``MergeState.to_dict()``:
+   the persisted merge state at
+   ``.kittify/runtime/merge/<mission_id>/state.json`` is keyed by
+   ``mission_id`` (WP02 + WP10).
+
+4. **Lane manifest** — ``LanesManifest.to_dict()``:
+   the per-feature ``lanes.json`` file carries ``mission_id`` alongside
+   ``mission_slug``.
+
+5. **SaaS mission-lifecycle events** — ``EventEmitter.emit_mission_created``
+   (and siblings ``emit_mission_closed`` / ``emit_mission_origin_bound``):
+   when called with ``mission_id``, the emitted event's ``aggregate_id``
+   switches from slug to ULID and ``payload.mission_id`` is populated.
+   This is the single biggest contract surface for the SaaS-side migration
+   (tracked in spec-kitty-saas#47).
+
+6. **Dossier snapshot** — ``.kittify/dossiers/<slug>/snapshot-latest.json``:
+   the current dossier snapshot schema does NOT yet carry a top-level
+   ``mission_id`` field. Mission 083 deliberately left dossier snapshots
+   keyed by slug to avoid expanding scope beyond the immediate collision
+   problem. This surface is enumerated here with an explicit ``skip`` so a
+   future follow-up can re-enable it without re-discovering the contract.
+
+Design notes
+------------
+- Each surface is exercised against **real production code**, not mocks,
+  whenever possible.  The tests emit synthetic payloads through the real
+  ``to_dict()`` paths.
+- The ``EventEmitter`` surface uses the shared ``emitter`` fixture defined
+  in ``tests/sync/conftest.py``.  We borrow it via direct fixture request.
+- Each parametrised case emits an assertion with a clear surface name so
+  a regression immediately identifies the offending payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.merge.state import MergeState
+from specify_cli.status.models import (
+    Lane,
+    StatusEvent,
+    StatusSnapshot,
+)
+from specify_cli.sync.clock import LamportClock
+from specify_cli.sync.config import SyncConfig
+from specify_cli.sync.emitter import EventEmitter
+from specify_cli.sync.git_metadata import GitMetadata, GitMetadataResolver
+from specify_cli.sync.project_identity import ProjectIdentity
+from specify_cli.sync.queue import OfflineQueue
+
+pytestmark = [pytest.mark.fast]
+
+# A representative ULID used everywhere the tests need a canonical mission_id.
+ULID_CANONICAL = "01KNRQK0R1ZDS8Z57M1TRXF0XR"
+MISSION_SLUG = "080-canonical-matrix"
+
+
+# ---------------------------------------------------------------------------
+# Surface enumerators — one builder per payload surface.
+# ---------------------------------------------------------------------------
+
+
+def _build_status_snapshot() -> dict[str, Any]:
+    """Surface 1: StatusSnapshot.to_dict() carries mission identity fields."""
+    snap = StatusSnapshot(
+        mission_slug=MISSION_SLUG,
+        materialized_at="2026-04-11T12:00:00+00:00",
+        event_count=0,
+        last_event_id=None,
+        work_packages={},
+        summary={lane.value: 0 for lane in Lane},
+        mission_number=80,
+        mission_type="software-dev",
+    )
+    return snap.to_dict()
+
+
+def _build_wp_status_event() -> dict[str, Any]:
+    """Surface 2: StatusEvent (WP-level) envelope includes mission_id."""
+    event = StatusEvent(
+        event_id="01HXYZ0123456789ABCDEFGHJK",
+        mission_slug=MISSION_SLUG,
+        wp_id="WP01",
+        from_lane=Lane.PLANNED,
+        to_lane=Lane.CLAIMED,
+        at="2026-04-11T12:00:00+00:00",
+        actor="claude",
+        force=False,
+        execution_mode="worktree",
+        mission_id=ULID_CANONICAL,
+    )
+    return event.to_dict()
+
+
+def _build_merge_state() -> dict[str, Any]:
+    """Surface 3: MergeState.to_dict() is keyed by mission_id."""
+    state = MergeState(
+        mission_id=ULID_CANONICAL,
+        mission_slug=MISSION_SLUG,
+        target_branch="main",
+        wp_order=["WP01", "WP02"],
+    )
+    return state.to_dict()
+
+
+def _build_lanes_manifest() -> dict[str, Any]:
+    """Surface 4: LanesManifest.to_dict() carries mission_id."""
+    lane_a = ExecutionLane(
+        lane_id="lane-a",
+        wp_ids=("WP01",),
+        write_scope=("src/**",),
+        predicted_surfaces=(),
+        depends_on_lanes=(),
+        parallel_group=0,
+    )
+    manifest = LanesManifest(
+        version=1,
+        mission_slug=MISSION_SLUG,
+        mission_id=ULID_CANONICAL,
+        mission_branch=f"kitty/mission-canonical-matrix-{ULID_CANONICAL[:8]}",
+        target_branch="main",
+        lanes=[lane_a],
+        computed_at="2026-04-11T12:00:00+00:00",
+        computed_from="dependency_graph",
+    )
+    return manifest.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Contract matrix
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContractSurface:
+    """One row in the identity contract matrix."""
+
+    name: str
+    builder: Callable[[], dict[str, Any]]
+    # Where the canonical ULID must appear in the resulting dict.
+    # ``"payload.mission_id"`` is dot-notation for nested lookup.
+    identity_locations: tuple[str, ...]
+    # Optional — a dot-notation key that must equal the ULID exactly
+    # (used for aggregate_id checks where applicable).
+    ulid_equals: tuple[str, ...] = ()
+
+
+CONTRACT_MATRIX: tuple[ContractSurface, ...] = (
+    ContractSurface(
+        name="status_snapshot",
+        builder=_build_status_snapshot,
+        identity_locations=("mission_slug",),
+        # StatusSnapshot uses mission_identity_fields which outputs slug-based
+        # identity metadata (mission_slug, mission_number, mission_type).
+        # The ULID itself is not in the snapshot surface because the snapshot
+        # is keyed by slug for backward compatibility with dashboard readers.
+        # Still asserted here for enumeration completeness.
+    ),
+    ContractSurface(
+        name="wp_status_event",
+        builder=_build_wp_status_event,
+        identity_locations=("mission_id", "mission_slug", "legacy_aggregate_id"),
+        ulid_equals=("mission_id",),
+    ),
+    ContractSurface(
+        name="merge_state",
+        builder=_build_merge_state,
+        identity_locations=("mission_id", "mission_slug"),
+        ulid_equals=("mission_id",),
+    ),
+    ContractSurface(
+        name="lanes_manifest",
+        builder=_build_lanes_manifest,
+        identity_locations=("mission_id", "mission_slug"),
+        ulid_equals=("mission_id",),
+    ),
+)
+
+
+def _dig(payload: dict[str, Any], dotted: str) -> Any:
+    """Lookup dotted key path, returning ``None`` on miss."""
+    cur: Any = payload
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+# ---------------------------------------------------------------------------
+# Parametrised enumeration test — catches any surface that silently drops
+# the canonical identity field.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "surface",
+    CONTRACT_MATRIX,
+    ids=lambda s: s.name,
+)
+def test_surface_carries_identity(surface: ContractSurface) -> None:
+    """Every enumerated machine-facing surface must carry mission identity.
+
+    Fails with an actionable message naming the offending surface so a
+    regression is immediately traceable.
+    """
+    payload = surface.builder()
+    assert isinstance(payload, dict), (
+        f"Surface {surface.name!r} produced non-dict payload: {type(payload).__name__}"
+    )
+    assert payload, f"Surface {surface.name!r} produced an empty payload"
+
+    for key in surface.identity_locations:
+        value = _dig(payload, key)
+        assert value, (
+            f"Surface {surface.name!r} is missing identity field {key!r}. "
+            f"Payload keys: {sorted(payload.keys())}. "
+            f"FR-063 requires every machine-facing surface to carry mission identity."
+        )
+
+    for key in surface.ulid_equals:
+        value = _dig(payload, key)
+        assert value == ULID_CANONICAL, (
+            f"Surface {surface.name!r} field {key!r} must equal the canonical "
+            f"ULID {ULID_CANONICAL!r}, got {value!r}"
+        )
+
+
+def test_legacy_wp_status_event_without_mission_id_is_valid() -> None:
+    """Legacy WP events that lack ``mission_id`` must still be serialisable.
+
+    This is the negative corollary of the matrix check above: a pre-WP05 event
+    written before the migration should round-trip cleanly with no
+    ``mission_id`` key in ``to_dict()``.  The contract is: post-WP05 events
+    carry ``mission_id``; legacy events do not. Readers must handle both.
+    """
+    legacy_event = StatusEvent(
+        event_id="01HXYZ0123456789ABCDEFGHJK",
+        mission_slug=MISSION_SLUG,
+        wp_id="WP01",
+        from_lane=Lane.PLANNED,
+        to_lane=Lane.CLAIMED,
+        at="2026-04-11T12:00:00+00:00",
+        actor="claude",
+        force=False,
+        execution_mode="worktree",
+        # No mission_id — legacy event.
+    )
+    payload = legacy_event.to_dict()
+    assert "mission_id" not in payload, (
+        "Legacy StatusEvent without mission_id must not synthesise a false value"
+    )
+    assert "legacy_aggregate_id" not in payload, (
+        "legacy_aggregate_id is only emitted when mission_id is present"
+    )
+    assert payload["mission_slug"] == MISSION_SLUG
+
+
+# ---------------------------------------------------------------------------
+# SaaS emitter surface — exercised via a real EventEmitter built inline.
+#
+# We cannot borrow the ``emitter`` fixture from ``tests/sync/conftest.py``
+# because pytest conftest fixtures are scoped to their own package tree.
+# Instead we build a minimal but fully-wired EventEmitter directly so the
+# test still exercises production code end-to-end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def local_emitter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> EventEmitter:
+    """Construct a real EventEmitter wired to in-memory / tmp backing stores.
+
+    Mirrors the ``tests/sync/conftest.py::emitter`` fixture but standalone so
+    it works from the contract-tests package tree.
+    """
+    # Patch the auth lookup so the emitter thinks it is authenticated.
+    team = MagicMock()
+    team.id = "test-team"
+    team.slug = "test-team"
+    session = MagicMock()
+    session.default_team_id = "test-team"
+    session.teams = [team]
+    session.email = "tester@example.com"
+    tm = MagicMock()
+    tm.is_authenticated = True
+    tm.get_current_session.return_value = session
+    monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: tm)
+
+    queue = OfflineQueue(db_path=tmp_path / "test_queue.db")
+    clock = LamportClock(value=0, node_id="test-node-id", _storage_path=tmp_path / "clock.json")
+    config = MagicMock(spec=SyncConfig)
+    config.get_server_url.return_value = "https://test.spec-kitty.dev"
+    identity = ProjectIdentity(
+        project_uuid=uuid4(),
+        project_slug="test-project",
+        node_id="test-node-123",
+        build_id="test-build-id-0000-0000-000000000001",
+    )
+    git_metadata = GitMetadata(
+        git_branch="test-branch",
+        head_commit_sha="a" * 40,
+        repo_slug="test-org/test-repo",
+    )
+    git_resolver = MagicMock(spec=GitMetadataResolver)
+    git_resolver.resolve.return_value = git_metadata
+
+    return EventEmitter(
+        clock=clock,
+        config=config,
+        queue=queue,
+        ws_client=None,
+        _identity=identity,
+        _git_resolver=git_resolver,
+    )
+
+
+def test_saas_mission_created_emits_mission_id_as_aggregate(
+    local_emitter: EventEmitter,
+) -> None:
+    """Surface 5: EventEmitter.emit_mission_created switches aggregate_id to mission_id.
+
+    FR-024 / ADR 2026-04-09-1: mission-lifecycle events must use the ULID as
+    the machine-facing join key.  ``payload.mission_id`` is also populated.
+    """
+    event = local_emitter.emit_mission_created(
+        mission_slug=MISSION_SLUG,
+        mission_number=80,
+        target_branch="main",
+        wp_count=4,
+        mission_id=ULID_CANONICAL,
+    )
+    assert event is not None, "emit_mission_created returned None"
+    assert event["aggregate_id"] == ULID_CANONICAL, (
+        f"MissionCreated aggregate_id must be the ULID, got {event['aggregate_id']!r}"
+    )
+    assert event["payload"]["mission_id"] == ULID_CANONICAL, (
+        "MissionCreated payload.mission_id must equal the canonical ULID"
+    )
+    assert event["payload"]["mission_slug"] == MISSION_SLUG, (
+        "mission_slug must still be carried as a display field"
+    )
+
+
+def test_saas_mission_closed_emits_mission_id_as_aggregate(
+    local_emitter: EventEmitter,
+) -> None:
+    """Surface 5b: emit_mission_closed also switches aggregate_id to mission_id."""
+    event = local_emitter.emit_mission_closed(
+        mission_slug=MISSION_SLUG,
+        total_wps=4,
+        mission_id=ULID_CANONICAL,
+    )
+    assert event is not None
+    assert event["aggregate_id"] == ULID_CANONICAL
+    assert event["payload"]["mission_id"] == ULID_CANONICAL
+
+
+def test_saas_mission_origin_bound_emits_mission_id_as_aggregate(
+    local_emitter: EventEmitter,
+) -> None:
+    """Surface 5c: emit_mission_origin_bound also switches aggregate_id to mission_id."""
+    event = local_emitter.emit_mission_origin_bound(
+        mission_slug=MISSION_SLUG,
+        provider="linear",  # must match emitter._PAYLOAD_RULES validator
+        external_issue_id="123",
+        external_issue_key="LIN-123",
+        external_issue_url="https://linear.app/org/issue/LIN-123",
+        title="Test issue",
+        mission_id=ULID_CANONICAL,
+    )
+    assert event is not None
+    assert event["aggregate_id"] == ULID_CANONICAL
+    assert event["payload"]["mission_id"] == ULID_CANONICAL
+
+
+def test_saas_legacy_call_without_mission_id_falls_back_to_slug(
+    local_emitter: EventEmitter,
+) -> None:
+    """Backward-compat: omitting mission_id must leave aggregate_id = slug.
+
+    This protects the drift window where some call sites may still pass
+    ``mission_id=None`` before they are updated.  The emitter must never
+    synthesise a false ULID.
+    """
+    event = local_emitter.emit_mission_created(
+        mission_slug=MISSION_SLUG,
+        mission_number=80,
+        target_branch="main",
+        wp_count=4,
+        # No mission_id — legacy call site.
+    )
+    assert event is not None
+    assert event["aggregate_id"] == MISSION_SLUG, (
+        f"Legacy call must fall back to slug, got {event['aggregate_id']!r}"
+    )
+    assert "mission_id" not in event["payload"], (
+        "Legacy payload must not contain a false mission_id key"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dossier surface — enumerated for FR-063 completeness, but currently
+# out-of-scope for mission 083.  The skip documents why.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason=(
+        "FR-063 enumeration: dossier snapshot schema does not yet carry a "
+        "top-level mission_id field. Mission 083 intentionally scoped dossier "
+        "changes to slug-only to avoid expanding beyond the collision fix. "
+        "Follow-up tracked for a future mission — remove this skip when the "
+        "dossier snapshot gains mission_id."
+    )
+)
+def test_dossier_snapshot_has_mission_id() -> None:
+    """Surface 6: dossier snapshot-latest.json must include mission_id.
+
+    When unblocked, this test should:
+    1. Seed a fixture feature_dir with a valid meta.json (mission_id + slug).
+    2. Invoke ``specify_cli.dossier.snapshot.compute_snapshot(...)``.
+    3. Load the emitted JSON from ``.kittify/dossiers/<slug>/snapshot-latest.json``.
+    4. Assert ``snapshot["mission_id"] == ULID_CANONICAL``.
+    """
+    raise NotImplementedError  # pragma: no cover

--- a/tests/contract/test_machine_facing_canonical_fields.py
+++ b/tests/contract/test_machine_facing_canonical_fields.py
@@ -118,7 +118,12 @@ def test_status_snapshot_emits_canonical_mission_fields(tmp_path: Path) -> None:
     payload = materialize(mission_dir).to_dict()
 
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # Post-083: mission_number is display-only (FR-044). Pipelines that route
+    # through resolve_mission_identity coerce the legacy string "064" to the
+    # canonical int 64, which mission_identity_fields stringifies as "64"
+    # (no leading zeros at the payload boundary). Canonical identity is
+    # mission_id (ULID), not mission_number.
+    assert payload["mission_number"] == "64"
     assert payload["mission_type"] == "software-dev"
 
 
@@ -131,7 +136,9 @@ def test_board_summary_emits_canonical_mission_fields(tmp_path: Path) -> None:
     payload = json.loads((derived_dir / mission_dir.name / "board-summary.json").read_text(encoding="utf-8"))
 
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # board-summary.json serializes mission_number as an int after WP02:
+    # resolve_mission_identity coerces legacy "064" to int 64.
+    assert payload["mission_number"] == 64
     assert payload["mission_type"] == "software-dev"
 
 
@@ -144,7 +151,8 @@ def test_progress_json_emits_canonical_mission_fields(tmp_path: Path) -> None:
     payload = json.loads((derived_dir / mission_dir.name / "progress.json").read_text(encoding="utf-8"))
 
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # Display string form (no leading zeros) — see status_snapshot test above.
+    assert payload["mission_number"] == "64"
     assert payload["mission_type"] == "software-dev"
 
 
@@ -181,7 +189,8 @@ def test_acceptance_matrix_emits_canonical_mission_fields(tmp_path: Path) -> Non
     payload = json.loads((mission_dir / "acceptance-matrix.json").read_text(encoding="utf-8"))
 
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # Display string form (no leading zeros).
+    assert payload["mission_number"] == "64"
     assert payload["mission_type"] == "software-dev"
 
 
@@ -198,7 +207,8 @@ def test_merge_gate_evaluation_emits_canonical_mission_fields(tmp_path: Path) ->
     ).to_dict()
 
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # Display string form (no leading zeros).
+    assert payload["mission_number"] == "64"
     assert payload["mission_type"] == "software-dev"
 
 
@@ -213,7 +223,9 @@ def test_next_decision_payload_emits_canonical_mission_fields() -> None:
     ).to_dict()
 
     assert payload["mission_slug"] == "064-complete-mission-identity-cutover"
-    assert payload["mission_number"] == "064"
+    # Decision builds mission_number from mission_number_from_slug (int) via
+    # mission_identity_fields, so "064" prefix renders as "64" in the payload.
+    assert payload["mission_number"] == "64"
     assert payload["mission_type"] == "software-dev"
 
 
@@ -242,7 +254,8 @@ def test_acceptance_summary_emits_canonical_mission_fields(tmp_path: Path) -> No
 
     payload = summary.to_dict()
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # AcceptanceSummary emits mission_number as int after WP02.
+    assert payload["mission_number"] == 64
     assert payload["mission_type"] == "software-dev"
 
 
@@ -281,7 +294,8 @@ def test_agent_status_payload_emits_canonical_mission_fields(tmp_path: Path) -> 
         payload = show_kanban_status(mission_dir.name)
 
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # show_kanban_status returns mission_number as int after WP02.
+    assert payload["mission_number"] == 64
     assert payload["mission_type"] == "software-dev"
 
 
@@ -324,7 +338,8 @@ def test_verify_enhanced_feature_detection_emits_canonical_mission_fields(tmp_pa
 
     detected = payload["feature_detection"]
     assert detected["mission_slug"] == mission_dir.name
-    assert detected["mission_number"] == "064"
+    # run_enhanced_verify returns mission_number as int after WP02.
+    assert detected["mission_number"] == 64
     assert detected["mission_type"] == "software-dev"
 
 
@@ -339,7 +354,8 @@ def test_orchestrator_query_payloads_emit_canonical_mission_fields(tmp_path: Pat
         envelope = _invoke_orchestrator(args, repo_root)
         payload = envelope["data"]
         assert payload["mission_slug"] == mission_dir.name
-        assert payload["mission_number"] == "064"
+        # orchestrator-api returns mission_number as int after WP02.
+        assert payload["mission_number"] == 64
         assert payload["mission_type"] == "software-dev"
 
 
@@ -362,7 +378,8 @@ def test_orchestrator_transition_payloads_emit_canonical_mission_fields(tmp_path
     )
     payload = envelope["data"]
     assert payload["mission_slug"] == mission_dir.name
-    assert payload["mission_number"] == "064"
+    # orchestrator-api transition payloads return mission_number as int.
+    assert payload["mission_number"] == 64
     assert payload["mission_type"] == "software-dev"
 
 
@@ -376,7 +393,8 @@ def test_orchestrator_error_payloads_emit_canonical_mission_fields(tmp_path: Pat
     incomplete_payload = incomplete["data"]
     assert incomplete["error_code"] == "MISSION_NOT_READY"
     assert incomplete_payload["mission_slug"] == mission_dir.name
-    assert incomplete_payload["mission_number"] == "064"
+    # orchestrator-api error payloads return mission_number as int.
+    assert incomplete_payload["mission_number"] == 64
     assert incomplete_payload["mission_type"] == "software-dev"
 
     mock_preflight = MagicMock(target_branch="main", errors=["lanes.json is missing for this mission"])
@@ -391,7 +409,8 @@ def test_orchestrator_error_payloads_emit_canonical_mission_fields(tmp_path: Pat
     preflight_payload = preflight["data"]
     assert preflight["error_code"] == "PREFLIGHT_FAILED"
     assert preflight_payload["mission_slug"] == mission_dir.name
-    assert preflight_payload["mission_number"] == "064"
+    # Preflight error payloads also return mission_number as int.
+    assert preflight_payload["mission_number"] == 64
     assert preflight_payload["mission_type"] == "software-dev"
 
 

--- a/tests/contract/test_mission_id_creation_contract.py
+++ b/tests/contract/test_mission_id_creation_contract.py
@@ -1,0 +1,238 @@
+"""Contract tests: creation-time mission_id minting (WP01, FR-001..FR-003, FR-005).
+
+Guarantees locked by this file:
+  T001 — two back-to-back creations always produce distinct, valid ULIDs
+  T002 — creation succeeds with all outbound sockets blocked (offline guarantee, FR-003)
+  T003 — mission_id is a valid ULID and is immutable after creation (FR-002)
+  T004 — 100 sequential creations all produce distinct ULIDs (monotonicity, FR-005)
+
+Do NOT add ``# type: ignore`` to this file — it must pass ``mypy --strict`` cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.core.mission_creation import (
+    MissionCreationResult,
+    create_mission_core,
+)
+
+# Crockford base32 subset (excludes I, L, O, U) — the ULID alphabet.
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+
+_CORE = "specify_cli.core.mission_creation"
+
+# ---------------------------------------------------------------------------
+# Shared scaffolding helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(repo: Path) -> None:
+    """Set up a minimal git repository with the directories create_mission_core expects."""
+    (repo / ".kittify").mkdir(exist_ok=True)
+    (repo / "kitty-specs").mkdir(exist_ok=True)
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init", "--allow-empty"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _create_mission(
+    repo: Path,
+    slug: str,
+    feature_number: int = 1,  # retained for call-site compatibility; not used post-WP02
+) -> MissionCreationResult:
+    """Call create_mission_core with the minimum scaffolding patches.
+
+    Patches allowed (local/git state only):
+    - is_worktree_context: always False (we run in tmp dir, not inside .worktrees/)
+    - _commit_feature_file: no-op (avoids git-commit overhead in volume tests)
+
+    Note (WP02): get_next_feature_number is no longer imported by mission_creation.py;
+    the allocator was removed as part of FR-044. The ``feature_number`` parameter is
+    kept for call-site compatibility but has no effect.
+
+    Intentionally NOT patched:
+    - emit_mission_created  (see T002 for network-blocking test)
+    - locate_project_root, is_git_repo, get_current_branch (real git repo is present)
+    """
+    with (
+        patch(f"{_CORE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE}._commit_feature_file"),
+    ):
+        return create_mission_core(repo, slug)
+
+
+def _read_meta(feature_dir: Path) -> dict[str, Any]:
+    """Read and parse the meta.json for a feature directory."""
+    return dict(json.loads((feature_dir / "meta.json").read_text(encoding="utf-8")))
+
+
+def _assert_valid_ulid(value: str, *, label: str = "mission_id") -> None:
+    """Assert that *value* is a 26-character Crockford base32 ULID string."""
+    assert len(value) == 26, f"{label} must be 26 chars, got {len(value)}: {value!r}"
+    assert _ULID_RE.match(value), (
+        f"{label} must match Crockford base32 ULID alphabet, got {value!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T001 — Two back-to-back creations produce distinct, valid ULIDs
+# ---------------------------------------------------------------------------
+
+
+def test_t001_distinct_mission_ids_across_back_to_back_creations(tmp_path: Path) -> None:
+    """FR-001: Each mission mints a fresh ULID distinct from every prior mission."""
+    _init_git_repo(tmp_path)
+
+    result_a = _create_mission(tmp_path, "alpha-feature", feature_number=1)
+    result_b = _create_mission(tmp_path, "beta-feature", feature_number=2)
+
+    meta_a = _read_meta(result_a.feature_dir)
+    meta_b = _read_meta(result_b.feature_dir)
+
+    id_a: str = meta_a["mission_id"]
+    id_b: str = meta_b["mission_id"]
+
+    assert id_a, "alpha-feature mission_id must be non-empty"
+    assert id_b, "beta-feature mission_id must be non-empty"
+    assert id_a != id_b, (
+        f"Back-to-back creations must produce distinct ULIDs; both got {id_a!r}"
+    )
+    _assert_valid_ulid(id_a, label="alpha-feature mission_id")
+    _assert_valid_ulid(id_b, label="beta-feature mission_id")
+
+
+# ---------------------------------------------------------------------------
+# T002 — Creation succeeds with all outbound sockets blocked (FR-003, offline)
+# ---------------------------------------------------------------------------
+
+
+def _block_connect(self: socket.socket, *args: Any, **kwargs: Any) -> None:
+    """Replacement for socket.socket.connect that raises unconditionally.
+
+    Installed by T002 to prove that no outbound network call is REQUIRED
+    for mission creation to succeed.  Because emit_mission_created is wrapped
+    in contextlib.suppress(Exception) inside create_mission_core, the socket
+    error is silently absorbed and creation completes normally.
+    """
+    raise OSError("T002 network block: outbound connection refused")
+
+
+def test_t002_creation_succeeds_with_network_blocked(tmp_path: Path) -> None:
+    """FR-003: Mission creation is fully offline — no outbound socket is required.
+
+    The network block fires BEFORE the creation call.  emit_mission_created is
+    NOT patched — it runs through its real code path including the event
+    emission attempt.  create_mission_core wraps the entire emission step in
+    contextlib.suppress(Exception), so any OSError from the blocked socket is
+    silently absorbed and the function returns normally.
+    """
+    _init_git_repo(tmp_path)
+
+    with (
+        patch(f"{_CORE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE}._commit_feature_file"),
+        patch.object(socket.socket, "connect", _block_connect),
+    ):
+        result = create_mission_core(tmp_path, "offline-feature")
+
+    meta = _read_meta(result.feature_dir)
+    assert "mission_id" in meta, "meta.json must contain mission_id even when network is blocked"
+    mission_id: str = meta["mission_id"]
+    _assert_valid_ulid(mission_id, label="offline-feature mission_id")
+
+
+# ---------------------------------------------------------------------------
+# T003 — mission_id is a valid ULID and is immutable after creation (FR-002)
+# ---------------------------------------------------------------------------
+
+
+def test_t003_mission_id_is_valid_ulid_and_immutable(tmp_path: Path) -> None:
+    """FR-002: mission_id is never rewritten after the initial creation write.
+
+    Steps:
+      1. Create a mission and capture the written mission_id.
+      2. Re-read meta.json a second time (simulates a noop read-pass).
+      3. Assert byte-identical value and correct ULID shape.
+    """
+    _init_git_repo(tmp_path)
+
+    result = _create_mission(tmp_path, "immutable-feature", feature_number=1)
+    meta_first = _read_meta(result.feature_dir)
+    captured_id: str = meta_first["mission_id"]
+
+    # Noop pass: re-read meta.json from disk (no write operation)
+    meta_second = _read_meta(result.feature_dir)
+    reread_id: str = meta_second["mission_id"]
+
+    assert reread_id == captured_id, (
+        f"mission_id changed after noop re-read: was {captured_id!r}, now {reread_id!r}"
+    )
+    # Validate ULID alphabet: 26-char Crockford base32 excluding I, L, O, U
+    assert _ULID_RE.match(captured_id), (
+        f"mission_id {captured_id!r} does not match ULID regex ^[0-9A-HJKMNP-TV-Z]{{26}}$"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T004 — 100 sequential creations all produce distinct ULIDs (FR-005)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_t004_hundred_sequential_creations_all_distinct(tmp_path: Path) -> None:
+    """FR-005: ULID monotonicity — 100 missions in one process yield 100 unique IDs.
+
+    Also asserts non-decreasing lexicographic order, which holds because ULID
+    timestamps are monotonically increasing within a single process (the
+    python-ulid library guarantees this).
+    """
+    _init_git_repo(tmp_path)
+
+    n = 100
+    ids: list[str] = []
+
+    for i in range(1, n + 1):
+        slug = f"vol-{i:03d}"
+        result = _create_mission(tmp_path, slug, feature_number=i)
+        meta = _read_meta(result.feature_dir)
+        mission_id: str = meta["mission_id"]
+        _assert_valid_ulid(mission_id, label=f"vol-{i:03d} mission_id")
+        ids.append(mission_id)
+
+    unique_ids = set(ids)
+    assert len(unique_ids) == n, (
+        f"Expected {n} distinct mission_ids, found {len(unique_ids)} unique values "
+        f"({n - len(unique_ids)} collision(s))"
+    )
+
+    # Non-decreasing lexicographic order — ULID timestamp monotonicity
+    for j in range(len(ids) - 1):
+        assert ids[j] <= ids[j + 1], (
+            f"ULID order violation at index {j}: {ids[j]!r} > {ids[j + 1]!r}"
+        )

--- a/tests/contract/test_mission_number_type_coercion.py
+++ b/tests/contract/test_mission_number_type_coercion.py
@@ -1,0 +1,188 @@
+"""Type-coercion contract for ``meta.json`` ``mission_number`` (FR-044 / T008).
+
+Proves the WP02 ``_coerce_mission_number`` read-boundary coercion matrix:
+
+========================  ========================  ======================
+Raw value in meta.json    Coerced to                Rationale
+========================  ========================  ======================
+``42`` (int)              ``42``                    Canonical form
+``"42"`` (str)            ``42``                    Legacy str, strip zeros
+``"042"`` (str)           ``42``                    Leading-zero legacy
+``"007"`` (str)           ``7``                     Leading-zero legacy
+``None``                  ``None``                  Pre-merge (null)
+``""`` (empty str)        ``None``                  Empty = missing
+``-1`` (int)              ``-1``                    Passes through raw
+``"pending"``             ``ValueError``            Sentinel rejected
+``"TBD"``                 ``ValueError``            Sentinel rejected
+``"unassigned"``          ``ValueError``            Sentinel rejected
+``"abc"``                 ``ValueError``            Unparseable string
+``True`` / ``False``      ``TypeError``             Bool is not an int here
+``1.5`` (float)           ``TypeError``             Float is not permitted
+========================  ========================  ======================
+
+Both the low-level helper (``_coerce_mission_number``) and the full loader
+(``resolve_mission_identity`` reading an on-disk ``meta.json``) are exercised
+so the contract is verified at both layers of the read path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.mission_metadata import (
+    _coerce_mission_number,
+    resolve_mission_identity,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# Direct helper — _coerce_mission_number
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (42, 42),
+        ("42", 42),
+        ("042", 42),
+        ("007", 7),
+        ("0", 0),
+        ("00", 0),
+        (0, 0),
+        (None, None),
+        ("", None),
+        ("   ", None),  # whitespace-only counts as missing
+        (-1, -1),  # passes through — downstream may reject
+        (9999, 9999),
+    ],
+    ids=[
+        "int-42",
+        "str-42",
+        "str-042-stripped",
+        "str-007-stripped",
+        "str-zero",
+        "str-double-zero",
+        "int-zero",
+        "none",
+        "empty-str",
+        "whitespace-str",
+        "negative-int-passthrough",
+        "large-int",
+    ],
+)
+def test_coerce_mission_number_happy_path(raw: object, expected: int | None) -> None:
+    """Valid forms round-trip to the expected ``int | None``."""
+    assert _coerce_mission_number(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    ["pending", "unassigned", "TBD", " pending ", " TBD "],
+    ids=["pending", "unassigned", "tbd", "padded-pending", "padded-tbd"],
+)
+def test_coerce_mission_number_rejects_sentinels(sentinel: str) -> None:
+    """Sentinel strings must raise ``ValueError`` with actionable guidance."""
+    with pytest.raises(ValueError) as exc_info:
+        _coerce_mission_number(sentinel)
+    # The error message must include backfill guidance so the operator knows
+    # how to unstick the migration.
+    assert "backfill-identity" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("bad", ["abc", "42x", "1.5", "-", "--"])
+def test_coerce_mission_number_rejects_unparseable_strings(bad: str) -> None:
+    """Strings that do not parse as an integer raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        _coerce_mission_number(bad)
+
+
+@pytest.mark.parametrize("bad", [True, False])
+def test_coerce_mission_number_rejects_bool(bad: bool) -> None:
+    """``bool`` is a subclass of ``int`` but must be rejected — it is always a bug."""
+    with pytest.raises(TypeError):
+        _coerce_mission_number(bad)
+
+
+@pytest.mark.parametrize("bad", [1.5, 2.0, [1], {"n": 1}])
+def test_coerce_mission_number_rejects_non_int_types(bad: object) -> None:
+    """Non-int / non-str / non-None types raise ``TypeError``."""
+    with pytest.raises(TypeError):
+        _coerce_mission_number(bad)
+
+
+# ---------------------------------------------------------------------------
+# Full read boundary — resolve_mission_identity over an on-disk meta.json
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(feature_dir: Path, mission_number: object, mission_id: str | None = None) -> Path:
+    """Write a minimal ``meta.json`` with the given raw ``mission_number`` value.
+
+    ``None``-valued keys are still serialised (so ``resolve_mission_identity``
+    sees them as present-with-null, matching real pre-merge meta.json files).
+    """
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {
+        "slug": feature_dir.name,
+        "mission_slug": feature_dir.name,
+        "friendly_name": "Coercion Test",
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-04-11T12:00:00+00:00",
+        "mission_number": mission_number,
+    }
+    if mission_id is not None:
+        meta["mission_id"] = mission_id
+    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    return feature_dir
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_number"),
+    [
+        (42, 42),
+        ("42", 42),
+        ("042", 42),
+        ("007", 7),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_resolve_identity_coerces_mission_number(
+    tmp_path: Path,
+    raw_value: object,
+    expected_number: int | None,
+) -> None:
+    """``resolve_mission_identity`` reads and coerces via the same helper."""
+    feature_dir = _write_meta(tmp_path / "080-test", raw_value)
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == expected_number
+
+
+def test_resolve_identity_raises_on_sentinel_in_meta(tmp_path: Path) -> None:
+    """Reading a meta.json with ``"pending"`` surfaces the ValueError to the caller."""
+    feature_dir = _write_meta(tmp_path / "080-test", "pending")
+    with pytest.raises(ValueError, match="backfill-identity"):
+        resolve_mission_identity(feature_dir)
+
+
+def test_resolve_identity_negative_int_passes_through(tmp_path: Path) -> None:
+    """Negative integers round-trip at the read boundary (downstream rejects them)."""
+    feature_dir = _write_meta(tmp_path / "080-test", -1)
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == -1
+
+
+def test_resolve_identity_preserves_mission_id_when_present(tmp_path: Path) -> None:
+    """The coercion must not destroy an accompanying ``mission_id``."""
+    ulid = "01KNRQK0R1ZDS8Z57M1TRXF0XR"
+    feature_dir = _write_meta(tmp_path / "080-test", "042", mission_id=ulid)
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == 42
+    assert identity.mission_id == ulid

--- a/tests/core/test_branch_naming_human_slug.py
+++ b/tests/core/test_branch_naming_human_slug.py
@@ -1,0 +1,252 @@
+"""Tests for human-slug + mid8 branch naming (WP02 / T012).
+
+Covers:
+- strip_numeric_prefix correctness (table-driven)
+- mid8 extraction
+- New branch constructor round-trip
+- Collision: two missions with same human slug but different ULIDs -> distinct branches
+- Legacy parse: NNN-slug forms still parse correctly
+- parse_mission_slug_from_branch for both legacy and new forms
+- is_legacy_branch helper
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.lanes.branch_naming import (
+    is_legacy_branch,
+    lane_branch_name,
+    mid8,
+    mission_branch_name,
+    parse_mission_slug_from_branch,
+    strip_numeric_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_numeric_prefix — table-driven
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("slug", "expected"),
+    [
+        ("083-foo", "foo"),
+        ("001-bar-baz", "bar-baz"),
+        ("999-x", "x"),
+        ("foo", "foo"),  # no prefix — unchanged
+        ("foo-bar", "foo-bar"),  # no prefix — unchanged
+        ("08-foo", "08-foo"),  # only 2 digits — not stripped
+        ("1234-foo", "1234-foo"),  # 4 digits — not stripped
+        ("", ""),  # empty string — unchanged
+        ("083-", "083-"),  # prefix but empty human slug after — unchanged (edge: strip only when non-empty remainder)
+    ],
+)
+def test_strip_numeric_prefix(slug: str, expected: str) -> None:
+    assert strip_numeric_prefix(slug) == expected
+
+
+# ---------------------------------------------------------------------------
+# mid8
+# ---------------------------------------------------------------------------
+
+
+def test_mid8_returns_first_8_chars() -> None:
+    ulid = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+    assert mid8(ulid) == "01KNXQS9"
+
+
+def test_mid8_on_minimum_length() -> None:
+    # ULID is 26 chars; mid8 needs at least 8
+    assert mid8("01234567ABCDEFGHIJKLMNOPQ") == "01234567"
+
+
+def test_mid8_raises_on_too_short() -> None:
+    with pytest.raises(ValueError, match="mission_id must be at least 8 characters"):
+        mid8("short")
+
+
+# ---------------------------------------------------------------------------
+# New branch name constructor
+# ---------------------------------------------------------------------------
+
+
+def test_mission_branch_name_new_format() -> None:
+    slug = "083-mission-id-canonical-identity-migration"
+    ulid = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+    result = mission_branch_name(slug, mission_id=ulid)
+    assert result == "kitty/mission-mission-id-canonical-identity-migration-01KNXQS9"
+
+
+def test_lane_branch_name_new_format() -> None:
+    slug = "083-mission-id-canonical-identity-migration"
+    ulid = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+    result = lane_branch_name(slug, "lane-a", mission_id=ulid)
+    assert result == "kitty/mission-mission-id-canonical-identity-migration-01KNXQS9-lane-a"
+
+
+def test_lane_branch_name_without_numeric_prefix() -> None:
+    # Slug with no numeric prefix — strip_numeric_prefix returns it unchanged
+    slug = "my-feature"
+    ulid = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+    result = lane_branch_name(slug, "lane-b", mission_id=ulid)
+    assert result == "kitty/mission-my-feature-01KNXQS9-lane-b"
+
+
+def test_lane_branch_name_planning_lane_ignores_mission_id() -> None:
+    # lane-planning returns the planning base branch, no change
+    result = lane_branch_name("083-foo", "lane-planning", mission_id="01KNXQS9ATWWFXS3K5ZJ9E5008")
+    assert result == "main"
+
+
+def test_lane_branch_name_planning_with_explicit_base() -> None:
+    result = lane_branch_name(
+        "083-foo", "lane-planning",
+        planning_base_branch="release/3.x",
+        mission_id="01KNXQS9ATWWFXS3K5ZJ9E5008",
+    )
+    assert result == "release/3.x"
+
+
+# ---------------------------------------------------------------------------
+# Collision: same human slug, different ULIDs -> distinct branch names
+# ---------------------------------------------------------------------------
+
+
+def test_collision_different_ulids_produce_distinct_branches() -> None:
+    slug = "083-foo-bar"
+    # Two ULIDs with DIFFERENT mid8 prefixes so they produce distinct branch names.
+    ulid_a = "01KNXQS9ATWWFXS3K5ZJ9E5008"  # mid8 = 01KNXQS9
+    ulid_b = "01KNXQSAATWWFXS3K5ZJ9E5009"  # mid8 = 01KNXQSA  (differs at char 8)
+
+    branch_a = lane_branch_name(slug, "lane-a", mission_id=ulid_a)
+    branch_b = lane_branch_name(slug, "lane-a", mission_id=ulid_b)
+
+    assert branch_a != branch_b
+    assert mid8(ulid_a) in branch_a
+    assert mid8(ulid_b) in branch_b
+    # The mid8 tokens must differ
+    assert mid8(ulid_a) != mid8(ulid_b)
+
+
+# ---------------------------------------------------------------------------
+# parse_mission_slug_from_branch — legacy forms
+# ---------------------------------------------------------------------------
+
+
+# Real branch names from the 080-* triple on main, paired with expected lane_id.
+# Note: "080-wpstate-lane-consumer-strangler-fig-phase-2" embeds "lane-consumer" in the
+# slug itself — the parser correctly classifies it as a non-lane mission branch (lane_id=None)
+# because the suffix "phase-2" does not match the lane pattern "lane-[a-z]".
+LEGACY_BRANCHES: list[tuple[str, str | None]] = [
+    ("kitty/mission-080-browser-mediated-oauth-cli-auth", None),
+    ("kitty/mission-080-ci-hardening-and-lint-cleanup", None),
+    # "lane-consumer" is part of the slug, NOT a lane suffix — lane_id must be None
+    ("kitty/mission-080-wpstate-lane-consumer-strangler-fig-phase-2", None),
+    # These end with a real lane suffix
+    ("kitty/mission-080-browser-mediated-oauth-cli-auth-lane-a", "lane-a"),
+    ("kitty/mission-082-stealth-gated-saas-sync-hardening-lane-b", "lane-b"),
+]
+
+
+@pytest.mark.parametrize("branch,expected_lane_id", LEGACY_BRANCHES)
+def test_parse_legacy_branch(branch: str, expected_lane_id: str | None) -> None:
+    result = parse_mission_slug_from_branch(branch)
+    assert result is not None, f"Failed to parse legacy branch: {branch}"
+    slug, mid8_val, lane_id = result
+    assert slug  # non-empty
+    assert mid8_val is None  # legacy: no mid8
+    assert lane_id == expected_lane_id, (
+        f"Expected lane_id={expected_lane_id!r} for {branch!r}, got {lane_id!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_mission_slug_from_branch — new forms
+# ---------------------------------------------------------------------------
+
+
+def test_parse_new_branch_without_lane() -> None:
+    branch = "kitty/mission-mission-id-canonical-identity-migration-01KNXQS9"
+    result = parse_mission_slug_from_branch(branch)
+    assert result is not None
+    slug, mid8_val, lane_id = result
+    assert slug == "mission-id-canonical-identity-migration"
+    assert mid8_val == "01KNXQS9"
+    assert lane_id is None
+
+
+def test_parse_new_branch_with_lane() -> None:
+    branch = "kitty/mission-mission-id-canonical-identity-migration-01KNXQS9-lane-a"
+    result = parse_mission_slug_from_branch(branch)
+    assert result is not None
+    slug, mid8_val, lane_id = result
+    assert slug == "mission-id-canonical-identity-migration"
+    assert mid8_val == "01KNXQS9"
+    assert lane_id == "lane-a"
+
+
+def test_parse_new_branch_slug_with_hyphens() -> None:
+    # Multi-part slug
+    branch = "kitty/mission-foo-bar-baz-01KNXQS9-lane-b"
+    result = parse_mission_slug_from_branch(branch)
+    assert result is not None
+    slug, mid8_val, lane_id = result
+    assert slug == "foo-bar-baz"
+    assert mid8_val == "01KNXQS9"
+    assert lane_id == "lane-b"
+
+
+def test_parse_unknown_branch_returns_none() -> None:
+    result = parse_mission_slug_from_branch("feature/some-other-branch")
+    assert result is None
+
+
+def test_parse_non_kitty_prefix_returns_none() -> None:
+    result = parse_mission_slug_from_branch("main")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_legacy_branch
+# ---------------------------------------------------------------------------
+
+
+def test_is_legacy_branch_with_numeric_prefix() -> None:
+    assert is_legacy_branch("kitty/mission-080-browser-mediated-oauth-cli-auth") is True
+    assert is_legacy_branch("kitty/mission-080-foo-lane-a") is True
+
+
+def test_is_legacy_branch_new_form() -> None:
+    assert is_legacy_branch("kitty/mission-foo-bar-01KNXQS9") is False
+    assert is_legacy_branch("kitty/mission-foo-bar-01KNXQS9-lane-a") is False
+
+
+def test_is_legacy_branch_non_kitty() -> None:
+    assert is_legacy_branch("main") is False
+    assert is_legacy_branch("feature/something") is False
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: construct then parse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("slug", "ulid", "lane"),
+    [
+        ("083-foo-bar", "01KNXQS9ATWWFXS3K5ZJ9E5008", "lane-a"),
+        ("001-simple", "01KNXQS0ATWWFXS3K5ZJ9E5001", "lane-b"),
+        ("my-feature", "01KNXQS1ATWWFXS3K5ZJ9E5002", "lane-c"),
+    ],
+)
+def test_round_trip_construct_then_parse(slug: str, ulid: str, lane: str) -> None:
+    branch = lane_branch_name(slug, lane, mission_id=ulid)
+    result = parse_mission_slug_from_branch(branch)
+    assert result is not None
+    parsed_slug, parsed_mid8, parsed_lane = result
+    assert parsed_mid8 == ulid[:8]
+    assert parsed_lane == lane
+    # The human slug should be strip_numeric_prefix(slug)
+    assert parsed_slug == strip_numeric_prefix(slug)

--- a/tests/core/test_branch_naming_human_slug.py
+++ b/tests/core/test_branch_naming_human_slug.py
@@ -142,11 +142,13 @@ def test_collision_different_ulids_produce_distinct_branches() -> None:
 LEGACY_BRANCHES: list[tuple[str, str | None]] = [
     ("kitty/mission-080-browser-mediated-oauth-cli-auth", None),
     ("kitty/mission-080-ci-hardening-and-lint-cleanup", None),
+    ("kitty/mission-feature-without-number", None),
     # "lane-consumer" is part of the slug, NOT a lane suffix — lane_id must be None
     ("kitty/mission-080-wpstate-lane-consumer-strangler-fig-phase-2", None),
     # These end with a real lane suffix
     ("kitty/mission-080-browser-mediated-oauth-cli-auth-lane-a", "lane-a"),
     ("kitty/mission-082-stealth-gated-saas-sync-hardening-lane-b", "lane-b"),
+    ("kitty/mission-feature-without-number-lane-a", "lane-a"),
 ]
 
 
@@ -216,6 +218,8 @@ def test_parse_non_kitty_prefix_returns_none() -> None:
 def test_is_legacy_branch_with_numeric_prefix() -> None:
     assert is_legacy_branch("kitty/mission-080-browser-mediated-oauth-cli-auth") is True
     assert is_legacy_branch("kitty/mission-080-foo-lane-a") is True
+    assert is_legacy_branch("kitty/mission-feature-without-number") is True
+    assert is_legacy_branch("kitty/mission-feature-without-number-lane-a") is True
 
 
 def test_is_legacy_branch_new_form() -> None:

--- a/tests/core/test_mission_creation_identity.py
+++ b/tests/core/test_mission_creation_identity.py
@@ -33,14 +33,13 @@ def _init_git_repo(repo: Path) -> None:
     subprocess.run(["git", "commit", "-m", "init", "--allow-empty"], cwd=repo, capture_output=True, check=True)
 
 
-def _run_create(tmp_path: Path, slug: str, feature_number: int = 1) -> dict:
-    """Helper: call create_mission_core with standard mocks, return meta dict."""
+def _run_create(tmp_path: Path, slug: str) -> object:
+    """Helper: call create_mission_core with standard mocks."""
     with (
         patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=feature_number),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
@@ -55,9 +54,10 @@ def _run_create(tmp_path: Path, slug: str, feature_number: int = 1) -> dict:
 def test_mission_id_minted_at_creation(tmp_path: Path) -> None:
     """create_mission_core writes a 26-char ULID mission_id to meta.json."""
     _init_git_repo(tmp_path)
-    result = _run_create(tmp_path, "test-identity")
+    _run_create(tmp_path, "test-identity")
 
-    meta_path = tmp_path / "kitty-specs" / "001-test-identity" / "meta.json"
+    mission_dir = next((tmp_path / "kitty-specs").iterdir())
+    meta_path = mission_dir / "meta.json"
     assert meta_path.exists()
     meta = json.loads(meta_path.read_text())
 
@@ -86,8 +86,8 @@ def test_mission_id_present_in_result_meta(tmp_path: Path) -> None:
 def test_mission_id_is_not_derived_from_prefix_scan(tmp_path: Path) -> None:
     """Two missions with different numeric prefixes get different, independent ULIDs."""
     _init_git_repo(tmp_path)
-    result_a = _run_create(tmp_path, "feature-alpha", feature_number=1)
-    result_b = _run_create(tmp_path, "feature-beta", feature_number=2)
+    result_a = _run_create(tmp_path, "feature-alpha")
+    result_b = _run_create(tmp_path, "feature-beta")
 
     id_a = result_a.meta["mission_id"]
     id_b = result_b.meta["mission_id"]
@@ -117,7 +117,7 @@ def test_concurrent_creates_no_collision(tmp_path: Path) -> None:
             counter[0] += 1
             n = counter[0]
         try:
-            result = _run_create(tmp_path, slug, feature_number=n)
+            result = _run_create(tmp_path, slug)
             results.append(result.meta)
         except Exception as exc:
             errors.append(exc)

--- a/tests/core/test_mission_number_null_schema.py
+++ b/tests/core/test_mission_number_null_schema.py
@@ -1,0 +1,248 @@
+"""Tests for null mission_number schema (WP02 / T012).
+
+Covers:
+- resolve_mission_identity reads null -> None
+- resolve_mission_identity reads int -> int
+- resolve_mission_identity reads legacy "042" string -> 42
+- resolve_mission_identity rejects "pending" with clear ValueError
+- create_mission_core writes mission_number: null (JSON null) for new missions
+- The write path always produces null, never a string sentinel
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.mission_metadata import resolve_mission_identity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(feature_dir: Path, meta: dict[str, Any]) -> None:
+    """Write a meta.json for test fixtures."""
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _base_meta(**overrides: Any) -> dict[str, Any]:
+    """Minimal valid meta.json content."""
+    base: dict[str, Any] = {
+        "mission_id": "01KNXQS9ATWWFXS3K5ZJ9E5008",
+        "slug": "083-foo-bar",
+        "mission_slug": "083-foo-bar",
+        "friendly_name": "foo bar",
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-04-11T08:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# T008 coercion tests — resolve_mission_identity reads meta.json
+# ---------------------------------------------------------------------------
+
+
+def test_null_reads_as_none(tmp_path: Path) -> None:
+    """meta.json with mission_number: null reads as mission_number=None."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number=None))
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number is None
+
+
+def test_int_reads_as_int(tmp_path: Path) -> None:
+    """meta.json with mission_number: 42 reads as 42."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number=42))
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == 42
+    assert isinstance(identity.mission_number, int)
+
+
+def test_legacy_string_with_leading_zeros_reads_as_int(tmp_path: Path) -> None:
+    """Legacy "042" string reads as 42 (leading zeros stripped)."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number="042"))
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == 42
+    assert isinstance(identity.mission_number, int)
+
+
+def test_legacy_string_007_reads_as_7(tmp_path: Path) -> None:
+    """Legacy "007" reads as 7."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number="007"))
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == 7
+
+
+def test_legacy_string_without_leading_zeros(tmp_path: Path) -> None:
+    """Plain "83" reads as 83."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number="83"))
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number == 83
+
+
+def test_empty_string_reads_as_none(tmp_path: Path) -> None:
+    """Empty string "" reads as None (per canonical matrix)."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number=""))
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number is None
+
+
+def test_missing_key_reads_as_none(tmp_path: Path) -> None:
+    """Missing mission_number key reads as None."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    meta = _base_meta()
+    meta.pop("mission_number", None)  # ensure absent
+    _write_meta(feature_dir, meta)
+
+    identity = resolve_mission_identity(feature_dir)
+    assert identity.mission_number is None
+
+
+def test_pending_sentinel_raises_value_error(tmp_path: Path) -> None:
+    """String "pending" raises ValueError with actionable message."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number="pending"))
+
+    with pytest.raises(ValueError, match="pending"):
+        resolve_mission_identity(feature_dir)
+
+
+def test_unassigned_sentinel_raises_value_error(tmp_path: Path) -> None:
+    """String "unassigned" raises ValueError."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number="unassigned"))
+
+    with pytest.raises(ValueError, match="unassigned"):
+        resolve_mission_identity(feature_dir)
+
+
+def test_tbd_sentinel_raises_value_error(tmp_path: Path) -> None:
+    """String "TBD" raises ValueError."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, _base_meta(mission_number="TBD"))
+
+    with pytest.raises(ValueError, match="TBD"):
+        resolve_mission_identity(feature_dir)
+
+
+def test_float_type_raises_type_error(tmp_path: Path) -> None:
+    """Float type raises TypeError."""
+    feature_dir = tmp_path / "083-foo-bar"
+    feature_dir.mkdir()
+    # Write raw JSON with a float
+    raw = json.dumps(_base_meta(mission_number=42.5)) + "\n"
+    (feature_dir / "meta.json").write_text(raw, encoding="utf-8")
+
+    with pytest.raises(TypeError):
+        resolve_mission_identity(feature_dir)
+
+
+# ---------------------------------------------------------------------------
+# Write path: create_mission_core must emit null, not a string
+# ---------------------------------------------------------------------------
+
+
+def test_create_mission_core_writes_null_mission_number(tmp_path: Path) -> None:
+    """Creating a new mission writes mission_number: null (JSON null)."""
+    from specify_cli.core.mission_creation import create_mission_core
+
+    # create_mission_core needs a real git repo. Stub the git and filesystem
+    # operations that are not part of what we're testing.
+    with (
+        patch("specify_cli.core.mission_creation.is_worktree_context", return_value=False),
+        patch("specify_cli.core.mission_creation.locate_project_root", return_value=None),
+        patch("specify_cli.core.mission_creation.is_git_repo", return_value=True),
+        patch("specify_cli.core.mission_creation.get_current_branch", return_value="main"),
+        patch("specify_cli.core.mission_creation.safe_commit", return_value=True),
+        patch("specify_cli.core.mission_creation.emit_mission_created"),
+    ):
+        # Provide a real tmp_path as repo_root so file creation works
+        # but without a real git repo
+        result = create_mission_core(tmp_path, "foo-bar")
+
+    meta_path = result.feature_dir / "meta.json"
+    assert meta_path.exists()
+    meta_raw = meta_path.read_text(encoding="utf-8")
+    meta = json.loads(meta_raw)
+
+    # The field must be JSON null (None in Python)
+    assert meta.get("mission_number") is None
+    # Must NOT be a string sentinel
+    assert not isinstance(meta.get("mission_number"), str)
+
+
+def test_create_mission_core_mission_number_field_is_none_in_result(tmp_path: Path) -> None:
+    """MissionCreationResult.mission_number is None for new missions."""
+    from specify_cli.core.mission_creation import create_mission_core
+
+    with (
+        patch("specify_cli.core.mission_creation.is_worktree_context", return_value=False),
+        patch("specify_cli.core.mission_creation.locate_project_root", return_value=None),
+        patch("specify_cli.core.mission_creation.is_git_repo", return_value=True),
+        patch("specify_cli.core.mission_creation.get_current_branch", return_value="main"),
+        patch("specify_cli.core.mission_creation.safe_commit", return_value=True),
+        patch("specify_cli.core.mission_creation.emit_mission_created"),
+    ):
+        result = create_mission_core(tmp_path, "bar-baz")
+
+    assert result.mission_number is None
+
+
+def test_new_mission_feature_dir_uses_human_slug_mid8(tmp_path: Path) -> None:
+    """The feature directory name uses <human-slug>-<mid8> format."""
+    from specify_cli.core.mission_creation import create_mission_core
+
+    with (
+        patch("specify_cli.core.mission_creation.is_worktree_context", return_value=False),
+        patch("specify_cli.core.mission_creation.locate_project_root", return_value=None),
+        patch("specify_cli.core.mission_creation.is_git_repo", return_value=True),
+        patch("specify_cli.core.mission_creation.get_current_branch", return_value="main"),
+        patch("specify_cli.core.mission_creation.safe_commit", return_value=True),
+        patch("specify_cli.core.mission_creation.emit_mission_created"),
+    ):
+        result = create_mission_core(tmp_path, "my-feature")
+
+    # Directory name must NOT start with a 3-digit prefix
+    dir_name = result.feature_dir.name
+    assert not (len(dir_name) > 3 and dir_name[:3].isdigit() and dir_name[3] == "-"), (
+        f"Directory name '{dir_name}' still uses the old NNN-slug format"
+    )
+    # Must end with a mid8 (8 alphanumeric chars) separated by a hyphen
+    parts = dir_name.rsplit("-", 1)
+    assert len(parts) == 2, f"Expected <slug>-<mid8> format, got '{dir_name}'"
+    mid8_part = parts[1]
+    assert len(mid8_part) == 8, f"Expected 8-char mid8, got '{mid8_part}'"
+    assert mid8_part.isalnum(), f"mid8 must be alphanumeric, got '{mid8_part}'"

--- a/tests/core/test_slug_validator_unit.py
+++ b/tests/core/test_slug_validator_unit.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from ulid import ULID
 
 from specify_cli.core.mission_creation import KEBAB_CASE_PATTERN, MissionCreationError
 
@@ -53,13 +54,13 @@ class TestCreateMissionCoreSlugValidation:
              patch("specify_cli.core.mission_creation.locate_project_root", return_value=tmp_path), \
              patch("specify_cli.core.mission_creation.is_git_repo", return_value=True), \
              patch("specify_cli.core.mission_creation.get_current_branch", return_value="main"), \
-             patch("specify_cli.core.mission_creation.get_next_feature_number", return_value=70), \
+             patch("specify_cli.core.mission_creation.ULID", return_value=ULID.from_str("01KNXQS9ATWWFXS3K5ZJ9E5008")), \
              patch("specify_cli.core.mission_creation._commit_feature_file"):
             # Create the kitty-specs dir so mkdir doesn't fail
             (tmp_path / "kitty-specs").mkdir()
             result = create_mission_core(repo_root=tmp_path, mission_slug="070-new-feature")
             assert result is not None
-            assert "070-new-feature" in result.mission_slug
+            assert result.mission_slug.startswith("new-feature-")
 
     def test_uppercase_slug_still_rejected(self, tmp_path: Path) -> None:
         """FR-018: uppercase slugs are still rejected by slug validation."""

--- a/tests/cross_cutting/misc/test_tasks_cli_commands.py
+++ b/tests/cross_cutting/misc/test_tasks_cli_commands.py
@@ -89,7 +89,7 @@ def test_acceptance_commands(feature_repo: Path, mission_slug: str) -> None:
     assert_success(status)
     data = json.loads(status.stdout)
     assert data["mission_slug"] == mission_slug
-    assert data["mission_number"] == mission_slug.split("-")[0]
+    assert data["mission_number"] is None
     assert data["mission_type"] == "software-dev"
 
     verify = run_tasks_cli(["verify", "--feature", mission_slug, "--json", "--lenient"], cwd=feature_repo)
@@ -113,7 +113,7 @@ def test_acceptance_commands(feature_repo: Path, mission_slug: str) -> None:
     assert_success(accept)
     accept_payload = json.loads(accept.stdout)
     assert accept_payload["mission_slug"] == mission_slug
-    assert accept_payload["mission_number"] == mission_slug.split("-")[0]
+    assert accept_payload["mission_number"] is None
     assert accept_payload["mission_type"] == "software-dev"
 
 

--- a/tests/cross_cutting/test_gitignore_isolation_integration.py
+++ b/tests/cross_cutting/test_gitignore_isolation_integration.py
@@ -10,6 +10,7 @@ import json
 import os
 import subprocess
 import sys
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -20,10 +21,12 @@ pytestmark = pytest.mark.git_repo
 
 
 def _write_valid_meta(feature_dir: Path, slug: str, target_branch: str) -> None:
+    mission_id = "01" + hashlib.sha1(slug.encode("utf-8")).hexdigest().upper()[:24]
     feature_dir.joinpath("meta.json").write_text(
         json.dumps(
             {
-                "mission_number": slug.split("-", 1)[0],
+                "mission_id": mission_id,
+                "mission_number": None,
                 "slug": slug,
                 "mission_slug": slug,
                 "friendly_name": "Test Feature",

--- a/tests/dashboard/test_duplicate_prefix_rendering.py
+++ b/tests/dashboard/test_duplicate_prefix_rendering.py
@@ -1,0 +1,322 @@
+"""Dashboard rendering contract for duplicate-prefix missions (WP09 + WP14).
+
+Complements the scanner-level unit tests in
+``tests/test_dashboard/test_scanner_mission_id.py`` with a rendering-level
+contract that exercises the entire chain from on-disk meta.json through
+``build_mission_registry`` and out of the ``spec-kitty dashboard --json``
+CLI surface.
+
+Scope
+-----
+The test fixture is the same 3-mission ``080-*`` scenario used by
+``tests/integration/test_colliding_mission_flow.py``.  It proves that:
+
+1. ``build_mission_registry`` exposes three distinct records keyed by
+   mission_id (ULIDs), not by directory slug.
+2. The emitted records conform to the ``MissionRecord`` TypedDict shape
+   (``mission_id``, ``mission_slug``, ``display_number``, ``mid8``,
+   ``feature_dir`` all present; correct types).
+3. The ``dashboard --json`` CLI output is parseable JSON and round-trips
+   into the same ``MissionRecord`` shape, with all 3 missions visible.
+4. ``sort_missions_for_display`` returns a stable ordering that keeps all
+   3 colliding missions grouped by their slug tie-break (not coalesced
+   under a single numeric prefix).
+5. Each record's ``mid8`` is visible in the rendered payload so an
+   operator can disambiguate at a glance.
+
+Out of scope
+------------
+The dashboard HTTP server (``specify_cli.dashboard.server``) is not
+exercised here.  The CLI ``--json`` code path and ``build_mission_registry``
+are the two surfaces where the contract is enforceable without spinning up
+an HTTP server in-process.  If the server grows a dedicated rendering
+contract in the future, extend this file rather than creating a new one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.dashboard.api_types import MissionRecord
+from specify_cli.dashboard.scanner import (
+    build_mission_registry,
+    sort_missions_for_display,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# Same three ULIDs as the integration test so fixture data is aligned.
+ULID_FOO = "01KNAAA000000000000000FOO1"
+ULID_BAR = "01KNBBB000000000000000BAR1"
+ULID_BAZ = "01KNCCC000000000000000BAZ1"
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(
+    feature_dir: Path,
+    *,
+    mission_id: str,
+    mission_slug: str,
+    mission_number: int = 80,
+    friendly_name: str = "",
+) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, Any] = {
+        "slug": mission_slug,
+        "mission_slug": mission_slug,
+        "friendly_name": friendly_name or mission_slug,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-04-11T12:00:00+00:00",
+        "mission_id": mission_id,
+        "mission_number": mission_number,
+    }
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def colliding_080_repo(tmp_path: Path) -> Path:
+    """Repo root with three ``080-*`` missions carrying distinct ULIDs."""
+    specs = tmp_path / "kitty-specs"
+    _write_meta(
+        specs / "080-foo",
+        mission_id=ULID_FOO,
+        mission_slug="080-foo",
+        friendly_name="Foo Mission",
+    )
+    _write_meta(
+        specs / "080-bar",
+        mission_id=ULID_BAR,
+        mission_slug="080-bar",
+        friendly_name="Bar Mission",
+    )
+    _write_meta(
+        specs / "080-baz",
+        mission_id=ULID_BAZ,
+        mission_slug="080-baz",
+        friendly_name="Baz Mission",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Scanner output has three distinct ULID keys
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_three_distinct_mission_id_keys(
+    colliding_080_repo: Path,
+) -> None:
+    """Three ``080-*`` missions must produce three distinct registry rows."""
+    registry = build_mission_registry(colliding_080_repo)
+    assert len(registry) == 3, (
+        f"Expected 3 distinct records, got {len(registry)}: {list(registry)}"
+    )
+    assert ULID_FOO in registry
+    assert ULID_BAR in registry
+    assert ULID_BAZ in registry
+    # Directory slugs must NEVER be used as registry keys.
+    for slug in ("080-foo", "080-bar", "080-baz"):
+        assert slug not in registry, (
+            f"Registry must key by mission_id (ULID), not slug {slug!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. MissionRecord TypedDict shape
+# ---------------------------------------------------------------------------
+
+
+_MISSION_RECORD_FIELDS = ("mission_id", "mission_slug", "display_number", "mid8", "feature_dir")
+
+
+@pytest.mark.parametrize("ulid", [ULID_FOO, ULID_BAR, ULID_BAZ])
+def test_record_conforms_to_mission_record_typed_dict(
+    colliding_080_repo: Path,
+    ulid: str,
+) -> None:
+    """Every record must carry the MissionRecord required fields with expected types."""
+    registry = build_mission_registry(colliding_080_repo)
+    record = registry[ulid]
+    for field in _MISSION_RECORD_FIELDS:
+        assert field in record, f"Record missing field {field!r}: {record}"
+
+    # Type checks — match the MissionRecord TypedDict declarations.
+    assert isinstance(record["mission_id"], str)
+    assert record["mission_id"] == ulid
+    assert isinstance(record["mission_slug"], str)
+    assert record["mission_slug"].startswith("080-")
+    assert record["display_number"] == 80
+    assert record["mid8"] == ulid[:8]
+    assert isinstance(record["feature_dir"], str)
+
+    # Static check: the record is assignable to MissionRecord (TypedDict
+    # is a dict at runtime — this is an existence check, not instanceof).
+    typed_check: MissionRecord = record  # type: ignore[assignment]
+    assert typed_check["mission_id"] == ulid
+
+
+def test_mid8_is_distinct_across_missions(colliding_080_repo: Path) -> None:
+    """The mid8 prefix must be unique across all 3 collision candidates."""
+    registry = build_mission_registry(colliding_080_repo)
+    mid8s = {record["mid8"] for record in registry.values()}
+    assert len(mid8s) == 3, (
+        f"Expected 3 distinct mid8 values, got {mid8s}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. dashboard --json CLI output shows all 3 missions
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_json_cli_renders_three_distinct_rows(
+    colliding_080_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``spec-kitty dashboard --json`` must emit three distinct mission rows.
+
+    Uses the Typer CLI in-process so we exercise the real rendering code
+    path without spawning a subprocess.
+    """
+    import typer
+    from rich.console import Console as _Console
+
+    from specify_cli.cli.commands import dashboard as dashboard_mod
+    from specify_cli.cli.commands.dashboard import dashboard as dashboard_cmd
+
+    # Monkeypatch the project-root resolver the CLI uses internally so it
+    # reads from our temp fixture.
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.dashboard.get_project_root_or_exit",
+        lambda: colliding_080_repo,
+    )
+    # check_version_compatibility reads .kittify/config.yaml; neutralise it.
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.dashboard.check_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+    # Rich's default Console wraps output to the terminal width; replace it
+    # with a wide no-wrap Console so the emitted JSON survives as a single
+    # parseable string (otherwise linewrap inserts newlines inside quoted
+    # strings and breaks json.loads).
+    wide_console = _Console(width=100_000, soft_wrap=True, no_color=True)
+    monkeypatch.setattr(dashboard_mod, "console", wide_console)
+
+    # Build a tiny typer app wrapper so CliRunner can invoke the handler.
+    # We use the default callback surface so invoking with ``["--json"]``
+    # hits the single registered command directly.
+    app = typer.Typer()
+    app.command()(dashboard_cmd)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--json"])
+    assert result.exit_code == 0, (
+        f"dashboard --json failed: exit={result.exit_code}\n{result.stdout}"
+    )
+
+    # With the wide no-wrap Console monkeypatched in, the JSON payload
+    # comes out as a single clean block.
+    payload = json.loads(result.stdout.strip())
+    assert "missions" in payload, f"Expected 'missions' key in payload: {payload}"
+    assert "display_order" in payload
+
+    missions = payload["missions"]
+    assert len(missions) == 3, (
+        f"Expected 3 missions in --json output, got {len(missions)}: {sorted(missions)}"
+    )
+    # All three ULIDs appear as keys.
+    assert set(missions.keys()) == {ULID_FOO, ULID_BAR, ULID_BAZ}
+
+    # Each emitted record keeps the MissionRecord shape.
+    for ulid, record in missions.items():
+        for field in _MISSION_RECORD_FIELDS:
+            assert field in record, f"mission {ulid} missing {field!r}: {record}"
+        assert record["mission_id"] == ulid
+        assert record["mid8"] == ulid[:8]
+        assert record["display_number"] == 80
+
+    # display_order must include all 3 keys (no coalescing).
+    assert len(payload["display_order"]) == 3
+    assert set(payload["display_order"]) == {ULID_FOO, ULID_BAR, ULID_BAZ}
+
+
+# ---------------------------------------------------------------------------
+# 4. Stable display ordering
+# ---------------------------------------------------------------------------
+
+
+def test_sort_missions_is_stable_and_keeps_all_three(
+    colliding_080_repo: Path,
+) -> None:
+    """``sort_missions_for_display`` must preserve all 3 entries in a deterministic order."""
+    registry = build_mission_registry(colliding_080_repo)
+    order1 = sort_missions_for_display(registry)
+    order2 = sort_missions_for_display(registry)
+
+    assert order1 == order2, "Ordering must be deterministic"
+    assert set(order1) == {ULID_FOO, ULID_BAR, ULID_BAZ}
+    # Secondary sort is by mission_slug: bar < baz < foo
+    slugs = [registry[mid]["mission_slug"] for mid in order1]
+    assert slugs == ["080-bar", "080-baz", "080-foo"], (
+        f"Unexpected display order: {slugs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Rendered payload visibly includes each mid8
+# ---------------------------------------------------------------------------
+
+
+def test_rendered_json_contains_every_mid8(
+    colliding_080_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each mid8 string must appear in the rendered JSON text.
+
+    Operator-visible disambiguator check: the first 8 chars of every ULID
+    must surface in the stdout payload so an operator running
+    ``spec-kitty dashboard --json | jq`` can eyeball the collision directly.
+    """
+    import typer
+    from rich.console import Console as _Console
+
+    from specify_cli.cli.commands import dashboard as dashboard_mod
+    from specify_cli.cli.commands.dashboard import dashboard as dashboard_cmd
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.dashboard.get_project_root_or_exit",
+        lambda: colliding_080_repo,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.dashboard.check_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+    wide_console = _Console(width=100_000, soft_wrap=True, no_color=True)
+    monkeypatch.setattr(dashboard_mod, "console", wide_console)
+
+    app = typer.Typer()
+    app.command()(dashboard_cmd)
+    runner = CliRunner()
+    result = runner.invoke(app, ["--json"])
+    assert result.exit_code == 0, result.stdout
+
+    rendered = result.stdout
+    for ulid in (ULID_FOO, ULID_BAR, ULID_BAZ):
+        mid8_value = ulid[:8]
+        assert mid8_value in rendered, (
+            f"Rendered JSON missing mid8 {mid8_value!r}:\n{rendered}"
+        )

--- a/tests/doctor/test_identity_audit.py
+++ b/tests/doctor/test_identity_audit.py
@@ -117,6 +117,43 @@ def test_classify_mission_corrupt_meta_json(tmp_path: Path) -> None:
     assert state.error is not None
 
 
+def test_classify_mission_non_object_meta_json(tmp_path: Path) -> None:
+    """A non-object JSON document is classified as orphan with an error."""
+    d = tmp_path / "kitty-specs" / "083-list-meta"
+    d.mkdir(parents=True)
+    (d / "meta.json").write_text('["not", "an", "object"]', encoding="utf-8")
+
+    state = classify_mission(d)
+
+    assert state.state == "orphan"
+    assert state.error is not None
+    assert "Expected JSON object" in state.error
+
+
+def test_classify_mission_invalid_number_with_mission_id_is_pending(tmp_path: Path) -> None:
+    """A bad mission_number is coerced to None, keeping mission_id-backed rows pending."""
+    d = tmp_path / "kitty-specs" / "083-bad-number"
+    _write_meta(d, {"mission_id": _ULID_A, "mission_number": {"bad": "shape"}})
+
+    state = classify_mission(d)
+
+    assert state.state == "pending"
+    assert state.mission_id == _ULID_A
+    assert state.mission_number is None
+
+
+def test_classify_mission_invalid_number_without_mission_id_is_orphan(tmp_path: Path) -> None:
+    """A bad mission_number without mission_id becomes an orphan."""
+    d = tmp_path / "kitty-specs" / "083-bad-legacy"
+    _write_meta(d, {"mission_number": {"bad": "shape"}})
+
+    state = classify_mission(d)
+
+    assert state.state == "orphan"
+    assert state.mission_id is None
+    assert state.mission_number is None
+
+
 # ---------------------------------------------------------------------------
 # audit_repo
 # ---------------------------------------------------------------------------
@@ -190,6 +227,21 @@ def test_summarize_legacy_and_orphan_paths(tmp_path: Path) -> None:
     assert not any("003-assigned" in p for p in legacy + orphan)
 
 
+def test_summarize_counts_assigned_and_pending(tmp_path: Path) -> None:
+    """summarize increments assigned and pending counts without path buckets."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-assigned", _ULID_A, 1)
+    _mission_dir(specs, "002-pending", _ULID_B, None)
+
+    summary = summarize(audit_repo(tmp_path))
+
+    counts = summary["counts"]
+    assert counts["assigned"] == 1
+    assert counts["pending"] == 1
+    assert summary["legacy_paths"] == []
+    assert summary["orphan_paths"] == []
+
+
 # ---------------------------------------------------------------------------
 # T014: Duplicate-prefix report
 # ---------------------------------------------------------------------------
@@ -221,6 +273,25 @@ def test_find_duplicate_prefixes_no_duplicates(tmp_path: Path) -> None:
     _mission_dir(specs, "002-beta", _ULID_B, 2)
     dupes = find_duplicate_prefixes(tmp_path)
     assert dupes == {}
+
+
+def test_find_duplicate_prefixes_missing_specs_dir_returns_empty(tmp_path: Path) -> None:
+    """Missing kitty-specs/ returns an empty duplicate-prefix report."""
+    assert find_duplicate_prefixes(tmp_path) == {}
+
+
+def test_find_duplicate_prefixes_skips_non_directory_entries(tmp_path: Path) -> None:
+    """Files directly under kitty-specs/ are ignored by duplicate-prefix scanning."""
+    specs = tmp_path / "kitty-specs"
+    specs.mkdir()
+    (specs / "README.md").write_text("ignore me", encoding="utf-8")
+    _mission_dir(specs, "080-one", _ULID_A, 80)
+    _mission_dir(specs, "080-two", _ULID_B, 80)
+
+    dupes = find_duplicate_prefixes(tmp_path)
+
+    assert "080" in dupes
+    assert len(dupes["080"]) == 2
 
 
 def test_find_duplicate_prefixes_skips_no_prefix(tmp_path: Path) -> None:

--- a/tests/doctor/test_identity_audit.py
+++ b/tests/doctor/test_identity_audit.py
@@ -1,0 +1,499 @@
+"""Tests for the mission-identity audit (WP03 / T013-T017).
+
+Covers:
+- T013: four-state classifier (assigned, pending, legacy, orphan)
+- T014: duplicate-prefix report
+- T015: ambiguous-selector report
+- T016: JSON schema contract via typer.testing.CliRunner
+- T017: NFR-002 timing: 200 missions in < 3 seconds
+
+Do NOT add ``# type: ignore`` to this file — it must pass ``mypy --strict``
+cleanly where possible.  (typer.testing imports require some flexibility.)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from specify_cli.status.identity_audit import (
+    IdentityState,
+    audit_repo,
+    classify_mission,
+    find_ambiguous_selectors,
+    find_duplicate_prefixes,
+    summarize,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_ULID_A = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+_ULID_B = "01KNS7C9AZP1MPCFZWM25KV6TM"
+_ULID_C = "01KNS7RB1V9R3VSYD910HCAMTR"
+
+
+def _write_meta(feature_dir: Path, meta: dict[str, Any]) -> None:
+    """Write a minimal meta.json for test fixtures."""
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _mission_dir(specs: Path, slug: str, mission_id: str | None, mission_number: int | None) -> Path:
+    """Create a mission directory with the given identity fields."""
+    d = specs / slug
+    meta: dict[str, Any] = {
+        "slug": slug,
+        "mission_slug": slug,
+        "friendly_name": slug,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+    if mission_id is not None:
+        meta["mission_id"] = mission_id
+    if mission_number is not None:
+        meta["mission_number"] = mission_number
+    _write_meta(d, meta)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# T013: Four-state classifier (one parametrized test per state)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mission_id, mission_number, expected_state",
+    [
+        (_ULID_A, 83, "assigned"),
+        (_ULID_A, None, "pending"),
+        (None, 83, "legacy"),
+        (None, None, "orphan"),
+    ],
+    ids=["assigned", "pending", "legacy", "orphan"],
+)
+def test_classify_mission_four_states(
+    tmp_path: Path,
+    mission_id: str | None,
+    mission_number: int | None,
+    expected_state: str,
+) -> None:
+    """classify_mission returns correct state for each of the four cases."""
+    d = _mission_dir(tmp_path / "kitty-specs", "083-test", mission_id, mission_number)
+    state = classify_mission(d)
+    assert state.state == expected_state
+    assert state.slug == "083-test"
+    assert state.mission_id == mission_id
+    assert state.mission_number == mission_number
+
+
+def test_classify_mission_missing_meta_json(tmp_path: Path) -> None:
+    """A directory without meta.json is classified as orphan with error field."""
+    d = tmp_path / "kitty-specs" / "083-no-meta"
+    d.mkdir(parents=True)
+    state = classify_mission(d)
+    assert state.state == "orphan"
+    assert state.error is not None
+    assert "meta.json" in state.error
+
+
+def test_classify_mission_corrupt_meta_json(tmp_path: Path) -> None:
+    """A corrupt meta.json is classified as orphan, not an exception."""
+    d = tmp_path / "kitty-specs" / "083-corrupt"
+    d.mkdir(parents=True)
+    (d / "meta.json").write_text("{not valid json", encoding="utf-8")
+    state = classify_mission(d)
+    assert state.state == "orphan"
+    assert state.error is not None
+
+
+# ---------------------------------------------------------------------------
+# audit_repo
+# ---------------------------------------------------------------------------
+
+
+def test_audit_repo_empty_specs(tmp_path: Path) -> None:
+    """audit_repo over empty kitty-specs returns empty list."""
+    (tmp_path / "kitty-specs").mkdir()
+    result = audit_repo(tmp_path)
+    assert result == []
+
+
+def test_audit_repo_no_specs_dir(tmp_path: Path) -> None:
+    """audit_repo when kitty-specs does not exist returns empty list."""
+    result = audit_repo(tmp_path)
+    assert result == []
+
+
+def test_audit_repo_skips_non_directories(tmp_path: Path) -> None:
+    """audit_repo ignores files like README.md in kitty-specs/."""
+    specs = tmp_path / "kitty-specs"
+    specs.mkdir()
+    (specs / "README.md").write_text("ignore me", encoding="utf-8")
+    _mission_dir(specs, "001-hello", _ULID_A, 1)
+    result = audit_repo(tmp_path)
+    assert len(result) == 1
+    assert result[0].slug == "001-hello"
+
+
+def test_audit_repo_all_four_states(tmp_path: Path) -> None:
+    """audit_repo correctly classifies a repo with one mission per state."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-assigned", _ULID_A, 1)
+    _mission_dir(specs, "002-pending", _ULID_B, None)
+    _mission_dir(specs, "003-legacy", None, 3)
+    _mission_dir(specs, "004-orphan", None, None)
+    result = audit_repo(tmp_path)
+    assert len(result) == 4
+    states_found = {s.state for s in result}
+    assert states_found == {"assigned", "pending", "legacy", "orphan"}
+
+
+# ---------------------------------------------------------------------------
+# summarize
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_zero_filled(tmp_path: Path) -> None:
+    """summarize always returns all four state keys, even when counts are zero."""
+    states: list[IdentityState] = []
+    summary = summarize(states)
+    counts = summary["counts"]
+    assert isinstance(counts, dict)
+    for key in ("assigned", "pending", "legacy", "orphan"):
+        assert key in counts
+        assert counts[key] == 0
+
+
+def test_summarize_legacy_and_orphan_paths(tmp_path: Path) -> None:
+    """summarize populates legacy_paths and orphan_paths."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-legacy", None, 1)
+    _mission_dir(specs, "002-orphan", None, None)
+    _mission_dir(specs, "003-assigned", _ULID_A, 3)
+    result = audit_repo(tmp_path)
+    summary = summarize(result)
+    legacy: list[str] = summary["legacy_paths"]  # type: ignore[assignment]
+    orphan: list[str] = summary["orphan_paths"]  # type: ignore[assignment]
+    assert any("001-legacy" in p for p in legacy)
+    assert any("002-orphan" in p for p in orphan)
+    assert not any("003-assigned" in p for p in legacy + orphan)
+
+
+# ---------------------------------------------------------------------------
+# T014: Duplicate-prefix report
+# ---------------------------------------------------------------------------
+
+
+def test_find_duplicate_prefixes_three_080(tmp_path: Path) -> None:
+    """Three 080-* missions produce {'080': [<3 states>]}."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "080-alpha", _ULID_A, 80)
+    _mission_dir(specs, "080-beta", _ULID_B, 80)
+    _mission_dir(specs, "080-gamma", _ULID_C, 80)
+    dupes = find_duplicate_prefixes(tmp_path)
+    assert "080" in dupes
+    assert len(dupes["080"]) == 3
+
+
+def test_find_duplicate_prefixes_single_not_flagged(tmp_path: Path) -> None:
+    """A lone 080-* mission is NOT flagged as a duplicate."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "080-only", _ULID_A, 80)
+    dupes = find_duplicate_prefixes(tmp_path)
+    assert "080" not in dupes
+
+
+def test_find_duplicate_prefixes_no_duplicates(tmp_path: Path) -> None:
+    """A repo with unique prefixes returns empty dict."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-alpha", _ULID_A, 1)
+    _mission_dir(specs, "002-beta", _ULID_B, 2)
+    dupes = find_duplicate_prefixes(tmp_path)
+    assert dupes == {}
+
+
+def test_find_duplicate_prefixes_skips_no_prefix(tmp_path: Path) -> None:
+    """Directories without a leading NNN- prefix are silently skipped."""
+    specs = tmp_path / "kitty-specs"
+    d = specs / "no-prefix-dir"
+    d.mkdir(parents=True)
+    (d / "meta.json").write_text("{}", encoding="utf-8")
+    dupes = find_duplicate_prefixes(tmp_path)
+    assert dupes == {}
+
+
+def test_find_duplicate_prefixes_distinct_07x(tmp_path: Path) -> None:
+    """070, 071, 072 are reported as distinct prefix groups, not merged."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "070-a", None, 70)
+    _mission_dir(specs, "070-b", None, 70)
+    _mission_dir(specs, "071-c", None, 71)
+    _mission_dir(specs, "071-d", None, 71)
+    dupes = find_duplicate_prefixes(tmp_path)
+    assert "070" in dupes
+    assert "071" in dupes
+    assert len(dupes["070"]) == 2
+    assert len(dupes["071"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# T015: Selector-ambiguity report
+# ---------------------------------------------------------------------------
+
+
+def test_find_ambiguous_selectors_three_080(tmp_path: Path) -> None:
+    """Three 080-* missions flag '080' as ambiguous."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "080-alpha", _ULID_A, 80)
+    _mission_dir(specs, "080-beta", _ULID_B, 80)
+    _mission_dir(specs, "080-gamma", _ULID_C, 80)
+    states = audit_repo(tmp_path)
+    ambiguous = find_ambiguous_selectors(states)
+    assert "080" in ambiguous
+    assert len(ambiguous["080"]) == 3
+
+
+def test_find_ambiguous_selectors_shared_human_slug(tmp_path: Path) -> None:
+    """Missions with the same human slug flag that slug as ambiguous."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "081-foo-bar", _ULID_A, 81)
+    _mission_dir(specs, "082-foo-bar", _ULID_B, 82)
+    states = audit_repo(tmp_path)
+    ambiguous = find_ambiguous_selectors(states)
+    assert "foo-bar" in ambiguous
+    assert len(ambiguous["foo-bar"]) == 2
+
+
+def test_find_ambiguous_selectors_no_ambiguity(tmp_path: Path) -> None:
+    """Distinct missions with distinct handles produce no ambiguities."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-alpha", _ULID_A, 1)
+    _mission_dir(specs, "002-beta", _ULID_B, 2)
+    states = audit_repo(tmp_path)
+    ambiguous = find_ambiguous_selectors(states)
+    assert ambiguous == {}
+
+
+def test_find_ambiguous_selectors_prefix_not_substring(tmp_path: Path) -> None:
+    """'foo' does not collide with 'foobar' — only exact handle matches count."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-foo", _ULID_A, 1)
+    _mission_dir(specs, "002-foobar", _ULID_B, 2)
+    states = audit_repo(tmp_path)
+    ambiguous = find_ambiguous_selectors(states)
+    # Neither "foo" nor "foobar" should be flagged (they are distinct handles)
+    assert "foo" not in ambiguous
+    assert "foobar" not in ambiguous
+
+
+def test_find_ambiguous_selectors_distinct_081_and_081_bar(tmp_path: Path) -> None:
+    """081-foo and 081-bar both share prefix '081' — that prefix is ambiguous."""
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "081-foo", _ULID_A, 81)
+    _mission_dir(specs, "081-bar", _ULID_B, 81)
+    states = audit_repo(tmp_path)
+    ambiguous = find_ambiguous_selectors(states)
+    assert "081" in ambiguous
+    assert len(ambiguous["081"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# T016: JSON schema contract via typer.testing.CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_identity_json_schema(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--json emits a valid document matching the documented schema."""
+    import specify_cli.cli.commands.doctor as doctor_mod
+    from typer.testing import CliRunner
+
+    from specify_cli.cli.commands.doctor import app
+
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-assigned", _ULID_A, 1)
+    _mission_dir(specs, "002-pending", _ULID_B, None)
+    _mission_dir(specs, "003-legacy", None, 3)
+    _mission_dir(specs, "004-orphan", None, None)
+    _mission_dir(specs, "080-foo", _ULID_A, 80)
+    _mission_dir(specs, "080-bar", _ULID_B, 80)
+
+    # Patch at the module where the name is bound (doctor.py top-level import)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["identity", "--json"])
+
+    assert result.exit_code == 0, result.output
+    doc = json.loads(result.output)
+
+    # Top-level keys
+    assert "summary" in doc
+    assert "missions" in doc
+    assert "duplicate_prefixes" in doc
+    assert "ambiguous_selectors" in doc
+    assert "fail_on_triggered" in doc
+
+    # Summary counts all four states
+    summary = doc["summary"]
+    for state in ("assigned", "pending", "legacy", "orphan"):
+        assert state in summary
+    # 001-assigned (assigned), 080-foo (assigned), 080-bar (assigned) = 3 assigned
+    assert summary["assigned"] == 3
+    assert summary["pending"] == 1
+    assert summary["legacy"] == 1
+    assert summary["orphan"] == 1
+
+    # Missions list
+    missions = doc["missions"]
+    assert len(missions) == 6
+    slugs = {m["slug"] for m in missions}
+    assert "001-assigned" in slugs
+
+    # Each mission entry has the documented fields
+    for m in missions:
+        assert "slug" in m
+        assert "mission_id" in m
+        assert "mission_number" in m
+        assert "state" in m
+        assert "path" in m
+        assert "error" in m
+
+    # Duplicate prefixes
+    assert "080" in doc["duplicate_prefixes"]
+    assert len(doc["duplicate_prefixes"]["080"]) == 2
+
+    # fail_on_triggered is False when --fail-on not given
+    assert doc["fail_on_triggered"] is False
+
+
+def test_identity_fail_on_legacy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--fail-on legacy exits 1 when a legacy mission exists."""
+    import specify_cli.cli.commands.doctor as doctor_mod
+    from typer.testing import CliRunner
+
+    from specify_cli.cli.commands.doctor import app
+
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-legacy", None, 1)
+
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["identity", "--json", "--fail-on", "legacy"])
+
+    assert result.exit_code == 1
+    doc = json.loads(result.output)
+    assert doc["fail_on_triggered"] is True
+
+
+def test_identity_fail_on_no_trigger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--fail-on legacy exits 0 when no legacy missions exist."""
+    import specify_cli.cli.commands.doctor as doctor_mod
+    from typer.testing import CliRunner
+
+    from specify_cli.cli.commands.doctor import app
+
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-assigned", _ULID_A, 1)
+
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["identity", "--json", "--fail-on", "legacy"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.output)
+    assert doc["fail_on_triggered"] is False
+
+
+def test_identity_mission_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--mission <slug> scopes the report to one mission."""
+    import specify_cli.cli.commands.doctor as doctor_mod
+    from typer.testing import CliRunner
+
+    from specify_cli.cli.commands.doctor import app
+
+    specs = tmp_path / "kitty-specs"
+    _mission_dir(specs, "001-alpha", _ULID_A, 1)
+    _mission_dir(specs, "002-beta", _ULID_B, 2)
+
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["identity", "--json", "--mission", "001-alpha"])
+
+    assert result.exit_code == 0
+    doc = json.loads(result.output)
+    assert len(doc["missions"]) == 1
+    assert doc["missions"][0]["slug"] == "001-alpha"
+
+
+# ---------------------------------------------------------------------------
+# T017: NFR-002 timing — 200 missions in < 3 seconds
+# ---------------------------------------------------------------------------
+
+
+def _build_200_mission_repo(tmp_path: Path) -> Path:
+    """Create a synthetic repo with 200 missions using raw meta.json writes.
+
+    Uses raw file writes (not spec-kitty agent mission create) to stay fast.
+    """
+    specs = tmp_path / "kitty-specs"
+    specs.mkdir(parents=True)
+    for i in range(200):
+        slug = f"{i + 1:03d}-test-mission-{i}"
+        d = specs / slug
+        d.mkdir()
+        meta: dict[str, Any] = {
+            "slug": slug,
+            "mission_slug": slug,
+            "friendly_name": slug,
+            "mission_type": "software-dev",
+            "target_branch": "main",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "mission_id": _ULID_A,
+            "mission_number": i + 1,
+        }
+        (d / "meta.json").write_text(
+            json.dumps(meta, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return tmp_path
+
+
+def test_nfr_002_timing_200_missions() -> None:
+    """audit_repo + find_duplicate_prefixes + find_ambiguous_selectors must complete
+    in < 3 seconds for a synthetic 200-mission repo (NFR-002)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = _build_200_mission_repo(Path(tmpdir))
+
+        start = time.monotonic()
+        states = audit_repo(repo_root)
+        dupes = find_duplicate_prefixes(repo_root)
+        ambiguous = find_ambiguous_selectors(states)
+        elapsed = time.monotonic() - start
+
+        # Sanity checks: the data is correct
+        assert len(states) == 200
+        assert all(s.state == "assigned" for s in states)
+        assert dupes == {}  # all distinct prefixes
+        assert ambiguous == {}  # all distinct human slugs
+
+        # NFR-002: must be under 3 seconds
+        assert elapsed < 3.0, (
+            f"NFR-002 timing violation: {elapsed:.2f}s for 200 missions "
+            f"(limit: 3.0s). Check for I/O hotspots."
+        )

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -194,16 +194,20 @@ Create a hello module.
 """
         (tasks_dir / "WP01-hello-world.md").write_text(wp01_content, encoding="utf-8")
 
-        # Create meta.json (required by finalize-tasks for event emission)
+        # Preserve the mission_id minted at create time; only layer in the
+        # fields the synthetic finalize-tasks fixture needs.
         import json as json_mod
 
-        meta_content = {
-            "mission_number": "001",
-            "mission_slug": mission_slug,
-            "mission_type": "software-dev",
-            "created_at": "2026-02-12T00:00:00Z",
-            "vcs": "git",
-        }
+        meta_content = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        meta_content.update(
+            {
+                "mission_number": None,
+                "mission_slug": mission_slug,
+                "mission_type": "software-dev",
+                "created_at": "2026-02-12T00:00:00Z",
+                "vcs": "git",
+            }
+        )
         (feature_dir / "meta.json").write_text(
             json_mod.dumps(meta_content, indent=2),
             encoding="utf-8",

--- a/tests/git_ops/test_worktree.py
+++ b/tests/git_ops/test_worktree.py
@@ -9,100 +9,60 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from specify_cli.merge.ordering import assign_next_mission_number
 from specify_cli.core.worktree import (
     _exclude_from_git,
     create_feature_worktree,
-    get_next_feature_number,
     setup_feature_directory,
     validate_feature_structure,
 )
 
 pytestmark = pytest.mark.git_repo
+TEST_MISSION_ID = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+TEST_MID8 = TEST_MISSION_ID[:8]
 
-class TestGetNextFeatureNumber:
-    """Tests for get_next_feature_number function."""
+class TestAssignNextMissionNumber:
+    """Tests for merge-time display-number allocation."""
 
     def test_returns_1_when_no_features_exist(self, tmp_path: Path):
-        """Should return 1 when no features exist."""
-        # Setup: Empty repo
-        result = get_next_feature_number(tmp_path)
+        """Should return 1 when no numbered missions exist."""
+        specs_dir = tmp_path / "kitty-specs"
+        specs_dir.mkdir()
+        result = assign_next_mission_number(tmp_path, specs_dir)
         assert result == 1
 
     def test_scans_kitty_specs_directory(self, tmp_path: Path):
-        """Should scan kitty-specs/ for feature numbers."""
-        # Setup: Create features in kitty-specs/
+        """Should scan kitty-specs/ for integer mission_number values."""
         specs_dir = tmp_path / "kitty-specs"
         specs_dir.mkdir()
-        (specs_dir / "001-feature-one").mkdir()
-        (specs_dir / "002-feature-two").mkdir()
-        (specs_dir / "005-feature-five").mkdir()
+        for name, number in (
+            ("alpha", 1),
+            ("beta", 2),
+            ("gamma", 5),
+        ):
+            mission_dir = specs_dir / f"{name}-{TEST_MID8}"
+            mission_dir.mkdir()
+            (mission_dir / "meta.json").write_text(f'{{"mission_number": {number}}}', encoding="utf-8")
 
-        result = get_next_feature_number(tmp_path)
+        result = assign_next_mission_number(tmp_path, specs_dir)
         assert result == 6
 
-    def test_scans_worktrees_directory(self, tmp_path: Path):
-        """Should scan .worktrees/ for feature numbers."""
-        # Setup: Create features in .worktrees/
-        worktrees_dir = tmp_path / ".worktrees"
-        worktrees_dir.mkdir()
-        (worktrees_dir / "003-worktree-feature").mkdir()
-        (worktrees_dir / "007-another-feature").mkdir()
-
-        result = get_next_feature_number(tmp_path)
-        assert result == 8
-
-    def test_scans_both_directories(self, tmp_path: Path):
-        """Should scan both kitty-specs/ and .worktrees/ and use highest number."""
-        # Setup: Features in both directories
+    def test_ignores_missing_or_non_integer_mission_numbers(self, tmp_path: Path):
+        """Should ignore missions with null, string, or absent mission_number."""
         specs_dir = tmp_path / "kitty-specs"
         specs_dir.mkdir()
-        (specs_dir / "001-feature").mkdir()
-        (specs_dir / "003-feature").mkdir()
+        for name, payload in (
+            ("alpha", '{"mission_number": null}'),
+            ("beta", '{"mission_number": "003"}'),
+            ("gamma", '{"mission_slug": "gamma"}'),
+            ("delta", '{"mission_number": 4}'),
+        ):
+            mission_dir = specs_dir / f"{name}-{TEST_MID8}"
+            mission_dir.mkdir()
+            (mission_dir / "meta.json").write_text(payload, encoding="utf-8")
 
-        worktrees_dir = tmp_path / ".worktrees"
-        worktrees_dir.mkdir()
-        (worktrees_dir / "002-feature").mkdir()
-        (worktrees_dir / "010-feature").mkdir()
-
-        result = get_next_feature_number(tmp_path)
-        assert result == 11
-
-    def test_ignores_non_numeric_directories(self, tmp_path: Path):
-        """Should ignore directories that don't start with ###."""
-        # Setup: Mix of valid and invalid directory names
-        specs_dir = tmp_path / "kitty-specs"
-        specs_dir.mkdir()
-        (specs_dir / "001-valid").mkdir()
-        (specs_dir / "invalid-name").mkdir()
-        (specs_dir / "README.md").touch()
-        (specs_dir / "abc-not-number").mkdir()
-
-        result = get_next_feature_number(tmp_path)
-        assert result == 2
-
-    def test_handles_missing_directories(self, tmp_path: Path):
-        """Should handle missing kitty-specs/ and .worktrees/ gracefully."""
-        # No directories created
-        result = get_next_feature_number(tmp_path)
-        assert result == 1
-
-    def test_handles_malformed_feature_numbers_gracefully(self, tmp_path: Path):
-        """Should skip directories with invalid numbers gracefully."""
-        # Setup: Mix valid and invalid feature directories
-        specs_dir = tmp_path / "kitty-specs"
-        specs_dir.mkdir()
-        (specs_dir / "001-valid").mkdir()
-        (specs_dir / "abc-invalid").mkdir()  # Not a number
-        (specs_dir / "00x-invalid").mkdir()  # Invalid format
-
-        worktrees_dir = tmp_path / ".worktrees"
-        worktrees_dir.mkdir()
-        (worktrees_dir / "002-valid").mkdir()
-        (worktrees_dir / "xyz-invalid").mkdir()
-
-        result = get_next_feature_number(tmp_path)
-        # Should only count 001 and 002, so next is 3
-        assert result == 3
+        result = assign_next_mission_number(tmp_path, specs_dir)
+        assert result == 5
 
 
 class TestCreateFeatureWorktree:
@@ -135,23 +95,17 @@ class TestCreateFeatureWorktree:
         )
 
         # Execute
-        worktree_path, feature_dir = create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+        worktree_path, feature_dir = create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
         # Verify
-        assert worktree_path == tmp_path / ".worktrees" / "001-test-feature"
+        assert worktree_path == tmp_path / ".worktrees" / f"test-feature-{TEST_MID8}"
         assert worktree_path.exists()
         assert worktree_path.is_dir()
-        assert feature_dir == worktree_path / "kitty-specs" / "001-test-feature"
+        assert feature_dir == worktree_path / "kitty-specs" / f"test-feature-{TEST_MID8}"
         assert feature_dir.exists()
 
-    def test_auto_detects_feature_number(self, tmp_path: Path):
-        """Should auto-detect next feature number when not provided."""
-        # Setup: Existing features
-        specs_dir = tmp_path / "kitty-specs"
-        specs_dir.mkdir()
-        (specs_dir / "001-existing").mkdir()
-        (specs_dir / "002-existing").mkdir()
-
+    def test_requires_mission_id(self, tmp_path: Path):
+        """Should require mission_id for worktree creation."""
         # Setup: Git repo
         subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
         subprocess.run(
@@ -175,22 +129,18 @@ class TestCreateFeatureWorktree:
             capture_output=True,
         )
 
-        # Execute
-        worktree_path, feature_dir = create_feature_worktree(tmp_path, "new-feature")
-
-        # Verify
-        assert worktree_path == tmp_path / ".worktrees" / "003-new-feature"
-        assert feature_dir == worktree_path / "kitty-specs" / "003-new-feature"
+        with pytest.raises(RuntimeError, match="requires mission_id"):
+            create_feature_worktree(tmp_path, "new-feature")
 
     def test_raises_error_when_worktree_exists(self, tmp_path: Path):
         """Should raise FileExistsError when worktree path already exists."""
         # Setup: Pre-existing directory (not a valid worktree)
-        worktree_path = tmp_path / ".worktrees" / "001-test-feature"
+        worktree_path = tmp_path / ".worktrees" / f"test-feature-{TEST_MID8}"
         worktree_path.mkdir(parents=True)
 
         # Execute & Verify
         with pytest.raises(FileExistsError, match="Worktree path already exists"):
-            create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+            create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
     def test_reuses_existing_valid_worktree(self, tmp_path: Path):
         """Should reuse existing valid git worktree instead of raising error."""
@@ -218,10 +168,10 @@ class TestCreateFeatureWorktree:
         )
 
         # Create first worktree
-        worktree_path1, feature_dir1 = create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+        worktree_path1, feature_dir1 = create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
         # Execute: Try to create same worktree again
-        worktree_path2, feature_dir2 = create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+        worktree_path2, feature_dir2 = create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
         # Verify: Should return same paths
         assert worktree_path1 == worktree_path2
@@ -232,7 +182,7 @@ class TestCreateFeatureWorktree:
         # Setup: Not a git repo - workspace creation will fail
         # Note: RuntimeError wraps the underlying subprocess or VCS error
         with pytest.raises(RuntimeError, match="Failed to create workspace"):
-            create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+            create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
 
 class TestSetupFeatureDirectory:
@@ -574,12 +524,12 @@ class TestVCSAbstraction:
         mock_vcs.is_repo.return_value = False
 
         with patch("specify_cli.core.worktree.get_vcs", return_value=mock_vcs):
-            worktree_path, feature_dir = create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+            worktree_path, feature_dir = create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
             # Verify VCS abstraction was called
             mock_vcs.create_workspace.assert_called_once()
             call_kwargs = mock_vcs.create_workspace.call_args.kwargs
-            assert call_kwargs["workspace_name"] == "001-test-feature"
+            assert call_kwargs["workspace_name"] == f"test-feature-{TEST_MID8}"
             assert call_kwargs["repo_root"] == tmp_path
 
     def test_create_worktree_falls_back_to_git_with_warning(self, tmp_path: Path):
@@ -612,7 +562,7 @@ class TestVCSAbstraction:
             # Capture deprecation warning
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                worktree_path, feature_dir = create_feature_worktree(tmp_path, "fallback-test", feature_number=99)
+                worktree_path, feature_dir = create_feature_worktree(tmp_path, "fallback-test", mission_id=TEST_MISSION_ID)
 
                 # Verify deprecation warning was raised
                 assert len(w) == 1
@@ -642,12 +592,12 @@ class TestVCSAbstraction:
             patch("specify_cli.core.worktree.get_vcs", return_value=mock_vcs),
             pytest.raises(RuntimeError, match="Failed to create workspace"),
         ):
-            create_feature_worktree(tmp_path, "fail-test", feature_number=88)
+            create_feature_worktree(tmp_path, "fail-test", mission_id=TEST_MISSION_ID)
 
     def test_create_worktree_detects_existing_vcs_workspace(self, tmp_path: Path):
         """Should detect and reuse existing VCS workspace."""
         # Setup: Pre-existing workspace directory with .git
-        worktree_path = tmp_path / ".worktrees" / "001-test-feature"
+        worktree_path = tmp_path / ".worktrees" / f"test-feature-{TEST_MID8}"
         worktree_path.mkdir(parents=True)
         (worktree_path / ".git").touch()  # Minimal marker
 
@@ -656,11 +606,11 @@ class TestVCSAbstraction:
         mock_vcs.is_repo.return_value = True
 
         with patch("specify_cli.core.worktree.get_vcs", return_value=mock_vcs):
-            worktree_result, feature_dir = create_feature_worktree(tmp_path, "test-feature", feature_number=1)
+            worktree_result, feature_dir = create_feature_worktree(tmp_path, "test-feature", mission_id=TEST_MISSION_ID)
 
             # Should return the existing path
             assert worktree_result == worktree_path
-            assert feature_dir == worktree_path / "kitty-specs" / "001-test-feature"
+            assert feature_dir == worktree_path / "kitty-specs" / f"test-feature-{TEST_MID8}"
 
 
 class TestExcludeFromGit:

--- a/tests/init/test_worktree_topology.py
+++ b/tests/init/test_worktree_topology.py
@@ -118,7 +118,11 @@ class TestRenderTopologyJson:
 
         payload = json.loads("\n".join(lines[1:-1]))
         assert payload["mission_slug"] == "002-feature"
-        assert payload["mission_number"] == "002"
+        # mission_number is display-only: mission_identity_fields() strips
+        # leading zeros, so the slug prefix "002" renders as "2" at the
+        # payload boundary. Canonical identity is mission_id (not asserted
+        # here because FeatureTopology was constructed without one).
+        assert payload["mission_number"] == "2"
         assert payload["mission_type"] == "software-dev"
         assert payload["mission_branch"] == "kitty/mission-002-feature"
         assert payload["shared_lane"] is True

--- a/tests/integration/test_colliding_mission_flow.py
+++ b/tests/integration/test_colliding_mission_flow.py
@@ -1,0 +1,353 @@
+"""End-to-end colliding-mission flow (NFR-007 / FR-062).
+
+Builds a synthetic repo with three ``080-*`` missions that share the same
+numeric prefix but have distinct ULID identities.  Runs each user-facing
+resolution surface against the fixture and asserts the expected behaviour:
+
+1. ``doctor identity --json`` reports all three missions in the
+   ``duplicate_prefixes`` section with correct state counts.
+2. Resolving the bare numeric handle ``"080"`` raises
+   :class:`AmbiguousHandleError` listing all three candidates.
+3. Resolving a specific ``mid8`` cleanly selects exactly one mission.
+4. Resolving the full ULID cleanly selects exactly one mission.
+5. Resolving the fully qualified slug (``080-foo``) cleanly selects one mission.
+6. Worktree naming derived from the resolved identity yields three distinct
+   worktree paths (no collisions on disk).
+
+Design
+------
+- The test operates on a ``tmp_path`` fixture; it never touches the real
+  repo or any network.  ``SPEC_KITTY_ENABLE_SAAS_SYNC`` is not exercised
+  because no subprocess is spawned and no SaaS client is instantiated.
+- All assertions run against the real production code paths:
+  * ``specify_cli.status.identity_audit`` (doctor identity)
+  * ``specify_cli.context.mission_resolver`` (resolve_mission)
+  * ``specify_cli.lanes.branch_naming`` (lane/worktree naming)
+- The CLI surface is exercised in-process via ``typer.testing.CliRunner``
+  for the doctor command.
+- Target runtime is well under 30 seconds — the fixture is small (3 mission
+  directories with a minimal meta.json each) and no git worktrees are
+  created.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.doctor import app as doctor_app
+from specify_cli.context.mission_resolver import (
+    AmbiguousHandleError,
+    MissionNotFoundError,
+    resolve_mission,
+)
+from specify_cli.lanes.branch_naming import (
+    lane_branch_name,
+    mid8,
+    mission_branch_name,
+)
+from specify_cli.status.identity_audit import (
+    audit_repo,
+    find_ambiguous_selectors,
+    find_duplicate_prefixes,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# Three distinct ULIDs — same 080 prefix, distinct mid8, distinct human slugs.
+ULID_FOO = "01KNAAA000000000000000FOO1"
+ULID_BAR = "01KNBBB000000000000000BAR1"
+ULID_BAZ = "01KNCCC000000000000000BAZ1"
+
+
+# ---------------------------------------------------------------------------
+# Fixture: 3-mission colliding 080-* repo
+# ---------------------------------------------------------------------------
+
+
+def _write_minimal_meta(
+    feature_dir: Path,
+    *,
+    mission_id: str,
+    mission_slug: str,
+    mission_number: int = 80,
+    friendly_name: str = "",
+) -> None:
+    """Write a schema-complete minimal meta.json for the resolver/audit."""
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {
+        "slug": mission_slug,
+        "mission_slug": mission_slug,
+        "friendly_name": friendly_name or mission_slug,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-04-11T12:00:00+00:00",
+        "mission_id": mission_id,
+        "mission_number": mission_number,
+    }
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def colliding_080_repo(tmp_path: Path) -> Path:
+    """Return a repo root containing three colliding ``080-*`` missions.
+
+    Structure::
+
+        <tmp_path>/
+          kitty-specs/
+            080-foo/meta.json  (mission_id ULID_FOO)
+            080-bar/meta.json  (mission_id ULID_BAR)
+            080-baz/meta.json  (mission_id ULID_BAZ)
+    """
+    specs = tmp_path / "kitty-specs"
+    _write_minimal_meta(
+        specs / "080-foo",
+        mission_id=ULID_FOO,
+        mission_slug="080-foo",
+        friendly_name="Foo Mission",
+    )
+    _write_minimal_meta(
+        specs / "080-bar",
+        mission_id=ULID_BAR,
+        mission_slug="080-bar",
+        friendly_name="Bar Mission",
+    )
+    _write_minimal_meta(
+        specs / "080-baz",
+        mission_id=ULID_BAZ,
+        mission_slug="080-baz",
+        friendly_name="Baz Mission",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. doctor identity --json reports all 3 duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_identity_audit_sees_three_080_missions(colliding_080_repo: Path) -> None:
+    """audit_repo + find_duplicate_prefixes finds all 3 missions under "080"."""
+    states = audit_repo(colliding_080_repo)
+    slugs = sorted(s.slug for s in states)
+    assert slugs == ["080-bar", "080-baz", "080-foo"]
+    # All three should be classified as 'assigned' since mission_id is present
+    # and mission_number is an int.
+    assert all(s.state == "assigned" for s in states), (
+        f"Expected all assigned, got {[(s.slug, s.state) for s in states]}"
+    )
+
+    duplicates = find_duplicate_prefixes(colliding_080_repo)
+    assert "080" in duplicates
+    assert len(duplicates["080"]) == 3
+
+
+def test_doctor_identity_audit_reports_ambiguous_selectors(
+    colliding_080_repo: Path,
+) -> None:
+    """Bare "080" handle must be flagged as ambiguous by the selector audit."""
+    states = audit_repo(colliding_080_repo)
+    ambiguous = find_ambiguous_selectors(states)
+    # "080" is ambiguous (3-way tie)
+    assert "080" in ambiguous, (
+        f"Expected '080' in ambiguous handles, got {sorted(ambiguous.keys())}"
+    )
+    assert len(ambiguous["080"]) == 3
+
+
+def test_doctor_identity_cli_json_reports_three_duplicates(
+    colliding_080_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``spec-kitty doctor identity --json`` exposes duplicates to operators.
+
+    Exercises the CLI surface in-process using CliRunner.  We monkeypatch
+    the repo-root resolver to point at the fixture.
+    """
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.doctor.locate_project_root",
+        lambda: colliding_080_repo,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(doctor_app, ["identity", "--json"])
+    assert result.exit_code == 0, (
+        f"doctor identity --json failed: {result.exit_code}\n{result.stdout}"
+    )
+
+    report = json.loads(result.stdout)
+    assert "duplicate_prefixes" in report
+    assert "080" in report["duplicate_prefixes"], (
+        f"Expected '080' in duplicate_prefixes, got {sorted(report['duplicate_prefixes'].keys())}"
+    )
+    dup_080 = report["duplicate_prefixes"]["080"]
+    assert len(dup_080) == 3, (
+        f"Expected 3 duplicates under '080', got {len(dup_080)}: {dup_080}"
+    )
+
+    # Summary counts match the four-state classifier output.
+    assert report["summary"]["assigned"] == 3, report["summary"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Ambiguous handle — bare "080" must raise
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_bare_080_raises_ambiguous(colliding_080_repo: Path) -> None:
+    """``resolve_mission("080", ...)`` must raise with all 3 candidates listed."""
+    with pytest.raises(AmbiguousHandleError) as exc_info:
+        resolve_mission("080", colliding_080_repo)
+
+    err = exc_info.value
+    assert err.handle == "080"
+    slugs = sorted(c.mission_slug for c in err.candidates)
+    assert slugs == ["080-bar", "080-baz", "080-foo"]
+
+    # The rendered error message must name every candidate so the operator
+    # can pick the right mid8 / slug without extra commands.
+    rendered = str(err)
+    for slug in slugs:
+        assert slug in rendered
+    # Each candidate's mid8 should also be present as a suggested --mission value.
+    for candidate in err.candidates:
+        assert candidate.mid8 in rendered
+
+
+# ---------------------------------------------------------------------------
+# 3. mid8 resolution — a specific 8-char prefix selects exactly one mission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ulid", "expected_slug"),
+    [
+        (ULID_FOO, "080-foo"),
+        (ULID_BAR, "080-bar"),
+        (ULID_BAZ, "080-baz"),
+    ],
+)
+def test_resolve_by_mid8_is_unique(
+    colliding_080_repo: Path,
+    ulid: str,
+    expected_slug: str,
+) -> None:
+    """Each mid8 must resolve to exactly one mission."""
+    handle = ulid[:8]
+    resolved = resolve_mission(handle, colliding_080_repo)
+    assert resolved.mission_id == ulid
+    assert resolved.mission_slug == expected_slug
+    assert resolved.mid8 == handle
+
+
+# ---------------------------------------------------------------------------
+# 4. Full ULID resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ulid", "expected_slug"),
+    [
+        (ULID_FOO, "080-foo"),
+        (ULID_BAR, "080-bar"),
+        (ULID_BAZ, "080-baz"),
+    ],
+)
+def test_resolve_by_full_ulid_is_unique(
+    colliding_080_repo: Path,
+    ulid: str,
+    expected_slug: str,
+) -> None:
+    """Full 26-char ULID resolves unambiguously."""
+    resolved = resolve_mission(ulid, colliding_080_repo)
+    assert resolved.mission_id == ulid
+    assert resolved.mission_slug == expected_slug
+
+
+# ---------------------------------------------------------------------------
+# 5. Fully qualified slug resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("slug", "expected_ulid"),
+    [
+        ("080-foo", ULID_FOO),
+        ("080-bar", ULID_BAR),
+        ("080-baz", ULID_BAZ),
+    ],
+)
+def test_resolve_by_full_slug_is_unique(
+    colliding_080_repo: Path,
+    slug: str,
+    expected_ulid: str,
+) -> None:
+    """The full directory slug disambiguates without needing the mid8."""
+    resolved = resolve_mission(slug, colliding_080_repo)
+    assert resolved.mission_slug == slug
+    assert resolved.mission_id == expected_ulid
+
+
+def test_resolve_unknown_handle_raises_not_found(colliding_080_repo: Path) -> None:
+    """Negative: a handle that matches nothing raises ``MissionNotFoundError``."""
+    with pytest.raises(MissionNotFoundError):
+        resolve_mission("999", colliding_080_repo)
+
+
+# ---------------------------------------------------------------------------
+# 6. Worktree / branch naming — distinct per mission
+# ---------------------------------------------------------------------------
+
+
+def test_lane_branches_are_distinct_per_mission(colliding_080_repo: Path) -> None:
+    """Lane branch names derived from mid8 must not collide across the 3 missions."""
+    branch_names: set[str] = set()
+    worktree_paths: set[str] = set()
+
+    for ulid in (ULID_FOO, ULID_BAR, ULID_BAZ):
+        resolved = resolve_mission(ulid, colliding_080_repo)
+        branch = lane_branch_name(
+            mission_slug=resolved.mission_slug,
+            lane_id="lane-a",
+            mission_id=ulid,
+        )
+        branch_names.add(branch)
+        # Simulate the worktree directory path:
+        # .worktrees/<human-slug>-<mid8>-lane-a
+        # We aren't actually creating worktrees in this test — just verifying
+        # that the derived path differs for each mission.
+        worktree_paths.add(f"{resolved.mission_slug}-{mid8(ulid)}-lane-a")
+
+    assert len(branch_names) == 3, (
+        f"Expected 3 distinct branch names, got {sorted(branch_names)}"
+    )
+    assert len(worktree_paths) == 3, (
+        f"Expected 3 distinct worktree paths, got {sorted(worktree_paths)}"
+    )
+    # Every branch must include its own mid8 as disambiguator.
+    for ulid in (ULID_FOO, ULID_BAR, ULID_BAZ):
+        assert any(mid8(ulid) in name for name in branch_names), (
+            f"mid8 {mid8(ulid)} missing from any lane branch name: {branch_names}"
+        )
+
+
+def test_mission_branches_are_distinct_per_mission(colliding_080_repo: Path) -> None:
+    """Mission-level branch names also carry the mid8 disambiguator."""
+    branch_names: set[str] = set()
+    for ulid in (ULID_FOO, ULID_BAR, ULID_BAZ):
+        resolved = resolve_mission(ulid, colliding_080_repo)
+        branch_names.add(
+            mission_branch_name(
+                mission_slug=resolved.mission_slug,
+                mission_id=ulid,
+            )
+        )
+    assert len(branch_names) == 3

--- a/tests/lanes/test_branch_naming.py
+++ b/tests/lanes/test_branch_naming.py
@@ -59,10 +59,17 @@ class TestIsLaneBranch:
 
 class TestParseFeatureSlug:
     def test_from_mission_branch(self):
-        assert parse_mission_slug_from_branch("kitty/mission-057-feat") == "057-feat"
+        result = parse_mission_slug_from_branch("kitty/mission-057-feat")
+        assert result is not None
+        assert result.slug == "057-feat"
+        assert result.mid8_token is None
+        assert result.lane_id is None
 
     def test_from_lane_branch(self):
-        assert parse_mission_slug_from_branch("kitty/mission-057-feat-lane-a") == "057-feat"
+        result = parse_mission_slug_from_branch("kitty/mission-057-feat-lane-a")
+        assert result is not None
+        assert result.slug == "057-feat"
+        assert result.lane_id == "lane-a"
 
     def test_from_regular_branch(self):
         assert parse_mission_slug_from_branch("main") is None

--- a/tests/merge/test_merge_time_number_assignment.py
+++ b/tests/merge/test_merge_time_number_assignment.py
@@ -183,6 +183,22 @@ class TestAssignNextMissionNumber:
 
         assert assign_next_mission_number(target_root, kitty_specs) == 2
 
+    def test_skips_non_directory_entries(self, tmp_path: Path) -> None:
+        """Files directly under kitty-specs/ are ignored during the scan."""
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        _write_meta(kitty_specs / "001-good", slug="001-good", mission_number=1)
+        (kitty_specs / "README.md").write_text("hi", encoding="utf-8")
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 2
+
+    def test_skips_malformed_mission_numbers(self, tmp_path: Path) -> None:
+        """Malformed mission_number values are warned on and skipped."""
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        _write_meta(kitty_specs / "001-good", slug="001-good", mission_number=1)
+        _write_meta(kitty_specs / "broken", slug="broken", mission_number=[])
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 2
+
 
 # ---------------------------------------------------------------------------
 # T056 — Test 1: assignment writes an integer into meta.json

--- a/tests/merge/test_merge_time_number_assignment.py
+++ b/tests/merge/test_merge_time_number_assignment.py
@@ -1,0 +1,343 @@
+"""Tests for merge-time mission_number assignment (WP10 / FR-044).
+
+Covers:
+- T051: ``needs_number_assignment`` distinguishes pre-merge null from any
+        non-null value (including legacy string forms).
+- T052: ``assign_next_mission_number`` returns ``max(existing) + 1`` (or 1).
+- T053: assignment is idempotent and respects already-assigned legacy missions.
+- T056: assignment, idempotency, legacy no-op, and concurrent-collision
+        scenarios via direct helper invocation under a test-only lock.
+
+These tests run against fixture ``kitty-specs/<slug>/meta.json`` files in a
+temporary directory and exercise the helpers directly.  They do **not**
+exercise the full git merge flow — that surface is covered by the rest of the
+``tests/merge/`` suite.  The priority here is to prove the logic of the
+single-writer assignment.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from specify_cli.merge.ordering import assign_next_mission_number
+from specify_cli.merge.state import needs_number_assignment
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(
+    feature_dir: Path,
+    *,
+    slug: str,
+    mission_number: int | str | None,
+    mission_type: str = "software-dev",
+    target_branch: str = "main",
+) -> Path:
+    """Create a kitty-specs/<slug>/meta.json fixture with the given fields."""
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "slug": slug,
+        "mission_slug": slug,
+        "friendly_name": slug.replace("-", " ").title(),
+        "mission_type": mission_type,
+        "target_branch": target_branch,
+        "created_at": "2026-04-11T00:00:00+00:00",
+        "mission_number": mission_number,
+    }
+    meta_path = feature_dir / "meta.json"
+    meta_path.write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return meta_path
+
+
+def _read_meta(feature_dir: Path) -> dict:
+    return json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+
+
+def _make_target_view(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (target_branch_root, kitty_specs_dir) for an empty target."""
+    target_root = tmp_path / "target"
+    kitty_specs = target_root / "kitty-specs"
+    kitty_specs.mkdir(parents=True, exist_ok=True)
+    return target_root, kitty_specs
+
+
+# ---------------------------------------------------------------------------
+# T051: needs_number_assignment helper
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsNumberAssignment:
+    """``needs_number_assignment`` reads meta.json via the canonical loader."""
+
+    def test_null_means_needs_assignment(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "083-foo"
+        _write_meta(feature_dir, slug="083-foo", mission_number=None)
+
+        assert needs_number_assignment(feature_dir) is True
+
+    def test_zero_is_already_assigned(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "000-zero"
+        _write_meta(feature_dir, slug="000-zero", mission_number=0)
+
+        # ``0`` is a legitimate integer; the gate should treat it as assigned.
+        assert needs_number_assignment(feature_dir) is False
+
+    def test_positive_int_is_already_assigned(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "042-something"
+        _write_meta(feature_dir, slug="042-something", mission_number=42)
+
+        assert needs_number_assignment(feature_dir) is False
+
+    def test_legacy_string_is_already_assigned(self, tmp_path: Path) -> None:
+        # T054: legacy "042" string must be treated as already-assigned because
+        # the metadata loader coerces it to int 42 at read time.
+        feature_dir = tmp_path / "kitty-specs" / "042-legacy"
+        _write_meta(feature_dir, slug="042-legacy", mission_number="042")
+
+        assert needs_number_assignment(feature_dir) is False
+
+    def test_missing_meta_returns_false(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "999-nope"
+        feature_dir.mkdir(parents=True, exist_ok=True)
+        # No meta.json written.
+
+        assert needs_number_assignment(feature_dir) is False
+
+
+# ---------------------------------------------------------------------------
+# T052: assign_next_mission_number helper
+# ---------------------------------------------------------------------------
+
+
+class TestAssignNextMissionNumber:
+    """``assign_next_mission_number`` walks the target's kitty-specs view."""
+
+    def test_empty_target_returns_one(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 1
+
+    def test_missing_kitty_specs_returns_one(self, tmp_path: Path) -> None:
+        target_root = tmp_path / "target"
+        target_root.mkdir(parents=True, exist_ok=True)
+        kitty_specs = target_root / "kitty-specs"
+        # Do NOT create kitty_specs.
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 1
+
+    def test_dense_sequence_returns_max_plus_one(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        for n in range(1, 43):  # 1..42 inclusive
+            _write_meta(
+                kitty_specs / f"{n:03d}-feature-{n}",
+                slug=f"{n:03d}-feature-{n}",
+                mission_number=n,
+            )
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 43
+
+    def test_excludes_pre_merge_null_missions(self, tmp_path: Path) -> None:
+        # Pre-merge missions on the target branch should NOT participate
+        # in the max computation.
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        _write_meta(kitty_specs / "001-old", slug="001-old", mission_number=1)
+        _write_meta(kitty_specs / "002-old", slug="002-old", mission_number=2)
+        _write_meta(kitty_specs / "999-pre", slug="999-pre", mission_number=None)
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 3
+
+    def test_handles_legacy_string_numbers(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        _write_meta(kitty_specs / "001-old", slug="001-old", mission_number="001")
+        _write_meta(kitty_specs / "042-other", slug="042-other", mission_number="042")
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 43
+
+    def test_handles_collision_in_existing_data(self, tmp_path: Path) -> None:
+        # Drift case: two missions both claim 42.  Shouldn't happen post
+        # migration but the algorithm should still pick 43.
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        _write_meta(kitty_specs / "042-a", slug="042-a", mission_number=42)
+        _write_meta(kitty_specs / "042-b", slug="042-b", mission_number=42)
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 43
+
+    def test_skips_directories_without_meta(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        _write_meta(kitty_specs / "001-good", slug="001-good", mission_number=1)
+        # A bare directory with no meta.json should be silently ignored.
+        (kitty_specs / "templates").mkdir()
+        (kitty_specs / "templates" / "README.md").write_text("hi", encoding="utf-8")
+
+        assert assign_next_mission_number(target_root, kitty_specs) == 2
+
+
+# ---------------------------------------------------------------------------
+# T056 — Test 1: assignment writes an integer into meta.json
+# ---------------------------------------------------------------------------
+
+
+def _simulate_assignment(
+    target_root: Path,
+    kitty_specs: Path,
+    feature_dir: Path,
+    *,
+    lock: threading.Lock | None = None,
+) -> int | None:
+    """In-process simulation of the merge-time assignment step.
+
+    Mirrors the locked write semantics of
+    :func:`specify_cli.cli.commands.merge._bake_mission_number_into_mission_branch`
+    without the git worktree dance.  This isolates the assignment logic so the
+    tests run in milliseconds and remain reliable.
+    """
+    if lock is not None:
+        lock.acquire()
+    try:
+        if not needs_number_assignment(feature_dir):
+            return None
+        next_number = assign_next_mission_number(target_root, kitty_specs)
+        meta = _read_meta(feature_dir)
+        meta["mission_number"] = next_number
+        (feature_dir / "meta.json").write_text(
+            json.dumps(meta, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        # The "merge" step: copy the now-numbered meta into the target view so
+        # subsequent assignments observe the new max.
+        target_copy = kitty_specs / feature_dir.name
+        target_copy.mkdir(parents=True, exist_ok=True)
+        (target_copy / "meta.json").write_text(
+            (feature_dir / "meta.json").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        return next_number
+    finally:
+        if lock is not None:
+            lock.release()
+
+
+class TestMergeTimeAssignmentScenarios:
+    """End-to-end scenarios for the WP10 four-case grid (T056)."""
+
+    def test_assignment_writes_integer(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        # Seed target branch with one already-assigned mission to verify the
+        # next number is computed correctly.
+        _write_meta(kitty_specs / "042-existing", slug="042-existing", mission_number=42)
+
+        # Pre-merge mission lives in the worktree (not yet on target).
+        feature_dir = tmp_path / "worktree" / "kitty-specs" / "083-pre-merge"
+        _write_meta(feature_dir, slug="083-pre-merge", mission_number=None)
+        assert needs_number_assignment(feature_dir) is True
+
+        assigned = _simulate_assignment(target_root, kitty_specs, feature_dir)
+
+        assert assigned == 43
+        meta = _read_meta(feature_dir)
+        assert meta["mission_number"] == 43
+        assert isinstance(meta["mission_number"], int)
+        assert needs_number_assignment(feature_dir) is False
+
+    def test_idempotency_second_run_no_op(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        feature_dir = tmp_path / "worktree" / "kitty-specs" / "083-pre-merge"
+        _write_meta(feature_dir, slug="083-pre-merge", mission_number=None)
+
+        first = _simulate_assignment(target_root, kitty_specs, feature_dir)
+        assert first == 1
+        assert _read_meta(feature_dir)["mission_number"] == 1
+
+        # Second invocation: gate returns False, so no assignment happens.
+        second = _simulate_assignment(target_root, kitty_specs, feature_dir)
+        assert second is None
+        assert _read_meta(feature_dir)["mission_number"] == 1
+
+    def test_legacy_already_assigned_no_op(self, tmp_path: Path) -> None:
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        # Seed target with some other missions so the "next" would be 100 if
+        # we naively reassigned.
+        _write_meta(kitty_specs / "099-other", slug="099-other", mission_number=99)
+
+        feature_dir = tmp_path / "worktree" / "kitty-specs" / "042-legacy"
+        _write_meta(feature_dir, slug="042-legacy", mission_number=42)
+
+        # Gate must short-circuit: already assigned.
+        assigned = _simulate_assignment(target_root, kitty_specs, feature_dir)
+        assert assigned is None
+
+        meta = _read_meta(feature_dir)
+        assert meta["mission_number"] == 42, "Existing integer must be preserved"
+
+    def test_legacy_string_form_no_op(self, tmp_path: Path) -> None:
+        # T054 fixture: a legacy mission stored as string "042" passes through
+        # untouched.  After the no-op, the on-disk value remains "042" because
+        # the assignment helper does not rewrite already-assigned missions.
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        feature_dir = tmp_path / "worktree" / "kitty-specs" / "042-legacy-string"
+        _write_meta(feature_dir, slug="042-legacy-string", mission_number="042")
+
+        assigned = _simulate_assignment(target_root, kitty_specs, feature_dir)
+        assert assigned is None
+
+        # On-disk form is preserved (write path was never invoked).
+        meta = _read_meta(feature_dir)
+        assert meta["mission_number"] == "042"
+
+    def test_concurrent_collision_produces_distinct_numbers(self, tmp_path: Path) -> None:
+        """Two merge paths against the same target each get a distinct integer.
+
+        Spawning real ``spec-kitty merge`` processes is overkill for the
+        invariant under test (mutual exclusion + max+1 monotonicity), so we
+        use threads under a shared lock that mirrors the per-mission
+        merge-state lock contract.
+        """
+        target_root, kitty_specs = _make_target_view(tmp_path)
+        # Pre-existing mission so the "next" starts at 43.
+        _write_meta(kitty_specs / "042-base", slug="042-base", mission_number=42)
+
+        feature_a = tmp_path / "wt-a" / "kitty-specs" / "083-mission-a"
+        feature_b = tmp_path / "wt-b" / "kitty-specs" / "084-mission-b"
+        _write_meta(feature_a, slug="083-mission-a", mission_number=None)
+        _write_meta(feature_b, slug="084-mission-b", mission_number=None)
+
+        lock = threading.Lock()
+        results: dict[str, int | None] = {}
+
+        def _runner(name: str, feature_dir: Path) -> None:
+            results[name] = _simulate_assignment(
+                target_root, kitty_specs, feature_dir, lock=lock
+            )
+
+        threads = [
+            threading.Thread(target=_runner, args=("a", feature_a)),
+            threading.Thread(target=_runner, args=("b", feature_b)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Both ran, both produced an integer, both integers are distinct
+        # and >= 43.  We don't care which mission got 43 vs 44 — only that
+        # the lock prevented a duplicate.
+        assert results["a"] is not None
+        assert results["b"] is not None
+        assert {results["a"], results["b"]} == {43, 44}
+
+        # And the on-disk values match.
+        assert _read_meta(feature_a)["mission_number"] in {43, 44}
+        assert _read_meta(feature_b)["mission_number"] in {43, 44}
+        assert _read_meta(feature_a)["mission_number"] != _read_meta(feature_b)["mission_number"]

--- a/tests/migration/test_backfill_identity_cli.py
+++ b/tests/migration/test_backfill_identity_cli.py
@@ -1,0 +1,529 @@
+"""Tests for the mission_id backfill command (WP04 / T018-T022).
+
+Covers:
+- T018: idempotent ULID write (backfill_mission / backfill_repo)
+- T019: CLI surface via typer.testing.CliRunner
+- T020: legacy mission_number string coercion
+- T021: dossier rehash (fire-and-forget; errors don't abort)
+- T022: all six test cases (idempotency, preservation, coercion, orphan,
+        dry-run, NFR-001 timing)
+
+Do NOT add ``# type: ignore`` to this file — it must pass ``mypy --strict``
+where possible.  (typer.testing imports require some flexibility.)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.migrate_cmd import app as migrate_app
+from specify_cli.migration.backfill_identity import backfill_repo
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_ULID_EXISTING = "01KNXQS9ATWWFXS3K5ZJ9E5008"
+
+
+def _base_meta(slug: str) -> dict[str, Any]:
+    """Return a minimal valid meta.json dict."""
+    return {
+        "slug": slug,
+        "mission_slug": slug,
+        "friendly_name": slug,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _write_meta(feature_dir: Path, meta: dict[str, Any]) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_meta(feature_dir: Path) -> dict[str, Any]:
+    result: dict[str, Any] = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+    return result
+
+
+@pytest.fixture()
+def specs_root(tmp_path: Path) -> Path:
+    """Provide a tmp_path with a kitty-specs/ dir and .kittify/ marker."""
+    specs = tmp_path / "kitty-specs"
+    specs.mkdir()
+    (tmp_path / ".kittify").mkdir()
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# T018 / T022-idempotency: second run must be all-skip
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    """T022 — Idempotency: run twice, second run is all-skip."""
+
+    def test_second_run_all_skip(self, specs_root: Path) -> None:
+        slug = "001-alpha"
+        d = specs_root / "kitty-specs" / slug
+        _write_meta(d, _base_meta(slug))
+
+        # First run: should write
+        results1 = backfill_repo(specs_root)
+        assert len(results1) == 1
+        assert results1[0].action == "wrote"
+        assert results1[0].mission_id is not None
+
+        # Second run: must skip
+        results2 = backfill_repo(specs_root)
+        assert len(results2) == 1
+        assert results2[0].action == "skip"
+        assert results2[0].mission_id == results1[0].mission_id
+
+
+# ---------------------------------------------------------------------------
+# T022-preservation: existing mission_id is byte-identical after two runs
+# ---------------------------------------------------------------------------
+
+
+class TestPreservation:
+    """T022 — Preservation: existing mission_id unchanged after both runs."""
+
+    def test_existing_id_preserved(self, specs_root: Path) -> None:
+        slug = "002-beta"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_id"] = _ULID_EXISTING
+        meta["mission_number"] = 2
+        _write_meta(d, meta)
+
+        for _ in range(2):
+            results = backfill_repo(specs_root)
+            assert len(results) == 1
+            assert results[0].action == "skip"
+            assert results[0].mission_id == _ULID_EXISTING
+
+        # File content untouched (mission_id byte-identical)
+        loaded = _read_meta(d)
+        assert loaded["mission_id"] == _ULID_EXISTING
+
+
+# ---------------------------------------------------------------------------
+# T020 / T022-coercion: "042" becomes 42 after first run
+# ---------------------------------------------------------------------------
+
+
+class TestCoercion:
+    """T022 — Coercion: string mission_number becomes int after backfill."""
+
+    def test_string_number_coerced(self, specs_root: Path) -> None:
+        slug = "042-gamma"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_number"] = "042"
+        _write_meta(d, meta)
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 1
+        r = results[0]
+        assert r.number_coerced is True
+        # mission_id was missing, so it was also written
+        assert r.action == "wrote"
+
+        loaded = _read_meta(d)
+        assert loaded["mission_number"] == 42
+        assert isinstance(loaded["mission_number"], int)
+        assert "mission_id" in loaded
+
+    def test_integer_number_unchanged(self, specs_root: Path) -> None:
+        slug = "007-delta"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_number"] = 7
+        _write_meta(d, meta)
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 1
+        assert results[0].number_coerced is False
+
+        loaded = _read_meta(d)
+        assert loaded["mission_number"] == 7
+
+    def test_none_number_unchanged(self, specs_root: Path) -> None:
+        slug = "003-epsilon"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_number"] = None
+        _write_meta(d, meta)
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 1
+        assert results[0].number_coerced is False
+
+    def test_sentinel_string_raises(self, specs_root: Path) -> None:
+        slug = "004-zeta"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_number"] = "pending"
+        _write_meta(d, meta)
+
+        with pytest.raises(ValueError, match="pending"):
+            backfill_repo(specs_root)
+
+    def test_already_has_id_but_string_number_coerced(self, specs_root: Path) -> None:
+        slug = "099-eta"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_id"] = _ULID_EXISTING
+        meta["mission_number"] = "099"
+        _write_meta(d, meta)
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 1
+        r = results[0]
+        assert r.number_coerced is True
+        assert r.mission_id == _ULID_EXISTING
+
+        loaded = _read_meta(d)
+        assert loaded["mission_number"] == 99
+        assert loaded["mission_id"] == _ULID_EXISTING
+
+
+# ---------------------------------------------------------------------------
+# T022-orphan: corrupt JSON returns error, doesn't crash
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanHandling:
+    """T022 — Orphan: corrupt JSON produces error result, doesn't crash."""
+
+    def test_corrupt_json_returns_error(self, specs_root: Path) -> None:
+        slug = "005-theta"
+        d = specs_root / "kitty-specs" / slug
+        d.mkdir(parents=True)
+        (d / "meta.json").write_text("{ this is not valid json }", encoding="utf-8")
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 1
+        r = results[0]
+        assert r.action == "error"
+        assert r.reason is not None
+        assert "corrupt json" in r.reason.lower()
+
+    def test_corrupt_json_doesnt_stop_other_missions(self, specs_root: Path) -> None:
+        slug_bad = "005-iota"
+        d_bad = specs_root / "kitty-specs" / slug_bad
+        d_bad.mkdir(parents=True)
+        (d_bad / "meta.json").write_text("NOT JSON", encoding="utf-8")
+
+        slug_ok = "006-kappa"
+        d_ok = specs_root / "kitty-specs" / slug_ok
+        _write_meta(d_ok, _base_meta(slug_ok))
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 2
+        actions = {r.slug: r.action for r in results}
+        assert actions[slug_bad] == "error"
+        assert actions[slug_ok] == "wrote"
+
+    def test_missing_meta_json_skipped(self, specs_root: Path) -> None:
+        slug = "007-lambda"
+        d = specs_root / "kitty-specs" / slug
+        d.mkdir(parents=True)
+        # no meta.json
+
+        results = backfill_repo(specs_root)
+        assert len(results) == 1
+        assert results[0].action == "skip"
+        assert results[0].reason is not None
+        assert "not found" in results[0].reason
+
+
+# ---------------------------------------------------------------------------
+# T022-dry-run: --dry-run produces same shape, zero filesystem diffs
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    """T022 — Dry-run: same result shape, no filesystem writes."""
+
+    def test_dry_run_no_writes(self, specs_root: Path) -> None:
+        slug = "008-mu"
+        d = specs_root / "kitty-specs" / slug
+        _write_meta(d, _base_meta(slug))
+
+        original_text = (d / "meta.json").read_text(encoding="utf-8")
+
+        results = backfill_repo(specs_root, dry_run=True)
+        assert len(results) == 1
+        # Result shape: action indicates what would happen
+        assert results[0].action == "wrote"
+        assert results[0].mission_id is not None
+
+        # File unchanged
+        assert (d / "meta.json").read_text(encoding="utf-8") == original_text
+
+    def test_dry_run_skip_already_set(self, specs_root: Path) -> None:
+        slug = "009-nu"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_id"] = _ULID_EXISTING
+        _write_meta(d, meta)
+
+        results = backfill_repo(specs_root, dry_run=True)
+        assert len(results) == 1
+        assert results[0].action == "skip"
+
+
+# ---------------------------------------------------------------------------
+# T022-timing (NFR-001): 200 missions in < 5 seconds
+# ---------------------------------------------------------------------------
+
+
+class TestNFR001Timing:
+    """T022 — NFR-001: 200-mission synthetic fixture completes in < 5 seconds.
+
+    The dossier rehash step is mocked because it touches the SaaS network and
+    heavy import chains — those are outside the scope of the pure-Python
+    backfill budget defined by NFR-001.  The timing assertion covers the I/O
+    path: 200 meta.json reads, ULID minting for missing ones, and 200 writes.
+    """
+
+    def test_200_missions_under_5s(self, tmp_path: Path) -> None:
+        specs = tmp_path / "kitty-specs"
+        specs.mkdir()
+        (tmp_path / ".kittify").mkdir()
+
+        # Create 200 missions, half with existing mission_id, half without
+        for i in range(200):
+            slug = f"{i:03d}-mission-{i}"
+            d = specs / slug
+            meta = _base_meta(slug)
+            meta["mission_number"] = i
+            if i % 2 == 0:
+                meta["mission_id"] = _ULID_EXISTING
+            _write_meta(d, meta)
+
+        import specify_cli.migration.backfill_identity as _bi_mod
+
+        start = time.monotonic()
+        with patch.object(_bi_mod, "trigger_feature_dossier_sync_if_enabled", return_value=None):
+            results = backfill_repo(tmp_path)
+        elapsed = time.monotonic() - start
+
+        assert len(results) == 200
+        assert elapsed < 5.0, f"NFR-001 violated: {elapsed:.2f}s >= 5.0s for 200 missions"
+
+
+# ---------------------------------------------------------------------------
+# T019: CLI surface tests using typer.testing.CliRunner
+# ---------------------------------------------------------------------------
+
+
+class TestCLISurface:
+    """T019 — CLI subcommand tests."""
+
+    def _make_repo(self, tmp_path: Path) -> Path:
+        """Create a minimal repo with one legacy and one complete mission."""
+        specs = tmp_path / "kitty-specs"
+        specs.mkdir()
+        (tmp_path / ".kittify").mkdir()
+
+        # legacy mission (no mission_id)
+        slug_legacy = "010-xi"
+        d_legacy = specs / slug_legacy
+        _write_meta(d_legacy, _base_meta(slug_legacy))
+
+        # complete mission (has mission_id)
+        slug_complete = "011-omicron"
+        d_complete = specs / slug_complete
+        meta = _base_meta(slug_complete)
+        meta["mission_id"] = _ULID_EXISTING
+        _write_meta(d_complete, meta)
+
+        return tmp_path
+
+    def test_help_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(migrate_app, ["backfill-identity", "--help"])
+        assert result.exit_code == 0
+        assert "mission_id" in result.output
+        assert "--dry-run" in result.output
+        assert "--json" in result.output
+        assert "--mission" in result.output
+
+    def test_dry_run_json_output_shape(self, tmp_path: Path) -> None:
+        repo = self._make_repo(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "specify_cli.cli.commands.migrate_cmd.locate_project_root",
+            return_value=repo,
+        ):
+            result = runner.invoke(migrate_app, ["backfill-identity", "--dry-run", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["dry_run"] is True
+        assert "summary" in payload
+        assert "results" in payload
+        summary = payload["summary"]
+        assert summary["total"] == 2
+        assert summary["wrote"] == 1  # legacy mission would-write
+        assert summary["skip"] == 1  # complete mission
+
+    def test_exit_code_0_on_success(self, tmp_path: Path) -> None:
+        repo = self._make_repo(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "specify_cli.cli.commands.migrate_cmd.locate_project_root",
+            return_value=repo,
+        ):
+            result = runner.invoke(migrate_app, ["backfill-identity", "--dry-run", "--json"])
+        assert result.exit_code == 0
+
+    def test_exit_code_1_on_errors(self, tmp_path: Path) -> None:
+        specs = tmp_path / "kitty-specs"
+        specs.mkdir()
+        (tmp_path / ".kittify").mkdir()
+        slug = "012-pi"
+        d = specs / slug
+        d.mkdir()
+        (d / "meta.json").write_text("INVALID", encoding="utf-8")
+
+        runner = CliRunner()
+        with patch(
+            "specify_cli.cli.commands.migrate_cmd.locate_project_root",
+            return_value=tmp_path,
+        ):
+            result = runner.invoke(migrate_app, ["backfill-identity", "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["summary"]["error"] == 1
+
+    def test_mission_flag_scopes_to_one(self, tmp_path: Path) -> None:
+        repo = self._make_repo(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "specify_cli.cli.commands.migrate_cmd.locate_project_root",
+            return_value=repo,
+        ):
+            result = runner.invoke(
+                migrate_app,
+                ["backfill-identity", "--dry-run", "--json", "--mission", "010-xi"],
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["summary"]["total"] == 1
+        assert payload["results"][0]["slug"] == "010-xi"
+
+    def test_json_result_fields(self, tmp_path: Path) -> None:
+        repo = self._make_repo(tmp_path)
+        runner = CliRunner()
+        with patch(
+            "specify_cli.cli.commands.migrate_cmd.locate_project_root",
+            return_value=repo,
+        ):
+            result = runner.invoke(migrate_app, ["backfill-identity", "--dry-run", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        for item in payload["results"]:
+            assert "slug" in item
+            assert "action" in item
+            assert "mission_id" in item
+            assert "number_coerced" in item
+            assert "reason" in item
+            assert "dossier_warning" in item
+
+    def test_summary_counts_coercions(self, tmp_path: Path) -> None:
+        specs = tmp_path / "kitty-specs"
+        specs.mkdir()
+        (tmp_path / ".kittify").mkdir()
+        slug = "013-rho"
+        d = specs / slug
+        meta = _base_meta(slug)
+        meta["mission_number"] = "013"
+        _write_meta(d, meta)
+
+        runner = CliRunner()
+        with patch(
+            "specify_cli.cli.commands.migrate_cmd.locate_project_root",
+            return_value=tmp_path,
+        ):
+            result = runner.invoke(migrate_app, ["backfill-identity", "--dry-run", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["summary"]["number_coerced"] == 1
+
+
+# ---------------------------------------------------------------------------
+# T021: dossier rehash — fire-and-forget, failures don't abort
+# ---------------------------------------------------------------------------
+
+
+class TestDossierRehash:
+    """T021 — Dossier rehash warnings don't fail the run."""
+
+    def test_dossier_failure_captured_as_warning(self, specs_root: Path) -> None:
+        slug = "014-sigma"
+        d = specs_root / "kitty-specs" / slug
+        _write_meta(d, _base_meta(slug))
+
+        import specify_cli.migration.backfill_identity as _bi_mod
+
+        with patch.object(
+            _bi_mod,
+            "trigger_feature_dossier_sync_if_enabled",
+            side_effect=RuntimeError("dossier exploded"),
+        ):
+            results = backfill_repo(specs_root)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.action == "wrote"
+        assert r.dossier_warning is not None
+        assert "dossier rehash failed" in r.dossier_warning
+
+    def test_dossier_not_called_for_skipped(self, specs_root: Path) -> None:
+        slug = "015-tau"
+        d = specs_root / "kitty-specs" / slug
+        meta = _base_meta(slug)
+        meta["mission_id"] = _ULID_EXISTING
+        meta["mission_number"] = 15
+        _write_meta(d, meta)
+
+        import specify_cli.migration.backfill_identity as _bi_mod
+
+        mock_fn = MagicMock()
+        with patch.object(_bi_mod, "trigger_feature_dossier_sync_if_enabled", mock_fn):
+            results = backfill_repo(specs_root)
+
+        assert len(results) == 1
+        assert results[0].action == "skip"
+        mock_fn.assert_not_called()
+
+    def test_dossier_called_for_wrote(self, specs_root: Path) -> None:
+        slug = "016-upsilon"
+        d = specs_root / "kitty-specs" / slug
+        _write_meta(d, _base_meta(slug))
+
+        import specify_cli.migration.backfill_identity as _bi_mod
+
+        mock_fn = MagicMock(return_value=None)
+        with patch.object(_bi_mod, "trigger_feature_dossier_sync_if_enabled", mock_fn):
+            results = backfill_repo(specs_root)
+
+        assert len(results) == 1
+        assert results[0].action == "wrote"
+        mock_fn.assert_called_once()

--- a/tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py
@@ -168,7 +168,13 @@ class TestFinalizeTasksBootstrap:
         # JSON output includes bootstrap stats
         data = json.loads(result.output)
         assert data["mission_slug"] == mission_slug
-        assert data["mission_number"] == "060"
+        # _build_minimal_feature does not write meta.json, so
+        # resolve_mission_identity() yields mission_number=None (JSON null).
+        # Post-083, mission_number is display-only and pre-merge missions
+        # legitimately have no numeric prefix. The canonical identity is
+        # mission_id, which is not asserted here because the fixture skips
+        # meta.json entirely.
+        assert data["mission_number"] is None
         assert data["mission_type"] == "software-dev"
         assert "bootstrap" in data
         assert data["bootstrap"]["total_wps"] == 2
@@ -208,7 +214,9 @@ class TestFinalizeTasksBootstrap:
         assert result.exit_code == 0, f"CLI error: {result.output}"
         data = json.loads(result.output)
         assert data["mission_slug"] == mission_slug
-        assert data["mission_number"] == "060"
+        # Fixture omits meta.json — mission_number resolves to None (JSON null)
+        # per the post-083 canonical identity model (FR-044).
+        assert data["mission_number"] is None
         assert data["mission_type"] == "software-dev"
 
         mock_bootstrap.assert_called_once_with(ANY, mission_slug, dry_run=True)

--- a/tests/specify_cli/cli/commands/test_selector_resolution.py
+++ b/tests/specify_cli/cli/commands/test_selector_resolution.py
@@ -68,6 +68,23 @@ def _build_task_repo(tmp_path: Path, mission_slug: str = "077-demo-mission") -> 
     return repo_root
 
 
+def _extract_json(output: str) -> dict:
+    """Extract the first JSON object from mixed stdout output."""
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        pass
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise ValueError(f"No valid JSON found in output:\n{output}")
+
+
 def test_canonical_only_returns_value(warning_stream: io.StringIO) -> None:
     result = resolve_selector(
         canonical_value="077-demo",
@@ -395,7 +412,7 @@ def test_agent_mission_create_canonical_succeeds(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert captured["mission"] == "software-dev"
-    payload = json.loads(result.output)
+    payload = _extract_json(result.output)
     assert payload["mission_type"] == "software-dev"
     assert "Warning:" not in result.output
 
@@ -549,7 +566,7 @@ def test_agent_tasks_status_canonical_selector_succeeds(tmp_path: Path) -> None:
         result = runner.invoke(tasks_app, ["status", "--mission", "077-demo-mission", "--json"])
 
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _extract_json(result.output)
     assert payload["total_wps"] == 1
     assert payload["work_packages"][0]["id"] == "WP01"
 

--- a/tests/specify_cli/context/test_resolver.py
+++ b/tests/specify_cli/context/test_resolver.py
@@ -20,6 +20,13 @@ from specify_cli.lanes.models import ExecutionLane, LanesManifest
 from specify_cli.lanes.persistence import write_lanes_json
 
 
+# Default canonical mission_id (ULID shape) used by the fixture.
+# WP07 removed silent fallback: meta.json MUST carry mission_id, or the
+# resolver raises MissingIdentityError. Legacy tests that previously relied
+# on implicit slug-as-mission_id must now pass an explicit mission_id.
+_DEFAULT_TEST_MISSION_ID = "01HVXYZTESTMISSION000000000"
+
+
 def _setup_project(
     tmp_path: Path,
     *,
@@ -30,8 +37,14 @@ def _setup_project(
     owned_files: list[str] | None = None,
     mission_id: str | None = None,
     lane_id: str = "lane-a",
+    omit_mission_id: bool = False,
 ) -> Path:
-    """Set up a minimal project structure for resolver tests."""
+    """Set up a minimal project structure for resolver tests.
+
+    By default the fixture writes a canonical ``mission_id`` into
+    ``meta.json`` because the resolver (post-WP07) hard-fails without one.
+    Pass ``omit_mission_id=True`` to exercise the MissingIdentityError path.
+    """
     # .kittify/config.yaml with project.uuid
     kittify_dir = tmp_path / ".kittify"
     kittify_dir.mkdir(parents=True)
@@ -50,8 +63,8 @@ def _setup_project(
         "target_branch": "main",
         "created_at": "2026-03-27T16:00:00+00:00",
     }
-    if mission_id:
-        meta["mission_id"] = mission_id
+    if not omit_mission_id:
+        meta["mission_id"] = mission_id or _DEFAULT_TEST_MISSION_ID
     (feature_dir / "meta.json").write_text(
         json.dumps(meta, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -117,7 +130,12 @@ class TestResolveContext:
         assert isinstance(ctx, MissionContext)
         assert ctx.wp_code == "WP01"
         assert ctx.mission_slug == "057-test-feature"
+        # mission_number is display-only. The legacy fixture stores
+        # feature_number="057" as a string, which the resolver preserves
+        # verbatim via mission_identity_fields (it only drops leading zeros
+        # when the source is an int). Canonical identity is mission_id.
         assert ctx.mission_number == "057"
+        assert ctx.mission_id == _DEFAULT_TEST_MISSION_ID
         assert ctx.mission_type == "software-dev"
         assert ctx.project_uuid == "test-project-uuid-1234"
         assert ctx.target_branch == "main"
@@ -173,12 +191,17 @@ class TestResolveContext:
         assert isinstance(ctx.owned_files, tuple)
         assert ctx.owned_files == ("src/**", "tests/**")
 
-    def test_mission_id_falls_back_to_mission_slug(self, tmp_path: Path) -> None:
-        """When meta.json has no mission_id, use mission_slug."""
-        repo = _setup_project(tmp_path)
-        ctx = resolve_context("WP01", "057-test-feature", "claude", repo)
-        # mission_slug is used as mission_id when mission_id is absent
-        assert ctx.mission_id == "057-test-feature"
+    def test_missing_mission_id_raises_missing_identity_error(self, tmp_path: Path) -> None:
+        """WP07 removed silent fallback: missing mission_id is a hard error.
+
+        Pre-083 tests expected resolve_context to silently fall back to the
+        mission_slug when meta.json had no mission_id. That fallback has been
+        removed — the canonical identity is mission_id and missing it must
+        raise MissingIdentityError, never silently succeed.
+        """
+        repo = _setup_project(tmp_path, omit_mission_id=True)
+        with pytest.raises(MissingIdentityError, match="mission_id"):
+            resolve_context("WP01", "057-test-feature", "claude", repo)
 
     def test_mission_id_from_meta_json(self, tmp_path: Path) -> None:
         repo = _setup_project(tmp_path, mission_id="01HVXYZ-REAL-MISSION-ID")

--- a/tests/specify_cli/context/test_resolver.py
+++ b/tests/specify_cli/context/test_resolver.py
@@ -21,9 +21,9 @@ from specify_cli.lanes.persistence import write_lanes_json
 
 
 # Default canonical mission_id (ULID shape) used by the fixture.
-# WP07 removed silent fallback: meta.json MUST carry mission_id, or the
-# resolver raises MissingIdentityError. Legacy tests that previously relied
-# on implicit slug-as-mission_id must now pass an explicit mission_id.
+# Legacy missions may still lack mission_id. The resolver now falls back to the
+# explicit mission directory name so context-bound commands stay deterministic
+# while the backfill/audit surfaces close out remaining legacy metadata.
 _DEFAULT_TEST_MISSION_ID = "01HVXYZTESTMISSION000000000"
 
 
@@ -42,8 +42,8 @@ def _setup_project(
     """Set up a minimal project structure for resolver tests.
 
     By default the fixture writes a canonical ``mission_id`` into
-    ``meta.json`` because the resolver (post-WP07) hard-fails without one.
-    Pass ``omit_mission_id=True`` to exercise the MissingIdentityError path.
+    ``meta.json``. Pass ``omit_mission_id=True`` to exercise the legacy
+    compatibility path where the resolver falls back to ``feature_dir.name``.
     """
     # .kittify/config.yaml with project.uuid
     kittify_dir = tmp_path / ".kittify"
@@ -191,17 +191,11 @@ class TestResolveContext:
         assert isinstance(ctx.owned_files, tuple)
         assert ctx.owned_files == ("src/**", "tests/**")
 
-    def test_missing_mission_id_raises_missing_identity_error(self, tmp_path: Path) -> None:
-        """WP07 removed silent fallback: missing mission_id is a hard error.
-
-        Pre-083 tests expected resolve_context to silently fall back to the
-        mission_slug when meta.json had no mission_id. That fallback has been
-        removed — the canonical identity is mission_id and missing it must
-        raise MissingIdentityError, never silently succeed.
-        """
+    def test_missing_mission_id_falls_back_to_explicit_mission_dir(self, tmp_path: Path) -> None:
+        """Legacy missions without mission_id still resolve deterministically."""
         repo = _setup_project(tmp_path, omit_mission_id=True)
-        with pytest.raises(MissingIdentityError, match="mission_id"):
-            resolve_context("WP01", "057-test-feature", "claude", repo)
+        ctx = resolve_context("WP01", "057-test-feature", "claude", repo)
+        assert ctx.mission_id == "057-test-feature"
 
     def test_mission_id_from_meta_json(self, tmp_path: Path) -> None:
         repo = _setup_project(tmp_path, mission_id="01HVXYZ-REAL-MISSION-ID")

--- a/tests/specify_cli/core/test_feature_creation.py
+++ b/tests/specify_cli/core/test_feature_creation.py
@@ -69,27 +69,36 @@ def test_happy_path_creates_directory_and_returns_result(tmp_path: Path) -> None
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=1),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
         result = create_mission_core(tmp_path, "test-feature")
 
     assert isinstance(result, MissionCreationResult)
-    assert result.mission_slug == "001-test-feature"
-    assert result.mission_number == "001"
+    # Post-083: mission_slug is "<human-slug>-<mid8>" where mid8 is the first
+    # 8 chars of the ULID mission_id. No NNN- prefix is assigned pre-merge.
+    assert result.mission_slug.startswith("test-feature-")
+    assert len(result.mission_slug) == len("test-feature-") + 8
+    # mission_number is None pre-merge (FR-044); a dense display number is
+    # assigned only at merge time. Canonical identity is mission_id (ULID).
+    assert result.mission_number is None
     assert result.target_branch == "main"
     assert result.current_branch == "main"
-    assert result.feature_dir == tmp_path / "kitty-specs" / "001-test-feature"
+    assert result.feature_dir == tmp_path / "kitty-specs" / result.mission_slug
     assert result.feature_dir.is_dir()
 
     # meta.json exists and has correct content
     meta_file = result.feature_dir / "meta.json"
     assert meta_file.exists()
     meta = json.loads(meta_file.read_text(encoding="utf-8"))
-    assert meta["mission_slug"] == "001-test-feature"
+    assert meta["mission_slug"] == result.mission_slug
     assert meta["target_branch"] == "main"
     assert meta["mission_type"] == "software-dev"
+    # Canonical mission identity fields (083+)
+    assert "mission_id" in meta
+    assert isinstance(meta["mission_id"], str)
+    assert len(meta["mission_id"]) == 26  # ULID is 26 chars
+    assert meta["mission_number"] is None  # pre-merge: JSON null
 
     # spec.md exists
     assert (result.feature_dir / "spec.md").exists()
@@ -112,7 +121,6 @@ def test_result_created_files_populated(tmp_path: Path) -> None:
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=5),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
@@ -216,7 +224,6 @@ def test_explicit_target_branch(tmp_path: Path) -> None:
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=1),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
@@ -243,7 +250,6 @@ def test_target_branch_defaults_to_current(tmp_path: Path) -> None:
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="develop"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=2),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
@@ -274,7 +280,6 @@ def test_documentation_mission_sets_doc_state(tmp_path: Path) -> None:
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=3),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
@@ -295,7 +300,6 @@ def test_default_mission_is_software_dev(tmp_path: Path) -> None:
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=1),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
@@ -305,12 +309,17 @@ def test_default_mission_is_software_dev(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Feature number / slug formatting tests
+# Mission identity / slug formatting tests (post-083: ULID + mid8)
 # ---------------------------------------------------------------------------
 
 
-def test_feature_number_zero_padded(tmp_path: Path) -> None:
-    """Feature number is zero-padded to 3 digits."""
+def test_slug_uses_mid8_suffix_not_numeric_prefix(tmp_path: Path) -> None:
+    """Post-083: mission_slug is '<human-slug>-<mid8>', not '<NNN>-<slug>'.
+
+    The canonical machine identity is mission_id (ULID); mission_number is
+    None until merge time. The 8-char mid8 suffix disambiguates missions
+    that share a human slug (FR-032, FR-044).
+    """
     _init_git_repo(tmp_path)
 
     with (
@@ -318,11 +327,18 @@ def test_feature_number_zero_padded(tmp_path: Path) -> None:
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
-        patch(f"{_CORE_MODULE}.get_next_feature_number", return_value=42),
         patch(f"{_CORE_MODULE}.emit_mission_created"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
     ):
         result = create_mission_core(tmp_path, "padded-test")
 
-    assert result.mission_number == "042"
-    assert result.mission_slug == "042-padded-test"
+    # No NNN- prefix — slug is "<human-slug>-<mid8>".
+    assert result.mission_slug.startswith("padded-test-")
+    assert len(result.mission_slug) == len("padded-test-") + 8
+    # mission_number is None pre-merge (no dense number assigned).
+    assert result.mission_number is None
+    # Canonical identity lives in meta.mission_id (ULID, 26 chars).
+    assert isinstance(result.meta["mission_id"], str)
+    assert len(result.meta["mission_id"]) == 26
+    # The mid8 suffix on the slug matches the first 8 chars of mission_id.
+    assert result.mission_slug.endswith(result.meta["mission_id"][:8])

--- a/tests/specify_cli/test_cli/test_map_requirements.py
+++ b/tests/specify_cli/test_cli/test_map_requirements.py
@@ -82,7 +82,7 @@ class TestMapRequirementsIndividual:
         payload = json.loads(result.stdout.strip())
         assert payload["result"] == "success"
         assert payload["mission_slug"] == "001-test"
-        assert payload["mission_number"] == "001"
+        assert payload["mission_number"] is None
         assert payload["mission_type"] == "software-dev"
         assert payload["mapped"]["WP01"] == ["FR-001", "FR-002"]
         assert _read_wp_refs(feature_dir, "WP01") == ["FR-001", "FR-002"]
@@ -208,7 +208,7 @@ class TestMapRequirementsBatch:
         payload = json.loads(result.stdout.strip())
         assert payload["result"] == "success"
         assert payload["mission_slug"] == "001-test"
-        assert payload["mission_number"] == "001"
+        assert payload["mission_number"] is None
         assert payload["mission_type"] == "software-dev"
         assert payload["mapped"]["WP01"] == ["FR-001", "FR-002"]
         assert payload["mapped"]["WP02"] == ["FR-003"]

--- a/tests/specify_cli/test_feature_metadata.py
+++ b/tests/specify_cli/test_feature_metadata.py
@@ -101,8 +101,7 @@ class TestValidateMeta:
         meta = _minimal_meta()
         del meta["mission_number"]
         errors = validate_meta(meta)
-        assert len(errors) == 1
-        assert "mission_number" in errors[0]
+        assert errors == []
 
     def test_empty_field_is_error(self) -> None:
         meta = _minimal_meta()
@@ -116,7 +115,7 @@ class TestValidateMeta:
         del meta["slug"]
         del meta["mission_type"]
         errors = validate_meta(meta)
-        assert len(errors) == 3
+        assert len(errors) == 2
 
     def test_unknown_fields_no_errors(self) -> None:
         meta = _minimal_meta()
@@ -127,7 +126,6 @@ class TestValidateMeta:
 
     def test_required_fields_constant(self) -> None:
         expected = {
-            "mission_number",
             "slug",
             "mission_slug",
             "friendly_name",
@@ -184,7 +182,7 @@ class TestWriteMeta:
 
     def test_invalid_meta_raises_valueerror(self, tmp_path: Path) -> None:
         meta = _minimal_meta()
-        del meta["mission_number"]
+        del meta["slug"]
 
         # Pre-create a valid file to check it is preserved
         _write_meta_file(tmp_path, _minimal_meta())

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -22,6 +22,7 @@ from specify_cli.status.emit import (
     _derive_from_lane,
     _find_wp_file,
     _legacy_alias_collapses_to_current_lane,
+    _load_mission_id,
     _mirror_phase1_frontmatter_lane,
     _phase1_dual_write_enabled,
     _saas_fan_out,
@@ -268,6 +269,19 @@ class TestBuildDoneEvidence:
             }
         )
         assert result.review.reviewer == "rev"
+
+
+# ── _load_mission_id ────────────────────────────────────────
+
+
+class TestLoadMissionId:
+    """Tests for tolerant mission_id reads from meta.json."""
+
+    def test_malformed_meta_returns_none(self, feature_dir: Path) -> None:
+        """Malformed meta.json degrades to None instead of raising."""
+        (feature_dir / "meta.json").write_text("{bad json", encoding="utf-8")
+
+        assert _load_mission_id(feature_dir) is None
 
 
 # ── emit_status_transition ───────────────────────────────────

--- a/tests/status/test_event_mission_id.py
+++ b/tests/status/test_event_mission_id.py
@@ -1,0 +1,504 @@
+"""Contract tests for status event mission_id migration (WP05 T027 + T028).
+
+FR-023: New events carry mission_id (ULID) as canonical machine identity.
+FR-053: Reader tolerates legacy event logs that carry only mission_slug.
+
+Test scenarios:
+    T027 — Back-compat read:
+        Fixture 1: Legacy event log (aggregate identity = mission_slug only)
+        Fixture 2: New-format event log (mission_id ULID + legacy_aggregate_id)
+        Fixture 3: Mixed log (both shapes interleaved)
+        All three must reduce to equivalent state via the public reader API.
+
+    T028 — Round-trip: emit → read → assert aggregate_id == meta.json.mission_id
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.status.emit import emit_status_transition
+from specify_cli.status.models import Lane, ULID_PATTERN, StatusEvent
+from specify_cli.status.store import EVENTS_FILENAME, read_events
+
+pytestmark = pytest.mark.fast
+
+# ---------------------------------------------------------------------------
+# Helpers / shared constants
+# ---------------------------------------------------------------------------
+
+_MISSION_SLUG = "083-mission-id-canonical-identity-migration"
+_MISSION_ID = "01KNXQS9ATWWFXS3K5ZJ9E5008"  # example ULID (26 chars, valid Crockford base32)
+_META_JSON = {
+    "mission_id": _MISSION_ID,
+    "mission_slug": _MISSION_SLUG,
+    "mission_number": 83,
+    "mission_type": "software-dev",
+}
+
+_LEGACY_EVENT: dict[str, Any] = {
+    "actor": "claude",
+    "at": "2026-01-01T00:00:00+00:00",
+    "event_id": "01JXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "evidence": None,
+    "execution_mode": "worktree",
+    "force": False,
+    "from_lane": "planned",
+    "mission_slug": _MISSION_SLUG,
+    "policy_metadata": None,
+    "reason": None,
+    "review_ref": None,
+    "to_lane": "claimed",
+    "wp_id": "WP01",
+}
+
+_NEW_FORMAT_EVENT: dict[str, Any] = {
+    "actor": "claude",
+    "at": "2026-01-01T00:00:00+00:00",
+    "event_id": "01JXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "evidence": None,
+    "execution_mode": "worktree",
+    "force": False,
+    "from_lane": "planned",
+    "legacy_aggregate_id": _MISSION_SLUG,
+    "mission_id": _MISSION_ID,
+    "mission_slug": _MISSION_SLUG,
+    "policy_metadata": None,
+    "reason": None,
+    "review_ref": None,
+    "to_lane": "claimed",
+    "wp_id": "WP01",
+}
+
+
+def _write_events(events_path: Path, events: list[dict[str, Any]]) -> None:
+    """Write a list of event dicts to a JSONL file."""
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    with events_path.open("w", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _make_feature_dir(tmp_path: Path, slug: str = _MISSION_SLUG, with_meta: bool = True) -> Path:
+    """Create a minimal feature directory under kitty-specs/<slug>/."""
+    kitty_specs = tmp_path / "kitty-specs"
+    feature_dir = kitty_specs / slug
+    feature_dir.mkdir(parents=True)
+    if with_meta:
+        meta_path = feature_dir / "meta.json"
+        meta_path.write_text(json.dumps(_META_JSON, indent=2), encoding="utf-8")
+    return feature_dir
+
+
+# ---------------------------------------------------------------------------
+# T027 — Fixture 1: Legacy event log (mission_slug only)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyEventRead:
+    """Fixture 1: events on disk carry only mission_slug (pre-WP05 format)."""
+
+    def test_read_events_returns_list(self, tmp_path: Path) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_LEGACY_EVENT])
+
+        events = read_events(feature_dir)
+        assert len(events) == 1
+
+    def test_legacy_event_has_correct_mission_slug(self, tmp_path: Path) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_LEGACY_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_slug == _MISSION_SLUG
+
+    def test_legacy_event_resolves_mission_id_from_meta(self, tmp_path: Path) -> None:
+        """Reader must resolve mission_id from meta.json for legacy events."""
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_LEGACY_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_id == _MISSION_ID
+
+    def test_legacy_event_mission_id_is_ulid(self, tmp_path: Path) -> None:
+        """Resolved mission_id must match ULID pattern."""
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_LEGACY_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_id is not None
+        assert ULID_PATTERN.match(events[0].mission_id), (
+            f"Expected ULID, got {events[0].mission_id!r}"
+        )
+
+    def test_legacy_event_missing_meta_yields_none_mission_id(self, tmp_path: Path) -> None:
+        """When meta.json is absent, mission_id should be None (not an error)."""
+        feature_dir = _make_feature_dir(tmp_path, with_meta=False)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_LEGACY_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_id is None
+
+    def test_legacy_event_correct_lane_state(self, tmp_path: Path) -> None:
+        """Reducer state derived from legacy events must be correct."""
+        from specify_cli.status.reducer import reduce
+
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_LEGACY_EVENT])
+
+        events = read_events(feature_dir)
+        snapshot = reduce(events)
+        assert snapshot.work_packages["WP01"]["lane"] == "claimed"
+
+
+# ---------------------------------------------------------------------------
+# T027 — Fixture 2: New-format event log (mission_id ULID + legacy_aggregate_id)
+# ---------------------------------------------------------------------------
+
+
+class TestNewFormatEventRead:
+    """Fixture 2: events carry mission_id + legacy_aggregate_id (post-WP05 format)."""
+
+    def test_new_format_event_has_mission_id(self, tmp_path: Path) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_NEW_FORMAT_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_id == _MISSION_ID
+
+    def test_new_format_event_has_correct_mission_slug(self, tmp_path: Path) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_NEW_FORMAT_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_slug == _MISSION_SLUG
+
+    def test_new_format_event_mission_id_is_ulid(self, tmp_path: Path) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_NEW_FORMAT_EVENT])
+
+        events = read_events(feature_dir)
+        assert events[0].mission_id is not None
+        assert ULID_PATTERN.match(events[0].mission_id)
+
+    def test_new_format_event_lane_state_equivalent(self, tmp_path: Path) -> None:
+        """State derived from new-format events must equal state from legacy events."""
+        from specify_cli.status.reducer import reduce
+
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, [_NEW_FORMAT_EVENT])
+
+        events = read_events(feature_dir)
+        snapshot = reduce(events)
+        assert snapshot.work_packages["WP01"]["lane"] == "claimed"
+
+
+# ---------------------------------------------------------------------------
+# T027 — Fixture 3: Mixed log (both shapes interleaved)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedEventLogRead:
+    """Fixture 3: event log contains both legacy and new-format events."""
+
+    @pytest.fixture
+    def mixed_events(self) -> list[dict[str, Any]]:
+        legacy = {**_LEGACY_EVENT, "event_id": "01JXXXXXXXXXXXXXXXXXAAAAAAAA", "wp_id": "WP01", "to_lane": "claimed"}
+        new_format = {
+            **_NEW_FORMAT_EVENT,
+            "event_id": "01JXXXXXXXXXXXXXXXXXBBBBBBBB",
+            "wp_id": "WP02",
+            "from_lane": "planned",
+            "to_lane": "claimed",
+        }
+        return [legacy, new_format]
+
+    def test_mixed_log_read_count(self, tmp_path: Path, mixed_events: list[dict[str, Any]]) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, mixed_events)
+
+        events = read_events(feature_dir)
+        assert len(events) == 2
+
+    def test_mixed_log_all_have_mission_id(self, tmp_path: Path, mixed_events: list[dict[str, Any]]) -> None:
+        """All events in a mixed log must resolve to a mission_id."""
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, mixed_events)
+
+        events = read_events(feature_dir)
+        for event in events:
+            assert event.mission_id == _MISSION_ID, (
+                f"Expected mission_id={_MISSION_ID!r} for {event.wp_id}, got {event.mission_id!r}"
+            )
+
+    def test_mixed_log_all_have_correct_slug(self, tmp_path: Path, mixed_events: list[dict[str, Any]]) -> None:
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, mixed_events)
+
+        events = read_events(feature_dir)
+        for event in events:
+            assert event.mission_slug == _MISSION_SLUG
+
+    def test_mixed_log_reducer_produces_coherent_state(
+        self, tmp_path: Path, mixed_events: list[dict[str, Any]]
+    ) -> None:
+        """Mixed log must reduce to the same lane state for both WPs."""
+        from specify_cli.status.reducer import reduce
+
+        feature_dir = _make_feature_dir(tmp_path)
+        events_path = feature_dir / EVENTS_FILENAME
+        _write_events(events_path, mixed_events)
+
+        events = read_events(feature_dir)
+        snapshot = reduce(events)
+        assert snapshot.work_packages["WP01"]["lane"] == "claimed"
+        assert snapshot.work_packages["WP02"]["lane"] == "claimed"
+
+    def test_legacy_and_new_format_produce_equivalent_state(self, tmp_path: Path) -> None:
+        """Fixture 1 and Fixture 2 must produce equivalent snapshot state."""
+        from specify_cli.status.reducer import reduce
+
+        # Fixture 1: legacy only
+        feature_dir_legacy = _make_feature_dir(tmp_path / "legacy")
+        _write_events(feature_dir_legacy / EVENTS_FILENAME, [_LEGACY_EVENT])
+        legacy_snapshot = reduce(read_events(feature_dir_legacy))
+
+        # Fixture 2: new format only
+        feature_dir_new = _make_feature_dir(tmp_path / "new")
+        _write_events(feature_dir_new / EVENTS_FILENAME, [_NEW_FORMAT_EVENT])
+        new_snapshot = reduce(read_events(feature_dir_new))
+
+        # Same WP state for WP01
+        assert legacy_snapshot.work_packages["WP01"]["lane"] == new_snapshot.work_packages["WP01"]["lane"]
+
+
+# ---------------------------------------------------------------------------
+# T027 — New event serialization: to_dict includes mission_id + legacy_aggregate_id
+# ---------------------------------------------------------------------------
+
+
+class TestNewEventSerialization:
+    """Verify the on-disk shape for new events (mission_id present)."""
+
+    def test_to_dict_includes_mission_id(self) -> None:
+        event = StatusEvent(
+            event_id="01KNXQS9ATWWFXS3K5ZJ9E5001",
+            mission_slug=_MISSION_SLUG,
+            mission_id=_MISSION_ID,
+            wp_id="WP01",
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.CLAIMED,
+            at="2026-01-01T00:00:00+00:00",
+            actor="claude",
+            force=False,
+            execution_mode="worktree",
+        )
+        d = event.to_dict()
+        assert d["mission_id"] == _MISSION_ID
+
+    def test_to_dict_includes_legacy_aggregate_id_when_mission_id_present(self) -> None:
+        """T025: legacy_aggregate_id must equal mission_slug for new events."""
+        event = StatusEvent(
+            event_id="01KNXQS9ATWWFXS3K5ZJ9E5001",
+            mission_slug=_MISSION_SLUG,
+            mission_id=_MISSION_ID,
+            wp_id="WP01",
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.CLAIMED,
+            at="2026-01-01T00:00:00+00:00",
+            actor="claude",
+            force=False,
+            execution_mode="worktree",
+        )
+        d = event.to_dict()
+        assert d["legacy_aggregate_id"] == _MISSION_SLUG
+
+    def test_to_dict_omits_legacy_aggregate_id_for_legacy_events(self) -> None:
+        """Events without mission_id must not carry legacy_aggregate_id."""
+        event = StatusEvent(
+            event_id="01KNXQS9ATWWFXS3K5ZJ9E5002",
+            mission_slug=_MISSION_SLUG,
+            mission_id=None,  # legacy: no mission_id
+            wp_id="WP01",
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.CLAIMED,
+            at="2026-01-01T00:00:00+00:00",
+            actor="claude",
+            force=False,
+            execution_mode="worktree",
+        )
+        d = event.to_dict()
+        assert "mission_id" not in d
+        assert "legacy_aggregate_id" not in d
+
+
+# ---------------------------------------------------------------------------
+# T028 — Round-trip: emit → read → assert aggregate_id == meta.json.mission_id
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripMissionId:
+    """T028: emit a new event, read it back, confirm mission_id matches meta.json."""
+
+    @pytest.fixture
+    def feature_dir_with_meta(self, tmp_path: Path) -> Path:
+        """Feature directory with meta.json containing mission_id."""
+        return _make_feature_dir(tmp_path)
+
+    def test_emitted_event_carries_mission_id_from_meta(
+        self, feature_dir_with_meta: Path
+    ) -> None:
+        """New events emitted by the pipeline must have mission_id == meta.json.mission_id."""
+        feature_dir = feature_dir_with_meta
+
+        with patch("specify_cli.status.emit._saas_fan_out"):
+            emit_status_transition(
+                feature_dir=feature_dir,
+                mission_slug=_MISSION_SLUG,
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="claude",
+            )
+
+        events = read_events(feature_dir)
+        # Filter to the WP01 claimed transition (bootstrap may already exist)
+        claimed_events = [e for e in events if e.wp_id == "WP01" and str(e.to_lane) == "claimed"]
+        assert claimed_events, "Expected at least one claimed event for WP01"
+
+        event = claimed_events[-1]
+        assert event.mission_id == _MISSION_ID, (
+            f"Expected mission_id={_MISSION_ID!r}, got {event.mission_id!r}"
+        )
+
+    def test_emitted_event_aggregate_id_is_ulid(self, feature_dir_with_meta: Path) -> None:
+        """T028: aggregate identity of new events (mission_id) must be a valid ULID."""
+        feature_dir = feature_dir_with_meta
+
+        with patch("specify_cli.status.emit._saas_fan_out"):
+            emit_status_transition(
+                feature_dir=feature_dir,
+                mission_slug=_MISSION_SLUG,
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="claude",
+            )
+
+        events = read_events(feature_dir)
+        claimed_events = [e for e in events if e.wp_id == "WP01" and str(e.to_lane) == "claimed"]
+        assert claimed_events
+
+        event = claimed_events[-1]
+        assert event.mission_id is not None
+        assert ULID_PATTERN.match(event.mission_id), (
+            f"mission_id {event.mission_id!r} does not match ULID pattern"
+        )
+
+    def test_emitted_event_legacy_aggregate_id_equals_mission_slug(
+        self, feature_dir_with_meta: Path
+    ) -> None:
+        """T028: on-disk event must carry legacy_aggregate_id == meta.json.mission_slug."""
+        import json as _json
+
+        feature_dir = feature_dir_with_meta
+
+        with patch("specify_cli.status.emit._saas_fan_out"):
+            emit_status_transition(
+                feature_dir=feature_dir,
+                mission_slug=_MISSION_SLUG,
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="claude",
+            )
+
+        events_path = feature_dir / EVENTS_FILENAME
+        raw_lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        # Find the claimed event for WP01
+        claimed_raw = [
+            _json.loads(line)
+            for line in raw_lines
+            if _json.loads(line).get("wp_id") == "WP01"
+            and _json.loads(line).get("to_lane") == "claimed"
+        ]
+        assert claimed_raw, "Expected at least one claimed event for WP01 in JSONL"
+
+        raw_event = claimed_raw[-1]
+        assert raw_event.get("legacy_aggregate_id") == _MISSION_SLUG, (
+            f"Expected legacy_aggregate_id={_MISSION_SLUG!r}, got {raw_event.get('legacy_aggregate_id')!r}"
+        )
+
+    def test_emitted_event_mission_id_matches_meta_json(
+        self, feature_dir_with_meta: Path
+    ) -> None:
+        """T028: Complete round-trip verification — emitted mission_id == meta.json.mission_id."""
+        import json as _json
+
+        feature_dir = feature_dir_with_meta
+
+        # Verify meta.json value
+        meta = _json.loads((feature_dir / "meta.json").read_text())
+        expected_mission_id = meta["mission_id"]
+        expected_slug = meta["mission_slug"]
+
+        with patch("specify_cli.status.emit._saas_fan_out"):
+            emit_status_transition(
+                feature_dir=feature_dir,
+                mission_slug=_MISSION_SLUG,
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="claude",
+            )
+
+        events = read_events(feature_dir)
+        claimed_events = [e for e in events if e.wp_id == "WP01" and str(e.to_lane) == "claimed"]
+        assert claimed_events
+
+        event = claimed_events[-1]
+        # Primary assertion: aggregate identity matches meta.json
+        assert event.mission_id == expected_mission_id
+        # Slug consistency: mission_slug field still matches
+        assert event.mission_slug == expected_slug
+
+    def test_round_trip_no_mission_id_in_meta_yields_none(self, tmp_path: Path) -> None:
+        """Legacy mission without mission_id in meta.json: emitted event has mission_id=None."""
+        feature_dir = _make_feature_dir(tmp_path, with_meta=True)
+        # Overwrite meta.json without mission_id
+        meta_without_id = {
+            "mission_slug": _MISSION_SLUG,
+            "mission_number": 83,
+            "mission_type": "software-dev",
+        }
+        (feature_dir / "meta.json").write_text(json.dumps(meta_without_id), encoding="utf-8")
+
+        with patch("specify_cli.status.emit._saas_fan_out"):
+            emit_status_transition(
+                feature_dir=feature_dir,
+                mission_slug=_MISSION_SLUG,
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="claude",
+            )
+
+        events = read_events(feature_dir)
+        claimed_events = [e for e in events if e.wp_id == "WP01" and str(e.to_lane) == "claimed"]
+        assert claimed_events
+
+        event = claimed_events[-1]
+        assert event.mission_id is None

--- a/tests/status/test_store.py
+++ b/tests/status/test_store.py
@@ -10,6 +10,7 @@ import pytest
 from specify_cli.status.models import Lane, StatusEvent
 from specify_cli.status.store import (
     EVENTS_FILENAME,
+    _SlugResolver,
     StoreError,
     append_event,
     read_events,
@@ -184,3 +185,30 @@ def test_blank_lines_skipped(tmp_path: Path) -> None:
 
     events = read_events(tmp_path)
     assert len(events) == 2
+
+
+def test_slug_resolver_finds_kitty_specs_two_levels_up(tmp_path: Path) -> None:
+    """Nested feature dirs still resolve via a kitty-specs root two levels up."""
+    mission_dir = tmp_path / "kitty-specs" / "034-feature-name"
+    mission_dir.mkdir(parents=True)
+    (mission_dir / "meta.json").write_text(
+        json.dumps({"mission_id": "01KNXQS9ATWWFXS3K5ZJ9E5008"}),
+        encoding="utf-8",
+    )
+    nested_feature_dir = mission_dir / "status"
+    nested_feature_dir.mkdir()
+
+    resolver = _SlugResolver(nested_feature_dir)
+
+    assert resolver.resolve("034-feature-name") == "01KNXQS9ATWWFXS3K5ZJ9E5008"
+
+
+def test_slug_resolver_returns_none_for_malformed_meta(tmp_path: Path) -> None:
+    """Malformed legacy meta.json leaves mission_id unresolved instead of crashing."""
+    mission_dir = tmp_path / "kitty-specs" / "034-feature-name"
+    mission_dir.mkdir(parents=True)
+    (mission_dir / "meta.json").write_text("{bad json", encoding="utf-8")
+
+    resolver = _SlugResolver(mission_dir)
+
+    assert resolver.resolve("034-feature-name") is None

--- a/tests/sync/test_diagnose.py
+++ b/tests/sync/test_diagnose.py
@@ -268,7 +268,7 @@ class TestOtherPayloads:
             aggregate_type="Mission",
             payload={
                 "mission_slug": "039-test-feature",
-                "mission_number": "039",
+                "mission_number": 39,  # int, not str (FR-044, WP02)
                 "target_branch": "main",
                 "wp_count": 5,
             },
@@ -284,7 +284,7 @@ class TestOtherPayloads:
             aggregate_type="Mission",
             payload={
                 "mission_slug": "BAD FORMAT",
-                "mission_number": "039",
+                "mission_number": 39,  # int, not str (FR-044, WP02)
                 "target_branch": "main",
                 "wp_count": 5,
             },

--- a/tests/sync/test_emit_mission_created_includes_mission_id.py
+++ b/tests/sync/test_emit_mission_created_includes_mission_id.py
@@ -28,7 +28,7 @@ class TestEmitMissionCreatedMissionId:
         """EventEmitter.emit_mission_created adds mission_id to payload when provided."""
         event = emitter.emit_mission_created(
             mission_slug="079-post-hardening",
-            mission_number="079",
+            mission_number=79,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=4,
             mission_id="01KNRQK0R1ZDS8Z57M1TRXF0XR",
@@ -45,7 +45,7 @@ class TestEmitMissionCreatedMissionId:
         """EventEmitter.emit_mission_created does NOT include mission_id key when not provided."""
         event = emitter.emit_mission_created(
             mission_slug="079-post-hardening",
-            mission_number="079",
+            mission_number=79,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=4,
             # mission_id omitted — legacy call
@@ -66,7 +66,7 @@ class TestEmitMissionCreatedMissionId:
         ):
             emit_mission_created(
                 mission_slug="079-post-hardening",
-                mission_number="079",
+                mission_number=79,  # int, not str (FR-044, WP02)
                 target_branch="main",
                 wp_count=4,
                 mission_id="01TESTULID12345678901234AB",
@@ -91,7 +91,7 @@ class TestEmitMissionCreatedMissionId:
         ):
             emit_mission_created(
                 mission_slug="028-sync",
-                mission_number="028",
+                mission_number=28,  # int, not str (FR-044, WP02)
                 target_branch="main",
                 wp_count=5,
                 # No mission_id

--- a/tests/sync/test_emitter_mission_id.py
+++ b/tests/sync/test_emitter_mission_id.py
@@ -1,0 +1,423 @@
+"""Contract tests: mission-level SaaS events use mission_id as aggregate identity (WP06).
+
+FR-024: Every outbound mission-lifecycle event envelope must carry
+  ``aggregate_id = mission_id`` (a ULID) so the SaaS side can join events
+  without relying on mutable slug strings.
+
+Payload shape contract (T031):
+  - ``mission_id``     (str, ULID)   — new primary key / aggregate identity
+  - ``mission_slug``   (str)         — human display; never used as identity
+  - ``mission_number`` (int | None)  — numeric display; None for pre-merge missions
+
+T032 — aggregate identity assertions for every mission-level emitter.
+T033 — mission_number type/null assertions (int or null in JSON, never string).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from specify_cli.sync.emitter import EventEmitter
+from specify_cli.sync.queue import OfflineQueue
+
+pytestmark = pytest.mark.fast
+
+# ULID regex: 26 chars from Crockford Base32 alphabet
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+
+# A valid ULID for tests (26 chars, valid Crockford Base32)
+_MISSION_ID = "01JWPQRS0V8ZXMNK3V5BYMCAEF"
+_MISSION_SLUG = "083-mission-id-canonical"
+_MISSION_NUMBER_INT = 83
+_MISSION_NUMBER_NONE = None
+
+
+# ---------------------------------------------------------------------------
+# T032 — emit_mission_created: aggregate_id == mission_id
+# ---------------------------------------------------------------------------
+
+
+class TestEmitMissionCreatedAggregateId:
+    """emit_mission_created must use mission_id as aggregate identity."""
+
+    def test_aggregate_id_is_mission_id(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """aggregate_id on emitted event equals the provided mission_id ULID."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=_MISSION_NUMBER_INT,
+            target_branch="main",
+            wp_count=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None, "emit_mission_created returned None"
+        assert event["aggregate_id"] == _MISSION_ID, (
+            f"Expected aggregate_id={_MISSION_ID!r}, got {event['aggregate_id']!r}"
+        )
+
+    def test_aggregate_id_is_ulid_shaped(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """aggregate_id matches the ULID character pattern."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=_MISSION_NUMBER_INT,
+            target_branch="main",
+            wp_count=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert _ULID_RE.match(event["aggregate_id"]), (
+            f"aggregate_id {event['aggregate_id']!r} is not a valid ULID"
+        )
+
+    def test_payload_contains_mission_id(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload includes mission_id field equal to meta.json mission_id."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=_MISSION_NUMBER_INT,
+            target_branch="main",
+            wp_count=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert "mission_id" in event["payload"], "mission_id missing from payload"
+        assert event["payload"]["mission_id"] == _MISSION_ID
+
+    def test_payload_contains_mission_slug(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload retains mission_slug as display metadata."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=_MISSION_NUMBER_INT,
+            target_branch="main",
+            wp_count=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["payload"]["mission_slug"] == _MISSION_SLUG
+
+    def test_payload_contains_mission_number(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload retains mission_number as display metadata (int)."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=_MISSION_NUMBER_INT,
+            target_branch="main",
+            wp_count=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["payload"]["mission_number"] == _MISSION_NUMBER_INT
+
+    def test_aggregate_id_is_not_mission_slug(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Regression guard: aggregate_id must not equal mission_slug."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=_MISSION_NUMBER_INT,
+            target_branch="main",
+            wp_count=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["aggregate_id"] != _MISSION_SLUG, (
+            "aggregate_id must be mission_id (ULID), not mission_slug"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T032 — emit_mission_closed: aggregate_id == mission_id
+# ---------------------------------------------------------------------------
+
+
+class TestEmitMissionClosedAggregateId:
+    """emit_mission_closed must use mission_id as aggregate identity."""
+
+    def test_aggregate_id_is_mission_id(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """aggregate_id on emitted event equals the provided mission_id ULID."""
+        event = emitter.emit_mission_closed(
+            mission_slug=_MISSION_SLUG,
+            total_wps=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None, "emit_mission_closed returned None"
+        assert event["aggregate_id"] == _MISSION_ID, (
+            f"Expected aggregate_id={_MISSION_ID!r}, got {event['aggregate_id']!r}"
+        )
+
+    def test_aggregate_id_is_ulid_shaped(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """aggregate_id matches the ULID character pattern."""
+        event = emitter.emit_mission_closed(
+            mission_slug=_MISSION_SLUG,
+            total_wps=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert _ULID_RE.match(event["aggregate_id"])
+
+    def test_payload_contains_mission_id(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload includes mission_id field."""
+        event = emitter.emit_mission_closed(
+            mission_slug=_MISSION_SLUG,
+            total_wps=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["payload"]["mission_id"] == _MISSION_ID
+
+    def test_payload_contains_mission_slug(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload retains mission_slug as display metadata."""
+        event = emitter.emit_mission_closed(
+            mission_slug=_MISSION_SLUG,
+            total_wps=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["payload"]["mission_slug"] == _MISSION_SLUG
+
+    def test_aggregate_id_is_not_mission_slug(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Regression guard: aggregate_id must not equal mission_slug."""
+        event = emitter.emit_mission_closed(
+            mission_slug=_MISSION_SLUG,
+            total_wps=6,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["aggregate_id"] != _MISSION_SLUG
+
+
+# ---------------------------------------------------------------------------
+# T032 — emit_mission_origin_bound: aggregate_id == mission_id
+# ---------------------------------------------------------------------------
+
+
+class TestEmitMissionOriginBoundAggregateId:
+    """emit_mission_origin_bound must use mission_id as aggregate identity."""
+
+    def test_aggregate_id_is_mission_id(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """aggregate_id on emitted event equals the provided mission_id ULID."""
+        event = emitter.emit_mission_origin_bound(
+            mission_slug=_MISSION_SLUG,
+            provider="jira",
+            external_issue_id="12345",
+            external_issue_key="SK-42",
+            external_issue_url="https://jira.example.com/browse/SK-42",
+            title="Test origin binding",
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None, "emit_mission_origin_bound returned None"
+        assert event["aggregate_id"] == _MISSION_ID, (
+            f"Expected aggregate_id={_MISSION_ID!r}, got {event['aggregate_id']!r}"
+        )
+
+    def test_aggregate_id_is_ulid_shaped(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """aggregate_id matches the ULID character pattern."""
+        event = emitter.emit_mission_origin_bound(
+            mission_slug=_MISSION_SLUG,
+            provider="linear",
+            external_issue_id="LIN-99",
+            external_issue_key="LIN-99",
+            external_issue_url="https://linear.app/team/issue/LIN-99",
+            title="Linear issue",
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert _ULID_RE.match(event["aggregate_id"])
+
+    def test_payload_contains_mission_id(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload includes mission_id field."""
+        event = emitter.emit_mission_origin_bound(
+            mission_slug=_MISSION_SLUG,
+            provider="jira",
+            external_issue_id="12345",
+            external_issue_key="SK-42",
+            external_issue_url="https://jira.example.com/browse/SK-42",
+            title="Test origin binding",
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["payload"]["mission_id"] == _MISSION_ID
+
+    def test_payload_contains_mission_slug(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Payload retains mission_slug as display metadata."""
+        event = emitter.emit_mission_origin_bound(
+            mission_slug=_MISSION_SLUG,
+            provider="jira",
+            external_issue_id="12345",
+            external_issue_key="SK-42",
+            external_issue_url="https://jira.example.com/browse/SK-42",
+            title="Test origin binding",
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["payload"]["mission_slug"] == _MISSION_SLUG
+
+    def test_aggregate_id_is_not_mission_slug(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Regression guard: aggregate_id must not equal mission_slug."""
+        event = emitter.emit_mission_origin_bound(
+            mission_slug=_MISSION_SLUG,
+            provider="jira",
+            external_issue_id="12345",
+            external_issue_key="SK-42",
+            external_issue_url="https://jira.example.com/browse/SK-42",
+            title="Test origin binding",
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        assert event["aggregate_id"] != _MISSION_SLUG
+
+
+# ---------------------------------------------------------------------------
+# T033 — mission_number type in payload (int | null, never string)
+# ---------------------------------------------------------------------------
+
+
+class TestMissionNumberTypeInPayload:
+    """mission_number must serialize as int or null, never as a string."""
+
+    def test_pre_merge_mission_number_is_json_null(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Pre-merge mission: mission_number=None serializes as JSON null."""
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=None,
+            target_branch="main",
+            wp_count=0,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        payload_json = json.dumps(event["payload"])
+        parsed = json.loads(payload_json)
+        # Must be null (None in Python), not "", not "pending", not absent
+        assert "mission_number" in parsed, "mission_number key missing from payload"
+        assert parsed["mission_number"] is None, (
+            f"Expected null, got {parsed['mission_number']!r}"
+        )
+        # Paranoia: raw JSON string must contain the null literal
+        assert '"mission_number": null' in payload_json or '"mission_number":null' in payload_json
+
+    def test_post_merge_mission_number_is_json_integer(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """Post-merge mission: mission_number=42 serializes as JSON integer 42."""
+        event = emitter.emit_mission_created(
+            mission_slug="042-my-feature",
+            mission_number=42,
+            target_branch="main",
+            wp_count=3,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        payload_json = json.dumps(event["payload"])
+        parsed = json.loads(payload_json)
+        assert parsed["mission_number"] == 42
+        assert isinstance(parsed["mission_number"], int), (
+            f"Expected int, got {type(parsed['mission_number'])}"
+        )
+        # Must not be a string like "42" or "042"
+        assert '"mission_number": 42' in payload_json or '"mission_number":42' in payload_json
+
+    def test_mission_number_never_empty_string(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """mission_number must not be an empty string in the payload JSON."""
+        # This test catches regression where "" was emitted instead of null
+        event = emitter.emit_mission_created(
+            mission_slug=_MISSION_SLUG,
+            mission_number=None,
+            target_branch="main",
+            wp_count=0,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        payload_json = json.dumps(event["payload"])
+        # Ensure we don't see the legacy empty-string sentinel
+        assert '"mission_number": ""' not in payload_json
+        assert '"mission_number":""' not in payload_json
+
+    def test_mission_number_type_coercion_guard(
+        self,
+        emitter: EventEmitter,
+        temp_queue: OfflineQueue,
+    ) -> None:
+        """mission_number=83 (int) round-trips as integer 83 through JSON."""
+        event = emitter.emit_mission_created(
+            mission_slug="083-mission-id",
+            mission_number=83,
+            target_branch="main",
+            wp_count=14,
+            mission_id=_MISSION_ID,
+        )
+        assert event is not None
+        parsed = json.loads(json.dumps(event["payload"]))
+        assert parsed["mission_number"] == 83
+        assert not isinstance(parsed["mission_number"], str)

--- a/tests/sync/test_event_emission.py
+++ b/tests/sync/test_event_emission.py
@@ -120,7 +120,7 @@ class TestFinalizeTasksEmitsBatch:
         # Emit FeatureCreated
         fc = emitter.emit_mission_created(
             mission_slug="028-cli-event-emission-sync",
-            mission_number="028",
+            mission_number=28,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=7,
             causation_id=causation_id,
@@ -155,7 +155,7 @@ class TestGitMetadataInBatchEvents:
         """FeatureCreated event includes git metadata fields."""
         event = emitter.emit_mission_created(
             mission_slug="033-observability",
-            mission_number="033",
+            mission_number=33,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=4,
         )
@@ -354,7 +354,7 @@ class TestIdentityInjection:
         """FeatureCreated event includes project_uuid."""
         event = emitter.emit_mission_created(
             mission_slug="032-identity-aware",
-            mission_number="032",
+            mission_number=32,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=5,
         )

--- a/tests/sync/test_events.py
+++ b/tests/sync/test_events.py
@@ -167,7 +167,7 @@ class TestEventEnvelope:
         events = [
             emitter.emit_wp_status_changed("WP01", "planned", "in_progress"),
             emitter.emit_wp_created("WP01", "Test", "033-test"),
-            emitter.emit_mission_created("033-test", "033", "2.x", 1),
+            emitter.emit_mission_created("033-test", 33, "2.x", 1),
         ]
         for event in events:
             assert event is not None
@@ -312,7 +312,7 @@ class TestMissionCreated:
         """MissionCreated event has correct structure."""
         event = emitter.emit_mission_created(
             mission_slug="028-cli-event-emission-sync",
-            mission_number="028",
+            mission_number=28,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=7,
         )
@@ -326,7 +326,7 @@ class TestMissionCreated:
         """created_at is optional."""
         event = emitter.emit_mission_created(
             "028-sync",
-            "028",
+            28,  # int, not str (FR-044, WP02)
             "main",
             5,
             created_at="2026-02-04T12:00:00+00:00",
@@ -495,7 +495,7 @@ class TestValidation:
 
     def test_invalid_mission_slug_returns_none(self, emitter: EventEmitter, temp_queue):
         """Invalid mission_slug format for MissionCreated causes validation failure."""
-        event = emitter.emit_mission_created("NoNumbers", "abc", "main", 5)
+        event = emitter.emit_mission_created("NoNumbers", 1, "main", 5)
         assert event is None
 
     def test_invalid_resolution_type_returns_none(self, emitter: EventEmitter, temp_queue):
@@ -510,7 +510,7 @@ class TestValidation:
 
     def test_negative_wp_count_returns_none(self, emitter: EventEmitter, temp_queue):
         """Negative wp_count for MissionCreated causes validation failure."""
-        event = emitter.emit_mission_created("028-sync", "028", "main", -1)
+        event = emitter.emit_mission_created("028-sync", 28, "main", -1)
         assert event is None
 
 
@@ -775,7 +775,7 @@ class TestInternalValidation:
         """Invalid created_at datetime string fails MissionCreated validation."""
         event = emitter.emit_mission_created(
             "028-sync",
-            "028",
+            28,  # int, not str (FR-044, WP02)
             "main",
             5,
             created_at="not-a-date",

--- a/tests/sync/test_integration.py
+++ b/tests/sync/test_integration.py
@@ -177,7 +177,7 @@ class TestMultiEventBatch:
         # Emit MissionCreated
         fc = emitter.emit_mission_created(
             mission_slug="028-cli-event-emission-sync",
-            mission_number="028",
+            mission_number=28,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=3,
             causation_id=causation_id,

--- a/tests/sync/test_sync_e2e_integration.py
+++ b/tests/sync/test_sync_e2e_integration.py
@@ -476,7 +476,7 @@ class TestNoDuplicateEmissions:
 
         emitter.emit_mission_created(
             mission_slug="032-identity-aware",
-            mission_number="032",
+            mission_number=32,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=3,
             causation_id=causation_id,
@@ -537,7 +537,7 @@ class TestFullWorkflowIntegration:
         # 1. Mission created (use valid mission_slug pattern: ###-slug-name)
         emitter.emit_mission_created(
             mission_slug="001-test-feature",
-            mission_number="001",
+            mission_number=1,  # int, not str (FR-044, WP02)
             target_branch="main",
             wp_count=1,
             causation_id=causation_id,

--- a/tests/tasks/conftest.py
+++ b/tests/tasks/conftest.py
@@ -7,6 +7,10 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+from ulid import ULID
+
+from specify_cli.lanes.branch_naming import mid8, strip_numeric_prefix
+
 
 def create_mission_fast(project: Path, slug: str, number: int = 1) -> Path:
     """Create a mission in-process, bypassing CLI subprocess overhead.
@@ -16,7 +20,9 @@ def create_mission_fast(project: Path, slug: str, number: int = 1) -> Path:
     create command itself.  Saves ~1 s per call by avoiding a full Python
     subprocess startup.
     """
-    mission_slug = f"{number:03d}-{slug}"
+    mission_id = str(ULID())
+    human_slug = strip_numeric_prefix(slug)
+    mission_slug = f"{human_slug}-{mid8(mission_id)}"
     feature_dir = project / "kitty-specs" / mission_slug
 
     # Directory structure
@@ -34,7 +40,8 @@ def create_mission_fast(project: Path, slug: str, number: int = 1) -> Path:
 
     # meta.json
     meta = {
-        "mission_number": f"{number:03d}",
+        "mission_id": mission_id,
+        "mission_number": None,
         "slug": mission_slug,
         "mission_slug": mission_slug,
         "friendly_name": slug.replace("-", " "),

--- a/tests/tasks/test_planning_workflow_integration.py
+++ b/tests/tasks/test_planning_workflow_integration.py
@@ -6,6 +6,7 @@ work correctly in main repository WITHOUT creating worktrees.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -28,9 +29,11 @@ def test_create_feature_in_main_no_worktree(test_project: Path, run_cli) -> None
     )
 
     assert result.returncode == 0, f"create failed: {result.stderr}"
+    payload = json.loads(result.stdout)
+    mission_slug = payload["mission_slug"]
+    feature_dir = Path(payload["feature_dir"])
 
     # Verify feature directory created in main repo
-    feature_dir = test_project / "kitty-specs" / "001-test-planning-workflow"
     assert feature_dir.exists(), "Feature directory not created in main repo"
     assert (feature_dir / "spec.md").exists(), "spec.md not created"
     assert (feature_dir / "tasks").is_dir(), "tasks/ directory not created"
@@ -38,7 +41,7 @@ def test_create_feature_in_main_no_worktree(test_project: Path, run_cli) -> None
     assert (feature_dir / "research").is_dir(), "research/ directory not created"
 
     # Verify NO worktree was created
-    worktree_dir = test_project / ".worktrees" / "001-test-planning-workflow"
+    worktree_dir = test_project / ".worktrees" / mission_slug
     assert not worktree_dir.exists(), "Worktree should NOT be created during feature creation"
 
     # Verify spec.md was committed to main
@@ -54,9 +57,8 @@ def test_create_feature_in_main_no_worktree(test_project: Path, run_cli) -> None
 def test_setup_plan_in_main(test_project: Path, run_cli) -> None:
     """Test that setup-plan command works in main repo and commits plan.md."""
     # Setup: create mission in-process (not the test target)
-    create_mission_fast(test_project, "plan-test")
-
-    feature_dir = test_project / "kitty-specs" / "001-plan-test"
+    feature_dir = create_mission_fast(test_project, "plan-test")
+    mission_slug = feature_dir.name
 
     # Create a minimal plan template for testing
     plan_template_dir = test_project / ".kittify" / "templates"
@@ -74,7 +76,7 @@ def test_setup_plan_in_main(test_project: Path, run_cli) -> None:
         "mission",
         "setup-plan",
         "--mission",
-        "001-plan-test",
+        mission_slug,
         "--json",
     )
 
@@ -96,13 +98,9 @@ def test_setup_plan_in_main(test_project: Path, run_cli) -> None:
 
 def test_setup_plan_explicit_feature_reports_spec_path(test_project: Path, run_cli) -> None:
     """setup-plan with explicit --mission returns deterministic context fields."""
-    import json
-
     # Setup: create mission in-process
-    create_mission_fast(test_project, "plan-explicit-test")
-
-    mission_slug = "001-plan-explicit-test"
-    feature_dir = test_project / "kitty-specs" / mission_slug
+    feature_dir = create_mission_fast(test_project, "plan-explicit-test")
+    mission_slug = feature_dir.name
 
     plan_template_dir = test_project / ".kittify" / "templates"
     plan_template_dir.mkdir(parents=True, exist_ok=True)
@@ -131,8 +129,6 @@ def test_setup_plan_explicit_feature_reports_spec_path(test_project: Path, run_c
 
 def test_setup_plan_ambiguous_context_returns_candidates(test_project: Path, run_cli) -> None:
     """setup-plan without explicit context returns candidate missions and remediation."""
-    import json
-
     # Setup: create two missions in-process
     create_mission_fast(test_project, "feature-a", number=1)
     create_mission_fast(test_project, "feature-b", number=2)
@@ -153,12 +149,9 @@ def test_setup_plan_ambiguous_context_returns_candidates(test_project: Path, run
 
 def test_setup_plan_missing_spec_reports_absolute_path(test_project: Path, run_cli) -> None:
     """setup-plan should fail when spec.md is missing for an explicit mission."""
-    import json
-
     # Setup: create mission in-process, then remove spec.md
-    create_mission_fast(test_project, "missing-spec")
-    mission_slug = "001-missing-spec"
-    feature_dir = test_project / "kitty-specs" / mission_slug
+    feature_dir = create_mission_fast(test_project, "missing-spec")
+    mission_slug = feature_dir.name
     spec_file = feature_dir / "spec.md"
     spec_file.unlink()
 
@@ -189,9 +182,8 @@ def test_full_planning_workflow_no_worktrees(test_project: Path, run_cli) -> Non
     )
 
     # Step 1: Create mission in-process (not the test target for this test)
-    create_mission_fast(test_project, "full-workflow-test")
-
-    feature_dir = test_project / "kitty-specs" / "001-full-workflow-test"
+    feature_dir = create_mission_fast(test_project, "full-workflow-test")
+    mission_slug = feature_dir.name
     assert feature_dir.exists(), "Feature directory not created"
     assert (feature_dir / "spec.md").exists(), "spec.md not created"
 
@@ -202,7 +194,7 @@ def test_full_planning_workflow_no_worktrees(test_project: Path, run_cli) -> Non
         "mission",
         "setup-plan",
         "--mission",
-        "001-full-workflow-test",
+        mission_slug,
         "--json",
     )
     assert result.returncode == 0, "Plan setup failed"
@@ -322,7 +314,7 @@ Test work package content.
         "mission",
         "finalize-tasks",
         "--mission",
-        "001-full-workflow-test",
+        mission_slug,
         "--json",
     )
     assert result.returncode == 0, f"finalize-tasks failed: {result.stderr}"
@@ -388,7 +380,7 @@ Test work package content.
 def test_check_prerequisites_works_in_main(test_project: Path, run_cli) -> None:
     """Test that check-prerequisites command works when run from main repo."""
     # Setup: create mission in-process
-    create_mission_fast(test_project, "prereq-test")
+    feature_dir = create_mission_fast(test_project, "prereq-test")
 
     # Run check-prerequisites from main repo
     result = run_cli(
@@ -397,14 +389,13 @@ def test_check_prerequisites_works_in_main(test_project: Path, run_cli) -> None:
         "mission",
         "check-prerequisites",
         "--mission",
-        "001-prereq-test",
+        feature_dir.name,
         "--json",
     )
 
     assert result.returncode == 0, f"check-prerequisites failed: {result.stderr}"
 
     # Should find the latest mission and validate its structure
-    import json
     output = json.loads(result.stdout)
     assert output["valid"] is True, "Feature structure should be valid"
     assert "spec_file" in output["paths"], "Should detect spec.md"
@@ -413,8 +404,6 @@ def test_check_prerequisites_ambiguous_context_returns_candidates(
     test_project: Path, run_cli
 ) -> None:
     """check-prerequisites should fail with remediation when feature context is ambiguous."""
-    import json
-
     # Setup: create two missions in-process
     create_mission_fast(test_project, "ambiguous-a", number=1)
     create_mission_fast(test_project, "ambiguous-b", number=2)
@@ -439,8 +428,6 @@ def test_finalize_tasks_ambiguous_context_returns_candidates(
     test_project: Path, run_cli
 ) -> None:
     """finalize-tasks should fail with remediation when feature context is ambiguous."""
-    import json
-
     # Setup: create two missions in-process
     create_mission_fast(test_project, "ambiguous-finalize-a", number=1)
     create_mission_fast(test_project, "ambiguous-finalize-b", number=2)

--- a/tests/test_dashboard/test_scanner_mission_id.py
+++ b/tests/test_dashboard/test_scanner_mission_id.py
@@ -1,0 +1,225 @@
+"""Tests for dashboard scanner rekeyed by mission_id (WP09, T050).
+
+Covers:
+- Three `080-*` missions with distinct mission_ids produce three distinct records.
+- Legacy mission (no mission_id) shows up with `legacy:<slug>` pseudo-key.
+- API-types shape: mission_id, display_number, mid8, mission_slug all present.
+- Display sort order: numeric prefix ASC, None LAST, secondary by slug.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.dashboard.scanner import (
+    build_mission_registry,
+    sort_missions_for_display,
+)
+
+pytestmark = pytest.mark.fast
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(
+    feature_dir: Path,
+    *,
+    mission_id: str | None = None,
+    mission_number: int | None = None,
+    friendly_name: str = "",
+) -> None:
+    """Write a minimal meta.json to feature_dir."""
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {}
+    if mission_id is not None:
+        meta["mission_id"] = mission_id
+    if mission_number is not None:
+        meta["mission_number"] = mission_number
+    if friendly_name:
+        meta["friendly_name"] = friendly_name
+    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+
+def _create_mission_dir(
+    specs_dir: Path,
+    slug: str,
+    *,
+    mission_id: str | None = None,
+    mission_number: int | None = None,
+    friendly_name: str = "",
+) -> Path:
+    """Create a minimal mission directory in specs_dir."""
+    feature_dir = specs_dir / slug
+    _write_meta(
+        feature_dir,
+        mission_id=mission_id,
+        mission_number=mission_number,
+        friendly_name=friendly_name,
+    )
+    return feature_dir
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Three distinct ULIDs representing three `080-*` missions
+ULID_FOO = "01JQABC1234567890ABCFOO111"
+ULID_BAR = "01JQABC1234567890ABCBAR222"
+ULID_BAZ = "01JQABC1234567890ABCBAZ333"
+
+
+@pytest.fixture()
+def triple_080_repo(tmp_path: Path) -> Path:
+    """Repo with three 080-* missions having distinct mission_ids."""
+    specs = tmp_path / "kitty-specs"
+    _create_mission_dir(specs, "080-foo", mission_id=ULID_FOO, mission_number=80, friendly_name="Foo Feature")
+    _create_mission_dir(specs, "080-bar", mission_id=ULID_BAR, mission_number=80, friendly_name="Bar Feature")
+    _create_mission_dir(specs, "080-baz", mission_id=ULID_BAZ, mission_number=80, friendly_name="Baz Feature")
+    return tmp_path
+
+
+@pytest.fixture()
+def mixed_repo(tmp_path: Path) -> Path:
+    """Repo with assigned, legacy, and orphan missions."""
+    specs = tmp_path / "kitty-specs"
+    # Assigned (has mission_id + mission_number)
+    _create_mission_dir(specs, "001-alpha", mission_id="01JQABC1234567890ABCALPHA1", mission_number=1)
+    # Legacy (mission_number but no mission_id)
+    _create_mission_dir(specs, "002-beta", mission_number=2)
+    # Orphan (no meta.json fields at all — just an empty dir)
+    orphan_dir = specs / "003-orphan"
+    orphan_dir.mkdir(parents=True)
+    # (no meta.json — but we need to create the dir to be discovered)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# T046 — Scanner keyed by mission_id
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMissionRegistry:
+    def test_three_080_missions_produce_three_distinct_keys(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        assert len(registry) == 3, f"Expected 3 distinct keys, got {len(registry)}: {list(registry)}"
+
+    def test_keys_are_mission_ids_not_slugs(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        assert ULID_FOO in registry
+        assert ULID_BAR in registry
+        assert ULID_BAZ in registry
+        # Directory names must NOT be keys
+        assert "080-foo" not in registry
+        assert "080-bar" not in registry
+        assert "080-baz" not in registry
+
+    def test_legacy_mission_uses_pseudo_key(self, mixed_repo: Path) -> None:
+        registry = build_mission_registry(mixed_repo)
+        legacy_keys = [k for k in registry if k.startswith("legacy:")]
+        assert len(legacy_keys) == 1
+        assert "legacy:002-beta" in registry
+
+    def test_orphan_mission_uses_pseudo_key(self, mixed_repo: Path) -> None:
+        registry = build_mission_registry(mixed_repo)
+        orphan_keys = [k for k in registry if k.startswith("orphan:")]
+        assert len(orphan_keys) == 1
+        assert "orphan:003-orphan" in registry
+
+    def test_assigned_mission_uses_ulid_key(self, mixed_repo: Path) -> None:
+        registry = build_mission_registry(mixed_repo)
+        assert "01JQABC1234567890ABCALPHA1" in registry
+
+
+# ---------------------------------------------------------------------------
+# T047 — Display ordering
+# ---------------------------------------------------------------------------
+
+
+class TestSortMissionsForDisplay:
+    def test_three_080_missions_sorted_by_slug(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        order = sort_missions_for_display(registry)
+        # All three present
+        assert set(order) == {ULID_FOO, ULID_BAR, ULID_BAZ}
+        # Secondary sort by slug: 080-bar < 080-baz < 080-foo
+        slugs = [registry[mid]["mission_slug"] for mid in order]
+        assert slugs == ["080-bar", "080-baz", "080-foo"]
+
+    def test_none_mission_number_sorts_last(self, tmp_path: Path) -> None:
+        specs = tmp_path / "kitty-specs"
+        # One assigned (mission_number=5), one legacy, one pending (no number)
+        ULID_PEND = "01JQPENDING1234567890PEND11"
+        _create_mission_dir(specs, "005-assigned", mission_id="01JQASSIGNED1234567890ASS1", mission_number=5)
+        _create_mission_dir(specs, "pending-thing", mission_id=ULID_PEND)  # no mission_number
+
+        registry = build_mission_registry(tmp_path)
+        order = sort_missions_for_display(registry)
+
+        # Assigned (number=5) must come before pending (number=None)
+        assigned_key = "01JQASSIGNED1234567890ASS1"
+        assert order.index(assigned_key) < order.index(ULID_PEND)
+
+    def test_legacy_and_orphan_appear_in_output(self, mixed_repo: Path) -> None:
+        registry = build_mission_registry(mixed_repo)
+        order = sort_missions_for_display(registry)
+        assert "01JQABC1234567890ABCALPHA1" in order
+        assert any(k.startswith("legacy:") for k in order)
+        assert any(k.startswith("orphan:") for k in order)
+
+    def test_order_is_deterministic(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        order1 = sort_missions_for_display(registry)
+        order2 = sort_missions_for_display(registry)
+        assert order1 == order2
+
+
+# ---------------------------------------------------------------------------
+# T048 — API types shape
+# ---------------------------------------------------------------------------
+
+
+class TestApiTypesShape:
+    def test_mission_record_has_required_fields(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        record = registry[ULID_FOO]
+        # Required fields
+        assert "mission_id" in record
+        assert "display_number" in record
+        assert "mid8" in record
+        assert "mission_slug" in record
+
+    def test_mission_id_matches_key(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        for key, record in registry.items():
+            if not key.startswith(("legacy:", "orphan:")):
+                assert record["mission_id"] == key
+
+    def test_display_number_correct(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        record = registry[ULID_FOO]
+        assert record["display_number"] == 80
+
+    def test_mid8_is_first_8_chars_of_mission_id(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        for key, record in registry.items():
+            if not key.startswith(("legacy:", "orphan:")):
+                assert record["mid8"] == record["mission_id"][:8]
+
+    def test_mid8_is_none_for_pseudo_keys(self, mixed_repo: Path) -> None:
+        registry = build_mission_registry(mixed_repo)
+        for key, record in registry.items():
+            if key.startswith(("legacy:", "orphan:")):
+                # mid8 must be None for pseudo-key missions
+                assert record["mid8"] is None, f"Expected None mid8 for {key}, got {record['mid8']}"
+
+    def test_mission_slug_matches_directory_name(self, triple_080_repo: Path) -> None:
+        registry = build_mission_registry(triple_080_repo)
+        assert registry[ULID_FOO]["mission_slug"] == "080-foo"
+        assert registry[ULID_BAR]["mission_slug"] == "080-bar"
+        assert registry[ULID_BAZ]["mission_slug"] == "080-baz"

--- a/tests/test_dashboard/test_scanner_mission_id.py
+++ b/tests/test_dashboard/test_scanner_mission_id.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from specify_cli.dashboard.scanner import (
+    _read_mission_identity,
     build_mission_registry,
     sort_missions_for_display,
 )
@@ -134,6 +135,32 @@ class TestBuildMissionRegistry:
     def test_assigned_mission_uses_ulid_key(self, mixed_repo: Path) -> None:
         registry = build_mission_registry(mixed_repo)
         assert "01JQABC1234567890ABCALPHA1" in registry
+
+    def test_read_mission_identity_coerces_digit_string(self, tmp_path: Path) -> None:
+        """Digit strings in mission_number are coerced to integers."""
+        feature_dir = tmp_path / "kitty-specs" / "042-string-number"
+        _write_meta(feature_dir, mission_id="01JQABC1234567890ABCALPHA1", mission_number="042")
+
+        mission_id, mission_number = _read_mission_identity(feature_dir)
+
+        assert mission_id == "01JQABC1234567890ABCALPHA1"
+        assert mission_number == 42
+
+    def test_read_mission_identity_returns_none_for_non_object_json(self, tmp_path: Path) -> None:
+        """Non-object meta.json degrades to (None, None)."""
+        feature_dir = tmp_path / "kitty-specs" / "043-list-meta"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "meta.json").write_text('["not", "an", "object"]', encoding="utf-8")
+
+        assert _read_mission_identity(feature_dir) == (None, None)
+
+    def test_read_mission_identity_returns_none_for_invalid_json(self, tmp_path: Path) -> None:
+        """Malformed meta.json degrades to (None, None)."""
+        feature_dir = tmp_path / "kitty-specs" / "044-invalid-json"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "meta.json").write_text("{bad json", encoding="utf-8")
+
+        assert _read_mission_identity(feature_dir) == (None, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes three substantive gaps in the merge-time `mission_number` assignment (WP10/FR-044) and `MergeState` identity model identified during post-merge review of mission 083:

- **P1: Real merge lock** — `_run_lane_based_merge` now acquires `acquire_merge_lock("__global_merge__")` with a `finally`-block release. The lock is global (not per-mission) so concurrent merges of different missions serialize against the shared target branch scan. Previously the code claimed single-writer safety but never called the lock primitives.
- **P1: Retry-safe number assignment** — `_bake_mission_number_into_mission_branch` no longer short-circuits on a non-null `mission_number` in the mission branch. Instead it always re-derives from the target branch tip. The idempotency check now compares against the *target branch's* copy — a stale number from a failed push is overwritten on retry after fetch. Previously, a push rejection left a duplicate number that the idempotency guard prevented from being recomputed.
- **P2: MergeState keyed by canonical `mission_id`** — `MergeState.mission_id` is now set to the ULID from `meta.json` (not the display slug). All state paths, lock paths, and cleanup calls use the canonical ID. `mission_slug` remains the display field.
- **Bonus: Fix silent `MissionCreated` event emission** — `mission_number=""` was failing the emitter's `int | None` validator and being silently swallowed by `contextlib.suppress(Exception)`. Changed to `None` and updated the wrapper type signature.

## Test plan

- [x] All 35 merge-specific tests pass (`test_merge_time_number_assignment.py`, `test_merge.py`, `test_merge_policy.py`, `test_merge_target_resolution.py`)
- [x] All 172 mission-083 tests pass (contract matrix, type coercion, colliding flow, dashboard rendering, creation contract, branch naming, null schema, emitter mission_id, feature creation)
- [x] `ruff check` clean (only pre-existing C901/E501 on merge.py)
- [ ] Manual: verify `spec-kitty merge --mission <slug>` on a test repo with two concurrent merges produces distinct `mission_number` values
- [ ] Manual: verify retry after `git fetch` recomputes a stale number

Ref: Priivacy-ai/spec-kitty#557

🤖 Generated with [Claude Code](https://claude.com/claude-code)