### PR TITLE
Release 3.1.5

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 4.1.5
+  version: 3.1.5
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-09T16:23:40.925198'
 environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.5] - 2026-04-15
+## [3.1.5] - 2026-04-16
 
 ### Changed
 
-- Promote `main` to the stable `4.x` release line. Release docs, install guidance,
-  and README messaging now point new users at `4.1.x` on GitHub Releases and PyPI,
+- Keep `main` on the stable `3.x` release line. Release docs, install guidance,
+  and README messaging now point new users at `3.1.x` on GitHub Releases and PyPI,
   while keeping `1.x-maintenance` explicitly maintenance-only.
 
 ### Fixed
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- Align README and user-facing release docs around swim-lane terminology and the new
-  `4.1.x` stable release line.
+- Align README and user-facing release docs around swim-lane terminology and the
+  `3.1.x` stable release line.
 
 ## [3.1.4] - 2026-04-15
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 ---
 
-## 🚀 What You Get in 4.1.x
+## 🚀 What You Get in 3.1.x
 
 | Capability | What Spec Kitty provides |
 |------------|--------------------------|
@@ -101,9 +101,9 @@ graph LR
 
 </div>
 
-**Current stable release line:** `v4.1.x` (current release: `4.1.5` on `main`, GitHub Releases, and PyPI)
+**Current stable release line:** `v3.1.x` (current release: `3.1.5` on `main`, GitHub Releases, and PyPI)
 
-**4.1.x highlights:**
+**3.1.x highlights:**
 - **Runtime loop is the primary workflow** — `spec-kitty next` drives implementation and review, and omitting `--result` is a safe query-only mode
 - **Review and merge resilience** — focused fix prompts, persisted `review-cycle-N.md` artifacts, `merge --resume`, `implement --recover`, and stronger recovery diagnostics in `doctor`
 - **Hosted auth and sync are first-class** — browser-based `spec-kitty auth login`, explicit SaaS rollout gating, and clearer tracker/discovery readiness checks
@@ -125,17 +125,17 @@ graph LR
 
 ## 📌 Release Track
 
-Spec Kitty now uses `main` as the stable `4.x` release line.
+Spec Kitty now uses `main` as the stable `3.x` release line.
 The former `1.x` line is deprecated and moves to `1.x-maintenance` for maintenance-only fixes.
 
 | Branch | Version | Status | Install |
 |--------|---------|--------|---------|
-| **main** | **4.1.x** | Current stable line | `pip install spec-kitty-cli` |
+| **main** | **3.1.x** | Current stable line | `pip install spec-kitty-cli` |
 | **1.x-maintenance** | **1.x** | Deprecated, maintenance-only | Install from a pinned maintenance tag or source checkout |
 
 **For users:** install the stable line from PyPI with `pip install spec-kitty-cli`.
-**For existing 3.x users:** upgrade to `4.1.x` and run `spec-kitty upgrade` in each project — the charter rename, mission identity, and prompt-neutrality migrations remain automatic.
-**For existing 1.x or 2.x users:** migrate to `4.1.x`; `1.x-maintenance` is maintenance-only and will no longer publish new PyPI releases.
+**For existing 3.0.x users:** upgrade to `3.1.x` and run `spec-kitty upgrade` in each project — the charter rename, mission identity, and prompt-neutrality migrations remain automatic.
+**For existing 1.x or 2.x users:** migrate to `3.1.x`; `1.x-maintenance` is maintenance-only and will no longer publish new PyPI releases.
 
 ---
 
@@ -147,7 +147,7 @@ Terminology note:
 - `Mission Type` = reusable blueprint
 - `Mission` = concrete tracked item
 - `Mission Run` = runtime/session instance
-- `--mission` is the canonical flag in 4.1.x; `--feature` is retained only as a hidden deprecated alias
+- `--mission` is the canonical flag in 3.1.x; `--feature` is retained only as a hidden deprecated alias
 
 ```bash
 # Verify host contract
@@ -1181,7 +1181,7 @@ If you encounter issues with an agent, please open an issue so we can refine the
 <details>
 <summary><h2>🚀 Releasing Stable Versions on GitHub and PyPI (Maintainers)</h2></summary>
 
-The stable `4.x` line now lives on `main` and publishes from semantic tags in the form `vX.Y.Z`.
+The stable `3.x` line now lives on `main` and publishes from semantic tags in the form `vX.Y.Z`.
 Prerelease testing builds can also publish from `main` using tags such as `vX.Y.ZaN`.
 The release workflow publishes both GitHub release artifacts and the PyPI package.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -4,7 +4,7 @@ Use this checklist for releases from `main`.
 
 > `main` is the primary release line and publishes both GitHub releases and PyPI packages.
 > `1.x-maintenance` is deprecated overall, reserved for critical maintenance only, and should not receive new PyPI releases.
-> Historical 2.x release notes remain in Git tags and changelog history; new stable and prerelease 4.x releases ship from `main`.
+> Historical 2.x release notes remain in Git tags and changelog history; new stable and prerelease 3.x releases ship from `main`.
 
 ## Pre-Release Preparation
 
@@ -58,7 +58,7 @@ Use this checklist for releases from `main`.
 - [ ] Add a populated `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`.
 - [ ] For prereleases, use the exact prerelease heading (`## [X.Y.ZaN] - YYYY-MM-DD`, etc.).
 - [ ] Review `README.md` release-track messaging:
-  - `main` should be described as the stable `4.x` line.
+  - `main` should be described as the stable `3.x` line.
   - `1.x-maintenance` should be described as deprecated maintenance-only.
 - [ ] Review installation docs if distribution channels changed.
 - [ ] If new ADRs were added, verify they are filed under the correct versioned architecture path.
@@ -177,7 +177,7 @@ git push origin vX.Y.ZaN
 
 - [ ] If this is a minor or major release, publish release notes and migration guidance.
 - [ ] If release-track policy changed, call it out explicitly:
-  - `main` is the stable `4.x` line
+  - `main` is the stable `3.x` line
   - `1.x-maintenance` is deprecated maintenance-only
   - no new `1.x` PyPI releases are planned
 

--- a/docs/how-to/use-dashboard.md
+++ b/docs/how-to/use-dashboard.md
@@ -59,7 +59,7 @@ This stops the background process and clears the `.kittify/.dashboard` metadata.
 
 ## Dashboard Auto-Start
 
-`spec-kitty init` does not auto-start the dashboard in the current `4.1.x` flow. If dashboard metadata is missing or stale, run `spec-kitty dashboard` again to recreate it.
+`spec-kitty init` does not auto-start the dashboard in the current `3.1.x` flow. If dashboard metadata is missing or stale, run `spec-kitty dashboard` again to recreate it.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,9 @@ Spec-kitty is a spec-driven development tool that coordinates AI agents through 
 | **Reference** | Precise descriptions of CLI commands, configuration, and APIs. | [CLI Commands](reference/cli-commands.md) |
 | **Explanation** | Background concepts, architecture, and design decisions. | [Spec-Driven Development](explanation/spec-driven-development.md) |
 
-## Latest Release: 4.1.5
+## Latest Release: 3.1.5
 
-Spec Kitty 4.1.5 (released 2026-04-15) starts the `4.1.x` stable line with upgrade hardening, neutral charter defaults, and release-surface cleanup:
+Spec Kitty 3.1.5 (released 2026-04-16) continues the `3.1.x` stable line with upgrade hardening, neutral charter defaults, and release-surface cleanup:
 
 - **Runtime loop is now the primary mental model** — `spec-kitty next` remains the canonical driver, and query mode is safe and read-only
 - **Hosted auth and SaaS sync are first-class** — browser-based `spec-kitty auth login`, explicit hosted rollout gating, and clearer tracker readiness checks
@@ -31,7 +31,7 @@ See the full [CHANGELOG](../CHANGELOG.md) for complete release notes.
 
 | Track | Use when | Entry point |
 |---|---|---|
-| `4.x` (current) | New projects and all projects on `main` or PyPI. | This documentation |
+| `3.x` (current) | New projects and all projects on `main` or PyPI. | This documentation |
 | `1.x` | Maintaining a deprecated legacy workflow (maintenance-only). | [Open 1.x docs](1x/index.md) |
 
 ## Verification Notes

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables Reference
 
-This page lists the user-facing environment variables that are active in the current `4.1.x` CLI surface.
+This page lists the user-facing environment variables that are active in the current `3.1.x` CLI surface.
 
 ---
 

--- a/docs/tutorials/claude-code-integration.md
+++ b/docs/tutorials/claude-code-integration.md
@@ -316,7 +316,7 @@ and WebSocket for live reload. Dark mode toggle.
 
 ### Starting the Dashboard
 
-`spec-kitty init` no longer auto-starts the dashboard in the current `4.1.x` flow. Start it when you want it:
+`spec-kitty init` no longer auto-starts the dashboard in the current `3.1.x` flow. Start it when you want it:
 
 ```bash
 spec-kitty dashboard --open

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -28,7 +28,7 @@ spec-kitty --version
 Expected output (abridged):
 
 ```
-spec-kitty-cli version 4.1.5
+spec-kitty-cli version 3.1.5
 ```
 
 ## Step 2: Initialize a Project

--- a/docs/tutorials/your-first-feature.md
+++ b/docs/tutorials/your-first-feature.md
@@ -135,7 +135,7 @@ You should see the feature merged into `main` and the worktrees cleaned up.
 
 ## Troubleshooting
 
-- **"Planning created a worktree"**: Planning stays in the main checkout in `4.1.x`. If you see an unexpected planning worktree, upgrade with `spec-kitty upgrade`.
+- **"Planning created a worktree"**: Planning stays in the main checkout in `3.1.x`. If you see an unexpected planning worktree, upgrade with `spec-kitty upgrade`.
 - **"WP has dependencies"**: Keep following the `spec-kitty next` decisions; the runtime will only issue implementation work when its dependencies are satisfied.
 - **Review fails validation**: Run `spec-kitty validate-tasks --fix` and re-run `/spec-kitty.review`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "4.1.5"
+version = "3.1.5"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Correct the mistaken 4.1.5 release to 3.1.5.\n\nChanges:\n- set package and metadata version to 3.1.5\n- rename the changelog entry to 3.1.5 with the corrected release date\n- revert release docs and README messaging from 4.x/4.1.x to 3.x/3.1.x\n- keep the release validation and package surface aligned with the corrected version\n\nFollow-up outside this PR:\n- 4.1.5 GitHub release/tag already removed\n- 4.1.5 PyPI release still needs to be yanked once authenticated