### PR TITLE
fix: preserve venv symlink in pre-commit hook (closes #669)

### DIFF
--- a/src/specify_cli/policy/hook_installer.py
+++ b/src/specify_cli/policy/hook_installer.py
@@ -48,6 +48,13 @@ def install(repo_root: Path) -> HookInstallRecord:
     written atomically (temp-file + ``os.replace``) with mode ``0o700`` and
     LF line endings.
 
+    Symlinks in ``sys.executable`` are intentionally **not** resolved. Pipx,
+    ``venv``, and ``virtualenv`` rely on Python being launched via the venv's
+    ``bin/python`` symlink so site initialization sets ``sys.prefix`` to the
+    venv and adds the venv's ``site-packages`` to ``sys.path``. Resolving the
+    symlink to the underlying interpreter would strip that context and make
+    ``specify_cli`` unimportable from the hook (issue #669).
+
     Args:
         repo_root: Path to the root of the git repository (must contain ``.git``).
 
@@ -55,13 +62,13 @@ def install(repo_root: Path) -> HookInstallRecord:
         A :class:`HookInstallRecord` describing the installed hook.
 
     Raises:
-        RuntimeError: If ``sys.executable`` cannot be resolved to an existing file.
+        RuntimeError: If ``sys.executable`` does not refer to an existing file.
     """
-    interpreter = Path(sys.executable).resolve(strict=False)
+    interpreter = Path(os.path.abspath(sys.executable))
     if not interpreter.is_file():
         raise RuntimeError(
             f"Cannot install pre-commit hook: sys.executable={sys.executable!r} "
-            f"resolves to {interpreter}, which does not exist."
+            f"(absolute: {interpreter}) does not exist."
         )
 
     installed_at = datetime.now(UTC).isoformat(timespec="seconds")

--- a/tests/policy/test_hook_installer_rendering.py
+++ b/tests/policy/test_hook_installer_rendering.py
@@ -37,10 +37,13 @@ def test_hook_rendering_shape(tmp_path: Path) -> None:
     )
     exec_line = exec_lines[0]
 
-    # Interpreter must appear in double quotes (handles paths with spaces)
-    resolved = str(Path(sys.executable).resolve(strict=False))
-    assert f'"{resolved}"' in exec_line, (
-        f'Expected quoted interpreter "{resolved}" in exec line: {exec_line!r}'
+    # Interpreter must appear in double quotes (handles paths with spaces).
+    # Symlinks are intentionally preserved (issue #669) so venv/pipx interpreters
+    # keep their sys.prefix — so we expect the abspath of sys.executable, not its
+    # resolved target.
+    expected = os.path.abspath(sys.executable)
+    assert f'"{expected}"' in exec_line, (
+        f'Expected quoted interpreter "{expected}" in exec line: {exec_line!r}'
     )
     assert "-m specify_cli.policy.commit_guard_hook" in exec_line, (
         f"Expected module invocation in exec line: {exec_line!r}"
@@ -59,6 +62,6 @@ def test_hook_rendering_shape(tmp_path: Path) -> None:
     assert isinstance(record, HookInstallRecord)
     assert record.shebang == "#!/bin/sh"
     assert record.module == "specify_cli.policy.commit_guard_hook"
-    assert record.interpreter == Path(sys.executable).resolve(strict=False)
+    assert record.interpreter == Path(os.path.abspath(sys.executable))
     assert record.mode == HOOK_MODE
     assert record.hook_path == hook

--- a/tests/regressions/test_issue_669_venv_symlink_preservation.py
+++ b/tests/regressions/test_issue_669_venv_symlink_preservation.py
@@ -1,0 +1,62 @@
+"""Regression test for issue #669: hook must preserve venv symlinks in sys.executable.
+
+Pre-fix code called ``Path(sys.executable).resolve(strict=False)``, which follows
+symlinks. On pipx (and any symlinked venv), ``sys.executable`` points at
+``<venv>/bin/python`` — a symlink to the base interpreter. Resolving the symlink
+strips the venv context: the resolved interpreter's ``sys.prefix`` points at the
+base install, so the venv's ``site-packages`` is not on ``sys.path`` and
+``specify_cli`` cannot be imported from the hook.
+
+The fix uses ``os.path.abspath`` instead of ``Path.resolve``, preserving the
+symlink so the hook invokes the venv's python wrapper.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.symlink requires admin/dev mode on Windows; bug is POSIX-surfaced",
+)
+def test_install_preserves_venv_symlink_in_exec_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hook's exec line points at the symlink, not the resolved target (regression #669)."""
+    from specify_cli.policy import hook_installer
+
+    fake_venv_bin = tmp_path / "fake-venv" / "bin"
+    fake_venv_bin.mkdir(parents=True)
+    symlink = fake_venv_bin / "python"
+    symlink.symlink_to(sys.executable)
+
+    assert symlink.is_symlink()
+    assert os.path.realpath(symlink) != str(symlink)
+
+    monkeypatch.setattr(sys, "executable", str(symlink))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+
+    record = hook_installer.install(repo)
+
+    assert record.interpreter == symlink, (
+        f"installer resolved through symlink; expected {symlink}, got {record.interpreter}"
+    )
+
+    hook_body = (repo / ".git" / "hooks" / "pre-commit").read_text()
+    exec_line = next(line for line in hook_body.splitlines() if line.startswith("exec "))
+    assert str(symlink) in exec_line, (
+        f"exec line should quote symlink path, got: {exec_line}"
+    )
+    assert os.path.realpath(symlink) not in exec_line, (
+        "exec line must not quote the resolved target — that breaks venv site.py init. "
+        f"got: {exec_line}"
+    )


### PR DESCRIPTION
## Summary

- Closes #669 — `git commit` fails with `ModuleNotFoundError: No module named 'specify_cli'` on pipx/venv installs.
- Root cause is **not** what the issue suspected (PATH heuristic). The installer already uses `sys.executable`; the bug is that it then calls `Path(sys.executable).resolve(strict=False)`, which follows the pipx venv's `bin/python` symlink to the underlying interpreter. Pipx/venv/virtualenv rely on Python being invoked *via* the symlink so site initialization sets `sys.prefix` to the venv and adds its `site-packages` to `sys.path`; the resolved target has neither.
- Fix: use `os.path.abspath(sys.executable)` instead of `Path.resolve` — preserves symlinks, still pins an absolute path.

## Cross-platform

| Platform / install | Today | After fix |
|---|---|---|
| POSIX pipx / symlinked venv (**the bug**) | resolves through symlink → `specify_cli` missing | symlink preserved → works |
| Windows pipx / venv (default, **copied** launcher) | no-op (resolve on non-symlink) | no-op — unchanged |
| Windows venv with `--symlinks` (dev mode) | same POSIX-style bug | fixed |
| System Python / Homebrew direct | no-op | no-op |

No Windows regression.

## Changes

- `src/specify_cli/policy/hook_installer.py` — swap `.resolve(strict=False)` → `os.path.abspath(...)`; docstring updated to explain why symlinks must not be resolved (references #669).
- `tests/regressions/test_issue_669_venv_symlink_preservation.py` — new regression test; monkeypatches `sys.executable` to a symlink into a fake venv, asserts the hook's `exec` line quotes the symlink, not the resolved target. Skipped on Windows (`os.symlink` requires dev mode).
- `tests/policy/test_hook_installer_rendering.py` — updated assertion to match the new (non-resolving) contract.

## Test plan

- [x] `pytest tests/regressions/test_issue_669_venv_symlink_preservation.py` — new test passes
- [x] `pytest tests/policy/test_hook_installer_rendering.py tests/policy/test_hook_installer_execution.py tests/policy/test_commit_guard.py` — all existing hook tests pass (19 passed)
- [x] `ruff check` — clean
- [ ] Manual pipx smoke test: `spec-kitty init` in fresh repo, `cat .git/hooks/pre-commit` — exec line should quote `~/.local/pipx/venvs/spec-kitty-cli/bin/python`, not the resolved Homebrew path; `git commit --allow-empty -m smoke` succeeds

Note: `tests/regressions/test_issue_105_hook_python_lookup.py` fails on this branch, but it also fails on clean `main` in this environment (its PATH-stripping logic removes `/opt/homebrew/bin` which holds `git`). Pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)