### PR TITLE
fix: auto-refresh charter bundle in context readers

### DIFF
--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -35,6 +35,49 @@ class SyncResult:
     error: str | None = None  # Error message if sync failed
 
 
+def ensure_charter_bundle_fresh(repo_root: Path) -> SyncResult | None:
+    """Auto-refresh extracted charter artifacts when charter.md exists."""
+    charter_dir = repo_root / ".kittify" / "charter"
+    charter_path = charter_dir / "charter.md"
+    if not charter_path.exists():
+        return None
+
+    metadata_path = charter_dir / "metadata.yaml"
+    expected_paths = (
+        charter_dir / "governance.yaml",
+        charter_dir / "directives.yaml",
+        metadata_path,
+    )
+    missing_files = [path.name for path in expected_paths if not path.exists()]
+    should_force = bool(missing_files)
+    stale = False
+
+    if not should_force:
+        try:
+            stale, _, _ = is_stale(charter_path, metadata_path)
+        except Exception as exc:
+            logger.warning("Failed to evaluate charter bundle freshness: %s", exc)
+            should_force = True
+
+    if not should_force and not stale:
+        return SyncResult(
+            synced=False,
+            stale_before=False,
+            files_written=[],
+            extraction_mode="",
+        )
+
+    if missing_files:
+        logger.info("Charter bundle incomplete (%s). Attempting auto-sync.", ", ".join(missing_files))
+    else:
+        logger.info("Charter bundle stale. Attempting auto-sync.")
+
+    result = sync(charter_path, charter_dir, force=should_force)
+    if result.error:
+        logger.warning("Charter auto-sync failed while refreshing extracted artifacts: %s", result.error)
+    return result
+
+
 def sync(
     charter_path: Path,
     output_dir: Path | None = None,
@@ -148,19 +191,26 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
         GovernanceConfig instance (empty if file missing)
     """
     charter_dir = repo_root / ".kittify" / "charter"
+    charter_path = charter_dir / "charter.md"
     governance_path = charter_dir / "governance.yaml"
+    refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not governance_path.exists():
-        logger.warning("governance.yaml not found. Run 'spec-kitty charter sync'.")
+        if charter_path.exists():
+            logger.warning("governance.yaml unavailable after charter auto-sync. Using empty governance config.")
+        else:
+            logger.warning("governance.yaml not found and charter.md is absent. Using empty governance config.")
         return GovernanceConfig()
 
     # Check staleness
-    charter_path = charter_dir / "charter.md"
     metadata_path = charter_dir / "metadata.yaml"
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:
-            logger.warning("Charter changed since last sync. Run 'spec-kitty charter sync' to update.")
+            if refresh_result and refresh_result.error:
+                logger.warning("Charter bundle is stale after auto-sync failure. Using last synced governance config.")
+            else:
+                logger.warning("Charter bundle remains stale. Using last synced governance config.")
 
     # Load and validate
     yaml = YAML()
@@ -181,18 +231,25 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
         DirectivesConfig instance (empty if file missing)
     """
     charter_dir = repo_root / ".kittify" / "charter"
+    charter_path = charter_dir / "charter.md"
     directives_path = charter_dir / "directives.yaml"
+    refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not directives_path.exists():
-        logger.warning("directives.yaml not found. Run 'spec-kitty charter sync'.")
+        if charter_path.exists():
+            logger.warning("directives.yaml unavailable after charter auto-sync. Using empty directives config.")
+        else:
+            logger.warning("directives.yaml not found and charter.md is absent. Using empty directives config.")
         return DirectivesConfig()
 
-    charter_path = charter_dir / "charter.md"
     metadata_path = charter_dir / "metadata.yaml"
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:
-            logger.warning("Charter changed since last sync. Run 'spec-kitty charter sync' to update.")
+            if refresh_result and refresh_result.error:
+                logger.warning("Charter bundle is stale after auto-sync failure. Using last synced directives config.")
+            else:
+                logger.warning("Charter bundle remains stale. Using last synced directives config.")
 
     yaml = YAML()
     data = yaml.load(directives_path)

--- a/src/specify_cli/charter/sync.py
+++ b/src/specify_cli/charter/sync.py
@@ -35,6 +35,49 @@ class SyncResult:
     error: str | None = None  # Error message if sync failed
 
 
+def ensure_charter_bundle_fresh(repo_root: Path) -> SyncResult | None:
+    """Auto-refresh extracted charter artifacts when charter.md exists."""
+    charter_dir = repo_root / ".kittify" / "charter"
+    charter_path = charter_dir / "charter.md"
+    if not charter_path.exists():
+        return None
+
+    metadata_path = charter_dir / "metadata.yaml"
+    expected_paths = (
+        charter_dir / "governance.yaml",
+        charter_dir / "directives.yaml",
+        metadata_path,
+    )
+    missing_files = [path.name for path in expected_paths if not path.exists()]
+    should_force = bool(missing_files)
+    stale = False
+
+    if not should_force:
+        try:
+            stale, _, _ = is_stale(charter_path, metadata_path)
+        except Exception as exc:
+            logger.warning("Failed to evaluate charter bundle freshness: %s", exc)
+            should_force = True
+
+    if not should_force and not stale:
+        return SyncResult(
+            synced=False,
+            stale_before=False,
+            files_written=[],
+            extraction_mode="",
+        )
+
+    if missing_files:
+        logger.info("Charter bundle incomplete (%s). Attempting auto-sync.", ", ".join(missing_files))
+    else:
+        logger.info("Charter bundle stale. Attempting auto-sync.")
+
+    result = sync(charter_path, charter_dir, force=should_force)
+    if result.error:
+        logger.warning("Charter auto-sync failed while refreshing extracted artifacts: %s", result.error)
+    return result
+
+
 def sync(
     charter_path: Path,
     output_dir: Path | None = None,
@@ -148,19 +191,26 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
         GovernanceConfig instance (empty if file missing)
     """
     charter_dir = repo_root / ".kittify" / "charter"
+    charter_path = charter_dir / "charter.md"
     governance_path = charter_dir / "governance.yaml"
+    refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not governance_path.exists():
-        logger.warning("governance.yaml not found. Run 'spec-kitty charter sync'.")
+        if charter_path.exists():
+            logger.warning("governance.yaml unavailable after charter auto-sync. Using empty governance config.")
+        else:
+            logger.warning("governance.yaml not found and charter.md is absent. Using empty governance config.")
         return GovernanceConfig()
 
     # Check staleness
-    charter_path = charter_dir / "charter.md"
     metadata_path = charter_dir / "metadata.yaml"
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:
-            logger.warning("Charter changed since last sync. Run 'spec-kitty charter sync' to update.")
+            if refresh_result and refresh_result.error:
+                logger.warning("Charter bundle is stale after auto-sync failure. Using last synced governance config.")
+            else:
+                logger.warning("Charter bundle remains stale. Using last synced governance config.")
 
     # Load and validate
     yaml = YAML()
@@ -181,18 +231,25 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
         DirectivesConfig instance (empty if file missing)
     """
     charter_dir = repo_root / ".kittify" / "charter"
+    charter_path = charter_dir / "charter.md"
     directives_path = charter_dir / "directives.yaml"
+    refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not directives_path.exists():
-        logger.warning("directives.yaml not found. Run 'spec-kitty charter sync'.")
+        if charter_path.exists():
+            logger.warning("directives.yaml unavailable after charter auto-sync. Using empty directives config.")
+        else:
+            logger.warning("directives.yaml not found and charter.md is absent. Using empty directives config.")
         return DirectivesConfig()
 
-    charter_path = charter_dir / "charter.md"
     metadata_path = charter_dir / "metadata.yaml"
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:
-            logger.warning("Charter changed since last sync. Run 'spec-kitty charter sync' to update.")
+            if refresh_result and refresh_result.error:
+                logger.warning("Charter bundle is stale after auto-sync failure. Using last synced directives config.")
+            else:
+                logger.warning("Charter bundle remains stale. Using last synced directives config.")
 
     yaml = YAML()
     data = yaml.load(directives_path)

--- a/tests/agent/cli/commands/test_charter_cli.py
+++ b/tests/agent/cli/commands/test_charter_cli.py
@@ -210,6 +210,37 @@ def test_context_bootstrap_then_compact(tmp_path: Path) -> None:
         assert second_payload["first_load"] is False
 
 
+def test_context_compact_mode_auto_syncs_missing_extracted_artifacts(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    charter_dir = repo_root / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True)
+
+    with patch("specify_cli.cli.commands.charter.find_repo_root") as mock_find_root:
+        mock_find_root.return_value = repo_root
+
+        generate_result = runner.invoke(app, ["generate", "--json"])
+        assert generate_result.exit_code == 0
+
+        first = runner.invoke(app, ["context", "--action", "plan", "--json"])
+        assert first.exit_code == 0
+        first_payload = json.loads(first.stdout)
+        assert first_payload["mode"] == "bootstrap"
+
+        for name in ("governance.yaml", "directives.yaml", "metadata.yaml"):
+            (charter_dir / name).unlink()
+
+        second = runner.invoke(app, ["context", "--action", "plan", "--json"])
+        assert second.exit_code == 0
+        second_payload = json.loads(second.stdout)
+        assert second_payload["mode"] == "compact"
+        assert second_payload["first_load"] is False
+        assert (charter_dir / "governance.yaml").exists()
+        assert (charter_dir / "directives.yaml").exists()
+        assert (charter_dir / "metadata.yaml").exists()
+        assert "Run 'spec-kitty charter sync'" not in second.stdout
+
+
 def test_help_output() -> None:
     result = runner.invoke(app, ["--help"])
 

--- a/tests/agent/test_workflow_charter_context.py
+++ b/tests/agent/test_workflow_charter_context.py
@@ -158,6 +158,17 @@ class TestPromptBuilderGovernanceContext:
         text = _governance_context(tmp_path, action="specify")
         assert "Governance:" in text
 
+    def test_compact_mode_auto_syncs_missing_governance_bundle(self, tmp_path: Path) -> None:
+        charter_dir = _make_charter_bundle(tmp_path, include_governance=False)
+
+        _governance_context(tmp_path, action="specify")
+        text = _governance_context(tmp_path, action="specify")
+
+        assert "Governance:" in text
+        assert (charter_dir / "governance.yaml").exists()
+        assert (charter_dir / "directives.yaml").exists()
+        assert (charter_dir / "metadata.yaml").exists()
+
     def test_missing_charter_falls_back_to_legacy_governance(self, tmp_path: Path) -> None:
         """Missing charter skips context injection and falls back gracefully."""
         (tmp_path / ".kittify" / "charter").mkdir(parents=True)

--- a/tests/charter/test_integration.py
+++ b/tests/charter/test_integration.py
@@ -15,6 +15,7 @@ from charter import (
     post_save_hook,
     sync,
 )
+from charter.sync import SyncResult, ensure_charter_bundle_fresh
 
 pytestmark = pytest.mark.fast
 
@@ -227,6 +228,138 @@ quality:
         assert config.testing.tdd_required is True
         assert config.quality.pr_approvals == 2
         assert config.quality.pre_commit_hooks is True
+
+
+class TestEnsureCharterBundleFresh:
+    def test_recovers_from_stale_check_exception(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        charter_path = charter_dir / "charter.md"
+        charter_path.write_text("## Testing\n\nCoverage: 80%", encoding="utf-8")
+        sync(charter_path)
+
+        call_count = 0
+        def raise_then_pass(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("corrupt metadata")
+            return (True, "old", "new")
+
+        with patch("charter.sync.is_stale", side_effect=raise_then_pass):
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="charter.sync"):
+                result = ensure_charter_bundle_fresh(tmp_path)
+
+        assert result is not None
+        assert result.synced
+        assert any("Failed to evaluate charter bundle freshness" in r.message for r in caplog.records)
+
+    def test_logs_sync_failure(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text("## Testing\n\nCoverage: 80%", encoding="utf-8")
+
+        with patch("charter.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                synced=False, stale_before=False, files_written=[],
+                extraction_mode="", error="Engine unavailable",
+            )
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="charter.sync"):
+                result = ensure_charter_bundle_fresh(tmp_path)
+
+        assert result is not None
+        assert result.error == "Engine unavailable"
+        assert any("Charter auto-sync failed" in r.message for r in caplog.records)
+
+
+class TestLoaderAutoSyncEdgeCases:
+    def test_governance_unavailable_after_failed_auto_sync(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text("## Testing\n\nCoverage: 80%", encoding="utf-8")
+
+        with patch("charter.sync.ensure_charter_bundle_fresh") as mock_ensure:
+            mock_ensure.return_value = SyncResult(
+                synced=False, stale_before=False, files_written=[],
+                extraction_mode="", error="Engine unavailable",
+            )
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="charter.sync"):
+                config = load_governance_config(tmp_path)
+
+        assert isinstance(config, GovernanceConfig)
+        assert any("governance.yaml unavailable after charter auto-sync" in r.message for r in caplog.records)
+
+    def test_governance_stale_after_sync_failure(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        charter_path = charter_dir / "charter.md"
+        charter_path.write_text("## Testing\n\nCoverage: 80%", encoding="utf-8")
+        sync(charter_path)
+        charter_path.write_text("## Testing\n\nCoverage: 95%", encoding="utf-8")
+
+        with patch("charter.sync.ensure_charter_bundle_fresh") as mock_ensure:
+            mock_ensure.return_value = SyncResult(
+                synced=False, stale_before=True, files_written=[],
+                extraction_mode="", error="Sync failed",
+            )
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="charter.sync"):
+                config = load_governance_config(tmp_path)
+
+        assert isinstance(config, GovernanceConfig)
+        assert any("stale after auto-sync failure" in r.message for r in caplog.records)
+
+    def test_directives_unavailable_after_failed_auto_sync(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text("## Testing\n\nCoverage: 80%", encoding="utf-8")
+
+        with patch("charter.sync.ensure_charter_bundle_fresh") as mock_ensure:
+            mock_ensure.return_value = SyncResult(
+                synced=False, stale_before=False, files_written=[],
+                extraction_mode="", error="Engine unavailable",
+            )
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="charter.sync"):
+                config = load_directives_config(tmp_path)
+
+        assert isinstance(config, DirectivesConfig)
+        assert any("directives.yaml unavailable after charter auto-sync" in r.message for r in caplog.records)
+
+    def test_directives_stale_after_sync_failure(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        charter_path = charter_dir / "charter.md"
+        charter_path.write_text("## Directives\n\n1. Keep tests strict", encoding="utf-8")
+        sync(charter_path)
+        charter_path.write_text("## Directives\n\n1. Updated directive", encoding="utf-8")
+
+        with patch("charter.sync.ensure_charter_bundle_fresh") as mock_ensure:
+            mock_ensure.return_value = SyncResult(
+                synced=False, stale_before=True, files_written=[],
+                extraction_mode="", error="Sync failed",
+            )
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="charter.sync"):
+                config = load_directives_config(tmp_path)
+
+        assert isinstance(config, DirectivesConfig)
+        assert any("stale after auto-sync failure" in r.message for r in caplog.records)
 
 
 class TestPerformance:

--- a/tests/charter/test_integration.py
+++ b/tests/charter/test_integration.py
@@ -72,21 +72,38 @@ Pre-commit hooks required.
         assert len(config.directives) == 2
         assert config.directives[0].id == "DIR-001"
 
-    def test_modify_charter_triggers_staleness_warning(
+    def test_modify_charter_auto_syncs_stale_bundle(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         charter_dir = tmp_path / ".kittify" / "charter"
         charter_dir.mkdir(parents=True)
         charter_path = charter_dir / "charter.md"
 
-        charter_path.write_text("## Testing\n\nCoverage: 80%")
+        charter_path.write_text(
+            """
+## Testing Standards
+
+We require 80% test coverage. TDD required.
+We use pytest as our framework and mypy --strict for type checking.
+""",
+            encoding="utf-8",
+        )
         sync(charter_path)
 
-        charter_path.write_text("## Testing\n\nCoverage: 90%")
+        charter_path.write_text(
+            """
+## Testing Standards
+
+We require 90% test coverage. TDD required.
+We use pytest as our framework and mypy --strict for type checking.
+""",
+            encoding="utf-8",
+        )
 
         caplog.clear()
-        load_governance_config(tmp_path)
-        assert any("Charter changed since last sync" in record.message for record in caplog.records)
+        config = load_governance_config(tmp_path)
+        assert config.testing.min_coverage == 90
+        assert not any("Run 'spec-kitty charter sync'" in record.message for record in caplog.records)
 
 
 class TestPostSaveHook:
@@ -138,7 +155,7 @@ class TestLoaderFunctions:
         assert isinstance(config, GovernanceConfig)
         assert config.testing.min_coverage == 0
         assert config.testing.tdd_required is False
-        assert any("governance.yaml not found" in record.message for record in caplog.records)
+        assert any("governance.yaml not found and charter.md is absent" in record.message for record in caplog.records)
 
     def test_load_directives_config_missing_yaml_returns_empty(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -148,7 +165,42 @@ class TestLoaderFunctions:
 
         assert isinstance(config, DirectivesConfig)
         assert len(config.directives) == 0
-        assert any("directives.yaml not found" in record.message for record in caplog.records)
+        assert any("directives.yaml not found and charter.md is absent" in record.message for record in caplog.records)
+
+    def test_load_governance_config_missing_yaml_auto_syncs_when_charter_present(self, tmp_path: Path) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text(
+            """
+## Testing Standards
+
+We require 85% test coverage. TDD required.
+We use pytest as our framework and mypy --strict for type checking.
+""",
+            encoding="utf-8",
+        )
+
+        config = load_governance_config(tmp_path)
+
+        assert config.testing.min_coverage == 85
+        assert (charter_dir / "governance.yaml").exists()
+        assert (charter_dir / "directives.yaml").exists()
+        assert (charter_dir / "metadata.yaml").exists()
+
+    def test_load_directives_config_missing_yaml_auto_syncs_when_charter_present(self, tmp_path: Path) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text(
+            "## Project Directives\n\n1. Keep tests strict\n2. Keep docs in sync\n",
+            encoding="utf-8",
+        )
+
+        config = load_directives_config(tmp_path)
+
+        assert len(config.directives) == 2
+        assert (charter_dir / "governance.yaml").exists()
+        assert (charter_dir / "directives.yaml").exists()
+        assert (charter_dir / "metadata.yaml").exists()
 
     def test_load_governance_config_with_values(self, tmp_path: Path) -> None:
         charter_dir = tmp_path / ".kittify" / "charter"


### PR DESCRIPTION
## Summary

Fixes #604.

`spec-kitty charter context` was reaching compact governance resolution through readers that only warned when extracted charter artifacts were missing or stale. That produced the bad UX where the runtime path told the operator to run `spec-kitty charter sync` manually, then silently succeeded with fallback defaults.

This change adds an auto-refresh chokepoint to both charter sync module trees and uses it from the config loaders so compact governance resolution self-heals when `charter.md` exists.

## What changed

- add `ensure_charter_bundle_fresh()` to `src/charter/sync.py`
- add the same freshness helper to `src/specify_cli/charter/sync.py`
- auto-sync when `charter.md` exists and extracted artifacts are missing or stale
- keep fallback behavior only when there is no charter or the auto-sync attempt fails
- replace the old manual-sync warnings in loader fallback paths with explicit auto-sync/fallback messages
- add regressions for:
  - stale bundle auto-refresh in integration tests
  - CLI `charter context --action ... --json` compact-mode self-heal
  - prompt-builder compact-mode self-heal on the `specify_cli` path

## Verification

- `ruff check src/charter/sync.py src/specify_cli/charter/sync.py tests/charter/test_integration.py tests/agent/cli/commands/test_charter_cli.py tests/agent/test_workflow_charter_context.py`
- `pytest -q tests/charter/test_integration.py tests/agent/cli/commands/test_charter_cli.py tests/agent/test_workflow_charter_context.py`
- `pytest -q tests/charter/test_context.py tests/charter/test_resolver.py tests/merge/test_profile_charter_e2e.py`
