### PR TITLE
fix: lighten merge-time sync fan-out

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -52,6 +52,7 @@ from specify_cli.merge.state import (
 from specify_cli.mission_metadata import resolve_mission_identity, write_meta
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace
 from specify_cli.post_merge.stale_assertions import StaleAssertionReport, run_check
+from specify_cli.sync.dossier_pipeline import trigger_feature_dossier_sync_if_enabled
 from specify_cli.status.wp_metadata import read_wp_frontmatter
 from specify_cli.tasks_support import TaskCliError, find_repo_root
 
@@ -196,6 +197,8 @@ def _mark_wp_merged_done(
                     evidence=evidence.to_dict(),
                     workspace_context=f"merge:{repo_root}",
                     repo_root=repo_root,
+                    ensure_sync_daemon=False,
+                    sync_dossier=False,
                 )
             except TransitionError as exc:
                 console.print(f"[yellow]Warning:[/yellow] Failed to mark {wp_id} approved before done: {exc}")
@@ -217,6 +220,8 @@ def _mark_wp_merged_done(
             evidence=evidence.to_dict(),
             workspace_context=f"merge:{repo_root}",
             repo_root=repo_root,
+            ensure_sync_daemon=False,
+            sync_dossier=False,
         )
     except TransitionError as exc:
         console.print(f"[yellow]Warning:[/yellow] Failed to mark {wp_id} done after merge: {exc}")
@@ -741,6 +746,7 @@ def _run_lane_based_merge_locked(
             console.print(f"  [dim]Skipping {lane.lane_id} (all WPs already done)[/dim]")
             continue
 
+        console.print(f"  [dim]Checking and merging {lane.lane_id}...[/dim]")
         lane_result = merge_lane_to_mission(main_repo, mission_slug, lane.lane_id, lanes_manifest)
         if lane_result.success:
             console.print(f"  [green]✓[/green] {lane.lane_id} → {lanes_manifest.mission_branch}")
@@ -776,6 +782,7 @@ def _run_lane_based_merge_locked(
     )
 
     # -- Mission-to-target merge (T010: honor strategy for this step only) --
+    console.print(f"  [dim]Merging mission branch into {lanes_manifest.target_branch}...[/dim]")
     mission_result = merge_mission_to_target(main_repo, mission_slug, lanes_manifest, strategy=strategy)
     if not mission_result.success:
         # T005: tolerate already-merged on retry
@@ -792,6 +799,7 @@ def _run_lane_based_merge_locked(
             console.print(f"  Commit: {mission_result.commit[:7]}")
 
     # -- T001: Mark WPs done with per-WP state tracking --
+    console.print("  [dim]Recording merged work packages as done...[/dim]")
     for lane in lanes_manifest.lanes:
         for wp_id in lane.wp_ids:
             if wp_id in completed_set:
@@ -891,7 +899,15 @@ def _run_lane_based_merge_locked(
         allow_empty=False,
     )
 
+    console.print("  [dim]Syncing dossier state for the merged mission...[/dim]")
+    trigger_feature_dossier_sync_if_enabled(
+        feature_dir,
+        mission_slug,
+        main_repo,
+    )
+
     # -- T013: Stale-assertion check (WP01 library import — NOT subprocess) --
+    console.print("  [dim]Running stale-assertion check...[/dim]")
     try:
         stale_report: StaleAssertionReport = run_check(
             base_ref=merge_base_sha,

--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -272,6 +272,8 @@ def emit_status_transition(
     repo_root: Path | None = None,
     policy_metadata: dict[str, Any] | None = None,
     review_result: Any = None,
+    ensure_sync_daemon: bool = True,
+    sync_dossier: bool = True,
 ) -> StatusEvent:
     """Central orchestration function for all status state changes.
 
@@ -298,6 +300,8 @@ def emit_status_transition(
         repo_root: Repository root for SaaS fan-out (optional).
         policy_metadata: Orchestrator policy metadata dict (optional).
         review_result: Structured ReviewResult for in_review -> * transitions (optional).
+        ensure_sync_daemon: If False, emit SaaS events without starting the local sync daemon.
+        sync_dossier: If False, skip dossier sync for this transition.
 
     Returns:
         The persisted StatusEvent.
@@ -414,10 +418,16 @@ def emit_status_transition(
     _mirror_phase1_frontmatter_lane(feature_dir, wp_id, resolved_lane)
 
     # Step 7: SaaS fan-out (never blocks canonical persistence)
-    _saas_fan_out(event, mission_slug, repo_root, policy_metadata=policy_metadata)
+    _saas_fan_out(
+        event,
+        mission_slug,
+        repo_root,
+        policy_metadata=policy_metadata,
+        ensure_sync_daemon=ensure_sync_daemon,
+    )
 
     # Step 8: Dossier sync (fire-and-forget, never blocks)
-    if repo_root is not None:
+    if sync_dossier and repo_root is not None:
         try:
             from specify_cli.sync.dossier_pipeline import (
                 trigger_feature_dossier_sync_if_enabled,
@@ -441,6 +451,7 @@ def _saas_fan_out(
     _repo_root: Path | None,
     *,
     policy_metadata: dict[str, Any] | None = None,
+    ensure_sync_daemon: bool = True,
 ) -> None:
     """Conditionally emit a SaaS telemetry event via the sync pipeline.
 
@@ -458,6 +469,7 @@ def _saas_fan_out(
             actor=event.actor,
             mission_slug=mission_slug,
             policy_metadata=policy_metadata,
+            ensure_daemon=ensure_sync_daemon,
         )
     except ImportError:
         pass  # SaaS sync not available (0.1x branch)

--- a/src/specify_cli/sync/events.py
+++ b/src/specify_cli/sync/events.py
@@ -40,9 +40,9 @@ def _resolve_repo_root() -> Path | None:
         return None
 
 
-def _ensure_dashboard_sync_daemon(repo_root: Path | None) -> None:
+def _ensure_dashboard_sync_daemon(repo_root: Path | None, *, ensure_daemon: bool = True) -> None:
     """Keep the machine-global sync daemon alive for authenticated sync sessions."""
-    if repo_root is None or not is_saas_sync_enabled():
+    if not ensure_daemon or repo_root is None or not is_saas_sync_enabled():
         return
 
     if not (repo_root / ".kittify").is_dir():
@@ -78,10 +78,10 @@ def _ensure_dashboard_sync_daemon(repo_root: Path | None) -> None:
         logger.warning("Could not ensure global sync daemon: %s", exc)
 
 
-def _ensure_dashboard_sync_daemon_for_active_project() -> Path | None:
+def _ensure_dashboard_sync_daemon_for_active_project(*, ensure_daemon: bool = True) -> Path | None:
     """Resolve the active project and keep its dashboard daemon healthy."""
     repo_root = _resolve_repo_root()
-    _ensure_dashboard_sync_daemon(repo_root)
+    _ensure_dashboard_sync_daemon(repo_root, ensure_daemon=ensure_daemon)
     return repo_root
 
 
@@ -189,9 +189,11 @@ def emit_wp_status_changed(
     mission_slug: str | None = None,
     causation_id: str | None = None,
     policy_metadata: dict[str, Any] | None = None,
+    *,
+    ensure_daemon: bool = True,
 ) -> dict[str, Any] | None:
     """Emit WPStatusChanged event via singleton."""
-    repo_root = _ensure_dashboard_sync_daemon_for_active_project()
+    repo_root = _ensure_dashboard_sync_daemon_for_active_project(ensure_daemon=ensure_daemon)
     event = get_emitter().emit_wp_status_changed(
         wp_id=wp_id,
         from_lane=from_lane,
@@ -213,9 +215,11 @@ def emit_wp_created(
     mission_slug: str,
     dependencies: list[str] | None = None,
     causation_id: str | None = None,
+    *,
+    ensure_daemon: bool = True,
 ) -> dict[str, Any] | None:
     """Emit WPCreated event via singleton."""
-    repo_root = _ensure_dashboard_sync_daemon_for_active_project()
+    repo_root = _ensure_dashboard_sync_daemon_for_active_project(ensure_daemon=ensure_daemon)
     event = get_emitter().emit_wp_created(
         wp_id=wp_id,
         title=title,
@@ -235,9 +239,11 @@ def emit_wp_assigned(
     phase: str,
     retry_count: int = 0,
     causation_id: str | None = None,
+    *,
+    ensure_daemon: bool = True,
 ) -> dict[str, Any] | None:
     """Emit WPAssigned event via singleton."""
-    repo_root = _ensure_dashboard_sync_daemon_for_active_project()
+    repo_root = _ensure_dashboard_sync_daemon_for_active_project(ensure_daemon=ensure_daemon)
     event = get_emitter().emit_wp_assigned(
         wp_id=wp_id,
         agent_id=agent_id,

--- a/tests/cli/commands/test_merge_status_commit.py
+++ b/tests/cli/commands/test_merge_status_commit.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-from specify_cli.cli.commands.merge import _run_lane_based_merge
+from specify_cli.cli.commands.merge import _mark_wp_merged_done, _run_lane_based_merge
 from specify_cli.merge.config import MergeStrategy
 
 pytestmark = pytest.mark.git_repo
@@ -159,6 +159,88 @@ class TestSafeCommitCalledAfterMarkDoneLoop:
         file_names = [f.name for f in files]
         assert "status.events.jsonl" in file_names
         assert "status.json" in file_names
+
+    def test_merge_batches_dossier_sync_once(self, tmp_path: Path) -> None:
+        mission_slug = "068-test-dossier"
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        feature_dir.mkdir(parents=True)
+
+        manifest = MagicMock()
+        manifest.target_branch = "main"
+        manifest.mission_branch = f"kitty/mission-{mission_slug}"
+
+        lane_a = MagicMock()
+        lane_a.lane_id = "lane-a"
+        lane_a.wp_ids = ["WP01", "WP02"]
+        manifest.lanes = [lane_a]
+
+        lane_result = MagicMock(success=True, errors=[])
+        mission_result = MagicMock(success=True, commit="abc1234", errors=[])
+
+        with (
+            patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
+            patch("specify_cli.cli.commands.merge.load_state", return_value=None),
+            patch("specify_cli.cli.commands.merge.save_state"),
+            patch("specify_cli.cli.commands.merge.get_main_repo_root", return_value=tmp_path),
+            patch("specify_cli.lanes.merge.merge_lane_to_mission", return_value=lane_result),
+            patch("specify_cli.lanes.merge.merge_mission_to_target", return_value=mission_result),
+            patch("specify_cli.cli.commands.merge._mark_wp_merged_done"),
+            patch("specify_cli.cli.commands.merge._assert_merged_wps_reached_done"),
+            patch("specify_cli.cli.commands.merge.safe_commit", return_value=True),
+            patch("specify_cli.post_merge.stale_assertions.run_check") as mock_run_check,
+            patch("specify_cli.policy.merge_gates.evaluate_merge_gates") as mock_gates,
+            patch("specify_cli.policy.config.load_policy_config") as mock_policy,
+            patch("specify_cli.cli.commands.merge.run_command", return_value=(0, "abc123", "")),
+            patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
+            patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
+            patch("specify_cli.cli.commands.merge.clear_state"),
+            patch("specify_cli.merge.state.MergeState"),
+            patch("specify_cli.cli.commands.merge.trigger_feature_dossier_sync_if_enabled") as mock_dossier,
+        ):
+            stale_report = MagicMock()
+            stale_report.findings = []
+            mock_run_check.return_value = stale_report
+
+            gate_eval = MagicMock()
+            gate_eval.overall_pass = True
+            gate_eval.gates = []
+            mock_gates.return_value = gate_eval
+
+            policy = MagicMock()
+            policy.merge_gates = []
+            mock_policy.return_value = policy
+
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=mission_slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+            )
+
+        mock_dossier.assert_called_once_with(feature_dir, mission_slug, tmp_path)
+
+
+class TestMergeDoneTransitions:
+    def test_mark_wp_merged_done_uses_lightweight_emit_path(self, tmp_path: Path) -> None:
+        mission_slug = "068-test-lightweight"
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        tasks_dir = feature_dir / "tasks"
+        _write_wp_file(tasks_dir, "WP01")
+
+        with (
+            patch("specify_cli.status.lane_reader.get_wp_lane", return_value="approved"),
+            patch("specify_cli.cli.commands.merge._has_transition_to", return_value=False),
+            patch("specify_cli.status.history_parser.extract_done_evidence", return_value=None),
+            patch("specify_cli.status.emit.emit_status_transition") as mock_emit,
+        ):
+            _mark_wp_merged_done(tmp_path, mission_slug, "WP01", "main")
+
+        mock_emit.assert_called_once()
+        kwargs = mock_emit.call_args.kwargs
+        assert kwargs["ensure_sync_daemon"] is False
+        assert kwargs["sync_dossier"] is False
 
     def test_safe_commit_called_before_worktree_removal(self, tmp_path: Path) -> None:
         """FR-019: safe_commit must precede any worktree removal step."""

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -940,6 +940,7 @@ class TestSaasFanOut:
             actor="test-actor",
             mission_slug="034-test-feature",
             policy_metadata=None,
+            ensure_daemon=True,
         )
 
     def test_planned_to_claimed_now_emits(self):
@@ -1201,3 +1202,29 @@ class TestReasonGuard:
         )
         assert event.reason == "Needs more planning"
         assert event.to_lane == Lane.PLANNED
+
+
+class TestMergeLightweightEmit:
+    def test_emit_status_transition_can_skip_dossier_sync_and_daemon_start(
+        self,
+        feature_dir: Path,
+    ) -> None:
+        with (
+            patch.object(emit_module, "_saas_fan_out") as mock_fanout,
+            patch("specify_cli.sync.dossier_pipeline.trigger_feature_dossier_sync_if_enabled") as mock_dossier,
+        ):
+            event = emit_status_transition(
+                feature_dir=feature_dir,
+                mission_slug="034-test-feature",
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="merge",
+                repo_root=feature_dir.parent.parent,
+                ensure_sync_daemon=False,
+                sync_dossier=False,
+            )
+
+        assert event.to_lane == Lane.CLAIMED
+        mock_fanout.assert_called_once()
+        assert mock_fanout.call_args.kwargs["ensure_sync_daemon"] is False
+        mock_dossier.assert_not_called()

--- a/tests/status/test_sync_lane_mapping.py
+++ b/tests/status/test_sync_lane_mapping.py
@@ -82,6 +82,7 @@ class TestCanonicalFanOut:
             actor="test-actor",
             mission_slug="039-test-feature",
             policy_metadata=None,
+            ensure_daemon=True,
         )
 
     def test_planned_to_claimed_now_emits(self) -> None:

--- a/tests/sync/test_events.py
+++ b/tests/sync/test_events.py
@@ -600,10 +600,27 @@ class TestConvenienceFunctions:
             patch("specify_cli.sync.events._request_dashboard_sync") as mock_trigger,
         ):
             emit_wp_status_changed("WP01", "planned", "in_progress")
-        mock_daemon.assert_called_once_with()
+        mock_daemon.assert_called_once_with(ensure_daemon=True)
         mock_publish.assert_called_once_with({"event_id": "evt-1"}, Path("/tmp/project"))
         mock_trigger.assert_called_once_with(Path("/tmp/project"))
         mock_emitter.emit_wp_status_changed.assert_called_once()
+
+    @patch("specify_cli.sync.events.get_emitter")
+    def test_emit_wp_status_changed_can_skip_daemon_start(self, mock_get):
+        """emit_wp_status_changed can suppress daemon startup during merge batching."""
+        mock_emitter = MagicMock()
+        mock_emitter.emit_wp_status_changed.return_value = {"event_id": "evt-1"}
+        mock_get.return_value = mock_emitter
+        with (
+            patch(
+                "specify_cli.sync.events._ensure_dashboard_sync_daemon_for_active_project",
+                return_value=Path("/tmp/project"),
+            ) as mock_daemon,
+            patch("specify_cli.sync.events._publish_event_via_sync_daemon"),
+            patch("specify_cli.sync.events._request_dashboard_sync"),
+        ):
+            emit_wp_status_changed("WP01", "planned", "in_progress", ensure_daemon=False)
+        mock_daemon.assert_called_once_with(ensure_daemon=False)
 
     @patch("specify_cli.sync.events.get_emitter")
     def test_emit_wp_created_delegates(self, mock_get):


### PR DESCRIPTION
## Summary
- avoid starting the local sync daemon for merge-time WP status transitions
- skip per-transition dossier sync during merge and run one mission-level dossier sync after the status commit
- add progress output around lane merges, mission merge, done-transition recording, and stale-assertion checking
- cover the lightweight merge path with targeted unit tests

## Testing
- `uv run --python /opt/homebrew/opt/python@3.11/bin/python3.11 --extra test pytest tests/sync/test_events.py tests/status/test_emit.py tests/cli/commands/test_merge_status_commit.py -q`
