### PR TITLE
Release 3.1.3

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.1.2
+  version: 3.1.3
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-09T16:23:40.925198'
 environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.3] - 2026-04-15
+
+### Fixed
+
+- Make `/spec-kitty.charter` use an LLM-led interview by default, with better
+  repo-scan guidance for greenfield/bootstrap repos, explicit doctrine-gap
+  handling, natural-language questioning, depth scaling, and commit-after-generate
+  behavior.
+- Preserve explicit empty `selected_paradigms`, `selected_directives`, and
+  `available_tools` during charter compilation instead of broadening them to
+  packaged defaults.
+
+### Docs
+
+- Add ADR recording that explicit empty charter selections must remain empty and
+  must not silently expand to shipped defaults.
+
 ## [3.1.2] - 2026-04-15
 
 ### Fixed — CI recovery & release readiness

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ graph LR
 
 </div>
 
-**Current stable release line:** `v3.1.x` (development version 3.1.2a2; `main`, GitHub Releases, and PyPI)
+**Current stable release line:** `v3.1.x` (current release 3.1.3 on `main`, GitHub Releases, and PyPI)
 
 **3.1.0 highlights:**
 - **Planning integrity** — read-only status commands no longer dirty the git tree; `spec-kitty next` without `--result` is a safe query-only operation

--- a/architecture/2.x/adr/2026-04-15-2-explicit-empty-charter-selections-remain-empty.md
+++ b/architecture/2.x/adr/2026-04-15-2-explicit-empty-charter-selections-remain-empty.md
@@ -1,0 +1,78 @@
+# ADR 2026-04-15-2: Explicit Empty Charter Selections Remain Empty
+
+- Status: Accepted
+- Date: 2026-04-15
+- Decision Makers: Spec Kitty maintainers
+- Supersedes: None
+- Related: `/spec-kitty.charter`, charter interview/generation flow, doctrine selection
+
+## Context
+
+`spec-kitty charter generate` compiles a project charter from
+`.kittify/charter/interview/answers.yaml`.
+
+That interview schema includes explicit selection lists for:
+
+- `selected_paradigms`
+- `selected_directives`
+- `available_tools`
+
+During emergency hardening of the charter flow, it became clear that the
+compiler treated explicit empty selections as "apply all shipped defaults".
+That behavior is wrong.
+
+If the interview or the agent leaves one of these lists empty, that means one of
+two things:
+
+1. no shipped doctrine/tooling cleanly fits the user's needs yet, or
+2. the user deliberately does not want shipped doctrine/tooling imposed.
+
+Broadening an explicit empty list into the full catalog force-feeds doctrine
+that the user did not ask for, misrepresents the interview outcome, and makes
+the generated charter less truthful than the source answers.
+
+## Decision
+
+Explicit empty charter selections remain empty.
+
+Specifically:
+
+- `selected_paradigms: []` stays `[]`
+- `selected_directives: []` stays `[]`
+- `available_tools: []` stays `[]`
+
+The compiler must not silently expand an explicit empty selection into mission
+defaults or the full packaged catalog.
+
+Defaults remain valid only when the user explicitly asks for defaults or when a
+bootstrap path generates non-empty default interview data before compilation.
+
+## Consequences
+
+### Positive
+
+- The generated charter reflects the interview truthfully.
+- Users are not force-fed shipped doctrine they did not ask for.
+- Doctrine gaps can be represented honestly as project-specific charter policy.
+- `/spec-kitty.charter` can safely say "do not force a near-match" and the
+  compiler will honor it.
+
+### Negative
+
+- Some generated charters will be intentionally sparse until doctrine is added
+  or the user chooses concrete shipped selections.
+- Existing assumptions that "empty means defaults" must not be reintroduced in
+  future compiler or CLI refactors.
+
+## Rules Going Forward
+
+1. Treat empty lists as an intentional state, not missing data.
+2. If defaults are desired, they must be made explicit before compilation.
+3. Any future charter compiler rewrite must preserve this invariant.
+4. Reviewers should reject changes that broaden explicit empty selections.
+
+## Implementation Notes
+
+The invariant is enforced in the charter compiler sanitization path and covered
+by regression tests asserting that compiled selections and rendered charter
+output preserve empty lists exactly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.1.2"
+version = "3.1.3"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/charter/compiler.py
+++ b/src/charter/compiler.py
@@ -99,21 +99,18 @@ def compile_charter(
     selected_paradigms = _sanitize_catalog_selection(
         values=interview.selected_paradigms,
         allowed=set(catalog.paradigms),
-        default=sorted(catalog.paradigms),
         label="selected_paradigms",
         diagnostics=diagnostics,
     )
     selected_directives = _sanitize_catalog_selection(
         values=interview.selected_directives,
         allowed=set(catalog.directives),
-        default=sorted(catalog.directives),
         label="selected_directives",
         diagnostics=diagnostics,
     )
     available_tools = _sanitize_catalog_selection(
         values=interview.available_tools,
         allowed=set(DEFAULT_TOOL_REGISTRY),
-        default=sorted(DEFAULT_TOOL_REGISTRY),
         label="available_tools",
         diagnostics=diagnostics,
     )
@@ -222,7 +219,6 @@ def _sanitize_catalog_selection(
     *,
     values: list[str],
     allowed: set[str],
-    default: list[str],
     label: str,
     diagnostics: list[str],
 ) -> list[str]:
@@ -248,7 +244,10 @@ def _sanitize_catalog_selection(
     if seen:
         return seen
 
-    return list(default)
+    # Explicitly empty selections remain empty. We do not broaden charter
+    # doctrine or tool choices just because the interview provided no shipped
+    # match.
+    return []
 
 
 def _default_doctrine_service(repo_root: Path | None) -> DoctrineService:

--- a/src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md
@@ -374,16 +374,29 @@ and per-file sizes. If `stale`, run sync before relying on governance config.
 
 ## Step 2: Run the Charter Interview
 
-**Fast path (deterministic defaults):**
+For agent-mediated governance setup, the preferred interview surface is the chat
+itself, not the CLI questionnaire.
+
+Recommended flow:
+
+1. Inspect the repo quickly.
+2. Ask the user a short targeted governance interview in chat.
+3. Synthesize `.kittify/charter/interview/answers.yaml` directly.
+4. Run `spec-kitty charter generate --from-interview --json`.
+
+Use the CLI interview only as a fallback when the user explicitly wants the CLI
+prompt loop or wants deterministic defaults.
+
+**CLI defaults path (fallback only):**
 
 ```bash
-spec-kitty charter interview --mission software-dev --profile minimal --defaults --json
+spec-kitty charter interview --mission-type software-dev --profile minimal --defaults --json
 ```
 
-**Full interactive interview:**
+**CLI comprehensive path (fallback only):**
 
 ```bash
-spec-kitty charter interview --mission software-dev --profile comprehensive
+spec-kitty charter interview --mission-type software-dev --profile comprehensive
 ```
 
 Key flags: `--profile minimal|comprehensive`, `--defaults`, `--json`,
@@ -412,17 +425,17 @@ and `library/*.md` reference documents.
 
 ## Step 4: Load Context for Workflow Actions
 
-Load governance context before each workflow action:
-
-```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
-```
+Do not preload all action contexts after generation.
 
 The runtime calls context automatically during slash commands. Manual
-invocation is useful for debugging what governance policy an action receives.
+invocation is useful only for debugging one immediate action, and should avoid
+consuming first-load state:
+
+```bash
+spec-kitty charter context --action specify --json --no-mark-loaded
+```
+
+Load context iteratively at the action boundary, not as part of charter setup.
 
 ---
 

--- a/src/doctrine/skills/spec-kitty-charter-doctrine/references/charter-command-map.md
+++ b/src/doctrine/skills/spec-kitty-charter-doctrine/references/charter-command-map.md
@@ -200,17 +200,20 @@ spec-kitty charter status [--json]
 
 ## Common Workflows
 
-**Bootstrap a new project:**
+**Bootstrap a new project with deterministic defaults:**
 
 ```bash
-spec-kitty charter interview --mission software-dev --profile minimal --defaults --json
+spec-kitty charter interview --mission-type software-dev --profile minimal --defaults --json
 spec-kitty charter generate --from-interview --json
 ```
 
-**Full interactive setup:**
+This is a CLI fallback. For agent-mediated `/spec-kitty.charter`, prefer a chat
+interview and write `answers.yaml` directly before generation.
+
+**Full interactive CLI setup:**
 
 ```bash
-spec-kitty charter interview --mission software-dev --profile comprehensive
+spec-kitty charter interview --mission-type software-dev --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
@@ -221,10 +224,10 @@ spec-kitty charter sync --json
 spec-kitty charter status --json
 ```
 
-**Verify governance before a workflow action:**
+**Inspect governance for one workflow action (debugging only):**
 
 ```bash
-spec-kitty charter context --action implement --json
+spec-kitty charter context --action implement --json --no-mark-loaded
 ```
 
 **Force regeneration:**
@@ -232,3 +235,7 @@ spec-kitty charter context --action implement --json
 ```bash
 spec-kitty charter generate --from-interview --force --json
 ```
+
+Do not chain all four action-context calls after generation. That dumps large
+bootstrap payloads into the agent context and consumes first-load state before
+the real workflow reaches those actions.

--- a/src/specify_cli/charter/compiler.py
+++ b/src/specify_cli/charter/compiler.py
@@ -70,21 +70,18 @@ def compile_charter(
     selected_paradigms = _sanitize_catalog_selection(
         values=interview.selected_paradigms,
         allowed=set(catalog.paradigms),
-        default=sorted(catalog.paradigms),
         label="selected_paradigms",
         diagnostics=diagnostics,
     )
     selected_directives = _sanitize_catalog_selection(
         values=interview.selected_directives,
         allowed=set(catalog.directives),
-        default=sorted(catalog.directives),
         label="selected_directives",
         diagnostics=diagnostics,
     )
     available_tools = _sanitize_catalog_selection(
         values=interview.available_tools,
         allowed=set(DEFAULT_TOOL_REGISTRY),
-        default=sorted(DEFAULT_TOOL_REGISTRY),
         label="available_tools",
         diagnostics=diagnostics,
     )
@@ -188,7 +185,6 @@ def _sanitize_catalog_selection(
     *,
     values: list[str],
     allowed: set[str],
-    default: list[str],
     label: str,
     diagnostics: list[str],
 ) -> list[str]:
@@ -214,7 +210,7 @@ def _sanitize_catalog_selection(
     if seen:
         return seen
 
-    return list(default)
+    return []
 
 
 def _build_references(

--- a/src/specify_cli/missions/software-dev/command-templates/charter.md
+++ b/src/specify_cli/missions/software-dev/command-templates/charter.md
@@ -11,11 +11,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -26,27 +87,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -58,15 +210,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/charter/test_compiler.py
+++ b/tests/charter/test_compiler.py
@@ -36,6 +36,25 @@ def test_compile_charter_contains_governance_activation_block() -> None:
     assert len(compiled.references) >= 2
 
 
+def test_compile_charter_preserves_explicit_empty_selections() -> None:
+    interview = default_interview(mission="software-dev", profile="minimal")
+    interview = apply_answer_overrides(
+        interview,
+        selected_paradigms=[],
+        selected_directives=[],
+        available_tools=[],
+    )
+
+    compiled = compile_charter(mission="software-dev", interview=interview)
+
+    assert compiled.selected_paradigms == []
+    assert compiled.selected_directives == []
+    assert compiled.available_tools == []
+    assert "selected_paradigms: []" in compiled.markdown
+    assert "selected_directives: []" in compiled.markdown
+    assert "available_tools: []" in compiled.markdown
+
+
 def test_compile_charter_renders_agent_profile_metadata_when_present() -> None:
     interview = default_interview(mission="software-dev", profile="minimal")
     interview = apply_answer_overrides(interview, agent_profile="reviewer", agent_role="reviewer")


### PR DESCRIPTION
## Summary
- fix `/spec-kitty.charter` to use an LLM-led interview by default
- preserve explicit empty charter selections instead of broadening them to defaults
- bump release metadata and add the ADR documenting the empty-selection invariant

## Validation
- python3 -m pytest -q tests/charter/test_compiler.py
- python3 -m pytest -q tests/upgrade/test_migration_robustness.py::TestMigrationRegistryCompleteness -v
- python3 scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- python3 -m build
- twine check dist/*
- ruff check --ignore C901 src/specify_cli/missions/software-dev/command-templates/charter.md src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md src/doctrine/skills/spec-kitty-charter-doctrine/references/charter-command-map.md src/charter/compiler.py src/specify_cli/charter/compiler.py tests/charter/test_compiler.py README.md

## Notes
- `C901` on `src/charter/compiler.py::_build_references_from_service` is pre-existing release debt; this branch does not increase its complexity.
