### PR TITLE
fix(charter): worktree loader canonical_root + migration worktree skip + restore FR-014 baseline

### DIFF
--- a/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py
+++ b/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Reproducible dashboard typed-contract capture for FR-014 regression.
+
+This script materializes a deterministic fixture project (charter present,
+one mission with three work packages in distinct lanes), invokes the
+dashboard typed-contract surfaces (``scan_all_features``, ``scan_feature_kanban``,
+``get_feature_artifacts``, ``resolve_project_charter_path``), redacts the
+output per R-4 (sort keys, scrub timestamps and non-identity ULIDs, sort
+semantically-unordered arrays), and prints the canonical JSON to stdout.
+
+The redacted JSON is committed under
+``kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json``
+and is the byte-identical anchor for
+``tests/test_dashboard/test_charter_chokepoint_regression.py``.
+
+Usage::
+
+    python kitty-specs/.../baseline/capture.py \
+        > kitty-specs/.../baseline/pre-wp23-dashboard-typed.json
+
+Determinism notes:
+
+* The fixture builds a tmp git repo in a deterministic location under the
+  system tmp directory keyed by a fixed seed (so local re-runs reuse it
+  cleanly).
+* All ``"*_at"`` ISO timestamps in the output are replaced with ``"<ts>"``.
+* ``"event_id"`` ULIDs are identity values for status-event lookups; per R-4,
+  identity ULIDs are kept stable by the fixture using fixed-string event ids
+  (e.g. ``"TESTWP01CLAIMED0000000000"``), so they never need redaction.
+* Any other 26-character ULID-shaped string under a non-identity key gets
+  collapsed to ``"<ulid>"``.
+* ``"path"`` fields containing the absolute fixture root get rewritten to
+  ``"<fixture_root>/..."`` so the JSON is location-independent.
+* Top-level lists that are semantically unordered (``features``,
+  ``kanban[lane]``) are sorted by their ``id`` field for determinism.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# Ensure the in-repo packages take priority over any installed copy.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+
+_TS_KEY_PATTERN = re.compile(r"_at$|^at$|^timestamp_utc$|^extracted_at$|^last_sync$|^updated_at$|^started_at$|^mtime$")
+_ULID_PATTERN = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+# Identity keys whose ULID values must NOT be redacted (they are required
+# to be stable across captures).
+_IDENTITY_ULID_KEYS = frozenset({"event_id", "mission_id"})
+
+
+def _redact(value: Any, key: str | None, fixture_root: str) -> Any:
+    """Apply R-4 redactions recursively.
+
+    * Keys matching ``_TS_KEY_PATTERN`` -> ``"<ts>"``
+    * 26-char ULID-shaped string under a non-identity key -> ``"<ulid>"``
+    * Any string containing the absolute fixture root -> ``<fixture_root>``
+      replacement.
+    """
+    if isinstance(value, dict):
+        # Sort keys deterministically by emitting an ordered dict.
+        return {k: _redact(value[k], k, fixture_root) for k in sorted(value.keys())}
+    if isinstance(value, list):
+        # We cannot blindly sort lists here — semantic ordering matters
+        # for, e.g., `subtasks`. The caller-level normalize_dashboard_payload
+        # explicitly sorts the lists that ARE order-irrelevant.
+        return [_redact(item, None, fixture_root) for item in value]
+    if isinstance(value, str):
+        # Path scrubbing happens before timestamp/ULID checks so paths
+        # never get clobbered.
+        scrubbed = value.replace(fixture_root, "<fixture_root>")
+        if key is not None and _TS_KEY_PATTERN.search(key):
+            return "<ts>"
+        if key is not None and key not in _IDENTITY_ULID_KEYS and _ULID_PATTERN.match(scrubbed):
+            return "<ulid>"
+        # Generic ISO-8601 string redaction for values that look like a
+        # timestamp regardless of key (e.g. when nested inside a meta dict).
+        if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", scrubbed):
+            return "<ts>"
+        return scrubbed
+    if isinstance(value, float):
+        # mtimes / sizes derived from filesystem can drift across runs;
+        # any float at this layer is treated as a timestamp surrogate.
+        return "<ts>"
+    return value
+
+
+def _normalize_dashboard_payload(payload: dict[str, Any], fixture_root: str) -> dict[str, Any]:
+    """R-4 finalization: sort semantically-unordered arrays, then redact."""
+    # Sort the features array by id for determinism (it is sorted by id desc
+    # in scanner.py:544 already, but we re-sort defensively).
+    if "features" in payload and isinstance(payload["features"], list):
+        payload["features"] = sorted(payload["features"], key=lambda f: f.get("id", ""))
+    # Sort each kanban lane by WP id for determinism.
+    if "kanban" in payload and isinstance(payload["kanban"], dict):
+        for lane_key in payload["kanban"]:
+            lane_value = payload["kanban"][lane_key]
+            if isinstance(lane_value, list):
+                payload["kanban"][lane_key] = sorted(lane_value, key=lambda w: w.get("id", ""))
+    redacted = _redact(payload, None, fixture_root)
+    return redacted  # type: ignore[no-any-return]
+
+
+def _build_fixture(root: Path) -> Path:
+    """Build a deterministic project fixture and return its absolute path."""
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True)
+    # Init git so the resolver does not blow up.
+    subprocess.run(["git", "init", "--quiet", str(root)], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.email", "baseline@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.name", "Baseline"],
+        check=True,
+    )
+
+    # Charter (the file presence drives the dashboard charter probe).
+    charter_dir = root / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True)
+    (charter_dir / "charter.md").write_text(
+        "# Project Charter\n\n## Policy Summary\n\n- Be deterministic.\n",
+        encoding="utf-8",
+    )
+
+    # One mission with three WPs in distinct lanes.
+    feature_dir = root / "kitty-specs" / "001-demo-feature"
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+    (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "friendly_name": "Demo Feature",
+                "mission_id": "01HXBASELINEDEMO000000000Z",  # 26-char identity ULID
+                "mission_number": 1,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    wp_template = """---
+work_package_id: {wp_id}
+subtasks: ["T1"]
+agent: codex
+---
+# Work Package Prompt: {wp_id}
+
+Body for {wp_id}.
+"""
+    for wp_id in ("WP01", "WP02", "WP03"):
+        (tasks_dir / f"{wp_id}-demo.md").write_text(
+            wp_template.format(wp_id=wp_id), encoding="utf-8"
+        )
+
+    # Seed status events: WP01 planned, WP02 in_progress, WP03 done.
+    from specify_cli.status.models import Lane, StatusEvent
+    from specify_cli.status.reducer import materialize
+    from specify_cli.status.store import append_event
+
+    transitions = [
+        ("WP01", Lane.PLANNED, Lane.PLANNED, "PLANNED"),
+        ("WP02", Lane.PLANNED, Lane.CLAIMED, "CLAIMED"),
+        ("WP02", Lane.CLAIMED, Lane.IN_PROGRESS, "PROGRESS"),
+        ("WP03", Lane.PLANNED, Lane.CLAIMED, "CLAIMED"),
+        ("WP03", Lane.CLAIMED, Lane.IN_PROGRESS, "PROGRESS"),
+        ("WP03", Lane.IN_PROGRESS, Lane.FOR_REVIEW, "REVIEW"),
+        ("WP03", Lane.FOR_REVIEW, Lane.IN_REVIEW, "INREVIEW"),
+        ("WP03", Lane.IN_REVIEW, Lane.APPROVED, "APPROVED"),
+        ("WP03", Lane.APPROVED, Lane.DONE, "DONE"),
+    ]
+    counter = 0
+    for wp_id, from_lane, to_lane, tag in transitions:
+        # Stable identity ULIDs derived from a counter so re-runs are identical.
+        ulid = f"TESTBASELINE{tag}{wp_id}{counter:04d}"[:26].ljust(26, "0")
+        append_event(
+            feature_dir,
+            StatusEvent(
+                event_id=ulid,
+                mission_slug=feature_dir.name,
+                wp_id=wp_id,
+                from_lane=from_lane,
+                to_lane=to_lane,
+                at="2026-04-14T12:00:00+00:00",
+                actor="baseline",
+                force=True,
+                execution_mode="direct_repo",
+            ),
+        )
+        counter += 1
+    materialize(feature_dir)
+
+    return root
+
+
+def _capture(fixture_root: Path) -> dict[str, Any]:
+    """Invoke the dashboard typed-contract surfaces and return the merged payload."""
+    from specify_cli.dashboard import scanner
+    from specify_cli.dashboard.charter_path import resolve_project_charter_path
+
+    features = scanner.scan_all_features(fixture_root)
+    feature_id = "001-demo-feature"
+    kanban = scanner.scan_feature_kanban(fixture_root, feature_id)
+    feature_dir = fixture_root / "kitty-specs" / feature_id
+    artifacts = scanner.get_feature_artifacts(feature_dir, fixture_root)
+    workflow = scanner.get_workflow_status(artifacts)
+    charter_path = resolve_project_charter_path(fixture_root)
+
+    return {
+        "features": features,
+        "kanban": kanban,
+        "feature_artifacts": artifacts,
+        "workflow_status": workflow,
+        "charter_path_resolved": charter_path is not None,
+    }
+
+
+def main() -> int:
+    fixture_root = Path(tempfile.gettempdir()) / "spec-kitty-wp03-baseline-fixture"
+    fixture_root = _build_fixture(fixture_root).resolve()
+    payload = _capture(fixture_root)
+    normalized = _normalize_dashboard_payload(payload, str(fixture_root))
+    sys.stdout.write(json.dumps(normalized, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json
+++ b/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json
@@ -1,0 +1,203 @@
+{
+  "charter_path_resolved": true,
+  "feature_artifacts": {
+    "charter": {
+      "exists": true,
+      "mtime": "<ts>",
+      "size": 58
+    },
+    "checklists": {
+      "exists": false,
+      "mtime": null,
+      "size": null
+    },
+    "contracts": {
+      "exists": false,
+      "mtime": null,
+      "size": null
+    },
+    "data_model": {
+      "exists": false,
+      "mtime": null,
+      "size": null
+    },
+    "kanban": {
+      "exists": true,
+      "mtime": "<ts>",
+      "size": null
+    },
+    "plan": {
+      "exists": true,
+      "mtime": "<ts>",
+      "size": 7
+    },
+    "quickstart": {
+      "exists": false,
+      "mtime": null,
+      "size": null
+    },
+    "research": {
+      "exists": false,
+      "mtime": null,
+      "size": null
+    },
+    "spec": {
+      "exists": true,
+      "mtime": "<ts>",
+      "size": 7
+    },
+    "tasks": {
+      "exists": true,
+      "mtime": "<ts>",
+      "size": 8
+    }
+  },
+  "features": [
+    {
+      "artifacts": {
+        "charter": {
+          "exists": true,
+          "mtime": "<ts>",
+          "size": 58
+        },
+        "checklists": {
+          "exists": false,
+          "mtime": null,
+          "size": null
+        },
+        "contracts": {
+          "exists": false,
+          "mtime": null,
+          "size": null
+        },
+        "data_model": {
+          "exists": false,
+          "mtime": null,
+          "size": null
+        },
+        "kanban": {
+          "exists": true,
+          "mtime": "<ts>",
+          "size": null
+        },
+        "plan": {
+          "exists": true,
+          "mtime": "<ts>",
+          "size": 7
+        },
+        "quickstart": {
+          "exists": false,
+          "mtime": null,
+          "size": null
+        },
+        "research": {
+          "exists": false,
+          "mtime": null,
+          "size": null
+        },
+        "spec": {
+          "exists": true,
+          "mtime": "<ts>",
+          "size": 7
+        },
+        "tasks": {
+          "exists": true,
+          "mtime": "<ts>",
+          "size": 8
+        }
+      },
+      "display_name": "001 - Demo Feature",
+      "id": "001-demo-feature",
+      "kanban_stats": {
+        "approved": 0,
+        "doing": 1,
+        "done": 0,
+        "for_review": 1,
+        "planned": 1,
+        "total": 3,
+        "weighted_percentage": "<ts>"
+      },
+      "meta": {
+        "friendly_name": "Demo Feature",
+        "mission_id": "01HXBASELINEDEMO000000000Z",
+        "mission_number": 1
+      },
+      "name": "Demo Feature",
+      "path": "kitty-specs/001-demo-feature",
+      "workflow": {
+        "implement": "in_progress",
+        "plan": "complete",
+        "specify": "complete",
+        "tasks": "complete"
+      },
+      "worktree": {
+        "exists": false,
+        "path": "<fixture_root>/.worktrees/001-demo-feature"
+      }
+    }
+  ],
+  "kanban": {
+    "approved": [],
+    "doing": [
+      {
+        "agent": "codex",
+        "agent_profile": "",
+        "assignee": "",
+        "id": "WP02",
+        "lane": "in_progress",
+        "model": "",
+        "phase": "",
+        "prompt_markdown": "# Work Package Prompt: WP02\n\nBody for WP02.",
+        "prompt_path": "kitty-specs/001-demo-feature/tasks/WP02-demo.md",
+        "role": "",
+        "subtasks": [
+          "T1"
+        ],
+        "title": "WP02"
+      }
+    ],
+    "done": [],
+    "for_review": [
+      {
+        "agent": "codex",
+        "agent_profile": "",
+        "assignee": "",
+        "id": "WP03",
+        "lane": "for_review",
+        "model": "",
+        "phase": "",
+        "prompt_markdown": "# Work Package Prompt: WP03\n\nBody for WP03.",
+        "prompt_path": "kitty-specs/001-demo-feature/tasks/WP03-demo.md",
+        "role": "",
+        "subtasks": [
+          "T1"
+        ],
+        "title": "WP03"
+      }
+    ],
+    "planned": [
+      {
+        "agent": "codex",
+        "agent_profile": "",
+        "assignee": "",
+        "id": "WP01",
+        "lane": "planned",
+        "model": "",
+        "phase": "",
+        "prompt_markdown": "# Work Package Prompt: WP01\n\nBody for WP01.",
+        "prompt_path": "kitty-specs/001-demo-feature/tasks/WP01-demo.md",
+        "role": "",
+        "subtasks": [
+          "T1"
+        ],
+        "title": "WP01"
+      }
+    ]
+  },
+  "workflow_status": {
+    "implement": "in_progress",
+    "plan": "complete",
+    "specify": "complete",
+    "tasks": "complete"
+  }
+}

--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -224,6 +224,21 @@ def post_save_hook(charter_path: Path) -> None:
         )
 
 
+def _resolve_bundle_root(repo_root: Path, refresh_result: SyncResult | None) -> Path:
+    """Return the canonical charter-bundle root for loader path construction.
+
+    The chokepoint materializes the bundle under the main-checkout canonical
+    root; loaders called from a worktree must anchor path construction on
+    that same root so the just-materialized derivatives are visible (FR-010).
+    Fall back to ``repo_root`` only when the chokepoint returned ``None``
+    (no ``charter.md`` under the canonical root) — in that case there is
+    nothing to read regardless of which root we use.
+    """
+    if refresh_result is not None and refresh_result.canonical_root is not None:
+        return refresh_result.canonical_root
+    return repo_root
+
+
 def load_governance_config(repo_root: Path) -> GovernanceConfig:
     """Load governance config from .kittify/charter/governance.yaml.
 
@@ -232,16 +247,23 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
 
     Performance: YAML loading only, no AI invocation (FR-4.5).
 
+    The loader routes through ``ensure_charter_bundle_fresh`` and anchors
+    every subsequent path on the returned ``canonical_root``, so worktree
+    callers read the main-checkout bundle that the chokepoint materialized
+    (FR-010). Callers therefore do not need to pre-resolve the canonical
+    root themselves.
+
     Args:
-        repo_root: Repository root directory
+        repo_root: Repository root directory (may be a worktree path).
 
     Returns:
         GovernanceConfig instance (empty if file missing)
     """
-    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    refresh_result = ensure_charter_bundle_fresh(repo_root)
+    bundle_root = _resolve_bundle_root(repo_root, refresh_result)
+    charter_dir = bundle_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
     charter_path = charter_dir / _CHARTER_FILENAME
     governance_path = charter_dir / _GOVERNANCE_FILENAME
-    refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not governance_path.exists():
         if charter_path.exists():
@@ -272,16 +294,22 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
     Falls back to empty DirectivesConfig if file missing.
     Checks staleness and logs warning if stale.
 
+    The loader routes through ``ensure_charter_bundle_fresh`` and anchors
+    every subsequent path on the returned ``canonical_root``, so worktree
+    callers read the main-checkout bundle that the chokepoint materialized
+    (FR-010).
+
     Args:
-        repo_root: Repository root directory
+        repo_root: Repository root directory (may be a worktree path).
 
     Returns:
         DirectivesConfig instance (empty if file missing)
     """
-    charter_dir = repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
+    refresh_result = ensure_charter_bundle_fresh(repo_root)
+    bundle_root = _resolve_bundle_root(repo_root, refresh_result)
+    charter_dir = bundle_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME
     charter_path = charter_dir / _CHARTER_FILENAME
     directives_path = charter_dir / _DIRECTIVES_FILENAME
-    refresh_result = ensure_charter_bundle_fresh(repo_root)
 
     if not directives_path.exists():
         if charter_path.exists():

--- a/src/specify_cli/upgrade/migrations/base.py
+++ b/src/specify_cli/upgrade/migrations/base.py
@@ -41,6 +41,10 @@ class BaseMigration(ABC):
     # If None, detection is used
     min_version: str | None = None
 
+    # Whether the migration should also run inside `.worktrees/*` checkouts
+    # when the upgrade runner is invoked with include_worktrees=True.
+    runs_on_worktrees: bool = True
+
     @abstractmethod
     def detect(self, project_path: Path) -> bool:
         """Detect if this migration is needed based on project state.

--- a/src/specify_cli/upgrade/migrations/m_3_2_3_unified_bundle.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_3_unified_bundle.py
@@ -101,29 +101,39 @@ class UnifiedBundleMigration(BaseMigration):  # type: ignore[misc]  # BaseMigrat
     # ------------------------------------------------------------------
 
     def detect(self, project_path: Path) -> bool:
-        """Return True whenever this migration should run on a 3.2.2 -> 3.2.3 upgrade.
+        """Return True for the main checkout; False for linked worktrees.
 
-        Rationale (review-cycle-1, Finding 1): ``MigrationRunner._apply_migration``
-        hard-skips any migration whose ``detect()`` returns False. The v1.0.0
-        contract says every 3.2.3 upgrade should emit a JSON report — including
-        no-charter, stale-metadata, and already-fresh cases. A narrow
-        "derivatives missing" check silently suppressed three of the four
-        fixture cases. Returning True unconditionally hands control to
-        ``apply()``, which then decides between the four cases (no charter,
-        charter+fresh, charter+stale, charter+missing-derivatives) and sets the
-        report's ``applied`` flag to distinguish refresh from no-op.
+        The migration's contract (see module docstring and §C-011/§C-012)
+        says worktree scanning and mutation are out of scope. The runner's
+        worktree-upgrade loop, however, iterates ``.worktrees/*`` and calls
+        ``detect()`` on each one. Returning True there would record this
+        migration against the worktree's ``.kittify/metadata.yaml`` even
+        though the chokepoint correctly materializes derivatives only at the
+        canonical main-checkout root. The net effect was "applied" metadata
+        on disk inside worktrees that never actually had the migration's
+        work done locally.
 
-        The migration is always safe to invoke (``can_apply`` always True and
-        ``apply`` is idempotent), so always-True here is the canonical semantic
-        for a "terminal-version sealer" migration.
+        A linked worktree has ``.git`` as a regular file that points at the
+        shared common dir (``gitdir: /path/to/main/.git/worktrees/<name>``);
+        the main checkout has ``.git`` as a directory. We detect that
+        distinction here and short-circuit to False for worktrees so the
+        runner records a clean "skipped / Not applicable" (per
+        ``MigrationRunner._upgrade_worktrees``). The main-checkout pass is
+        unchanged: always True, ``apply()`` handles all four fixture cases
+        (no charter, charter+fresh, charter+stale, charter+missing-derivs)
+        and sets ``applied`` accordingly.
 
         Args:
             project_path: Root of the project (.kittify parent).
 
         Returns:
-            Always True — the runner will call ``apply()`` which handles the
-            four cases internally.
+            True iff ``project_path`` is the main checkout (``.git`` is a
+            directory or absent). False for linked worktrees (``.git`` is
+            a file).
         """
+        git_marker = project_path / ".git"
+        if git_marker.is_file():
+            return False
         return True
 
     def can_apply(self, project_path: Path) -> tuple[bool, str]:

--- a/src/specify_cli/upgrade/migrations/m_3_2_3_unified_bundle.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_3_unified_bundle.py
@@ -95,6 +95,7 @@ class UnifiedBundleMigration(BaseMigration):  # type: ignore[misc]  # BaseMigrat
         ".gitignore."
     )
     target_version = TARGET_VERSION
+    runs_on_worktrees = False
 
     # ------------------------------------------------------------------
     # Detection / gating
@@ -104,24 +105,21 @@ class UnifiedBundleMigration(BaseMigration):  # type: ignore[misc]  # BaseMigrat
         """Return True for the main checkout; False for linked worktrees.
 
         The migration's contract (see module docstring and §C-011/§C-012)
-        says worktree scanning and mutation are out of scope. The runner's
-        worktree-upgrade loop, however, iterates ``.worktrees/*`` and calls
-        ``detect()`` on each one. Returning True there would record this
-        migration against the worktree's ``.kittify/metadata.yaml`` even
-        though the chokepoint correctly materializes derivatives only at the
-        canonical main-checkout root. The net effect was "applied" metadata
-        on disk inside worktrees that never actually had the migration's
-        work done locally.
+        says worktree scanning and mutation are out of scope. The upgrade
+        runner now honors ``runs_on_worktrees = False`` and skips this
+        migration entirely for `.worktrees/*` checkouts; this method keeps
+        the same policy as a direct-call guardrail. Returning True on a
+        linked worktree would wrongly treat that worktree as an upgrade
+        target even though the chokepoint materializes derivatives only at
+        the canonical main-checkout root.
 
         A linked worktree has ``.git`` as a regular file that points at the
         shared common dir (``gitdir: /path/to/main/.git/worktrees/<name>``);
         the main checkout has ``.git`` as a directory. We detect that
-        distinction here and short-circuit to False for worktrees so the
-        runner records a clean "skipped / Not applicable" (per
-        ``MigrationRunner._upgrade_worktrees``). The main-checkout pass is
-        unchanged: always True, ``apply()`` handles all four fixture cases
-        (no charter, charter+fresh, charter+stale, charter+missing-derivs)
-        and sets ``applied`` accordingly.
+        distinction here and short-circuit to False for worktrees. The main-
+        checkout pass is unchanged: always True, ``apply()`` handles all
+        four fixture cases (no charter, charter+fresh, charter+stale,
+        charter+missing-derivs) and sets ``applied`` accordingly.
 
         Args:
             project_path: Root of the project (.kittify parent).

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -261,6 +261,10 @@ class MigrationRunner:
             Dict with warnings and errors lists
         """
         result: dict[str, Any] = {"warnings": [], "errors": []}
+        worktree_migrations = [migration for migration in migrations if migration.runs_on_worktrees]
+
+        if not worktree_migrations:
+            return result
 
         worktrees_dir = self.project_path / WORKTREES_DIR
         if not worktrees_dir.exists():
@@ -284,7 +288,7 @@ class MigrationRunner:
                 wt_metadata = self._create_initial_metadata(wt_version)
 
             # Apply migrations to worktree
-            for migration in migrations:
+            for migration in worktree_migrations:
                 if wt_metadata.has_migration(migration.migration_id):
                     continue
 
@@ -329,7 +333,8 @@ class MigrationRunner:
                         )
                     result["errors"].extend([f"Worktree {worktree.name}: {e}" for e in migration_result.errors])
 
-            # Save worktree metadata
+            # Save worktree metadata only when at least one migration in this
+            # upgrade target is allowed to touch worktrees.
             if not dry_run:
                 wt_metadata.version = target_version
                 wt_metadata.last_upgraded_at = datetime.now()

--- a/tests/charter/test_worktree_charter_via_canonical_root.py
+++ b/tests/charter/test_worktree_charter_via_canonical_root.py
@@ -208,3 +208,53 @@ def test_worktree_bundle_never_materializes_locally(tmp_path: Path) -> None:
             assert not local.exists(), (
                 f"Worktree leak: {local} should not exist — canonical root writes only"
             )
+
+
+def test_loaders_from_worktree_return_canonical_content(tmp_path: Path) -> None:
+    """FR-010 content transparency: ``load_governance_config`` and
+    ``load_directives_config`` invoked from a worktree return the SAME
+    content as when invoked from the main checkout.
+
+    Regression guard for a post-merge reviewer finding where the loaders
+    called the chokepoint but then rebuilt paths from the caller's
+    ``repo_root`` rather than from the ``SyncResult.canonical_root``.
+    The chokepoint materialized the bundle in the main checkout, but the
+    loader then checked ``worktree/.kittify/charter/governance.yaml``,
+    found nothing, logged ``governance.yaml unavailable after charter
+    auto-sync``, and returned an empty ``GovernanceConfig()``. Worktree
+    readers therefore saw an empty charter even though the chokepoint
+    itself was correct.
+    """
+    from charter.sync import load_directives_config, load_governance_config
+
+    main_root = _init_main_checkout(tmp_path / "main").resolve()
+    worktree_root = _add_linked_worktree(
+        main_root,
+        (tmp_path / "worktree-loaders").resolve(),
+        "feature/worktree-loaders",
+    ).resolve()
+    _clear_resolver_cache()
+
+    # Populate the bundle from the main checkout first so we have a
+    # known-good reference to compare against.
+    gov_main = load_governance_config(main_root)
+    dir_main = load_directives_config(main_root)
+
+    _clear_resolver_cache()
+
+    # Invoke the loaders from the WORKTREE path. The chokepoint maps back
+    # to main and the loaders must anchor subsequent path construction on
+    # the canonical root, not on ``worktree_root``.
+    gov_worktree = load_governance_config(worktree_root)
+    dir_worktree = load_directives_config(worktree_root)
+
+    # Both configs must round-trip identically. An empty config would
+    # indicate the loader read the wrong tree.
+    assert gov_worktree.model_dump() == gov_main.model_dump(), (
+        "load_governance_config(worktree) does not match load_governance_config(main); "
+        "the loader is not consuming SyncResult.canonical_root."
+    )
+    assert dir_worktree.model_dump() == dir_main.model_dump(), (
+        "load_directives_config(worktree) does not match load_directives_config(main); "
+        "the loader is not consuming SyncResult.canonical_root."
+    )

--- a/tests/upgrade/test_unified_bundle_migration.py
+++ b/tests/upgrade/test_unified_bundle_migration.py
@@ -617,3 +617,78 @@ def test_upgrade_runner_invokes_migration_on_stale_metadata(
     assert report["charter_present"] is True
     assert report["chokepoint_refreshed"] is True
     assert report["applied"] is True
+
+
+# ---------------------------------------------------------------------------
+# Post-merge reviewer regression: worktree-skip semantics (P2)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_false_inside_linked_worktree(tmp_path: Path) -> None:
+    """``detect()`` must return False for a linked worktree so the runner
+    records a clean ``skipped`` there instead of marking the migration as
+    applied in the worktree's own ``.kittify/metadata.yaml``.
+
+    Regression guard for a post-merge reviewer finding: the runner's
+    ``_upgrade_worktrees`` loop iterates ``.worktrees/*`` on the default
+    upgrade path. Before this fix ``detect()`` returned True
+    unconditionally, so the runner recorded ``m_3_2_3_unified_bundle`` as
+    applied inside every worktree even though the chokepoint correctly
+    materializes derivatives only at the canonical main-checkout root.
+    That violates the migration's "NO worktree scanning, NO worktree
+    mutation" contract (§C-011 / §C-012).
+    """
+    from specify_cli.upgrade.migrations.m_3_2_3_unified_bundle import (
+        UnifiedBundleMigration,
+    )
+
+    main_root = tmp_path / "main"
+    main_root.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch=main", str(main_root)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(main_root), "config", "user.email", "t@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(main_root), "config", "user.name", "T"],
+        check=True,
+    )
+    (main_root / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(main_root), "add", "seed.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(main_root), "commit", "-q", "-m", "seed"],
+        check=True,
+    )
+
+    worktree = tmp_path / "worktree-skip"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(main_root),
+            "worktree",
+            "add",
+            "-b",
+            "feature/worktree-skip",
+            str(worktree),
+        ],
+        check=True,
+    )
+
+    # In a linked worktree, ``.git`` is a FILE pointing at the shared
+    # common dir. In the main checkout, ``.git`` is a directory. The
+    # migration's detect() uses that distinction.
+    assert (worktree / ".git").is_file()
+    assert (main_root / ".git").is_dir()
+
+    migration = UnifiedBundleMigration()
+    assert migration.detect(main_root) is True, (
+        "detect(main_checkout) must be True so the migration runs on 3.2.3 upgrades"
+    )
+    assert migration.detect(worktree) is False, (
+        "detect(linked_worktree) must be False so the runner's worktree loop "
+        "skips the migration (no worktree scanning / mutation per §C-011/§C-012)"
+    )

--- a/tests/upgrade/test_unified_bundle_migration.py
+++ b/tests/upgrade/test_unified_bundle_migration.py
@@ -692,3 +692,55 @@ def test_detect_returns_false_inside_linked_worktree(tmp_path: Path) -> None:
         "detect(linked_worktree) must be False so the runner's worktree loop "
         "skips the migration (no worktree scanning / mutation per §C-011/§C-012)"
     )
+
+
+def test_runner_include_worktrees_does_not_mutate_worktree_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The live runner must skip this migration entirely for `.worktrees/*`.
+
+    `detect(False)` alone is insufficient if the runner still records a
+    "skipped / Not applicable" migration or bumps the worktree metadata
+    version. Phase 2's contract is stricter: no worktree scanning and no
+    worktree mutation for `m_3_2_3_unified_bundle` on the default upgrade
+    path.
+    """
+    from specify_cli.upgrade.runner import MigrationRunner
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    _make_322_project(project)
+
+    worktree = project / ".worktrees" / "001-demo-lane-a"
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "worktree",
+            "add",
+            "-b",
+            "feature/001-demo-lane-a",
+            str(worktree),
+        ],
+        check=True,
+    )
+
+    wt_kittify = worktree / ".kittify"
+    wt_kittify.mkdir(parents=True, exist_ok=True)
+    wt_metadata = wt_kittify / "metadata.yaml"
+    wt_metadata.write_text(_METADATA_YAML_3_2_2, encoding="utf-8")
+    before = wt_metadata.read_text("utf-8")
+
+    monkeypatch.chdir(project)
+    _clear_resolver_cache()
+
+    runner = MigrationRunner(project)
+    result = runner.upgrade("3.2.3", include_worktrees=True, force=True)
+
+    assert result.success is True, result.errors
+    assert wt_metadata.read_text("utf-8") == before, (
+        "worktree metadata changed even though "
+        "m_3_2_3_unified_bundle is out of scope for worktree upgrades"
+    )


### PR DESCRIPTION
## Summary

Post-merge follow-up for the `unified-charter-bundle-chokepoint-01KP5Q2G` mission (squash `33e33e7a`). Addresses two reviewer-reported defects and one mission-review finding.

**P1 — Worktree loaders read the wrong tree (FR-010 regression).** `load_governance_config()` / `load_directives_config()` in `src/charter/sync.py` called the chokepoint correctly, then discarded `SyncResult.canonical_root` and rebuilt path construction from the caller's `repo_root`. Worktree callers therefore hit empty configs — the chokepoint materialized the bundle at the main checkout, but the loader read from the worktree. Every reader that flows through `resolve_governance()` or `_render_compact_governance(repo_root)` (which is every non-bootstrap action and every post-first-load compact call in `build_charter_context()`) was silently degraded. Fix: factor a `_resolve_bundle_root()` helper and anchor all path construction on `SyncResult.canonical_root`.

**P2 — `spec-kitty upgrade` scanned and mutated worktrees by default.** The migration's `detect()` returned True unconditionally, so the runner's `_upgrade_worktrees` loop recorded `m_3_2_3_unified_bundle` as *applied* in every worktree's `.kittify/metadata.yaml` — violating the migration's own contract ("NO worktree scanning, NO worktree mutation" per §C-011 / §C-012). Fix: `detect()` now returns False when `project_path/.git` is a regular file (the linked-worktree marker); the main checkout (where `.git` is a directory) still gets True.

**DRIFT-001 — FR-014 dashboard regression test was broken.** The squash merge silently dropped `kitty-specs/.../baseline/capture.py` (243 LOC) and `baseline/pre-wp23-dashboard-typed.json` (203 LOC), both created pre-rewire by feature-branch commit `0a7d4b19`. `tests/test_dashboard/test_charter_chokepoint_regression.py` references them by hardcoded path and was erroring on `FileNotFoundError` instead of enforcing byte-identity. Restored verbatim from `0a7d4b19`.

Both P1 and P2 come with dedicated regression tests — content-transparency for the loaders (`test_loaders_from_worktree_return_canonical_content`), `detect()` worktree-vs-main distinction for the migration (`test_detect_returns_false_inside_linked_worktree`).

## Note on diff size

Local `main` is 50 commits ahead of `origin/main` — the mission squash merge (`33e33e7a`) and its post-merge chore (`6363bbea`) haven't been pushed yet. GitHub will display this PR as 51 commits until `main` is pushed. After `git push origin main` the delta collapses to a single commit. Consider pushing `main` before merging this so CI runs against the right base.

## Test plan

- [x] `pytest tests/charter/` — 279 passed, 1 skipped
- [x] `pytest tests/upgrade/` — 428 passed
- [x] `pytest tests/charter/test_worktree_charter_via_canonical_root.py::test_loaders_from_worktree_return_canonical_content` — passes (was reproducing the bug pre-fix)
- [x] `pytest tests/upgrade/test_unified_bundle_migration.py::test_detect_returns_false_inside_linked_worktree` — passes
- [x] `pytest tests/test_dashboard/test_charter_chokepoint_regression.py` — passes (was erroring pre-restore)
- [ ] Verify no downstream agent workflow regressions (`spec-kitty next --agent` inside a worktree returns populated governance context)
- [ ] Verify `spec-kitty upgrade` against a project with worktrees leaves worktree `.kittify/metadata.yaml` untouched on the default path

🤖 Generated with [Claude Code](https://claude.com/claude-code)