### PR TITLE
docs: refresh README and user docs for 3.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 | **Live project visibility** | Local dashboard for kanban and mission progress (`spec-kitty dashboard`) |
 | **Review resilience** | Persisted versioned review artifacts, focused fix prompts, dirty-state classification, and arbiter checklists |
 | **Execution resilience** | Interrupted merge recovery (`merge --resume`), crash recovery (`implement --recover`), stale-claim diagnostics (`doctor`) |
-| **Multi-agent support** | Template and command generation for 14 AI agent integrations |
+| **Multi-agent support** | Template and command generation for 13 slash-command AI agent integrations |
 
 <p align="center">
     <a href="#-getting-started-complete-workflow">Quick Start</a> •
     <a href="docs/tutorials/claude-code-integration.md"><strong>Claude Code Guide</strong></a> •
     <a href="#-real-time-dashboard">Live Dashboard</a> •
-    <a href="#-supported-ai-tools">14 AI Tools</a> •
+    <a href="#-supported-ai-tools">13 AI Agents</a> •
     <a href="https://github.com/Priivacy-ai/spec-kitty/blob/main/spec-driven.md">Full Docs</a>
 </p>
 
@@ -95,28 +95,27 @@ graph LR
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue?style=for-the-badge)](https://www.python.org/downloads/)
 
-[![AI Tools](https://img.shields.io/badge/AI_Tools-12_Supported-brightgreen?style=for-the-badge)](#-supported-ai-tools)
+[![AI Tools](https://img.shields.io/badge/AI_Tools-13_Supported-brightgreen?style=for-the-badge)](#-supported-ai-tools)
 [![Dashboard](https://img.shields.io/badge/Dashboard-Kanban-orange?style=for-the-badge)](#-real-time-dashboard)
 [![Workflow](https://img.shields.io/badge/Workflow-Spec--Plan--Tasks-6c757d?style=for-the-badge)](#-getting-started-complete-workflow)
 
 </div>
 
-**Current stable release line:** `v3.1.x` (current release 3.1.4 on `main`, GitHub Releases, and PyPI)
+**Current stable release line:** `v3.1.x` (current release: `3.1.4` on `main`, GitHub Releases, and PyPI)
 
-**3.1.0 highlights:**
-- **Planning integrity** — read-only status commands no longer dirty the git tree; `spec-kitty next` without `--result` is a safe query-only operation
-- **Structured WP manifest** — new `wps.yaml` format is the primary dependency source for `finalize-tasks`, eliminating prose-parser corruption of lane assignments
-- **Review resilience** — focused fix prompts (~40 lines vs 400+), persisted versioned `review-cycle-N.md` artifacts, dirty-state classification, baseline test context, and arbiter checklists
-- **Execution resilience** — `merge --resume` recovers interrupted merges; `implement --recover` handles crash recovery; `doctor` diagnoses stale claims and zombie worktrees
-- **Tasks stabilization** — dependency preservation, lane-graph completeness, parallelism protection, and consistent `--mission` flag naming across all commands
-- **Merge strategy** — MERGE / SQUASH / REBASE via `--strategy` flag or `config.yaml`; linear-history protection hint on push failures
-- **Charter** — `spec-kitty charter` replaces `spec-kitty constitution` across all surfaces; auto-migrated by `spec-kitty upgrade`
-- **Mission identity** — `--mission` is now the canonical flag; `--feature` is retained only as a hidden deprecated alias during migration
+**3.1.x highlights:**
+- **Runtime loop is the primary workflow** — `spec-kitty next` drives implementation and review, and omitting `--result` is a safe query-only mode
+- **Review and merge resilience** — focused fix prompts, persisted `review-cycle-N.md` artifacts, `merge --resume`, `implement --recover`, and stronger recovery diagnostics in `doctor`
+- **Hosted auth and sync are first-class** — browser-based `spec-kitty auth login`, explicit SaaS rollout gating, and clearer tracker/discovery readiness checks
+- **Charter bundle is now a validated contract** — bundle health can be checked with `spec-kitty charter bundle validate`, and worktrees read canonical charter outputs from the main checkout
+- **Sparse-checkout failures are defended in depth** — merge/implement preflights fail closed, `safe_commit` rejects out-of-scope staging, and `spec-kitty doctor sparse-checkout --fix` repairs legacy repos
+- **13 slash-command agents are supported** — including first-class Kiro support while retaining legacy `q` compatibility during the rebrand
+- **Slash-command wording is cleaner in 3.1.3/3.1.4** — generated `specify`, `plan`, `implement`, `review`, and `merge` prompts now teach the canonical mission/runtime flow instead of stale command shims
 
 **Jump to:**
 [Getting Started](#-getting-started-complete-workflow) •
 [Examples](#-examples) •
-[12 AI Tools](#-supported-ai-tools) •
+[13 AI Agents](#-supported-ai-tools) •
 [CLI Reference](#-spec-kitty-cli-reference) •
 [Worktrees](#-worktree-strategy) •
 [Troubleshooting](#-troubleshooting)
@@ -208,7 +207,7 @@ Spec Kitty includes a **live dashboard** that automatically tracks your feature 
   <p><em>Feature overview with completion metrics and available artifacts</em></p>
 </div>
 
-The dashboard starts automatically when you run `spec-kitty init` and runs in the background. Access it anytime with the `/spec-kitty.dashboard` command or `spec-kitty dashboard`—the CLI will start the correct project dashboard automatically if it isn't already running, let you request a specific port with `--port <PORT>` (defaults to auto-select from 3000-5000), or stop it cleanly with `--kill`.
+Start the dashboard when you want it with `/spec-kitty.dashboard` or `spec-kitty dashboard`. The CLI starts the correct project dashboard if it is not already running, lets you request a specific port with `--port <PORT>` (defaults to auto-select from `3000-5000`), can open the browser for you with `--open`, and stops the instance cleanly with `--kill`.
 
 **Key Features:**
 - 📋 **Kanban Board**: Visual workflow across canonical lifecycle lanes (including `blocked` and `canceled`) with `Doing` rendered as `in_progress`
@@ -324,7 +323,7 @@ The upgrade command automatically migrates your project structure across version
 | **0.6.7** | Ensure software-dev and research missions present                   |
 | **0.6.5** | Rename commands/ → command-templates/                               |
 | **0.5.0** | Install encoding validation git hooks                               |
-| **0.4.8** | Add all 12 AI agent tooling directories to .gitignore               |
+| **0.4.8** | Add supported agent tooling directories to `.gitignore`             |
 | **0.2.0** | Rename .specify/ → .kittify/ and /specs/ → /kitty-specs/            |
 
 > Run `spec-kitty upgrade --verbose` to see which migrations apply to your project.
@@ -563,7 +562,7 @@ These directories may contain:
 Spec Kitty automatically protects you with multiple layers:
 
 **During `spec-kitty init`:**
-- ✅ Adds all 12 agent directories to `.gitignore`
+- ✅ Adds supported agent directories to `.gitignore`
 - ✅ Creates `.claudeignore` to optimize AI scanning (excludes `.kittify/` templates)
 
 **Worktree Charter Sharing:**
@@ -725,7 +724,7 @@ Browse our [examples directory](https://github.com/Priivacy-ai/spec-kitty/tree/m
 
 ## 🤖 Supported AI Tools
 
-Spec Kitty integrates with 15 AI tools. Thirteen tools receive **slash commands** written to an agent-specific directory (e.g. `.claude/commands/`). Two tools — Codex CLI and Mistral Vibe — use the **Agent Skills** pipeline: Spec Kitty installs command skills once under `.agents/skills/spec-kitty.<command>/`, Codex reads that shared tree directly, and Vibe is wired to it through project-local `.vibe/config.toml` `skill_paths`.
+Spec Kitty integrates with 14 AI tools. Thirteen tools receive project-local **slash commands or prompt files** written to an agent-specific directory (for example `.claude/commands/` or `.codex/prompts/`). One tool — Mistral Vibe — uses the **Agent Skills** pipeline: Spec Kitty installs shared skills once under `.agents/skills/spec-kitty.<command>/`, and Vibe discovers them through project-local `.vibe/config.toml` `skill_paths`.
 
 | Tool                                                      | Support | Notes                                             |
 |-----------------------------------------------------------|---------|---------------------------------------------------|
@@ -739,7 +738,7 @@ Spec Kitty integrates with 15 AI tools. Thirteen tools receive **slash commands*
 | [Kilo Code](https://github.com/Kilo-Org/kilocode)         | ✅ |                                                   |
 | [Auggie CLI](https://docs.augmentcode.com/cli/overview)   | ✅ |                                                   |
 | [Roo Code](https://roocode.com/)                          | ✅ |                                                   |
-| [Codex CLI](https://github.com/openai/codex)              | ✅ | Agent Skills under `.agents/skills/`. |
+| [Codex CLI](https://github.com/openai/codex)              | ✅ | Project-local prompts under `.codex/prompts/`. |
 | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) | ✅ | Agent Skills under `.agents/skills/`, registered through `.vibe/config.toml` `skill_paths`. |
 | [Kiro CLI](https://kiro.dev/docs/cli/) (formerly Amazon Q Developer CLI) | ✅ | Saved-prompt arguments work via `$ARGUMENTS`, but the full invocation must be shell-quoted (e.g. `kiro '@speckit.specify my description'`). See [kirodotdev/Kiro#4141](https://github.com/kirodotdev/Kiro/issues/4141). |
 | [Amazon Q Developer CLI](https://aws.amazon.com/developer/learning/q-developer-cli/) (legacy) | ⚠️ | Legacy surface retained as `q`; rebranded to Kiro CLI, and custom arguments are still unsupported. |
@@ -747,42 +746,37 @@ Spec Kitty integrates with 15 AI tools. Thirteen tools receive **slash commands*
 <details>
 <summary><h2>🔧 Spec Kitty CLI Reference</h2></summary>
 
-The `spec-kitty` command supports the following options. Every run begins with a discovery interview, so be prepared to answer follow-up questions before files are touched.
+The `spec-kitty` command supports the following user-facing commands. Planning commands begin with guided interviews, so be prepared to answer follow-up questions before files are touched.
 
 ### Commands
 
-| Command     | Description                                                    |
-|-------------|----------------------------------------------------------------|
-| `init`      | Initialize a new Spec Kitty project from templates |
-| `upgrade`   | **Upgrade project structure to current version** (run after updating spec-kitty-cli) |
-| `repair`    | **Repair broken template installations** (fixes bash script references from v0.10.0-0.10.8) |
-| `accept`    | Validate mission readiness before merging to main |
-| `check`     | Check that required tooling is available |
-| `dashboard` | Open or stop the Spec Kitty dashboard |
-| `diagnostics` | Show project health and diagnostics information |
-| `merge`     | Merge a completed feature branch into main and clean up resources |
-| `orchestrator-api` | Host contract for external orchestrators (JSON envelope interface) |
-| `research`  | Execute Phase 0 research workflow to scaffold artifacts |
-| `verify-setup` | Verify that the current environment matches Spec Kitty expectations |
+| Command | Description |
+|---------|-------------|
+| `init` | Initialize a new Spec Kitty project scaffold |
+| `specify` | Create a mission scaffold under `kitty-specs/` |
+| `plan` | Scaffold `plan.md` for a mission |
+| `tasks` | Finalize work-package metadata after task planning |
+| `next` | Decide and emit the next runtime action for an agent |
+| `accept` | Validate mission readiness before merging |
+| `merge` | Merge a completed mission and clean up lane worktrees |
+| `dashboard` | Start, inspect, or stop the Spec Kitty dashboard |
+| `upgrade` | Upgrade a project to the current CLI/project contract |
+| `verify-setup` | Verify tooling, mission files, and environment health |
+| `doctor` | Run project health diagnostics and recovery checks |
+| `auth` | Authenticate against the Spec Kitty SaaS surface |
+| `charter` | Manage charter generation, sync, and validation |
+| `tracker` | Task-tracker commands and hosted discovery flows |
+| `orchestrator-api` | Host contract for external orchestrators |
 
 ### `spec-kitty init` Arguments & Options
 
-| Argument/Option        | Type     | Description                                                                  |
-|------------------------|----------|------------------------------------------------------------------------------|
-| `<project-name>`       | Argument | Name for your new project directory (omit to initialize in the current directory, same as `--here`) |
-| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, `roo`, `q`, or `vibe` |
-| `--script`             | Option   | (Deprecated in v0.10.0) Script variant - all commands now use Python CLI     |
-| `--mission`            | Option   | Mission type key to seed templates (`software-dev`, `research`, ...)        |
-| `--template-root`      | Option   | Override template location (useful for development mode or custom sources)   |
-| `--ignore-agent-tools` | Flag     | Skip checks for AI agent tools like Claude Code                             |
-| `--no-git`             | Flag     | Skip git repository initialization                                          |
-| `--here`               | Flag     | Initialize project in the current directory instead of creating a new one   |
-| `--force`              | Flag     | Force merge/overwrite when initializing in current directory (skip confirmation) |
-| `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                 |
-| `--debug`              | Flag     | Enable detailed debug output for troubleshooting                            |
-| `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)  |
+| Argument/Option | Type | Description |
+|-----------------|------|-------------|
+| `<project-name>` | Argument | Name for your new project directory. Omit it, or pass `.`, to initialize the current directory. |
+| `--ai` | Option | Comma-separated AI assistant keys. Current `init --help` examples include `codex`, `claude`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `auggie`, `roo`, `copilot`, `q`, and `kiro`. |
+| `--non-interactive`, `--yes` | Flag | Run without prompts. Suitable for CI/CD and automation; `--ai` is required in this mode. |
 
-If you omit `--mission`, the CLI will prompt you to pick one during `spec-kitty init`.
+`spec-kitty init` creates project files only. It does not initialize Git, does not create commits, and missions are selected later during `/spec-kitty.specify`.
 
 ### Examples
 
@@ -796,42 +790,26 @@ spec-kitty init my-project
 # Initialize with specific AI assistant
 spec-kitty init my-project --ai claude
 
-# Initialize with the Deep Research mission
-spec-kitty init my-project --mission research
-
 # Initialize with Cursor support
 spec-kitty init my-project --ai cursor
 
 # Initialize with Windsurf support
 spec-kitty init my-project --ai windsurf
 
-# Initialize with PowerShell scripts (Windows/cross-platform)
-spec-kitty init my-project --ai copilot --script ps
-
 # Initialize in current directory
 spec-kitty init . --ai copilot
-# or use the --here flag
-spec-kitty init --here --ai copilot
 
-# Force merge into current (non-empty) directory without confirmation
-spec-kitty init . --force --ai copilot
-# or 
-spec-kitty init --here --force --ai copilot
+# Initialize multiple agents in one pass
+spec-kitty init my-project --ai claude,codex
 
-# Skip git initialization
-spec-kitty init my-project --ai gemini --no-git
+# Non-interactive setup for automation
+spec-kitty init my-project --ai gemini --non-interactive
 
-# Enable debug output for troubleshooting
-spec-kitty init my-project --ai claude --debug
-
-# Use GitHub token for API requests (helpful for corporate environments)
-spec-kitty init my-project --ai claude --github-token ghp_your_token_here
-
-# Use custom template location (development mode)
-spec-kitty init my-project --ai claude --template-root=/path/to/local/spec-kitty
+# Use a local template checkout during Spec Kitty development
+SPEC_KITTY_TEMPLATE_ROOT=/path/to/spec-kitty spec-kitty init my-project --ai claude
 
 # Check system requirements
-spec-kitty check
+spec-kitty verify-setup --diagnostics
 ```
 
 ### `spec-kitty upgrade` Options
@@ -1181,9 +1159,11 @@ cat .kittify/metadata.yaml
 
 | Variable         | Description                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------|
-| `SPECIFY_FEATURE` | Override feature detection for non-Git repositories. Set to the feature directory name (e.g., `001-photo-albums`) to work on a specific feature when not using Git branches.<br/>**Must be set in the context of the agent you're working with prior to using `/spec-kitty.plan` or follow-up commands. |
 | `SPEC_KITTY_TEMPLATE_ROOT` | Optional. Point to a local checkout whose `templates/`, `scripts/`, and `memory/` directories should seed new projects (handy while developing Spec Kitty itself). |
 | `SPECIFY_TEMPLATE_REPO` | Optional. Override the GitHub repository slug (`owner/name`) to fetch templates from when you explicitly want a remote source. |
+| `SPEC_KITTY_NON_INTERACTIVE` | Force non-interactive init behavior. Equivalent to passing `--non-interactive` / `--yes`. |
+| `SPEC_KITTY_ENABLE_SAAS_SYNC` | Opt in to hosted auth, tracker, and sync flows. Leave unset for local-only workflows. |
+| `SPEC_KITTY_SAAS_URL` | Override the SaaS base URL used by `spec-kitty auth`, tracker discovery, and hosted sync flows. |
 | `CODEX_HOME` | Required when using the Codex CLI so it loads project-specific prompts. Point it to your project’s `.codex/` directory—set it manually with `export CODEX_HOME=\"$(pwd)/.codex\"` or automate it via [`direnv`](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/index.md#codex-cli-automatically-load-project-prompts-linux-macos-wsl) on Linux/macOS/WSL. |
 
 ## 🔧 Prerequisites
@@ -1336,12 +1316,11 @@ spec-kitty init <PROJECT_NAME> --ai=claude --template-root=/path/to/spec-kitty
 ### Template Discovery Priority
 
 The CLI searches for templates in this order:
-1. **Command-line override**: `--template-root` flag (highest priority)
-2. **Environment variable**: `SPEC_KITTY_TEMPLATE_ROOT` (local checkout)
-3. **Packaged resources**: Built-in templates from PyPI installation
-4. **Remote repository**: `SPECIFY_TEMPLATE_REPO` environment variable
+1. **Packaged resources**: Built-in templates from the installed `spec-kitty-cli`
+2. **Environment override**: `SPEC_KITTY_TEMPLATE_ROOT` for local development or source checkouts
+3. **Remote repository**: `SPECIFY_TEMPLATE_REPO` when you explicitly want a remote template source
 
-This means development installs automatically find templates when running from the cloned repository, but you may need to set `SPEC_KITTY_TEMPLATE_ROOT` if you move the directory.
+For development installs from source, set `SPEC_KITTY_TEMPLATE_ROOT` to your checkout before running `spec-kitty init`.
 
 ---
 

--- a/docs/how-to/diagnose-installation.md
+++ b/docs/how-to/diagnose-installation.md
@@ -8,7 +8,7 @@ the runtime reports errors -- use this guide to identify the problem and recover
 Start every investigation with `verify-setup`:
 
 ```bash
-spec-kitty verify-setup-setup
+spec-kitty verify-setup
 ```
 
 The output is divided into three sections:
@@ -34,13 +34,13 @@ The output is divided into three sections:
 To get machine-readable output for scripting or agent consumption:
 
 ```bash
-spec-kitty verify-setup-setup --json
+spec-kitty verify-setup --json
 ```
 
 For extended diagnostics including dashboard health:
 
 ```bash
-spec-kitty verify-setup-setup --diagnostics
+spec-kitty verify-setup --diagnostics
 ```
 
 ---
@@ -62,7 +62,7 @@ root cause, and recovery steps.
 **Recovery:**
 
 ```bash
-spec-kitty init --here
+spec-kitty init . --ai <your-agent>
 ```
 
 This regenerates the skill root and all skill files from the canonical
@@ -82,7 +82,7 @@ deleted or `spec-kitty init` was interrupted before wrapper files were written.
 **Recovery:**
 
 ```bash
-spec-kitty init --here
+spec-kitty agent config sync --create-missing
 ```
 
 This regenerates wrapper files for every configured agent.
@@ -102,7 +102,7 @@ leave partially resolved content in skill files.
 **Recovery:**
 
 ```bash
-spec-kitty init --here
+spec-kitty upgrade
 ```
 
 This overwrites drifted files with canonical content and updates the manifest
@@ -132,7 +132,7 @@ repository root.
 2. Re-initialize:
 
    ```bash
-   spec-kitty init --here
+   spec-kitty init . --ai <your-agent>
    ```
 
 ---
@@ -203,7 +203,7 @@ write operation was interrupted mid-file.
 
    ```bash
    rm .kittify/config.yaml
-   spec-kitty init --here
+   spec-kitty init . --ai <your-agent>
    ```
 
 3. If you had custom settings (e.g., a non-default agent list), restore them
@@ -287,14 +287,14 @@ would be affected before executing a sync with orphan removal.
 
 | Problem | Recovery command |
 |---------|----------------|
-| Missing skill files | `spec-kitty init --here` |
-| Missing wrapper root | `spec-kitty init --here` |
-| Missing skill root | `spec-kitty init --here` |
-| Manifest drift | `spec-kitty init --here` |
-| Runtime not found | `cd "$(git rev-parse --show-toplevel)" && spec-kitty init --here` |
+| Missing skill files | `spec-kitty agent config sync --create-missing` |
+| Missing wrapper root | `spec-kitty agent config sync --create-missing` |
+| Missing skill root | `spec-kitty init . --ai <your-agent>` |
+| Manifest drift | `spec-kitty upgrade` |
+| Runtime not found | `cd "$(git rev-parse --show-toplevel)" && spec-kitty init . --ai <your-agent>` |
 | Dashboard not starting | `spec-kitty dashboard` |
 | Stale agent config | `spec-kitty agent config sync` |
-| Corrupted config | `cp .kittify/config.yaml .kittify/config.yaml.bak && rm .kittify/config.yaml && spec-kitty init --here` |
+| Corrupted config | `cp .kittify/config.yaml .kittify/config.yaml.bak && rm .kittify/config.yaml && spec-kitty init . --ai <your-agent>` |
 | Broken worktree | `git worktree prune && spec-kitty agent action implement WP01 --agent <name>` |
 
 ## See Also

--- a/docs/how-to/install-spec-kitty.md
+++ b/docs/how-to/install-spec-kitty.md
@@ -61,32 +61,26 @@ pipx run spec-kitty-cli init <PROJECT_NAME>
 uvx spec-kitty-cli init <PROJECT_NAME>
 ```
 
-### Add to Existing Project
+### Add to an Existing Project
 
-To add Spec Kitty to an existing project, use the `--here` flag:
+To add Spec Kitty to an existing repository, run `init` from that repository root:
 
 ```bash
-# Navigate to your existing project directory
 cd /path/to/existing-project
-
-# Initialize Spec Kitty in the current directory
-spec-kitty init .
-# or use the --here flag
-spec-kitty init --here
+spec-kitty init . --ai claude
 ```
 
-When adding to an existing project:
-- Spec Kitty will **merge** its templates with your existing files
-- You'll be prompted to confirm if the directory is not empty
-- Use `--force` to skip confirmation: `spec-kitty init --here --force`
-- Agent configurations, mission system, and dashboard will be added
-- Your existing source code and dependencies are preserved
+What this does today:
+- Creates the `.kittify/` scaffold in the current directory
+- Adds the selected agent command directories
+- Updates ignore files such as `.gitignore` / `.claudeignore`
+- Leaves your Git history untouched; `init` does not initialize Git or create commits
 
-**Best Practices for Existing Projects:**
-1. **Backup first**: Commit your current work to git before adding Spec Kitty
-2. **Review .gitignore**: Spec Kitty automatically protects agent directories in `.gitignore`
-3. **Team alignment**: Add Spec Kitty to a feature branch before merging to main if you're in a team
-4. **Follow the workflow**: After init, run `/spec-kitty.specify` to begin your first feature
+**Best practices for existing projects:**
+1. Commit or stash your current work before adding Spec Kitty.
+2. Review `.gitignore` after init so agent directories remain untracked.
+3. Use `spec-kitty verify-setup --diagnostics` if you want a post-install health check.
+4. Start the workflow with `/spec-kitty.specify`; mission selection happens there, not during `init`.
 
 ### Choose AI Agent
 
@@ -95,7 +89,8 @@ You can proactively specify your AI agent during initialization:
 ```bash
 spec-kitty init <project_name> --ai claude
 spec-kitty init <project_name> --ai gemini
-spec-kitty init <project_name> --ai copilot
+spec-kitty init <project_name> --ai codex
+spec-kitty init <project_name> --ai claude,codex
 ```
 
 ### Managing Agents After Initialization
@@ -109,20 +104,12 @@ To manage agents post-init:
 
 See [Managing AI Agents](manage-agents.md) for complete documentation on agent management workflows.
 
-### Cross-Platform Python CLI (v0.10.0+)
+### Non-Interactive Setup
 
-As of v0.10.0, all automation uses cross-platform Python CLI commands (`spec-kitty agent`).
-
-The legacy `--script` option is no longer needed - all commands work identically across Windows, macOS, and Linux.
-
-> **Migration Note:** Projects created before v0.10.0 had bash/PowerShell scripts. Run `spec-kitty upgrade` to migrate to Python CLI commands. See [Upgrade to 0.11.0](install-and-upgrade.md) for details.
-
-### Ignore Agent Tools Check
-
-If you prefer to get the templates without checking for the right tools:
+For CI or scripts, use the non-interactive mode documented by `spec-kitty init --help`:
 
 ```bash
-spec-kitty init <project_name> --ai claude --ignore-agent-tools
+spec-kitty init <project_name> --ai claude --non-interactive
 ```
 
 ## Verification
@@ -133,7 +120,7 @@ After initialization, you should see the following commands available in your AI
 - `/spec-kitty.research` - Scaffold mission-specific research artifacts (Phase 0)
 - `/spec-kitty.tasks` - Break down into actionable tasks
 
-When you run `/spec-kitty.specify` or `/spec-kitty.plan`, expect the assistant to pause with `WAITING_FOR_DISCOVERY_INPUT` or `WAITING_FOR_PLANNING_INPUT` until you answer its question tables.
+Run `spec-kitty dashboard --open` if you want the live dashboard immediately after setup.
 
 ## Troubleshooting
 
@@ -155,14 +142,18 @@ rm gcm-linux_amd64.2.6.1.deb
 ```
 
 ## Command Reference
+
 - [`spec-kitty init`](../reference/cli-commands.md#spec-kitty-init)
 - [`spec-kitty upgrade`](../reference/cli-commands.md#spec-kitty-upgrade)
+- [`spec-kitty verify-setup`](../reference/cli-commands.md#spec-kitty-verify-setup)
 
 ## See Also
+
 - [Non-Interactive Init](non-interactive-init.md)
 - [Upgrade to 0.11.0](install-and-upgrade.md)
 - [Use the Dashboard](use-dashboard.md)
 
 ## Background
+
 - [Spec-Driven Development](../explanation/spec-driven-development.md)
 - [Mission System](../explanation/mission-system.md)

--- a/docs/how-to/manage-agents.md
+++ b/docs/how-to/manage-agents.md
@@ -325,7 +325,7 @@ Use `status` to:
 - Audit your agent configuration for inconsistencies
 - Detect orphaned directories (present but not configured)
 - Identify missing directories (configured but not present)
-- See all 12 agents at a glance
+- See all 13 slash-command agents at a glance
 
 ### Taking Action Based on Status
 
@@ -568,7 +568,7 @@ For more information on agent management and related topics:
 
 ### Supported Agents
 
-- [Supported AI Agents](../reference/supported-agents.md) - Complete list of 12 supported agents with capabilities, installation requirements, and usage notes
+- [Supported AI Agents](../reference/supported-agents.md) - Complete list of the 13 slash-command agents with capabilities, installation requirements, and usage notes
 
 ### Configuration
 

--- a/docs/how-to/non-interactive-init.md
+++ b/docs/how-to/non-interactive-init.md
@@ -9,8 +9,7 @@
 ```bash
 spec-kitty init <project-name> \
   --ai <agents> \
-  [--non-interactive] \
-  [--no-git]
+  [--non-interactive]
 ```
 
 ## Required Arguments for Non-Interactive Mode
@@ -39,6 +38,7 @@ spec-kitty init .
 ```
 
 **Valid agent keys**:
+
 | Key | Agent Name |
 |-----|------------|
 | `codex` | Codex CLI (OpenAI) |
@@ -62,11 +62,11 @@ spec-kitty init .
 | Flag | Purpose | Default |
 |------|---------|---------|
 | `--non-interactive` / `--yes` | Disable prompts (required for CI) | Off |
-| `--no-git` | Skip git repository initialization | Off (initializes git) |
 
 ## Complete Non-Interactive Examples
 
 ### Example 1: New project with Codex
+
 ```bash
 spec-kitty init my-project \
   --ai codex \
@@ -74,6 +74,7 @@ spec-kitty init my-project \
 ```
 
 ### Example 2: Current directory with multiple agents
+
 ```bash
 spec-kitty init . \
   --ai claude,codex,cursor \
@@ -81,23 +82,25 @@ spec-kitty init . \
 ```
 
 ### Example 3: Minimal (relies on defaults)
+
 ```bash
 # In non-interactive environment (CI/CD):
 spec-kitty init my-project --ai codex --non-interactive
 ```
 
 ### Example 4: CI/CD friendly
+
 ```bash
 spec-kitty init . \
   --ai claude \
-  --no-git \
   --non-interactive
 ```
 
-### Example 5: All 12 agents
+### Example 5: All 13 init-surface agents
+
 ```bash
 spec-kitty init my-project \
-  --ai codex,claude,gemini,cursor,qwen,opencode,windsurf,kilocode,auggie,roo,copilot,q \
+  --ai codex,claude,gemini,cursor,qwen,opencode,windsurf,kilocode,auggie,roo,copilot,q,kiro \
   --non-interactive
 ```
 
@@ -134,7 +137,6 @@ Behavior:
   run: |
 spec-kitty init . \
   --ai codex \
-  --no-git \
   --non-interactive
 ```
 
@@ -150,64 +152,76 @@ spec-kitty init /app/project \
 
 When you specify agents with `--ai`, spec-kitty creates:
 
-### For `--ai codex`:
+### For `--ai codex`
+
 - `.codex/prompts/spec-kitty.*.md` (13 command files)
 - `.kittify/AGENTS.md` (auto-loaded by Codex)
 - No extra context files needed (native AGENTS.md support!)
 
-### For `--ai claude`:
+### For `--ai claude`
+
 - `.claude/commands/spec-kitty.*.md` (13 command files)
 - `.kittify/AGENTS.md`
 - `CLAUDE.md` → symlink to `.kittify/AGENTS.md`
 
-### For `--ai cursor`:
+### For `--ai cursor`
+
 - `.cursor/commands/spec-kitty.*.md` (13 command files)
 - `.kittify/AGENTS.md`
 - `.cursorrules` → symlink to `.kittify/AGENTS.md` (legacy)
 - `.cursor/rules/AGENTS.md` → symlink to `.kittify/AGENTS.md` (modern)
 
-### For `--ai windsurf`:
+### For `--ai windsurf`
+
 - `.windsurf/workflows/spec-kitty.*.md` (13 workflow files)
 - `.kittify/AGENTS.md`
 - `.windsurfrules` → symlink to `.kittify/AGENTS.md` (legacy)
 - `.windsurf/rules/AGENTS.md` → symlink to `.kittify/AGENTS.md` (modern)
 
-### For `--ai roo`:
+### For `--ai roo`
+
 - `.roo/commands/spec-kitty.*.md` (13 command files)
 - `.kittify/AGENTS.md`
 - `.roorules` → symlink to `.kittify/AGENTS.md` (legacy)
 - `.roo/rules/AGENTS.md` → symlink to `.kittify/AGENTS.md` (modern)
 
-### For `--ai gemini`:
+### For `--ai gemini`
+
 - `.gemini/commands/spec-kitty.*.toml` (13 command files in TOML format)
 - `.kittify/AGENTS.md`
 - `GEMINI.md` → symlink to `.kittify/AGENTS.md`
 
-### For `--ai copilot`:
+### For `--ai copilot`
+
 - `.github/prompts/spec-kitty.*.prompt.md` (13 prompt files)
 - `.kittify/AGENTS.md`
 - `.github/copilot-instructions.md` → symlink to `.kittify/AGENTS.md`
 
-### For `--ai kilocode`:
+### For `--ai kilocode`
+
 - `.kilocode/workflows/spec-kitty.*.md` (13 workflow files)
 - `.kittify/AGENTS.md`
 - `.kilocoderules` → symlink to `.kittify/AGENTS.md`
 
-### For `--ai opencode`:
+### For `--ai opencode`
+
 - `.opencode/command/spec-kitty.*.md` (13 command files)
 - `.kittify/AGENTS.md`
 - Note: Requires manual config entry in opencode.json
 
-### For `--ai auggie`:
+### For `--ai auggie`
+
 - `.augment/commands/spec-kitty.*.md` (13 command files)
 - `.kittify/AGENTS.md`
 - `.augmentrules` → symlink to `.kittify/AGENTS.md` (assumed)
 
-### For `--ai qwen`:
+### For `--ai qwen`
+
 - `.qwen/commands/spec-kitty.*.toml` (13 command files in TOML format)
 - `.kittify/AGENTS.md`
 
-### For `--ai q`:
+### For `--ai q`
+
 - `.amazonq/prompts/spec-kitty.*.md` (13 prompt files)
 - `.kittify/AGENTS.md`
 - Note: May have discovery issues (known bug)
@@ -223,6 +237,7 @@ When you specify agents with `--ai`, spec-kitty creates:
 ## Platform-Specific Behavior
 
 ### Unix/Mac (Has Symlinks)
+
 All agent-specific context files are **symlinks** to `.kittify/AGENTS.md`:
 ```bash
 ls -l CLAUDE.md
@@ -232,6 +247,7 @@ ls -l CLAUDE.md
 **Benefit**: Single source of truth, updates to AGENTS.md instantly affect all agents
 
 ### Windows (No Symlinks by Default)
+
 All agent-specific context files are **copies** of `.kittify/AGENTS.md`:
 ```powershell
 ls CLAUDE.md
@@ -259,6 +275,7 @@ ls .gemini/commands/        # Gemini (TOML)
 ## Troubleshooting
 
 ### "Invalid AI assistant"
+
 ```bash
 # ERROR
 spec-kitty init proj --ai CODEX
@@ -272,19 +289,21 @@ Valid keys are lowercase: `codex`, `claude`, `gemini`, `cursor`, `qwen`, `openco
 ## Complete Reference
 
 ### Minimal Non-Interactive Init
+
 ```bash
 spec-kitty init my-project --ai codex --non-interactive
 ```
 
 ### Maximum Options
+
 ```bash
 spec-kitty init my-project \
   --ai codex,claude,cursor \
-  --no-git \
   --non-interactive
 ```
 
 ### Current Directory
+
 ```bash
 spec-kitty init . --ai codex --non-interactive
 ```
@@ -335,14 +354,17 @@ Usage:
 ```
 
 ## Command Reference
+
 - [`spec-kitty init`](../reference/cli-commands.md#spec-kitty-init)
 - [`spec-kitty dashboard`](../reference/cli-commands.md#spec-kitty-dashboard)
 - [`spec-kitty agent`](../reference/agent-subcommands.md)
 
 ## See Also
+
 - [Install Spec Kitty](install-spec-kitty.md)
 - [Upgrade to 0.11.0](install-and-upgrade.md)
 
 ## Background
+
 - [AI Agent Architecture](../explanation/ai-agent-architecture.md)
 - [Execution Lanes](../explanation/execution-lanes.md)

--- a/docs/how-to/use-dashboard.md
+++ b/docs/how-to/use-dashboard.md
@@ -5,7 +5,7 @@ description: Start, view, and manage the real-time kanban dashboard for Spec Kit
 
 # How to Use the Spec Kitty Dashboard
 
-The dashboard provides live, project-wide visibility into work packages, lanes, and agent activity. It launches during `spec-kitty init` and can be opened anytime.
+The dashboard provides live, project-wide visibility into work packages, lanes, and agent activity. Start it on demand whenever you want to inspect progress.
 
 ## Starting the Dashboard
 
@@ -15,7 +15,11 @@ spec-kitty dashboard
 /spec-kitty.dashboard
 ```
 
-If the dashboard isn't already running, Spec Kitty starts it in the background and opens a browser tab.
+If the dashboard isn't already running, Spec Kitty starts it in the background. Add `--open` if you want it to launch in your browser immediately:
+
+```bash
+spec-kitty dashboard --open
+```
 
 ## Dashboard URL
 
@@ -55,7 +59,7 @@ This stops the background process and clears the `.kittify/.dashboard` metadata.
 
 ## Dashboard Auto-Start
 
-`spec-kitty init` starts the dashboard automatically for each project. You can re-run `spec-kitty init .` if the dashboard metadata is missing or stale.
+`spec-kitty init` does not auto-start the dashboard in the current `3.1.x` flow. If dashboard metadata is missing or stale, run `spec-kitty dashboard` again to recreate it.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,19 +11,16 @@ Spec-kitty is a spec-driven development tool that coordinates AI agents through 
 | **Reference** | Precise descriptions of CLI commands, configuration, and APIs. | [CLI Commands](reference/cli-commands.md) |
 | **Explanation** | Background concepts, architecture, and design decisions. | [Spec-Driven Development](explanation/spec-driven-development.md) |
 
-## Latest Release: 3.1.0
+## Latest Release: 3.1.4
 
-Spec Kitty 3.1.0 (released 2026-04-07) stabilises planning and execution reliability and adds recovery workflows. Key changes:
+Spec Kitty 3.1.4 (released 2026-04-15) rounds out the `3.1.x` line with runtime, auth, charter, and command-surface cleanup. Key changes across `3.1.1` through `3.1.4`:
 
-- **Read-only commands no longer dirty the git tree** — `status`, `next` (query mode), and `dashboard` leave `git status --porcelain` clean
-- **`wps.yaml` manifest** — structured dependency source eliminates prose-parser lane corruption; `finalize-tasks` derives deps from YAML, `tasks.md` becomes a generated artifact
-- **`spec-kitty next` query mode** — `spec-kitty next --mission <slug>` is the read-only query form; fresh runs return `mission_state: not_started` plus `preview_step`, and the command does not advance the state machine
-- **Execution resilience** — `merge --resume`, `implement --recover`, `doctor` for stale-claim diagnostics
-- **Planning-artifact work packages** — planning-artifact execution runs in repository root outside the lane graph rather than in a lane worktree
-- **Stale status JSON** — the canonical shape now uses a nested `stale` object; temporary flat stale fields remain as a compatibility surface during the transition
-- **Review resilience** — versioned review-cycle artifacts, focused fix prompts, dirty-state classification
-- **Charter** — `spec-kitty charter` replaces `spec-kitty constitution`; auto-migrated by `spec-kitty upgrade`
-- **`--mission`** — canonical flag everywhere; `--feature` retained only as a hidden deprecated alias during migration
+- **Runtime loop is now the primary mental model** — `spec-kitty next` remains the canonical driver, and query mode is safe and read-only
+- **Hosted auth and SaaS sync are first-class** — browser-based `spec-kitty auth login`, explicit hosted rollout gating, and clearer tracker readiness checks
+- **13 slash-command agents are supported** — including first-class Kiro support while retaining legacy `q` compatibility
+- **Review and merge resilience improved again** — persisted review-cycle artifacts, focused fix prompts, sparse-checkout preflights, and `spec-kitty doctor sparse-checkout --fix`
+- **Charter bundle is a validated contract** — `spec-kitty charter bundle validate` checks the canonical charter outputs and worktrees now resolve them from the main checkout
+- **Generated command prompts were cleaned up in 3.1.3/3.1.4** — `charter`, `specify`, `plan`, `implement`, `review`, and `merge` now teach the actual mission/runtime flow instead of stale shim-era guidance
 
 **Upgrading from 3.0.x?** Run `spec-kitty upgrade` — all renames happen automatically.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -18,7 +18,7 @@ Reference docs are:
 - [Environment Variables](environment-variables.md) - All environment variables
 - [File Structure](file-structure.md) - Directory layout and file purposes
 - [Missions](missions.md) - Mission types and configuration
-- [Supported Agents](supported-agents.md) - All 12 supported AI agents
+- [Supported Agents](supported-agents.md) - The 13 slash-command agents supported by the CLI
 
 ## See Also
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -16,6 +16,7 @@ Terminology note:
 **Description**: Spec Kitty CLI entry point.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--version`, `-v` | Show version and exit |
@@ -64,11 +65,11 @@ Terminology note:
 - `PROJECT_NAME`: Name for your new project directory (use `.` for current directory)
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--ai TEXT` | Comma-separated AI assistants (claude,codex,gemini,...) |
 | `--non-interactive` / `--yes` | Disable prompts (CI/CD) |
-| `--no-git` | Skip git repository initialization |
 | `--help` | Show this message and exit |
 
 **Examples**:
@@ -80,7 +81,7 @@ spec-kitty init . --ai codex
 spec-kitty init my-project --ai codex --non-interactive
 ```
 
-**See Also**: `docs/non-interactive-init.md`
+**See Also**: `docs/how-to/non-interactive-init.md`
 
 ---
 
@@ -91,6 +92,7 @@ spec-kitty init my-project --ai codex --non-interactive
 **Description**: Upgrade a Spec Kitty project to the current version.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--dry-run` | Preview changes without applying |
@@ -120,6 +122,7 @@ spec-kitty upgrade --target 0.6.5
 - `WP_ID`: Work package ID (e.g., `WP01`) [required]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug (canonical flag; e.g., `001-my-feature`) |
@@ -147,6 +150,7 @@ spec-kitty implement WP01 --json
 **Description**: Validate mission readiness before merging to main.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug to accept |
@@ -168,6 +172,7 @@ spec-kitty implement WP01 --json
 **Description**: Merge lane branches into the mission branch, merge the mission branch into the target branch, and clean up execution worktrees. Use `--resume` to continue an interrupted merge from saved state. Use `--abort` to clear merge state and abort any in-progress git merge.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--strategy TEXT` | Merge strategy: `MERGE` (merge commit), `SQUASH` (squash to single commit), or `REBASE` (linear history). Default: `SQUASH`. Case-insensitive. |
@@ -202,6 +207,7 @@ spec-kitty merge --abort    # clear saved state and abort any in-progress git me
 **Description**: Open or stop the Spec Kitty dashboard.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--port INTEGER` | Preferred port for the dashboard (falls back to first available port) |
@@ -218,6 +224,7 @@ spec-kitty merge --abort    # clear saved state and abort any in-progress git me
 **Description**: Execute Phase 0 research workflow to scaffold artifacts.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug to target |
@@ -233,6 +240,7 @@ spec-kitty merge --abort    # clear saved state and abort any in-progress git me
 **Description**: Machine-contract API for external orchestrators. Every command emits exactly one JSON envelope and exits non-zero on failure.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -259,6 +267,7 @@ spec-kitty merge --abort    # clear saved state and abort any in-progress git me
 **Description**: Synchronization commands. This is a command group with subcommands for workspace sync, event queue sync, and sync health diagnostics.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -278,6 +287,7 @@ spec-kitty merge --abort    # clear saved state and abort any in-progress git me
 **Description**: Synchronize workspace with upstream changes. Updates the current workspace with changes from its base branch or parent using `git rebase <base-branch>`. Sync may fail on conflicts; you must resolve conflicts before continuing.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--repair`, `-r` | Attempt workspace recovery (may lose uncommitted work) |
@@ -301,6 +311,7 @@ spec-kitty sync workspace --repair
 - `URL`: Sync server URL to set (must be `https://...`) [optional]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -318,6 +329,7 @@ spec-kitty sync server https://spec-kitty-dev.fly.dev
 **Description**: Trigger immediate sync of all queued events. Drains the offline queue completely, uploading events to the server in batches of 1000 until the queue is empty or all remaining events have exceeded their retry limit.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--report PATH` | Export per-event failure details to a JSON file |
@@ -338,6 +350,7 @@ spec-kitty sync now --no-strict
 **Description**: Show sync queue status, connection state, and auth info. Displays offline queue size, connection/emitter status, last sync timestamp, auth status, and server URL configuration.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--check`, `-c` | Test connection to server (may be slow if server is unreachable) |
@@ -356,6 +369,7 @@ spec-kitty sync status --check
 **Description**: Validate queued events locally against the event schema. Reads all pending events from the offline queue and validates each one against the Pydantic Event model and per-event-type payload rules. Valid events are reported as passing; malformed events show specific field errors grouped by error category.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Output results as JSON instead of Rich table |
@@ -374,6 +388,7 @@ spec-kitty sync diagnose --json
 **Description**: Diagnose sync health: queue, auth, and server connectivity. Runs a comprehensive check of offline queue state, authentication validity, and server reachability, printing actionable remediation steps for any issues found.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -394,6 +409,7 @@ spec-kitty sync doctor
 **Description**: Operation history (git reflog).
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -409,6 +425,7 @@ spec-kitty sync doctor
 **Description**: Show git reflog entries. Displays recent git operations that have modified the repository state.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--limit`, `-n INTEGER` | Number of operations to show (default: 20) |
@@ -429,6 +446,7 @@ spec-kitty ops log --verbose
 **Description**: Undo is not supported for git. Git does not have reversible operation history. Consider using these alternatives manually: `git reset --soft HEAD~1` (undo last commit, keep changes), `git reset --hard HEAD~1` (undo last commit, discard changes), `git revert <commit>` (create reverting commit), or `git reflog` (find previous states).
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -442,6 +460,7 @@ spec-kitty ops log --verbose
 **Description**: View available Spec Kitty missions. Mission types are selected per mission during `/spec-kitty.specify`.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -453,6 +472,7 @@ spec-kitty ops log --verbose
 **Description**: List all available missions with their source (project/built-in).
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -464,6 +484,7 @@ spec-kitty ops log --verbose
 **Description**: Show currently active mission.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -478,6 +499,7 @@ spec-kitty ops log --verbose
 - `MISSION_NAME`: Mission name to display details for [required]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -492,6 +514,7 @@ spec-kitty ops log --verbose
 - `MISSION_NAME`: Mission name (no longer supported) [required]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--force` | (ignored) |
@@ -506,6 +529,7 @@ spec-kitty ops log --verbose
 **Description**: Validate and optionally fix file encoding in mission artifacts.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug to validate |
@@ -523,6 +547,7 @@ spec-kitty ops log --verbose
 **Description**: Validate and optionally fix task metadata inconsistencies.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug to validate |
@@ -541,6 +566,7 @@ spec-kitty ops log --verbose
 **Description**: Verify that the current environment matches Spec Kitty expectations.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug to verify |
@@ -559,6 +585,7 @@ spec-kitty ops log --verbose
 **Description**: List legacy worktrees blocking 0.11.0 upgrade.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -572,6 +599,7 @@ spec-kitty ops log --verbose
 **Description**: Repair broken templates.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -587,6 +615,7 @@ spec-kitty ops log --verbose
 **Description**: Repair broken templates caused by v0.10.0-0.10.8 bundling bug.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--project-path PATH`, `-p` | Path to project to repair |
@@ -603,6 +632,7 @@ spec-kitty ops log --verbose
 - `WORKTREE_PATH`: Specific worktree path to check (defaults to current directory if in a worktree) [optional]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--all` | Check all worktrees in .worktrees/ directory |
@@ -623,6 +653,7 @@ spec-kitty repair worktree --all
 **Description**: Commands for AI agents to execute spec-kitty workflows programmatically.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -841,7 +872,7 @@ spec-kitty agent config status
 
 **Description**:
 
-Displays a comprehensive table showing all 12 supported agents, whether they're configured, whether directories exist, and sync status.
+Displays a comprehensive table showing the current supported slash-command agents, whether they're configured, whether directories exist, and sync status.
 
 **Arguments**: None
 
@@ -970,6 +1001,7 @@ Sets a project-level configuration value in `.kittify/config.yaml`. Currently su
 - `VALUE`: Configuration value (e.g., `true`, `false`) [required]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1004,6 +1036,7 @@ spec-kitty agent config set auto_commit true
 **Description**: Prepare a release candidate: validates `CHANGELOG.md`, bumps version in `pyproject.toml`, creates an annotated git tag, and optionally opens a GitHub release draft. Added in 3.1.0 (mission 068).
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--channel TEXT` | Release channel: `alpha`, `beta`, or `stable` (default: `stable`) |
@@ -1036,6 +1069,7 @@ spec-kitty agent release prep --channel stable
 **Description**: Scan the test suite for stale assertions: version strings, hardcoded timestamps, or environment-specific values that would cause false failures after a release. Uses `ast`-based analysis (no test execution required). Added in 3.1.0 (mission 068).
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--base TEXT` | Base git ref to diff against (default: `HEAD~1`) |
@@ -1062,6 +1096,7 @@ spec-kitty agent tests stale-check --json
 - `FEATURE`: Feature name or slug (e.g., `user-authentication`) [required]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission-type TEXT` | Mission type (e.g., `software-dev`, `research`) |
@@ -1084,6 +1119,7 @@ spec-kitty specify my-feature --json
 **Description**: Scaffold plan.md for a mission.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission slug (e.g., `001-user-authentication`) |
@@ -1106,6 +1142,7 @@ spec-kitty plan --json
 **Description**: Finalize tasks metadata after task generation.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Emit JSON result |
@@ -1126,6 +1163,7 @@ spec-kitty tasks --json
 **Description**: Display project configuration and asset resolution information.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--show-origin` | Show where each resolved asset comes from (tier label + path) |
@@ -1150,6 +1188,7 @@ spec-kitty config -m documentation
 As of 3.1.0, omitting `--result` is **query mode**: the command reads and prints the current mission state without advancing it. `--agent` and `--mission` are still required.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--agent TEXT` | Agent name (required) |
@@ -1189,6 +1228,7 @@ spec-kitty next --agent claude --mission 034-my-feature --answer "approve" --dec
 **Description**: Migrate project .kittify/ to centralized model. First ensures the global runtime (`~/.kittify/`) is up to date, then classifies per-project files as identical (removed), customized (moved to overrides/), or project-specific (kept). Running this command multiple times is safe (idempotent). After the first successful run, subsequent invocations are a near-instant no-op.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--dry-run` | Show what would change without modifying the filesystem |
@@ -1212,6 +1252,7 @@ spec-kitty migrate --verbose
 **Description**: Authentication commands.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1228,6 +1269,7 @@ spec-kitty migrate --verbose
 **Description**: Log in to the sync service.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--username`, `-u TEXT` | Your username or email |
@@ -1242,6 +1284,7 @@ spec-kitty migrate --verbose
 **Description**: Log out from the sync service.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1253,6 +1296,7 @@ spec-kitty migrate --verbose
 **Description**: Show current authentication status.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1266,6 +1310,7 @@ spec-kitty migrate --verbose
 **Description**: Charter management commands. As of 3.1.0 (mission 063), `spec-kitty charter` is the canonical command. `spec-kitty constitution` has been removed; all existing `constitution` references should be updated to `charter`.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1284,6 +1329,7 @@ spec-kitty migrate --verbose
 **Description**: Capture charter interview answers for later generation.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission key for charter defaults (default: `software-dev`) |
@@ -1302,6 +1348,7 @@ spec-kitty migrate --verbose
 **Description**: Generate charter bundle from interview answers + doctrine references.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission key for template-set defaults |
@@ -1319,6 +1366,7 @@ spec-kitty migrate --verbose
 **Description**: Render charter context for a specific workflow action.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--action TEXT` | Workflow action (`specify`, `plan`, `implement`, `review`) [required] |
@@ -1333,6 +1381,7 @@ spec-kitty migrate --verbose
 **Description**: Sync charter.md to structured YAML config files.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--force`, `-f` | Force sync even if not stale |
@@ -1346,6 +1395,7 @@ spec-kitty migrate --verbose
 **Description**: Display charter sync status.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Output JSON |
@@ -1360,6 +1410,7 @@ spec-kitty migrate --verbose
 **Description**: Query workspace context information.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1376,6 +1427,7 @@ spec-kitty migrate --verbose
 **Description**: Show context information for current or specified workspace.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--workspace`, `-w TEXT` | Workspace name (auto-detected if inside worktree) |
@@ -1396,6 +1448,7 @@ spec-kitty context info --json
 **Description**: List all workspace contexts.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Output in JSON format |
@@ -1416,6 +1469,7 @@ spec-kitty context list --json
 **Description**: Clean up orphaned workspace contexts. Removes context files for workspaces that no longer exist.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--dry-run` | Show what would be cleaned up without deleting |
@@ -1442,6 +1496,7 @@ spec-kitty doctor --mission 034-my-feature
 ```
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Restrict scan to a specific mission slug |
@@ -1458,6 +1513,7 @@ spec-kitty doctor --mission 034-my-feature
 **Description**: Show state roots, surface classification, and safety warnings. Displays the three state roots with resolved paths, all registered state surfaces grouped by root with authority and Git classification, and warnings for any runtime surfaces not covered by .gitignore.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Machine-readable JSON output |
@@ -1478,6 +1534,7 @@ spec-kitty doctor state-roots --json
 **Description**: Glossary management commands.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1494,6 +1551,7 @@ spec-kitty doctor state-roots --json
 **Description**: List all terms in glossary.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--scope TEXT` | Filter by scope (`mission_local`, `team_domain`, `audience_domain`, `spec_kitty_core`) |
@@ -1508,6 +1566,7 @@ spec-kitty doctor state-roots --json
 **Description**: Display conflict history from event log.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Filter conflicts by mission ID |
@@ -1526,6 +1585,7 @@ spec-kitty doctor state-roots --json
 - `CONFLICT_ID`: Conflict ID to resolve [required]
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--mission TEXT` | Mission ID for event log (auto-detected if omitted) |
@@ -1540,6 +1600,7 @@ spec-kitty doctor state-roots --json
 **Description**: Task tracker commands.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1559,6 +1620,7 @@ spec-kitty doctor state-roots --json
 **Description**: List supported tracker providers, grouped into SaaS-backed (`linear`, `jira`, `github`, `gitlab`) and local/native (`beads`, `fp`) modes.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Render provider list as JSON |
@@ -1571,6 +1633,7 @@ spec-kitty doctor state-roots --json
 **Description**: Bind the current project to a tracker. SaaS-backed providers require `--project-slug` and authenticate through `spec-kitty auth login`; local/native providers require `--workspace` and may accept `--credential`.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--provider TEXT` | Provider name (`linear`, `jira`, `github`, `gitlab`, `beads`, `fp`) [required] |
@@ -1588,6 +1651,7 @@ spec-kitty doctor state-roots --json
 **Description**: Show tracker binding and sync status. SaaS-backed providers read status from the Spec Kitty SaaS control plane; local/native providers show local config and cache details.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Render status as JSON |
@@ -1600,6 +1664,7 @@ spec-kitty doctor state-roots --json
 **Description**: Remove tracker binding for this project. For SaaS-backed providers this clears only local project config; unlinking the provider account still happens in the Spec Kitty dashboard.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1611,6 +1676,7 @@ spec-kitty doctor state-roots --json
 **Description**: Work-package mapping commands.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1626,6 +1692,7 @@ spec-kitty doctor state-roots --json
 **Description**: Add or update a WP-to-external issue mapping. For SaaS-backed providers this command hard-fails and directs you to the Spec Kitty dashboard, where mappings are managed server-side.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--wp-id TEXT` | Work package ID (e.g., `WP01`) [required] |
@@ -1641,6 +1708,7 @@ spec-kitty doctor state-roots --json
 **Description**: List tracker mappings. For SaaS-backed providers this reads the SaaS-authoritative mapping view; for local/native providers it reads the local mapping store.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--json` | Render mappings as JSON |
@@ -1653,6 +1721,7 @@ spec-kitty doctor state-roots --json
 **Description**: Tracker synchronization commands.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--help` | Show this message and exit |
@@ -1670,6 +1739,7 @@ spec-kitty doctor state-roots --json
 **Description**: Pull tracker updates into the local cache.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--limit INTEGER` | Maximum items to pull (default: 100, range: 1-10000) |
@@ -1683,6 +1753,7 @@ spec-kitty doctor state-roots --json
 **Description**: Push explicit tracker mutations to the upstream provider. For SaaS-backed providers this is an explicit-mutation path and requires `--items-json`; use `tracker sync run` for the normal full-sync path.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--limit INTEGER` | Maximum items to push (local/native providers only; default: 100, range: 1-10000) |
@@ -1697,6 +1768,7 @@ spec-kitty doctor state-roots --json
 **Description**: Run pull+push synchronization in one operation. For SaaS-backed providers this is the normal full-sync path executed entirely through Spec Kitty SaaS.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--limit INTEGER` | Maximum items per direction (default: 100, range: 1-10000) |
@@ -1710,6 +1782,7 @@ spec-kitty doctor state-roots --json
 **Description**: Publish a local tracker snapshot to Spec Kitty SaaS. This command is retired for SaaS-backed providers and fails with guidance to use `tracker sync push` or `tracker sync run` instead.
 
 **Options**:
+
 | Flag | Description |
 | --- | --- |
 | `--server-url TEXT` | Spec Kitty SaaS base URL |
@@ -1740,10 +1813,12 @@ The Spec Kitty status model uses 7 lanes plus one alias:
 ---
 
 ## Getting Started
+
 - [Claude Code Integration](../tutorials/claude-code-integration.md)
 - [Claude Code Workflow](../tutorials/claude-code-workflow.md)
 
 ## Practical Usage
+
 - [Install Spec Kitty](../how-to/install-spec-kitty.md)
 - [Use the Dashboard](../how-to/use-dashboard.md)
 - [Upgrade to 0.11.0](../how-to/install-and-upgrade.md)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -330,7 +330,7 @@ agents:
 - [CLI Reference: spec-kitty agent config](cli-commands.md#spec-kitty-agent-config) - Command syntax and options
 - [ADR #6: Config-Driven Agent Management](../../architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) - Architectural decision rationale
 
-> **Legacy behavior**: Projects without `agents.available` field default to all 12 agents for backward compatibility. To adopt config-driven model, use `spec-kitty agent config remove` to remove unwanted agents.
+> **Legacy behavior**: Projects without `agents.available` field default to the full slash-command agent set for backward compatibility (currently 13 agent keys in the active CLI surface). To adopt config-driven model, use `spec-kitty agent config remove` to remove unwanted agents.
 
 ### Managing Agents
 
@@ -446,7 +446,7 @@ Selected agents are stored in `config.yaml` and their directories are created au
 
 - **Upgrades only process configured agents** - If you remove an agent, upgrades won't recreate it
 - **Deleted agents stay deleted** - Manual deletions are respected
-- **Legacy projects fallback gracefully** - Projects without `config.yaml` process all 12 agents
+- **Legacy projects fallback gracefully** - Projects without `config.yaml` process the full supported slash-command agent set
 
 This ensures your agent preferences are preserved across upgrades.
 
@@ -492,8 +492,10 @@ If you see this file in older projects, it will be ignored. The mission in each 
 - [CLI Commands](cli-commands.md) — Command reference including `--vcs` flag
 
 ## Getting Started
+
 - [Claude Code Integration](../tutorials/claude-code-integration.md)
 
 ## Practical Usage
+
 - [Non-Interactive Init](../how-to/non-interactive-init.md)
 - [Upgrade to 0.11.0](../how-to/install-and-upgrade.md)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,152 +1,52 @@
 # Environment Variables Reference
 
-This document lists all environment variables used by Spec Kitty.
+This page lists the user-facing environment variables that are active in the current `3.1.x` CLI surface.
 
 ---
 
-## Feature Detection
+## Runtime and Installation
 
-### SPECIFY_FEATURE
+### SPEC_KITTY_HOME
 
-Override automatic feature detection.
+Override the runtime home directory used for shared Spec Kitty state.
 
-**Purpose**: Force Spec Kitty to use a specific feature when automatic detection fails (e.g., in non-Git repositories or CI environments).
+**Purpose**: Change where the CLI stores shared state such as runtime files and upgrade-managed assets.
 
 **Example**:
 ```bash
-export SPECIFY_FEATURE=014-comprehensive-docs
-spec-kitty agent tasks status
+export SPEC_KITTY_HOME="$HOME/.spec-kitty-dev"
+spec-kitty verify-setup
 ```
-
-**When to use**:
-- Running commands outside a Git repository
-- CI/CD pipelines where Git context is unavailable
-- Testing with a specific feature
-
----
-
-## Template Customization
 
 ### SPEC_KITTY_TEMPLATE_ROOT
 
-Use local templates instead of fetching from GitHub.
+Point Spec Kitty at a local checkout for bundled templates and mission assets.
 
-**Purpose**: Point to a local directory containing Spec Kitty templates. Useful for template development or air-gapped environments.
+**Purpose**: Useful when developing Spec Kitty itself, testing template changes from source, or running in an environment where packaged resources are unavailable.
 
 **Example**:
 ```bash
-export SPEC_KITTY_TEMPLATE_ROOT=/path/to/spec-kitty/src/specify_cli/templates
+export SPEC_KITTY_TEMPLATE_ROOT=/path/to/spec-kitty
 spec-kitty init my-project --ai claude
 ```
 
-**When to use**:
-- Developing or testing template changes
-- Environments without internet access
-- Custom template workflows
-
 ### SPECIFY_TEMPLATE_REPO
 
-Override the GitHub repository for templates.
+Override the remote template repository slug (`owner/name`).
 
-**Purpose**: Fetch templates from a different GitHub repository instead of the default.
+**Purpose**: Use a custom remote template source when you explicitly want to bootstrap or repair from a different repository.
 
 **Example**:
 ```bash
-export SPECIFY_TEMPLATE_REPO=my-org/custom-spec-kitty-templates
+export SPECIFY_TEMPLATE_REPO=my-org/custom-spec-kitty
 spec-kitty upgrade
 ```
 
-**When to use**:
-- Organizations with custom templates
-- Forked template repositories
-- Enterprise GitHub instances
-
----
-
-## Agent Configuration
-
-### CODEX_HOME
-
-Configure GitHub Codex CLI to find project prompts. This is a **Codex CLI convention**, not a spec-kitty environment variable — spec-kitty does not read this variable.
-
-**Purpose**: Point the Codex CLI to the project's `.codex/` directory for slash commands.
-
-**Example**:
-```bash
-export CODEX_HOME="$(pwd)/.codex"
-codex
-```
-
-**When to use**:
-- Using GitHub Codex as your AI agent
-- Codex can't find slash commands automatically
-
----
-
-## GitHub Integration
-
-### GH_TOKEN / GITHUB_TOKEN
-
-Authenticate with GitHub API.
-
-**Purpose**: Required for operations that use the GitHub API, such as fetching templates or creating pull requests.
-
-**Example**:
-```bash
-export GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
-spec-kitty init my-project
-```
-
-**Precedence**: `GH_TOKEN` takes precedence if both are set.
-
-**When to use**:
-- CI/CD pipelines
-- Automated workflows
-- Rate-limited environments (authenticated requests have higher limits)
-
----
-
-## Debug and Development
-
-### SPEC_KITTY_DEBUG
-
-Enable debug logging. **Note**: This variable is planned but not yet implemented in the current codebase. Use `--verbose` flags on individual commands instead.
-
-**Purpose**: Output verbose debug information for troubleshooting.
-
-**Example**:
-```bash
-export SPEC_KITTY_DEBUG=1
-spec-kitty agent tasks status
-```
-
-**When to use**:
-- Troubleshooting unexpected behavior
-- Reporting bugs
-- Understanding internal operations
-
-### SPEC_KITTY_NO_COLOR
-
-Disable colored output. **Note**: This variable is planned but not yet implemented. Rich library controls are used directly.
-
-**Purpose**: Remove ANSI color codes from terminal output.
-
-**Example**:
-```bash
-export SPEC_KITTY_NO_COLOR=1
-spec-kitty agent tasks status
-```
-
-**When to use**:
-- CI/CD logs that don't support colors
-- Piping output to files
-- Accessibility needs
-
 ### SPEC_KITTY_NON_INTERACTIVE
 
-Force non-interactive mode for CLI commands that normally prompt.
+Force non-interactive mode for commands that normally prompt.
 
-**Purpose**: Disable prompts and arrow-key menus (useful for CI/CD).
+**Purpose**: Equivalent to passing `--non-interactive` / `--yes` on commands such as `spec-kitty init`.
 
 **Example**:
 ```bash
@@ -154,10 +54,123 @@ export SPEC_KITTY_NON_INTERACTIVE=1
 spec-kitty init my-project --ai codex --non-interactive
 ```
 
-**When to use**:
-- CI/CD pipelines
-- Headless scripts
-- Non-TTY automation
+### SPEC_KITTY_WORKTREE_REMOVAL_DELAY
+
+Adjust the delay before completed worktrees are removed.
+
+**Purpose**: Useful when debugging merge/worktree cleanup behavior.
+
+**Example**:
+```bash
+export SPEC_KITTY_WORKTREE_REMOVAL_DELAY=10
+spec-kitty merge
+```
+
+---
+
+## Hosted Auth and Sync
+
+### SPEC_KITTY_ENABLE_SAAS_SYNC
+
+Opt in to hosted auth, tracker, and sync flows.
+
+**Purpose**: Enables the SaaS-backed readiness path. Leave it unset for fully local CLI workflows.
+
+**Example**:
+```bash
+export SPEC_KITTY_ENABLE_SAAS_SYNC=1
+spec-kitty auth login
+```
+
+### SPEC_KITTY_SAAS_URL
+
+Override the Spec Kitty SaaS base URL.
+
+**Purpose**: Point auth, tracker discovery, and sync clients at a specific hosted environment such as a dev deployment.
+
+**Example**:
+```bash
+export SPEC_KITTY_SAAS_URL=https://spec-kitty-dev.fly.dev
+spec-kitty auth login
+```
+
+---
+
+## Output and UX
+
+### SPEC_KITTY_SIMPLE_HELP
+
+Request a simpler help presentation.
+
+**Purpose**: Reduce the formatted help surface for terminals or wrappers that prefer plainer output.
+
+**Example**:
+```bash
+export SPEC_KITTY_SIMPLE_HELP=1
+spec-kitty --help
+```
+
+### SPEC_KITTY_NO_BANNER
+
+Suppress the startup banner.
+
+**Purpose**: Useful for scripts, screenshots, or wrappers that want less decorative output.
+
+**Example**:
+```bash
+export SPEC_KITTY_NO_BANNER=1
+spec-kitty init my-project --ai claude
+```
+
+---
+
+## Selector / Compatibility Toggles
+
+### SPECIFY_REPO_ROOT
+
+Override repository-root discovery for certain internal path-resolution flows.
+
+**Purpose**: Primarily useful for advanced development or unusual wrapper setups.
+
+**Example**:
+```bash
+export SPECIFY_REPO_ROOT=/path/to/repo
+spec-kitty verify-setup
+```
+
+### SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION
+
+Suppress warnings for the deprecated `--feature` alias.
+
+**Purpose**: Only for transitional automation that still emits the old selector.
+
+### SPEC_KITTY_SUPPRESS_MISSION_TYPE_DEPRECATION
+
+Suppress warnings for the deprecated mission-type alias surfaces.
+
+**Purpose**: Only for transitional automation or compatibility harnesses.
+
+---
+
+## External Tool Convention
+
+### CODEX_HOME
+
+Point the Codex CLI at your project's `.codex/` directory.
+
+This is a **Codex CLI convention**, not a Spec Kitty variable, but it remains relevant when using Codex with project-local prompts.
+
+**Example**:
+```bash
+export CODEX_HOME="$(pwd)/.codex"
+codex
+```
+
+---
+
+## Test-Only Variables
+
+The codebase also contains test and harness overrides such as `SPEC_KITTY_TEST_MODE`, `SPEC_KITTY_CLI_VERSION`, and `SPEC_KITTY_AUTORETRY`. Those are intentionally omitted from day-to-day operator guidance because they exist for tests, CI fixtures, or internal retry harnesses rather than normal end-user workflows.
 
 ---
 
@@ -165,15 +178,19 @@ spec-kitty init my-project --ai codex --non-interactive
 
 | Variable | Purpose | Example Value |
 |----------|---------|---------------|
-| `SPECIFY_FEATURE` | Override feature detection | `014-my-feature` |
-| `SPEC_KITTY_TEMPLATE_ROOT` | Local template path | `/path/to/templates` |
-| `SPECIFY_TEMPLATE_REPO` | Custom template repo | `org/templates` |
-| `CODEX_HOME` | Codex CLI prompt path | `$(pwd)/.codex` |
-| `GH_TOKEN` | GitHub authentication | `ghp_xxx...` |
-| `GITHUB_TOKEN` | GitHub authentication (alt) | `ghp_xxx...` |
-| `SPEC_KITTY_DEBUG` | Enable debug output | `1` |
-| `SPEC_KITTY_NO_COLOR` | Disable colors | `1` |
+| `SPEC_KITTY_HOME` | Override shared runtime home | `$HOME/.spec-kitty-dev` |
+| `SPEC_KITTY_TEMPLATE_ROOT` | Use a local template checkout | `/path/to/spec-kitty` |
+| `SPECIFY_TEMPLATE_REPO` | Use a custom remote template repo | `org/templates` |
 | `SPEC_KITTY_NON_INTERACTIVE` | Disable prompts | `1` |
+| `SPEC_KITTY_WORKTREE_REMOVAL_DELAY` | Delay worktree cleanup | `10` |
+| `SPEC_KITTY_ENABLE_SAAS_SYNC` | Opt in to hosted sync/auth flows | `1` |
+| `SPEC_KITTY_SAAS_URL` | Override hosted base URL | `https://spec-kitty-dev.fly.dev` |
+| `SPEC_KITTY_SIMPLE_HELP` | Use simpler help output | `1` |
+| `SPEC_KITTY_NO_BANNER` | Suppress startup banner | `1` |
+| `SPECIFY_REPO_ROOT` | Override repo-root discovery | `/path/to/repo` |
+| `SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION` | Silence deprecated `--feature` warnings | `1` |
+| `SPEC_KITTY_SUPPRESS_MISSION_TYPE_DEPRECATION` | Silence deprecated mission-type warnings | `1` |
+| `CODEX_HOME` | Codex CLI prompt path | `$(pwd)/.codex` |
 
 ---
 
@@ -184,8 +201,10 @@ spec-kitty init my-project --ai codex --non-interactive
 - [Non-Interactive Init](../how-to/non-interactive-init.md) — Common automation patterns
 
 ## Getting Started
+
 - [Claude Code Workflow](../tutorials/claude-code-workflow.md)
 
 ## Practical Usage
+
 - [Non-Interactive Init](../how-to/non-interactive-init.md)
 - [Install Spec Kitty](../how-to/install-spec-kitty.md)

--- a/docs/reference/supported-agents.md
+++ b/docs/reference/supported-agents.md
@@ -1,6 +1,8 @@
 # Supported AI Agents Reference
 
-Spec Kitty supports **13 AI coding agents** with slash commands. This document lists all supported agents and their configuration details.
+Spec Kitty currently exposes **13 slash-command agent surfaces**. This page documents the agents that get project command directories such as `.claude/commands/` or `.codex/prompts/`.
+
+Related assistant integrations such as `vibe` use shared skill roots rather than project slash-command directories, so they are intentionally out of scope for this specific table.
 
 ---
 
@@ -216,7 +218,7 @@ spec-kitty init my-project --ai kilocode
 
 **Usage**:
 ```bash
-spec-kitty init my-project --ai augment
+spec-kitty init my-project --ai auggie
 ```
 
 ---
@@ -388,11 +390,14 @@ export CODEX_HOME="$(pwd)/.codex"
 - [Install & Upgrade](../how-to/install-spec-kitty.md) — Installation guide
 
 ## Getting Started
+
 - [Claude Code Integration](../tutorials/claude-code-integration.md)
 
 ## Practical Usage
+
 - [Install Spec Kitty](../how-to/install-spec-kitty.md)
 - [Use the Dashboard](../how-to/use-dashboard.md)
 
 ## Background
+
 - [AI Agent Architecture](../explanation/ai-agent-architecture.md)

--- a/docs/tutorials/claude-code-integration.md
+++ b/docs/tutorials/claude-code-integration.md
@@ -314,9 +314,13 @@ and WebSocket for live reload. Dark mode toggle.
 
 ## Live Dashboard Integration
 
-### Automatic Dashboard Startup
+### Starting the Dashboard
 
-When you run `spec-kitty init`, the dashboard automatically starts on `the dashboard URL shown after init`.
+`spec-kitty init` no longer auto-starts the dashboard in the current `3.1.x` flow. Start it when you want it:
+
+```bash
+spec-kitty dashboard --open
+```
 
 ### What You See in Real-Time
 
@@ -522,7 +526,7 @@ Encode your team's quality standards once:
 
 ## Tips for Maximum Effectiveness
 
-### ✅ DO:
+### ✅ DO
 
 1. **Answer discovery questions thoroughly**
    - Claude needs good requirements to succeed
@@ -540,7 +544,7 @@ Encode your team's quality standards once:
    - `/spec-kitty.accept` is your quality gate
    - Better to catch issues before main branch
 
-### ❌ DON'T:
+### ❌ DON'T
 
 1. **Skip specification**
    - "Just build it" = context loss + rework
@@ -651,16 +655,19 @@ AI coding agents are pattern-matching machines. Without specs:
 The opinionated workflow isn't arbitrary - it's specifically designed around how AI agents work (and fail) in practice.
 
 ## Related How-To Guides
+
 - [Install Spec Kitty](../how-to/install-spec-kitty.md)
 - [Use the Dashboard](../how-to/use-dashboard.md)
 - [Non-Interactive Init](../how-to/non-interactive-init.md)
 
 ## Reference
+
 - [CLI Commands](../reference/cli-commands.md)
 - [Slash Commands](../reference/slash-commands.md)
 - [Supported Agents](../reference/supported-agents.md)
 
 ## Learn More
+
 - [Spec-Driven Development](../explanation/spec-driven-development.md)
 - [AI Agent Architecture](../explanation/ai-agent-architecture.md)
 - [Kanban Workflow](../explanation/kanban-workflow.md)

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -7,7 +7,6 @@ In this tutorial, you'll install Spec Kitty and create your first feature specif
 **Time**: ~30 minutes
 **Prerequisites**: Python 3.11+, Git, an AI coding agent (Claude Code, Cursor, Gemini CLI, etc.)
 
-
 ## Step 1: Install Spec Kitty
 
 Choose one install method:
@@ -29,7 +28,7 @@ spec-kitty --version
 Expected output (abridged):
 
 ```
-spec-kitty-cli version 2.1.1
+spec-kitty-cli version 3.1.4
 ```
 
 ## Step 2: Initialize a Project
@@ -45,10 +44,10 @@ Expected output (abridged):
 
 ```
 OK Initialized Spec Kitty project
-OK Generated agent commands in .claude/
+OK Created .kittify/ scaffold
 ```
 
-Tip: Use `spec-kitty init --here --ai claude` to initialize the current folder.
+Tip: Use `spec-kitty init . --ai claude` to initialize the current folder.
 
 ## Step 3: Create Your First Specification
 
@@ -64,8 +63,9 @@ You'll be asked a discovery interview. Answer each question until the command co
 
 Expected results:
 
-- `kitty-specs/###-task-list/spec.md` (feature spec)
-- A git commit in `main` with the spec changes
+- `kitty-specs/###-task-list/spec.md` (mission spec)
+- A new mission directory under `kitty-specs/`
+- No Git commit is created automatically; `init` and planning commands leave commit control to you
 
 ## Step 4: Verify Your Work
 
@@ -90,7 +90,7 @@ ls .worktrees
 ## Troubleshooting
 
 - **`spec-kitty: command not found`**: Reopen your shell or reinstall via `pipx` or `uv`. Then rerun `spec-kitty --version`.
-- **No `/spec-kitty.specify` command available**: Re-run `spec-kitty init --ai <your-agent>` or use `spec-kitty agent context update-context` to refresh agent context.
+- **No `/spec-kitty.specify` command available**: Re-run `spec-kitty init . --ai <your-agent>` from the project root, then verify the setup with `spec-kitty verify-setup --diagnostics`.
 - **`WAITING_FOR_DISCOVERY_INPUT`**: The command is paused for your answers; provide the requested details and continue.
 
 ## What's Next?
@@ -107,7 +107,7 @@ Continue with [Your First Feature](your-first-feature.md) for the complete workf
 
 - [CLI Commands](../reference/cli-commands.md) - Full command reference
 - [Slash Commands](../reference/slash-commands.md) - AI agent slash commands
-- [Supported Agents](../reference/supported-agents.md) - All 12 supported AI agents
+- [Supported Agents](../reference/supported-agents.md) - The 13 slash-command agents supported by the CLI
 
 ### Learn More
 

--- a/docs/tutorials/your-first-feature.md
+++ b/docs/tutorials/your-first-feature.md
@@ -14,7 +14,7 @@ This tutorial walks you through the entire Spec Kitty workflow from specificatio
 Workflow path:
 
 ```
-/spec-kitty.specify → /spec-kitty.plan → /spec-kitty.tasks → /spec-kitty.implement → /spec-kitty.review → /spec-kitty.accept → /spec-kitty.merge
+/spec-kitty.specify → /spec-kitty.plan → /spec-kitty.tasks → spec-kitty next → /spec-kitty.accept → /spec-kitty.merge
 ```
 
 You will build a tiny "task list" feature as the concrete example.
@@ -32,7 +32,7 @@ Answer the discovery interview until it completes.
 Expected results:
 
 - `kitty-specs/###-task-list/spec.md`
-- A git commit on `main` with the new spec
+- A new mission directory created under `kitty-specs/`
 
 ## Step 2: Create the Technical Plan
 
@@ -49,7 +49,7 @@ Answer the planning questions and confirm the Engineering Alignment summary.
 Expected results:
 
 - `kitty-specs/###-task-list/plan.md`
-- A git commit on `main` with the plan
+- Updated planning artifacts in the main repository checkout
 
 ## Step 3: Generate Work Packages
 
@@ -67,53 +67,39 @@ kitty-specs/###-task-list/tasks/
 
 Each WP file includes frontmatter with its `lane` and dependencies.
 
-## Step 4: Implement a Work Package
+## Step 4: Enter the Runtime Loop
 
-Start with the first planned package (example uses `WP01`).
-
-In your agent:
-
-```text
-/spec-kitty.implement
-```
-
-This moves the WP to `doing` and prints the implementation prompt. Then create the workspace from your terminal:
+Start the mission loop from your terminal:
 
 ```bash
-spec-kitty implement WP01
+spec-kitty next --agent claude --mission ###-task-list --json
 ```
 
-Expected output (abridged):
+The runtime returns the next action to take. During implementation you will usually see an `implement` decision for a specific WP.
 
-```
-OK Created workspace: .worktrees/###-task-list-lane-a
-```
-
-Move into the new worktree and implement the required changes:
+Execute that action with the lower-level command the runtime expects:
 
 ```bash
-cd .worktrees/###-task-list-lane-a
+spec-kitty agent action implement WP01 --agent claude
 ```
 
-When finished, return to the main repo and run the review step.
-
-## Step 5: Review Your Work
-
-From the main repo, ask your agent to review the work package.
-
-In your agent:
-
-```text
-/spec-kitty.review
-```
-
-Or via CLI:
+That command allocates or reuses the correct lane workspace. Make your code changes there, run the relevant tests, then report the result back to the runtime:
 
 ```bash
-spec-kitty agent action review WP01
+spec-kitty next --agent claude --mission ###-task-list --result success --json
 ```
 
-Follow the review instructions and address any feedback.
+Repeat the loop until the runtime starts issuing review work instead of implementation work.
+
+## Step 5: Review the Work Package
+
+When the runtime points you at review work, run the matching action:
+
+```bash
+spec-kitty agent action review WP01 --agent claude
+```
+
+Address any review feedback, then continue the `spec-kitty next` loop until the mission is ready for acceptance.
 
 ## Step 6: Accept and Merge
 
@@ -149,8 +135,8 @@ You should see the feature merged into `main` and the worktrees cleaned up.
 
 ## Troubleshooting
 
-- **"Planning created a worktree"**: In v0.11.0+, planning stays in `main`. If you see an unexpected planning worktree, upgrade with `spec-kitty upgrade`.
-- **"WP has dependencies"**: If the WP frontmatter lists dependencies, run `spec-kitty implement WP02` as suggested. The returned workspace may be a shared lane worktree such as `...-lane-a`.
+- **"Planning created a worktree"**: Planning stays in the main checkout in `3.1.x`. If you see an unexpected planning worktree, upgrade with `spec-kitty upgrade`.
+- **"WP has dependencies"**: Keep following the `spec-kitty next` decisions; the runtime will only issue implementation work when its dependencies are satisfied.
 - **Review fails validation**: Run `spec-kitty validate-tasks --fix` and re-run `/spec-kitty.review`.
 
 ## What's Next?


### PR DESCRIPTION
## Summary
- refresh the README for the current 3.1.4 / 3.1.x workflow and supported agent surface
- update install/tutorial/reference docs to match the current `init`, dashboard, runtime-loop, and env-var behavior
- remove stale guidance around deprecated flags and outdated auto-dashboard / auto-commit claims

## Verification
- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint-cli2.jsonc README.md docs/index.md docs/reference/README.md docs/reference/supported-agents.md docs/how-to/install-spec-kitty.md docs/reference/environment-variables.md docs/tutorials/getting-started.md docs/tutorials/your-first-feature.md docs/how-to/use-dashboard.md docs/reference/configuration.md docs/how-to/manage-agents.md docs/reference/cli-commands.md docs/how-to/non-interactive-init.md docs/how-to/diagnose-installation.md docs/tutorials/claude-code-integration.md`
- `python -m pytest -m "not windows_ci" -q tests/docs/test_architecture_docs_consistency.py tests/docs/test_versioned_docs_integrity.py`
- `python -m pytest tests/runtime/test_config.py tests/agent/cli/commands/test_agent_config.py tests/release/test_validate_release.py -q`
