### PR TITLE
fix: address low-risk sonar findings

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -16,6 +16,14 @@ from kernel.atomic import atomic_write
 
 
 BOOTSTRAP_ACTIONS: frozenset[str] = frozenset({"specify", "plan", "implement", "review"})
+BOOTSTRAP_HEADER = "Charter Context (Bootstrap):"
+BOOTSTRAP_FIRST_LOAD_NOTE = (
+    "  - This is the first load for this action. Use the summary and follow references as needed."
+)
+POLICY_SUMMARY_HEADER = "Policy Summary:"
+NO_POLICY_SUMMARY_NOTE = "  - No explicit policy summary section found in charter.md."
+REFERENCE_DOCS_HEADER = "Reference Docs:"
+NO_REFERENCES_NOTE = "  - No references manifest found."
 
 
 @dataclass(frozen=True)
@@ -278,18 +286,18 @@ def _render_action_scoped(
     content, and renders a structured context block.
     """
     lines: list[str] = [
-        "Charter Context (Bootstrap):",
+        BOOTSTRAP_HEADER,
         f"  - Source: {charter_path}",
-        "  - This is the first load for this action. Use the summary and follow references as needed.",
+        BOOTSTRAP_FIRST_LOAD_NOTE,
         "",
-        "Policy Summary:",
+        POLICY_SUMMARY_HEADER,
     ]
 
     if summary:
         for item in summary[:8]:
             lines.append(f"  - {item}")
     else:
-        lines.append("  - No explicit policy summary section found in charter.md.")
+        lines.append(NO_POLICY_SUMMARY_NOTE)
 
     lines.append("")
 
@@ -298,7 +306,7 @@ def _render_action_scoped(
     lines.append("")
 
     # --- Reference Docs section ---
-    lines.append("Reference Docs:")
+    lines.append(REFERENCE_DOCS_HEADER)
 
     filtered_references = _filter_references_for_action(references, action)
 
@@ -309,7 +317,7 @@ def _render_action_scoped(
             local_path = reference.get("local_path", "")
             lines.append(f"  - {ref_id}: {title} ({local_path})")
     else:
-        lines.append("  - No references manifest found.")
+        lines.append(NO_REFERENCES_NOTE)
 
     return "\n".join(lines)
 
@@ -345,21 +353,21 @@ def _filter_references_for_action(references: list[dict[str, str]], action: str)
 
 def _render_bootstrap(charter_path: Path, summary: list[str], references: list[dict[str, str]]) -> str:
     lines: list[str] = [
-        "Charter Context (Bootstrap):",
+        BOOTSTRAP_HEADER,
         f"  - Source: {charter_path}",
-        "  - This is the first load for this action. Use the summary and follow references as needed.",
+        BOOTSTRAP_FIRST_LOAD_NOTE,
         "",
-        "Policy Summary:",
+        POLICY_SUMMARY_HEADER,
     ]
 
     if summary:
         for item in summary[:8]:
             lines.append(f"  - {item}")
     else:
-        lines.append("  - No explicit policy summary section found in charter.md.")
+        lines.append(NO_POLICY_SUMMARY_NOTE)
 
     lines.append("")
-    lines.append("Reference Docs:")
+    lines.append(REFERENCE_DOCS_HEADER)
     if references:
         for reference in references[:10]:
             ref_id = reference.get("id", "unknown")
@@ -367,7 +375,7 @@ def _render_bootstrap(charter_path: Path, summary: list[str], references: list[d
             local_path = reference.get("local_path", "")
             lines.append(f"  - {ref_id}: {title} ({local_path})")
     else:
-        lines.append("  - No references manifest found.")
+        lines.append(NO_REFERENCES_NOTE)
 
     return "\n".join(lines)
 
@@ -383,6 +391,7 @@ def _render_compact_governance(repo_root: Path) -> str:
     paradigms = ", ".join(resolution.paradigms) if resolution.paradigms else "(none)"
     directives = ", ".join(resolution.directives) if resolution.directives else "(none)"
     tools = ", ".join(resolution.tools) if resolution.tools else "(none)"
+    diagnostics = " | ".join(resolution.diagnostics) if resolution.diagnostics else None
 
     lines = [
         "Governance:",
@@ -391,8 +400,8 @@ def _render_compact_governance(repo_root: Path) -> str:
         f"  - Directives: {directives}",
         f"  - Tools: {tools}",
     ]
-    if resolution.diagnostics:
-        lines.append(f"  - Diagnostics: {' | '.join(resolution.diagnostics)}")
+    if diagnostics:
+        lines.append(f"  - Diagnostics: {diagnostics}")
     return "\n".join(lines)
 
 

--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -70,7 +70,6 @@ def _match_wp_section_id(title: str) -> str | None:
     if remainder and not (remainder[0].isspace() or remainder[0] in "—:-"):
         return None
     return f"WP{int(suffix[:digit_count]):02d}"
-    return None
 
 
 def _split_wp_sections(tasks_content: str) -> dict[str, str]:

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -49,6 +49,15 @@ __all__ = [
 ]
 
 
+def _mission_mid8(key: str, mission_id: str | None) -> str | None:
+    """Return the display short-id for real mission IDs only."""
+    if key.startswith(("legacy:", "orphan:")):
+        return None
+    if mission_id:
+        return mission_id[:8]
+    return None
+
+
 def read_file_resilient(file_path: Path, *, auto_fix: bool = True) -> tuple[str | None, str | None]:
     """Read a file with resilience to encoding errors.
 
@@ -343,8 +352,7 @@ def build_mission_registry(project_dir: Path) -> dict[str, dict[str, Any]]:
         key = _mission_record_key(feature_dir, mission_id, mission_number)
 
         # mid8 is meaningful only when key is an actual mission_id (ULID).
-        is_pseudo = key.startswith(("legacy:", "orphan:"))
-        mid8: str | None = None if is_pseudo else (mission_id[:8] if mission_id else None)
+        mid8 = _mission_mid8(key, mission_id)
 
         registry[key] = {
             "mission_id": key,  # canonical key, may be pseudo

--- a/src/specify_cli/migration/backfill_identity.py
+++ b/src/specify_cli/migration/backfill_identity.py
@@ -188,7 +188,9 @@ def backfill_mission(feature_dir: Path, *, dry_run: bool = False) -> BackfillRes
             reason="mission_id already present",
         )
 
-    action: BackfillAction = "skip" if dry_run and skip_id else "wrote" if not skip_id else "skip"
+    action: BackfillAction = "skip"
+    if not skip_id:
+        action = "wrote"
     # If mission_id was already present but number was coerced, report "wrote"
     if number_coerced and not dry_run:
         action = "wrote"


### PR DESCRIPTION
## Summary
- replace repeated charter bootstrap literals with shared constants in `src/charter/context.py`
- remove one unreachable dependency-parser return and simplify two nested conditional expressions in dashboard/backfill helpers
- confirm there are no currently open GitHub Dependabot or code-scanning alerts for this repo

## Sonar/alerts investigated
- GitHub Dependabot alerts: none open as of 2026-04-14
- GitHub code-scanning alerts: none open as of 2026-04-14
- Previous nightly `CI Quality` run on `main` (run `24327107497`, 2026-04-13 05:23 UTC) failed at the SonarCloud quality gate

## Validation
- `pytest tests/charter/test_context.py tests/charter/test_context_parity.py tests/core/test_dependency_parser.py tests/specify_cli/migration/test_backfill_identity.py tests/cross_cutting/dashboard/test_dashboard_encoding_resilience.py`
- `pytest tests/agent/test_workflow_charter_context.py tests/next/test_prompt_builder_unit.py tests/charter/test_context_v2.py`

## Notes
- `ruff check` on the touched files still reports two pre-existing findings in `src/charter/context.py` (`C901 build_context_v2`, `ARG001 profile`). This PR does not suppress them.
