### PR TITLE
fix: address actionable sonar issues

### DIFF
--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -23,6 +23,18 @@ from charter.schemas import (
 
 logger = logging.getLogger(__name__)
 
+_KITTIFY_DIRNAME = ".kittify"
+_CHARTER_DIRNAME = "charter"
+_CHARTER_FILENAME = "charter.md"
+_METADATA_FILENAME = "metadata.yaml"
+_GOVERNANCE_FILENAME = "governance.yaml"
+_DIRECTIVES_FILENAME = "directives.yaml"
+_SYNC_OUTPUT_FILES = [
+    _GOVERNANCE_FILENAME,
+    _DIRECTIVES_FILENAME,
+    _METADATA_FILENAME,
+]
+
 
 @dataclass
 class SyncResult:
@@ -37,15 +49,15 @@ class SyncResult:
 
 def ensure_charter_bundle_fresh(repo_root: Path) -> SyncResult | None:
     """Auto-refresh extracted charter artifacts when charter.md exists."""
-    charter_dir = repo_root / ".kittify" / "charter"
-    charter_path = charter_dir / "charter.md"
+    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    charter_path = charter_dir / _CHARTER_FILENAME
     if not charter_path.exists():
         return None
 
-    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path = charter_dir / _METADATA_FILENAME
     expected_paths = (
-        charter_dir / "governance.yaml",
-        charter_dir / "directives.yaml",
+        charter_dir / _GOVERNANCE_FILENAME,
+        charter_dir / _DIRECTIVES_FILENAME,
         metadata_path,
     )
     missing_files = [path.name for path in expected_paths if not path.exists()]
@@ -98,7 +110,7 @@ def sync(
         output_dir = charter_path.parent
 
     # Metadata path
-    metadata_path = output_dir / "metadata.yaml"
+    metadata_path = output_dir / _METADATA_FILENAME
 
     try:
         # Read charter content once
@@ -125,11 +137,7 @@ def sync(
         write_extraction_result(result, output_dir)
 
         # List files written
-        files_written = [
-            "governance.yaml",
-            "directives.yaml",
-            "metadata.yaml",
-        ]
+        files_written = list(_SYNC_OUTPUT_FILES)
 
         logger.info(f"Charter synced successfully (mode: {result.metadata.extraction_mode})")
 
@@ -190,9 +198,9 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
     Returns:
         GovernanceConfig instance (empty if file missing)
     """
-    charter_dir = repo_root / ".kittify" / "charter"
-    charter_path = charter_dir / "charter.md"
-    governance_path = charter_dir / "governance.yaml"
+    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    charter_path = charter_dir / _CHARTER_FILENAME
+    governance_path = charter_dir / _GOVERNANCE_FILENAME
     refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not governance_path.exists():
@@ -203,7 +211,7 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
         return GovernanceConfig()
 
     # Check staleness
-    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path = charter_dir / _METADATA_FILENAME
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:
@@ -230,9 +238,9 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
     Returns:
         DirectivesConfig instance (empty if file missing)
     """
-    charter_dir = repo_root / ".kittify" / "charter"
-    charter_path = charter_dir / "charter.md"
-    directives_path = charter_dir / "directives.yaml"
+    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    charter_path = charter_dir / _CHARTER_FILENAME
+    directives_path = charter_dir / _DIRECTIVES_FILENAME
     refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not directives_path.exists():
@@ -242,7 +250,7 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
             logger.warning("directives.yaml not found and charter.md is absent. Using empty directives config.")
         return DirectivesConfig()
 
-    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path = charter_dir / _METADATA_FILENAME
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:

--- a/src/specify_cli/charter/sync.py
+++ b/src/specify_cli/charter/sync.py
@@ -23,6 +23,18 @@ from specify_cli.charter.schemas import (
 
 logger = logging.getLogger(__name__)
 
+_KITTIFY_DIRNAME = ".kittify"
+_CHARTER_DIRNAME = "charter"
+_CHARTER_FILENAME = "charter.md"
+_METADATA_FILENAME = "metadata.yaml"
+_GOVERNANCE_FILENAME = "governance.yaml"
+_DIRECTIVES_FILENAME = "directives.yaml"
+_SYNC_OUTPUT_FILES = [
+    _GOVERNANCE_FILENAME,
+    _DIRECTIVES_FILENAME,
+    _METADATA_FILENAME,
+]
+
 
 @dataclass
 class SyncResult:
@@ -37,15 +49,15 @@ class SyncResult:
 
 def ensure_charter_bundle_fresh(repo_root: Path) -> SyncResult | None:
     """Auto-refresh extracted charter artifacts when charter.md exists."""
-    charter_dir = repo_root / ".kittify" / "charter"
-    charter_path = charter_dir / "charter.md"
+    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    charter_path = charter_dir / _CHARTER_FILENAME
     if not charter_path.exists():
         return None
 
-    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path = charter_dir / _METADATA_FILENAME
     expected_paths = (
-        charter_dir / "governance.yaml",
-        charter_dir / "directives.yaml",
+        charter_dir / _GOVERNANCE_FILENAME,
+        charter_dir / _DIRECTIVES_FILENAME,
         metadata_path,
     )
     missing_files = [path.name for path in expected_paths if not path.exists()]
@@ -98,7 +110,7 @@ def sync(
         output_dir = charter_path.parent
 
     # Metadata path
-    metadata_path = output_dir / "metadata.yaml"
+    metadata_path = output_dir / _METADATA_FILENAME
 
     try:
         # Read charter content once
@@ -125,11 +137,7 @@ def sync(
         write_extraction_result(result, output_dir)
 
         # List files written
-        files_written = [
-            "governance.yaml",
-            "directives.yaml",
-            "metadata.yaml",
-        ]
+        files_written = list(_SYNC_OUTPUT_FILES)
 
         logger.info(f"Charter synced successfully (mode: {result.metadata.extraction_mode})")
 
@@ -190,9 +198,9 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
     Returns:
         GovernanceConfig instance (empty if file missing)
     """
-    charter_dir = repo_root / ".kittify" / "charter"
-    charter_path = charter_dir / "charter.md"
-    governance_path = charter_dir / "governance.yaml"
+    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    charter_path = charter_dir / _CHARTER_FILENAME
+    governance_path = charter_dir / _GOVERNANCE_FILENAME
     refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not governance_path.exists():
@@ -203,7 +211,7 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
         return GovernanceConfig()
 
     # Check staleness
-    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path = charter_dir / _METADATA_FILENAME
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:
@@ -230,9 +238,9 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
     Returns:
         DirectivesConfig instance (empty if file missing)
     """
-    charter_dir = repo_root / ".kittify" / "charter"
-    charter_path = charter_dir / "charter.md"
-    directives_path = charter_dir / "directives.yaml"
+    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    charter_path = charter_dir / _CHARTER_FILENAME
+    directives_path = charter_dir / _DIRECTIVES_FILENAME
     refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not directives_path.exists():
@@ -242,7 +250,7 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
             logger.warning("directives.yaml not found and charter.md is absent. Using empty directives config.")
         return DirectivesConfig()
 
-    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path = charter_dir / _METADATA_FILENAME
     if charter_path.exists() and metadata_path.exists():
         stale, _, _ = is_stale(charter_path, metadata_path)
         if stale:

--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -41,7 +41,7 @@ import re
 
 _WP_SECTION_HEADER = re.compile(r"(?m)^(?:##|###)\s+(?P<title>.+)$")
 _WP_ID_TITLE = re.compile(r"^(?:Work Package\s+)?(?P<wp_id>WP\d{2})(?:\b|:)")
-_WP_NUMBER_TITLE = re.compile(r"^Work Package\s+(?P<wp_number>\d{1,2})(?:\b|\s*[—:-]|$)")
+_WORK_PACKAGE_PREFIX = "Work Package "
 
 # Matches any top-level ## heading (exactly two #s).  Used by _split_wp_sections
 # to find the stop boundary for the final WP section.  Sub-headings (### or
@@ -53,8 +53,23 @@ def _match_wp_section_id(title: str) -> str | None:
     """Return canonical ``WP##`` when ``title`` is a work-package heading."""
     if explicit_id_match := _WP_ID_TITLE.match(title):
         return explicit_id_match.group("wp_id")
-    if numeric_match := _WP_NUMBER_TITLE.match(title):
-        return f"WP{int(numeric_match.group('wp_number')):02d}"
+    if not title.startswith(_WORK_PACKAGE_PREFIX):
+        return None
+
+    suffix = title[len(_WORK_PACKAGE_PREFIX) :]
+    digit_count = 0
+    while digit_count < len(suffix) and digit_count < 2 and suffix[digit_count].isdigit():
+        digit_count += 1
+
+    if digit_count == 0:
+        return None
+    if digit_count < len(suffix) and suffix[digit_count].isdigit():
+        return None
+
+    remainder = suffix[digit_count:]
+    if remainder and not (remainder[0].isspace() or remainder[0] in "—:-"):
+        return None
+    return f"WP{int(suffix[:digit_count]):02d}"
     return None
 
 


### PR DESCRIPTION
## Summary
- replace repeated charter bundle file literals with shared constants in both charter sync modules
- remove the numeric work-package heading regex hotspot by switching to bounded string parsing
- target the actionable Sonar findings from the nightly `main` run; no suppressions added

## Validation
- `pytest tests/core/test_dependency_parser.py tests/charter/test_sync.py -q`
- `ruff check src/charter/sync.py src/specify_cli/charter/sync.py src/specify_cli/core/dependency_parser.py`
- `python -m compileall src/specify_cli/core/dependency_parser.py src/specify_cli/charter/sync.py src/charter/sync.py`

## Context
Nightly `CI Quality` on `main` ([run 637](https://github.com/Priivacy-ai/spec-kitty/actions/runs/24327107497)) had no open GitHub code-scanning or Dependabot alerts, but SonarCloud still reported actionable code issues:
- new duplicated literal findings in `src/charter/sync.py` and `src/specify_cli/charter/sync.py`
- a new regex DoS hotspot in `src/specify_cli/core/dependency_parser.py`

The Sonar quality gate is also red on coverage and hotspot-review state, but those remaining gate failures are not code suppressions in this patch.
