### PR TITLE
Release 3.1.4

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.1.3
+  version: 3.1.4
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-09T16:23:40.925198'
 environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.4] - 2026-04-15
+
+### Fixed
+
+- Make `/spec-kitty.plan` stop instructing agents to update imaginary
+  agent-specific context files or hunt for non-existent `agent context update`
+  commands. Planning now stays focused on the actual mission artifacts it owns.
+- Clarify `/spec-kitty.specify` mission-handle timing and non-blocking charter
+  behavior so creation-time flows do not assume a mission already exists or stop
+  on missing charter state.
+- Tighten generated `/spec-kitty.implement`, `/spec-kitty.review`, and
+  `/spec-kitty.merge` wrappers so they use the canonical `--mission <handle>`
+  language and explicitly avoid redundant context rediscovery, including
+  separate charter loads.
+
 ## [3.1.3] - 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ graph LR
 
 </div>
 
-**Current stable release line:** `v3.1.x` (current release 3.1.3 on `main`, GitHub Releases, and PyPI)
+**Current stable release line:** `v3.1.x` (current release 3.1.4 on `main`, GitHub Releases, and PyPI)
 
 **3.1.0 highlights:**
 - **Planning integrity** — read-only status commands no longer dirty the git tree; `spec-kitty next` without `--result` is a safe query-only operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.1.3"
+version = "3.1.4"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -36,11 +36,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/src/specify_cli/missions/software-dev/command-templates/plan.md
+++ b/src/specify_cli/missions/software-dev/command-templates/plan.md
@@ -22,7 +22,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -65,6 +75,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -155,7 +181,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -200,14 +225,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -225,7 +243,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/src/specify_cli/missions/software-dev/command-templates/review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/review.md
@@ -36,11 +36,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -23,7 +23,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -75,6 +86,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/src/specify_cli/shims/generator.py
+++ b/src/specify_cli/shims/generator.py
@@ -125,8 +125,8 @@ def generate_shim_content(command: str, agent_name: str, arg_placeholder: str) -
         "---\n"
         f"<!-- spec-kitty-command-version: {version} -->\n"
         "Run this exact command and treat its output as authoritative.\n"
-        "Do not rediscover context from branches, files, or prompt contents.\n"
-        "In repos with multiple missions, pass --mission <slug> in your arguments.\n"
+        "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
+        "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"
         "\n"
         f"`{cli_call}`\n"
     )

--- a/tests/runtime/test_doctor_command_file_health.py
+++ b/tests/runtime/test_doctor_command_file_health.py
@@ -64,9 +64,9 @@ def _write_full_consumer_file_set(
 
 
 def _current_marker() -> str:
-    from importlib.metadata import version
+    from specify_cli.shims.generator import _get_cli_version
 
-    return f"<!-- spec-kitty-command-version: {version('spec-kitty-cli')} -->"
+    return f"<!-- spec-kitty-command-version: {_get_cli_version()} -->"
 
 
 def _new_layout_shim() -> str:
@@ -77,8 +77,8 @@ def _new_layout_shim() -> str:
         "---\n"
         f"{_current_marker()}\n"
         "Run this exact command and treat its output as authoritative.\n"
-        "Do not rediscover context from branches, files, or prompt contents.\n"
-        "In repos with multiple missions, pass --mission <slug> in your arguments.\n"
+        "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
+        "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"
         "\n"
         "`spec-kitty agent action implement $ARGUMENTS --agent claude`\n"
     )
@@ -89,8 +89,8 @@ def _legacy_layout_shim() -> str:
     return (
         f"{_current_marker()}\n"
         "Run this exact command and treat its output as authoritative.\n"
-        "Do not rediscover context from branches, files, or prompt contents.\n"
-        "In repos with multiple missions, pass --mission <slug> in your arguments.\n"
+        "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
+        "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"
         "\n"
         "`spec-kitty agent action implement $ARGUMENTS --agent claude`\n"
     )
@@ -159,8 +159,8 @@ def test_stale_marker_emits_warning(tmp_path: Path) -> None:
             "---\n"
             f"{stale}\n"
             "Run this exact command and treat its output as authoritative.\n"
-            "Do not rediscover context from branches, files, or prompt contents.\n"
-            "In repos with multiple missions, pass --mission <slug> in your arguments.\n"
+            "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
+            "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"
             "\n"
             "`spec-kitty agent action implement $ARGUMENTS --agent claude`\n"
         )

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/charter.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/charter.prompt.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/implement.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/implement.prompt.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/plan.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/plan.prompt.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/review.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/review.prompt.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/charter.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/charter.toml
@@ -12,11 +12,72 @@ prompt = """
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -27,27 +88,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -59,16 +211,55 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.
 """

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/implement.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/implement.toml
@@ -37,11 +37,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/plan.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/plan.toml
@@ -23,7 +23,17 @@ prompt = """
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -66,6 +76,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -156,7 +182,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -201,14 +226,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -226,7 +244,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/review.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/review.toml
@@ -37,11 +37,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -24,7 +24,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -76,6 +87,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/charter.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/charter.toml
@@ -12,11 +12,72 @@ prompt = """
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -27,27 +88,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -59,16 +211,55 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.
 """

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/implement.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/implement.toml
@@ -37,11 +37,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/plan.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/plan.toml
@@ -23,7 +23,17 @@ prompt = """
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -66,6 +76,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -156,7 +182,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -201,14 +226,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -226,7 +244,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/review.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/review.toml
@@ -37,11 +37,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
@@ -24,7 +24,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -76,6 +87,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/charter.md
@@ -13,11 +13,72 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
 
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -28,27 +89,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -60,15 +212,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/implement.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/plan.md
@@ -24,7 +24,17 @@ description: Create an implementation plan
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -67,6 +77,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -157,7 +183,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -202,14 +227,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -227,7 +245,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/review.md
@@ -38,11 +38,16 @@ You **MUST** consider the user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -77,6 +88,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/shims/test_generator.py
+++ b/tests/specify_cli/shims/test_generator.py
@@ -115,7 +115,9 @@ class TestGenerateShimContent:
     def test_prohibition_line_position(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.splitlines()
-        assert lines[5] == "Do not rediscover context from branches, files, or prompt contents."
+        assert lines[5] == (
+            "Do not rediscover context from branches, files, prompt contents, or separate charter loads."
+        )
 
     def test_direct_implement_command(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
@@ -161,7 +163,9 @@ class TestGenerateShimContent:
         lines = content.splitlines()
         # Frontmatter occupies lines 0..2, version marker line 3, invariant
         # line 4, prohibition line 5, mission hint line 6.
-        assert lines[6] == "In repos with multiple missions, pass --mission <slug> in your arguments."
+        assert lines[6] == (
+            "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug)."
+        )
 
     def test_shim_content_version_marker_present_in_head(self) -> None:
         """Marker must appear in the file head (no longer line 0 — line 3)."""

--- a/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
@@ -10,9 +10,72 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
+
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -23,27 +86,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -55,15 +209,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
@@ -35,11 +35,16 @@ You **MUST** consider this user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
@@ -24,7 +24,17 @@ user-invocable: true
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -64,6 +74,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -154,7 +180,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -199,14 +224,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -224,7 +242,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
@@ -35,11 +35,16 @@ You **MUST** consider this user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -74,6 +85,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
@@ -10,9 +10,72 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+## Repo Scope
+
+`/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.
+
+- Run it from the repository root.
+- Do **not** try to resolve a mission handle for this command.
+- For charter subcommands, `--mission-type` means the reusable mission blueprint
+  (for example `software-dev` or `documentation`), not a mission instance in
+  `kitty-specs/`.
+- The hidden `--mission` flag on `spec-kitty charter ...` is only a deprecated
+  alias for `--mission-type`.
+
+If you need deterministic context before interviewing:
+
+1. Confirm you are in the repo root.
+2. Check whether a charter already exists:
+
+```bash
+spec-kitty charter status --json
+```
+
+3. If needed, inspect available mission blueprints:
+
+```bash
+spec-kitty mission list
+```
+
+For this command, the default mission type is `software-dev` unless the user
+explicitly wants a different mission blueprint.
+
+## Skill Load
+
+Before proceeding, load the `spec-kitty-charter-doctrine` skill for the charter
+lifecycle model, doctrine access patterns, and action-context rules.
+
+If the skill conflicts with this command contract, follow this command contract.
+
 ## Command Contract
 
-This command delegates charter work to the CLI charter workflow. Do not hand-author long governance content in chat unless the user explicitly asks for manual drafting.
+This command owns the user interview in chat. Do not default to
+`spec-kitty charter interview --defaults` unless the user explicitly asks for a
+fast bootstrap with canned defaults.
+
+The CLI charter workflow is a compiler and persistence surface, not the primary
+interview experience. Your job is to:
+
+1. Inspect the repo quickly to form an initial governance hypothesis.
+2. Ask the user a short, targeted interview in chat.
+3. Synthesize the answers into `.kittify/charter/interview/answers.yaml`.
+4. Run `spec-kitty charter generate --from-interview --json`.
+5. Verify generation with `spec-kitty charter status --json`.
+
+Do not preload governance context for all workflow actions as part of charter
+generation. Action context is loaded iteratively at the actual action boundary.
+
+## Doctrine Gaps
+
+If no shipped paradigm or directive cleanly fits the user's needs:
+
+- Do **not** force a near-match just to populate selections.
+- Keep `selected_paradigms` and `selected_directives` narrow and truthful.
+- Encode the missing policy as project-specific charter policy in the interview
+  answers and generated charter.
+- Say clearly that this is a doctrine gap, not an existing doctrine match.
+- Treat it as a candidate for later doctrine extraction rather than solving it by
+  misclassifying the project now.
 
 ### Output location
 
@@ -23,27 +86,118 @@ This command delegates charter work to the CLI charter workflow. Do not hand-aut
 
 ## Execution Paths
 
-### Path A: Deterministic minimal setup (fast)
+### Path A: LLM-led interview (default)
 
-Use when user wants speed, defaults, or bootstrap:
+Use this for normal `/spec-kitty.charter` runs.
+
+1. Inspect the repo quickly before asking questions. Prefer high-signal files:
+   - `README.md`
+   - `AGENTS.md`
+   - `CLAUDE.md`
+   - `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`
+   - existing `.kittify/charter/*` artifacts if present
+   - If `.claudeignore` exists, respect it during repo inspection and do not
+     spend time reading ignored paths unless the user explicitly asks.
+   - If `.claudeignore` does not exist, treat the following as low-signal Spec
+     Kitty bootstrap artifacts by default and do not over-interpret them as
+     project intent:
+     - `.kittify/config.yaml`
+     - `.kittify/metadata.yaml`
+     - `.kittify/skills-manifest.json`
+     - `.kittify/missions/`
+     - `.kittify/templates/`
+     - `.kittify/scripts/`
+     - agent wrapper directories such as `.claude/`, `.codex/`, `.gemini/`,
+       `.cursor/`, `.opencode/`
+   - If the repo is otherwise sparse, say so plainly. A freshly initialized
+     Spec Kitty workspace with mostly `.kittify/` metadata is a greenfield
+     bootstrap case, not a signal-rich codebase.
+   - In that greenfield case, stop spending time inspecting Spec Kitty init
+     relics and start the interview. The user's answers are the primary source
+     of governance intent.
+   - If charter status or repo inspection reports "not inside a git repository"
+     but the directory is clearly a new project bootstrap, treat that as a
+     greenfield setup condition rather than a reason to delay the interview.
+2. Ask a short targeted interview in chat:
+   - If the user already gave strong context, ask 1-3 clarifying questions.
+   - If the invocation is empty, start the interview and wait after one focused question.
+   - Ask natural-language questions. Do **not** ask the user to answer in YAML,
+     bullet-schema, numbered templates, or "Purpose / Work / Must enforce"
+     formatting.
+   - The LLM is responsible for structuring and normalizing the user's answers
+     into the interview schema later. The user should only have to answer the
+     substance of the question.
+   - If examples are needed, keep them conceptual and brief; do not imply that
+     the user must mirror the example format.
+   - Match interview depth to project complexity and the user's stated
+     preference for speed vs rigor.
+   - If the user wants "lightweight", "fast", "minimal", or clearly low-overhead
+     governance, keep the interview to 2-3 questions maximum unless the user
+     asks for more.
+   - If the repo and user context indicate a large, long-lived, high-risk, or
+     highly regulated codebase, increase interview depth accordingly and cover
+     governance areas that would materially affect long-term operation.
+   - For long interviews, check in periodically. If the user seems tired,
+     impatient, or overloaded, ask whether they want to continue in depth,
+     switch to a lighter pass, or stop and generate a first draft now.
+   - Prefer progressive disclosure: start with the minimum set of questions
+     needed to produce a truthful charter, then deepen only when the project
+     complexity or the user's answers justify it.
+3. Synthesize the interview into `.kittify/charter/interview/answers.yaml` using the
+   schema expected by `spec-kitty charter generate`.
+4. Run:
 
 ```bash
-spec-kitty charter interview --defaults --profile minimal --json
 spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+5. Treat the generated charter bundle as a real repository change. If
+   `.kittify/charter/charter.md` or other generated charter artifacts changed,
+   stage and commit them before concluding the command unless the user
+   explicitly asked not to commit.
+
+### Commit expectation
+
+- Do **not** stop at "there is an uncommitted charter change."
+- After successful generation, the default behavior is to create the commit.
+- Use a concise commit message that makes the governance action explicit, for
+  example:
+
+```bash
+git add .kittify/charter/
+git commit -m "chore: generate project charter"
 ```
 
-### Path B: Interactive interview (full)
+- If generation produced no diff, say so and do not create an empty commit.
+- If unrelated dirty changes exist, avoid sweeping them into the charter commit;
+  stage only the charter-related files.
 
-Use when the user wants project-specific policy capture:
+### Path B: CLI interview fallback
+
+Use this only when the user explicitly wants the CLI questionnaire itself:
 
 ```bash
 spec-kitty charter interview --profile comprehensive
 spec-kitty charter generate --from-interview
 ```
 
+### Path C: Deterministic defaults bootstrap
+
+Use this only when the user explicitly asks for defaults, speed, CI bootstrap, or
+“just make me a starter charter”:
+
+```bash
+spec-kitty charter interview --defaults --profile minimal --json
+spec-kitty charter generate --from-interview --json
+spec-kitty charter status --json
+```
+
+When you use defaults, say clearly that no real interview happened.
+
 ## Editing Rules
 
-- To revise policy inputs, rerun `charter interview` (or edit `answers.yaml`) and regenerate.
+- The preferred editable source for this command is `.kittify/charter/interview/answers.yaml`.
+- To revise policy inputs, edit `answers.yaml` (or rerun `charter interview`) and regenerate.
 - Use `--force` with generate if the charter already exists and must be replaced.
 - Keep charter concise; full detail belongs in reference docs listed in `references.yaml`.
 
@@ -55,15 +209,54 @@ After generation, verify status:
 spec-kitty charter status --json
 ```
 
+Do not chain `status` with four `context` calls and dump all of it back into the
+LLM. That burns first-load state and floods the context window with bootstrap
+payloads intended for later action boundaries.
+
 ## Charter Context Bootstrap
 
-After charter generation, first-run lifecycle actions should load context explicitly:
+Do not preload all action contexts here.
+
+The next real workflow action will load its own context automatically.
+
+If you need to inspect one action manually for debugging, query a single action
+without consuming first-load state:
 
 ```bash
-spec-kitty charter context --action specify --json
-spec-kitty charter context --action plan --json
-spec-kitty charter context --action implement --json
-spec-kitty charter context --action review --json
+spec-kitty charter context --action specify --json --no-mark-loaded
 ```
 
-Use JSON `text` as governance context. If `mode=bootstrap`, follow referenced docs as needed.
+Use JSON `text` as governance context only for the immediate next action. Do not
+eagerly inject `specify`, `plan`, `implement`, and `review` all at once.
+
+## Interview Output Shape
+
+When you synthesize `.kittify/charter/interview/answers.yaml`, match the CLI schema:
+
+```yaml
+schema_version: 1.0.0
+mission: software-dev
+profile: comprehensive
+answers:
+  project_intent: "..."
+  languages_frameworks: "..."
+  testing_requirements: "..."
+  quality_gates: "..."
+  review_policy: "..."
+  performance_targets: "..."
+  deployment_constraints: "..."
+  documentation_policy: "..."
+  risk_boundaries: "..."
+  amendment_process: "..."
+  exception_policy: "..."
+selected_paradigms:
+  - domain-driven-design
+selected_directives:
+  - DIRECTIVE_001
+available_tools:
+  - git
+```
+
+Select paradigms, directives, and tools deliberately from repo evidence plus user
+answers. Do not silently accept the full catalog unless the user explicitly asks
+for defaults.

--- a/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
@@ -35,11 +35,16 @@ You **MUST** consider this user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action implement --mission <mission-slug> --json
+spec-kitty agent context resolve --action implement --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action implement ...` is the authoritative work
+package prompt and execution context. Do **not** separately call
+`spec-kitty charter context` or rummage through unrelated files looking for a
+"newer" prompt unless the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
@@ -24,7 +24,17 @@ user-invocable: true
 
 **Do NOT cd anywhere**. Stay in the project root checkout root.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+`/spec-kitty.plan` operates on an existing mission, so use `--mission <handle>`
+when the CLI needs a mission selector.
+
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- Prefer `mission_id` or `mid8` when the repo has multiple similarly named
+  missions.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -64,6 +74,22 @@ This command runs in the **project root checkout**, not in a worktree.
 - The plan template is committed to the target branch after generation
 
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<mission>/tasks/`). Never refer to a folder by name alone.
+
+## Agent Context Files (do not mutate)
+
+This command does **not** update agent-specific context files.
+
+- Do **not** search for or mutate `CLAUDE.md`, `AGENTS.md`, or similar
+  agent-specific files as part of `/spec-kitty.plan`.
+- Do **not** hunt for updater scripts or imaginary `spec-kitty agent context update`
+  commands. No supported context-update command exists in this release.
+- Planning outputs are the mission planning artifacts only:
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/`
+  - `quickstart.md`
+  - `occurrence_map.yaml` when bulk-edit planning applies
 
 ## Planning Interrogation (mandatory)
 
@@ -154,7 +180,6 @@ If the mission is not a bulk edit, skip this step.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
    - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -199,14 +224,7 @@ If the mission is not a bulk edit, skip this step.
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
-   - Run ``
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 
@@ -224,7 +242,6 @@ After reporting:
 - `research.md` path (if generated)
 - `data-model.md` path (if generated)
 - `contracts/` contents (if generated)
-- Agent context file updated
 
 **YOU MUST STOP HERE.**
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
@@ -35,11 +35,16 @@ You **MUST** consider this user input before proceeding (if not empty).
 Run:
 
 ```bash
-spec-kitty agent context resolve --action review --mission <mission-slug> --json
+spec-kitty agent context resolve --action review --mission <handle> --json
 ```
 
 Then execute the returned `check_prerequisites` command and capture
 `feature_dir`. All paths must be absolute.
+
+The output of `spec-kitty agent action review ...` is the authoritative work
+package prompt and review context. Do **not** separately call
+`spec-kitty charter context` or go hunting for alternate prompt files unless
+the command output tells you to.
 
 ### 2. Load Work Package Prompt
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
@@ -25,7 +25,18 @@ cd /path/to/project/root  # Your project root checkout
 
 **Worktrees are created later** during `/spec-kitty.implement`, after task finalization computes execution lanes.
 
-**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+## Mission Handle Rule
+
+Before `mission create`, there is no mission handle yet.
+
+- Do **not** pass `--mission` to `spec-kitty agent mission branch-context`.
+- Do **not** pass `--mission` to `spec-kitty agent mission create`.
+- After `create` succeeds, use `--mission <handle>` for commands that operate on
+  the created mission.
+- `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of
+  the ULID), or `mission_slug`.
+- The resolver disambiguates by `mission_id` and returns a structured
+  `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input
 
@@ -74,6 +85,8 @@ spec-kitty charter context --action specify --json
 
 - If JSON `mode` is `bootstrap`, treat JSON `text` as the initial governance context and consult referenced docs as needed.
 - If JSON `mode` is `compact`, proceed with concise governance context.
+- If no charter exists yet, note that and continue. Missing charter is not a
+  blocker for `/spec-kitty.specify`.
 
 ## Discovery Gate (mandatory)
 


### PR DESCRIPTION
## Summary
- fix stale /spec-kitty.plan prompt guidance that referenced a non-existent agent context update flow
- tighten specify/implement/review/merge command contracts around mission handles and context authority
- regenerate slash-command and skill baselines for the prompt-surface changes

## Validation
- python3 -m pytest -q tests/specify_cli/shims/test_generator.py tests/runtime/test_doctor_command_file_health.py
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 python3 -m pytest -q tests/specify_cli/shims/test_direct_commands.py
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 python3 -m pytest -q tests/specify_cli/regression/test_twelve_agent_parity.py tests/specify_cli/skills/test_command_renderer.py
- python3 scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- python3 -m build
- source .venv-release/bin/activate && twine check dist/*