### PR TITLE
chore: remove legacy agent-profiles cruft

### DIFF
--- a/src/doctrine/agent-profiles/README.md
+++ b/src/doctrine/agent-profiles/README.md
@@ -1,8 +1,0 @@
-# Agent Profiles
-
-`agent-profiles` define execution profile defaults for supported agents and
-tooling contexts.
-
-Profiles are used to encode stable behavior preferences (for example verbosity,
-command style, or safety defaults) without hardcoding those assumptions into
-command templates.

--- a/tests/audit/test_no_legacy_agent_profiles_path.py
+++ b/tests/audit/test_no_legacy_agent_profiles_path.py
@@ -1,0 +1,57 @@
+"""Regression guards for the removed legacy doctrine profile path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEGACY_DIRNAME = "agent" + "-" + "profiles"
+LEGACY_PATH = REPO_ROOT / "src" / "doctrine" / LEGACY_DIRNAME
+ACTIVE_CODEBASE_PATHS: tuple[Path, ...] = (
+    REPO_ROOT / "src",
+    REPO_ROOT / "tests",
+    REPO_ROOT / "docs",
+    REPO_ROOT / "architecture",
+    REPO_ROOT / "research",
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "CHANGELOG.md",
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "pyproject.toml",
+)
+
+
+def _active_codebase_files() -> list[Path]:
+    files: list[Path] = []
+    for path in ACTIVE_CODEBASE_PATHS:
+        if not path.exists():
+            continue
+        if path.is_file():
+            files.append(path)
+            continue
+        files.extend(
+            candidate
+            for candidate in path.rglob("*")
+            if candidate.is_file() and "__pycache__" not in candidate.parts and candidate.suffix != ".pyc"
+        )
+    return sorted(files)
+
+
+def test_legacy_agent_profiles_directory_removed() -> None:
+    """The old hyphenated doctrine directory must stay deleted."""
+    assert not LEGACY_PATH.exists(), (
+        "Legacy doctrine path reintroduced: "
+        f"{LEGACY_PATH.relative_to(REPO_ROOT)}"
+    )
+
+
+def test_no_legacy_agent_profiles_path_literals_in_active_codebase() -> None:
+    """The active codebase must not mention the removed hyphenated path."""
+    violations = [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in _active_codebase_files()
+        if LEGACY_DIRNAME in path.read_text(encoding="utf-8", errors="ignore")
+    ]
+    assert violations == [], (
+        f"Found legacy {LEGACY_DIRNAME!r} path references in active codebase files: "
+        + ", ".join(violations)
+    )

--- a/tests/cross_cutting/packaging/test_package_bundling.py
+++ b/tests/cross_cutting/packaging/test_package_bundling.py
@@ -6,6 +6,8 @@ import zipfile
 
 import pytest
 
+LEGACY_SDIST_SEGMENT = "/src/doctrine/" + "agent" + "-" + "profiles"
+
 
 def test_command_templates_not_bundled():
     """WP10: command-templates directories must not exist in src/specify_cli or src/doctrine.
@@ -65,6 +67,11 @@ def test_sdist_bundles_templates(build_artifacts: dict[str, Path]):
         ]
         assert len(cmd_templates) == 0, (
             f"Non-canonical command-templates found in sdist: {cmd_templates[:5]}"
+        )
+        legacy_agent_profile_paths = [m for m in members if LEGACY_SDIST_SEGMENT in m]
+        assert legacy_agent_profile_paths == [], (
+            f"Legacy {LEGACY_SDIST_SEGMENT} entries found in sdist: "
+            f"{legacy_agent_profile_paths[:5]}"
         )
 
         # Git hooks are intentionally not bundled in 2.x

--- a/tests/doctrine/test_wheel_packaging.py
+++ b/tests/doctrine/test_wheel_packaging.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.slow
 # in isolation. Use the fallback fixtures below.
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+LEGACY_DOCTRINE_DIR = "doctrine/" + "agent" + "-" + "profiles" + "/"
 
 
 def _build_wheel_fallback(tmpdir: str) -> Path:
@@ -60,6 +61,8 @@ def test_wheel_contains_doctrine_package_data(wheel_path: Path) -> None:
     ]
     missing = [path for path in required_prefixes if path not in names]
     assert not missing, f"Missing doctrine wheel assets: {missing}"
+    legacy_paths = sorted(name for name in names if name.startswith(LEGACY_DOCTRINE_DIR))
+    assert legacy_paths == [], f"Legacy {LEGACY_DOCTRINE_DIR} wheel assets should be absent: {legacy_paths}"
 
 
 def test_wheel_install_imports_doctrine_and_lists_profiles(


### PR DESCRIPTION
## Summary
- delete the orphaned src/doctrine legacy agent-profile path
- add an audit guard so the removed hyphenated path cannot reappear in the active codebase
- assert wheel and sdist artifacts do not bundle legacy doctrine cruft

## Testing
- PYTHONPATH=src uv run --python 3.12 pytest tests/audit/test_no_legacy_agent_profiles_path.py tests/doctrine/test_wheel_packaging.py tests/cross_cutting/packaging/test_package_bundling.py tests/doctrine/test_service.py tests/doctrine/test_profile_repository.py tests/doctrine/test_shipped_profiles.py tests/charter/test_catalog.py -q