### PR TITLE
fix(sync): guard fcntl import for Windows (#586)

### DIFF
--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import secrets
@@ -64,6 +65,22 @@ DAEMON_PORT_MAX_ATTEMPTS = 50
 # behaviour changes in a backwards-incompatible way.  ensure_sync_daemon_running
 # compares this against the running daemon and restarts it on mismatch.
 DAEMON_PROTOCOL_VERSION = 1
+
+
+def _is_daemon_lock_contention(exc: OSError) -> bool:
+    """Return True when a non-blocking lock failed due to normal contention."""
+    if isinstance(exc, BlockingIOError):
+        return True
+
+    if exc.errno is None:
+        return False
+
+    if sys.platform == "win32":
+        return exc.errno in {errno.EACCES, errno.EDEADLK}
+
+    # Python documents flock(LOCK_NB) contention as EACCES or EAGAIN,
+    # depending on the platform's backend.
+    return exc.errno in {errno.EACCES, errno.EAGAIN}
 
 
 def _get_package_version() -> str:
@@ -516,9 +533,13 @@ def ensure_sync_daemon_running(
                     fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
                 break
-            except (BlockingIOError, OSError):
-                # Unix raises BlockingIOError; Windows msvcrt raises OSError
-                # (errno EDEADLK / EACCES) when the lock is held elsewhere.
+            except OSError as exc:
+                if not _is_daemon_lock_contention(exc):
+                    return DaemonStartOutcome(
+                        started=False,
+                        skipped_reason=f"start_failed: {exc}",
+                        pid=None,
+                    )
                 time.sleep(0.1)
         if not acquired:
             return DaemonStartOutcome(

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import json
 import logging
 import secrets
@@ -20,6 +19,11 @@ from enum import Enum
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+if sys.platform == "win32":
+    import msvcrt
+else:  # pragma: no cover - platform-specific
+    import fcntl
 
 if TYPE_CHECKING:
     from specify_cli.sync.config import SyncConfig
@@ -506,10 +510,15 @@ def ensure_sync_daemon_running(
         acquired = False
         for _ in range(100):
             try:
-                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                if sys.platform == "win32":
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
                 break
-            except BlockingIOError:
+            except (BlockingIOError, OSError):
+                # Unix raises BlockingIOError; Windows msvcrt raises OSError
+                # (errno EDEADLK / EACCES) when the lock is held elsewhere.
                 time.sleep(0.1)
         if not acquired:
             return DaemonStartOutcome(
@@ -533,7 +542,10 @@ def ensure_sync_daemon_running(
         return DaemonStartOutcome(started=True, skipped_reason=None, pid=pid)
     finally:
         if acquired:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            if sys.platform == "win32":
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
         lock_fd.close()
 
 

--- a/tests/sync/test_issue_586_windows_import.py
+++ b/tests/sync/test_issue_586_windows_import.py
@@ -25,6 +25,8 @@ pytestmark = pytest.mark.fast
 
 def test_daemon_module_imports_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     """On Windows (no ``fcntl``), ``specify_cli.sync.daemon`` must still import."""
+    import specify_cli.sync.daemon as daemon_module
+
     # Simulate a Windows interpreter.
     monkeypatch.setattr(sys, "platform", "win32")
 
@@ -39,13 +41,8 @@ def test_daemon_module_imports_on_windows(monkeypatch: pytest.MonkeyPatch) -> No
     )
     monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
 
-    # Remove any cached daemon module so the top-level platform branch
-    # re-executes.  We restore the native (Unix) version in ``finally`` below
-    # so sibling tests that patch ``daemon.fcntl`` aren't broken by our fake
-    # Windows import lingering in ``sys.modules``.
-    sys.modules.pop("specify_cli.sync.daemon", None)
     try:
-        module = importlib.import_module("specify_cli.sync.daemon")
+        module = importlib.reload(daemon_module)
         # Sanity: the module loaded and exposes its public API.
         assert hasattr(module, "ensure_sync_daemon_running")
         assert hasattr(module, "get_sync_daemon_status")
@@ -54,5 +51,4 @@ def test_daemon_module_imports_on_windows(monkeypatch: pytest.MonkeyPatch) -> No
         # real platform.  ``monkeypatch`` teardown would do this too, but only
         # *after* this finally block runs.
         monkeypatch.undo()
-        sys.modules.pop("specify_cli.sync.daemon", None)
-        importlib.import_module("specify_cli.sync.daemon")
+        importlib.reload(daemon_module)

--- a/tests/sync/test_issue_586_windows_import.py
+++ b/tests/sync/test_issue_586_windows_import.py
@@ -1,0 +1,58 @@
+"""Regression test for issue #586: `spec-kitty --help` failed on Windows with
+``ModuleNotFoundError: No module named 'fcntl'``.
+
+The root cause was ``src/specify_cli/sync/daemon.py`` importing ``fcntl``
+unconditionally at module top.  ``fcntl`` is a Unix-only stdlib module, so the
+CLI could not even start on Windows — the daemon module is imported eagerly
+via the dashboard command registration chain.
+
+The fix branches on ``sys.platform == "win32"`` and uses ``msvcrt.locking``
+instead.  This test simulates the Windows environment on a Unix host by
+stubbing ``sys.modules`` so we can confirm the daemon module imports cleanly
+when ``fcntl`` is absent and ``msvcrt`` is the available locking backend.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+
+def test_daemon_module_imports_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows (no ``fcntl``), ``specify_cli.sync.daemon`` must still import."""
+    # Simulate a Windows interpreter.
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    # On a Unix host ``msvcrt`` doesn't exist — provide a stub so the
+    # ``import msvcrt`` branch succeeds.  Calls against it aren't exercised
+    # by this test; we only verify the import does not raise.
+    fake_msvcrt = types.SimpleNamespace(
+        locking=lambda *_args, **_kwargs: None,
+        LK_NBLCK=1,
+        LK_UNLCK=2,
+        LK_LOCK=3,
+    )
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    # Remove any cached daemon module so the top-level platform branch
+    # re-executes.  We restore the native (Unix) version in ``finally`` below
+    # so sibling tests that patch ``daemon.fcntl`` aren't broken by our fake
+    # Windows import lingering in ``sys.modules``.
+    sys.modules.pop("specify_cli.sync.daemon", None)
+    try:
+        module = importlib.import_module("specify_cli.sync.daemon")
+        # Sanity: the module loaded and exposes its public API.
+        assert hasattr(module, "ensure_sync_daemon_running")
+        assert hasattr(module, "get_sync_daemon_status")
+    finally:
+        # Undo Windows monkeypatches eagerly so the reload below picks up the
+        # real platform.  ``monkeypatch`` teardown would do this too, but only
+        # *after* this finally block runs.
+        monkeypatch.undo()
+        sys.modules.pop("specify_cli.sync.daemon", None)
+        importlib.import_module("specify_cli.sync.daemon")

--- a/tests/sync/test_issue_598_hang_fixes.py
+++ b/tests/sync/test_issue_598_hang_fixes.py
@@ -19,6 +19,7 @@ code paths fire without inserting 100 k rows.
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import sqlite3
 import threading
@@ -709,6 +710,54 @@ class TestDaemonBoundedFlock:
 
         assert outcome.started is False
         assert "could not acquire daemon lock" in outcome.skipped_reason
+
+    def test_lock_contention_oserror_retries(self, monkeypatch, tmp_path):
+        """A plain OSError(EAGAIN) is normal LOCK_NB contention, not a hard failure."""
+        daemon, state_file, lock_file, cfg = self._daemon_env(monkeypatch, tmp_path)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _: None)
+        daemon._write_daemon_file(state_file, "http://127.0.0.1:9400", 9400, "tok", 1234)
+        monkeypatch.setattr(daemon, "_check_sync_daemon_health", lambda *a, **kw: True)
+        monkeypatch.setattr(daemon, "_daemon_version_matches", lambda *a, **kw: True)
+
+        attempt = {"n": 0}
+        real_flock = fcntl.flock
+
+        def flaky_flock(fd, op):
+            if op == (fcntl.LOCK_EX | fcntl.LOCK_NB):
+                attempt["n"] += 1
+                if attempt["n"] < 3:
+                    raise OSError(errno.EAGAIN, "locked")
+            return real_flock(fd, op)
+
+        monkeypatch.setattr(daemon.fcntl, "flock", flaky_flock)
+
+        outcome = daemon.ensure_sync_daemon_running(
+            intent=daemon.DaemonIntent.REMOTE_REQUIRED, config=cfg,
+        )
+
+        assert outcome.started is True
+        assert attempt["n"] == 3
+
+    def test_unexpected_lock_oserror_returns_start_failed_without_retry(self, monkeypatch, tmp_path):
+        """Non-contention OSErrors should fail fast instead of sleeping for 10 seconds."""
+        daemon, state_file, lock_file, cfg = self._daemon_env(monkeypatch, tmp_path)
+
+        sleep_calls = []
+        monkeypatch.setattr(daemon.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+        def broken_flock(fd, op):
+            if op == (fcntl.LOCK_EX | fcntl.LOCK_NB):
+                raise OSError(errno.EBADF, "bad file descriptor")
+
+        monkeypatch.setattr(daemon.fcntl, "flock", broken_flock)
+
+        outcome = daemon.ensure_sync_daemon_running(
+            intent=daemon.DaemonIntent.REMOTE_REQUIRED, config=cfg,
+        )
+
+        assert outcome.started is False
+        assert outcome.skipped_reason == "start_failed: [Errno 9] bad file descriptor"
+        assert sleep_calls == []
 
     def test_lock_not_unlocked_when_never_acquired(self, monkeypatch, tmp_path):
         """The finally block must NOT call flock(LOCK_UN) when lock was never acquired."""


### PR DESCRIPTION
Fixes #586.

## Summary

- `src/specify_cli/sync/daemon.py` imported `fcntl` unconditionally at module top. `fcntl` is Unix-only, so on Windows every CLI invocation — including `spec-kitty --help` — crashed with `ModuleNotFoundError: No module named 'fcntl'`. The module is pulled in eagerly through the dashboard command registration chain (`cli/commands/__init__.py` → `dashboard` → `dashboard.handlers.api` → `sync.daemon`), so lazy imports in the CLI command bodies aren't enough to avoid it.
- Guarded the import on `sys.platform == "win32"` and branched the two `fcntl.flock` sites to `msvcrt.locking` on Windows. This mirrors the pattern already in `specify_cli.tracker.credentials` and `specify_cli.runtime.bootstrap`. `msvcrt.LK_NBLCK` gives us the same non-blocking semantics the bounded retry loop at `daemon.py:511` relies on, and we now catch `OSError` alongside `BlockingIOError` so either backend's contention error funnels into the retry path.
- Added `tests/sync/test_issue_586_windows_import.py`, which monkeypatches `sys.platform` to `"win32"` and stubs `msvcrt` so the Windows import branch gets executed on Unix CI. Teardown restores the native module so the existing tests in `test_issue_598_hang_fixes.py` that patch `daemon.fcntl` continue to work.
- Scope is deliberately narrow: this restores CLI usability on Windows. Running the sync daemon end-to-end on Windows (subprocess detachment, signal-based shutdown, `start_new_session=True`) remains out of scope and should be tracked as a follow-up alongside adding a Windows job to `.github/workflows/` so the next regression of this class is caught in CI rather than by users.

## Test plan

- [x] `PYTHONPATH=src pytest tests/sync/` — 1377 passed, 3 skipped locally on macOS (new Windows-simulation test included).
- [x] `PYTHONPATH=src python -m specify_cli --help` — boots cleanly on Unix.
- [x] `PYTHONPATH=src python -c "from specify_cli.sync.daemon import ensure_sync_daemon_running, get_sync_daemon_status"` — public API still exported.
- [ ] Issue reporter (@kleysonr) confirms `spec-kitty --help` and `spec-kitty agent tasks status` no longer raise `ModuleNotFoundError: No module named 'fcntl'` on Windows once a release containing this fix is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)