### PR TITLE
fix: remove pytest and junit prompt bias

### DIFF
--- a/src/charter/catalog.py
+++ b/src/charter/catalog.py
@@ -58,7 +58,7 @@ def load_doctrine_catalog(
     present but shipped set is empty" (every selection is invalid).
     """
     doctrine_root = resolve_doctrine_root()
-    normalized_languages = normalize_languages(active_languages)
+    normalized_languages = None if active_languages is None else normalize_languages(active_languages)
 
     domains_present: set[str] = set()
 

--- a/src/charter/catalog.py
+++ b/src/charter/catalog.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
 from kernel.paths import get_package_asset_root as _get_package_asset_root
 
 _log = logging.getLogger(__name__)
@@ -40,15 +41,16 @@ class DoctrineCatalog:
     agent_profiles: frozenset[str]
     domains_present: frozenset[str] = frozenset()
 
-
-def load_doctrine_catalog() -> DoctrineCatalog:
+def load_doctrine_catalog(
+    *,
+    include_proposed: bool = False,
+    active_languages: list[str] | tuple[str, ...] | None = None,
+) -> DoctrineCatalog:
     """Load doctrine catalogs from package assets with development fallbacks.
 
-    Only canonised ``shipped/`` artifacts participate in the catalog. The
-    pre-WP01 opt-in flag for unpromoted artifacts was removed as part of
-    the ``excise-doctrine-curation-and-inline-references-01KP54J6`` mission
-    (EPIC #461, Phase 1); the curation surface that consumed those
-    artifacts has been deleted.
+    By default, only canonised ``shipped/`` artifacts participate in the catalog.
+    Callers may opt into ``_proposed/`` artifacts explicitly to support curation
+    flows that need visibility into pre-canonisation content.
 
     ``DoctrineCatalog.domains_present`` records which artifact domains have a
     ``shipped/`` directory on disk.  The resolver uses this to distinguish between
@@ -56,17 +58,24 @@ def load_doctrine_catalog() -> DoctrineCatalog:
     present but shipped set is empty" (every selection is invalid).
     """
     doctrine_root = resolve_doctrine_root()
+    normalized_languages = normalize_languages(active_languages)
 
     domains_present: set[str] = set()
 
     paradigms, paradigms_present = _load_yaml_id_catalog_with_presence(
-        doctrine_root / "paradigms", "**/*.paradigm.yaml"
+        doctrine_root / "paradigms",
+        "**/*.paradigm.yaml",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if paradigms_present:
         domains_present.add("paradigms")
 
     directives, directives_present = _load_yaml_id_catalog_with_presence(
-        doctrine_root / "directives", "**/*.directive.yaml"
+        doctrine_root / "directives",
+        "**/*.directive.yaml",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if directives_present:
         domains_present.add("directives")
@@ -76,25 +85,37 @@ def load_doctrine_catalog() -> DoctrineCatalog:
         domains_present.add("template_sets")
 
     tactics, tactics_present = _load_yaml_id_catalog_with_presence(
-        doctrine_root / "tactics", "**/*.tactic.yaml"
+        doctrine_root / "tactics",
+        "**/*.tactic.yaml",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if tactics_present:
         domains_present.add("tactics")
 
     styleguides, styleguides_present = _load_yaml_id_catalog_with_presence(
-        doctrine_root / "styleguides", "**/*.styleguide.yaml"
+        doctrine_root / "styleguides",
+        "**/*.styleguide.yaml",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if styleguides_present:
         domains_present.add("styleguides")
 
     toolguides, toolguides_present = _load_yaml_id_catalog_with_presence(
-        doctrine_root / "toolguides", "**/*.toolguide.yaml"
+        doctrine_root / "toolguides",
+        "**/*.toolguide.yaml",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if toolguides_present:
         domains_present.add("toolguides")
 
     procedures, procedures_present = _load_yaml_id_catalog_with_presence(
-        doctrine_root / "procedures", "**/*.procedure.yaml"
+        doctrine_root / "procedures",
+        "**/*.procedure.yaml",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if procedures_present:
         domains_present.add("procedures")
@@ -103,6 +124,8 @@ def load_doctrine_catalog() -> DoctrineCatalog:
         doctrine_root / "agent_profiles",
         "**/*.agent.yaml",
         id_field="profile-id",
+        include_proposed=include_proposed,
+        active_languages=normalized_languages,
     )
     if profiles_present:
         domains_present.add("agent_profiles")
@@ -159,6 +182,8 @@ def _load_yaml_id_catalog(
     pattern: str,
     *,
     id_field: str = "id",
+    include_proposed: bool = False,
+    active_languages: list[str] | tuple[str, ...] | None = None,
 ) -> set[str]:
     """Load ID values from doctrine YAML files in a directory.
 
@@ -168,7 +193,13 @@ def _load_yaml_id_catalog(
         id_field: YAML key containing the artifact ID. Defaults to ``"id"``.
                   Use ``"profile-id"`` for agent profile files.
     """
-    ids, _ = _load_yaml_id_catalog_with_presence(directory, pattern, id_field=id_field)
+    ids, _ = _load_yaml_id_catalog_with_presence(
+        directory,
+        pattern,
+        id_field=id_field,
+        include_proposed=include_proposed,
+        active_languages=active_languages,
+    )
     return ids
 
 
@@ -177,6 +208,8 @@ def _load_yaml_id_catalog_with_presence(
     pattern: str,
     *,
     id_field: str = "id",
+    include_proposed: bool = False,
+    active_languages: list[str] | tuple[str, ...] | None = None,
 ) -> tuple[set[str], bool]:
     """Load ID values from doctrine YAML files, also reporting domain presence.
 
@@ -198,10 +231,13 @@ def _load_yaml_id_catalog_with_presence(
         return set(), False
 
     shipped_dir = directory / "shipped"
-    if shipped_dir.is_dir():
-        # Structured layout: shipped/ is the sole canonical source.
+    proposed_dir = directory / "_proposed"
+    if shipped_dir.is_dir() or proposed_dir.is_dir():
+        # Structured layout: domain is present regardless of content.
         present = True
-        scan_roots = [shipped_dir]
+        scan_roots = [shipped_dir] if shipped_dir.is_dir() else []
+        if include_proposed and proposed_dir.is_dir():
+            scan_roots.append(proposed_dir)
     else:
         # Preserve generic helper behavior for tests or flat directories.
         present = True
@@ -214,6 +250,12 @@ def _load_yaml_id_catalog_with_presence(
             try:
                 data = yaml.load(path.read_text(encoding="utf-8")) or {}
             except (OSError, YAMLError, TypeError):
+                continue
+
+            if isinstance(data, dict) and not applies_to_languages_match(
+                data.get("applies_to_languages"),
+                active_languages,
+            ):
                 continue
 
             if isinstance(data, dict):

--- a/src/charter/compiler.py
+++ b/src/charter/compiler.py
@@ -17,6 +17,7 @@ from charter.interview import (
     LocalSupportDeclaration,
     validate_local_support_declarations,
 )
+from charter.language_scope import extract_declared_languages
 from charter.resolver import DEFAULT_TOOL_REGISTRY
 
 if TYPE_CHECKING:
@@ -89,7 +90,8 @@ def compile_charter(
             DRG overlay at ``<repo_root>/.kittify/doctrine/graph.yaml``. When
             ``None`` the compiler uses the shipped layer only.
     """
-    catalog = doctrine_catalog or load_doctrine_catalog()
+    active_languages = extract_declared_languages("\n".join(str(value) for value in interview.answers.values()))
+    catalog = doctrine_catalog or load_doctrine_catalog(active_languages=active_languages)
     diagnostics: list[str] = []
 
     if doctrine_service is None:
@@ -698,7 +700,10 @@ def _render_charter_markdown(
 ) -> str:
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    testing = interview.answers.get("testing_requirements", "Use pytest with measurable coverage goals.")
+    testing = interview.answers.get(
+        "testing_requirements",
+        "Use the project's declared testing approach, or mark it as NEEDS CLARIFICATION.",
+    )
     quality = interview.answers.get("quality_gates", "Tests, lint, and type checks must pass before merge.")
     performance = interview.answers.get("performance_targets", "No explicit performance policy provided.")
     deployment = interview.answers.get("deployment_constraints", "No deployment constraints provided.")

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from charter.language_scope import infer_repo_languages
 from charter.resolver import GovernanceResolutionError, resolve_governance
 from kernel.atomic import atomic_write
 
@@ -38,7 +39,11 @@ def _build_doctrine_service(repo_root: Path) -> object:
     doctrine_root = resolve_doctrine_root()
     project_root_candidates = [repo_root / "src" / "doctrine", repo_root / "doctrine"]
     project_root = next((path for path in project_root_candidates if path.is_dir()), None)
-    return DoctrineService(shipped_root=doctrine_root, project_root=project_root)
+    return DoctrineService(
+        shipped_root=doctrine_root,
+        project_root=project_root,
+        active_languages=infer_repo_languages(repo_root),
+    )
 
 
 def _normalize_directive_id(raw: str) -> str:

--- a/src/charter/defaults.yaml
+++ b/src/charter/defaults.yaml
@@ -8,22 +8,23 @@
 mission: software-dev
 profile: minimal
 
-selected_paradigms:
-  - test-first
+answers:
+  project_intent: "Deliver predictable changes with clear reviewability."
+  languages_frameworks: "Use only the languages, frameworks, and tools explicitly declared by this project."
+  testing_requirements: "Use the project's declared test approach. If none is declared, mark it as NEEDS CLARIFICATION."
+  quality_gates: "Only require the quality gates explicitly declared by this project before merge."
+  review_policy: "At least one focused reviewer approves before merge."
+  performance_targets: "CLI operations should complete quickly (typically under 2 seconds)."
+  deployment_constraints: "Must run on macOS and Linux developer environments."
+  documentation_policy: "Update docs whenever command behavior or workflow semantics change."
+  risk_boundaries: "Do not relax quality/security standards without explicit maintainer approval."
+  amendment_process: "Changes are proposed via PR and reviewed before adoption."
+  exception_policy: "Exceptions must be documented in PR notes with scope and sunset criteria."
 
-selected_directives:
-  - DIRECTIVE_001   # Architectural Integrity Standard
-  - DIRECTIVE_010   # Specification Fidelity Requirement
-  - DIRECTIVE_025   # Boy Scout Rule
-  - DIRECTIVE_028   # Search Tool Discipline
-  - DIRECTIVE_030   # Test and Typecheck Quality Gate
-  - DIRECTIVE_033   # Targeted Staging Policy
+selected_paradigms: []
+
+selected_directives: []
 
 available_tools:
   - git
-  - mypy
-  - uv
-  - pytest
-  - python
-  - ruff
   - spec-kitty

--- a/src/charter/interview.py
+++ b/src/charter/interview.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.resources
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Iterable
 
 from ruamel.yaml import YAML
 
@@ -142,15 +143,9 @@ QUESTION_PROMPTS: dict[str, str] = {
     "exception_policy": "How should exceptions to the charter be handled?",
 }
 
-_DEFAULT_MISSION_PARADIGMS: dict[str, tuple[str, ...]] = {
-    "software-dev": ("domain-driven-design", "test-first"),
-}
+_DEFAULT_MISSION_PARADIGMS: dict[str, tuple[str, ...]] = {}
 
-_DEFAULT_MISSION_DIRECTIVES: dict[str, tuple[str, ...]] = {
-    # Prefer doctrine-backed test-first defaults for software delivery rather than
-    # selecting the entire directive catalog.
-    "software-dev": ("DIRECTIVE_004", "DIRECTIVE_027"),
-}
+_DEFAULT_MISSION_DIRECTIVES: dict[str, tuple[str, ...]] = {}
 
 
 _UNSET = object()
@@ -229,20 +224,8 @@ def default_interview(
 ) -> CharterInterview:
     """Return deterministic default interview answers."""
     catalog = doctrine_catalog or load_doctrine_catalog()
-
-    answers: dict[str, str] = {
-        "project_intent": "Deliver predictable, testable changes with clear reviewability.",
-        "languages_frameworks": "Python 3.11+, pytest, and repo-local tooling.",
-        "testing_requirements": "pytest with 80%+ coverage and test-first behavior for risky changes.",
-        "quality_gates": "Tests pass, lint clean, type checks pass, and no unresolved review findings.",
-        "review_policy": "At least one focused reviewer approves before merge.",
-        "performance_targets": "CLI operations should complete quickly (typically under 2 seconds).",
-        "deployment_constraints": "Must run on macOS and Linux developer environments.",
-        "documentation_policy": "Update docs whenever command behavior or workflow semantics change.",
-        "risk_boundaries": "Do not relax quality/security standards without explicit maintainer approval.",
-        "amendment_process": "Changes are proposed via PR and reviewed before adoption.",
-        "exception_policy": "Exceptions must be documented in PR notes with scope and sunset criteria.",
-    }
+    defaults = _load_packaged_defaults()
+    answers: dict[str, str] = dict(defaults.get("answers", {}))
 
     if profile == "minimal":
         answers = {key: answers[key] for key in MINIMAL_QUESTION_ORDER}
@@ -262,9 +245,18 @@ def default_interview(
         mission=mission,
         profile=profile,
         answers=answers,
-        selected_paradigms=default_paradigms or sorted(catalog.paradigms),
-        selected_directives=default_directives or sorted(catalog.directives),
-        available_tools=sorted(DEFAULT_TOOL_REGISTRY),
+        selected_paradigms=_normalize_iterable(
+            defaults.get("selected_paradigms"),
+            fallback=default_paradigms,
+        ),
+        selected_directives=_normalize_iterable(
+            defaults.get("selected_directives"),
+            fallback=default_directives,
+        ),
+        available_tools=_normalize_iterable(
+            defaults.get("available_tools"),
+            fallback=sorted(DEFAULT_TOOL_REGISTRY),
+        ),
     )
 
 
@@ -372,6 +364,43 @@ def _normalize_optional_string(raw: object) -> str | None:
         return None
     value = str(raw).strip()
     return value or None
+
+
+def _load_packaged_defaults() -> dict[str, object]:
+    """Load authoritative default interview content from ``defaults.yaml``."""
+    empty = {
+        "answers": {},
+        "selected_paradigms": [],
+        "selected_directives": [],
+        "available_tools": [],
+    }
+    try:
+        defaults_path = importlib.resources.files("charter").joinpath("defaults.yaml")
+        content = defaults_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, TypeError):
+        return empty
+
+    yaml = YAML(typ="safe")
+    try:
+        data = yaml.load(content) or {}
+    except Exception:
+        return empty
+
+    if not isinstance(data, dict):
+        return empty
+
+    answers = data.get("answers")
+    normalized_answers = (
+        {str(key): str(value) for key, value in answers.items()}
+        if isinstance(answers, dict)
+        else {}
+    )
+    return {
+        "answers": normalized_answers,
+        "selected_paradigms": _normalize_list(data.get("selected_paradigms")),
+        "selected_directives": _normalize_list(data.get("selected_directives")),
+        "available_tools": _normalize_list(data.get("available_tools")),
+    }
 
 
 def _resolve_default_selection(

--- a/src/charter/language_scope.py
+++ b/src/charter/language_scope.py
@@ -1,0 +1,48 @@
+"""Helpers for deriving active project languages from charter inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+from charter.interview import read_interview_answers
+from doctrine.shared.scoping import normalize_languages
+
+
+_LANGUAGE_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("python", (r"\bpython\b", r"\bpytest\b", r"\bmypy\b", r"\bruff\b")),
+    ("typescript", (r"\btypescript\b", r"\btsc\b")),
+    ("javascript", (r"\bjavascript\b", r"\bjest\b", r"\bnode(?:\.js)?\b", r"\bnpm\b", r"\bpnpm\b", r"\byarn\b")),
+    ("rust", (r"\brust\b", r"\bcargo\b", r"\brustc\b")),
+    ("java", (r"\bjava\b", r"\bjunit\b", r"\bgradle\b", r"\bmaven\b")),
+    ("swift", (r"\bswift\b", r"\bxctest\b")),
+    ("ruby", (r"\bruby\b", r"\brspec\b", r"\brails\b")),
+    ("php", (r"\bphp\b", r"\bphpunit\b")),
+)
+
+
+def extract_declared_languages(text: str) -> list[str]:
+    """Return canonical language identifiers mentioned in free-form text."""
+    haystack = text.lower()
+    matches: list[str] = []
+    for language, patterns in _LANGUAGE_PATTERNS:
+        if any(re.search(pattern, haystack) for pattern in patterns):
+            matches.append(language)
+    return list(normalize_languages(matches))
+
+
+def infer_repo_languages(repo_root: Path) -> list[str]:
+    """Infer active project languages from interview answers or charter content."""
+    interview_path = repo_root / ".kittify" / "charter" / "interview" / "answers.yaml"
+    interview = read_interview_answers(interview_path)
+    if interview is not None:
+        combined = "\n".join(str(value) for value in interview.answers.values())
+        languages = extract_declared_languages(combined)
+        if languages:
+            return languages
+
+    charter_path = repo_root / ".kittify" / "charter" / "charter.md"
+    if charter_path.exists():
+        return extract_declared_languages(charter_path.read_text(encoding="utf-8"))
+
+    return []

--- a/src/charter/resolver.py
+++ b/src/charter/resolver.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from charter.interview import CharterInterview
 
 DEFAULT_TEMPLATE_SET = "software-dev-default"
-DEFAULT_TOOL_REGISTRY: frozenset[str] = frozenset({"spec-kitty", "git", "python", "pytest", "ruff", "mypy", "uv"})
+DEFAULT_TOOL_REGISTRY: frozenset[str] = frozenset({"spec-kitty", "git"})
 
 
 class GovernanceResolutionError(ValueError):

--- a/src/doctrine/agent_profiles/profile.py
+++ b/src/doctrine/agent_profiles/profile.py
@@ -162,6 +162,7 @@ class AgentProfile(BaseModel):
 
     # Optional fields
     specialization_context: SpecializationContext | None = Field(default=None, alias="specialization-context")
+    applies_to_languages: list[str] = Field(default_factory=list)
     directive_references: list[DirectiveRef] = Field(default_factory=list, alias="directive-references")
     # Supports both forms:
     #   excluding: [field_name]            → removes entire field from resolved result

--- a/src/doctrine/agent_profiles/repository.py
+++ b/src/doctrine/agent_profiles/repository.py
@@ -21,6 +21,8 @@ from pydantic import ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
+
 from .profile import AgentProfile, Role, TaskContext
 from .validation import reject_agent_profile_inline_refs
 
@@ -181,6 +183,7 @@ class AgentProfileRepository:
         self,
         shipped_dir: Path | None = None,
         project_dir: Path | None = None,
+        active_languages: list[str] | tuple[str, ...] | None = None,
     ):
         """Initialize repository with shipped and/or project directories.
 
@@ -191,6 +194,7 @@ class AgentProfileRepository:
         self._profiles: dict[str, AgentProfile] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
+        self._active_languages = normalize_languages(active_languages)
         self._hierarchy_index: dict[str, list[str]] | None = None
         self._load()
 
@@ -220,6 +224,8 @@ class AgentProfileRepository:
                         data, file_path=str(yaml_file)
                     )
                     profile = AgentProfile.model_validate(data)
+                    if not applies_to_languages_match(profile.applies_to_languages, self._active_languages):
+                        continue
                     shipped_profiles[profile.profile_id] = profile
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(
@@ -255,10 +261,14 @@ class AgentProfileRepository:
                     if profile_id in shipped_profiles:
                         # Merge with shipped profile
                         merged = self._merge_profiles(shipped_profiles[profile_id], data)
+                        if not applies_to_languages_match(merged.applies_to_languages, self._active_languages):
+                            continue
                         self._profiles[profile_id] = merged
                     else:
                         # New project-only profile
                         profile = AgentProfile.model_validate(data)
+                        if not applies_to_languages_match(profile.applies_to_languages, self._active_languages):
+                            continue
                         self._profiles[profile.profile_id] = profile
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(

--- a/src/doctrine/agent_profiles/repository.py
+++ b/src/doctrine/agent_profiles/repository.py
@@ -194,7 +194,7 @@ class AgentProfileRepository:
         self._profiles: dict[str, AgentProfile] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
-        self._active_languages = normalize_languages(active_languages)
+        self._active_languages = None if active_languages is None else normalize_languages(active_languages)
         self._hierarchy_index: dict[str, list[str]] | None = None
         self._load()
 

--- a/src/doctrine/agent_profiles/shipped/implementer.agent.yaml
+++ b/src/doctrine/agent_profiles/shipped/implementer.agent.yaml
@@ -95,8 +95,6 @@ specialization-context:
     - react
     - vue
     - spring
-    - pytest
-    - jest
   file-patterns:
     - "src/**/*.py"
     - "src/**/*.ts"

--- a/src/doctrine/agent_profiles/shipped/python-implementer.agent.yaml
+++ b/src/doctrine/agent_profiles/shipped/python-implementer.agent.yaml
@@ -3,6 +3,8 @@ name: Python Pedro
 description: Python-specialist implementer applying TDD, type safety, and idiomatic Python 3.12+ practices
 schema-version: "1.0"
 role: implementer
+applies_to_languages:
+  - python
 specializes-from: implementer
 capabilities:
   - python-implementation

--- a/src/doctrine/agent_profiles/shipped/reviewer.agent.yaml
+++ b/src/doctrine/agent_profiles/shipped/reviewer.agent.yaml
@@ -28,8 +28,6 @@ context-sources:
     - code-review-incremental
     - language-driven-design
     - reverse-speccing
-  toolguides:
-    - python-review-checks
   additional:
     - review-checklist
     - security-guidelines
@@ -152,7 +150,3 @@ tactic-references:
     rationale: Detect terminology conflicts in diffs as early signals of architectural problems or missing bounded context boundaries
   - id: reverse-speccing
     rationale: Validate that tests serve as executable specifications by reconstructing system understanding from test code alone
-
-toolguide-references:
-  - id: python-review-checks
-    rationale: Catalog of automated checks (ruff, mypy, bandit, pip-audit, import-linter, etc.) to run or verify before approving Python code

--- a/src/doctrine/missions/software-dev/templates/plan-template.md
+++ b/src/doctrine/missions/software-dev/templates/plan-template.md
@@ -25,7 +25,7 @@ The planner will not begin until all planning questions have been answered—cap
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
 **Project Type**: [single/web/mobile - determines source structure]
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]

--- a/src/doctrine/procedures/models.py
+++ b/src/doctrine/procedures/models.py
@@ -84,5 +84,6 @@ class Procedure(BaseModel):
     exit_condition: str
     steps: list[ProcedureStep] = Field(min_length=1)
     anti_patterns: list[ProcedureAntiPattern] = Field(default_factory=list)
+    applies_to_languages: list[str] = Field(default_factory=list)
     notes: str | None = None
     references: list[ProcedureReference] = Field(default_factory=list)

--- a/src/doctrine/procedures/repository.py
+++ b/src/doctrine/procedures/repository.py
@@ -11,6 +11,8 @@ from pydantic import ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
+
 from .models import Procedure
 from .validation import reject_procedure_inline_refs
 
@@ -22,10 +24,12 @@ class ProcedureRepository:
         self,
         shipped_dir: Path | None = None,
         project_dir: Path | None = None,
+        active_languages: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._procedures: dict[str, Procedure] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
+        self._active_languages = normalize_languages(active_languages)
         self._load()
 
     @staticmethod
@@ -52,6 +56,8 @@ class ProcedureRepository:
                         continue
                     reject_procedure_inline_refs(data, file_path=str(yaml_file))
                     procedure = Procedure.model_validate(data)
+                    if not applies_to_languages_match(procedure.applies_to_languages, self._active_languages):
+                        continue
                     shipped[procedure.id] = procedure
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(
@@ -80,9 +86,13 @@ class ProcedureRepository:
 
                     if procedure_id in shipped:
                         merged = self._merge_procedures(shipped[procedure_id], data)
+                        if not applies_to_languages_match(merged.applies_to_languages, self._active_languages):
+                            continue
                         self._procedures[procedure_id] = merged
                     else:
                         procedure = Procedure.model_validate(data)
+                        if not applies_to_languages_match(procedure.applies_to_languages, self._active_languages):
+                            continue
                         self._procedures[procedure.id] = procedure
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(

--- a/src/doctrine/procedures/repository.py
+++ b/src/doctrine/procedures/repository.py
@@ -29,7 +29,7 @@ class ProcedureRepository:
         self._procedures: dict[str, Procedure] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
-        self._active_languages = normalize_languages(active_languages)
+        self._active_languages = None if active_languages is None else normalize_languages(active_languages)
         self._load()
 
     @staticmethod

--- a/src/doctrine/schemas/agent-profile.schema.yaml
+++ b/src/doctrine/schemas/agent-profile.schema.yaml
@@ -290,6 +290,10 @@ properties:
     type: integer
     description: Maximum number of tasks this agent can handle concurrently
     minimum: 1
+  applies_to_languages:
+    type: array
+    items:
+      type: string
   context-sources:
     $ref: '#/definitions/agent_context_sources'
   specialization:

--- a/src/doctrine/schemas/procedure.schema.yaml
+++ b/src/doctrine/schemas/procedure.schema.yaml
@@ -103,6 +103,10 @@ properties:
     description: Common mistakes or failure modes to avoid when following this procedure.
     items:
       $ref: '#/definitions/procedure_anti_pattern'
+  applies_to_languages:
+    type: array
+    items:
+      type: string
   notes:
     type: string
     description: Free-form notes, rationale, or supplementary material that does not fit into structured fields.

--- a/src/doctrine/schemas/styleguide.schema.yaml
+++ b/src/doctrine/schemas/styleguide.schema.yaml
@@ -94,6 +94,10 @@ properties:
       type: string
   quality_test:
     type: string
+  applies_to_languages:
+    type: array
+    items:
+      type: string
   references:
     type: array
     items:

--- a/src/doctrine/schemas/tactic.schema.yaml
+++ b/src/doctrine/schemas/tactic.schema.yaml
@@ -103,6 +103,10 @@ properties:
     type: array
     items:
       type: string
+  applies_to_languages:
+    type: array
+    items:
+      type: string
   references:
     type: array
     minItems: 1

--- a/src/doctrine/schemas/toolguide.schema.yaml
+++ b/src/doctrine/schemas/toolguide.schema.yaml
@@ -34,6 +34,10 @@ properties:
     type: array
     items:
       type: string
+  applies_to_languages:
+    type: array
+    items:
+      type: string
   last_updated:
     type: string
     description: ISO 8601 date the guide was last reviewed or updated (e.g. 2026-04-05).

--- a/src/doctrine/service.py
+++ b/src/doctrine/service.py
@@ -27,7 +27,7 @@ class DoctrineService:
     ) -> None:
         self._shipped_root = shipped_root
         self._project_root = project_root
-        self._active_languages = normalize_languages(active_languages)
+        self._active_languages = None if active_languages is None else normalize_languages(active_languages)
         self._cache: dict[str, object] = {}
 
     def _shipped_dir(self, artifact: str) -> Path | None:

--- a/src/doctrine/service.py
+++ b/src/doctrine/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
+from doctrine.shared.scoping import normalize_languages
 from doctrine.agent_profiles import AgentProfileRepository
 from doctrine.directives import DirectiveRepository
 from doctrine.mission_step_contracts import MissionStepContractRepository
@@ -22,9 +23,11 @@ class DoctrineService:
         self,
         shipped_root: Path | None = None,
         project_root: Path | None = None,
+        active_languages: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._shipped_root = shipped_root
         self._project_root = project_root
+        self._active_languages = normalize_languages(active_languages)
         self._cache: dict[str, object] = {}
 
     def _shipped_dir(self, artifact: str) -> Path | None:
@@ -52,6 +55,7 @@ class DoctrineService:
             self._cache["tactics"] = TacticRepository(
                 shipped_dir=self._shipped_dir("tactics"),
                 project_dir=self._project_dir("tactics"),
+                active_languages=self._active_languages,
             )
         return cast(TacticRepository, self._cache["tactics"])
 
@@ -61,6 +65,7 @@ class DoctrineService:
             self._cache["styleguides"] = StyleguideRepository(
                 shipped_dir=self._shipped_dir("styleguides"),
                 project_dir=self._project_dir("styleguides"),
+                active_languages=self._active_languages,
             )
         return cast(StyleguideRepository, self._cache["styleguides"])
 
@@ -70,6 +75,7 @@ class DoctrineService:
             self._cache["toolguides"] = ToolguideRepository(
                 shipped_dir=self._shipped_dir("toolguides"),
                 project_dir=self._project_dir("toolguides"),
+                active_languages=self._active_languages,
             )
         return cast(ToolguideRepository, self._cache["toolguides"])
 
@@ -88,6 +94,7 @@ class DoctrineService:
             self._cache["procedures"] = ProcedureRepository(
                 shipped_dir=self._shipped_dir("procedures"),
                 project_dir=self._project_dir("procedures"),
+                active_languages=self._active_languages,
             )
         return cast(ProcedureRepository, self._cache["procedures"])
 
@@ -106,6 +113,6 @@ class DoctrineService:
             self._cache["agent_profiles"] = AgentProfileRepository(
                 shipped_dir=self._shipped_dir("agent_profiles"),
                 project_dir=self._project_dir("agent_profiles"),
+                active_languages=self._active_languages,
             )
         return cast(AgentProfileRepository, self._cache["agent_profiles"])
-

--- a/src/doctrine/shared/scoping.py
+++ b/src/doctrine/shared/scoping.py
@@ -1,0 +1,43 @@
+"""Shared helpers for optional doctrine artifact scoping."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def normalize_languages(values: Iterable[str] | None) -> tuple[str, ...]:
+    """Return lowercase, de-duplicated language identifiers."""
+    if values is None:
+        return ()
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        item = str(value).strip().lower()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        normalized.append(item)
+    return tuple(normalized)
+
+
+def applies_to_languages_match(
+    artifact_languages: Iterable[str] | None,
+    active_languages: Iterable[str] | None,
+) -> bool:
+    """Return whether an artifact should load for the active language set.
+
+    Rules:
+    - Unscoped artifacts always load.
+    - When active languages are unknown/empty, scoped artifacts do not load.
+    - Otherwise any overlap between artifact and active languages is sufficient.
+    """
+    artifact_scope = set(normalize_languages(artifact_languages))
+    if not artifact_scope:
+        return True
+
+    active_scope = set(normalize_languages(active_languages))
+    if not active_scope:
+        return False
+
+    return bool(artifact_scope & active_scope)

--- a/src/doctrine/shared/scoping.py
+++ b/src/doctrine/shared/scoping.py
@@ -29,11 +29,15 @@ def applies_to_languages_match(
 
     Rules:
     - Unscoped artifacts always load.
-    - When active languages are unknown/empty, scoped artifacts do not load.
+    - When no active language filter is provided, scoped artifacts still load.
+    - When active languages are explicitly empty/unknown, scoped artifacts do not load.
     - Otherwise any overlap between artifact and active languages is sufficient.
     """
     artifact_scope = set(normalize_languages(artifact_languages))
     if not artifact_scope:
+        return True
+
+    if active_languages is None:
         return True
 
     active_scope = set(normalize_languages(active_languages))

--- a/src/doctrine/skills/ad-hoc-profile-load/SKILL.md
+++ b/src/doctrine/skills/ad-hoc-profile-load/SKILL.md
@@ -66,7 +66,7 @@ from doctrine.agent_profiles.profile import TaskContext
 
 context = TaskContext(
     languages=["python"],
-    frameworks=["fastapi", "pytest"],
+    frameworks=["fastapi", "<project-test-runner>"],
     file_patterns=["src/**/*.py"],
     domain_keywords=["architecture", "design"],
 )

--- a/src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md
@@ -94,7 +94,7 @@ For each matched section, the parser extracts structured data from:
    - `90%+ coverage` → `testing.min_coverage: 90`
    - `TDD required` → `testing.tdd_required: true`
    - `< 2 seconds` → `performance.cli_timeout_seconds: 2.0`
-   - `mypy --strict` → `testing.type_checking: "mypy --strict"`
+   - `<project-type-checker>` → `testing.type_checking: "<project-type-checker>"`
    - `1 approval` → `quality.pr_approvals: 1`
    - `conventional commits` → `commits.convention: "conventional"`
    - `pre-commit hooks` → `quality.pre_commit_hooks: true`
@@ -109,10 +109,10 @@ from YAML blocks and tables that contain keys like `selected_paradigms`,
 testing:
   min_coverage: 90              # Minimum test coverage %
   tdd_required: false           # TDD mandatory
-  framework: pytest             # Test framework
-  type_checking: "mypy --strict" # Type checker
+  framework: <project-runner>   # Test framework / runner
+  type_checking: "<project-type-checker>" # Type checker
 quality:
-  linting: ruff                 # Linter
+  linting: "<project-linter>"   # Linter
   pr_approvals: 1               # Required approvals before merge
   pre_commit_hooks: false       # Pre-commit hooks required
 commits:
@@ -224,7 +224,7 @@ styleguide = service.styleguides.get("python-conventions")
 ```
 
 **Toolguides** — Operational guidance for specific tools. Teaches agents
-how to use git, pytest, diagramming tools, etc. within the project's
+how to use git, the project's test runner, diagramming tools, etc. within the project's
 governance constraints.
 
 ```python
@@ -301,7 +301,7 @@ with project artifacts taking precedence on field-level merge.
 - `documentation-default` — Documentation creation (Divio)
 - `research-default` — Research and evidence gathering
 
-**Default tool registry:** spec-kitty, git, python, pytest, ruff, mypy, uv
+**Default tool registry:** spec-kitty, git
 
 ### Interview Profiles
 
@@ -346,17 +346,13 @@ answers:
   amendment_process: "..."
   exception_policy: "..."
 selected_paradigms:
-  - "test-first"
+  - "<project-paradigm>"
 selected_directives:
-  - "TEST_FIRST"
+  - "<project-directive>"
 available_tools:
   - "spec-kitty"
   - "git"
-  - "python"
-  - "pytest"
-  - "ruff"
-  - "mypy"
-  - "uv"
+  - "<project-tool>"
 ```
 
 ---
@@ -500,7 +496,7 @@ from doctrine.agent_profiles.profile import TaskContext
 
 context = TaskContext(
     languages=["python"],
-    frameworks=["pytest", "typer"],
+    frameworks=["<project-test-runner>", "typer"],
     file_patterns=["src/**/*.py"],
     domain_keywords=["cli", "testing"],
 )
@@ -511,9 +507,9 @@ profile = service.agent_profiles.find_best_match(context)
 # profile.initialization_declaration → startup context text
 ```
 
-Profiles support hierarchy (`specializes_from` field). A `python-implementer`
-specializes from `implementer`, inheriting base capabilities and adding
-language-specific ones.
+Profiles support hierarchy (`specializes_from` field). Language-specific
+profiles can specialize from `implementer`, inheriting base capabilities and
+adding stack-specific ones.
 
 ### Action-Scoped Doctrine via Action Indices
 

--- a/src/doctrine/skills/spec-kitty-charter-doctrine/references/doctrine-artifact-structure.md
+++ b/src/doctrine/skills/spec-kitty-charter-doctrine/references/doctrine-artifact-structure.md
@@ -90,9 +90,9 @@ Top-level keys and their purpose:
 |-----|------|-------------|
 | `testing.min_coverage` | int | Minimum test coverage percentage (0 = not enforced) |
 | `testing.tdd_required` | bool | Whether TDD is mandated |
-| `testing.framework` | string | Test framework name (e.g., "pytest") |
-| `testing.type_checking` | string | Type checking tool (e.g., "mypy") |
-| `quality.linting` | string | Linting tool (e.g., "ruff") |
+| `testing.framework` | string | Test framework / runner name (e.g., "project-test-runner") |
+| `testing.type_checking` | string | Type checking tool (e.g., "project-type-checker") |
+| `quality.linting` | string | Linting tool (e.g., "project-linter") |
 | `quality.pr_approvals` | int | Required PR approvals before merge |
 | `quality.pre_commit_hooks` | bool | Whether pre-commit hooks are required |
 | `commits.convention` | string | Commit message convention (e.g., "conventional") |

--- a/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
@@ -194,7 +194,7 @@ The prompt contains all context, acceptance criteria, and review feedback
    CRITICAL: A module with passing tests but no callers is NOT implemented.
    The most common review failure is dead code — tests pass but the feature
    is never invoked from the live command path.
-7. Run tests: pytest tests/... -v
+7. Run the project's declared validation command before handoff
 8. Commit: git add -A && git commit -m "feat(WP##): <description>"
 9. Mark subtasks done: spec-kitty agent tasks mark-status T001 T002 ... --status done
 10. Move to for_review: spec-kitty agent tasks move-task WP## --to for_review --note "Ready for review"
@@ -702,7 +702,7 @@ git show --stat HEAD
 Run the full test suite on main after merge to catch cross-lane integration issues:
 
 ```bash
-pytest tests/ -v
+# Run the validation command declared by this project or mission.
 ```
 
 This is the only point where all WP code from all lanes coexists — earlier

--- a/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
@@ -296,8 +296,8 @@ For each Non-Functional Requirement (NFR) with a measurable threshold:
 # Count new test files and estimate
 git diff <baseline_merge_commit>..HEAD --stat | grep "tests/"
 
-# Example: NFR-006 — mypy strict clean
-# Check if any mypy ignore directives were added
+# Example: NFR-006 — project type-checking clean
+# Check if any type-check suppression directives were added
 git diff <baseline_merge_commit>..HEAD -- src/ | grep -n "type: ignore\|noqa"
 ```
 

--- a/src/doctrine/skills/spec-kitty-mission-review/references/mission-review-fr-trace-guide.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/references/mission-review-fr-trace-guide.md
@@ -38,7 +38,7 @@ is dead code. The tests verify the module's internal behavior; they do not
 verify that the module is invoked by the system.
 
 **Example**: A new mission `status_validator` module is introduced with full
-pytest coverage. All tests pass. The module is never imported from any live
+project-test-runner coverage. All tests pass. The module is never imported from any live
 command path. When a user runs `spec-kitty implement WP01`, the validator
 is never called because no code path invokes it.
 

--- a/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
@@ -226,7 +226,7 @@ from doctrine.agent_profiles import AgentProfileRepository
 from doctrine.service import DoctrineService
 
 repo = AgentProfileRepository()
-profile = repo.resolve_profile("<profile-id>")  # e.g. "python-implementer"
+profile = repo.resolve_profile("<profile-id>")  # e.g. "implementer"
 
 # Internalize identity — acknowledge this at session start
 print(profile.initialization_declaration)

--- a/src/doctrine/styleguides/models.py
+++ b/src/doctrine/styleguides/models.py
@@ -61,4 +61,5 @@ class Styleguide(BaseModel):
     anti_patterns: list[AntiPattern] = Field(default_factory=list)
     tooling: dict[str, str] = Field(default_factory=dict)
     quality_test: str | None = None
+    applies_to_languages: list[str] = Field(default_factory=list)
     references: list[str] = Field(default_factory=list)

--- a/src/doctrine/styleguides/python-implementation.styleguide.yaml
+++ b/src/doctrine/styleguides/python-implementation.styleguide.yaml
@@ -2,6 +2,8 @@ schema_version: "1.0"
 id: python-implementation
 title: Python Implementation Styleguide
 scope: code
+applies_to_languages:
+  - python
 principles:
   - Use explicit typing for public functions.
   - Keep functions focused and side effects minimal.

--- a/src/doctrine/styleguides/repository.py
+++ b/src/doctrine/styleguides/repository.py
@@ -37,7 +37,7 @@ class StyleguideRepository:
         self._styleguides: dict[str, Styleguide] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
-        self._active_languages = normalize_languages(active_languages)
+        self._active_languages = None if active_languages is None else normalize_languages(active_languages)
         self._load()
 
     @staticmethod

--- a/src/doctrine/styleguides/repository.py
+++ b/src/doctrine/styleguides/repository.py
@@ -19,6 +19,8 @@ from pydantic import ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
+
 from .models import Styleguide
 from .validation import reject_styleguide_inline_refs
 
@@ -30,10 +32,12 @@ class StyleguideRepository:
         self,
         shipped_dir: Path | None = None,
         project_dir: Path | None = None,
+        active_languages: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._styleguides: dict[str, Styleguide] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
+        self._active_languages = normalize_languages(active_languages)
         self._load()
 
     @staticmethod
@@ -60,6 +64,8 @@ class StyleguideRepository:
                         continue
                     reject_styleguide_inline_refs(data, file_path=str(yaml_file))
                     styleguide = Styleguide.model_validate(data)
+                    if not applies_to_languages_match(styleguide.applies_to_languages, self._active_languages):
+                        continue
                     shipped[styleguide.id] = styleguide
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(
@@ -90,9 +96,13 @@ class StyleguideRepository:
                         merged = self._merge_styleguides(
                             shipped[styleguide_id], data
                         )
+                        if not applies_to_languages_match(merged.applies_to_languages, self._active_languages):
+                            continue
                         self._styleguides[styleguide_id] = merged
                     else:
                         styleguide = Styleguide.model_validate(data)
+                        if not applies_to_languages_match(styleguide.applies_to_languages, self._active_languages):
+                            continue
                         self._styleguides[styleguide.id] = styleguide
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(

--- a/src/doctrine/styleguides/shipped/python-conventions.styleguide.yaml
+++ b/src/doctrine/styleguides/shipped/python-conventions.styleguide.yaml
@@ -2,6 +2,8 @@ schema_version: "1.0"
 id: python-conventions
 title: Python Conventions Styleguide
 scope: code
+applies_to_languages:
+  - python
 
 principles:
   - "Guard clauses over nesting: validate inputs early and fail fast rather than wrapping logic in conditional branches."

--- a/src/doctrine/tactics/models.py
+++ b/src/doctrine/tactics/models.py
@@ -49,6 +49,7 @@ class Tactic(BaseModel):
     purpose: str | None = None
     steps: list[TacticStep] = Field(min_length=1)
     failure_modes: list[str] = Field(default_factory=list)
+    applies_to_languages: list[str] = Field(default_factory=list)
     references: list[TacticReference] = Field(default_factory=list)
     opposed_by: list[Contradiction] = Field(default_factory=list)
     notes: str | None = None

--- a/src/doctrine/tactics/repository.py
+++ b/src/doctrine/tactics/repository.py
@@ -17,6 +17,8 @@ from pydantic import ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
+
 from .models import Tactic
 from .validation import reject_tactic_inline_refs
 
@@ -28,10 +30,12 @@ class TacticRepository:
         self,
         shipped_dir: Path | None = None,
         project_dir: Path | None = None,
+        active_languages: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._tactics: dict[str, Tactic] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
+        self._active_languages = normalize_languages(active_languages)
         self._load()
 
     @staticmethod
@@ -58,6 +62,8 @@ class TacticRepository:
                         continue
                     reject_tactic_inline_refs(data, file_path=str(yaml_file))
                     tactic = Tactic.model_validate(data)
+                    if not applies_to_languages_match(tactic.applies_to_languages, self._active_languages):
+                        continue
                     shipped[tactic.id] = tactic
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(
@@ -86,9 +92,13 @@ class TacticRepository:
 
                     if tactic_id in shipped:
                         merged = self._merge_tactics(shipped[tactic_id], data)
+                        if not applies_to_languages_match(merged.applies_to_languages, self._active_languages):
+                            continue
                         self._tactics[tactic_id] = merged
                     else:
                         tactic = Tactic.model_validate(data)
+                        if not applies_to_languages_match(tactic.applies_to_languages, self._active_languages):
+                            continue
                         self._tactics[tactic.id] = tactic
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(

--- a/src/doctrine/tactics/repository.py
+++ b/src/doctrine/tactics/repository.py
@@ -35,7 +35,7 @@ class TacticRepository:
         self._tactics: dict[str, Tactic] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
-        self._active_languages = normalize_languages(active_languages)
+        self._active_languages = None if active_languages is None else normalize_languages(active_languages)
         self._load()
 
     @staticmethod

--- a/src/doctrine/tactics/shipped/test-pyramid-progression.tactic.yaml
+++ b/src/doctrine/tactics/shipped/test-pyramid-progression.tactic.yaml
@@ -10,23 +10,23 @@ steps:
   - title: Run fast unit tests first
     description: Execute all tests marked `fast` before anything else. These tests are cheap, isolated, and provide the quickest signal on regressions.
     examples:
-      - "pytest tests/ -m fast -q"
+      - "<project-test-command>  # fastest unit-focused subset first"
   - title: Run integration tests second
     description: If fast tests pass, run tests that require real git repositories or filesystem state (marked `git_repo`).
     examples:
-      - "pytest tests/ -m git_repo -q"
+      - "<project-test-command>  # integration-focused subset second"
   - title: Run slow tests third
     description: If integration tests pass, run slower integration or system-level tests (marked `slow`).
     examples:
-      - "pytest tests/ -m slow -q"
+      - "<project-test-command>  # slow/system subset third"
   - title: Run end-to-end tests fourth
     description: If all prior layers pass, run E2E and cross-cutting tests. Exclude distribution tests unless doing a release verification.
     examples:
-      - "pytest tests/e2e/ tests/cross_cutting/ -m 'not distribution' -q"
+      - "<project-test-command>  # end-to-end and cross-cutting checks"
   - title: Run distribution/smoke tests last
     description: Only run distribution or UI smoke tests when a release is being validated.
     examples:
-      - "pytest tests/ -m distribution -q  # release validation only"
+      - "<project-test-command>  # release validation only"
   - title: Stop at first failing layer
     description: >
       If any layer fails, do not proceed to the next. Fix the failures at the

--- a/src/doctrine/templates/plan-template.md
+++ b/src/doctrine/templates/plan-template.md
@@ -24,7 +24,7 @@ The planner will not begin until all planning questions have been answered—cap
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]  
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
 **Project Type**: [single/web/mobile - determines source structure]  
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  

--- a/src/doctrine/templates/plan-template.md
+++ b/src/doctrine/templates/plan-template.md
@@ -24,7 +24,7 @@ The planner will not begin until all planning questions have been answered—cap
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]  
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
 **Project Type**: [single/web/mobile - determines source structure]  
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  

--- a/src/doctrine/toolguides/models.py
+++ b/src/doctrine/toolguides/models.py
@@ -15,4 +15,5 @@ class Toolguide(BaseModel):
     guide_path: str = Field(pattern=r"^src/doctrine/.+\.md$")
     summary: str
     commands: list[str] = Field(default_factory=list)
+    applies_to_languages: list[str] = Field(default_factory=list)
     last_updated: str | None = None

--- a/src/doctrine/toolguides/repository.py
+++ b/src/doctrine/toolguides/repository.py
@@ -30,7 +30,7 @@ class ToolguideRepository:
         self._toolguides: dict[str, Toolguide] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
-        self._active_languages = normalize_languages(active_languages)
+        self._active_languages = None if active_languages is None else normalize_languages(active_languages)
         self._load()
 
     @staticmethod

--- a/src/doctrine/toolguides/repository.py
+++ b/src/doctrine/toolguides/repository.py
@@ -12,6 +12,8 @@ from pydantic import ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
+
 from .models import Toolguide
 from .validation import reject_toolguide_inline_refs
 
@@ -23,10 +25,12 @@ class ToolguideRepository:
         self,
         shipped_dir: Path | None = None,
         project_dir: Path | None = None,
+        active_languages: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._toolguides: dict[str, Toolguide] = {}
         self._shipped_dir = shipped_dir or self._default_shipped_dir()
         self._project_dir = project_dir
+        self._active_languages = normalize_languages(active_languages)
         self._load()
 
     @staticmethod
@@ -51,6 +55,8 @@ class ToolguideRepository:
                         continue
                     reject_toolguide_inline_refs(data, file_path=str(yaml_file))
                     toolguide = Toolguide.model_validate(data)
+                    if not applies_to_languages_match(toolguide.applies_to_languages, self._active_languages):
+                        continue
                     shipped[toolguide.id] = toolguide
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(
@@ -79,9 +85,13 @@ class ToolguideRepository:
 
                     if tg_id in shipped:
                         merged = self._merge(shipped[tg_id], data)
+                        if not applies_to_languages_match(merged.applies_to_languages, self._active_languages):
+                            continue
                         self._toolguides[tg_id] = merged
                     else:
                         toolguide = Toolguide.model_validate(data)
+                        if not applies_to_languages_match(toolguide.applies_to_languages, self._active_languages):
+                            continue
                         self._toolguides[toolguide.id] = toolguide
                 except (YAMLError, ValidationError, OSError) as e:
                     warnings.warn(

--- a/src/doctrine/toolguides/shipped/python-review-checks.toolguide.yaml
+++ b/src/doctrine/toolguides/shipped/python-review-checks.toolguide.yaml
@@ -3,6 +3,8 @@ id: python-review-checks
 tool: python-quality-stack
 title: Python Review Checks
 guide_path: src/doctrine/toolguides/shipped/PYTHON_REVIEW_CHECKS.md
+applies_to_languages:
+  - python
 summary: >
   Catalog of automated checks a reviewer should run or verify have been run
   before approving Python code. Organized by category: formatting, linting,

--- a/src/specify_cli/charter/compiler.py
+++ b/src/specify_cli/charter/compiler.py
@@ -494,7 +494,10 @@ def _render_charter_markdown(
 ) -> str:
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    testing = interview.answers.get("testing_requirements", "Use pytest with measurable coverage goals.")
+    testing = interview.answers.get(
+        "testing_requirements",
+        "Use the project's declared testing approach, or mark it as NEEDS CLARIFICATION.",
+    )
     quality = interview.answers.get("quality_gates", "Tests, lint, and type checks must pass before merge.")
     performance = interview.answers.get("performance_targets", "No explicit performance policy provided.")
     deployment = interview.answers.get("deployment_constraints", "No deployment constraints provided.")

--- a/src/specify_cli/charter/interview.py
+++ b/src/specify_cli/charter/interview.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.resources
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Iterable
 
 from ruamel.yaml import YAML
 
@@ -100,20 +101,8 @@ def default_interview(
 ) -> CharterInterview:
     """Return deterministic default interview answers."""
     catalog = doctrine_catalog or load_doctrine_catalog()
-
-    answers: dict[str, str] = {
-        "project_intent": "Deliver predictable, testable changes with clear reviewability.",
-        "languages_frameworks": "Python 3.11+, pytest, and repo-local tooling.",
-        "testing_requirements": "pytest with 80%+ coverage and test-first behavior for risky changes.",
-        "quality_gates": "Tests pass, lint clean, type checks pass, and no unresolved review findings.",
-        "review_policy": "At least one focused reviewer approves before merge.",
-        "performance_targets": "CLI operations should complete quickly (typically under 2 seconds).",
-        "deployment_constraints": "Must run on macOS and Linux developer environments.",
-        "documentation_policy": "Update docs whenever command behavior or workflow semantics change.",
-        "risk_boundaries": "Do not relax quality/security standards without explicit maintainer approval.",
-        "amendment_process": "Changes are proposed via PR and reviewed before adoption.",
-        "exception_policy": "Exceptions must be documented in PR notes with scope and sunset criteria.",
-    }
+    defaults = _load_packaged_defaults()
+    answers: dict[str, str] = dict(defaults.get("answers", {}))
 
     if profile == "minimal":
         answers = {key: answers[key] for key in MINIMAL_QUESTION_ORDER}
@@ -122,9 +111,18 @@ def default_interview(
         mission=mission,
         profile=profile,
         answers=answers,
-        selected_paradigms=sorted(catalog.paradigms),
-        selected_directives=sorted(catalog.directives),
-        available_tools=sorted(DEFAULT_TOOL_REGISTRY),
+        selected_paradigms=_normalize_iterable(
+            defaults.get("selected_paradigms"),
+            fallback=[],
+        ),
+        selected_directives=_normalize_iterable(
+            defaults.get("selected_directives"),
+            fallback=[],
+        ),
+        available_tools=_normalize_iterable(
+            defaults.get("available_tools"),
+            fallback=sorted(DEFAULT_TOOL_REGISTRY),
+        ),
     )
 
 
@@ -211,3 +209,40 @@ def _normalize_list(raw: object) -> list[str]:
 def _normalize_csv(raw: str) -> list[str]:
     parts = [part.strip() for part in raw.split(",")]
     return [part for part in parts if part]
+
+
+def _load_packaged_defaults() -> dict[str, object]:
+    """Load authoritative default interview content from the charter package."""
+    empty = {
+        "answers": {},
+        "selected_paradigms": [],
+        "selected_directives": [],
+        "available_tools": [],
+    }
+    try:
+        defaults_path = importlib.resources.files("charter").joinpath("defaults.yaml")
+        content = defaults_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, TypeError):
+        return empty
+
+    yaml = YAML(typ="safe")
+    try:
+        data = yaml.load(content) or {}
+    except Exception:
+        return empty
+
+    if not isinstance(data, dict):
+        return empty
+
+    answers = data.get("answers")
+    normalized_answers = (
+        {str(key): str(value) for key, value in answers.items()}
+        if isinstance(answers, dict)
+        else {}
+    )
+    return {
+        "answers": normalized_answers,
+        "selected_paradigms": _normalize_list(data.get("selected_paradigms")),
+        "selected_directives": _normalize_list(data.get("selected_directives")),
+        "available_tools": _normalize_list(data.get("available_tools")),
+    }

--- a/src/specify_cli/charter/resolver.py
+++ b/src/specify_cli/charter/resolver.py
@@ -16,7 +16,7 @@ from specify_cli.charter.sync import (
 )
 
 DEFAULT_TEMPLATE_SET = "software-dev-default"
-DEFAULT_TOOL_REGISTRY: frozenset[str] = frozenset({"spec-kitty", "git", "python", "pytest", "ruff", "mypy", "uv"})
+DEFAULT_TOOL_REGISTRY: frozenset[str] = frozenset({"spec-kitty", "git"})
 
 
 class GovernanceResolutionError(ValueError):

--- a/src/specify_cli/missions/software-dev/templates/plan-template.md
+++ b/src/specify_cli/missions/software-dev/templates/plan-template.md
@@ -25,7 +25,7 @@ The planner will not begin until all planning questions have been answered—cap
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
 **Project Type**: [single/web/mobile - determines source structure]
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]

--- a/src/specify_cli/review/baseline.py
+++ b/src/specify_cli/review/baseline.py
@@ -1,15 +1,15 @@
 """Baseline test capture for Spec Kitty review loop stabilization.
 
 Captures baseline test results at implement time (before the agent starts
-coding) by running the test suite on the base branch.  Results are cached
-as a committed artifact (baseline-tests.json).  At review time, the review
-prompt includes a "Baseline Context" section showing which failures are
-pre-existing vs. newly introduced.
+coding) when the project explicitly configures a baseline-capable test
+command. Results are cached as a committed artifact (baseline-tests.json).
+At review time, the review prompt includes a "Baseline Context" section
+showing which failures are pre-existing vs. newly introduced.
 
 Design decisions:
 - Capture timing: implement time, not claim time.
-- Output format: JUnit XML via pytest --junitxml, parsed via xml.etree.ElementTree (stdlib).
-- Non-pytest projects: configure review.test_command in .kittify/config.yaml.
+- Baseline capture is opt-in via ``review.test_command`` in ``.kittify/config.yaml``.
+- Supported output formats are parser-specific; JUnit XML is supported today.
 - Artifact format: structured JSON with test name, status, one-line error for failures only.
 """
 from __future__ import annotations
@@ -112,13 +112,13 @@ class BaselineTestResult:
         path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
 
 
-def _get_test_command(repo_root: Path) -> tuple[str, str]:
-    """Return (command_template, output_format) from config or defaults.
+def _get_test_command(repo_root: Path) -> tuple[str | None, str | None]:
+    """Return configured ``(command_template, output_format)`` or ``(None, None)``.
 
-    The command template uses ``{output_file}`` as a placeholder that will
-    be substituted at runtime with the path to the JUnit XML output file.
-
-    Default: ``("pytest --junitxml={output_file}", "junit_xml")``
+    The command template may use ``{output_file}`` as a placeholder that will
+    be substituted at runtime with the path to the parser-specific output file.
+    Baseline capture is intentionally opt-in; when no command is configured,
+    callers should skip baseline capture silently.
     """
     config_path = repo_root / ".kittify" / "config.yaml"
     if config_path.exists():
@@ -136,7 +136,7 @@ def _get_test_command(repo_root: Path) -> tuple[str, str]:
         except Exception as exc:
             logger.warning("Could not read config.yaml: %s", exc)
 
-    return ("pytest --junitxml={output_file}", "junit_xml")
+    return (None, None)
 
 
 def _parse_junit_xml(junit_xml_path: Path) -> tuple[int, int, int, int, list[BaselineFailure]]:
@@ -208,7 +208,7 @@ def capture_baseline(
         feature_dir: Path to the feature directory in kitty-specs/.
         wp_slug: Slug of the WP task file (e.g. "WP04-baseline-test-capture").
         test_command: Optional override for the test command.  If None, reads
-            from config or falls back to pytest.
+            from config; without config, baseline capture is skipped.
     """
     artifact_dir = feature_dir / "tasks" / wp_slug
     artifact_path = artifact_dir / "baseline-tests.json"
@@ -224,6 +224,24 @@ def capture_baseline(
     if repo_root is None:
         logger.warning("Could not find repo root from %s; skipping baseline capture.", worktree_path)
         return _make_sentinel(wp_id, base_branch, "")
+
+    # Determine test command
+    if test_command is None:
+        test_command, output_format = _get_test_command(repo_root)
+    else:
+        output_format = "junit_xml"
+
+    if not test_command:
+        logger.info("No review.test_command configured; skipping baseline capture for %s.", wp_id)
+        return None
+
+    if output_format != "junit_xml":
+        logger.info(
+            "Baseline capture configured with unsupported output format %r; skipping baseline capture for %s.",
+            output_format,
+            wp_id,
+        )
+        return None
 
     # Resolve base commit hash
     try:
@@ -241,10 +259,6 @@ def capture_baseline(
     except Exception as exc:
         logger.warning("git rev-parse failed: %s", exc)
         return _make_sentinel(wp_id, base_branch, "")
-
-    # Determine test command
-    if test_command is None:
-        test_command, _fmt = _get_test_command(repo_root)
 
     # Create temp dir for the worktree and JUnit output
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -286,7 +300,7 @@ def capture_baseline(
                 logger.warning("Test command failed to execute: %s", exc)
                 return _make_sentinel(wp_id, base_branch, base_commit)
 
-            # Parse JUnit XML (pytest exits non-zero when tests fail — that's OK)
+            # Parse JUnit XML (test runners often exit non-zero when tests fail — that's OK)
             if not junit_xml_path.exists():
                 logger.warning(
                     "JUnit XML not produced by baseline test run (exit=%d). stderr: %s",

--- a/src/specify_cli/spec_kitty_events/error_log.py
+++ b/src/specify_cli/spec_kitty_events/error_log.py
@@ -21,7 +21,7 @@ class ErrorLog:
         >>> error_log = ErrorLog(storage)
         >>> error_log.log_error(ErrorEntry(
         ...     timestamp=datetime.now(),
-        ...     action_attempted="Run pytest",
+        ...     action_attempted="Run project validation",
         ...     error_message="AssertionError: test failed"
         ... ))
         >>> errors = error_log.get_recent_errors(limit=10)

--- a/src/specify_cli/templates/plan-template.md
+++ b/src/specify_cli/templates/plan-template.md
@@ -24,7 +24,7 @@ The planner will not begin until all planning questions have been answered—cap
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]  
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
 **Project Type**: [single/web/mobile - determines source structure]  
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  

--- a/src/specify_cli/templates/plan-template.md
+++ b/src/specify_cli/templates/plan-template.md
@@ -24,7 +24,7 @@ The planner will not begin until all planning questions have been answered—cap
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
 **Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]  
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
 **Project Type**: [single/web/mobile - determines source structure]  
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  

--- a/tests/charter/test_catalog.py
+++ b/tests/charter/test_catalog.py
@@ -1,6 +1,10 @@
 """Scope: mock-boundary tests for doctrine catalog loading — no real git."""
 
+from pathlib import Path
+
 import pytest
+from ruamel.yaml import YAML
+
 from charter.catalog import load_doctrine_catalog
 
 pytestmark = pytest.mark.fast
@@ -34,3 +38,80 @@ def test_catalog_includes_mission_template_sets() -> None:
 
     # Assert
     assert "software-dev-default" in catalog.template_sets
+
+
+def test_catalog_filters_language_scoped_artifacts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    doctrine_root = tmp_path / "doctrine"
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    fixtures = {
+        Path("styleguides/shipped/python.styleguide.yaml"): {
+            "schema_version": "1.0",
+            "id": "python-style",
+            "title": "Python Style",
+            "scope": "code",
+            "applies_to_languages": ["python"],
+            "principles": ["Use Python idioms"],
+        },
+        Path("styleguides/shipped/generic.styleguide.yaml"): {
+            "schema_version": "1.0",
+            "id": "generic-style",
+            "title": "Generic Style",
+            "scope": "code",
+            "principles": ["Be clear"],
+        },
+        Path("toolguides/shipped/python.toolguide.yaml"): {
+            "schema_version": "1.0",
+            "id": "python-toolguide",
+            "tool": "pytest",
+            "title": "Python Toolguide",
+            "guide_path": "src/doctrine/toolguides/shipped/python.md",
+            "summary": "Python checks",
+            "applies_to_languages": ["python"],
+        },
+        Path("toolguides/shipped/generic.toolguide.yaml"): {
+            "schema_version": "1.0",
+            "id": "generic-toolguide",
+            "tool": "git",
+            "title": "Generic Toolguide",
+            "guide_path": "src/doctrine/toolguides/shipped/generic.md",
+            "summary": "Generic checks",
+        },
+        Path("agent_profiles/shipped/python.agent.yaml"): {
+            "profile-id": "python-implementer",
+            "name": "Python Implementer",
+            "role": "implementer",
+            "purpose": "Python specialist",
+            "applies_to_languages": ["python"],
+            "specialization": {"primary-focus": "python"},
+        },
+        Path("agent_profiles/shipped/generic.agent.yaml"): {
+            "profile-id": "generic-implementer",
+            "name": "Generic Implementer",
+            "role": "implementer",
+            "purpose": "General specialist",
+            "specialization": {"primary-focus": "general"},
+        },
+        Path("missions/software-dev/mission.yaml"): {
+            "name": "software-dev",
+            "description": "Software development mission",
+        },
+    }
+
+    for relative_path, data in fixtures.items():
+        path = doctrine_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            yaml.dump(data, handle)
+
+    monkeypatch.setattr("charter.catalog.resolve_doctrine_root", lambda: doctrine_root)
+
+    catalog = load_doctrine_catalog(active_languages=["typescript"])
+
+    assert "generic-style" in catalog.styleguides
+    assert "python-style" not in catalog.styleguides
+    assert "generic-toolguide" in catalog.toolguides
+    assert "python-toolguide" not in catalog.toolguides
+    assert "generic-implementer" in catalog.agent_profiles
+    assert "python-implementer" not in catalog.agent_profiles

--- a/tests/charter/test_catalog.py
+++ b/tests/charter/test_catalog.py
@@ -115,3 +115,57 @@ def test_catalog_filters_language_scoped_artifacts(monkeypatch: pytest.MonkeyPat
     assert "python-toolguide" not in catalog.toolguides
     assert "generic-implementer" in catalog.agent_profiles
     assert "python-implementer" not in catalog.agent_profiles
+
+
+def test_catalog_keeps_language_scoped_artifacts_when_active_languages_are_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    doctrine_root = tmp_path / "doctrine"
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    fixtures = {
+        Path("styleguides/shipped/python.styleguide.yaml"): {
+            "schema_version": "1.0",
+            "id": "python-style",
+            "title": "Python Style",
+            "scope": "code",
+            "applies_to_languages": ["python"],
+            "principles": ["Use Python idioms"],
+        },
+        Path("toolguides/shipped/python.toolguide.yaml"): {
+            "schema_version": "1.0",
+            "id": "python-toolguide",
+            "tool": "pytest",
+            "title": "Python Toolguide",
+            "guide_path": "src/doctrine/toolguides/shipped/python.md",
+            "summary": "Python checks",
+            "applies_to_languages": ["python"],
+        },
+        Path("agent_profiles/shipped/python.agent.yaml"): {
+            "profile-id": "python-implementer",
+            "name": "Python Implementer",
+            "role": "implementer",
+            "purpose": "Python specialist",
+            "applies_to_languages": ["python"],
+            "specialization": {"primary-focus": "python"},
+        },
+        Path("missions/software-dev/mission.yaml"): {
+            "name": "software-dev",
+            "description": "Software development mission",
+        },
+    }
+
+    for relative_path, data in fixtures.items():
+        path = doctrine_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            yaml.dump(data, handle)
+
+    monkeypatch.setattr("charter.catalog.resolve_doctrine_root", lambda: doctrine_root)
+
+    catalog = load_doctrine_catalog()
+
+    assert "python-style" in catalog.styleguides
+    assert "python-toolguide" in catalog.toolguides
+    assert "python-implementer" in catalog.agent_profiles

--- a/tests/charter/test_catalog.py
+++ b/tests/charter/test_catalog.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from ruamel.yaml import YAML
 
-from charter.catalog import load_doctrine_catalog
+from charter.catalog import _load_yaml_id_catalog, load_doctrine_catalog
 
 pytestmark = pytest.mark.fast
 
@@ -169,3 +169,28 @@ def test_catalog_keeps_language_scoped_artifacts_when_active_languages_are_unset
     assert "python-style" in catalog.styleguides
     assert "python-toolguide" in catalog.toolguides
     assert "python-implementer" in catalog.agent_profiles
+
+
+def test_load_yaml_id_catalog_scans_proposed_when_requested(tmp_path: Path) -> None:
+    doctrine_dir = tmp_path / "styleguides"
+    shipped_dir = doctrine_dir / "shipped"
+    proposed_dir = doctrine_dir / "_proposed"
+    shipped_dir.mkdir(parents=True)
+    proposed_dir.mkdir(parents=True)
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    with (shipped_dir / "shipped.styleguide.yaml").open("w", encoding="utf-8") as handle:
+        yaml.dump(
+            {"schema_version": "1.0", "id": "shipped-style", "title": "Shipped", "scope": "code"},
+            handle,
+        )
+    with (proposed_dir / "proposed.styleguide.yaml").open("w", encoding="utf-8") as handle:
+        yaml.dump(
+            {"schema_version": "1.0", "id": "proposed-style", "title": "Proposed", "scope": "code"},
+            handle,
+        )
+
+    ids = _load_yaml_id_catalog(doctrine_dir, "*.styleguide.yaml", include_proposed=True)
+
+    assert ids == {"shipped-style", "proposed-style"}

--- a/tests/charter/test_compiler.py
+++ b/tests/charter/test_compiler.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from charter.catalog import load_doctrine_catalog
 from charter.compiler import compile_charter, write_compiled_charter
 from charter.interview import (
     CharterInterview,
@@ -33,7 +34,7 @@ def test_compile_charter_contains_governance_activation_block() -> None:
     assert compiled.template_set == "software-dev-default"
     assert "## Governance Activation" in compiled.markdown
     assert "selected_directives" in compiled.markdown
-    assert len(compiled.references) >= 2
+    assert "available_tools: [git, spec-kitty]" in compiled.markdown
 
 
 def test_compile_charter_preserves_explicit_empty_selections() -> None:
@@ -113,6 +114,10 @@ def test_compile_with_doctrine_service_none_uses_drg_backed_path() -> None:
     toolguides resolved via the graph, not just paradigms + directives.
     """
     interview = default_interview(mission="software-dev", profile="minimal")
+    interview = apply_answer_overrides(
+        interview,
+        selected_directives=["DIRECTIVE_003"],
+    )
 
     compiled = compile_charter(mission="software-dev", interview=interview, doctrine_service=None)
 
@@ -123,8 +128,8 @@ def test_compile_with_doctrine_service_none_uses_drg_backed_path() -> None:
     assert not any(fallback_msg in d for d in compiled.diagnostics), (
         f"Unexpected legacy fallback diagnostic: {compiled.diagnostics}"
     )
-    # The DRG-backed path resolves transitive artifacts. For the default
-    # interview the shipped graph should yield at least one tactic.
+    # The DRG-backed path resolves transitive artifacts. With an explicit shipped
+    # directive selection the bundled graph should yield at least one tactic.
     kinds = {reference.kind for reference in compiled.references}
     assert "tactic" in kinds, (
         "DRG-backed path should have resolved transitive tactics; "
@@ -142,6 +147,10 @@ def test_compile_with_repo_root_uses_project_drg_overlay(tmp_path: Path) -> None
     mission review.
     """
     interview = default_interview(mission="software-dev", profile="minimal")
+    interview = apply_answer_overrides(
+        interview,
+        selected_directives=["DIRECTIVE_003"],
+    )
 
     # An empty project overlay at .kittify/doctrine/graph.yaml is enough
     # to prove the repo_root branch executes load_validated_graph. We use
@@ -440,13 +449,17 @@ def test_compile_with_local_support_file_creates_local_reference() -> None:
 def test_compile_local_support_reference_is_additive_not_replacement() -> None:
     """Local support reference must not replace the shipped directive reference."""
     interview = default_interview(mission="software-dev", profile="minimal")
-    directive_id = interview.selected_directives[0] if interview.selected_directives else "DIRECTIVE_004"
+    directive_id = sorted(load_doctrine_catalog().directives)[0]
     decl = LocalSupportDeclaration(
         path="docs/custom-directive.md",
         target_kind="directive",
         target_id=directive_id,
     )
-    interview = apply_answer_overrides(interview, local_supporting_files=[decl])
+    interview = apply_answer_overrides(
+        interview,
+        selected_directives=[directive_id],
+        local_supporting_files=[decl],
+    )
 
     compiled = compile_charter(mission="software-dev", interview=interview)
 
@@ -460,13 +473,17 @@ def test_compile_local_support_reference_is_additive_not_replacement() -> None:
 def test_compile_local_support_overlap_emits_warning_diagnostic() -> None:
     """When local file targets a shipped directive, a diagnostic warning is emitted."""
     interview = default_interview(mission="software-dev", profile="minimal")
-    directive_id = interview.selected_directives[0] if interview.selected_directives else "DIRECTIVE_004"
+    directive_id = sorted(load_doctrine_catalog().directives)[0]
     decl = LocalSupportDeclaration(
         path="docs/custom.md",
         target_kind="directive",
         target_id=directive_id,
     )
-    interview = apply_answer_overrides(interview, local_supporting_files=[decl])
+    interview = apply_answer_overrides(
+        interview,
+        selected_directives=[directive_id],
+        local_supporting_files=[decl],
+    )
 
     compiled = compile_charter(mission="software-dev", interview=interview)
 
@@ -515,6 +532,10 @@ def test_yaml_fallback_resolves_directives_from_shipped_subdirectory() -> None:
     in bundled doctrine.' when DoctrineService was absent.
     """
     interview = default_interview(mission="software-dev", profile="minimal")
+    interview = apply_answer_overrides(
+        interview,
+        selected_directives=["DIRECTIVE_003"],
+    )
 
     # Exercise the YAML scanning fallback explicitly (no DoctrineService)
     compiled = compile_charter(mission="software-dev", interview=interview, doctrine_service=None)

--- a/tests/charter/test_context.py
+++ b/tests/charter/test_context.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from charter.context import CharterContextResult, build_charter_context
+from charter.context import CharterContextResult, _build_doctrine_service, build_charter_context
 
 pytestmark = pytest.mark.fast
 
@@ -384,3 +384,33 @@ class TestNoPerActionFiltering:
                                         f"comparison with '{other.value}'. "
                                         f"FR-009 prohibits per-action filtering."
                                     )
+
+
+def test_build_doctrine_service_prefers_repo_src_overlay(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: dict[str, object] = {}
+
+    class StubDoctrineService:
+        def __init__(self, *, shipped_root: Path, project_root: Path | None, active_languages: list[str]) -> None:
+            calls["shipped_root"] = shipped_root
+            calls["project_root"] = project_root
+            calls["active_languages"] = active_languages
+
+    shipped_root = tmp_path / "shipped-doctrine"
+    shipped_root.mkdir()
+    project_root = tmp_path / "src" / "doctrine"
+    project_root.mkdir(parents=True)
+
+    monkeypatch.setattr("charter.catalog.resolve_doctrine_root", lambda: shipped_root)
+    monkeypatch.setattr("charter.context.infer_repo_languages", lambda repo_root: ["python", "typescript"])
+    monkeypatch.setattr("doctrine.service.DoctrineService", StubDoctrineService)
+
+    service = _build_doctrine_service(tmp_path)
+
+    assert isinstance(service, StubDoctrineService)
+    assert calls == {
+        "shipped_root": shipped_root,
+        "project_root": project_root,
+        "active_languages": ["python", "typescript"],
+    }

--- a/tests/charter/test_generator.py
+++ b/tests/charter/test_generator.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.fast
 
 
 def test_build_charter_draft_defaults() -> None:
-    """Draft built with defaults selects expected template set, directives, and paradigms."""
+    """Draft built with defaults keeps packaged doctrine selections neutral."""
     # Arrange
     # (no precondition)
 
@@ -22,7 +22,8 @@ def test_build_charter_draft_defaults() -> None:
 
     # Assert
     assert draft.template_set == "software-dev-default"
-    assert len(draft.selected_directives) >= 1
+    assert draft.selected_directives == []
+    assert draft.selected_paradigms == []
     assert "selected_directives" in draft.markdown
 
 

--- a/tests/charter/test_interview.py
+++ b/tests/charter/test_interview.py
@@ -1,11 +1,13 @@
 """Scope: mock-boundary tests for charter interview persistence — no real git."""
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 from charter.interview import (
     MINIMAL_QUESTION_ORDER,
     QUESTION_ORDER,
+    _load_packaged_defaults,
     apply_answer_overrides,
     default_interview,
     read_interview_answers,
@@ -94,3 +96,61 @@ def test_apply_answer_overrides_updates_agent_identity_fields() -> None:
 
     assert updated.agent_profile == "architect"
     assert updated.agent_role == "reviewer"
+
+
+def test_load_packaged_defaults_returns_empty_when_resource_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "charter.interview.importlib.resources.files",
+        lambda package: (_ for _ in ()).throw(FileNotFoundError("missing")),
+    )
+
+    defaults = _load_packaged_defaults()
+
+    assert defaults == {
+        "answers": {},
+        "selected_paradigms": [],
+        "selected_directives": [],
+        "available_tools": [],
+    }
+
+
+def test_load_packaged_defaults_returns_empty_on_invalid_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubResource:
+        def joinpath(self, name: str) -> "StubResource":
+            assert name == "defaults.yaml"
+            return self
+
+        def read_text(self, encoding: str = "utf-8") -> str:
+            assert encoding == "utf-8"
+            return "answers: ["
+
+    monkeypatch.setattr("charter.interview.importlib.resources.files", lambda package: StubResource())
+
+    defaults = _load_packaged_defaults()
+
+    assert defaults["answers"] == {}
+    assert defaults["selected_paradigms"] == []
+
+
+def test_load_packaged_defaults_returns_empty_when_yaml_is_not_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubResource:
+        def joinpath(self, name: str) -> "StubResource":
+            assert name == "defaults.yaml"
+            return self
+
+        def read_text(self, encoding: str = "utf-8") -> str:
+            assert encoding == "utf-8"
+            return "- not-a-mapping\n"
+
+    monkeypatch.setattr("charter.interview.importlib.resources.files", lambda package: StubResource())
+
+    defaults = _load_packaged_defaults()
+
+    assert defaults["answers"] == {}
+    assert defaults["available_tools"] == []

--- a/tests/charter/test_interview.py
+++ b/tests/charter/test_interview.py
@@ -25,7 +25,9 @@ def test_default_interview_minimal_uses_minimal_question_set() -> None:
     assert interview.mission == "software-dev"
     assert interview.profile == "minimal"
     assert set(interview.answers.keys()) == set(MINIMAL_QUESTION_ORDER)
-    assert len(interview.selected_directives) >= 1
+    assert interview.selected_paradigms == []
+    assert interview.selected_directives == []
+    assert interview.available_tools == ["git", "spec-kitty"]
 
 
 def test_default_interview_comprehensive_includes_full_questions() -> None:

--- a/tests/charter/test_language_scope.py
+++ b/tests/charter/test_language_scope.py
@@ -1,0 +1,48 @@
+"""Tests for deriving active languages from charter inputs."""
+
+from pathlib import Path
+
+import pytest
+
+from charter.interview import apply_answer_overrides, default_interview, write_interview_answers
+from charter.language_scope import extract_declared_languages, infer_repo_languages
+
+pytestmark = pytest.mark.fast
+
+
+def test_extract_declared_languages_deduplicates_alias_hits() -> None:
+    languages = extract_declared_languages(
+        "Python services with pytest and ruff. TypeScript frontend built with tsc."
+    )
+
+    assert languages == ["python", "typescript"]
+
+
+def test_infer_repo_languages_prefers_interview_answers(tmp_path: Path) -> None:
+    answers_path = tmp_path / ".kittify" / "charter" / "interview" / "answers.yaml"
+    answers_path.parent.mkdir(parents=True, exist_ok=True)
+
+    interview = apply_answer_overrides(
+        default_interview(mission="software-dev", profile="minimal"),
+        answers={"languages_frameworks": "Python backend with pytest checks"},
+    )
+    write_interview_answers(answers_path, interview)
+
+    (tmp_path / ".kittify" / "charter" / "charter.md").write_text(
+        "JavaScript only",
+        encoding="utf-8",
+    )
+
+    assert infer_repo_languages(tmp_path) == ["python"]
+
+
+def test_infer_repo_languages_falls_back_to_charter_markdown(tmp_path: Path) -> None:
+    charter_path = tmp_path / ".kittify" / "charter" / "charter.md"
+    charter_path.parent.mkdir(parents=True, exist_ok=True)
+    charter_path.write_text("This repository uses Java, Maven, and JUnit.", encoding="utf-8")
+
+    assert infer_repo_languages(tmp_path) == ["java"]
+
+
+def test_infer_repo_languages_returns_empty_without_inputs(tmp_path: Path) -> None:
+    assert infer_repo_languages(tmp_path) == []

--- a/tests/cross_cutting/misc/test_plan_validation.py
+++ b/tests/cross_cutting/misc/test_plan_validation.py
@@ -24,7 +24,7 @@ def test_detect_unfilled_plan_with_template():
 
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 
 ## Charter Check
 [Gates determined based on charter file]
@@ -97,7 +97,7 @@ def test_validate_plan_filled_strict_mode():
             """# Implementation Plan: [FEATURE]
 **Language/Version**: [e.g., Python 3.11 or NEEDS CLARIFICATION]
 **Primary Dependencies**: [e.g., FastAPI or NEEDS CLARIFICATION]
-**Testing**: [e.g., pytest or NEEDS CLARIFICATION]
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 [Gates determined based on charter file]
 # [REMOVE IF UNUSED] Option 1: Single project
 # [REMOVE IF UNUSED] Option 2: Web application
@@ -123,7 +123,7 @@ def test_validate_plan_filled_lenient_mode(capsys):
             """# Implementation Plan: [FEATURE]
 **Language/Version**: [e.g., Python 3.11 or NEEDS CLARIFICATION]
 **Primary Dependencies**: [e.g., FastAPI or NEEDS CLARIFICATION]
-**Testing**: [e.g., pytest or NEEDS CLARIFICATION]
+**Testing**: [Project-specific test approach or NEEDS CLARIFICATION]
 [Gates determined based on charter file]
 # [REMOVE IF UNUSED] Option 1: Single project
 # [REMOVE IF UNUSED] Option 2: Web application

--- a/tests/doctrine/procedures/test_repository.py
+++ b/tests/doctrine/procedures/test_repository.py
@@ -99,3 +99,38 @@ class TestProcedureRepository:
         shipped.mkdir()
         repo = ProcedureRepository(shipped_dir=shipped)
         assert repo.list_all() == []
+
+    def test_skips_project_procedures_when_language_scope_does_not_match(
+        self, tmp_path: Path, sample_procedure_data: dict
+    ) -> None:
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+        with (shipped / "curation-interview.procedure.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(sample_procedure_data, handle)
+
+        project = tmp_path / "project"
+        project.mkdir()
+        with (project / "curation-interview.procedure.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump({**sample_procedure_data, "applies_to_languages": ["python"]}, handle)
+        with (project / "python-only.procedure.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    **sample_procedure_data,
+                    "id": "python-only",
+                    "name": "Python Only",
+                    "applies_to_languages": ["python"],
+                },
+                handle,
+            )
+
+        repo = ProcedureRepository(
+            shipped_dir=shipped,
+            project_dir=project,
+            active_languages=["typescript"],
+        )
+
+        assert repo.get("curation-interview") is not None
+        assert repo.get("python-only") is None

--- a/tests/doctrine/styleguides/test_repository.py
+++ b/tests/doctrine/styleguides/test_repository.py
@@ -180,3 +180,61 @@ class TestStyleguideRepository:
 
         assert "generic-style" in styleguide_ids
         assert "python-style" not in styleguide_ids
+
+    def test_skips_project_styleguides_when_language_scope_does_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        with (shipped / "merge-test.styleguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "merge-test",
+                    "title": "Base Title",
+                    "scope": "code",
+                    "principles": ["Original principle"],
+                },
+                handle,
+            )
+        with (project / "merge-test.styleguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "merge-test",
+                    "title": "Python Override",
+                    "scope": "code",
+                    "applies_to_languages": ["python"],
+                    "principles": ["Override principle"],
+                },
+                handle,
+            )
+        with (project / "python-only.styleguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "python-only",
+                    "title": "Python Only",
+                    "scope": "code",
+                    "applies_to_languages": ["python"],
+                    "principles": ["Python only"],
+                },
+                handle,
+            )
+
+        repo = StyleguideRepository(
+            shipped_dir=shipped,
+            project_dir=project,
+            active_languages=["typescript"],
+        )
+
+        merge_test = repo.get("merge-test")
+        assert merge_test is not None
+        assert merge_test.title == "Base Title"
+        assert repo.get("python-only") is None

--- a/tests/doctrine/styleguides/test_repository.py
+++ b/tests/doctrine/styleguides/test_repository.py
@@ -141,3 +141,42 @@ class TestStyleguideRepository:
         assert sg is not None
         assert sg.title == "Overridden Title"
         assert sg.scope.value == "testing"
+
+    def test_filters_language_scoped_styleguides_when_active_languages_do_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        with (shipped / "python.styleguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "python-style",
+                    "title": "Python Style",
+                    "scope": "code",
+                    "applies_to_languages": ["python"],
+                    "principles": ["Use Python idioms"],
+                },
+                handle,
+            )
+        with (shipped / "generic.styleguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "generic-style",
+                    "title": "Generic Style",
+                    "scope": "code",
+                    "principles": ["Be clear"],
+                },
+                handle,
+            )
+
+        repo = StyleguideRepository(shipped_dir=shipped, active_languages=["typescript"])
+        styleguide_ids = {styleguide.id for styleguide in repo.list_all()}
+
+        assert "generic-style" in styleguide_ids
+        assert "python-style" not in styleguide_ids

--- a/tests/doctrine/tactics/test_repository.py
+++ b/tests/doctrine/tactics/test_repository.py
@@ -202,3 +202,58 @@ class TestTacticRepository:
 
         assert "generic-tactic" in tactic_ids
         assert "python-tactic" not in tactic_ids
+
+    def test_skips_project_tactics_when_language_scope_does_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        with (shipped / "merge-test.tactic.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "merge-test",
+                    "name": "Base Name",
+                    "steps": [{"title": "Base Step"}],
+                },
+                handle,
+            )
+        with (project / "merge-test.tactic.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "merge-test",
+                    "name": "Python Override",
+                    "applies_to_languages": ["python"],
+                    "steps": [{"title": "Python Step"}],
+                },
+                handle,
+            )
+        with (project / "python-only.tactic.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "python-only",
+                    "name": "Python Only",
+                    "applies_to_languages": ["python"],
+                    "steps": [{"title": "Python Step"}],
+                },
+                handle,
+            )
+
+        repo = TacticRepository(
+            shipped_dir=shipped,
+            project_dir=project,
+            active_languages=["typescript"],
+        )
+
+        merge_test = repo.get("merge-test")
+        assert merge_test is not None
+        assert merge_test.name == "Base Name"
+        assert repo.get("python-only") is None

--- a/tests/doctrine/tactics/test_repository.py
+++ b/tests/doctrine/tactics/test_repository.py
@@ -165,3 +165,40 @@ class TestTacticRepository:
         assert loaded.purpose == tactic.purpose
         assert len(loaded.steps) == len(tactic.steps)
         assert len(loaded.references) == len(tactic.references)
+
+    def test_filters_language_scoped_tactics_when_active_languages_do_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        with (shipped / "python.tactic.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "python-tactic",
+                    "name": "Python Tactic",
+                    "applies_to_languages": ["python"],
+                    "steps": [{"title": "Run Python workflow"}],
+                },
+                handle,
+            )
+        with (shipped / "generic.tactic.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "generic-tactic",
+                    "name": "Generic Tactic",
+                    "steps": [{"title": "Run generic workflow"}],
+                },
+                handle,
+            )
+
+        repo = TacticRepository(shipped_dir=shipped, active_languages=["typescript"])
+        tactic_ids = {tactic.id for tactic in repo.list_all()}
+
+        assert "generic-tactic" in tactic_ids
+        assert "python-tactic" not in tactic_ids

--- a/tests/doctrine/test_generic_artifact_language_bias.py
+++ b/tests/doctrine/test_generic_artifact_language_bias.py
@@ -1,0 +1,76 @@
+"""Regression guard against language-specific tool bias in generic shipped artifacts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DENYLIST = (
+    r"\bpytest\b",
+    r"\bjunit\b",
+    r"\bjest\b",
+    r"\bcargo\s+test\b",
+    r"\bxctest\b",
+    r"\bmypy\b",
+    r"\bruff\b",
+    r"\bgradle\b",
+    r"\bmaven\b",
+    r"\bphpunit\b",
+    r"\brspec\b",
+)
+GENERIC_SURFACES = (
+    Path("src/doctrine/agent_profiles/shipped"),
+    Path("src/doctrine/skills"),
+    Path("src/doctrine/tactics/shipped"),
+    Path("src/doctrine/templates"),
+    Path("src/doctrine/missions/software-dev/templates"),
+    Path("src/specify_cli/missions/software-dev/templates"),
+    Path("src/specify_cli/templates"),
+    Path("src/charter/defaults.yaml"),
+)
+ALLOWED_PATH_SNIPPETS = (
+    "python-",
+    "PYTHON_",
+    "claudeignore-template",
+)
+
+
+def _iter_generic_artifacts() -> list[Path]:
+    paths: list[Path] = []
+    for surface in GENERIC_SURFACES:
+        absolute = REPO_ROOT / surface
+        if absolute.is_file():
+            paths.append(absolute)
+            continue
+        if not absolute.is_dir():
+            continue
+        paths.extend(path for path in absolute.rglob("*") if path.is_file())
+    return sorted(paths)
+
+
+def _is_allowlisted(path: Path, content: str) -> bool:
+    as_posix = path.as_posix()
+    if any(snippet in as_posix for snippet in ALLOWED_PATH_SNIPPETS):
+        return True
+    return "applies_to_languages:" in content
+
+
+def test_generic_shipped_artifacts_do_not_embed_language_specific_tool_bias() -> None:
+    violations: list[str] = []
+
+    for path in _iter_generic_artifacts():
+        content = path.read_text(encoding="utf-8")
+        if _is_allowlisted(path, content):
+            continue
+
+        for pattern in DENYLIST:
+            if re.search(pattern, content, flags=re.IGNORECASE):
+                violations.append(f"{path.relative_to(REPO_ROOT)} matches {pattern}")
+
+    assert violations == []

--- a/tests/doctrine/test_profile_repository.py
+++ b/tests/doctrine/test_profile_repository.py
@@ -266,6 +266,43 @@ specialization:
         assert "generic" in profile_ids
         assert "python-only" in profile_ids
 
+    def test_skips_project_profiles_when_language_scope_does_not_match(
+        self, shipped_profiles_dir: Path, tmp_path: Path
+    ) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "python-pedro.agent.yaml").write_text(
+            """profile-id: python-pedro
+applies_to_languages:
+  - python
+routing-priority: 99
+""",
+            encoding="utf-8",
+        )
+        (project / "typescript-reviewer.agent.yaml").write_text(
+            """profile-id: typescript-reviewer
+name: TypeScript Reviewer
+purpose: Review TypeScript changes
+role: reviewer
+applies_to_languages:
+  - typescript
+specialization:
+  primary-focus: TypeScript review
+""",
+            encoding="utf-8",
+        )
+
+        repo = AgentProfileRepository(
+            shipped_dir=shipped_profiles_dir,
+            project_dir=project,
+            active_languages=["go"],
+        )
+
+        python_pedro = repo.get("python-pedro")
+        assert python_pedro is not None
+        assert python_pedro.routing_priority == 90
+        assert repo.get("typescript-reviewer") is None
+
 
 class TestAgentProfileRepositoryBoundaries:
     """Test boundary conditions."""

--- a/tests/doctrine/test_profile_repository.py
+++ b/tests/doctrine/test_profile_repository.py
@@ -231,6 +231,41 @@ specialization:
         assert "generic" in profile_ids
         assert "python-only" not in profile_ids
 
+    def test_keeps_language_scoped_profiles_when_active_languages_are_unset(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+
+        (shipped / "python-only.agent.yaml").write_text(
+            """profile-id: python-only
+name: Python Only
+purpose: Python specialist
+role: implementer
+applies_to_languages:
+  - python
+specialization:
+  primary-focus: Python implementation
+""",
+            encoding="utf-8",
+        )
+        (shipped / "generic.agent.yaml").write_text(
+            """profile-id: generic
+name: Generic
+purpose: Generic specialist
+role: implementer
+specialization:
+  primary-focus: General implementation
+""",
+            encoding="utf-8",
+        )
+
+        repo = AgentProfileRepository(shipped_dir=shipped)
+        profile_ids = {profile.profile_id for profile in repo.list_all()}
+
+        assert "generic" in profile_ids
+        assert "python-only" in profile_ids
+
 
 class TestAgentProfileRepositoryBoundaries:
     """Test boundary conditions."""

--- a/tests/doctrine/test_profile_repository.py
+++ b/tests/doctrine/test_profile_repository.py
@@ -196,6 +196,41 @@ class TestAgentProfileRepositoryMany:
             "custom-reviewer",
         }
 
+    def test_filters_language_scoped_profiles_when_active_languages_do_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+
+        (shipped / "python-only.agent.yaml").write_text(
+            """profile-id: python-only
+name: Python Only
+purpose: Python specialist
+role: implementer
+applies_to_languages:
+  - python
+specialization:
+  primary-focus: Python implementation
+""",
+            encoding="utf-8",
+        )
+        (shipped / "generic.agent.yaml").write_text(
+            """profile-id: generic
+name: Generic
+purpose: Generic specialist
+role: implementer
+specialization:
+  primary-focus: General implementation
+""",
+            encoding="utf-8",
+        )
+
+        repo = AgentProfileRepository(shipped_dir=shipped, active_languages=["typescript"])
+        profile_ids = {profile.profile_id for profile in repo.list_all()}
+
+        assert "generic" in profile_ids
+        assert "python-only" not in profile_ids
+
 
 class TestAgentProfileRepositoryBoundaries:
     """Test boundary conditions."""

--- a/tests/doctrine/test_scoping.py
+++ b/tests/doctrine/test_scoping.py
@@ -1,0 +1,22 @@
+"""Tests for doctrine language-scoping helpers."""
+
+import pytest
+
+from doctrine.shared.scoping import applies_to_languages_match, normalize_languages
+
+pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
+
+
+def test_normalize_languages_none_returns_empty_tuple() -> None:
+    assert normalize_languages(None) == ()
+
+
+def test_normalize_languages_deduplicates_and_skips_blanks() -> None:
+    assert normalize_languages([" Python ", "", "python", "TypeScript"]) == (
+        "python",
+        "typescript",
+    )
+
+
+def test_applies_to_languages_match_rejects_scoped_artifact_for_explicit_empty_scope() -> None:
+    assert applies_to_languages_match(["python"], ()) is False

--- a/tests/doctrine/test_service.py
+++ b/tests/doctrine/test_service.py
@@ -225,3 +225,55 @@ def test_service_filters_language_scoped_artifacts_when_active_languages_do_not_
     assert service.toolguides.get("python-tool") is None
     assert service.agent_profiles.get("generic-implementer") is not None
     assert service.agent_profiles.get("python-implementer") is None
+
+
+def test_service_keeps_language_scoped_artifacts_when_active_languages_are_unset(
+    tmp_path: Path,
+) -> None:
+    shipped_root = tmp_path / "shipped-root"
+
+    _write_yaml(
+        shipped_root / "styleguides" / "shipped" / "python.styleguide.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "python-style",
+            "title": "Python Style",
+            "scope": "code",
+            "applies_to_languages": ["python"],
+            "principles": ["Use Python idioms"],
+        },
+    )
+    _write_yaml(
+        shipped_root / "toolguides" / "shipped" / "python.toolguide.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "python-tool",
+            "tool": "pytest",
+            "title": "Python Tool",
+            "guide_path": "src/doctrine/toolguides/shipped/python.md",
+            "summary": "Python tool",
+            "applies_to_languages": ["python"],
+        },
+    )
+    _write_yaml(
+        shipped_root / "agent_profiles" / "shipped" / "python.agent.yaml",
+        {
+            "profile-id": "python-implementer",
+            "name": "Python Implementer",
+            "role": "implementer",
+            "purpose": "Python specialist",
+            "applies_to_languages": ["python"],
+            "specialization": {
+                "primary-focus": "python",
+                "secondary-awareness": "testing",
+                "avoidance-boundary": "other stacks",
+                "success-definition": "ship Python changes safely",
+            },
+        },
+    )
+
+    service = DoctrineService(shipped_root=shipped_root)
+
+    assert service.styleguides.get("python-style") is not None
+    assert service.toolguides.get("python-tool") is not None
+    assert service.agent_profiles.get("python-implementer") is not None

--- a/tests/doctrine/test_service.py
+++ b/tests/doctrine/test_service.py
@@ -135,3 +135,93 @@ def test_service_honors_custom_shipped_and_project_roots(tmp_path: Path) -> None
 # relationships are expressed exclusively via edges in
 # ``src/doctrine/graph.yaml`` and are validated by the DRG cycle/shape tests.
 
+
+def test_service_filters_language_scoped_artifacts_when_active_languages_do_not_match(
+    tmp_path: Path,
+) -> None:
+    shipped_root = tmp_path / "shipped-root"
+
+    _write_yaml(
+        shipped_root / "styleguides" / "shipped" / "python.styleguide.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "python-style",
+            "title": "Python Style",
+            "scope": "code",
+            "applies_to_languages": ["python"],
+            "principles": ["Use Python idioms"],
+        },
+    )
+    _write_yaml(
+        shipped_root / "styleguides" / "shipped" / "generic.styleguide.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "generic-style",
+            "title": "Generic Style",
+            "scope": "code",
+            "principles": ["Be clear"],
+        },
+    )
+    _write_yaml(
+        shipped_root / "toolguides" / "shipped" / "python.toolguide.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "python-tool",
+            "tool": "pytest",
+            "title": "Python Tool",
+            "guide_path": "src/doctrine/toolguides/shipped/python.md",
+            "summary": "Python tool",
+            "applies_to_languages": ["python"],
+        },
+    )
+    _write_yaml(
+        shipped_root / "toolguides" / "shipped" / "generic.toolguide.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "generic-tool",
+            "tool": "git",
+            "title": "Generic Tool",
+            "guide_path": "src/doctrine/toolguides/shipped/generic.md",
+            "summary": "Generic tool",
+        },
+    )
+    _write_yaml(
+        shipped_root / "agent_profiles" / "shipped" / "python.agent.yaml",
+        {
+            "profile-id": "python-implementer",
+            "name": "Python Implementer",
+            "role": "implementer",
+            "purpose": "Python specialist",
+            "applies_to_languages": ["python"],
+            "specialization": {
+                "primary-focus": "python",
+                "secondary-awareness": "testing",
+                "avoidance-boundary": "other stacks",
+                "success-definition": "ship Python changes safely",
+            },
+        },
+    )
+    _write_yaml(
+        shipped_root / "agent_profiles" / "shipped" / "generic.agent.yaml",
+        {
+            "profile-id": "generic-implementer",
+            "name": "Generic Implementer",
+            "role": "implementer",
+            "purpose": "General specialist",
+            "specialization": {
+                "primary-focus": "general implementation",
+                "secondary-awareness": "quality",
+                "avoidance-boundary": "none",
+                "success-definition": "ship changes safely",
+            },
+        },
+    )
+
+    service = DoctrineService(shipped_root=shipped_root, active_languages=["typescript"])
+
+    assert service.styleguides.get("generic-style") is not None
+    assert service.styleguides.get("python-style") is None
+    assert service.toolguides.get("generic-tool") is not None
+    assert service.toolguides.get("python-tool") is None
+    assert service.agent_profiles.get("generic-implementer") is not None
+    assert service.agent_profiles.get("python-implementer") is None

--- a/tests/doctrine/toolguides/test_repository.py
+++ b/tests/doctrine/toolguides/test_repository.py
@@ -109,3 +109,43 @@ class TestToolguideRepository:
         assert toolguide.title == "Overridden Title"
         assert toolguide.commands == ["spec-kitty"]
 
+    def test_filters_language_scoped_toolguides_when_active_languages_do_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        with (shipped / "python.toolguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "python-toolguide",
+                    "tool": "pytest",
+                    "title": "Python Toolguide",
+                    "guide_path": "src/doctrine/toolguides/shipped/python.md",
+                    "summary": "Python checks",
+                    "applies_to_languages": ["python"],
+                },
+                handle,
+            )
+        with (shipped / "generic.toolguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "generic-toolguide",
+                    "tool": "git",
+                    "title": "Generic Toolguide",
+                    "guide_path": "src/doctrine/toolguides/shipped/generic.md",
+                    "summary": "Generic checks",
+                },
+                handle,
+            )
+
+        repo = ToolguideRepository(shipped_dir=shipped, active_languages=["typescript"])
+        toolguide_ids = {toolguide.id for toolguide in repo.list_all()}
+
+        assert "generic-toolguide" in toolguide_ids
+        assert "python-toolguide" not in toolguide_ids

--- a/tests/doctrine/toolguides/test_repository.py
+++ b/tests/doctrine/toolguides/test_repository.py
@@ -149,3 +149,64 @@ class TestToolguideRepository:
 
         assert "generic-toolguide" in toolguide_ids
         assert "python-toolguide" not in toolguide_ids
+
+    def test_skips_project_toolguides_when_language_scope_does_not_match(
+        self, tmp_path: Path
+    ) -> None:
+        shipped = tmp_path / "shipped"
+        shipped.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+
+        with (shipped / "merge-test.toolguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "merge-test",
+                    "tool": "bash",
+                    "title": "Base Title",
+                    "guide_path": "src/doctrine/toolguides/shipped/base.md",
+                    "summary": "Base summary",
+                },
+                handle,
+            )
+        with (project / "merge-test.toolguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "merge-test",
+                    "tool": "pytest",
+                    "title": "Python Override",
+                    "guide_path": "src/doctrine/toolguides/shipped/python.md",
+                    "summary": "Python summary",
+                    "applies_to_languages": ["python"],
+                },
+                handle,
+            )
+        with (project / "python-only.toolguide.yaml").open("w", encoding="utf-8") as handle:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "python-only",
+                    "tool": "pytest",
+                    "title": "Python Only",
+                    "guide_path": "src/doctrine/toolguides/shipped/python.md",
+                    "summary": "Python summary",
+                    "applies_to_languages": ["python"],
+                },
+                handle,
+            )
+
+        repo = ToolguideRepository(
+            shipped_dir=shipped,
+            project_dir=project,
+            active_languages=["typescript"],
+        )
+
+        merge_test = repo.get("merge-test")
+        assert merge_test is not None
+        assert merge_test.tool == "bash"
+        assert repo.get("python-only") is None

--- a/tests/next/test_prompt_builder_unit.py
+++ b/tests/next/test_prompt_builder_unit.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from charter.compiler import compile_charter, write_compiled_charter
+from charter.interview import apply_answer_overrides, default_interview
 from tests.lane_test_utils import write_single_lane_manifest
 from specify_cli.next.prompt_builder import (
     _mission_context_header,
@@ -327,6 +330,50 @@ class TestBuildPromptWP:
         assert "--to approved" in text
         assert "REJECT" in text
         assert path.exists()
+        path.unlink()
+
+    def test_implement_prompt_for_non_python_charter_contains_no_python_default_bias(
+        self, feature_with_wp: Path
+    ) -> None:
+        repo_root = feature_with_wp.parent.parent
+        charter_dir = repo_root / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True, exist_ok=True)
+
+        interview = default_interview(mission="software-dev", profile="minimal")
+        interview = apply_answer_overrides(
+            interview,
+            answers={
+                "project_intent": "Build a TypeScript service.",
+                "languages_frameworks": "TypeScript 5, Node.js, and repo-local tooling.",
+                "testing_requirements": "Vitest for unit and integration checks.",
+                "quality_gates": "Project tests pass and project lint/type-check commands pass.",
+            },
+            selected_paradigms=[],
+            selected_directives=[],
+            available_tools=["git", "pnpm"],
+        )
+        compiled = compile_charter(mission="software-dev", interview=interview)
+        write_compiled_charter(charter_dir, compiled, force=True)
+
+        text, path = build_prompt(
+            action="implement",
+            feature_dir=feature_with_wp,
+            mission_slug="042-test-feature",
+            wp_id="WP01",
+            agent="claude",
+            repo_root=repo_root,
+            mission_type="software-dev",
+        )
+        sanitized = text.lower().replace(str(repo_root).lower(), "")
+        for forbidden in (
+            r"\bpytest\b",
+            r"\bjunit\b",
+            r"\bmypy\b",
+            r"\bruff\b",
+            r"\bcargo\b",
+            r"\bjest\b",
+        ):
+            assert re.search(forbidden, sanitized) is None
         path.unlink()
 
 

--- a/tests/review/test_baseline.py
+++ b/tests/review/test_baseline.py
@@ -589,6 +589,24 @@ class TestCoverageEdgeCases:
         assert result is not None
         assert result.failed == -1
 
+    def test_capture_baseline_skips_unsupported_output_format(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        feature_dir = repo / "kitty-specs" / "066-test"
+        (feature_dir / "tasks" / "WP04-test").mkdir(parents=True)
+
+        with patch("specify_cli.review.baseline._get_test_command", return_value=("pytest-json", "json")):
+            result = capture_baseline(
+                worktree_path=repo,
+                base_branch="main",
+                wp_id="WP04",
+                mission_slug="066-test",
+                feature_dir=feature_dir,
+                wp_slug="WP04-test",
+            )
+
+        assert result is None
+
     def test_capture_baseline_junit_xml_missing(self, tmp_path: Path) -> None:
         """Sentinel when JUnit XML is not produced (test runner didn't write it)."""
         repo = tmp_path / "repo"

--- a/tests/review/test_baseline.py
+++ b/tests/review/test_baseline.py
@@ -151,7 +151,7 @@ class TestCaptureBaseline:
             result.stdout = "abc1234def5\n"
             result.stderr = ""
             # Detect JUnit XML write
-            if isinstance(cmd, str) and "pytest" in cmd:
+            if isinstance(cmd, str) and "--junitxml=" in cmd:
                 # Extract output file path from the command string
                 import re
                 m = re.search(r"--junitxml=(\S+)", cmd)
@@ -167,6 +167,7 @@ class TestCaptureBaseline:
                 mission_slug="066-test",
                 feature_dir=feature_dir,
                 wp_slug="WP04-test",
+                test_command="custom-runner --junitxml={output_file}",
             )
 
         artifact = wp_task_dir / "baseline-tests.json"
@@ -203,6 +204,7 @@ class TestCaptureBaseline:
                 mission_slug="066-test",
                 feature_dir=feature_dir,
                 wp_slug="WP04-test",
+                test_command="custom-runner --junitxml={output_file}",
             )
 
         assert call_count == 0, "No subprocess calls expected when cache exists"
@@ -232,6 +234,7 @@ class TestCaptureBaseline:
                 mission_slug="066-test",
                 feature_dir=feature_dir,
                 wp_slug="WP04-test",
+                test_command="custom-runner --junitxml={output_file}",
             )
 
         assert result is not None
@@ -434,11 +437,10 @@ class TestConfigCustomTestCommand:
     """test_config_custom_test_command — config overrides default pytest command."""
 
     def test_default_command(self, tmp_path: Path) -> None:
-        """Without config, default pytest command is returned."""
+        """Without config, baseline capture remains disabled."""
         cmd, fmt = _get_test_command(tmp_path)
-        assert "pytest" in cmd
-        assert "{output_file}" in cmd
-        assert fmt == "junit_xml"
+        assert cmd is None
+        assert fmt is None
 
     def test_custom_command_from_config(self, tmp_path: Path) -> None:
         """Config review.test_command overrides the default."""
@@ -467,18 +469,19 @@ class TestConfigCustomTestCommand:
         assert fmt == "junit_xml"
 
     def test_missing_config_file(self, tmp_path: Path) -> None:
-        """Missing .kittify/config.yaml falls back to defaults."""
+        """Missing .kittify/config.yaml leaves baseline capture disabled."""
         cmd, fmt = _get_test_command(tmp_path)
-        assert "pytest" in cmd
-        assert fmt == "junit_xml"
+        assert cmd is None
+        assert fmt is None
 
     def test_config_without_review_section(self, tmp_path: Path) -> None:
-        """Config without 'review' key falls back to defaults."""
+        """Config without 'review' key leaves baseline capture disabled."""
         kittify = tmp_path / ".kittify"
         kittify.mkdir()
         (kittify / "config.yaml").write_text("agents:\n  available:\n    - claude\n", encoding="utf-8")
         cmd, fmt = _get_test_command(tmp_path)
-        assert "pytest" in cmd
+        assert cmd is None
+        assert fmt is None
 
 
 # ---------------------------------------------------------------------------
@@ -538,6 +541,26 @@ class TestCoverageEdgeCases:
         assert result is not None
         assert result.failed == -1
 
+    def test_capture_baseline_skips_when_no_test_command_configured(self, tmp_path: Path) -> None:
+        """No review.test_command means no subprocess work and no sentinel noise."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        feature_dir = repo / "kitty-specs" / "066-test"
+        (feature_dir / "tasks" / "WP04-test").mkdir(parents=True)
+
+        with patch("subprocess.run") as run_mock:
+            result = capture_baseline(
+                worktree_path=repo,
+                base_branch="main",
+                wp_id="WP04",
+                mission_slug="066-test",
+                feature_dir=feature_dir,
+                wp_slug="WP04-test",
+            )
+
+        assert result is None
+        run_mock.assert_not_called()
+
     def test_capture_baseline_git_rev_parse_fails(self, tmp_path: Path) -> None:
         """Sentinel returned when git rev-parse fails with non-zero exit."""
         repo = tmp_path / "repo"
@@ -560,6 +583,7 @@ class TestCoverageEdgeCases:
                 mission_slug="066-test",
                 feature_dir=feature_dir,
                 wp_slug="WP04-test",
+                test_command="custom-runner --junitxml={output_file}",
             )
 
         assert result is not None
@@ -588,6 +612,7 @@ class TestCoverageEdgeCases:
                 mission_slug="066-test",
                 feature_dir=feature_dir,
                 wp_slug="WP04-test",
+                test_command="custom-runner --junitxml={output_file}",
             )
 
         assert result is not None

--- a/tests/specify_cli/charter/test_defaults_unit.py
+++ b/tests/specify_cli/charter/test_defaults_unit.py
@@ -1,0 +1,147 @@
+"""Unit tests for specify_cli charter defaults and markdown fallbacks."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from specify_cli.charter.compiler import CharterReference, _render_charter_markdown
+from specify_cli.charter.interview import (
+    CharterInterview,
+    _load_packaged_defaults,
+    default_interview,
+)
+from specify_cli.charter.resolver import DEFAULT_TOOL_REGISTRY
+
+pytestmark = pytest.mark.fast
+
+
+class _StubResource:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def joinpath(self, name: str) -> "_StubResource":
+        assert name == "defaults.yaml"
+        return self
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        assert encoding == "utf-8"
+        return self._content
+
+
+def test_load_packaged_defaults_returns_empty_when_resource_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "specify_cli.charter.interview.importlib.resources.files",
+        lambda package: (_ for _ in ()).throw(FileNotFoundError("missing defaults")),
+    )
+
+    defaults = _load_packaged_defaults()
+
+    assert defaults == {
+        "answers": {},
+        "selected_paradigms": [],
+        "selected_directives": [],
+        "available_tools": [],
+    }
+
+
+def test_load_packaged_defaults_returns_empty_on_invalid_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "specify_cli.charter.interview.importlib.resources.files",
+        lambda package: _StubResource("answers: ["),
+    )
+
+    defaults = _load_packaged_defaults()
+
+    assert defaults["answers"] == {}
+    assert defaults["available_tools"] == []
+
+
+def test_load_packaged_defaults_returns_empty_when_yaml_is_not_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "specify_cli.charter.interview.importlib.resources.files",
+        lambda package: _StubResource("- not-a-mapping\n"),
+    )
+
+    defaults = _load_packaged_defaults()
+
+    assert defaults["answers"] == {}
+    assert defaults["selected_paradigms"] == []
+    assert defaults["selected_directives"] == []
+
+
+def test_default_interview_loads_packaged_defaults_and_falls_back_to_tool_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "specify_cli.charter.interview.load_doctrine_catalog",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "specify_cli.charter.interview._load_packaged_defaults",
+        lambda: {
+            "answers": {
+                "project_intent": "Keep upgrades deterministic.",
+                "languages_frameworks": "Python and pytest.",
+                "testing_requirements": "Run focused tests.",
+                "quality_gates": "CI green.",
+                "review_policy": "One reviewer.",
+                "performance_targets": "N/A",
+                "deployment_constraints": "Local only",
+            },
+            "selected_paradigms": [],
+            "selected_directives": [],
+        },
+    )
+
+    interview = default_interview(mission="software-dev", profile="minimal")
+
+    assert interview.answers["project_intent"] == "Keep upgrades deterministic."
+    assert interview.selected_paradigms == []
+    assert interview.selected_directives == []
+    assert interview.available_tools == sorted(DEFAULT_TOOL_REGISTRY)
+
+
+def test_render_charter_markdown_uses_testing_fallback_when_missing() -> None:
+    markdown = _render_charter_markdown(
+        mission="software-dev",
+        template_set="software-dev-default",
+        interview=CharterInterview(
+            mission="software-dev",
+            profile="minimal",
+            answers={
+                "project_intent": "Make the CLI reliable.",
+                "languages_frameworks": "Python",
+                "quality_gates": "CI green.",
+                "review_policy": "One reviewer.",
+                "performance_targets": "N/A",
+                "deployment_constraints": "None.",
+            },
+            selected_paradigms=[],
+            selected_directives=[],
+            available_tools=["git"],
+        ),
+        selected_paradigms=[],
+        selected_directives=[],
+        available_tools=["git"],
+        references=[
+            CharterReference(
+                id="USER:PROJECT_PROFILE",
+                kind="user_profile",
+                title="User Project Profile",
+                summary="Captured answers.",
+                source_path=".kittify/charter/interview/answers.yaml",
+                local_path="library/user-project-profile.md",
+                content="profile",
+            )
+        ],
+    )
+
+    assert "Use the project's declared testing approach" in markdown


### PR DESCRIPTION
## Summary
- make baseline test capture opt-in so unconfigured projects no longer run `pytest --junitxml` by default
- neutralize shipped charter defaults and wire `src/charter/defaults.yaml` into both charter interview stacks
- add language scoping for doctrine artifacts and tag Python-only shipped profiles/toolguides/styleguides so they stay out of non-Python projects
- remove remaining generic `pytest`/`junit`/`mypy`/`ruff` examples from shipped doctrine/templates and add a denylist regression test plus a prompt-level non-Python regression

## Testing
- `pytest tests/doctrine/test_profile_repository.py tests/doctrine/styleguides/test_repository.py tests/doctrine/toolguides/test_repository.py tests/doctrine/tactics/test_repository.py tests/doctrine/test_service.py tests/charter/test_catalog.py tests/next/test_prompt_builder_unit.py tests/doctrine/test_generic_artifact_language_bias.py tests/charter/test_interview.py tests/charter/test_compiler.py tests/charter/test_resolver.py tests/review/test_baseline.py tests/merge/test_profile_charter_e2e.py tests/cross_cutting/misc/test_plan_validation.py -q`
