### PR TITLE
fix: reduce SonarCloud charter maintainability findings

### DIFF
--- a/src/charter/compiler.py
+++ b/src/charter/compiler.py
@@ -212,7 +212,7 @@ def _resolve_template_set(
         return mission_default
 
     if catalog.template_sets:
-        return sorted(catalog.template_sets)[0]
+        return min(catalog.template_sets)
 
     return mission_default
 

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -17,6 +17,14 @@ from kernel.atomic import atomic_write
 
 
 BOOTSTRAP_ACTIONS: frozenset[str] = frozenset({"specify", "plan", "implement", "review"})
+BOOTSTRAP_HEADER = "Charter Context (Bootstrap):"
+FIRST_LOAD_GUIDANCE = (
+    "  - This is the first load for this action. Use the summary and follow references as needed."
+)
+POLICY_SUMMARY_HEADER = "Policy Summary:"
+NO_POLICY_SUMMARY_MESSAGE = "  - No explicit policy summary section found in charter.md."
+REFERENCE_DOCS_HEADER = "Reference Docs:"
+NONE_LABEL = "(none)"
 
 
 @dataclass(frozen=True)
@@ -194,18 +202,18 @@ def _render_action_scoped(
     content, and renders a structured context block.
     """
     lines: list[str] = [
-        "Charter Context (Bootstrap):",
+        BOOTSTRAP_HEADER,
         f"  - Source: {charter_path}",
-        "  - This is the first load for this action. Use the summary and follow references as needed.",
+        FIRST_LOAD_GUIDANCE,
         "",
-        "Policy Summary:",
+        POLICY_SUMMARY_HEADER,
     ]
 
     if summary:
         for item in summary[:8]:
             lines.append(f"  - {item}")
     else:
-        lines.append("  - No explicit policy summary section found in charter.md.")
+        lines.append(NO_POLICY_SUMMARY_MESSAGE)
 
     lines.append("")
 
@@ -214,7 +222,7 @@ def _render_action_scoped(
     lines.append("")
 
     # --- Reference Docs section ---
-    lines.append("Reference Docs:")
+    lines.append(REFERENCE_DOCS_HEADER)
 
     filtered_references = _filter_references_for_action(references, action)
 
@@ -261,21 +269,21 @@ def _filter_references_for_action(references: list[dict[str, str]], action: str)
 
 def _render_bootstrap(charter_path: Path, summary: list[str], references: list[dict[str, str]]) -> str:
     lines: list[str] = [
-        "Charter Context (Bootstrap):",
+        BOOTSTRAP_HEADER,
         f"  - Source: {charter_path}",
-        "  - This is the first load for this action. Use the summary and follow references as needed.",
+        FIRST_LOAD_GUIDANCE,
         "",
-        "Policy Summary:",
+        POLICY_SUMMARY_HEADER,
     ]
 
     if summary:
         for item in summary[:8]:
             lines.append(f"  - {item}")
     else:
-        lines.append("  - No explicit policy summary section found in charter.md.")
+        lines.append(NO_POLICY_SUMMARY_MESSAGE)
 
     lines.append("")
-    lines.append("Reference Docs:")
+    lines.append(REFERENCE_DOCS_HEADER)
     if references:
         for reference in references[:10]:
             ref_id = reference.get("id", "unknown")
@@ -296,9 +304,9 @@ def _render_compact_governance(repo_root: Path) -> str:
     except Exception as exc:
         return f"Governance: unavailable ({exc})"
 
-    paradigms = ", ".join(resolution.paradigms) if resolution.paradigms else "(none)"
-    directives = ", ".join(resolution.directives) if resolution.directives else "(none)"
-    tools = ", ".join(resolution.tools) if resolution.tools else "(none)"
+    paradigms = ", ".join(resolution.paradigms) if resolution.paradigms else NONE_LABEL
+    directives = ", ".join(resolution.directives) if resolution.directives else NONE_LABEL
+    tools = ", ".join(resolution.tools) if resolution.tools else NONE_LABEL
 
     lines = [
         "Governance:",
@@ -571,18 +579,18 @@ def build_charter_context(
     summary = _extract_policy_summary(charter_content)
 
     lines: list[str] = [
-        "Charter Context (Bootstrap):",
+        BOOTSTRAP_HEADER,
         f"  - Source: {charter_path}",
-        "  - This is the first load for this action. Use the summary and follow references as needed.",
+        FIRST_LOAD_GUIDANCE,
         "",
-        "Policy Summary:",
+        POLICY_SUMMARY_HEADER,
     ]
 
     if summary:
         for item in summary[:8]:
             lines.append(f"  - {item}")
     else:
-        lines.append("  - No explicit policy summary section found in charter.md.")
+        lines.append(NO_POLICY_SUMMARY_MESSAGE)
 
     lines.append("")
 
@@ -648,7 +656,7 @@ def build_charter_context(
     lines.append("")
 
     # Reference Docs section
-    lines.append("Reference Docs:")
+    lines.append(REFERENCE_DOCS_HEADER)
     references = _load_references(references_path)
     filtered_references = _filter_references_for_action(references, normalized)
     if filtered_references:

--- a/tests/charter/test_compiler.py
+++ b/tests/charter/test_compiler.py
@@ -1,12 +1,12 @@
-"""Scope: mock-boundary tests for charter compiler bundle generation — no real git."""
+"""Scope: mock-boundary tests for charter compiler bundle generation -- no real git."""
 
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from charter.catalog import load_doctrine_catalog
-from charter.compiler import compile_charter, write_compiled_charter
+from charter.catalog import DoctrineCatalog, load_doctrine_catalog
+from charter.compiler import _resolve_template_set, compile_charter, write_compiled_charter
 from charter.interview import (
     CharterInterview,
     LocalSupportDeclaration,
@@ -35,6 +35,28 @@ def test_compile_charter_contains_governance_activation_block() -> None:
     assert "## Governance Activation" in compiled.markdown
     assert "selected_directives" in compiled.markdown
     assert "available_tools: [git, spec-kitty]" in compiled.markdown
+
+
+def test_resolve_template_set_uses_smallest_available_fallback() -> None:
+    catalog = DoctrineCatalog(
+        template_sets={"zeta-default", "alpha-default"},
+        paradigms=[],
+        directives=[],
+        tactics=[],
+        styleguides=[],
+        toolguides=[],
+        procedures=[],
+        agent_profiles=[],
+    )
+
+    assert (
+        _resolve_template_set(
+            mission="software-dev",
+            requested_template_set=None,
+            catalog=catalog,
+        )
+        == "alpha-default"
+    )
 
 
 def test_compile_charter_preserves_explicit_empty_selections() -> None:

--- a/tests/charter/test_context.py
+++ b/tests/charter/test_context.py
@@ -10,7 +10,13 @@ from unittest.mock import patch
 
 import pytest
 
-from charter.context import CharterContextResult, _build_doctrine_service, build_charter_context
+from charter.context import (
+    CharterContextResult,
+    _build_doctrine_service,
+    _render_action_scoped,
+    _render_bootstrap,
+    build_charter_context,
+)
 
 pytestmark = pytest.mark.fast
 
@@ -91,6 +97,22 @@ def _setup_fixture_repo(tmp_path: Path) -> None:
     (charter_dir / "references.yaml").write_text(_REFERENCES_YAML, encoding="utf-8")
 
 
+def _write_graph_fixture(tmp_path: Path) -> None:
+    from io import StringIO
+
+    from doctrine.drg.models import DRGGraph
+    from ruamel.yaml import YAML
+
+    yaml = YAML(typ="safe")
+    graph_data = yaml.load(StringIO(_MINIMAL_GRAPH_YAML))
+    mock_graph = DRGGraph.model_validate(graph_data)
+
+    def patched_load_graph(path: Path) -> DRGGraph:
+        return mock_graph
+
+    return patched_load_graph
+
+
 # ---------------------------------------------------------------------------
 # T021: build_charter_context functional tests
 # ---------------------------------------------------------------------------
@@ -157,17 +179,7 @@ class TestBuildContextV2:
         # First load with depth=None (state decides: first_load -> depth 2)
         _setup_fixture_repo(tmp_path)
 
-        from io import StringIO
-
-        from doctrine.drg.models import DRGGraph
-        from ruamel.yaml import YAML
-
-        yaml = YAML(typ="safe")
-        graph_data = yaml.load(StringIO(_MINIMAL_GRAPH_YAML))
-        mock_graph = DRGGraph.model_validate(graph_data)
-
-        def patched_load_graph(path: Path) -> DRGGraph:
-            return mock_graph
+        patched_load_graph = _write_graph_fixture(tmp_path)
 
         with (
             patch("doctrine.drg.loader.load_graph", side_effect=patched_load_graph),
@@ -278,11 +290,55 @@ class TestBuildContextV2:
         result = self._call(tmp_path)
         assert result.references_count >= 0
 
+    def test_build_context_uses_fallback_summary_when_policy_section_missing(
+        self, tmp_path: Path
+    ) -> None:
+        _setup_fixture_repo(tmp_path)
+        charter_path = tmp_path / ".kittify" / "charter" / "charter.md"
+        charter_path.write_text("# Project Charter\n", encoding="utf-8")
+
+        patched_load_graph = _write_graph_fixture(tmp_path)
+
+        with (
+            patch("doctrine.drg.loader.load_graph", side_effect=patched_load_graph),
+            patch("charter.catalog.resolve_doctrine_root", return_value=tmp_path),
+            patch("doctrine.drg.validator.assert_valid"),
+        ):
+            result = build_charter_context(tmp_path, action="implement", depth=2)
+
+        assert "No explicit policy summary section found in charter.md." in result.text
+
     def test_depth_field_matches_input(self, tmp_path: Path) -> None:
         """The depth field in the result matches the input depth."""
         for d in [1, 2, 3]:
             result = self._call(tmp_path, depth=d)
             assert result.depth == d
+
+
+def test_render_bootstrap_uses_fallback_labels_without_summary_or_references() -> None:
+    text = _render_bootstrap(Path("/tmp/charter.md"), [], [])
+
+    assert "Policy Summary:" in text
+    assert "No explicit policy summary section found in charter.md." in text
+    assert "Reference Docs:" in text
+    assert "No references manifest found." in text
+
+
+def test_render_action_scoped_uses_fallback_labels_without_summary_or_references(tmp_path: Path) -> None:
+    with patch("charter.context._append_action_doctrine_lines") as append_action_doctrine_lines:
+        append_action_doctrine_lines.return_value = None
+        text = _render_action_scoped(
+            tmp_path,
+            "implement",
+            tmp_path / "charter.md",
+            [],
+            [],
+        )
+
+    assert "Policy Summary:" in text
+    assert "No explicit policy summary section found in charter.md." in text
+    assert "Reference Docs:" in text
+    assert "No references manifest found." in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- factor repeated charter bootstrap strings in `src/charter/context.py` into shared constants
- replace the fallback `sorted(...)[0]` template-set pick with `min(...)` in `src/charter/compiler.py`
- add a regression test for the template-set fallback ordering

## Validation
- `python3 -m pytest tests/charter/test_context.py tests/charter/test_compiler.py -q`
- `python3 -m pytest tests/charter -q`

## Notes
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- No suppressions added; this is code cleanup only.