### PR TITLE
feat: Charter Synthesizer Phase 3 — evidence inputs, production adapter, neutrality gate (#88)

### DIFF
--- a/architecture/adrs/2026-04-19-6-synthesizer-model-selection.md
+++ b/architecture/adrs/2026-04-19-6-synthesizer-model-selection.md
@@ -1,0 +1,78 @@
+# ADR-6: Charter Synthesizer Model Selection
+
+**Date**: 2026-04-19
+**Status**: Accepted
+**Deciders**: Robert Douglass
+**Supersedes**: N/A
+
+## Context
+
+The charter synthesizer's production adapter calls an LLM to generate
+project-local governance doctrine artifacts (directives, tactics, styleguides)
+from interview answers and evidence inputs. The model selection affects:
+
+- Output quality: doctrine should reflect nuanced judgment, not generic text.
+- Cost: synthesis runs are infrequent (typically once per project setup or
+  major change), so per-run cost matters more than per-request latency.
+- Configurability: different projects have different quality/cost trade-offs.
+
+## Decision
+
+**Default model**: `claude-sonnet-4-6`
+
+Rationale:
+- Strong reasoning quality — sufficient for interpreting mixed evidence
+  (code signals, URL references, corpus guidance) and generating coherent
+  doctrine with appropriate project-specific nuance.
+- Appropriate cost tier — synthesis is infrequent; the higher cost vs.
+  Haiku is justified by the importance of the output.
+- Not Opus — Opus is better reserved for exceptional cases; Sonnet is the
+  right balance for a default that operators can upgrade.
+
+## Override Mechanism
+
+Operators can override the model per-project in `.kittify/config.yaml`:
+
+```yaml
+charter:
+  synthesis:
+    model: claude-opus-4-7   # override to Opus for higher quality
+    timeout_seconds: 180     # optional: increase API timeout
+```
+
+Any `claude-*` model identifier is accepted. The adapter validates that the
+string is non-empty and falls back to the default on any parse error.
+
+## Cost Model (Advisory)
+
+Approximate cost per full synthesis run (8–12 targets):
+
+| Component | Estimate |
+|-----------|----------|
+| Input tokens per run | 15,000–40,000 |
+| Output tokens per run | 2,000–4,000 |
+| Sonnet 4.6 cost | ~$0.05–$0.25 per run |
+| Opus 4.7 cost | ~$0.25–$1.25 per run |
+
+These are approximate; actual cost depends on interview richness, evidence
+volume, and target count.
+
+## Alternatives Considered
+
+- **`claude-haiku-4-5`**: Rejected — insufficient reasoning depth for the
+  "interpret mixed evidence → coherent doctrine" task.
+- **`claude-opus-4-7`**: Viable but higher cost; available as per-project
+  override for projects that value maximum output quality.
+- **Provider-neutral (OpenAI, Gemini)**: Deferred — the `SynthesisAdapter`
+  protocol supports future providers; ADR-6 scopes to Claude for Phase 3.
+- **Fixed hardcoded model**: Rejected — model families evolve; operators need
+  the ability to update without a code change.
+
+## Consequences
+
+- `anthropic>=0.55.0` added to project runtime dependencies.
+- `ANTHROPIC_API_KEY` environment variable required for production adapter.
+- `ProductionAdapter` raises `ProductionAdapterUnavailableError` when the key
+  is missing or when the API returns a timeout or error response.
+- Future provider support: implement a new `SynthesisAdapter` in a separate
+  file; no changes to `adapter.py` seam required (ADR-2026-04-17-1).

--- a/kitty-specs/charter-synthesizer-phase-3-completion-01KPJFHG/meta.json
+++ b/kitty-specs/charter-synthesizer-phase-3-completion-01KPJFHG/meta.json
@@ -1,0 +1,20 @@
+{
+  "created_at": "2026-04-19T09:00:59.616082+00:00",
+  "friendly_name": "Charter Synthesizer Phase 3 Completion: Richer Inputs and Production Adapter",
+  "mission_id": "01KPJFHGQ2QQRT3JP7T37M84HN",
+  "mission_number": 88,
+  "mission_slug": "charter-synthesizer-phase-3-completion-01KPJFHG",
+  "mission_type": "software-dev",
+  "slug": "charter-synthesizer-phase-3-completion-01KPJFHG",
+  "source_description": "Complete remaining Phase 3 charter synthesizer scope: code-reading input adapter (#482), URL-fetching input adapter (#484), best-practice corpus loader (#486), production adapter / ADR-6 model selection (#521), and neutrality synthesis-path tripwires (#653). Builds on the Phase 3 tranche 1 baseline already landed via PR #677.",
+  "target_branch": "main",
+  "tracks": [
+    "#465",
+    "#653",
+    "#482",
+    "#484",
+    "#486",
+    "#521"
+  ],
+  "vcs": "git"
+}

--- a/kitty-specs/phase-3-charter-synthesizer-pipeline-01KPE222/contracts/adapter.py
+++ b/kitty-specs/phase-3-charter-synthesizer-pipeline-01KPE222/contracts/adapter.py
@@ -48,8 +48,9 @@ class SynthesisRequest:
     interview_snapshot: Mapping[str, Any]
     doctrine_snapshot: Mapping[str, Any]
     drg_snapshot: Mapping[str, Any]
-    adapter_hints: Mapping[str, str] | None
-    run_id: str  # ULID. Excluded from fixture-hash per R-0-6 rule 4.
+    adapter_hints: Mapping[str, str] | None = None
+    run_id: str = ""  # ULID. Excluded from fixture-hash per R-0-6 rule 4.
+    evidence: Any = None  # EvidenceBundle | None — added by WP01 (charter phase 3)
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "google-re2>=1.1",  # RE2 engine for linear-time regex (ReDoS prevention)
     "cryptography>=42.0",  # AES-256-GCM + scrypt KDF for auth file fallback storage (feature 080)
     "keyring>=24.0; sys_platform != \"win32\"",  # OS keystore abstraction for auth secure storage backends (feature 080)
+    "anthropic>=0.55.0",  # Claude API for production adapter (ADR-6)
 ]
 
 [project.urls]
@@ -170,6 +171,7 @@ markers = [
     "no_readiness_stub: Opt out of any autouse readiness-stub fixture so the test exercises its own readiness wiring (mission 082 tracker CLI tests)",
     "architectural: Architectural enforcement tests (layer rules, import-graph invariants)",
     "windows_ci: Tests that require a native win32 environment — auto-skipped on non-Windows",
+    "live_adapter: tests that call the real Anthropic API (deselect with -m 'not live_adapter')",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ artifacts = [
     "src/specify_cli/**/*.yaml",
     "src/specify_cli/**/*.yml",
     "src/specify_cli/**/*.json",
+    "src/charter/**/*.yaml",
+    "src/charter/**/*.yml",
     "src/doctrine/**/*.md",
     "src/doctrine/**/*.yaml",
     "src/doctrine/**/*.yml",

--- a/pytest.ini
+++ b/pytest.ini
@@ -35,3 +35,4 @@ markers =
     git_repo: tests that create real git repositories (subprocess git init)
     no_readiness_stub: opt out of any autouse readiness-stub fixture so the test exercises its own readiness wiring (mission 082 tracker CLI tests)
     windows_ci: tests that must pass on the native windows-latest CI job (runs only on windows-latest; covers hook execution, file-backed auth store, path helpers, worktree fallback, regression guards)
+    live_adapter: tests that call the real Anthropic API (deselect with -m 'not live_adapter')

--- a/src/charter/corpus/__init__.py
+++ b/src/charter/corpus/__init__.py
@@ -1,0 +1,4 @@
+"""Bundled best-practice corpus for charter synthesis."""
+from pathlib import Path
+
+CORPUS_ROOT: Path = Path(__file__).parent

--- a/src/charter/corpus/generic.corpus.yaml
+++ b/src/charter/corpus/generic.corpus.yaml
@@ -1,0 +1,37 @@
+schema_version: "1"
+profile_key: "generic"
+snapshot_id: "generic-v1.0.0"
+entries:
+  - topic: "testing philosophy"
+    tags: ["testing", "ci", "quality"]
+    guidance: |
+      Effective software testing balances confidence with velocity. A layered
+      strategy — fast unit tests for business logic, integration tests for
+      system boundaries, and a small number of end-to-end tests for critical
+      paths — provides maximum signal at minimum cost.
+
+      Tests should be deterministic, isolated, and independently runnable.
+      Avoid shared mutable state between tests. A test suite that cannot be
+      run reliably is not a safety net.
+
+  - topic: "code organisation"
+    tags: ["structure", "modules", "architecture"]
+    guidance: |
+      Organise code by domain concern, not by technical layer. A module
+      boundary should correspond to a concept in the problem domain.
+
+      Keep modules small and focused. A module that imports from many
+      unrelated areas of the codebase is a sign of insufficient decomposition.
+      Dependencies should flow inward (domain logic has no dependency on
+      infrastructure).
+
+  - topic: "documentation standards"
+    tags: ["docs", "api", "maintainability"]
+    guidance: |
+      Documentation serves three audiences: the newcomer who needs a tutorial,
+      the practitioner who needs a how-to guide, and the maintainer who needs
+      to understand why a decision was made.
+
+      Maintain a README that answers: what is this, why does it exist, how do
+      I set it up, how do I run it. Keep documentation close to the code it
+      describes. Outdated documentation is worse than no documentation.

--- a/src/charter/corpus/javascript.corpus.yaml
+++ b/src/charter/corpus/javascript.corpus.yaml
@@ -1,0 +1,28 @@
+schema_version: "1"
+profile_key: "javascript"
+snapshot_id: "javascript-v1.0.0"
+entries:
+  - topic: "testing philosophy"
+    tags: ["testing", "jest", "javascript", "ci"]
+    guidance: |
+      JavaScript/TypeScript projects should use a fast, parallelisable test
+      runner with built-in assertion and mocking support. Jest and Vitest are
+      the dominant choices; prefer Vitest for new ESM projects due to native
+      module support.
+
+      Test at the component boundary: unit tests for pure functions and
+      business logic, component tests for UI behaviour, and a small number of
+      end-to-end tests via browser automation for critical user flows.
+
+  - topic: "code organisation"
+    tags: ["javascript", "typescript", "modules", "structure"]
+    guidance: |
+      Prefer named exports over default exports to support better editor
+      tooling and explicit import sites. Organise code by feature, not by
+      technical type (avoid flat components/, services/, utils/ trees
+      that grow without bound).
+
+      Use TypeScript strict mode. Avoid any; prefer unknown and narrow
+      explicitly. Barrel files (index.ts) are convenient but can create
+      circular dependencies — use them sparingly and only at feature
+      boundaries.

--- a/src/charter/corpus/python.corpus.yaml
+++ b/src/charter/corpus/python.corpus.yaml
@@ -1,0 +1,42 @@
+schema_version: "1"
+profile_key: "python"
+snapshot_id: "python-v1.0.0"
+entries:
+  - topic: "testing philosophy"
+    tags: ["testing", "pytest", "python", "ci"]
+    guidance: |
+      Python projects benefit from a layered test strategy built around the
+      stack's native tools. pytest provides fixtures, parametrization, and
+      plugin support that enable expressive, composable test suites.
+
+      Prefer fixture injection over global state. Mark slow tests to enable
+      fast subset runs during development. Use coverage gates on changed lines
+      rather than global thresholds to keep the gate meaningful.
+
+      Integration tests should target real infrastructure (database, queue)
+      rather than mocks when the divergence cost of mocking is higher than
+      the benefit. Use in-memory or containerised instances for isolation.
+
+  - topic: "code organisation"
+    tags: ["python", "packages", "src-layout"]
+    guidance: |
+      Use the src-layout: place all importable code under src/<package>/
+      to prevent accidental imports of the development tree instead of the
+      installed package. This catches packaging bugs before they reach users.
+
+      Prefer explicit imports over star imports. Keep __init__.py files
+      thin — they should re-export the stable public API, not contain
+      business logic.
+
+  - topic: "type safety"
+    tags: ["python", "mypy", "typing"]
+    guidance: |
+      Python type annotations with mypy in strict mode provide early error
+      detection and improved IDE support without the overhead of a compiled
+      language. Enable strict mode in mypy.ini and treat type errors as
+      build failures in CI.
+
+      Prefer from __future__ import annotations to defer annotation
+      evaluation and avoid circular import issues. Use TypeVar, Protocol,
+      and TypedDict to model generic and structural types rather than
+      resorting to Any.

--- a/src/charter/evidence/__init__.py
+++ b/src/charter/evidence/__init__.py
@@ -1,0 +1,4 @@
+"""Charter evidence collection package."""
+from charter.evidence.code_reader import CodeReadingCollector
+
+__all__ = ["CodeReadingCollector"]

--- a/src/charter/evidence/code_reader.py
+++ b/src/charter/evidence/code_reader.py
@@ -1,0 +1,299 @@
+"""Heuristic code-reading collector for charter synthesis.
+
+Walks the project repository up to a configurable depth, detects the primary
+language / framework / test-framework stack, and returns a ``CodeSignals``
+dataclass suitable for injection into an ``EvidenceBundle``.
+
+No external runtime dependencies — stdlib ``pathlib`` and ``os.walk`` only.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from charter.synthesizer.evidence import CodeSignals
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EXCLUDED_DIRS: frozenset[str] = frozenset(
+    {
+        "node_modules",
+        ".venv",
+        "venv",
+        "env",
+        "__pycache__",
+        ".git",
+        "dist",
+        "build",
+        ".worktrees",
+        ".mypy_cache",
+        ".tox",
+    }
+)
+
+# Indicator file → language (order matters for resolution when multiple found)
+LANGUAGE_INDICATORS: dict[str, str] = {
+    "pyproject.toml": "python",
+    "setup.py": "python",
+    "setup.cfg": "python",
+    "requirements.txt": "python",
+    "go.mod": "go",
+    "Cargo.toml": "rust",
+    "pom.xml": "java",
+    "build.gradle": "java",
+    "Gemfile": "ruby",
+    "composer.json": "php",
+    # package.json is handled separately (js vs ts disambiguation)
+    "package.json": "javascript",
+}
+
+FRAMEWORK_INDICATORS: dict[str, str] = {
+    "manage.py": "django",
+    "next.config.ts": "nextjs",
+    "next.config.js": "nextjs",
+    "angular.json": "angular",
+    "svelte.config.js": "svelte",
+    "svelte.config.ts": "svelte",
+    "nuxt.config.ts": "nuxt",
+    "nuxt.config.js": "nuxt",
+}
+
+TEST_FRAMEWORK_INDICATORS: dict[str, str] = {
+    "pytest.ini": "pytest",
+    "conftest.py": "pytest",
+    "jest.config.js": "jest",
+    "jest.config.ts": "jest",
+    "vitest.config.ts": "vitest",
+    "vitest.config.js": "vitest",
+}
+
+LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
+    "python": [".py"],
+    "typescript": [".ts", ".tsx"],
+    "javascript": [".js", ".jsx", ".mjs"],
+    "go": [".go"],
+    "rust": [".rs"],
+    "java": [".java"],
+    "ruby": [".rb"],
+    "php": [".php"],
+}
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CodeReadingError(Exception):
+    """Raised when the repository root does not exist."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _is_test_file(rel_path: str, filename: str) -> bool:
+    """Return True when *filename* looks like a test file."""
+    name = filename.lower()
+    # Python patterns
+    if name.startswith("test_") and name.endswith(".py"):
+        return True
+    if name.endswith("_test.py"):
+        return True
+    # JS/TS patterns
+    for suffix in (".test.ts", ".spec.ts", ".test.js", ".spec.js"):
+        if name.endswith(suffix):
+            return True
+    # Directory-based heuristic
+    parts = rel_path.replace("\\", "/").split("/")
+    if "tests" in parts or "__tests__" in parts:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Collector
+# ---------------------------------------------------------------------------
+
+
+class CodeReadingCollector:
+    """Walk a repository and return :class:`~charter.synthesizer.evidence.CodeSignals`.
+
+    Parameters
+    ----------
+    repo_root:
+        Absolute path to the repository root.
+    max_depth:
+        Maximum directory depth to walk (root = 0).  Defaults to 3.
+    """
+
+    def __init__(self, repo_root: Path, max_depth: int = 3) -> None:
+        self._repo_root = repo_root
+        self._max_depth = max_depth
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def collect(self) -> CodeSignals:
+        """Walk the repository and return detected ``CodeSignals``.
+
+        Raises
+        ------
+        CodeReadingError
+            If *repo_root* does not exist.
+
+        Notes
+        -----
+        All internal detection errors are swallowed; the method returns an
+        "unknown" ``CodeSignals`` instance rather than propagating them.
+        """
+        if not self._repo_root.exists():
+            raise CodeReadingError(
+                f"Repository root does not exist: {self._repo_root}"
+            )
+
+        try:
+            return self._detect()
+        except Exception:  # noqa: BLE001
+            return self._unknown_signals()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _detect(self) -> CodeSignals:
+        indicator_files: set[str] = set()
+        source_files: list[str] = []
+        test_files: list[str] = []
+        ts_files = 0
+        js_files = 0
+
+        root_str = str(self._repo_root)
+
+        for dirpath, dirnames, filenames in os.walk(root_str):
+            # Compute depth relative to root
+            rel = os.path.relpath(dirpath, root_str)
+            depth = 0 if rel == "." else rel.count(os.sep) + 1
+            if depth > self._max_depth:
+                dirnames.clear()
+                continue
+
+            # Prune excluded directories in-place so os.walk skips them
+            dirnames[:] = [
+                d for d in dirnames if d not in EXCLUDED_DIRS
+            ]
+
+            for filename in filenames:
+                abs_path = os.path.join(dirpath, filename)
+                rel_path = os.path.relpath(abs_path, root_str).replace(
+                    os.sep, "/"
+                )
+
+                # Track indicator filenames for language/framework detection
+                indicator_files.add(filename)
+
+                # Count TS vs JS files for disambiguation
+                if filename.endswith(".ts") or filename.endswith(".tsx"):
+                    ts_files += 1
+                elif filename.endswith(".js") or filename.endswith(".jsx") or filename.endswith(".mjs"):
+                    js_files += 1
+
+                # Bucket into source vs test
+                if _is_test_file(rel_path, filename):
+                    test_files.append(rel_path)
+                else:
+                    source_files.append(rel_path)
+
+        # --- language detection ------------------------------------------
+        language = self._detect_language(indicator_files, ts_files, js_files)
+
+        # --- framework detection ----------------------------------------
+        frameworks: list[str] = []
+        for indicator, fw in FRAMEWORK_INDICATORS.items():
+            if indicator in indicator_files and fw not in frameworks:
+                frameworks.append(fw)
+
+        # --- test framework detection ------------------------------------
+        test_fws: list[str] = []
+        for indicator, tf in TEST_FRAMEWORK_INDICATORS.items():
+            if indicator in indicator_files and tf not in test_fws:
+                test_fws.append(tf)
+
+        # Pytest fallback: look for tests/test_*.py or tests/*_test.py
+        if not test_fws and language == "python":
+            for f in test_files:
+                parts = f.split("/")
+                if "tests" in parts:
+                    test_fws.append("pytest")
+                    break
+
+        # --- stack_id ---------------------------------------------------
+        parts_stack: list[str] = [language]
+        if frameworks:
+            parts_stack.append(frameworks[0])
+        if test_fws:
+            parts_stack.append(test_fws[0])
+
+        stack_id = "+".join(parts_stack) if language != "unknown" else "unknown"
+
+        # --- representative files (5 source + 5 test) -------------------
+        representative: list[str] = (
+            source_files[:5] + test_files[:5]
+        )
+
+        return CodeSignals(
+            stack_id=stack_id,
+            primary_language=language,
+            frameworks=tuple(frameworks),
+            test_frameworks=tuple(test_fws),
+            scope_tag=language,
+            representative_files=tuple(representative),
+            detected_at=_utcnow_iso(),
+        )
+
+    def _detect_language(
+        self,
+        indicator_files: set[str],
+        ts_files: int,
+        js_files: int,
+    ) -> str:
+        """Return the primary language string."""
+        # TypeScript takes precedence over JavaScript when tsconfig.json present
+        if "package.json" in indicator_files:
+            if "tsconfig.json" in indicator_files:
+                return "typescript"
+            # Majority-extension heuristic
+            total_js_ts = ts_files + js_files
+            if total_js_ts > 0 and ts_files / total_js_ts > 0.5:
+                return "typescript"
+            return "javascript"
+
+        # Check remaining language indicators in priority order
+        for indicator, lang in LANGUAGE_INDICATORS.items():
+            if indicator == "package.json":
+                continue  # handled above
+            if indicator in indicator_files:
+                return lang
+
+        return "unknown"
+
+    @staticmethod
+    def _unknown_signals() -> CodeSignals:
+        return CodeSignals(
+            stack_id="unknown",
+            primary_language="unknown",
+            frameworks=(),
+            test_frameworks=(),
+            scope_tag="unknown",
+            representative_files=(),
+            detected_at=_utcnow_iso(),
+        )

--- a/src/charter/evidence/corpus_loader.py
+++ b/src/charter/evidence/corpus_loader.py
@@ -1,0 +1,60 @@
+"""Corpus loader for charter synthesis evidence."""
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any
+
+import ruamel.yaml
+
+from charter.corpus import CORPUS_ROOT
+from charter.synthesizer.evidence import CorpusEntry, CorpusSnapshot
+
+
+class CorpusLoaderError(Exception):
+    """Raised when a corpus file cannot be loaded or parsed."""
+
+
+class CorpusLoader:
+    """Load a profile-keyed best-practice corpus snapshot."""
+
+    def __init__(self, corpus_root: Path | None = None) -> None:
+        self._root = Path(corpus_root) if corpus_root is not None else CORPUS_ROOT
+
+    def load(self, profile_key: str) -> CorpusSnapshot | None:
+        """Return a CorpusSnapshot for the given profile key.
+
+        Matching order: exact primary language -> "generic" fallback -> None.
+        """
+        primary = profile_key.split("+")[0]
+        for candidate in [primary, "generic"]:
+            path = self._root / f"{candidate}.corpus.yaml"
+            if path.exists():
+                return self._load_file(path)
+        return None
+
+    def _load_file(self, path: Path) -> CorpusSnapshot:
+        try:
+            yaml = ruamel.yaml.YAML()
+            with path.open("r", encoding="utf-8") as fh:
+                data: dict[str, Any] = yaml.load(fh)
+            return _parse_snapshot(data)
+        except (ValueError, KeyError, TypeError) as exc:
+            raise CorpusLoaderError(f"Failed to parse corpus file {path}: {exc}") from exc
+
+
+def _parse_snapshot(data: dict[str, Any]) -> CorpusSnapshot:
+    entries = tuple(
+        CorpusEntry(
+            topic=str(e["topic"]),
+            tags=tuple(str(t) for t in e.get("tags", [])),
+            guidance=str(e["guidance"]).strip(),
+        )
+        for e in data.get("entries", [])
+    )
+    return CorpusSnapshot(
+        snapshot_id=str(data["snapshot_id"]),
+        profile_key=str(data["profile_key"]),
+        entries=entries,
+        loaded_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    )

--- a/src/charter/evidence/orchestrator.py
+++ b/src/charter/evidence/orchestrator.py
@@ -1,0 +1,92 @@
+"""Evidence orchestration for charter synthesis."""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import ruamel.yaml
+
+from charter.evidence.code_reader import CodeReadingCollector
+from charter.evidence.corpus_loader import CorpusLoader
+from charter.synthesizer.evidence import CodeSignals, CorpusSnapshot, EvidenceBundle
+
+
+@dataclass
+class EvidenceResult:
+    """Result of evidence collection — always has a bundle (may be empty)."""
+
+    bundle: EvidenceBundle
+    warnings: list[str] = field(default_factory=list)
+
+
+class EvidenceOrchestrator:
+    """Coordinates evidence collection from all configured sources."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        url_list: tuple[str, ...] = (),
+        skip_code: bool = False,
+        skip_corpus: bool = False,
+        corpus_root: Path | None = None,
+    ) -> None:
+        self._repo_root = repo_root
+        self._url_list = url_list
+        self._skip_code = skip_code
+        self._skip_corpus = skip_corpus
+        self._corpus_root = corpus_root
+
+    def collect(self) -> EvidenceResult:
+        """Run all enabled collectors with exception isolation."""
+        warnings: list[str] = []
+        code_signals: CodeSignals | None = None
+        corpus_snapshot: CorpusSnapshot | None = None
+
+        if not self._skip_code:
+            try:
+                collector = CodeReadingCollector(self._repo_root)
+                code_signals = collector.collect()
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"Code-reading evidence collection failed: {exc}")
+
+        if not self._skip_corpus:
+            profile_key = code_signals.stack_id if code_signals else "generic"
+            try:
+                loader = CorpusLoader(corpus_root=self._corpus_root)
+                corpus_snapshot = loader.load(profile_key)
+                if corpus_snapshot is None:
+                    warnings.append(
+                        f"No corpus found for profile '{profile_key}' or 'generic'; "
+                        "synthesis proceeds without corpus evidence."
+                    )
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"Corpus loading failed: {exc}")
+
+        bundle = EvidenceBundle(
+            code_signals=code_signals,
+            url_list=self._url_list,
+            corpus_snapshot=corpus_snapshot,
+            collected_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+        return EvidenceResult(bundle=bundle, warnings=warnings)
+
+
+def load_url_list_from_config(repo_root: Path) -> tuple[str, ...]:
+    """Read charter.synthesis_inputs.url_list from .kittify/config.yaml.
+
+    Returns empty tuple if the key is absent or the file does not exist.
+    """
+    config_path = repo_root / ".kittify" / "config.yaml"
+    if not config_path.exists():
+        return ()
+    yaml = ruamel.yaml.YAML()
+    try:
+        with config_path.open("r", encoding="utf-8") as fh:
+            config = yaml.load(fh) or {}
+    except Exception:  # noqa: BLE001
+        return ()
+    charter_cfg = config.get("charter") or {}
+    synthesis_inputs = charter_cfg.get("synthesis_inputs") or {}
+    raw = synthesis_inputs.get("url_list") or []
+    return tuple(u for u in raw if u and isinstance(u, str))

--- a/src/charter/neutrality/language_scoped_allowlist.yaml
+++ b/src/charter/neutrality/language_scoped_allowlist.yaml
@@ -44,3 +44,13 @@ paths:
     owner: "charter team"
     reason: "Spec Kitty itself is a Python package; setup-doctor skill necessarily references Python tooling."
     added_in: "3.2.0"
+  - path: "src/charter/corpus/python.corpus.yaml"
+    scope: python
+    owner: "charter team"
+    reason: "Python best-practice corpus; pytest/mypy/pip references are the subject matter, not accidental bias."
+    added_in: "3.3.0"
+  - path: "src/charter/corpus/javascript.corpus.yaml"
+    scope: javascript
+    owner: "charter team"
+    reason: "JavaScript best-practice corpus; Jest/Vitest/TypeScript references are the subject matter."
+    added_in: "3.3.0"

--- a/src/charter/synthesizer/errors.py
+++ b/src/charter/synthesizer/errors.py
@@ -10,6 +10,7 @@ See data-model.md §E-8 for the authoritative error taxonomy.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from rich.console import Console
 from rich.panel import Panel
@@ -270,4 +271,32 @@ class ManifestIntegrityError(SynthesisError):
             f"Manifest integrity check failed: artifact '{self.offending_artifact}' "
             f"listed in {self.manifest_path} does not match its on-disk content hash. "
             f"Re-run 'charter synthesize' to repair."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Neutrality gate error
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NeutralityGateViolation(SynthesisError):
+    """Raised when a generic-scoped synthesized artifact contains language/tool-specific bias.
+
+    Promotion is blocked. The staging directory is preserved for operator inspection.
+    Raised after staging, before the first ``os.replace`` in ``promote()``.
+
+    FR-011, FR-012 — data-model.md §E-8
+    """
+
+    artifact_urn: str  # URN of the offending artifact
+    detected_terms: tuple[str, ...]  # banned terms found in the artifact body
+    staging_dir: Path  # preserved staging directory path
+
+    def __str__(self) -> str:
+        terms = ", ".join(f"'{t}'" for t in self.detected_terms)
+        return (
+            f"Neutrality gate blocked promotion of {self.artifact_urn}.\n"
+            f"Language-specific terms detected in a generic-scoped artifact: {terms}.\n"
+            f"Inspect the staged artifact at: {self.staging_dir}"
         )

--- a/src/charter/synthesizer/evidence.py
+++ b/src/charter/synthesizer/evidence.py
@@ -1,0 +1,132 @@
+"""Evidence bundle dataclasses for Phase 3 charter synthesis.
+
+These frozen dataclasses transport structured evidence inputs (code signals,
+URL lists, corpus snapshots) into the synthesis pipeline without modifying
+the adapter interface.  Only ``EvidenceBundle`` is attached to
+``SynthesisRequest``; all other types are nested inside it.
+
+Timestamps (``detected_at``, ``loaded_at``, ``collected_at``) are excluded
+from hash computation so that re-collecting the same evidence at different
+times produces identical fixture hashes.
+
+See data-model.md §E-5 for authoritative field documentation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_STACK_ID_RE = re.compile(r"^[a-z][a-z0-9+]*$")
+_SNAPSHOT_ID_RE = re.compile(r"^[a-z][a-z0-9-]+-v[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+@dataclass(frozen=True)
+class CodeSignals:
+    """Structured stack signals from the code-reading collector.
+
+    Invariants enforced in ``__post_init__``:
+
+    - ``scope_tag`` must equal ``primary_language`` (used by neutrality gate).
+    - ``stack_id`` must match ``^[a-z][a-z0-9+]*$``.
+    - Every path in ``representative_files`` must be a non-empty repo-relative
+      forward-slash path (no leading ``/``).
+
+    ``detected_at`` is an ISO 8601 UTC string that is intentionally excluded
+    from hash computation.
+    """
+
+    stack_id: str
+    primary_language: str
+    frameworks: tuple[str, ...]
+    test_frameworks: tuple[str, ...]
+    scope_tag: str  # equals primary_language; used by neutrality gate
+    representative_files: tuple[str, ...]  # repo-relative forward-slash paths
+    detected_at: str  # ISO 8601 UTC — excluded from hash
+
+    def __post_init__(self) -> None:
+        if self.scope_tag != self.primary_language:
+            raise ValueError(
+                f"scope_tag must equal primary_language, "
+                f"got {self.scope_tag!r} != {self.primary_language!r}"
+            )
+        if not _STACK_ID_RE.match(self.stack_id):
+            raise ValueError(f"Invalid stack_id format: {self.stack_id!r}")
+        for f in self.representative_files:
+            if not f or f.startswith("/"):
+                raise ValueError(
+                    "representative_files must be non-empty repo-relative paths "
+                    f"without leading slash: {f!r}"
+                )
+
+
+@dataclass(frozen=True)
+class CorpusEntry:
+    """One best-practice entry within a corpus snapshot."""
+
+    topic: str
+    tags: tuple[str, ...]
+    guidance: str
+
+
+@dataclass(frozen=True)
+class CorpusSnapshot:
+    """Profile-keyed best-practice corpus snapshot.
+
+    Invariants enforced in ``__post_init__``:
+
+    - ``snapshot_id`` must match ``^[a-z][a-z0-9-]+-v[0-9]+\\.[0-9]+\\.[0-9]+$``
+      (e.g. ``python-v1.0.0``).
+
+    ``loaded_at`` is an ISO 8601 UTC string that is intentionally excluded
+    from hash computation.
+    """
+
+    snapshot_id: str  # e.g. "python-v1.0.0" — recorded in provenance
+    profile_key: str
+    entries: tuple[CorpusEntry, ...]
+    loaded_at: str  # ISO 8601 UTC — excluded from hash
+
+    def __post_init__(self) -> None:
+        if not _SNAPSHOT_ID_RE.match(self.snapshot_id):
+            raise ValueError(f"Invalid snapshot_id format: {self.snapshot_id!r}")
+
+
+@dataclass(frozen=True)
+class EvidenceBundle:
+    """Aggregated evidence inputs for one synthesis run.
+
+    This is the ONLY transport for evidence into the synthesis pipeline.
+    ``adapter_hints`` is NOT used for evidence.
+
+    Invariants enforced in ``__post_init__``:
+
+    - No empty strings in ``url_list``.
+
+    ``collected_at`` is an ISO 8601 UTC string that is intentionally excluded
+    from hash computation.
+
+    The ``is_empty`` property returns ``True`` when no evidence has been
+    populated (all fields at their defaults).  When ``is_empty`` is ``True``,
+    ``normalize_request_for_hash`` produces byte-for-byte identical output to
+    the pre-evidence code path.
+    """
+
+    code_signals: CodeSignals | None = None
+    url_list: tuple[str, ...] = ()  # bare URLs; production adapter reads them natively
+    corpus_snapshot: CorpusSnapshot | None = None
+    collected_at: str = ""  # ISO 8601 UTC — excluded from hash
+
+    def __post_init__(self) -> None:
+        for u in self.url_list:
+            if not u:
+                raise ValueError("url_list must not contain empty strings")
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True when no evidence has been populated."""
+        return (
+            self.code_signals is None
+            and not self.url_list
+            and self.corpus_snapshot is None
+        )

--- a/src/charter/synthesizer/production_adapter.py
+++ b/src/charter/synthesizer/production_adapter.py
@@ -6,9 +6,10 @@ import os
 from typing import Any
 
 import anthropic
+from ruamel.yaml import YAML
 
 from charter.synthesizer.adapter import AdapterOutput
-from charter.synthesizer.errors import ProductionAdapterUnavailableError
+from charter.synthesizer.errors import ProductionAdapterUnavailableError, SynthesisSchemaError
 from charter.synthesizer.request import SynthesisRequest
 
 _DEFAULT_MODEL = "claude-sonnet-4-6"
@@ -72,8 +73,7 @@ class ProductionAdapter:
         body_text = "".join(
             block.text for block in message.content if hasattr(block, "text")
         )
-        # AdapterOutput.body is Mapping[str, Any]; wrap text in a dict
-        body: dict[str, Any] = {"text": body_text}
+        body = _parse_yaml_mapping(body_text, request)
         return AdapterOutput(
             body=body,
             generated_at=datetime.datetime.now(datetime.timezone.utc),
@@ -136,3 +136,38 @@ def _format_evidence(evidence: Any) -> str:
         for entry in snap.entries[:3]:
             sections.append(f"  [{entry.topic}] {entry.guidance[:200]}")
     return "\n".join(sections)
+
+
+def _parse_yaml_mapping(
+    response_text: str,
+    request: SynthesisRequest,
+) -> dict[str, Any]:
+    """Parse the model response into a YAML mapping for schema validation."""
+    yaml_text = response_text.strip()
+    if yaml_text.startswith("```"):
+        lines = yaml_text.splitlines()
+        if lines:
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        yaml_text = "\n".join(lines).strip()
+
+    yaml = YAML(typ="safe")
+    try:
+        parsed = yaml.load(yaml_text)
+    except Exception as exc:  # noqa: BLE001
+        raise SynthesisSchemaError(
+            artifact_kind=request.target.kind,
+            artifact_slug=request.target.slug,
+            validation_errors=(f"Adapter returned invalid YAML: {exc}",),
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise SynthesisSchemaError(
+            artifact_kind=request.target.kind,
+            artifact_slug=request.target.slug,
+            validation_errors=(
+                "Adapter returned YAML that is not a mapping/object.",
+            ),
+        )
+    return dict(parsed)

--- a/src/charter/synthesizer/production_adapter.py
+++ b/src/charter/synthesizer/production_adapter.py
@@ -1,0 +1,138 @@
+"""Production adapter for charter synthesis using the Anthropic Claude API."""
+from __future__ import annotations
+
+import datetime
+import os
+from typing import Any
+
+import anthropic
+
+from charter.synthesizer.adapter import AdapterOutput
+from charter.synthesizer.errors import ProductionAdapterUnavailableError
+from charter.synthesizer.request import SynthesisRequest
+
+_DEFAULT_MODEL = "claude-sonnet-4-6"
+_DEFAULT_TIMEOUT = 120
+_DEFAULT_MAX_TOKENS = 8192
+
+
+class ProductionAdapter:
+    """SynthesisAdapter implementation backed by Anthropic Claude."""
+
+    id: str = "production"
+
+    def __init__(
+        self,
+        model: str = _DEFAULT_MODEL,
+        timeout_seconds: int = _DEFAULT_TIMEOUT,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+        api_key: str | None = None,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            raise ProductionAdapterUnavailableError(
+                adapter_id="production",
+                reason="ANTHROPIC_API_KEY environment variable is not set",
+                remediation=(
+                    "Set the ANTHROPIC_API_KEY environment variable to your Anthropic "
+                    "API key and retry."
+                ),
+            )
+        self.version: str = model
+        self._model = model
+        self._timeout = timeout_seconds
+        self._max_tokens = max_tokens
+        self._client = anthropic.Anthropic(api_key=resolved_key)
+
+    def generate(self, request: SynthesisRequest) -> AdapterOutput:
+        """Call Claude to produce a single artifact body for the given request."""
+        prompt = _build_synthesis_prompt(request)
+        try:
+            message = self._client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                timeout=self._timeout,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.APITimeoutError as exc:
+            raise ProductionAdapterUnavailableError(
+                adapter_id="production",
+                reason=f"Claude API call timed out after {self._timeout}s",
+                remediation=(
+                    "Increase charter.synthesis.timeout_seconds in .kittify/config.yaml."
+                ),
+            ) from exc
+        except anthropic.APIError as exc:
+            raise ProductionAdapterUnavailableError(
+                adapter_id="production",
+                reason=f"Claude API error: {exc}",
+                remediation="Check your API key and retry.",
+            ) from exc
+
+        body_text = "".join(
+            block.text for block in message.content if hasattr(block, "text")
+        )
+        # AdapterOutput.body is Mapping[str, Any]; wrap text in a dict
+        body: dict[str, Any] = {"text": body_text}
+        return AdapterOutput(
+            body=body,
+            generated_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+
+    def generate_batch(
+        self, requests: list[SynthesisRequest]
+    ) -> list[AdapterOutput]:
+        """Produce outputs for a batch of requests (sequential implementation)."""
+        return [self.generate(r) for r in requests]
+
+
+def _build_synthesis_prompt(request: SynthesisRequest) -> str:
+    """Build the synthesis prompt for a single target."""
+    target = request.target
+    parts: list[str] = [
+        f"You are generating a {target.kind} artifact for a software project's governance doctrine.",
+        f"Artifact: {target.slug}",
+        f"Title: {target.title}",
+        "",
+        "## Interview Context",
+        _format_interview(request.interview_snapshot),
+    ]
+
+    if request.evidence is not None and not request.evidence.is_empty:
+        parts += ["", "## Project Evidence", _format_evidence(request.evidence)]
+
+    parts += [
+        "",
+        "## Task",
+        f"Write the {target.kind} content as valid YAML following the doctrine schema for {target.kind} artifacts.",
+        "Be specific to the project context. Avoid generic filler.",
+    ]
+    return "\n".join(parts)
+
+
+def _format_interview(snapshot: dict[str, Any]) -> str:
+    lines = []
+    for key, value in sorted(snapshot.items()):
+        if value:
+            lines.append(f"- {key}: {value}")
+    return "\n".join(lines) or "(no interview data)"
+
+
+def _format_evidence(evidence: Any) -> str:
+    sections = []
+    if evidence.code_signals:
+        cs = evidence.code_signals
+        sections.append(f"Stack: {cs.stack_id}")
+        if cs.representative_files:
+            files = ", ".join(cs.representative_files[:5])
+            sections.append(f"Representative files: {files}")
+    if evidence.url_list:
+        sections.append("Reference URLs (please read these for additional context):")
+        for url in evidence.url_list:
+            sections.append(f"  - {url}")
+    if evidence.corpus_snapshot:
+        snap = evidence.corpus_snapshot
+        sections.append(f"Best-practice corpus ({snap.snapshot_id}):")
+        for entry in snap.entries[:3]:
+            sections.append(f"  [{entry.topic}] {entry.guidance[:200]}")
+    return "\n".join(sections)

--- a/src/charter/synthesizer/request.py
+++ b/src/charter/synthesizer/request.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from typing import Any
 from collections.abc import Mapping
 
+from charter.synthesizer.evidence import EvidenceBundle
+
 
 # ---------------------------------------------------------------------------
 # Validation helpers
@@ -134,6 +136,7 @@ class SynthesisRequest:
     drg_snapshot: Mapping[str, Any]
     run_id: str  # ULID — excluded from fixture hash
     adapter_hints: Mapping[str, str] | None = None
+    evidence: EvidenceBundle | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +169,54 @@ def _mapping_to_sorted(m: Mapping[str, Any]) -> dict[str, Any]:
             result[k] = repr(v)
         else:
             result[k] = v
+    return result
+
+
+def _evidence_to_jsonable(e: EvidenceBundle) -> dict[str, Any]:
+    """Serialize an EvidenceBundle to a JSON-serializable dict for hashing.
+
+    Rules:
+    - All sequences sorted for order-independence.
+    - Timestamps (detected_at, loaded_at, collected_at) excluded.
+    - corpus entries sorted by topic.
+
+    This function is called only when evidence is non-None and non-empty.
+    """
+    result: dict[str, Any] = {}
+
+    if e.code_signals is not None:
+        cs = e.code_signals
+        result["code_signals"] = {
+            "frameworks": sorted(cs.frameworks),
+            "primary_language": cs.primary_language,
+            "representative_files": sorted(cs.representative_files),
+            "scope_tag": cs.scope_tag,
+            "stack_id": cs.stack_id,
+            "test_frameworks": sorted(cs.test_frameworks),
+            # detected_at excluded from hash
+        }
+
+    if e.url_list:
+        result["url_list"] = sorted(e.url_list)
+
+    if e.corpus_snapshot is not None:
+        snap = e.corpus_snapshot
+        result["corpus_snapshot"] = {
+            "entries": [
+                {
+                    "guidance": entry.guidance,
+                    "tags": sorted(entry.tags),
+                    "topic": entry.topic,
+                }
+                for entry in sorted(snap.entries, key=lambda x: x.topic)
+            ],
+            "profile_key": snap.profile_key,
+            "snapshot_id": snap.snapshot_id,
+            # loaded_at excluded from hash
+        }
+
+    # collected_at excluded from hash
+
     return result
 
 
@@ -207,6 +258,11 @@ def normalize_request_for_hash(
             else None
         ),
     }
+    # Backward-compat guarantee: when evidence is None or empty, the key is
+    # absent from the normalized dict, producing byte-for-byte identical output
+    # to the pre-evidence code path (ADR-2026-04-17-1).
+    if request.evidence is not None and not request.evidence.is_empty:
+        normalized["evidence"] = _evidence_to_jsonable(request.evidence)
     return json.dumps(normalized, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
 
 

--- a/src/charter/synthesizer/synthesize_pipeline.py
+++ b/src/charter/synthesizer/synthesize_pipeline.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 from collections.abc import Mapping
 from typing import Any, Literal
 
@@ -45,7 +46,7 @@ from .adapter import AdapterOutput, SynthesisAdapter
 from .errors import SynthesisSchemaError
 from .interview_mapping import resolve_sections
 from .orchestrator import SynthesisResult
-from .request import SynthesisRequest, SynthesisTarget, compute_inputs_hash
+from .request import SynthesisRequest, SynthesisTarget, compute_inputs_hash, _evidence_to_jsonable
 from .targets import build_targets, detect_duplicates, order_targets
 
 
@@ -84,6 +85,11 @@ class ProvenanceEntry(BaseModel):
     """ISO 8601 UTC string from ``AdapterOutput.generated_at``."""
 
     adapter_notes: str | None = None
+    evidence_bundle_hash: str | None = None
+    """SHA-256 hex digest of the serialized EvidenceBundle, or None if absent."""
+
+    corpus_snapshot_id: str | None = None
+    """snapshot_id from EvidenceBundle.corpus_snapshot, or None if absent."""
 
     @model_validator(mode="after")
     def _check_source_provenance(self) -> ProvenanceEntry:
@@ -207,6 +213,31 @@ def _content_hash(yaml_bytes: bytes) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Evidence hash helper
+# ---------------------------------------------------------------------------
+
+
+def _compute_evidence_hashes(request: SynthesisRequest) -> tuple[str | None, str | None]:
+    """Return (evidence_bundle_hash, corpus_snapshot_id) for a SynthesisRequest.
+
+    Returns (None, None) when request.evidence is None or empty so that
+    ProvenanceEntry fields remain null for legacy requests.
+    """
+    if request.evidence is None or request.evidence.is_empty:
+        return None, None
+    evidence_bytes = json.dumps(
+        _evidence_to_jsonable(request.evidence), sort_keys=True, ensure_ascii=True
+    ).encode("utf-8")
+    evidence_hash = hashlib.sha256(evidence_bytes).hexdigest()
+    corpus_id = (
+        request.evidence.corpus_snapshot.snapshot_id
+        if request.evidence.corpus_snapshot is not None
+        else None
+    )
+    return evidence_hash, corpus_id
+
+
+# ---------------------------------------------------------------------------
 # Adapter dispatch helpers
 # ---------------------------------------------------------------------------
 
@@ -317,8 +348,12 @@ def run(
                 drg_snapshot=request.drg_snapshot,
                 run_id=request.run_id,
                 adapter_hints=request.adapter_hints,
+                evidence=request.evidence,
             )
         )
+
+    # Compute evidence hashes once — reused for all targets (same request evidence).
+    evidence_hash, corpus_id = _compute_evidence_hashes(request)
 
     # Stage 5: dispatch adapter
     outputs: list[AdapterOutput] = _dispatch_batch(adapter, per_target_requests)
@@ -363,6 +398,8 @@ def run(
             source_urns=list(target.source_urns),
             generated_at=generated_at_str,
             adapter_notes=output.notes,
+            evidence_bundle_hash=evidence_hash,
+            corpus_snapshot_id=corpus_id,
         )
 
         results.append((output.body, provenance))
@@ -445,9 +482,13 @@ def run_all(
             drg_snapshot=request.drg_snapshot,
             run_id=request.run_id,
             adapter_hints=request.adapter_hints,
+            evidence=request.evidence,
         )
         for t in all_targets
     ]
+
+    # Compute evidence hashes once — reused for all targets (same request evidence).
+    evidence_hash, corpus_id = _compute_evidence_hashes(request)
 
     outputs = _dispatch_batch(adapter, per_target_requests)
 
@@ -487,6 +528,8 @@ def run_all(
             source_urns=list(target.source_urns),
             generated_at=generated_at_str,
             adapter_notes=output.notes,
+            evidence_bundle_hash=evidence_hash,
+            corpus_snapshot_id=corpus_id,
         )
 
         results.append((output.body, provenance))

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -36,7 +36,8 @@ from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
-from .errors import StagingPromoteError
+from .errors import NeutralityGateViolation, StagingPromoteError
+from .evidence import EvidenceBundle
 from .manifest import (
     MANIFEST_PATH,
     ManifestArtifactEntry,
@@ -95,12 +96,115 @@ def _compute_content_hash(yaml_bytes: bytes) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Neutrality gate helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_generic_scoped(
+    target_kind: str,  # noqa: ARG001 — reserved for future kind-level rules
+    target_slug: str,
+    evidence: EvidenceBundle | None,
+) -> bool:
+    """Return True if this artifact slot should be checked for language-specific bias.
+
+    An artifact is generic-scoped when there is no code-signals scope_tag
+    or when the artifact slug does not contain the scope_tag as a component.
+    Conservative default: if evidence is absent, all artifacts are generic-scoped.
+
+    Scope determination rules:
+    - No evidence / no code_signals → generic (lint it)
+    - scope_tag == "unknown" → generic (lint it)
+    - scope_tag IS a substring of slug → language-scoped (skip lint)
+    - scope_tag NOT in slug → generic (lint it)
+
+    Example: scope_tag="python", slug="python-style-guide" → language-scoped (False)
+    Example: scope_tag="python", slug="testing-philosophy" → generic (True)
+    """
+    if evidence is None or evidence.code_signals is None:
+        return True  # no scope info → assume generic, apply lint
+
+    scope_tag = evidence.code_signals.scope_tag
+    if scope_tag == "unknown":
+        return True
+
+    # A language-scoped artifact slug typically contains the scope_tag as a component.
+    # e.g. "python-style-guide" contains "python"; "testing-philosophy" does not.
+    return scope_tag not in target_slug
+
+
+def _run_neutrality_gate(
+    staging_dir: StagingDir,
+    results: list[tuple[Any, ProvenanceEntry]],
+    evidence: EvidenceBundle | None,
+) -> None:
+    """Scan generic-scoped staged artifacts for language bias.
+
+    Iterates over all (body, provenance) results. For each artifact that is
+    generic-scoped (per ``_is_generic_scoped``), runs ``run_neutrality_lint``
+    on the staged content file. If any banned term is found, raises
+    ``NeutralityGateViolation`` immediately without promoting.
+
+    The staging directory is NOT wiped on gate failure — the caller's context
+    manager routes it to ``.failed/`` for operator inspection (KD-2, FR-011).
+
+    Parameters
+    ----------
+    staging_dir:
+        The active staging directory (pre-promote state).
+    results:
+        All ``(body, ProvenanceEntry)`` pairs from ``run_all()``.
+    evidence:
+        EvidenceBundle from the synthesis request, used to determine scope_tag.
+    """
+    from charter.neutrality.lint import run_neutrality_lint
+
+    for _body, prov in results:
+        kind = prov.artifact_kind
+        slug = prov.artifact_slug
+
+        if not _is_generic_scoped(kind, slug, evidence):
+            # Language-scoped artifact — language-specific terms are expected here.
+            continue
+
+        # Determine the staged content path for this specific artifact.
+        # The artifact_id is embedded in the URN for directives.
+        artifact_id: str | None = None
+        if kind == "directive":
+            artifact_id = prov.artifact_urn.split(":", 1)[1]
+        filename = _artifact_filename(kind, slug, artifact_id)
+        staged_path = staging_dir.path_for_content(kind, filename)
+
+        if not staged_path.exists():
+            # Staged file missing — skip (shouldn't happen in normal flow).
+            continue
+
+        # Scan only this specific staged file, treating the staging root as repo_root
+        # so that _repo_relative_string produces stable paths.
+        lint_result = run_neutrality_lint(
+            repo_root=staging_dir.root,
+            scan_roots=[staged_path],
+        )
+
+        # Gate only on actual banned-term hits — not on stale allowlist entries.
+        # Stale entries are expected when scanning staged files against the default
+        # allowlist (which references repo-relative paths that don't exist in staging).
+        if lint_result.hits:
+            # Collect up to 5 hit matches for the error message.
+            terms = tuple(hit.match for hit in lint_result.hits[:5])
+            raise NeutralityGateViolation(
+                artifact_urn=prov.artifact_urn,
+                detected_terms=terms,
+                staging_dir=staging_dir.root,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
 
 def promote(
-    request: SynthesisRequest,  # noqa: ARG001 — reserved for WP04/WP05 wiring
+    request: SynthesisRequest,
     staging_dir: StagingDir,
     results: list[tuple[Mapping[str, Any], ProvenanceEntry]],
     validation_callback: Callable[[StagingDir], None],
@@ -182,6 +286,16 @@ def promote(
     except Exception as exc:
         staging_dir.commit_to_failed(f"Validation failed: {exc}")
         raise
+
+    # ------------------------------------------------------------------
+    # Step 2b: neutrality lint gate (FR-011, FR-012)
+    #
+    # Runs AFTER validation and BEFORE the first os.replace call.
+    # Scans generic-scoped staged artifacts for language-specific bias.
+    # On NeutralityGateViolation the staging dir is NOT wiped — the
+    # StagingDir context manager in the caller routes it to .failed/.
+    # ------------------------------------------------------------------
+    _run_neutrality_gate(staging_dir, results, request.evidence)
 
     # ------------------------------------------------------------------
     # Step 3: ordered os.replace into final live trees
@@ -292,4 +406,4 @@ def promote(
     return manifest
 
 
-__all__ = ["promote"]
+__all__ = ["promote", "_is_generic_scoped", "_run_neutrality_gate"]

--- a/src/specify_cli/cli/commands/charter.py
+++ b/src/specify_cli/cli/commands/charter.py
@@ -505,6 +505,7 @@ def status(
 def _build_synthesis_request(
     repo_root: Path,
     adapter_name: str,
+    evidence: Any = None,
 ) -> tuple[Any, Any]:
     """Build a SynthesisRequest + adapter from the project's current interview state.
 
@@ -571,23 +572,69 @@ def _build_synthesis_request(
         doctrine_snapshot=doctrine_snapshot,
         drg_snapshot=drg_snapshot,
         run_id=run_id,
+        evidence=evidence,
     )
 
     if adapter_name == "fixture":
         adapter_obj = FixtureAdapter()
+    elif adapter_name == "production":
+        from charter.synthesizer.production_adapter import ProductionAdapter
+        model = _resolve_model_from_config(repo_root)
+        timeout = _resolve_timeout_from_config(repo_root)
+        adapter_obj = ProductionAdapter(model=model, timeout_seconds=timeout)
     else:
-        # Production adapter: not yet implemented; raise a helpful error
         from charter.synthesizer.errors import ProductionAdapterUnavailableError
         raise ProductionAdapterUnavailableError(
             adapter_id=adapter_name,
-            reason="Production LLM adapter is not yet configured",
+            reason=f"Unknown adapter '{adapter_name}'",
             remediation=(
                 "Use '--adapter fixture' for testing with pre-recorded fixtures, "
-                "or configure an LLM adapter in .kittify/config.yaml."
+                "or '--adapter production' to call the Anthropic Claude API."
             ),
         )
 
     return request, adapter_obj
+
+
+def _load_kittify_config(repo_root: Path) -> dict[str, Any]:
+    """Load .kittify/config.yaml as a plain dict. Returns {} on any error."""
+    config_path = repo_root / ".kittify" / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import ruamel.yaml
+        yaml = ruamel.yaml.YAML()
+        with config_path.open() as fh:
+            result = yaml.load(fh)
+        return dict(result) if isinstance(result, dict) else {}
+    except Exception:
+        return {}
+
+
+def _resolve_model_from_config(repo_root: Path) -> str:
+    """Return the synthesis model from config, defaulting to claude-sonnet-4-6 (ADR-6)."""
+    config = _load_kittify_config(repo_root)
+    model = (
+        config.get("charter", {})
+        .get("synthesis", {})
+        .get("model", "")
+    )
+    return str(model) if model else "claude-sonnet-4-6"
+
+
+def _resolve_timeout_from_config(repo_root: Path) -> int:
+    """Return the synthesis timeout in seconds from config, defaulting to 120."""
+    config = _load_kittify_config(repo_root)
+    timeout = (
+        config.get("charter", {})
+        .get("synthesis", {})
+        .get("timeout_seconds", 0)
+    )
+    try:
+        val = int(timeout)
+        return val if val > 0 else 120
+    except (TypeError, ValueError):
+        return 120
 
 
 @app.command("synthesize")
@@ -603,6 +650,21 @@ def charter_synthesize(
         help="Stage and validate artifacts but do not promote to live tree.",
     ),
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+    skip_code_evidence: bool = typer.Option(
+        False,
+        "--skip-code-evidence",
+        help="Skip code-reading evidence collection.",
+    ),
+    skip_corpus: bool = typer.Option(
+        False,
+        "--skip-corpus",
+        help="Skip best-practice corpus loading.",
+    ),
+    dry_run_evidence: bool = typer.Option(
+        False,
+        "--dry-run-evidence",
+        help="Print evidence summary and exit without running synthesis.",
+    ),
 ) -> None:
     """Generate project-local doctrine from interview answers (full synthesis).
 
@@ -619,13 +681,48 @@ def charter_synthesize(
 
         spec-kitty charter synthesize --adapter fixture --dry-run
     """
-    from charter.synthesizer.errors import SynthesisError, render_error_panel
+    from charter.evidence.orchestrator import EvidenceOrchestrator, load_url_list_from_config
+    from charter.synthesizer.errors import NeutralityGateViolation, SynthesisError, render_error_panel
 
     err_console = Console(stderr=True)
 
     try:
         repo_root = find_repo_root()
-        request, syn_adapter = _build_synthesis_request(repo_root, adapter)
+
+        # Collect evidence before building the synthesis request
+        url_list = load_url_list_from_config(repo_root)
+        orchestrator = EvidenceOrchestrator(
+            repo_root=repo_root,
+            url_list=url_list,
+            skip_code=skip_code_evidence,
+            skip_corpus=skip_corpus,
+        )
+        evidence_result = orchestrator.collect()
+        for warning in evidence_result.warnings:
+            console.print(f"[yellow]\u26a0 {warning}[/yellow]")
+
+        if dry_run_evidence:
+            bundle = evidence_result.bundle
+            console.print("[bold]Evidence dry-run summary:[/bold]")
+            if bundle.code_signals:
+                cs = bundle.code_signals
+                console.print(f"  Code signals: stack={cs.stack_id}, lang={cs.primary_language}")
+                console.print(f"  Representative files: {len(cs.representative_files)} found")
+            else:
+                console.print("  Code signals: none (skipped or not detected)")
+            console.print(f"  URL list: {len(bundle.url_list)} URL(s) configured")
+            if bundle.corpus_snapshot:
+                console.print(
+                    f"  Corpus: {bundle.corpus_snapshot.snapshot_id} "
+                    f"({len(bundle.corpus_snapshot.entries)} entries)"
+                )
+            else:
+                console.print("  Corpus: none")
+            for w in evidence_result.warnings:
+                console.print(f"  [yellow]Warning: {w}[/yellow]")
+            raise typer.Exit(0)
+
+        request, syn_adapter = _build_synthesis_request(repo_root, adapter, evidence=evidence_result.bundle)
 
         if dry_run:
             # Dry-run: stage but do not promote
@@ -669,6 +766,15 @@ def charter_synthesize(
         console.print(f"Primary artifact: {result.target_kind}:{result.target_slug}")
         console.print(f"Adapter: {result.effective_adapter_id} v{result.effective_adapter_version}")
 
+    except typer.Exit:
+        raise
+    except NeutralityGateViolation as e:
+        render_error_panel(e, err_console)
+        err_console.print(
+            f"\n[yellow]Staging directory preserved at:[/yellow] {e.staging_dir}\n"
+            "Inspect the staged artifacts, adjust the synthesis prompt or scope, and retry."
+        )
+        raise typer.Exit(code=1) from e
     except SynthesisError as e:
         render_error_panel(e, err_console)
         raise typer.Exit(code=1) from e

--- a/tests/charter/evidence/test_code_reader.py
+++ b/tests/charter/evidence/test_code_reader.py
@@ -1,0 +1,190 @@
+"""Tests for CodeReadingCollector.
+
+Each test creates a synthetic project in tmp_path so the suite is
+fully self-contained and does not depend on the real spec-kitty repo layout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from charter.evidence.code_reader import CodeReadingCollector, CodeReadingError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_file(path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Python / Django / pytest project
+# ---------------------------------------------------------------------------
+
+
+def test_python_django_pytest(tmp_path):
+    """Detect python+django+pytest from a canonical Django project layout."""
+    _make_file(tmp_path / "pyproject.toml", "[tool.poetry]\nname = 'myapp'")
+    _make_file(tmp_path / "manage.py", "#!/usr/bin/env python")
+    _make_file(tmp_path / "conftest.py", "import pytest")
+    _make_file(tmp_path / "myapp" / "views.py", "from django.http import HttpResponse")
+    _make_file(tmp_path / "tests" / "test_views.py", "def test_index(): pass")
+
+    signals = CodeReadingCollector(tmp_path).collect()
+
+    assert signals.stack_id == "python+django+pytest"
+    assert signals.primary_language == "python"
+    assert signals.scope_tag == "python"
+    assert "django" in signals.frameworks
+    assert "pytest" in signals.test_frameworks
+
+
+# ---------------------------------------------------------------------------
+# Test 2: TypeScript / Next.js / Jest
+# ---------------------------------------------------------------------------
+
+
+def test_typescript_nextjs_jest(tmp_path):
+    """Detect typescript+nextjs+jest from a Next.js project layout."""
+    _make_file(tmp_path / "package.json", '{"name":"myapp"}')
+    _make_file(tmp_path / "tsconfig.json", '{"compilerOptions":{}}')
+    _make_file(tmp_path / "next.config.ts", "export default {};")
+    _make_file(tmp_path / "jest.config.ts", "export default {};")
+    _make_file(tmp_path / "src" / "index.ts", "export const x = 1;")
+    _make_file(tmp_path / "__tests__" / "index.test.ts", "test('x', () => {});")
+
+    signals = CodeReadingCollector(tmp_path).collect()
+
+    assert signals.stack_id == "typescript+nextjs+jest"
+    assert signals.primary_language == "typescript"
+    assert "nextjs" in signals.frameworks
+    assert "jest" in signals.test_frameworks
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Go project
+# ---------------------------------------------------------------------------
+
+
+def test_go_project(tmp_path):
+    """Detect go from a minimal Go project."""
+    _make_file(tmp_path / "go.mod", "module example.com/myapp\n\ngo 1.21")
+    _make_file(tmp_path / "main.go", "package main\n\nfunc main() {}")
+
+    signals = CodeReadingCollector(tmp_path).collect()
+
+    assert signals.primary_language == "go"
+    assert signals.stack_id == "go"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Unknown / empty directory
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_empty_dir(tmp_path):
+    """Empty directory returns unknown signals without raising."""
+    signals = CodeReadingCollector(tmp_path).collect()
+
+    assert signals.stack_id == "unknown"
+    assert signals.primary_language == "unknown"
+    assert signals.frameworks == ()
+    assert signals.test_frameworks == ()
+    assert signals.representative_files == ()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Exclusion of node_modules
+# ---------------------------------------------------------------------------
+
+
+def test_node_modules_excluded(tmp_path):
+    """Files inside node_modules must not appear in representative_files."""
+    _make_file(tmp_path / "package.json", '{"name":"myapp"}')
+    _make_file(tmp_path / "tsconfig.json", '{"compilerOptions":{}}')
+    _make_file(tmp_path / "src" / "index.ts", "export const x = 1;")
+    # Simulate a heavy transitive dependency that must NOT be walked
+    _make_file(tmp_path / "node_modules" / "heavy.ts", "export const y = 2;")
+
+    signals = CodeReadingCollector(tmp_path).collect()
+
+    for f in signals.representative_files:
+        assert "node_modules" not in f, (
+            f"Expected node_modules to be excluded but found: {f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Depth limit
+# ---------------------------------------------------------------------------
+
+
+def test_depth_limit(tmp_path):
+    """A file at depth 4 must not appear when max_depth=3."""
+    # depth 0: tmp_path
+    # depth 1: level1/
+    # depth 2: level1/level2/
+    # depth 3: level1/level2/level3/
+    # depth 4: level1/level2/level3/level4/  <- beyond limit
+    _make_file(tmp_path / "pyproject.toml", "")
+    deep_file = (
+        tmp_path / "level1" / "level2" / "level3" / "level4" / "deep.py"
+    )
+    _make_file(deep_file, "# deep")
+
+    signals = CodeReadingCollector(tmp_path, max_depth=3).collect()
+
+    for f in signals.representative_files:
+        assert "deep.py" not in f, (
+            f"File beyond max_depth should not appear: {f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Nonexistent root raises CodeReadingError
+# ---------------------------------------------------------------------------
+
+
+def test_nonexistent_root_raises(tmp_path):
+    """Passing a path that does not exist must raise CodeReadingError."""
+    missing = tmp_path / "nonexistent"
+    with pytest.raises(CodeReadingError):
+        CodeReadingCollector(missing).collect()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Performance — 1 000 Python files in < 5 seconds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(10)
+def test_performance_1000_files(tmp_path):
+    """collect() must complete in under 5 seconds on a 1 000-file tree."""
+    import time
+
+    _make_file(tmp_path / "pyproject.toml", "")
+
+    # Spread 1 000 files across 3 levels (≤ max_depth)
+    count = 0
+    for level1 in range(10):
+        for level2 in range(10):
+            for level3 in range(10):
+                f = (
+                    tmp_path
+                    / f"pkg{level1}"
+                    / f"sub{level2}"
+                    / f"mod{level3}.py"
+                )
+                _make_file(f, f"# {count}")
+                count += 1
+
+    start = time.monotonic()
+    signals = CodeReadingCollector(tmp_path).collect()
+    elapsed = time.monotonic() - start
+
+    assert signals.primary_language == "python"
+    assert elapsed < 5.0, f"collect() took {elapsed:.2f}s, expected < 5s"

--- a/tests/charter/evidence/test_corpus_loader.py
+++ b/tests/charter/evidence/test_corpus_loader.py
@@ -1,0 +1,66 @@
+import pytest
+from pathlib import Path
+from charter.evidence.corpus_loader import CorpusLoader, CorpusLoaderError
+
+
+def test_exact_match_python():
+    snap = CorpusLoader().load("python")
+    assert snap is not None
+    assert snap.profile_key == "python"
+    assert len(snap.entries) >= 3
+    assert snap.snapshot_id.startswith("python-v")
+
+
+def test_prefix_match():
+    """python+django+pytest resolves to python corpus."""
+    snap = CorpusLoader().load("python+django+pytest")
+    assert snap is not None
+    assert snap.profile_key == "python"
+
+
+def test_generic_fallback():
+    """Unknown language falls back to generic corpus."""
+    snap = CorpusLoader().load("rust")
+    assert snap is not None
+    assert snap.profile_key == "generic"
+
+
+def test_none_when_no_file(tmp_path):
+    """Returns None when no matching file and no generic fallback."""
+    loader = CorpusLoader(corpus_root=tmp_path)
+    result = loader.load("cobol")
+    assert result is None
+
+
+def test_snapshot_id_recorded():
+    snap = CorpusLoader().load("python")
+    assert snap is not None
+    assert snap.snapshot_id
+    assert "v" in snap.snapshot_id
+
+
+def test_javascript_corpus():
+    snap = CorpusLoader().load("javascript")
+    assert snap is not None
+    assert snap.profile_key == "javascript"
+    assert len(snap.entries) >= 2
+
+
+def test_loaded_at_is_iso_utc():
+    snap = CorpusLoader().load("python")
+    assert snap is not None
+    assert snap.loaded_at  # non-empty
+
+
+def test_malformed_snapshot_id_raises(tmp_path):
+    """CorpusLoaderError raised on invalid snapshot_id format."""
+    bad_yaml = (
+        "schema_version: '1'\n"
+        "profile_key: test\n"
+        "snapshot_id: INVALID_FORMAT\n"
+        "entries: []\n"
+    )
+    (tmp_path / "test.corpus.yaml").write_text(bad_yaml)
+    loader = CorpusLoader(corpus_root=tmp_path)
+    with pytest.raises((CorpusLoaderError, ValueError)):
+        loader.load("test")

--- a/tests/charter/evidence/test_orchestrator.py
+++ b/tests/charter/evidence/test_orchestrator.py
@@ -1,0 +1,126 @@
+"""Tests for EvidenceOrchestrator and load_url_list_from_config."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import ruamel.yaml
+
+from charter.evidence.orchestrator import (
+    EvidenceOrchestrator,
+    EvidenceResult,
+    load_url_list_from_config,
+)
+
+
+def test_full_collection_returns_bundle(tmp_path: Path) -> None:
+    """With a Python project, both code signals and corpus are populated."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+    (tmp_path / "main.py").write_text("# main\n")
+    orch = EvidenceOrchestrator(repo_root=tmp_path, url_list=("https://example.com",))
+    result = orch.collect()
+    assert isinstance(result, EvidenceResult)
+    assert result.bundle.code_signals is not None
+    assert result.bundle.code_signals.primary_language == "python"
+    assert result.bundle.url_list == ("https://example.com",)
+    assert result.bundle.corpus_snapshot is not None  # generic fallback at minimum
+    assert result.warnings == []
+
+
+def test_code_failure_emits_warning(tmp_path: Path) -> None:
+    """Code-reading failure -> warning, synthesis proceeds with None code_signals."""
+    orch = EvidenceOrchestrator(repo_root=tmp_path / "nonexistent")
+    result = orch.collect()
+    assert result.bundle.code_signals is None
+    assert any("code-reading" in w.lower() for w in result.warnings)
+
+
+def test_skip_code_evidence(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("")
+    orch = EvidenceOrchestrator(repo_root=tmp_path, skip_code=True)
+    result = orch.collect()
+    assert result.bundle.code_signals is None
+    assert result.warnings == [] or all("corpus" in w.lower() for w in result.warnings)
+
+
+def test_skip_corpus(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("")
+    orch = EvidenceOrchestrator(repo_root=tmp_path, skip_corpus=True)
+    result = orch.collect()
+    assert result.bundle.corpus_snapshot is None
+
+
+def test_url_list_assembled(tmp_path: Path) -> None:
+    urls = ("https://a.example.com", "https://b.example.com")
+    orch = EvidenceOrchestrator(repo_root=tmp_path, url_list=urls)
+    result = orch.collect()
+    assert result.bundle.url_list == urls
+
+
+def test_load_url_list_absent(tmp_path: Path) -> None:
+    assert load_url_list_from_config(tmp_path) == ()
+
+
+def test_load_url_list_present(tmp_path: Path) -> None:
+    kittify = tmp_path / ".kittify"
+    kittify.mkdir()
+    yaml = ruamel.yaml.YAML()
+    config = {"charter": {"synthesis_inputs": {"url_list": ["https://x.com", "https://y.com"]}}}
+    with (kittify / "config.yaml").open("w") as fh:
+        yaml.dump(config, fh)
+    result = load_url_list_from_config(tmp_path)
+    assert set(result) == {"https://x.com", "https://y.com"}
+
+
+def test_bundle_is_empty_when_all_skipped(tmp_path: Path) -> None:
+    orch = EvidenceOrchestrator(repo_root=tmp_path, skip_code=True, skip_corpus=True)
+    result = orch.collect()
+    assert result.bundle.code_signals is None
+    assert result.bundle.corpus_snapshot is None
+    assert result.bundle.url_list == ()
+    assert result.bundle.is_empty
+
+
+@pytest.mark.integration
+def test_dry_run_evidence_on_spec_kitty_repo() -> None:
+    """charter synthesize --adapter fixture --dry-run-evidence exits 0 and detects a language.
+
+    spec-kitty has both Python indicators (pyproject.toml, src/specify_cli/) and JavaScript
+    indicators (package.json for Playwright/test tooling), so the heuristic detector may
+    legitimately select either 'python' or 'javascript' as the primary language.  The test
+    verifies that the detector commits to a specific, non-unknown language rather than
+    checking for a particular one — either is acceptable (acceptance criterion #9).
+    """
+    import os
+
+    repo_root = Path(__file__).parent.parent.parent.parent  # root of spec-kitty repo in worktree
+    src_path = str(repo_root / "src")
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{src_path}:{existing_pythonpath}" if existing_pythonpath else src_path
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "specify_cli",
+            "charter",
+            "synthesize",
+            "--adapter",
+            "fixture",
+            "--dry-run-evidence",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "Evidence dry-run summary" in result.stdout
+    assert "Code signals:" in result.stdout
+    # spec-kitty has both pyproject.toml (Python) and package.json (JavaScript tooling),
+    # so either language is a valid detection outcome — but "unknown" is not acceptable.
+    assert "lang=python" in result.stdout or "lang=javascript" in result.stdout, (
+        f"Expected lang=python or lang=javascript in output, got:\n{result.stdout}"
+    )

--- a/tests/charter/fixtures/synthesizer/styleguide/testing-style-guide/989fe75fe842.styleguide.yaml
+++ b/tests/charter/fixtures/synthesizer/styleguide/testing-style-guide/989fe75fe842.styleguide.yaml
@@ -13,5 +13,5 @@ anti_patterns:
     bad_example: "assert obj._internal_cache == {...}"
     good_example: "assert obj.get_result() == expected_value"
 tooling:
-  framework: pytest
-  coverage: pytest-cov
+  framework: your-project-test-runner
+  coverage: your-project-coverage-tool

--- a/tests/charter/fixtures/synthesizer/tactic/biased-generic-tactic/f1b5d4c7f2d3.tactic.yaml
+++ b/tests/charter/fixtures/synthesizer/tactic/biased-generic-tactic/f1b5d4c7f2d3.tactic.yaml
@@ -1,0 +1,12 @@
+id: biased-generic-tactic
+schema_version: '1.0'
+name: Biased Generic Tactic
+purpose: >
+  A deliberately biased generic tactic used in integration tests to verify
+  that the neutrality gate rejects language-specific terms in generic artifacts.
+steps:
+  - title: Always run pytest
+    description: >
+      Always run pytest to verify your code. Configure pytest.ini for test
+      discovery. Use pytest-cov to measure coverage. Install junit-xml reporter
+      for CI integration.

--- a/tests/charter/fixtures/synthesizer/tactic/how-we-apply-directive-010/b606c08cd95c.tactic.yaml
+++ b/tests/charter/fixtures/synthesizer/tactic/how-we-apply-directive-010/b606c08cd95c.tactic.yaml
@@ -1,0 +1,20 @@
+id: how-we-apply-directive-010
+schema_version: '1.0'
+name: How We Apply DIRECTIVE_010
+purpose: >
+  Describes how this project implements and enforces DIRECTIVE_010 in practice,
+  drawing on Python best practices and the project corpus guidance.
+steps:
+  - title: Test at multiple levels
+    description: >
+      Write unit tests for business logic, integration tests for system
+      boundaries, and a small suite of end-to-end tests for critical paths.
+      Fast tests run on every commit; the full suite runs in CI.
+  - title: Apply Python testing idioms
+    description: >
+      Python projects use pytest with fixture injection and parametrize for
+      expressive test cases. Configure coverage thresholds in pyproject.toml.
+  - title: Review coverage before merging
+    description: >
+      Confirm that coverage meets or exceeds the project threshold before
+      opening a pull request.

--- a/tests/charter/synthesizer/test_evidence.py
+++ b/tests/charter/synthesizer/test_evidence.py
@@ -1,0 +1,231 @@
+"""Invariant tests for EvidenceBundle and related frozen dataclasses.
+
+Nine test cases covering:
+1. EvidenceBundle.is_empty is True for all defaults.
+2. EvidenceBundle.is_empty is False when any field is non-empty.
+3. CodeSignals raises ValueError when scope_tag != primary_language.
+4. CodeSignals raises ValueError for invalid stack_id format.
+5. CodeSignals raises ValueError for representative_files with leading slash.
+6. CorpusSnapshot raises ValueError for invalid snapshot_id format.
+7. EvidenceBundle raises ValueError for url_list with empty strings.
+8. All four dataclasses are frozen (FrozenInstanceError on mutation).
+9. All four dataclasses are hashable (usable as dict keys / in sets).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from charter.synthesizer.evidence import (
+    CodeSignals,
+    CorpusEntry,
+    CorpusSnapshot,
+    EvidenceBundle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal valid instances
+# ---------------------------------------------------------------------------
+
+def _make_code_signals(**overrides: object) -> CodeSignals:
+    defaults = dict(
+        stack_id="python",
+        primary_language="python",
+        frameworks=("django",),
+        test_frameworks=("pytest",),
+        scope_tag="python",
+        representative_files=("src/main.py",),
+        detected_at="2026-04-19T10:00:00+00:00",
+    )
+    defaults.update(overrides)  # type: ignore[arg-type]
+    return CodeSignals(**defaults)  # type: ignore[arg-type]
+
+
+def _make_corpus_entry(**overrides: object) -> CorpusEntry:
+    defaults = dict(
+        topic="testing",
+        tags=("quality", "coverage"),
+        guidance="Write tests for all public APIs.",
+    )
+    defaults.update(overrides)  # type: ignore[arg-type]
+    return CorpusEntry(**defaults)  # type: ignore[arg-type]
+
+
+def _make_corpus_snapshot(**overrides: object) -> CorpusSnapshot:
+    defaults = dict(
+        snapshot_id="python-v1.0.0",
+        profile_key="python",
+        entries=(_make_corpus_entry(),),
+        loaded_at="2026-04-19T10:00:00+00:00",
+    )
+    defaults.update(overrides)  # type: ignore[arg-type]
+    return CorpusSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+def _make_bundle(**overrides: object) -> EvidenceBundle:
+    return EvidenceBundle(**overrides)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Case 1: is_empty True when all defaults
+# ---------------------------------------------------------------------------
+
+def test_evidence_bundle_default_is_empty() -> None:
+    """EvidenceBundle() with all defaults reports is_empty=True."""
+    bundle = EvidenceBundle()
+    assert bundle.is_empty is True
+
+
+# ---------------------------------------------------------------------------
+# Case 2: is_empty False when any field is non-empty
+# ---------------------------------------------------------------------------
+
+def test_evidence_bundle_not_empty_with_code_signals() -> None:
+    bundle = EvidenceBundle(code_signals=_make_code_signals())
+    assert bundle.is_empty is False
+
+
+def test_evidence_bundle_not_empty_with_url_list() -> None:
+    bundle = EvidenceBundle(url_list=("https://example.com",))
+    assert bundle.is_empty is False
+
+
+def test_evidence_bundle_not_empty_with_corpus_snapshot() -> None:
+    bundle = EvidenceBundle(corpus_snapshot=_make_corpus_snapshot())
+    assert bundle.is_empty is False
+
+
+# ---------------------------------------------------------------------------
+# Case 3: scope_tag != primary_language raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_code_signals_scope_tag_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="scope_tag must equal primary_language"):
+        _make_code_signals(scope_tag="javascript")
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Invalid stack_id format raises ValueError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_stack_id", [
+    "Python",       # uppercase
+    "123python",    # starts with digit
+    "",             # empty string
+    "py thon",      # space
+    "_python",      # leading underscore
+])
+def test_code_signals_invalid_stack_id_raises(bad_stack_id: str) -> None:
+    with pytest.raises(ValueError, match="Invalid stack_id format"):
+        _make_code_signals(stack_id=bad_stack_id)
+
+
+def test_code_signals_valid_stack_id_with_plus() -> None:
+    """stack_id may contain '+' (e.g. 'c++')."""
+    cs = _make_code_signals(stack_id="c++", primary_language="c++", scope_tag="c++")
+    assert cs.stack_id == "c++"
+
+
+# ---------------------------------------------------------------------------
+# Case 5: representative_files with leading slash raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_code_signals_leading_slash_in_files_raises() -> None:
+    with pytest.raises(ValueError, match="repo-relative paths without leading slash"):
+        _make_code_signals(representative_files=("/absolute/path.py",))
+
+
+def test_code_signals_empty_string_in_files_raises() -> None:
+    with pytest.raises(ValueError, match="repo-relative paths without leading slash"):
+        _make_code_signals(representative_files=("",))
+
+
+# ---------------------------------------------------------------------------
+# Case 6: Invalid snapshot_id format raises ValueError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_snapshot_id", [
+    "Python-v1.0.0",    # uppercase
+    "python-1.0.0",     # missing 'v' prefix
+    "python-v1",        # incomplete semver
+    "python-v1.0",      # incomplete semver (two parts only)
+    "",                 # empty string
+    "python_v1.0.0",    # underscore instead of hyphen before v
+])
+def test_corpus_snapshot_invalid_id_raises(bad_snapshot_id: str) -> None:
+    with pytest.raises(ValueError, match="Invalid snapshot_id format"):
+        _make_corpus_snapshot(snapshot_id=bad_snapshot_id)
+
+
+def test_corpus_snapshot_valid_id() -> None:
+    snap = _make_corpus_snapshot(snapshot_id="python-v2.10.3")
+    assert snap.snapshot_id == "python-v2.10.3"
+
+
+# ---------------------------------------------------------------------------
+# Case 7: url_list with empty string raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_evidence_bundle_empty_url_raises() -> None:
+    with pytest.raises(ValueError, match="url_list must not contain empty strings"):
+        EvidenceBundle(url_list=("https://example.com", ""))
+
+
+# ---------------------------------------------------------------------------
+# Case 8: Frozen dataclasses raise FrozenInstanceError on mutation
+# ---------------------------------------------------------------------------
+
+def test_code_signals_is_frozen() -> None:
+    cs = _make_code_signals()
+    with pytest.raises(Exception):  # FrozenInstanceError
+        cs.stack_id = "new-id"  # type: ignore[misc]
+
+
+def test_corpus_entry_is_frozen() -> None:
+    entry = _make_corpus_entry()
+    with pytest.raises(Exception):
+        entry.topic = "other"  # type: ignore[misc]
+
+
+def test_corpus_snapshot_is_frozen() -> None:
+    snap = _make_corpus_snapshot()
+    with pytest.raises(Exception):
+        snap.snapshot_id = "other-v1.0.0"  # type: ignore[misc]
+
+
+def test_evidence_bundle_is_frozen() -> None:
+    bundle = EvidenceBundle()
+    with pytest.raises(Exception):
+        bundle.collected_at = "2026-01-01T00:00:00+00:00"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Case 9: All dataclasses are hashable
+# ---------------------------------------------------------------------------
+
+def test_all_dataclasses_are_hashable() -> None:
+    cs = _make_code_signals()
+    entry = _make_corpus_entry()
+    snap = _make_corpus_snapshot()
+    bundle = EvidenceBundle(
+        code_signals=cs,
+        url_list=("https://example.com",),
+        corpus_snapshot=snap,
+    )
+
+    # Usable as dict keys
+    d = {cs: "code_signals", entry: "entry", snap: "snap", bundle: "bundle"}
+    assert len(d) == 4
+
+    # Usable in sets
+    s = {cs, entry, snap, bundle}
+    assert len(s) == 4
+
+
+def test_identical_bundles_have_same_hash() -> None:
+    """Two EvidenceBundles with identical content hash to the same value."""
+    b1 = EvidenceBundle(url_list=("https://a.com", "https://b.com"))
+    b2 = EvidenceBundle(url_list=("https://a.com", "https://b.com"))
+    assert hash(b1) == hash(b2)
+    assert b1 == b2

--- a/tests/charter/synthesizer/test_production_adapter.py
+++ b/tests/charter/synthesizer/test_production_adapter.py
@@ -1,0 +1,268 @@
+"""Unit tests for ProductionAdapter.
+
+All tests mock the Anthropic client — no live API calls.
+Live-API tests are decorated @pytest.mark.live_adapter and skipped by default.
+"""
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from charter.synthesizer.adapter import AdapterOutput, SynthesisAdapter
+from charter.synthesizer.errors import ProductionAdapterUnavailableError
+from charter.synthesizer.production_adapter import ProductionAdapter, _DEFAULT_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def minimal_request():
+    from charter.synthesizer.request import SynthesisRequest, SynthesisTarget
+
+    return SynthesisRequest(
+        target=SynthesisTarget(
+            kind="tactic",
+            slug="how-we-work",
+            title="How We Work",
+            artifact_id="how-we-work",
+            source_section="testing_philosophy",
+            source_urns=("urn:drg:directive:DIRECTIVE_010",),
+        ),
+        interview_snapshot={"testing_philosophy": "We test everything."},
+        doctrine_snapshot={},
+        drg_snapshot={},
+        run_id="test-run",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instantiation tests
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(ProductionAdapterUnavailableError) as exc_info:
+        ProductionAdapter()
+    # The error string must mention ANTHROPIC_API_KEY
+    assert "ANTHROPIC_API_KEY" in str(exc_info.value)
+
+
+def test_adapter_id_is_production():
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("anthropic.Anthropic"):
+            adapter = ProductionAdapter()
+    assert adapter.id == "production"
+
+
+def test_adapter_version_defaults_to_default_model():
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("anthropic.Anthropic"):
+            adapter = ProductionAdapter()
+    assert adapter.version == _DEFAULT_MODEL
+
+
+def test_version_reflects_custom_model():
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("anthropic.Anthropic"):
+            adapter = ProductionAdapter(model="claude-opus-4-7")
+    assert adapter.version == "claude-opus-4-7"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_conformance():
+    """ProductionAdapter must satisfy SynthesisAdapter protocol at runtime."""
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("anthropic.Anthropic"):
+            adapter = ProductionAdapter()
+    assert isinstance(adapter, SynthesisAdapter)
+
+
+# ---------------------------------------------------------------------------
+# generate() tests
+# ---------------------------------------------------------------------------
+
+
+@patch("anthropic.Anthropic")
+def test_generate_returns_adapter_output(mock_cls, minimal_request):
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text="Generated content")]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    output = adapter.generate(minimal_request)
+
+    assert isinstance(output, AdapterOutput)
+
+
+@patch("anthropic.Anthropic")
+def test_generate_body_contains_text(mock_cls, minimal_request):
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text="Generated content")]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    output = adapter.generate(minimal_request)
+
+    # AdapterOutput.body is Mapping[str, Any]
+    assert "text" in output.body
+    assert output.body["text"] == "Generated content"
+
+
+@patch("anthropic.Anthropic")
+def test_generate_sets_generated_at(mock_cls, minimal_request):
+    import datetime
+
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text="some output")]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    output = adapter.generate(minimal_request)
+
+    assert isinstance(output.generated_at, datetime.datetime)
+    assert output.generated_at.tzinfo is not None  # must be timezone-aware
+
+
+@patch("anthropic.Anthropic")
+def test_generate_concatenates_multiple_content_blocks(mock_cls, minimal_request):
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    block1 = MagicMock(text="Hello ")
+    block2 = MagicMock(text="World")
+    mock_message.content = [block1, block2]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    output = adapter.generate(minimal_request)
+
+    assert output.body["text"] == "Hello World"
+
+
+# ---------------------------------------------------------------------------
+# Error handling tests
+# ---------------------------------------------------------------------------
+
+
+@patch("anthropic.Anthropic")
+def test_timeout_raises_unavailable_error(mock_cls, minimal_request):
+    import anthropic as anthropic_module
+
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_client.messages.create.side_effect = anthropic_module.APITimeoutError(
+        request=MagicMock()
+    )
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    with pytest.raises(ProductionAdapterUnavailableError) as exc_info:
+        adapter.generate(minimal_request)
+    assert "timed out" in str(exc_info.value)
+
+
+@patch("anthropic.Anthropic")
+def test_api_error_raises_unavailable_error(mock_cls, minimal_request):
+    import anthropic as anthropic_module
+
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_client.messages.create.side_effect = anthropic_module.APIStatusError(
+        message="Unauthorized",
+        response=mock_response,
+        body={"error": {"type": "authentication_error", "message": "Unauthorized"}},
+    )
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    with pytest.raises(ProductionAdapterUnavailableError) as exc_info:
+        adapter.generate(minimal_request)
+    assert "Claude API error" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# generate_batch() tests
+# ---------------------------------------------------------------------------
+
+
+@patch("anthropic.Anthropic")
+def test_generate_batch_returns_list(mock_cls, minimal_request):
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text="output")]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    outputs = adapter.generate_batch([minimal_request, minimal_request])
+
+    assert len(outputs) == 2
+    for output in outputs:
+        assert isinstance(output, AdapterOutput)
+
+
+# ---------------------------------------------------------------------------
+# Seam lint tests (adapter.py must remain unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_seam_has_synthesis_adapter():
+    from charter.synthesizer import adapter as seam_module
+
+    assert hasattr(seam_module, "SynthesisAdapter")
+
+
+def test_adapter_seam_has_adapter_output():
+    from charter.synthesizer import adapter as seam_module
+
+    assert hasattr(seam_module, "AdapterOutput")
+
+
+def test_adapter_seam_has_batch_capable():
+    from charter.synthesizer import adapter as seam_module
+
+    assert hasattr(seam_module, "BatchCapableSynthesisAdapter")
+
+
+def test_adapter_seam_generate_signature():
+    from charter.synthesizer import adapter as seam_module
+
+    sig = inspect.signature(seam_module.SynthesisAdapter.generate)
+    assert "request" in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# Live adapter test — skipped in CI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.live_adapter
+def test_live_generate(minimal_request):  # pragma: no cover
+    """Live integration test — skipped unless -m live_adapter is passed."""
+    adapter = ProductionAdapter()  # requires ANTHROPIC_API_KEY in env
+    output = adapter.generate(minimal_request)
+    assert output.body
+    assert output.generated_at

--- a/tests/charter/synthesizer/test_production_adapter.py
+++ b/tests/charter/synthesizer/test_production_adapter.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from charter.synthesizer.adapter import AdapterOutput, SynthesisAdapter
-from charter.synthesizer.errors import ProductionAdapterUnavailableError
+from charter.synthesizer.errors import ProductionAdapterUnavailableError, SynthesisSchemaError
 from charter.synthesizer.production_adapter import ProductionAdapter, _DEFAULT_MODEL
 
 
@@ -97,7 +97,7 @@ def test_generate_returns_adapter_output(mock_cls, minimal_request):
     mock_client = MagicMock()
     mock_cls.return_value = mock_client
     mock_message = MagicMock()
-    mock_message.content = [MagicMock(text="Generated content")]
+    mock_message.content = [MagicMock(text="id: how-we-work\nschema_version: \"1.0\"\nname: How We Work\nsteps:\n  - title: Start here\n")]
     mock_client.messages.create.return_value = mock_message
 
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
@@ -112,16 +112,16 @@ def test_generate_body_contains_text(mock_cls, minimal_request):
     mock_client = MagicMock()
     mock_cls.return_value = mock_client
     mock_message = MagicMock()
-    mock_message.content = [MagicMock(text="Generated content")]
+    mock_message.content = [MagicMock(text="id: how-we-work\nschema_version: \"1.0\"\nname: How We Work\nsteps:\n  - title: Start here\n")]
     mock_client.messages.create.return_value = mock_message
 
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
         adapter = ProductionAdapter()
     output = adapter.generate(minimal_request)
 
-    # AdapterOutput.body is Mapping[str, Any]
-    assert "text" in output.body
-    assert output.body["text"] == "Generated content"
+    assert output.body["id"] == "how-we-work"
+    assert output.body["name"] == "How We Work"
+    assert output.body["steps"][0]["title"] == "Start here"
 
 
 @patch("anthropic.Anthropic")
@@ -131,7 +131,7 @@ def test_generate_sets_generated_at(mock_cls, minimal_request):
     mock_client = MagicMock()
     mock_cls.return_value = mock_client
     mock_message = MagicMock()
-    mock_message.content = [MagicMock(text="some output")]
+    mock_message.content = [MagicMock(text="id: how-we-work\nschema_version: \"1.0\"\nname: How We Work\nsteps:\n  - title: Start here\n")]
     mock_client.messages.create.return_value = mock_message
 
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
@@ -147,8 +147,8 @@ def test_generate_concatenates_multiple_content_blocks(mock_cls, minimal_request
     mock_client = MagicMock()
     mock_cls.return_value = mock_client
     mock_message = MagicMock()
-    block1 = MagicMock(text="Hello ")
-    block2 = MagicMock(text="World")
+    block1 = MagicMock(text="id: how-we-work\nschema_version: \"1.0\"\n")
+    block2 = MagicMock(text="name: How We Work\nsteps:\n  - title: Start here\n")
     mock_message.content = [block1, block2]
     mock_client.messages.create.return_value = mock_message
 
@@ -156,7 +156,41 @@ def test_generate_concatenates_multiple_content_blocks(mock_cls, minimal_request
         adapter = ProductionAdapter()
     output = adapter.generate(minimal_request)
 
-    assert output.body["text"] == "Hello World"
+    assert output.body["id"] == "how-we-work"
+    assert output.body["steps"][0]["title"] == "Start here"
+
+
+@patch("anthropic.Anthropic")
+def test_generate_strips_yaml_fences(mock_cls, minimal_request):
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = [
+        MagicMock(
+            text="```yaml\nid: how-we-work\nschema_version: \"1.0\"\nname: How We Work\nsteps:\n  - title: Start here\n```"
+        )
+    ]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    output = adapter.generate(minimal_request)
+
+    assert output.body["id"] == "how-we-work"
+
+
+@patch("anthropic.Anthropic")
+def test_generate_invalid_yaml_raises_schema_error(mock_cls, minimal_request):
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text="not: [valid")]
+    mock_client.messages.create.return_value = mock_message
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        adapter = ProductionAdapter()
+    with pytest.raises(SynthesisSchemaError):
+        adapter.generate(minimal_request)
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +246,7 @@ def test_generate_batch_returns_list(mock_cls, minimal_request):
     mock_client = MagicMock()
     mock_cls.return_value = mock_client
     mock_message = MagicMock()
-    mock_message.content = [MagicMock(text="output")]
+    mock_message.content = [MagicMock(text="id: how-we-work\nschema_version: \"1.0\"\nname: How We Work\nsteps:\n  - title: Start here\n")]
     mock_client.messages.create.return_value = mock_message
 
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):

--- a/tests/charter/synthesizer/test_request.py
+++ b/tests/charter/synthesizer/test_request.py
@@ -1,0 +1,315 @@
+"""Tests for SynthesisRequest, SynthesisTarget, and normalize_request_for_hash.
+
+Covers:
+T001 — Backward-compat: existing requests (no evidence) produce identical hashes.
+T002 — EvidenceBundle() empty produces same hash as evidence=None.
+T003 — Non-empty code signals produce a different hash.
+T004 — URL list is order-insensitive.
+T005 — representative_files is order-insensitive.
+T006 — run_id is excluded from hash.
+T007 — detected_at is excluded from hash (timestamps do not affect hash).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from charter.synthesizer.evidence import (
+    CodeSignals,
+    CorpusEntry,
+    CorpusSnapshot,
+    EvidenceBundle,
+)
+from charter.synthesizer.request import (
+    SynthesisRequest,
+    SynthesisTarget,
+    compute_inputs_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture helpers
+# ---------------------------------------------------------------------------
+
+_ADAPTER_ID = "fixture"
+_ADAPTER_VERSION = "0.1.0"
+
+
+def _make_target() -> SynthesisTarget:
+    return SynthesisTarget(
+        kind="directive",
+        slug="project-decision-doc-directive",
+        title="Project Decision Documentation Directive",
+        artifact_id="PROJECT_001",
+        source_section="testing_philosophy",
+        source_urns=("directive:DIRECTIVE_003",),
+    )
+
+
+def _make_base_request(**overrides: object) -> SynthesisRequest:
+    """Create the canonical sample request (matches conftest.py fixture)."""
+    defaults: dict = dict(
+        target=_make_target(),
+        interview_snapshot={
+            "mission_type": "software_dev",
+            "language_scope": ["python"],
+            "testing_philosophy": "test-driven development with high coverage",
+            "neutrality_posture": "balanced",
+            "selected_directives": ["DIRECTIVE_003"],
+            "risk_appetite": "moderate",
+        },
+        doctrine_snapshot={
+            "directives": {
+                "DIRECTIVE_003": {
+                    "id": "DIRECTIVE_003",
+                    "title": "Decision Documentation",
+                    "body": "Document significant architectural decisions via ADRs.",
+                }
+            },
+            "tactics": {},
+            "styleguides": {},
+        },
+        drg_snapshot={
+            "nodes": [
+                {"urn": "directive:DIRECTIVE_003", "kind": "directive", "id": "DIRECTIVE_003"}
+            ],
+            "edges": [],
+            "schema_version": "1",
+        },
+        run_id="01KPE222CD1MMCYEGB3ZCY51VR",
+        adapter_hints={"language": "python"},
+    )
+    defaults.update(overrides)
+    return SynthesisRequest(**defaults)  # type: ignore[arg-type]
+
+
+def _make_code_signals(
+    *,
+    detected_at: str = "2026-04-19T10:00:00+00:00",
+) -> CodeSignals:
+    return CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=("django",),
+        test_frameworks=("pytest",),
+        scope_tag="python",
+        representative_files=("src/main.py", "src/utils.py"),
+        detected_at=detected_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T001 — Backward-compat: no evidence → byte-for-byte identical hash
+# ---------------------------------------------------------------------------
+
+# Hash recorded before WP01 was implemented (pre-evidence code path).
+# DO NOT change this value — it is the backward-compat anchor.
+_PRE_WP01_HASH = "7a21550328faa83b24c32270b97cb4abf34eb6e2558d029fe7b45fac4632ab7a"
+
+
+def test_backward_compat_no_evidence_hash_unchanged() -> None:
+    """Requests without evidence produce the same hash as the pre-WP01 code path."""
+    request = _make_base_request()
+    h = compute_inputs_hash(request, _ADAPTER_ID, _ADAPTER_VERSION)
+    assert h == _PRE_WP01_HASH, (
+        f"Hash changed! Got {h!r}, expected {_PRE_WP01_HASH!r}. "
+        "This breaks backward compatibility with existing fixtures. "
+        "See ADR-2026-04-17-1."
+    )
+
+
+def test_backward_compat_explicit_none_evidence_hash_unchanged() -> None:
+    """Explicitly passing evidence=None produces the same hash as the pre-WP01 path."""
+    request = _make_base_request(evidence=None)
+    h = compute_inputs_hash(request, _ADAPTER_ID, _ADAPTER_VERSION)
+    assert h == _PRE_WP01_HASH
+
+
+# ---------------------------------------------------------------------------
+# T002 — EvidenceBundle() empty produces same hash as evidence=None
+# ---------------------------------------------------------------------------
+
+def test_empty_evidence_bundle_same_hash_as_none() -> None:
+    """An empty EvidenceBundle (is_empty=True) does not change the hash."""
+    request_none = _make_base_request(evidence=None)
+    request_empty = _make_base_request(evidence=EvidenceBundle())
+
+    h_none = compute_inputs_hash(request_none, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_empty = compute_inputs_hash(request_empty, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_none == h_empty
+    assert h_empty == _PRE_WP01_HASH
+
+
+# ---------------------------------------------------------------------------
+# T003 — Non-empty code signals produce a different hash
+# ---------------------------------------------------------------------------
+
+def test_non_empty_code_signals_change_hash() -> None:
+    """Adding code signals to the evidence changes the fixture hash."""
+    request_no_evidence = _make_base_request(evidence=None)
+    request_with_signals = _make_base_request(
+        evidence=EvidenceBundle(code_signals=_make_code_signals())
+    )
+
+    h_base = compute_inputs_hash(request_no_evidence, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_signals = compute_inputs_hash(request_with_signals, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_base != h_signals
+
+
+def test_url_list_changes_hash() -> None:
+    """Adding URLs to the evidence changes the fixture hash."""
+    request_no_evidence = _make_base_request(evidence=None)
+    request_with_urls = _make_base_request(
+        evidence=EvidenceBundle(url_list=("https://example.com",))
+    )
+
+    h_base = compute_inputs_hash(request_no_evidence, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_urls = compute_inputs_hash(request_with_urls, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_base != h_urls
+
+
+def test_corpus_snapshot_changes_hash() -> None:
+    """Adding a corpus snapshot to the evidence changes the fixture hash."""
+    request_no_evidence = _make_base_request(evidence=None)
+    snap = CorpusSnapshot(
+        snapshot_id="python-v1.0.0",
+        profile_key="python",
+        entries=(CorpusEntry(topic="testing", tags=("quality",), guidance="Write tests."),),
+        loaded_at="2026-04-19T10:00:00+00:00",
+    )
+    request_with_corpus = _make_base_request(
+        evidence=EvidenceBundle(corpus_snapshot=snap)
+    )
+
+    h_base = compute_inputs_hash(request_no_evidence, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_corpus = compute_inputs_hash(request_with_corpus, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_base != h_corpus
+
+
+# ---------------------------------------------------------------------------
+# T004 — URL list is order-insensitive
+# ---------------------------------------------------------------------------
+
+def test_url_list_order_insensitive() -> None:
+    """("b", "a") and ("a", "b") produce the same hash."""
+    request_ab = _make_base_request(
+        evidence=EvidenceBundle(url_list=("https://a.com", "https://b.com"))
+    )
+    request_ba = _make_base_request(
+        evidence=EvidenceBundle(url_list=("https://b.com", "https://a.com"))
+    )
+
+    h_ab = compute_inputs_hash(request_ab, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_ba = compute_inputs_hash(request_ba, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_ab == h_ba
+
+
+# ---------------------------------------------------------------------------
+# T005 — representative_files is order-insensitive
+# ---------------------------------------------------------------------------
+
+def test_representative_files_order_insensitive() -> None:
+    """Different orderings of representative_files produce the same hash."""
+    signals_ab = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=("src/a.py", "src/b.py"),
+        detected_at="2026-04-19T10:00:00+00:00",
+    )
+    signals_ba = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=("src/b.py", "src/a.py"),
+        detected_at="2026-04-19T10:00:00+00:00",
+    )
+
+    request_ab = _make_base_request(evidence=EvidenceBundle(code_signals=signals_ab))
+    request_ba = _make_base_request(evidence=EvidenceBundle(code_signals=signals_ba))
+
+    h_ab = compute_inputs_hash(request_ab, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_ba = compute_inputs_hash(request_ba, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_ab == h_ba
+
+
+# ---------------------------------------------------------------------------
+# T006 — run_id is excluded from hash
+# ---------------------------------------------------------------------------
+
+def test_run_id_excluded_from_hash() -> None:
+    """Changing run_id does not change the fixture hash."""
+    request_a = _make_base_request(run_id="01AAAAAAAAAAAAAAAAAAAAAAAAA")
+    request_b = _make_base_request(run_id="01ZZZZZZZZZZZZZZZZZZZZZZZZZ")
+
+    h_a = compute_inputs_hash(request_a, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_b = compute_inputs_hash(request_b, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_a == h_b
+
+
+# ---------------------------------------------------------------------------
+# T007 — detected_at (and other timestamps) excluded from hash
+# ---------------------------------------------------------------------------
+
+def test_detected_at_excluded_from_hash() -> None:
+    """Same evidence with different detected_at timestamps produce the same hash."""
+    signals_t1 = _make_code_signals(detected_at="2026-01-01T00:00:00+00:00")
+    signals_t2 = _make_code_signals(detected_at="2026-12-31T23:59:59+00:00")
+
+    request_t1 = _make_base_request(evidence=EvidenceBundle(code_signals=signals_t1))
+    request_t2 = _make_base_request(evidence=EvidenceBundle(code_signals=signals_t2))
+
+    h_t1 = compute_inputs_hash(request_t1, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_t2 = compute_inputs_hash(request_t2, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_t1 == h_t2
+
+
+def test_corpus_loaded_at_excluded_from_hash() -> None:
+    """Same corpus snapshot with different loaded_at produces the same hash."""
+    snap_t1 = CorpusSnapshot(
+        snapshot_id="python-v1.0.0",
+        profile_key="python",
+        entries=(CorpusEntry(topic="testing", tags=("quality",), guidance="Write tests."),),
+        loaded_at="2026-01-01T00:00:00+00:00",
+    )
+    snap_t2 = CorpusSnapshot(
+        snapshot_id="python-v1.0.0",
+        profile_key="python",
+        entries=(CorpusEntry(topic="testing", tags=("quality",), guidance="Write tests."),),
+        loaded_at="2026-12-31T23:59:59+00:00",
+    )
+
+    request_t1 = _make_base_request(evidence=EvidenceBundle(corpus_snapshot=snap_t1))
+    request_t2 = _make_base_request(evidence=EvidenceBundle(corpus_snapshot=snap_t2))
+
+    h_t1 = compute_inputs_hash(request_t1, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_t2 = compute_inputs_hash(request_t2, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_t1 == h_t2
+
+
+def test_collected_at_excluded_from_hash() -> None:
+    """Same bundle with different collected_at produces the same hash."""
+    cs = _make_code_signals()
+    bundle_t1 = EvidenceBundle(code_signals=cs, collected_at="2026-01-01T00:00:00+00:00")
+    bundle_t2 = EvidenceBundle(code_signals=cs, collected_at="2026-12-31T23:59:59+00:00")
+
+    request_t1 = _make_base_request(evidence=bundle_t1)
+    request_t2 = _make_base_request(evidence=bundle_t2)
+
+    h_t1 = compute_inputs_hash(request_t1, _ADAPTER_ID, _ADAPTER_VERSION)
+    h_t2 = compute_inputs_hash(request_t2, _ADAPTER_ID, _ADAPTER_VERSION)
+
+    assert h_t1 == h_t2

--- a/tests/charter/synthesizer/test_write_pipeline.py
+++ b/tests/charter/synthesizer/test_write_pipeline.py
@@ -1,0 +1,324 @@
+"""Unit tests for write_pipeline neutrality gate — WP06 (T035–T039).
+
+Tests:
+- _is_generic_scoped: no evidence, language-scoped slug, generic slug
+- _run_neutrality_gate: biased content raises NeutralityGateViolation
+- _run_neutrality_gate: language-scoped artifact skipped
+- _run_neutrality_gate: neutral content passes
+- Gate timing < 5s
+- Fixture helpers for staged content
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from charter.synthesizer.errors import NeutralityGateViolation
+from charter.synthesizer.write_pipeline import _is_generic_scoped
+
+
+# ---------------------------------------------------------------------------
+# Test fixture helpers — inline staged directories (T038)
+# ---------------------------------------------------------------------------
+
+
+def _staged_generic_with_pytest_bias(tmp_path: Path) -> Path:
+    """A generic tactic body containing 'pytest' — should trigger gate."""
+    staged_dir = tmp_path / "staging" / "generic"
+    staged_dir.mkdir(parents=True)
+    (staged_dir / "testing-philosophy.tactic.yaml").write_text(
+        "title: Testing Philosophy\n"
+        "body: |\n"
+        "  Always run pytest to verify your code.\n"
+        "  Configure pytest.ini for test discovery.\n"
+    )
+    return staged_dir
+
+
+def _staged_language_scoped(tmp_path: Path) -> Path:
+    """A python-scoped tactic containing 'pytest' — should NOT trigger gate."""
+    staged_dir = tmp_path / "staging" / "python-scoped"
+    staged_dir.mkdir(parents=True)
+    (staged_dir / "python-style-guide.tactic.yaml").write_text(
+        "title: Python Style Guide\n"
+        "body: |\n"
+        "  Use pytest for Python test discovery.\n"
+    )
+    return staged_dir
+
+
+def _staged_neutral_generic(tmp_path: Path) -> Path:
+    """A generic tactic with no language-specific terms — should pass gate."""
+    staged_dir = tmp_path / "staging" / "neutral"
+    staged_dir.mkdir(parents=True)
+    (staged_dir / "testing-philosophy.tactic.yaml").write_text(
+        "title: Testing Philosophy\n"
+        "body: |\n"
+        "  Test at multiple levels: unit, integration, and end-to-end.\n"
+        "  Fast tests should run frequently; slow tests in CI.\n"
+    )
+    return staged_dir
+
+
+# ---------------------------------------------------------------------------
+# _is_generic_scoped tests (T036, T039)
+# ---------------------------------------------------------------------------
+
+
+def test_is_generic_scoped_no_evidence() -> None:
+    """Without evidence, all artifacts are generic-scoped."""
+    assert _is_generic_scoped("tactic", "testing-philosophy", None) is True
+
+
+def test_is_generic_scoped_no_code_signals() -> None:
+    """With evidence but no code_signals, all artifacts are generic-scoped."""
+    from charter.synthesizer.evidence import EvidenceBundle
+
+    bundle = EvidenceBundle()
+    assert _is_generic_scoped("tactic", "testing-philosophy", bundle) is True
+
+
+def test_is_generic_scoped_unknown_scope_tag() -> None:
+    """scope_tag == 'unknown' → generic-scoped even with code_signals."""
+    from charter.synthesizer.evidence import CodeSignals, EvidenceBundle
+
+    cs = CodeSignals(
+        stack_id="unknown",
+        primary_language="unknown",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="unknown",
+        representative_files=(),
+        detected_at="2026-01-01T00:00:00+00:00",
+    )
+    bundle = EvidenceBundle(code_signals=cs)
+    assert _is_generic_scoped("tactic", "unknown-style-guide", bundle) is True
+
+
+def test_is_generic_scoped_python_scoped_slug_is_not_generic() -> None:
+    """With scope_tag='python', a slug containing 'python' is NOT generic-scoped."""
+    from charter.synthesizer.evidence import CodeSignals, EvidenceBundle
+
+    cs = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=(),
+        detected_at="2026-01-01T00:00:00+00:00",
+    )
+    bundle = EvidenceBundle(code_signals=cs)
+    assert _is_generic_scoped("tactic", "python-style-guide", bundle) is False
+
+
+def test_is_generic_scoped_python_scope_but_generic_slug() -> None:
+    """With scope_tag='python', a slug without 'python' IS generic-scoped."""
+    from charter.synthesizer.evidence import CodeSignals, EvidenceBundle
+
+    cs = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=(),
+        detected_at="2026-01-01T00:00:00+00:00",
+    )
+    bundle = EvidenceBundle(code_signals=cs)
+    assert _is_generic_scoped("tactic", "testing-philosophy", bundle) is True
+
+
+def test_is_generic_scoped_different_kinds() -> None:
+    """_is_generic_scoped works for directives and styleguides (target_kind ignored for now)."""
+    from charter.synthesizer.evidence import CodeSignals, EvidenceBundle
+
+    cs = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=(),
+        detected_at="2026-01-01T00:00:00+00:00",
+    )
+    bundle = EvidenceBundle(code_signals=cs)
+    # directive: slug doesn't contain scope_tag → generic
+    assert _is_generic_scoped("directive", "commit-message-format", bundle) is True
+    # styleguide: slug contains scope_tag → language-scoped
+    assert _is_generic_scoped("styleguide", "python-docstrings", bundle) is False
+
+
+# ---------------------------------------------------------------------------
+# _run_neutrality_gate via full staging setup (T039)
+# ---------------------------------------------------------------------------
+
+
+def _make_staging_dir_with_artifact(
+    tmp_path: Path,
+    kind: str,
+    slug: str,
+    content: str,
+    artifact_id: str | None = None,
+) -> "tuple[object, object]":
+    """Create a StagingDir and a matching ProvenanceEntry for testing the gate."""
+    import hashlib
+
+    from charter.synthesizer.staging import StagingDir
+    from charter.synthesizer.synthesize_pipeline import ProvenanceEntry, canonical_yaml
+
+    run_id = "01KPWP06TESTGATE00000001"
+    stage = StagingDir.create(tmp_path, run_id)
+
+    body: dict[str, str] = {"title": slug, "body": content}
+    yaml_bytes = canonical_yaml(body)
+    content_hash = hashlib.sha256(yaml_bytes).hexdigest()
+
+    # Determine artifact_id / urn
+    effective_artifact_id = artifact_id or slug
+    urn = f"{kind}:{effective_artifact_id}"
+
+    # Write content to staged location
+    if kind == "directive":
+        import re
+        m = re.search(r"\d+", effective_artifact_id)
+        nnn = m.group(0).zfill(3) if m else "000"
+        filename = f"{nnn}-{slug}.directive.yaml"
+    elif kind == "tactic":
+        filename = f"{slug}.tactic.yaml"
+    else:
+        filename = f"{slug}.styleguide.yaml"
+
+    staged_path = stage.path_for_content(kind, filename)
+    staged_path.write_text(content)
+
+    prov = ProvenanceEntry(
+        schema_version="1",
+        artifact_urn=urn,
+        artifact_kind=kind,  # type: ignore[arg-type]
+        artifact_slug=slug,
+        artifact_content_hash=content_hash,
+        inputs_hash="a" * 64,
+        adapter_id="fixture",
+        adapter_version="1.0.0",
+        source_section=None,
+        source_urns=["directive:DIRECTIVE_003"],
+        generated_at="2026-04-19T00:00:00+00:00",
+    )
+
+    return stage, prov
+
+
+def test_gate_fires_on_biased_generic_content(tmp_path: Path) -> None:
+    """Generic artifact with 'pytest' triggers NeutralityGateViolation."""
+    from charter.synthesizer.write_pipeline import _run_neutrality_gate
+
+    biased_content = (
+        "Always run pytest to verify your code.\n"
+        "Configure pytest.ini for test discovery.\n"
+    )
+    stage, prov = _make_staging_dir_with_artifact(
+        tmp_path, "tactic", "testing-philosophy", biased_content
+    )
+
+    with pytest.raises(NeutralityGateViolation) as exc_info:
+        _run_neutrality_gate(stage, [({"title": "test"}, prov)], evidence=None)
+
+    err = exc_info.value
+    assert err.artifact_urn == "tactic:testing-philosophy"
+    assert len(err.detected_terms) > 0
+    assert any("pytest" in t for t in err.detected_terms)
+    # Staging dir preserved (points to staging root)
+    assert err.staging_dir == stage.root
+
+
+def test_gate_skips_language_scoped_artifact(tmp_path: Path) -> None:
+    """Language-scoped artifact with 'pytest' does NOT trigger NeutralityGateViolation."""
+    from charter.synthesizer.evidence import CodeSignals, EvidenceBundle
+    from charter.synthesizer.write_pipeline import _run_neutrality_gate
+
+    cs = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=(),
+        detected_at="2026-04-19T00:00:00+00:00",
+    )
+    bundle = EvidenceBundle(code_signals=cs)
+
+    biased_content = "Use pytest for Python test discovery.\n"
+    # Slug contains "python" → language-scoped → gate must skip
+    stage, prov = _make_staging_dir_with_artifact(
+        tmp_path, "tactic", "python-style-guide", biased_content
+    )
+
+    # Should not raise
+    _run_neutrality_gate(stage, [({"title": "test"}, prov)], evidence=bundle)
+
+
+def test_gate_passes_on_neutral_generic_content(tmp_path: Path) -> None:
+    """Clean generic artifact passes the neutrality gate without raising."""
+    from charter.synthesizer.write_pipeline import _run_neutrality_gate
+
+    neutral_content = (
+        "Test at multiple levels: unit, integration, and end-to-end.\n"
+        "Fast tests should run frequently; slow tests in CI.\n"
+    )
+    stage, prov = _make_staging_dir_with_artifact(
+        tmp_path, "tactic", "testing-philosophy", neutral_content
+    )
+
+    # Should not raise
+    _run_neutrality_gate(stage, [({"title": "test"}, prov)], evidence=None)
+
+
+def test_gate_passes_on_empty_results(tmp_path: Path) -> None:
+    """Gate with no results raises nothing."""
+    from charter.synthesizer.staging import StagingDir
+    from charter.synthesizer.write_pipeline import _run_neutrality_gate
+
+    stage = StagingDir.create(tmp_path, "01KPWP06EMPTY000000001")
+    _run_neutrality_gate(stage, [], evidence=None)
+
+
+def test_gate_timing(tmp_path: Path) -> None:
+    """Neutrality gate completes in under 5 seconds on neutral content."""
+    from charter.synthesizer.write_pipeline import _run_neutrality_gate
+
+    neutral_content = (
+        "Test at multiple levels: unit, integration, and end-to-end.\n"
+        "Fast tests should run frequently; slow tests in CI.\n"
+    )
+    stage, prov = _make_staging_dir_with_artifact(
+        tmp_path, "tactic", "testing-philosophy", neutral_content
+    )
+
+    start = time.monotonic()
+    _run_neutrality_gate(stage, [({"title": "test"}, prov)], evidence=None)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0, f"Gate took {elapsed:.2f}s (must be < 5s)"
+
+
+def test_gate_preserves_staging_on_violation(tmp_path: Path) -> None:
+    """Staging dir root is preserved (not wiped) when the gate raises."""
+    from charter.synthesizer.write_pipeline import _run_neutrality_gate
+
+    biased_content = "Always run pytest to verify your code.\n"
+    stage, prov = _make_staging_dir_with_artifact(
+        tmp_path, "tactic", "testing-philosophy", biased_content
+    )
+
+    staging_root = stage.root
+    assert staging_root.exists()
+
+    with pytest.raises(NeutralityGateViolation):
+        _run_neutrality_gate(stage, [({"title": "test"}, prov)], evidence=None)
+
+    # Staging root must still exist — gate must NOT wipe it
+    assert staging_root.exists(), "Gate must not wipe staging dir on violation"

--- a/tests/charter/test_phase3_integration.py
+++ b/tests/charter/test_phase3_integration.py
@@ -1,0 +1,403 @@
+"""Phase 3 integration tests — all Phase 3 acceptance gates from #465.
+
+These tests exercise the complete Phase 3 pipeline components:
+- EvidenceBundle structure and populating (Gate 1)
+- Evidence enrichment changes inputs_hash (Gate 2)
+- ProvenanceEntry has evidence_bundle_hash + corpus_snapshot_id (Gate 3)
+- SynthesisRequest.evidence field correctly threaded (Gate 4)
+- Neutrality gate _is_generic_scoped scoping logic (Gate 5)
+- NeutralityGateViolation field structure (Gate 6)
+- CorpusLoader returns CorpusSnapshot for Python profile (Gate 7)
+- CodeReadingCollector detects Python project (Gate 8)
+- CLI --dry-run-evidence exits 0 and prints summary (Gate 9)
+
+No call to the full orchestrator.synthesize() is required — the components
+are tested directly per the WP07 recommended approach.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from charter.synthesizer.evidence import (
+    CodeSignals,
+    CorpusEntry,
+    CorpusSnapshot,
+    EvidenceBundle,
+)
+from charter.synthesizer.request import SynthesisRequest, SynthesisTarget
+
+
+# ---------------------------------------------------------------------------
+# Shared helper: enriched evidence bundle
+# ---------------------------------------------------------------------------
+
+
+def _make_evidence() -> EvidenceBundle:
+    """Construct the standard enriched-evidence bundle for Phase 3 tests.
+
+    Uses empty strings for timestamps (excluded from hash computation) so that
+    fixture hash lookups are deterministic regardless of when tests are run.
+    """
+    cs = CodeSignals(
+        stack_id="python+django+pytest",
+        primary_language="python",
+        frameworks=("django",),
+        test_frameworks=("pytest",),
+        scope_tag="python",
+        representative_files=("src/myapp/models.py", "tests/test_models.py"),
+        detected_at="",  # excluded from hash
+    )
+    corpus = CorpusSnapshot(
+        snapshot_id="python-v1.0.0",
+        profile_key="python",
+        entries=(
+            CorpusEntry(
+                topic="testing philosophy",
+                tags=("testing",),
+                guidance="Test at multiple levels.",
+            ),
+        ),
+        loaded_at="",  # excluded from hash
+    )
+    return EvidenceBundle(
+        code_signals=cs,
+        url_list=("https://docs.djangoproject.com/", "https://docs.pytest.org/"),
+        corpus_snapshot=corpus,
+        collected_at="",  # excluded from hash
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1: EvidenceBundle correctly structures all three evidence source types
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_evidence_bundle_structure() -> None:
+    """Gate 1: EvidenceBundle carries code signals, URL list, and corpus snapshot."""
+    bundle = _make_evidence()
+
+    assert not bundle.is_empty, "Enriched bundle must not be empty"
+    assert bundle.code_signals is not None, "code_signals must be populated"
+    assert bundle.code_signals.stack_id == "python+django+pytest"
+    assert bundle.code_signals.primary_language == "python"
+    assert bundle.code_signals.scope_tag == "python"
+    assert "django" in bundle.code_signals.frameworks
+    assert "pytest" in bundle.code_signals.test_frameworks
+    assert len(bundle.url_list) == 2
+    assert "https://docs.djangoproject.com/" in bundle.url_list
+    assert bundle.corpus_snapshot is not None, "corpus_snapshot must be populated"
+    assert bundle.corpus_snapshot.snapshot_id == "python-v1.0.0"
+    assert bundle.corpus_snapshot.profile_key == "python"
+    assert len(bundle.corpus_snapshot.entries) == 1
+    assert bundle.corpus_snapshot.entries[0].topic == "testing philosophy"
+
+
+# ---------------------------------------------------------------------------
+# Gate 2: Same interview + different evidence → different inputs_hash
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_hash_differentiation() -> None:
+    """Gate 2: enriched evidence produces a different inputs_hash than no evidence."""
+    from charter.synthesizer.request import compute_inputs_hash
+
+    target = SynthesisTarget(
+        kind="tactic",
+        slug="how-we-apply-directive-010",
+        title="How we apply Directive 010",
+        artifact_id="how-we-apply-directive-010",
+        source_section="testing_philosophy",
+        source_urns=("urn:drg:directive:DIRECTIVE_010",),
+    )
+    base_kwargs: dict = dict(
+        target=target,
+        interview_snapshot={"testing_philosophy": "We test at multiple levels."},
+        doctrine_snapshot={},
+        drg_snapshot={},
+        run_id="test",
+    )
+
+    req_empty = SynthesisRequest(**base_kwargs)
+    hash_empty = compute_inputs_hash(req_empty, "fixture", "1.0.0")
+
+    req_enriched = SynthesisRequest(**base_kwargs, evidence=_make_evidence())
+    hash_enriched = compute_inputs_hash(req_enriched, "fixture", "1.0.0")
+
+    assert hash_empty != hash_enriched, (
+        "Enriched evidence must change the inputs_hash; "
+        f"both produced: {hash_empty[:12]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 3: ProvenanceEntry has evidence_bundle_hash and corpus_snapshot_id fields
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_provenance_fields_exist() -> None:
+    """Gate 3: ProvenanceEntry Pydantic model has evidence_bundle_hash and corpus_snapshot_id."""
+    from charter.synthesizer.synthesize_pipeline import ProvenanceEntry
+
+    # ProvenanceEntry is a Pydantic model (not a dataclass), so use model_fields.
+    field_names = set(ProvenanceEntry.model_fields.keys())
+    assert "evidence_bundle_hash" in field_names, (
+        "ProvenanceEntry must have an evidence_bundle_hash field"
+    )
+    assert "corpus_snapshot_id" in field_names, (
+        "ProvenanceEntry must have a corpus_snapshot_id field"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 4: SynthesisRequest.evidence field is correctly set
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_synthesis_request_carries_evidence() -> None:
+    """Gate 4: SynthesisRequest.evidence field threads evidence into the pipeline."""
+    target = SynthesisTarget(
+        kind="tactic",
+        slug="how-we-apply-directive-010",
+        title="How we apply Directive 010",
+        artifact_id="how-we-apply-directive-010",
+        source_section="testing_philosophy",
+        source_urns=("urn:drg:directive:DIRECTIVE_010",),
+    )
+    evidence = _make_evidence()
+    req = SynthesisRequest(
+        target=target,
+        interview_snapshot={},
+        doctrine_snapshot={},
+        drg_snapshot={},
+        run_id="test",
+        evidence=evidence,
+    )
+
+    assert req.evidence is not None, "SynthesisRequest.evidence must be set"
+    assert req.evidence.code_signals is not None
+    assert req.evidence.code_signals.stack_id == "python+django+pytest"
+    assert req.evidence.url_list == (
+        "https://docs.djangoproject.com/",
+        "https://docs.pytest.org/",
+    )
+    assert req.evidence.corpus_snapshot is not None
+    assert req.evidence.corpus_snapshot.snapshot_id == "python-v1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Gate 5: Neutrality gate _is_generic_scoped logic is correct
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_is_generic_scoped_logic() -> None:
+    """Gate 5: _is_generic_scoped returns correct results for all scope combinations."""
+    from charter.synthesizer.write_pipeline import _is_generic_scoped
+
+    # No evidence → all artifacts are generic-scoped
+    assert _is_generic_scoped("tactic", "testing-philosophy", None) is True
+
+    # Evidence with no code_signals → all generic
+    empty_bundle = EvidenceBundle()
+    assert _is_generic_scoped("tactic", "testing-philosophy", empty_bundle) is True
+
+    # Python scope_tag → python-scoped slug is NOT generic
+    cs = CodeSignals(
+        stack_id="python",
+        primary_language="python",
+        frameworks=(),
+        test_frameworks=(),
+        scope_tag="python",
+        representative_files=(),
+        detected_at="",
+    )
+    bundle = EvidenceBundle(code_signals=cs)
+    assert _is_generic_scoped("tactic", "python-style-guide", bundle) is False, (
+        "slug containing scope_tag must be language-scoped, not generic"
+    )
+    assert _is_generic_scoped("tactic", "testing-philosophy", bundle) is True, (
+        "slug not containing scope_tag must be generic-scoped"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 6: NeutralityGateViolation has correct structured fields
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_neutrality_violation_structure() -> None:
+    """Gate 6: NeutralityGateViolation is a dataclass with artifact_urn, detected_terms, staging_dir."""
+    from charter.synthesizer.errors import NeutralityGateViolation
+
+    field_names = {f.name for f in dataclasses.fields(NeutralityGateViolation)}
+    assert "artifact_urn" in field_names, (
+        "NeutralityGateViolation must have artifact_urn"
+    )
+    assert "detected_terms" in field_names, (
+        "NeutralityGateViolation must have detected_terms"
+    )
+    assert "staging_dir" in field_names, (
+        "NeutralityGateViolation must have staging_dir"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 7: CorpusLoader returns CorpusSnapshot for Python profile
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_corpus_loader_returns_snapshot() -> None:
+    """Gate 7: CorpusLoader.load() returns a valid CorpusSnapshot for Python."""
+    from charter.evidence.corpus_loader import CorpusLoader
+
+    snap = CorpusLoader().load("python+django+pytest")
+
+    assert snap is not None, "CorpusLoader must return a snapshot for 'python+django+pytest'"
+    assert snap.profile_key == "python", (
+        f"Expected profile_key='python', got {snap.profile_key!r}"
+    )
+    assert snap.snapshot_id, "snapshot_id must be non-empty (used for provenance)"
+    # Verify the snapshot_id matches the expected format
+    assert snap.snapshot_id == "python-v1.0.0", (
+        f"Expected snapshot_id='python-v1.0.0', got {snap.snapshot_id!r}"
+    )
+    assert len(snap.entries) > 0, "Python corpus must have at least one entry"
+
+
+# ---------------------------------------------------------------------------
+# Gate 8: CodeReadingCollector detects Python project from filesystem signals
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_code_reader_detects_python(tmp_path: Path) -> None:
+    """Gate 8: CodeReadingCollector identifies primary_language='python' for a Python project."""
+    from charter.evidence.code_reader import CodeReadingCollector
+
+    # Create minimal Python project structure
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'test-project'\nversion = '0.1.0'\n"
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("# main module\n")
+    (tmp_path / "conftest.py").write_text("# pytest conftest\n")
+
+    collector = CodeReadingCollector(tmp_path)
+    signals = collector.collect()
+
+    assert signals.primary_language == "python", (
+        f"Expected primary_language='python', got {signals.primary_language!r}"
+    )
+    assert signals.scope_tag == "python", (
+        "scope_tag must equal primary_language for neutrality gate correctness"
+    )
+    assert "pytest" in signals.test_frameworks, (
+        "conftest.py should be detected as a pytest indicator"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 9: CLI --dry-run-evidence exits 0 and prints evidence summary
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_dry_run_evidence_smoke() -> None:
+    """Gate 9: charter synthesize --adapter fixture --dry-run-evidence exits 0."""
+    import os
+
+    repo_root = Path(__file__).parent.parent.parent
+    src_path = str(repo_root / "src")
+
+    # The `synthesize` subcommand lives in the worktree source, not the installed
+    # package. We must prepend the worktree src/ to PYTHONPATH so that
+    # `python -m specify_cli` picks up the development version of charter.py.
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{src_path}:{existing_pythonpath}" if existing_pythonpath else src_path
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "specify_cli",
+            "charter",
+            "synthesize",
+            "--adapter",
+            "fixture",
+            "--dry-run-evidence",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit code 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "Evidence dry-run summary" in result.stdout, (
+        f"Expected 'Evidence dry-run summary' in stdout; got:\n{result.stdout}"
+    )
+    # spec-kitty is a Python project — code signals should detect Python
+    assert "Code signals:" in result.stdout, (
+        f"Expected 'Code signals:' in stdout; got:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bonus: fixture adapter uses evidence hash for lookup
+# ---------------------------------------------------------------------------
+
+
+def test_phase3_fixture_adapter_evidence_hash() -> None:
+    """Evidence changes the hash, and the fixture adapter resolves the enriched-evidence fixture."""
+    from charter.synthesizer.fixture_adapter import FixtureAdapter, FixtureAdapterMissingError
+    from charter.synthesizer.request import compute_inputs_hash, short_hash
+
+    target = SynthesisTarget(
+        kind="tactic",
+        slug="how-we-apply-directive-010",
+        title="How we apply Directive 010",
+        artifact_id="how-we-apply-directive-010",
+        source_section="testing_philosophy",
+        source_urns=("urn:drg:directive:DIRECTIVE_010",),
+    )
+    interview = {"testing_philosophy": "We test at multiple levels."}
+
+    req_empty = SynthesisRequest(
+        target=target,
+        interview_snapshot=interview,
+        doctrine_snapshot={},
+        drg_snapshot={},
+        run_id="test",
+    )
+    req_enriched = SynthesisRequest(
+        target=target,
+        interview_snapshot=interview,
+        doctrine_snapshot={},
+        drg_snapshot={},
+        run_id="test",
+        evidence=_make_evidence(),
+    )
+
+    hash_empty = compute_inputs_hash(req_empty, "fixture", "1.0.0")
+    hash_enriched = compute_inputs_hash(req_enriched, "fixture", "1.0.0")
+
+    # Different hashes confirm evidence is included in the hash
+    assert hash_empty != hash_enriched, (
+        "Evidence must change the inputs_hash for fixture lookup"
+    )
+    assert short_hash(hash_empty) != short_hash(hash_enriched)
+
+    # Fixture adapter must successfully load the enriched-evidence fixture
+    # (the fixture was created at b606c08cd95c.tactic.yaml for this exact hash)
+    adapter = FixtureAdapter()
+    output = adapter.generate(req_enriched)
+    assert output is not None
+    assert output.body, "Enriched fixture body must be non-empty"


### PR DESCRIPTION
## Summary

Completes Phase 3 of the charter synthesizer (closes #465). Three new evidence sources enrich synthesis beyond interview-only inputs, a working production adapter ships for the first time, and a pre-promotion neutrality lint gate prevents language-specific bias from propagating into generic doctrine.

**Evidence inputs**
- Code-reading collector (`src/charter/evidence/code_reader.py`) — heuristic stack detection (language, framework, test framework) with depth-limited walk and scope tagging
- URL list configuration — operators declare reference URLs in `.kittify/config.yaml`; the production adapter (Claude) reads them natively; Spec Kitty does not fetch
- Best-practice corpus loader (`src/charter/evidence/corpus_loader.py`) — profile-keyed snapshots bundled under `src/charter/corpus/` (generic, python, javascript)

**Evidence orchestration + CLI**
- `EvidenceOrchestrator` coordinates all three sources with exception isolation; individual failures emit warnings, synthesis proceeds
- `charter synthesize` gains `--skip-code-evidence`, `--skip-corpus`, `--dry-run-evidence`
- URL list read from `charter.synthesis_inputs.url_list` in `.kittify/config.yaml`

**Production adapter (ADR-6)**
- `ProductionAdapter` implements the frozen `SynthesisAdapter` seam — no structural changes to `adapter.py`
- Default model: `claude-sonnet-4-6`, per-project override via `.kittify/config.yaml`
- `anthropic>=0.55.0` added to dependencies
- ADR-6 documents model rationale, override, and cost model (~$0.05–$0.25/run at Sonnet pricing)

**Neutrality gate**
- `NeutralityGateViolation` added to error taxonomy
- Gate runs in `write_pipeline.promote()` before first `os.replace`; generic-scoped artifacts scanned, language-scoped skipped
- Staging directory preserved for inspection on gate failure
- Caught and fixed real bias in existing `testing-style-guide` fixture (pytest references in a generic artifact)

**Packaging fix**
- `src/charter/**/*.yaml` added to wheel artifacts — corpus files and neutrality data files now ship correctly

## Test Coverage

644 tests pass. New:
- `test_evidence.py` — 27 invariant tests
- `test_request.py` — 13 hash tests (backward-compat anchored to hardcoded pre-Phase-3 hash)
- `test_code_reader.py` — 8 tests incl. performance (<5s on 1k-file tree)
- `test_corpus_loader.py` — 8 tests
- `test_orchestrator.py` — 9 unit + 1 CLI integration
- `test_write_pipeline.py` — 12 gate tests
- `test_production_adapter.py` — 16 mocked + 1 `@pytest.mark.live_adapter` (skipped in CI)
- `test_phase3_integration.py` — 10 integration tests covering all Phase 3 acceptance gates from #465

Key invariants verified: backward-compat hash parity for `evidence=None`, `adapter.py` seam unchanged (empty diff), zero HTTP fetch calls in `src/charter/`.

## Tracks

Closes #465 | Related: #482 #484 #486 #521 #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)