### PR TITLE
doctrine: add black-box integration testing directive and tactic

### DIFF
--- a/src/doctrine/directives/shipped/036-black-box-integration-testing.directive.yaml
+++ b/src/doctrine/directives/shipped/036-black-box-integration-testing.directive.yaml
@@ -1,0 +1,37 @@
+schema_version: "1.0"
+id: DIRECTIVE_036
+title: Black-Box Integration Testing
+intent: >
+  Exercise the application under test through its external interfaces only,
+  without reference to its internal code structure, implementation details,
+  or internal paths. Test cases derive from specifications, requirements,
+  and design parameters, and assertions are made on observable outputs
+  returned through those external interfaces.
+tactic_refs:
+  - black-box-integration-testing
+enforcement: required
+scope: >
+  Applies to integration tests that validate functional behavior across
+  the external boundary of the application under test — HTTP APIs, message
+  interfaces, command-line entry points, and other published interfaces
+  through which a user or client interacts with the system.
+procedures:
+  - Derive test cases from specifications, requirements, and design parameters rather than from reading the implementation.
+  - Drive the application under test exclusively through its published external interface (e.g., HTTP request, CLI invocation, message send).
+  - Select both valid and invalid inputs and determine the expected output in advance of execution.
+  - Assert on observable outputs returned across the external interface — responses, status codes, persisted records, emitted events, logs, stored artifacts.
+  - Apply standard black-box design techniques where relevant — equivalence partitioning, boundary value analysis, decision table testing, state transition testing, error guessing — to choose inputs.
+integrity_rules:
+  - Tests categorized as black-box integration tests must not import the internal modules of the application under test to invoke business logic directly.
+  - Tests categorized as black-box integration tests must not patch, monkeypatch, or otherwise replace the internal collaborators of the application under test.
+  - Substitution of third-party dependencies outside the application under test is permitted only when the substitute preserves the observable contract the application relies on.
+  - Assertions must target externally observable state, not private attributes or internal call sequences of the application under test.
+validation_criteria:
+  - Each black-box integration test can be read and understood without reference to the internal code structure of the application under test.
+  - Each black-box integration test exercises the application under test through an external interface and asserts on observable outputs of that interface.
+  - Inputs for each test trace back to a specification, requirement, or design parameter rather than to an implementation detail.
+references:
+  - type: directive
+    id: DIRECTIVE_030
+  - type: directive
+    id: DIRECTIVE_034

--- a/src/doctrine/directives/shipped/036-black-box-integration-testing.directive.yaml
+++ b/src/doctrine/directives/shipped/036-black-box-integration-testing.directive.yaml
@@ -2,34 +2,44 @@ schema_version: "1.0"
 id: DIRECTIVE_036
 title: Black-Box Integration Testing
 intent: >
-  Exercise the application under test through its external interfaces only,
+  Exercise the system under test through its external interfaces only,
   without reference to its internal code structure, implementation details,
   or internal paths. Test cases derive from specifications, requirements,
   and design parameters, and assertions are made on observable outputs
-  returned through those external interfaces.
+  returned through those external interfaces. "Black-box" refers to the
+  technique (absence of structural knowledge) and is independent of test
+  scope — the scope is selected separately by responsibility, not by
+  default to end-to-end.
 tactic_refs:
   - black-box-integration-testing
+  - test-boundaries-by-responsibility
 enforcement: required
 scope: >
-  Applies to integration tests that validate functional behavior across
-  the external boundary of the application under test — HTTP APIs, message
-  interfaces, command-line entry points, and other published interfaces
-  through which a user or client interacts with the system.
+  Applies to integration-level tests — tests that exercise more than one
+  collaborator together through an external interface of the system under
+  test. The system under test may be a deployed service, a compose stack,
+  or an in-process composition of a module and its collaborators; the
+  responsibility boundary — not the deployment topology — determines
+  what is inside the system under test for a given test. Unit-level
+  tests and full end-to-end tests are governed by their own directives.
 procedures:
+  - Select the responsibility boundary for the test using the test-boundaries-by-responsibility tactic before writing the test.
   - Derive test cases from specifications, requirements, and design parameters rather than from reading the implementation.
-  - Drive the application under test exclusively through its published external interface (e.g., HTTP request, CLI invocation, message send).
+  - Drive the system under test exclusively through its published external interface (e.g., HTTP request, CLI invocation, message send, public module API).
   - Select both valid and invalid inputs and determine the expected output in advance of execution.
   - Assert on observable outputs returned across the external interface — responses, status codes, persisted records, emitted events, logs, stored artifacts.
   - Apply standard black-box design techniques where relevant — equivalence partitioning, boundary value analysis, decision table testing, state transition testing, error guessing — to choose inputs.
 integrity_rules:
-  - Tests categorized as black-box integration tests must not import the internal modules of the application under test to invoke business logic directly.
-  - Tests categorized as black-box integration tests must not patch, monkeypatch, or otherwise replace the internal collaborators of the application under test.
-  - Substitution of third-party dependencies outside the application under test is permitted only when the substitute preserves the observable contract the application relies on.
-  - Assertions must target externally observable state, not private attributes or internal call sequences of the application under test.
+  - Black-box integration tests must not import inside-boundary modules of the system under test to invoke business logic directly.
+  - Black-box integration tests must not patch, monkeypatch, or otherwise replace inside-boundary collaborators of the system under test.
+  - Substitution of outside-boundary dependencies — other services, third-party systems, filesystem, network, clock — is permitted when the substitute preserves the observable contract the system under test relies on.
+  - Assertions must target externally observable state, not private attributes or internal call sequences of inside-boundary components.
+  - The responsibility boundary used by the test must be stated (in test name, docstring, or supporting doc) so reviewers can judge which components were exercised for real and which were substituted.
 validation_criteria:
-  - Each black-box integration test can be read and understood without reference to the internal code structure of the application under test.
-  - Each black-box integration test exercises the application under test through an external interface and asserts on observable outputs of that interface.
+  - Each black-box integration test can be read and understood without reference to the internal code structure of inside-boundary components.
+  - Each black-box integration test exercises the system under test through an external interface and asserts on observable outputs of that interface.
   - Inputs for each test trace back to a specification, requirement, or design parameter rather than to an implementation detail.
+  - The responsibility boundary applied by the test is identifiable from the test itself.
 references:
   - type: directive
     id: DIRECTIVE_030

--- a/src/doctrine/tactics/shipped/black-box-integration-testing.tactic.yaml
+++ b/src/doctrine/tactics/shipped/black-box-integration-testing.tactic.yaml
@@ -3,20 +3,35 @@ id: black-box-integration-testing
 name: Black-Box Integration Testing
 purpose: >
   Validate the functionality of an application under test without peering
-  into its internal structures or workings, by driving the application
-  through its external interfaces and asserting on observable outputs.
-  Tests are derived from external descriptions of the software —
-  specifications, requirements, and design parameters — rather than from
-  its code.
+  into its internal structures or workings, by driving it through an external
+  interface and asserting on observable outputs. Tests are derived from
+  external descriptions of the software — specifications, requirements, and
+  design parameters — rather than from its code. "Black-box" describes the
+  testing technique (no structural knowledge of the system under test),
+  not the size of the slice under test. Applied here at the integration
+  boundary — exercising more than one collaborator together through a
+  single external interface — but the same discipline also applies at the
+  module, acceptance, and system levels.
 steps:
+  - title: Select the responsibility boundary
+    description: >
+      Before choosing what to run for real and what to substitute, decide
+      which components are directly responsible for the behavior under test
+      and which are outside that responsibility. Use the
+      test-boundaries-by-responsibility tactic to make this selection
+      explicit. The responsibility boundary — not the deployment boundary —
+      defines the "system under test" for this tactic.
+    examples:
+      - "Responsibility: job intake + validation + persistence. Inside: JobService, Validator, JobRepository. Outside: object storage, email delivery, upstream identity provider."
   - title: Anchor the test in a specification
     description: Identify the specification, requirement, or design parameter the test covers. Record it in the test name or docstring so the test can be read without reference to the implementation.
     examples:
       - "Covers REQ-user-registration-3: a POST /users with a duplicate email returns 409."
   - title: Identify the external interface
-    description: Determine the published interface through which the application under test will be driven — HTTP endpoint, CLI command, message topic, or equivalent. All test traffic goes through this interface.
+    description: Determine the published interface through which the system under test will be driven — HTTP endpoint, CLI command, message topic, public module API, or equivalent. All test traffic goes through this interface. The interface is "external" relative to the responsibility boundary selected above; it does not have to be a network boundary.
     examples:
       - "HTTP: POST /api/jobs. Assertions: response status, response body, GET /api/jobs/{id} read-back, emitted event on the job-events topic."
+      - "Module public API: JobService.submit(...) with a stubbed object-storage port. Assertions: returned Job aggregate, persisted row, emitted domain event."
   - title: Select inputs using black-box techniques
     description: >
       Choose valid and invalid inputs using standard black-box design techniques —
@@ -25,12 +40,29 @@ steps:
       code paths. Determine the expected output for each input in advance.
     examples:
       - "Boundary: empty payload, single-item payload, payload at documented size limit, payload one byte over limit."
-  - title: Stand up the application under test at its deployable boundary
-    description: Run the application as it would run for a client — the deployable artifact or compose stack — not an in-process instantiation that bypasses the external interface. Third-party dependencies outside the application may be substituted only where the substitute preserves the observable contract.
+  - title: Stand up the system under test at its responsibility boundary
+    description: >
+      Run the components inside the responsibility boundary together, wired
+      as they would be in production, and drive them through the external
+      interface identified above. At the integration level this is often a
+      deployable artifact or compose stack; at the module level it may be
+      an in-process composition of collaborators behind a public API. The
+      constraint is that the test does not bypass the external interface
+      to call inside-boundary collaborators directly — not that the whole
+      product must be booted.
     examples:
-      - "docker compose up of the service plus its database; no in-process import of the service's request handler."
+      - "docker compose up of the service plus its database when the database is inside the responsibility boundary."
+      - "In-process composition of a domain module plus its in-memory persistence adapter, exercised through the module's public API."
+  - title: Substitute dependencies outside the responsibility boundary
+    description: >
+      Components outside the responsibility boundary — other services,
+      third-party systems, filesystem, network, clock, external APIs —
+      may be substituted with stubs, fakes, or in-memory equivalents,
+      provided the substitute preserves the observable contract the
+      system under test relies on. The goal is to isolate the behavior
+      under test, not to reproduce the full production topology.
   - title: Drive the test through the external interface only
-    description: Issue requests, commands, or messages through the external interface. Do not import internal modules of the application under test to invoke business logic directly, and do not patch or monkeypatch internal collaborators.
+    description: Issue requests, commands, or messages through the external interface of the system under test. Do not import inside-boundary modules to invoke business logic directly, and do not patch or monkeypatch inside-boundary collaborators.
   - title: Assert on observable outputs
     description: Assertions target what a client of the external interface can observe — response payloads and status codes, persisted records readable through the interface, emitted events, logs, or stored artifacts. Do not assert on private attributes or internal call sequences.
     examples:
@@ -38,12 +70,23 @@ steps:
   - title: Cover both happy path and required failure behavior
     description: For each behavior under test, include at least one valid-input case and one invalid-input case where the specification defines failure, refusal, or validation behavior.
 failure_modes:
-  - "Importing internal modules of the application under test to call business logic directly — this is unit-style coverage, not black-box integration coverage."
-  - "Patching or monkeypatching internal collaborators of the application under test, which couples the test to the implementation it is supposed to treat as opaque."
+  - "Equating black-box with full-stack or end-to-end testing, and booting the entire product when a responsibility-scoped slice with stubbed outside-boundary dependencies would validate the behavior faster and more reliably."
+  - "Importing inside-boundary modules of the system under test to call business logic directly — this is unit-style coverage dressed up as integration coverage, not black-box coverage of the slice."
+  - "Patching or monkeypatching inside-boundary collaborators, which couples the test to the implementation it is supposed to treat as opaque."
+  - "Excessive substitution — stubbing components that are actually part of the responsibility boundary, so the test exercises mostly test doubles rather than real behavior."
+  - "Insufficient substitution — refusing to stub obviously outside-boundary systems (third-party APIs, clock, network) and accepting slow, flaky tests as the cost of 'realism'."
   - "Asserting on private attributes or internal call sequences rather than on outputs observable through the external interface."
   - "Deriving inputs from reading the implementation rather than from the specification, which blinds the test to missing functionality and spec drift."
   - "Omitting the invalid-input case, so specified failure or refusal behavior goes unverified."
 references:
+  - name: Test Boundaries by Functional Responsibility
+    type: tactic
+    id: test-boundaries-by-responsibility
+    when: Use this tactic first to select which components are inside vs. outside the responsibility boundary before applying black-box integration testing.
+  - name: Acceptance Test First
+    type: tactic
+    id: acceptance-test-first
+    when: Acceptance tests define the outer behavioral boundary that black-box integration tests can refine at intermediate scopes.
   - name: Test and Typecheck Quality Gate
     type: directive
     id: DIRECTIVE_030
@@ -52,14 +95,14 @@ references:
     type: directive
     id: DIRECTIVE_034
     when: Black-box integration tests can be written first to capture the external contract before implementation.
-  - name: Test Boundaries by Responsibility
-    type: tactic
-    id: test-boundaries-by-responsibility
-    when: Use this tactic to decide which tests belong at the black-box integration boundary versus inside the unit boundary.
 notes: >
   Black-box testing is also referred to as specification-based testing or
   behavioral testing. It is distinguished from white-box testing, in which
-  tests are designed with knowledge of the internal code structure. An
-  advantage of the black-box approach is that tests are executed from the
-  perspective of a user or client of the application under test and remain
-  valid under internal refactoring that preserves the external contract.
+  tests are designed with knowledge of the internal code structure.
+  Black-box techniques are level-agnostic and apply at unit, module,
+  integration, system, and acceptance levels — the technique is the
+  absence of structural knowledge, not a commitment to any particular
+  deployment topology. An advantage of the black-box approach is that
+  tests are executed from the perspective of a client of the system
+  under test and remain valid under internal refactoring that preserves
+  the external contract.

--- a/src/doctrine/tactics/shipped/black-box-integration-testing.tactic.yaml
+++ b/src/doctrine/tactics/shipped/black-box-integration-testing.tactic.yaml
@@ -1,0 +1,65 @@
+schema_version: "1.0"
+id: black-box-integration-testing
+name: Black-Box Integration Testing
+purpose: >
+  Validate the functionality of an application under test without peering
+  into its internal structures or workings, by driving the application
+  through its external interfaces and asserting on observable outputs.
+  Tests are derived from external descriptions of the software —
+  specifications, requirements, and design parameters — rather than from
+  its code.
+steps:
+  - title: Anchor the test in a specification
+    description: Identify the specification, requirement, or design parameter the test covers. Record it in the test name or docstring so the test can be read without reference to the implementation.
+    examples:
+      - "Covers REQ-user-registration-3: a POST /users with a duplicate email returns 409."
+  - title: Identify the external interface
+    description: Determine the published interface through which the application under test will be driven — HTTP endpoint, CLI command, message topic, or equivalent. All test traffic goes through this interface.
+    examples:
+      - "HTTP: POST /api/jobs. Assertions: response status, response body, GET /api/jobs/{id} read-back, emitted event on the job-events topic."
+  - title: Select inputs using black-box techniques
+    description: >
+      Choose valid and invalid inputs using standard black-box design techniques —
+      equivalence partitioning, boundary value analysis, decision table testing,
+      state transition testing, and error guessing — without consulting internal
+      code paths. Determine the expected output for each input in advance.
+    examples:
+      - "Boundary: empty payload, single-item payload, payload at documented size limit, payload one byte over limit."
+  - title: Stand up the application under test at its deployable boundary
+    description: Run the application as it would run for a client — the deployable artifact or compose stack — not an in-process instantiation that bypasses the external interface. Third-party dependencies outside the application may be substituted only where the substitute preserves the observable contract.
+    examples:
+      - "docker compose up of the service plus its database; no in-process import of the service's request handler."
+  - title: Drive the test through the external interface only
+    description: Issue requests, commands, or messages through the external interface. Do not import internal modules of the application under test to invoke business logic directly, and do not patch or monkeypatch internal collaborators.
+  - title: Assert on observable outputs
+    description: Assertions target what a client of the external interface can observe — response payloads and status codes, persisted records readable through the interface, emitted events, logs, or stored artifacts. Do not assert on private attributes or internal call sequences.
+    examples:
+      - "Assert HTTP 201 and a Location header; assert a follow-up GET returns the created resource; assert an event appears on the event stream."
+  - title: Cover both happy path and required failure behavior
+    description: For each behavior under test, include at least one valid-input case and one invalid-input case where the specification defines failure, refusal, or validation behavior.
+failure_modes:
+  - "Importing internal modules of the application under test to call business logic directly — this is unit-style coverage, not black-box integration coverage."
+  - "Patching or monkeypatching internal collaborators of the application under test, which couples the test to the implementation it is supposed to treat as opaque."
+  - "Asserting on private attributes or internal call sequences rather than on outputs observable through the external interface."
+  - "Deriving inputs from reading the implementation rather than from the specification, which blinds the test to missing functionality and spec drift."
+  - "Omitting the invalid-input case, so specified failure or refusal behavior goes unverified."
+references:
+  - name: Test and Typecheck Quality Gate
+    type: directive
+    id: DIRECTIVE_030
+    when: Black-box integration tests are part of the integration-level gate that must pass before handoff.
+  - name: Test-First Development
+    type: directive
+    id: DIRECTIVE_034
+    when: Black-box integration tests can be written first to capture the external contract before implementation.
+  - name: Test Boundaries by Responsibility
+    type: tactic
+    id: test-boundaries-by-responsibility
+    when: Use this tactic to decide which tests belong at the black-box integration boundary versus inside the unit boundary.
+notes: >
+  Black-box testing is also referred to as specification-based testing or
+  behavioral testing. It is distinguished from white-box testing, in which
+  tests are designed with knowledge of the internal code structure. An
+  advantage of the black-box approach is that tests are executed from the
+  perspective of a user or client of the application under test and remain
+  valid under internal refactoring that preserves the external contract.


### PR DESCRIPTION
## Summary
- Adds `DIRECTIVE_036` (Black-Box Integration Testing) and companion tactic `black-box-integration-testing` directly to `shipped/`, using the new direct-to-approved flow.
- Scope and intent language is drawn from standard testing literature ([Wikipedia](https://en.wikipedia.org/wiki/Black-box_testing), [GeeksforGeeks](https://www.geeksforgeeks.org/software-testing/software-engineering-black-box-testing/), [Imperva](https://www.imperva.com/learn/application-security/black-box-testing/)) so the directive stands on the established paradigm rather than on any single project's phrasing.
- Addresses #203 — steers agents toward testing through external interfaces with observable-output assertions instead of unit-style coverage dressed up as integration.

## Test plan
- [x] New YAML files validate against `directive.schema.yaml` and `tactic.schema.yaml`
- [ ] CI doctrine validation passes

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)