### PR TITLE
fix: address actionable sonar findings

### DIFF
--- a/src/specify_cli/charter/interview.py
+++ b/src/specify_cli/charter/interview.py
@@ -100,7 +100,8 @@ def default_interview(
     doctrine_catalog: DoctrineCatalog | None = None,
 ) -> CharterInterview:
     """Return deterministic default interview answers."""
-    catalog = doctrine_catalog or load_doctrine_catalog()
+    if doctrine_catalog is None:
+        load_doctrine_catalog()
     defaults = _load_packaged_defaults()
     answers: dict[str, str] = dict(defaults.get("answers", {}))
 

--- a/src/specify_cli/cli/commands/agent/status.py
+++ b/src/specify_cli/cli/commands/agent/status.py
@@ -30,6 +30,7 @@ app = typer.Typer(
 )
 
 console = Console()
+PROJECT_ROOT_NOT_FOUND = "Could not locate project root"
 
 
 def _find_mission_slug(
@@ -123,7 +124,7 @@ def _resolve_feature_dir(
     repo_root = locate_project_root(cwd)
 
     if repo_root is None:
-        console.print("[red]Error:[/red] Could not locate project root")
+        console.print(f"[red]Error:[/red] {PROJECT_ROOT_NOT_FOUND}")
         raise typer.Exit(1)
 
     mission_slug = _find_mission_slug(
@@ -171,7 +172,7 @@ def emit(
         cwd = Path.cwd().resolve()
         repo_root = locate_project_root(cwd)
         if repo_root is None:
-            _output_error(json_output, "Could not locate project root")
+            _output_error(json_output, PROJECT_ROOT_NOT_FOUND)
             raise typer.Exit(1)
 
         main_repo_root = get_main_repo_root(repo_root)
@@ -273,7 +274,7 @@ def materialize(
         cwd = Path.cwd().resolve()
         repo_root = locate_project_root(cwd)
         if repo_root is None:
-            _output_error(json_output, "Could not locate project root")
+            _output_error(json_output, PROJECT_ROOT_NOT_FOUND)
             raise typer.Exit(1)
 
         main_repo_root = get_main_repo_root(repo_root)
@@ -447,13 +448,9 @@ def doctor(
         # Project-specific section
         console.print(f"\n[bold]Mission Status: {result.mission_slug}[/bold]")
         if result.is_healthy:
-            console.print(
-                f"  [green]Healthy[/green]"
-            )
+            console.print("  [green]Healthy[/green]")
         else:
-            console.print(
-                f"  [yellow]Issues found[/yellow]"
-            )
+            console.print("  [yellow]Issues found[/yellow]")
             table = Table(title="Doctor Findings")
             table.add_column("Severity", style="bold")
             table.add_column("Category")
@@ -650,9 +647,9 @@ def validate(
     repo_root = locate_project_root(cwd)
     if repo_root is None:
         if json_output:
-            print(json.dumps({"error": "Could not locate project root"}))
+            print(json.dumps({"error": PROJECT_ROOT_NOT_FOUND}))
         else:
-            console.print("[red]Error:[/red] Could not locate project root")
+            console.print(f"[red]Error:[/red] {PROJECT_ROOT_NOT_FOUND}")
         raise typer.Exit(1)
 
     mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, json_output=json_output, repo_root=repo_root)

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -65,6 +65,8 @@ from specify_cli.tasks_support import (
 )
 
 logger = logging.getLogger(__name__)
+TASKS_MD_FILENAME = "tasks.md"
+UTC_SECOND_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def _collect_status_artifacts(feature_dir: Path) -> list[Path]:
@@ -84,7 +86,7 @@ def _collect_status_artifacts(feature_dir: Path) -> list[Path]:
     candidates = [
         feature_dir / "status.events.jsonl",
         feature_dir / "status.json",
-        feature_dir / "tasks.md",
+        feature_dir / TASKS_MD_FILENAME,
     ]
     return [p for p in candidates if p.exists()]
 
@@ -390,7 +392,7 @@ def _persist_review_feedback(
     cycle_n = ReviewCycleArtifact.next_cycle_number(sub_artifact_dir)
 
     body = feedback_source.read_text(encoding="utf-8")
-    reviewed_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    reviewed_at = datetime.now(UTC).strftime(UTC_SECOND_TIMESTAMP_FORMAT)
 
     parsed_affected: list[AffectedFile] = []
     if affected_files:
@@ -439,7 +441,7 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
     # Use planning repo root to resolve kitty-specs/ (main branch is authoritative)
     main_repo_root = get_main_repo_root(repo_root)
     feature_dir = main_repo_root / "kitty-specs" / mission_slug
-    tasks_md = feature_dir / "tasks.md"
+    tasks_md = feature_dir / TASKS_MD_FILENAME
 
     if not tasks_md.exists():
         return []  # No tasks.md, can't check
@@ -1463,7 +1465,7 @@ def move_task(
                 updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
 
             # Build history entry
-            timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            timestamp = datetime.now(UTC).strftime(UTC_SECOND_TIMESTAMP_FORMAT)
             agent_name = agent or extract_scalar(updated_front, "agent") or "unknown"
             shell_pid_val = shell_pid or extract_scalar(updated_front, "shell_pid") or ""
             note_text = note_text or f"Moved to {target_lane}"
@@ -1693,7 +1695,7 @@ def mark_status(
         # Ensure we operate on the target branch for this feature
         main_repo_root, target_branch = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
-        tasks_md = feature_dir / "tasks.md"
+        tasks_md = feature_dir / TASKS_MD_FILENAME
 
         with feature_status_lock(main_repo_root, mission_slug):
             if not tasks_md.exists():
@@ -1943,7 +1945,7 @@ def add_history(
         wp = locate_work_package(repo_root, mission_slug, task_id)
 
         # Build history entry
-        timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = datetime.now(UTC).strftime(UTC_SECOND_TIMESTAMP_FORMAT)
         agent_name = agent or extract_scalar(wp.frontmatter, "agent") or "unknown"
         shell_pid_val = shell_pid or extract_scalar(wp.frontmatter, "shell_pid") or ""
 
@@ -2019,7 +2021,7 @@ def finalize_tasks(
         # Ensure we operate on the target branch for this feature
         main_repo_root, _ = _ensure_target_branch_checked_out(repo_root, mission_slug, json_output)
         feature_dir = main_repo_root / "kitty-specs" / mission_slug
-        tasks_md = feature_dir / "tasks.md"
+        tasks_md = feature_dir / TASKS_MD_FILENAME
         tasks_dir = feature_dir / "tasks"
 
         if not tasks_md.exists():
@@ -2375,7 +2377,7 @@ def map_requirements(
             raise typer.Exit(1)
 
         tasks_md_refs: dict[str, list[str]] = {}
-        tasks_md_file = feature_dir / "tasks.md"
+        tasks_md_file = feature_dir / TASKS_MD_FILENAME
         if tasks_md_file.exists():
             from specify_cli.cli.commands.agent.mission import (
                 _parse_requirement_refs_from_tasks_md,

--- a/src/specify_cli/cli/commands/charter_bundle.py
+++ b/src/specify_cli/cli/commands/charter_bundle.py
@@ -127,7 +127,7 @@ def _is_git_tracked(canonical_root: Path, rel: str) -> bool:
             text=True,
             check=False,
         )
-    except (FileNotFoundError, OSError):
+    except OSError:
         return False
     return result.returncode == 0
 

--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -39,7 +39,7 @@ import re
 # Section splitter
 # ---------------------------------------------------------------------------
 
-_WP_SECTION_HEADER = re.compile(r"(?m)^(?:##|###)\s+(?P<title>[^\n]+)$")
+_WP_SECTION_HEADER = re.compile(r"(?m)^#{2,3}[ \t]+(?P<title>[^\n]+)$")
 _WP_ID_TITLE = re.compile(r"^(?:Work Package\s+)?(?P<wp_id>WP\d{2})(?:\b|:)")
 _WORK_PACKAGE_PREFIX = "Work Package "
 

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -35,6 +35,8 @@ from specify_cli.core.atomic import atomic_write
 
 logger = logging.getLogger(__name__)
 
+_SPEC_KITTY_DIRNAME = ".spec-kitty"
+
 
 def _sync_root() -> Path:
     """Return the sync state directory for the current platform.
@@ -46,7 +48,7 @@ def _sync_root() -> Path:
     if sys.platform == "win32":
         from specify_cli.paths import get_runtime_root  # noqa: PLC0415
         return get_runtime_root().sync_dir
-    return Path.home() / ".spec-kitty" / "sync"
+    return Path.home() / _SPEC_KITTY_DIRNAME / "sync"
 
 
 def _daemon_root() -> Path:
@@ -60,12 +62,12 @@ def _daemon_root() -> Path:
     if sys.platform == "win32":
         from specify_cli.paths import get_runtime_root  # noqa: PLC0415
         return get_runtime_root().daemon_dir
-    return Path.home() / ".spec-kitty"
+    return Path.home() / _SPEC_KITTY_DIRNAME
 
 
 # Module-level path constants derived from platform-aware helpers so that
 # existing code referencing these names continues to work unchanged.
-SPEC_KITTY_DIR = Path.home() / ".spec-kitty"
+SPEC_KITTY_DIR = Path.home() / _SPEC_KITTY_DIRNAME
 DAEMON_STATE_FILE = _daemon_root() / "sync-daemon"
 DAEMON_LOG_FILE = _daemon_root() / "sync-daemon.log"
 DAEMON_LOCK_FILE = _daemon_root() / "sync-daemon.lock"


### PR DESCRIPTION
## Summary
- harden the shared dependency parser heading regex shape to address the actionable Sonar ReDoS hotspot candidate
- remove a redundant charter bundle exception branch and a dead local variable in charter interview defaults
- centralize the `.spec-kitty` directory literal used by the sync daemon helpers

## Validation
- `pytest -q tests/core/test_dependency_parser.py tests/charter/test_interview.py tests/sync/test_daemon.py tests/charter/test_bundle_validate_cli.py`
- `python -m compileall src/specify_cli/core/dependency_parser.py src/specify_cli/charter/interview.py src/specify_cli/sync/daemon.py src/specify_cli/cli/commands/charter_bundle.py`

## Notes
- GitHub code-scanning and Dependabot currently report no open alerts for `Priivacy-ai/spec-kitty`.
- SonarCloud hotspot status changes are not possible from this automation environment without Sonar auth. Public reads work, but `POST /api/hotspots/change_status` returns `401`, so the remaining intentional localhost/daemon hotspots still need review in SonarCloud itself.
