### PR TITLE
fix: address charter synthesizer sonar findings

### DIFF
--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -31,6 +31,7 @@ All filesystem writes go through ``PathGuard`` (FR-016).
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,6 +49,14 @@ from .manifest import (
 from .request import SynthesisRequest, SynthesisTarget
 from .synthesize_pipeline import ProvenanceEntry, canonical_yaml
 from .topic_resolver import ResolvedTopic, resolve as resolve_topic
+
+_KITTIFY_DIRNAME = ".kittify"
+_DIRECTIVE_DEFAULT_NUMERIC_SEGMENT = "000"
+_DOCTRINE_SUBDIRS = {
+    "directive": "directives",
+    "tactic": "tactics",
+    "styleguide": "styleguides",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +97,92 @@ def _new_ulid() -> str:
     return ts_part + rand_part
 
 
+def _directive_numeric_segment(artifact_id: str | None) -> str:
+    """Extract the numeric suffix from a directive artifact id."""
+    if not artifact_id:
+        return _DIRECTIVE_DEFAULT_NUMERIC_SEGMENT
+
+    _, _, suffix = artifact_id.rpartition("_")
+    return suffix.zfill(3) if suffix.isdigit() else _DIRECTIVE_DEFAULT_NUMERIC_SEGMENT
+
+
+def _manifest_filename(kind: str, slug: str, artifact_id: str | None) -> str:
+    """Return the manifest content filename for a synthesized artifact."""
+    if kind == "directive":
+        return f"{_directive_numeric_segment(artifact_id)}-{slug}.directive.yaml"
+    if kind == "tactic":
+        return f"{slug}.tactic.yaml"
+    if kind == "styleguide":
+        return f"{slug}.styleguide.yaml"
+    raise ValueError(f"Unknown artifact kind: {kind!r}")
+
+
+def _doctrine_subdir(kind: str) -> str:
+    return _DOCTRINE_SUBDIRS[kind]
+
+
+def _artifact_id_from_provenance(kind: str, artifact_urn: str) -> str | None:
+    if kind != "directive":
+        return None
+    return artifact_urn.split(":", 1)[1]
+
+
+def _build_manifest_entry(body: Mapping[str, Any], prov: ProvenanceEntry) -> ManifestArtifactEntry:
+    kind = prov.artifact_kind
+    slug = prov.artifact_slug
+    artifact_id = _artifact_id_from_provenance(kind, prov.artifact_urn)
+    filename = _manifest_filename(kind, slug, artifact_id)
+    yaml_bytes = canonical_yaml(body)
+    content_hash = hashlib.sha256(yaml_bytes).hexdigest()
+    rel_content = f"{_KITTIFY_DIRNAME}/doctrine/{_doctrine_subdir(kind)}/{filename}"
+    rel_prov = f"{_KITTIFY_DIRNAME}/charter/provenance/{kind}-{slug}.yaml"
+    return ManifestArtifactEntry(
+        kind=kind,  # type: ignore[arg-type]
+        slug=slug,
+        path=rel_content,
+        provenance_path=rel_prov,
+        content_hash=content_hash,
+    )
+
+
+def _merge_manifest_entries(
+    existing: SynthesisManifest,
+    new_entries_by_key: Mapping[tuple[str, str], ManifestArtifactEntry],
+) -> list[ManifestArtifactEntry]:
+    """Update existing entries in place and append genuinely new ones."""
+    merged: list[ManifestArtifactEntry] = []
+    existing_keys: set[tuple[str, str]] = set()
+
+    for entry in existing.artifacts:
+        key = (entry.kind, entry.slug)
+        existing_keys.add(key)
+        merged.append(new_entries_by_key.get(key, entry))
+
+    for key, new_entry in new_entries_by_key.items():
+        if key not in existing_keys:
+            merged.append(new_entry)
+
+    return merged
+
+
+def _resolve_adapter_identity(
+    existing: SynthesisManifest,
+    new_adapter_ids: set[str],
+    new_adapter_versions: set[str],
+) -> tuple[str, str]:
+    """Prefer a unique adapter identity from regenerated artifacts."""
+    if len(new_adapter_ids) != 1:
+        return existing.adapter_id, existing.adapter_version
+
+    primary_adapter_id = next(iter(new_adapter_ids))
+    primary_adapter_version = (
+        next(iter(new_adapter_versions))
+        if len(new_adapter_versions) == 1
+        else existing.adapter_version
+    )
+    return primary_adapter_id, primary_adapter_version
+
+
 def _rewrite_manifest(
     existing: SynthesisManifest,
     new_results: list[tuple[Mapping[str, Any], ProvenanceEntry]],
@@ -116,30 +211,7 @@ def _rewrite_manifest(
     SynthesisManifest
         The merged manifest (not yet written to disk; caller does the write).
     """
-    import hashlib
-    import re
     from datetime import UTC, datetime
-
-    # Filename helper (mirrors write_pipeline._artifact_filename)
-    _DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
-
-    def _filename(kind: str, slug: str, artifact_id: str | None) -> str:
-        if kind == "directive":
-            nnn = "000"
-            if artifact_id:
-                m = _DIRECTIVE_NUM_RE.search(artifact_id)
-                if m:
-                    nnn = m.group(1).zfill(3)
-            return f"{nnn}-{slug}.directive.yaml"
-        elif kind == "tactic":
-            return f"{slug}.tactic.yaml"
-        elif kind == "styleguide":
-            return f"{slug}.styleguide.yaml"
-        else:
-            raise ValueError(f"Unknown artifact kind: {kind!r}")
-
-    def _doctrine_subdir(kind: str) -> str:
-        return {"directive": "directives", "tactic": "tactics", "styleguide": "styleguides"}[kind]
 
     # Build a key → new ManifestArtifactEntry dict for regenerated artifacts
     new_entries_by_key: dict[tuple[str, str], ManifestArtifactEntry] = {}
@@ -149,50 +221,16 @@ def _rewrite_manifest(
     for body, prov in new_results:
         kind = prov.artifact_kind
         slug = prov.artifact_slug
-        artifact_id: str | None = None
-        if kind == "directive":
-            artifact_id = prov.artifact_urn.split(":", 1)[1]
-
-        filename = _filename(kind, slug, artifact_id)
-        yaml_bytes = canonical_yaml(body)
-        content_hash = hashlib.sha256(yaml_bytes).hexdigest()
-
-        rel_content = f".kittify/doctrine/{_doctrine_subdir(kind)}/{filename}"
-        rel_prov = f".kittify/charter/provenance/{kind}-{slug}.yaml"
-
-        new_entries_by_key[(kind, slug)] = ManifestArtifactEntry(
-            kind=kind,  # type: ignore[arg-type]
-            slug=slug,
-            path=rel_content,
-            provenance_path=rel_prov,
-            content_hash=content_hash,
-        )
+        new_entries_by_key[(kind, slug)] = _build_manifest_entry(body, prov)
         new_adapter_ids.add(prov.adapter_id)
         new_adapter_versions.add(prov.adapter_version)
 
-    # Merge: existing entries updated where regenerated, retained otherwise
-    merged: list[ManifestArtifactEntry] = []
-    existing_keys: set[tuple[str, str]] = set()
-    for entry in existing.artifacts:
-        key = (entry.kind, entry.slug)
-        existing_keys.add(key)
-        if key in new_entries_by_key:
-            merged.append(new_entries_by_key[key])
-        else:
-            merged.append(entry)
-
-    # Add genuinely new artifacts (not previously in the manifest)
-    for key, new_entry in new_entries_by_key.items():
-        if key not in existing_keys:
-            merged.append(new_entry)
-
-    # Adapter identity (aggregate from new results; fall back to existing)
-    if len(new_adapter_ids) == 1:
-        primary_adapter_id = new_adapter_ids.pop()
-        primary_adapter_version = new_adapter_versions.pop() if len(new_adapter_versions) == 1 else existing.adapter_version
-    else:
-        primary_adapter_id = existing.adapter_id
-        primary_adapter_version = existing.adapter_version
+    merged = _merge_manifest_entries(existing, new_entries_by_key)
+    primary_adapter_id, primary_adapter_version = _resolve_adapter_identity(
+        existing,
+        new_adapter_ids,
+        new_adapter_versions,
+    )
 
     return SynthesisManifest(
         schema_version="1",
@@ -442,7 +480,7 @@ def run(
             spec_kitty_version=_SPEC_KITTY_VERSION,
             shipped_drg=shipped_drg,
         )
-        existing_graph_path = _repo_root / ".kittify" / "doctrine" / "graph.yaml"
+        existing_graph_path = _repo_root / _KITTIFY_DIRNAME / "doctrine" / "graph.yaml"
         project_graph = updated_overlay
         if existing_graph_path.exists():
             project_graph = _merge_project_overlay(
@@ -472,7 +510,7 @@ def run(
 
     guard = _PathGuard(
         repo_root=_repo_root,
-        extra_allowed_prefixes=(_repo_root / ".kittify",),
+        extra_allowed_prefixes=(_repo_root / _KITTIFY_DIRNAME,),
     )
     _dump_manifest(new_manifest, manifest_path, guard)
 
@@ -504,7 +542,7 @@ def _load_project_artifacts_from_provenance(
     """
     from ruamel.yaml import YAML  # noqa: PLC0415
 
-    prov_dir = repo_root / ".kittify" / "charter" / "provenance"
+    prov_dir = repo_root / _KITTIFY_DIRNAME / "charter" / "provenance"
     if not prov_dir.exists():
         return []
 
@@ -548,7 +586,7 @@ def _load_merged_drg(
     """
     from ruamel.yaml import YAML  # noqa: PLC0415
 
-    project_graph_path = repo_root / ".kittify" / "doctrine" / "graph.yaml"
+    project_graph_path = repo_root / _KITTIFY_DIRNAME / "doctrine" / "graph.yaml"
     if not project_graph_path.exists():
         return request.drg_snapshot
 

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -30,7 +30,6 @@ All filesystem writes go through ``PathGuard`` (FR-016).
 from __future__ import annotations
 
 import hashlib
-import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, UTC
 from pathlib import Path
@@ -53,7 +52,22 @@ from .synthesize_pipeline import ProvenanceEntry, canonical_yaml
 # Filename helpers (data-model §E-2 "Filename rule")
 # ---------------------------------------------------------------------------
 
-_DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
+_KITTIFY_DIRNAME = ".kittify"
+_DIRECTIVE_DEFAULT_NUMERIC_SEGMENT = "000"
+_DOCTRINE_SUBDIRS = {
+    "directive": "directives",
+    "tactic": "tactics",
+    "styleguide": "styleguides",
+}
+
+
+def _directive_numeric_segment(artifact_id: str | None) -> str:
+    """Extract the numeric suffix from a directive artifact id."""
+    if not artifact_id:
+        return _DIRECTIVE_DEFAULT_NUMERIC_SEGMENT
+
+    _, _, suffix = artifact_id.rpartition("_")
+    return suffix.zfill(3) if suffix.isdigit() else _DIRECTIVE_DEFAULT_NUMERIC_SEGMENT
 
 
 def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> str:
@@ -66,12 +80,7 @@ def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> 
     - styleguide: ``<slug>.styleguide.yaml``
     """
     if kind == "directive":
-        nnn = "000"
-        if artifact_id:
-            m = _DIRECTIVE_NUM_RE.search(artifact_id)
-            if m:
-                nnn = m.group(1).zfill(3)
-        return f"{nnn}-{slug}.directive.yaml"
+        return f"{_directive_numeric_segment(artifact_id)}-{slug}.directive.yaml"
     elif kind == "tactic":
         return f"{slug}.tactic.yaml"
     elif kind == "styleguide":
@@ -82,11 +91,7 @@ def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> 
 
 def _doctrine_kind_subdir(kind: str) -> str:
     """Return the doctrine subdirectory name for a given artifact kind."""
-    return {
-        "directive": "directives",
-        "tactic": "tactics",
-        "styleguide": "styleguides",
-    }[kind]
+    return _DOCTRINE_SUBDIRS[kind]
 
 
 def _compute_content_hash(yaml_bytes: bytes) -> str:
@@ -137,6 +142,7 @@ def promote(
     StagingPromoteError
         If any ``os.replace`` call or the manifest write fails.
     """
+    _ = request
     if repo_root is None:
         # staging_dir.root == .kittify/charter/.staging/<run_id>
         # → repo_root == staging_dir.root.parent.parent.parent.parent
@@ -189,12 +195,12 @@ def promote(
     # Ensure destination directories exist.
     for kind_subdir in ("directives", "tactics", "styleguides"):
         guard.mkdir(
-            repo_root / ".kittify" / "doctrine" / kind_subdir,
+            repo_root / _KITTIFY_DIRNAME / "doctrine" / kind_subdir,
             caller="write_pipeline.promote[mkdir-doctrine]",
         )
 
     guard.mkdir(
-        repo_root / ".kittify" / "charter" / "provenance",
+        repo_root / _KITTIFY_DIRNAME / "charter" / "provenance",
         caller="write_pipeline.promote[mkdir-provenance]",
     )
 
@@ -215,12 +221,12 @@ def promote(
 
             # Content: staging → .kittify/doctrine/<kind-subdir>/<filename>
             staged_content = staging_dir.path_for_content(kind, filename)
-            live_content = repo_root / ".kittify" / "doctrine" / _doctrine_kind_subdir(kind) / filename
+            live_content = repo_root / _KITTIFY_DIRNAME / "doctrine" / _doctrine_kind_subdir(kind) / filename
             guard.replace(staged_content, live_content, caller="write_pipeline.promote[content-replace]")
 
             # Provenance: staging → .kittify/charter/provenance/<kind>-<slug>.yaml
             staged_prov = staging_dir.path_for_provenance(kind, slug)
-            live_prov = repo_root / ".kittify" / "charter" / "provenance" / f"{kind}-{slug}.yaml"
+            live_prov = repo_root / _KITTIFY_DIRNAME / "charter" / "provenance" / f"{kind}-{slug}.yaml"
             guard.replace(staged_prov, live_prov, caller="write_pipeline.promote[prov-replace]")
 
             rel_content = str(live_content.relative_to(repo_root))
@@ -239,7 +245,7 @@ def promote(
         # Check for a staged DRG overlay graph and promote it
         staged_graph = staging_dir.root / "doctrine" / "graph.yaml"
         if staged_graph.exists():
-            live_graph = repo_root / ".kittify" / "doctrine" / "graph.yaml"
+            live_graph = repo_root / _KITTIFY_DIRNAME / "doctrine" / "graph.yaml"
             guard.replace(staged_graph, live_graph, caller="write_pipeline.promote[graph-replace]")
 
     except Exception as exc:


### PR DESCRIPTION
## Summary
- remove the directive-id regex hotspot from charter synthesizer filename generation
- centralize repeated `.kittify` paths in the touched synthesizer modules
- split manifest rewrite logic into smaller helpers to clear Sonar maintainability findings

## Validation
- `ruff check src/charter/synthesizer/write_pipeline.py src/charter/synthesizer/resynthesize_pipeline.py`
- `python3 -m pytest tests/charter/synthesizer/test_staging_atomicity.py tests/charter/synthesizer/test_orchestrator_resynthesize.py -q`
- `python3 -m pytest tests/charter/synthesizer/test_orchestrator_synthesize.py -q`
- `python3 -m pytest tests/charter/synthesizer -q`

## Notes
- No GitHub Dependabot alerts were open.
- No GitHub code-scanning alerts were open.
- This PR fixes the actionable code issues found in the touched SonarCloud files; it does not suppress findings.