### PR TITLE
fix: harden charter generated synthesis handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Charter synthesizer now has a real harness-owned operator path: the new generated-artifact adapter reads agent-authored YAML from `.kittify/charter/generated/` and promotes validated doctrine into the live `.kittify/doctrine/` tree.
+- `spec-kitty charter resynthesize --list-topics` now lists valid project-artifact selectors, DRG URNs, and interview-section selectors, including hyphenated aliases for section names.
+
+### Changed
+
+- `spec-kitty charter synthesize` and `spec-kitty charter resynthesize` now default to the generated-artifact adapter. `--adapter fixture` remains available only for deterministic offline regression runs.
+- `spec-kitty charter synthesize --dry-run` is now a real stage-and-validate pass: it writes the staged artifact set, runs project DRG validation and neutrality gating, and only skips the final promote step.
+
+### Fixed
+
+- Directive provenance now records canonical URNs (`directive:PROJECT_<NNN>`) instead of slug-based placeholders, which restores correct directive filenames, provenance reload, and `directive:PROJECT_<NNN>` resynthesis.
+- Bounded resynthesis now preserves evidence inputs end-to-end, so regenerated provenance entries keep the correct `evidence_bundle_hash` and `corpus_snapshot_id`.
+
 ## [3.2.0] - 2026-04-19
 
 ### Removed

--- a/kitty-specs/charter-synthesizer-phase-3-completion-01KPJFHG/meta.json
+++ b/kitty-specs/charter-synthesizer-phase-3-completion-01KPJFHG/meta.json
@@ -1,20 +1,19 @@
 {
   "created_at": "2026-04-19T09:00:59.616082+00:00",
-  "friendly_name": "Charter Synthesizer Phase 3 Completion: Richer Inputs and Production Adapter",
+  "friendly_name": "Charter Synthesizer Phase 3 Completion: Richer Inputs and Harness Validation",
   "mission_id": "01KPJFHGQ2QQRT3JP7T37M84HN",
   "mission_number": 88,
   "mission_slug": "charter-synthesizer-phase-3-completion-01KPJFHG",
   "mission_type": "software-dev",
   "slug": "charter-synthesizer-phase-3-completion-01KPJFHG",
-  "source_description": "Complete remaining Phase 3 charter synthesizer scope: code-reading input adapter (#482), URL-fetching input adapter (#484), best-practice corpus loader (#486), production adapter / ADR-6 model selection (#521), and neutrality synthesis-path tripwires (#653). Builds on the Phase 3 tranche 1 baseline already landed via PR #677.",
+  "source_description": "Complete remaining Phase 3 charter synthesizer scope: code-reading input adapter (#482), declared URL evidence inputs (#484), best-practice corpus loader (#486), the harness-owned generated-artifact validation/promote path, and neutrality synthesis-path tripwires (#653). Builds on the Phase 3 tranche 1 baseline already landed via PR #677.",
   "target_branch": "main",
   "tracks": [
     "#465",
     "#653",
     "#482",
     "#484",
-    "#486",
-    "#521"
+    "#486"
   ],
   "vcs": "git"
 }

--- a/kitty-specs/phase-3-charter-synthesizer-pipeline-01KPE222/quickstart.md
+++ b/kitty-specs/phase-3-charter-synthesizer-pipeline-01KPE222/quickstart.md
@@ -2,7 +2,7 @@
 
 **Audience**: operators configuring a project's charter and generating project-local doctrine for the first time (US-1), plus reviewers running targeted resynthesis (US-2 / US-3 / US-4).
 **Mission**: `phase-3-charter-synthesizer-pipeline-01KPE222`
-**Status**: forward-looking — describes the operator experience once WP3.1 → WP3.8 have merged. Commands below do not yet exist on `main`.
+**Status**: partially landed — the CLI commands exist on `main`, and the canonical operator path is the harness-owned generated-artifact adapter.
 
 ---
 
@@ -10,7 +10,8 @@
 
 - spec-kitty version ≥ the release that ships this tranche.
 - A project whose charter interview has been completed (i.e. `.kittify/charter/charter.md` is present and fresh).
-- A configured synthesis adapter (governed by ADR-6, #521). For local dry runs without a production adapter, `--adapter fixture` opts into the test-only adapter (R-0-5).
+- Agent-authored artifact YAML written under `.kittify/charter/generated/`.
+- For deterministic regression testing, `--adapter fixture` remains available as the test-only adapter.
 
 ---
 
@@ -20,12 +21,12 @@
 # From your project root (NOT a worktree).
 # Assumes /spec-kitty.charter has already run.
 
-# Inspect what synthesis will produce before committing:
+# Inspect and validate what synthesis will promote before committing:
 spec-kitty charter synthesize --dry-run
 
-# Run the real synthesis. Artifacts, provenance, project DRG, and manifest
-# land under .kittify/doctrine/ (content) and .kittify/charter/ (bookkeeping)
-# in a single atomic promote.
+# Run the real synthesis. The command reads generated inputs from
+# .kittify/charter/generated/, then promotes validated artifacts, provenance,
+# project DRG, and manifest state into the live trees.
 spec-kitty charter synthesize
 
 # Verify the committed bundle:
@@ -66,7 +67,7 @@ spec-kitty charter context --action specify --json | jq '.context' | head -40
 
 1. Orchestrator read interview answers + shipped doctrine + shipped DRG.
 2. Interview-mapping selected `SynthesisTarget`s (see `data-model.md §E-2`).
-3. Each target was passed through the adapter seam (fixture or production).
+3. Each target was passed through the adapter seam (generated-artifact or fixture).
 4. Every returned body was schema-validated against its shipped-kind schema (FR-019).
 5. All artifacts + provenance sidecars + project DRG overlay were staged under `.kittify/charter/.staging/<runid>/` with internal `doctrine/` and `charter/` subtrees mirroring the final layout.
 6. The merged (shipped + project) DRG was validated — zero dangling refs (FR-008), zero duplicate edges, no cycles.
@@ -154,9 +155,11 @@ No files are written. No model call was made.
 ## 6 · Dry-run for fixture / CI environments
 
 ```bash
-# Uses the test-only fixture adapter. Requires corresponding fixture files
-# under tests/charter/fixtures/synthesizer/<kind>/<slug>/<hash>.<kind>.yaml.
-# Missing fixtures fail loudly with the expected path.
+# Generated-adapter mode is the operator default and reads harness-authored YAML
+# from .kittify/charter/generated/.
+spec-kitty charter synthesize
+
+# The fixture adapter remains available for deterministic regression tests.
 spec-kitty charter synthesize --adapter fixture
 ```
 
@@ -165,7 +168,7 @@ Useful for:
 - CI jobs that verify layout + provenance + manifest integrity without live model access.
 - Regression tests on the fixture set itself.
 
-Do NOT use `--adapter fixture` for production synthesis. The fixture adapter's output is test data, and the provenance stamp (`adapter_id=fixture`) makes that obvious to any later auditor.
+Do NOT use `--adapter fixture` for operator synthesis. The fixture adapter's output is test data, and the provenance stamp (`adapter_id=fixture`) makes that obvious to any later auditor.
 
 ---
 
@@ -209,7 +212,7 @@ Check that `.kittify/charter/synthesis-manifest.yaml` exists. If missing, the li
 
 ### "FixtureAdapterMissingError — expected_path=..."
 
-You're in `--adapter fixture` mode and the fixture for this request is missing. The error names the exact path at which the fixture should live. Record it (run the production adapter once, capture its output, copy to the named path) and rerun.
+You're in `--adapter fixture` mode and the fixture for this request is missing. The error names the exact path at which the fixture should live. Record a fixture there if this is a regression test, or switch back to the default generated adapter for normal operator flows.
 
 ### "I want to regenerate everything"
 

--- a/kitty-specs/phase-3-charter-synthesizer-pipeline-01KPE222/spec.md
+++ b/kitty-specs/phase-3-charter-synthesizer-pipeline-01KPE222/spec.md
@@ -9,7 +9,7 @@
 | Created | 2026-04-17 |
 | Status | Draft (specify) |
 
-**Roadmap anchors**: Charter EPIC #461 · Phase 3 tracker #465 · WPs #485 #483 #487 #488 #489 · ADR-6 #521 · ADR-7 #523 · ADR-8 #522
+**Roadmap anchors**: Charter EPIC #461 · Phase 3 tracker #465 · WPs #485 #483 #487 #488 #489 · ADR-7 #523 · ADR-8 #522
 
 ---
 
@@ -17,7 +17,7 @@
 
 Phases 0–2 of the charter engineering EPIC are complete and merged. `DoctrineService` already supports an additive shipped + project layer, and `charter compile` / `charter context` already instantiate it with a non-`None` `project_root`. The real gap is that `project_root` is resolved only from code-local candidates (`repo_root/src/doctrine` or `repo_root/doctrine`), which are the *shipped-layer* locations — there is no supported project-local doctrine path under `.kittify/` for runtime doctrine resolution, and no code path writes a project-local artifact. The result is that the charter interview collects project-specific signal — mission type, language scope, directive/tactic/styleguide selections, neutrality posture — and then discards the opportunity to materialize *project-tuned* doctrine from it. (The project-layer DRG overlay is a partial exception: `_drg_helpers` already reads `.kittify/doctrine/graph.yaml` when present, but no code path writes it.)
 
-Phase 3 closes that gap by introducing a Charter Synthesizer: a pipeline that turns (interview answers + shipped doctrine + shipped DRG) into project-local directives, tactics, and styleguides, stored in a layout that the existing doctrine repositories and DRG helpers already recognise — artifact **content** under `.kittify/doctrine/`, synthesis **bookkeeping** (provenance, commit manifest, staging) under `.kittify/charter/`. Synthesis must be deterministic in its orchestration, validation, and bookkeeping — but the actual prose generation is model-driven. This forces a specific architectural split: a narrow provider-agnostic seam for the generation step, with fixture-backed testing, surrounded by deterministic machinery that can be byte-reproducibly tested and guarded.
+Phase 3 closes that gap by introducing a Charter Synthesizer: a pipeline that turns (interview answers + shipped doctrine + shipped DRG) into project-local directives, tactics, and styleguides, stored in a layout that the existing doctrine repositories and DRG helpers already recognise — artifact **content** under `.kittify/doctrine/`, synthesis **bookkeeping** (provenance, commit manifest, staging) under `.kittify/charter/`. Synthesis must be deterministic in its orchestration, validation, and bookkeeping, while the actual doctrine text remains harness-owned. This forces a specific architectural split: a narrow provider-agnostic seam for the generation step, with a file-backed generated-artifact adapter for real operator flows and a fixture-backed adapter for tests, surrounded by deterministic machinery that can be byte-reproducibly tested and guarded.
 
 The mission must preserve the hard invariants established by earlier phases: shipped doctrine in `src/doctrine/` is read-only at runtime; synthesized content lives only under `.kittify/doctrine/`; synthesis bookkeeping lives only under `.kittify/charter/`; the merged DRG (shipped + project) contains no dangling references; every synthesized artifact carries provenance. It must also resist scope creep — autonomous code-reading, URL-fetching, cross-repo charter visibility, and free-text topic rewriting belong to later tranches or separate missions, not Phase 3.
 
@@ -26,7 +26,7 @@ The mission must preserve the hard invariants established by earlier phases: shi
 ### In Scope (Tranche 1)
 
 - Synthesizer orchestration layer: input normalization, synthesis target selection, artifact writing, provenance recording, project DRG emission, cross-layer validation.
-- Narrow provider-agnostic synthesis adapter interface, with a fixture adapter usable by the full test suite and a pinned default production adapter.
+- Narrow provider-agnostic synthesis adapter interface, with a generated-artifact adapter for harness-authored YAML and a fixture adapter usable by the full test suite.
 - Interview-driven synthesis path: a fresh `spec-kitty charter synthesize` run that takes current interview answers and produces a full project-local artifact set.
 - Project-local artifact storage for three artifact kinds only: **directives**, **tactics**, **styleguides**. Content lives under `.kittify/doctrine/{directives,tactics,styleguides}/` using the filename conventions the existing repositories already glob (`*.directive.yaml`, `*.tactic.yaml`, `*.styleguide.yaml`).
 - Provenance writer: per-artifact record of inputs, adapter identity, adapter version, inputs hash, source references (interview section and/or DRG URNs), and generation timestamp. Provenance sidecars and the synthesis manifest (commit marker) live under `.kittify/charter/` — synthesis bookkeeping is kept separate from doctrine content so doctrine consumers are unaffected.
@@ -115,7 +115,7 @@ The mission must preserve the hard invariants established by earlier phases: shi
 |----|-------------|--------|
 | FR-001 | The synthesizer SHALL accept as inputs the current charter interview answers, the shipped doctrine catalog, and the merged shipped+project DRG graph. | Accepted |
 | FR-002 | The synthesizer SHALL produce, for Tranche 1, only artifacts of kind `directive`, `tactic`, and `styleguide`. | Accepted |
-| FR-003 | The synthesizer SHALL expose a narrow provider-agnostic adapter interface for the generation step, such that production and fixture adapters are substitutable without changes to orchestration code. | Accepted |
+| FR-003 | The synthesizer SHALL expose a narrow provider-agnostic adapter interface for the generation step, such that the generated-artifact adapter and the fixture adapter are substitutable without changes to orchestration code. | Accepted |
 | FR-004 | The fixture adapter SHALL be used for 100% of automated tests; no automated test SHALL require a live model call. | Accepted |
 | FR-005 | Synthesized artifact content (directives, tactics, styleguides, project DRG graph) SHALL be written only under `.kittify/doctrine/`, using filenames that match the existing repository globs: `*.directive.yaml`, `*.tactic.yaml`, `*.styleguide.yaml`, plus `graph.yaml`. Synthesis bookkeeping (per-artifact provenance sidecars, commit-marker manifest, and ephemeral staging) SHALL be written only under `.kittify/charter/`. | Accepted |
 | FR-006 | Every synthesized artifact SHALL have a provenance record containing: artifact URN, inputs hash, adapter id, adapter version, source references (interview section label and/or DRG URN(s)), and `generated_at` timestamp. | Accepted |
@@ -158,7 +158,7 @@ The mission must preserve the hard invariants established by earlier phases: shi
 | C-003 | No live network calls are permitted in the automated test suite; the LLM adapter must be swappable for a fixture adapter. | Accepted |
 | C-004 | `--topic` accepts only structured selectors; free-text topics are rejected with a structured error. | Accepted |
 | C-005 | Synthesis in this tranche covers only `directive`, `tactic`, and `styleguide` artifacts; `paradigm`, `procedure`, `toolguide`, and `agent_profile` remain shipped-layer-only. | Accepted |
-| C-006 | ADR-6 (synthesizer model selection) governs the default production adapter but is not a prerequisite for merging WP3.1; the mission may ship with a pinned default adapter. | Accepted |
+| C-006 | Harness-owned inference remains outside spec-kitty. The CLI may validate and promote harness-authored artifacts, but it SHALL NOT embed a vendor-specific model client. | Accepted |
 | C-007 | ADR-7 (existing project migration design) is out of scope for this mission. | Accepted |
 | C-008 | ADR-8 (monorepo / cross-repo charter visibility) is out of scope for this mission. | Accepted |
 | C-009 | The project DRG layer is additive only (per existing `merge_layers()` semantics); no deletions or silent replacements of shipped nodes/edges are permitted. | Accepted |
@@ -184,7 +184,7 @@ The mission must preserve the hard invariants established by earlier phases: shi
 
 - **SynthesisRequest** — input envelope: trigger (fresh | resynthesize), adapter id, topic selector (if any), interview-answers snapshot, shipped-doctrine snapshot, DRG snapshot.
 - **SynthesisTarget** — a single unit of synthesis: artifact kind (directive | tactic | styleguide), target slug, source references (interview section labels and/or DRG URNs).
-- **SynthesisAdapter** — provider-agnostic interface: `generate(target, context) -> AdapterOutput`. Fixture implementation for tests; pinned default implementation for production; governed by ADR-6.
+- **SynthesisAdapter** — provider-agnostic interface: `generate(target, context) -> AdapterOutput`. Generated-artifact implementation for operator flows; fixture implementation for tests.
 - **AdapterOutput** — artifact body + adapter metadata (adapter id, adapter version, inputs hash contribution).
 - **SynthesisResult** — artifact body, provenance entry, validation status. Returned per-target before any filesystem write.
 - **ProvenanceEntry** — record tied to a written artifact: artifact URN, inputs hash, adapter id, adapter version, source references, `generated_at`, content hash of the written body.
@@ -204,7 +204,7 @@ The mission must preserve the hard invariants established by earlier phases: shi
 
 ## 8. Dependencies
 
-- ADR-6 (synthesizer model selection, #521) — informs the default production adapter. This mission proceeds with a fixture adapter + a pinned default while ADR-6 is finalized in parallel. ADR-6 is a *soft* dependency for the production default only.
+- Harness-owned synthesis contract — generation remains the responsibility of the invoking LLM harness; spec-kitty consumes generated artifacts and provides validation, staging, and promotion.
 - ADR-7 (existing 3.x project migration, #523) — out of scope here; flagged so its eventual design can re-use the Phase 3 bundle format without rework.
 - ADR-8 (monorepo / cross-repo charter visibility, #522) — out of scope here; flagged so its design can assume the Phase 3 bundle format as a building block.
 - Existing DRG validator (`src/doctrine/drg/validator.py`) — hard dependency; used as the gatekeeper for FR-008 / NFR-009.
@@ -246,9 +246,9 @@ Risk detail belongs primarily to `/spec-kitty.plan`, but the specify phase recor
 - **R-1: Seam leak** — if the adapter interface leaks generation concerns into orchestration (e.g., prompt shaping, retry policy), determinism erodes. Mitigation: WP3.1 defines the interface with no prompt-engineering surface; prompts live inside adapters.
 - **R-2: DoctrineService wiring ripple** — switching charter compile/context to pass `project_root` may surface behavioral differences for projects that have never had a project layer. Mitigation: activation is gated on the presence of a synthesized artifact set; legacy projects see no change until their first `charter synthesize` run.
 - **R-3: Bundle manifest drift** — extending bundle contents without a version bump risks silent breakage of `bundle validate`. Mitigation: any extension is additive and backwards-compatible; if not, the plan phase must call a v1.1.0 bump explicitly.
-- **R-4: Provenance brittleness under model churn** — swapping production adapters could invalidate every provenance entry. Mitigation: adapter id + adapter version are first-class provenance fields; invalidation is observable, not hidden.
+- **R-4: Provenance brittleness under adapter churn** — changing generated-artifact or fixture adapter semantics could invalidate provenance expectations. Mitigation: adapter id + adapter version are first-class provenance fields; invalidation is observable, not hidden.
 - **R-5: Topic selector ambiguity escalation** — users may push back on structured-only selectors. Mitigation: structured error output enumerates candidates so the affordance is teachable; free-text is an explicit later-tranche decision, not a silent no.
-- **R-6: ADR-6 dependency creep** — if WP3.1 is blocked on ADR-6 resolution, the whole tranche stalls. Mitigation: C-006 fixes a pinned default adapter so the architecture can merge while ADR-6 is being finalized.
+- **R-6: harness-contract drift** — if spec-kitty and the invoking harness disagree about where generated artifacts live or how they are identified, operator runs fail late. Mitigation: C-006 freezes the no-internal-LLM rule and the generated-artifact adapter path.
 
 Sequencing constraint (spec-level): WP3.1 must land before WP3.2/3.6/3.7/3.8 begin. WP3.6 and WP3.7 can proceed in parallel once WP3.2 establishes the artifact body contract. WP3.8 depends on WP3.6 and WP3.7 being durable enough to drive bounded recomputation. Likely file clusters (charter package, doctrine DRG package, CLI commands, bundle manifest) are a plan-phase concern.
 

--- a/src/charter/synthesizer/errors.py
+++ b/src/charter/synthesizer/errors.py
@@ -219,6 +219,36 @@ class FixtureAdapterMissingError(SynthesisError):
         )
 
 
+@dataclass(frozen=True)
+class GeneratedArtifactMissingError(SynthesisError):
+    """The harness-owned generated-artifact adapter cannot find an expected file."""
+
+    expected_path: str
+    kind: str
+    slug: str
+
+    def __str__(self) -> str:
+        return (
+            f"No generated artifact found for {self.kind}:{self.slug}; "
+            f"expected YAML at {self.expected_path}. "
+            "Write the agent-authored artifact there, then rerun synthesis."
+        )
+
+
+@dataclass(frozen=True)
+class GeneratedArtifactLoadError(SynthesisError):
+    """The harness-owned generated-artifact adapter could not parse or trust a file."""
+
+    artifact_path: str
+    reason: str
+
+    def __str__(self) -> str:
+        return (
+            f"Generated artifact at {self.artifact_path} could not be loaded: "
+            f"{self.reason}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Staging / promote errors
 # ---------------------------------------------------------------------------

--- a/src/charter/synthesizer/generated_artifact_adapter.py
+++ b/src/charter/synthesizer/generated_artifact_adapter.py
@@ -1,0 +1,123 @@
+"""Harness-owned adapter for agent-authored doctrine YAML.
+
+This adapter is the production-facing charter synthesis seam after the
+Anthropic SDK removal: the LLM harness writes artifact YAML files, and
+spec-kitty validates, stages, and promotes them. No network calls occur here.
+
+Input layout
+------------
+    .kittify/charter/generated/
+      directives/<NNN>-<slug>.directive.yaml
+      tactics/<slug>.tactic.yaml
+      styleguides/<slug>.styleguide.yaml
+
+Each file must already contain the final artifact body for its target. The
+adapter verifies that the on-disk ``id`` matches the target's expected
+artifact identity before handing it to the schema gate.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from collections.abc import Mapping
+
+from ruamel.yaml import YAML
+
+from .adapter import AdapterOutput
+from .errors import GeneratedArtifactLoadError, GeneratedArtifactMissingError
+from .request import SynthesisRequest
+
+GENERATED_ADAPTER_VERSION = "1.0.0"
+
+
+class GeneratedArtifactAdapter:
+    """Load agent-authored doctrine YAML from `.kittify/charter/generated/`."""
+
+    id: str = "generated"
+    version: str = GENERATED_ADAPTER_VERSION
+
+    def __init__(self, repo_root: Path, input_root: Path | None = None) -> None:
+        self._repo_root = repo_root
+        self._input_root = input_root or repo_root / ".kittify" / "charter" / "generated"
+
+    def _path_for_target(self, request: SynthesisRequest) -> Path:
+        target = request.target
+        subdir = {
+            "directive": "directives",
+            "tactic": "tactics",
+            "styleguide": "styleguides",
+        }[target.kind]
+        return self._input_root / subdir / target.filename
+
+    def _load_body(self, path: Path) -> Mapping[str, Any]:
+        yaml = YAML(typ="safe")
+        try:
+            raw = yaml.load(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            raise GeneratedArtifactLoadError(
+                artifact_path=str(path),
+                reason=f"invalid YAML: {exc}",
+            ) from exc
+
+        if not isinstance(raw, dict):
+            raise GeneratedArtifactLoadError(
+                artifact_path=str(path),
+                reason="top-level YAML document must be a mapping",
+            )
+        return raw
+
+    def _assert_target_identity(
+        self,
+        request: SynthesisRequest,
+        body: Mapping[str, Any],
+        path: Path,
+    ) -> None:
+        raw_id = body.get("id")
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            raise GeneratedArtifactLoadError(
+                artifact_path=str(path),
+                reason="artifact body must include a non-empty 'id' field",
+            )
+
+        expected_id = request.target.artifact_id
+        actual_id = raw_id.strip()
+        if actual_id != expected_id:
+            raise GeneratedArtifactLoadError(
+                artifact_path=str(path),
+                reason=(
+                    f"artifact id mismatch: expected '{expected_id}', "
+                    f"got '{actual_id}'"
+                ),
+            )
+
+    def generate(self, request: SynthesisRequest) -> AdapterOutput:
+        path = self._path_for_target(request)
+        if not path.exists():
+            raise GeneratedArtifactMissingError(
+                expected_path=str(path),
+                kind=request.target.kind,
+                slug=request.target.slug,
+            )
+
+        body = self._load_body(path)
+        self._assert_target_identity(request, body, path)
+
+        generated_at = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+        try:
+            rel_path = path.relative_to(self._repo_root)
+            note_path = rel_path.as_posix()
+        except ValueError:
+            note_path = str(path)
+
+        return AdapterOutput(
+            body=body,
+            generated_at=generated_at,
+            notes=f"generated-artifact:{note_path}",
+        )
+
+    def generate_batch(
+        self, requests: list[SynthesisRequest]
+    ) -> list[AdapterOutput]:
+        return [self.generate(request) for request in requests]

--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -425,6 +425,7 @@ def run(
         drg_snapshot=request.drg_snapshot,
         run_id=run_id,
         adapter_hints=request.adapter_hints,
+        evidence=request.evidence,
     )
 
     # ------------------------------------------------------------------
@@ -503,34 +504,25 @@ def _load_project_artifacts_from_provenance(
 
     Returns an empty list if the provenance directory does not exist.
     """
-    from ruamel.yaml import YAML  # noqa: PLC0415
+    from .provenance import load_yaml as load_provenance  # noqa: PLC0415
 
     prov_dir = repo_root / ".kittify" / "charter" / "provenance"
     if not prov_dir.exists():
         return []
 
-    yaml = YAML()
     targets: list[SynthesisTarget] = []
     for prov_file in sorted(prov_dir.glob("*.yaml")):
         try:
-            raw = yaml.load(prov_file.read_text(encoding="utf-8"))
-            if not isinstance(raw, dict):
-                continue
-            kind = raw.get("artifact_kind", "")
-            slug = raw.get("artifact_slug", "")
-            artifact_urn = raw.get("artifact_urn", f"{kind}:{slug}")
-            artifact_id = artifact_urn.split(":", 1)[1] if ":" in artifact_urn else slug
-            source_section = raw.get("source_section")
-            source_urns = raw.get("source_urns", []) or []
+            prov = load_provenance(prov_file)
             # Reconstruct a minimal SynthesisTarget from provenance data
             # (title is not stored in provenance; use slug as fallback)
             target = SynthesisTarget(
-                kind=kind,
-                slug=slug,
-                title=slug.replace("-", " ").title(),
-                artifact_id=artifact_id,
-                source_section=source_section,
-                source_urns=tuple(source_urns),
+                kind=prov.artifact_kind,
+                slug=prov.artifact_slug,
+                title=prov.artifact_slug.replace("-", " ").title(),
+                artifact_id=prov.artifact_urn.split(":", 1)[1],
+                source_section=prov.source_section,
+                source_urns=tuple(prov.source_urns),
             )
             targets.append(target)
         except Exception:  # noqa: BLE001, S112

--- a/src/charter/synthesizer/synthesize_pipeline.py
+++ b/src/charter/synthesizer/synthesize_pipeline.py
@@ -237,6 +237,16 @@ def _compute_evidence_hashes(request: SynthesisRequest) -> tuple[str | None, str
     return evidence_hash, corpus_id
 
 
+def _artifact_urn_for_target(target: SynthesisTarget) -> str:
+    """Return the canonical artifact URN for provenance.
+
+    Directives are keyed by project artifact id (for example ``PROJECT_001``),
+    while tactics and styleguides use their slug as both ``artifact_id`` and
+    URN suffix.
+    """
+    return target.urn
+
+
 # ---------------------------------------------------------------------------
 # Adapter dispatch helpers
 # ---------------------------------------------------------------------------
@@ -387,7 +397,7 @@ def run(
             generated_at_str = generated_at_str + "+00:00"
 
         provenance = ProvenanceEntry(
-            artifact_urn=f"{target.kind}:{target.slug}",
+            artifact_urn=_artifact_urn_for_target(target),
             artifact_kind=target.kind,  # type: ignore[arg-type]
             artifact_slug=target.slug,
             artifact_content_hash=content_hash,
@@ -517,7 +527,7 @@ def run_all(
             generated_at_str = generated_at_str + "+00:00"
 
         provenance = ProvenanceEntry(
-            artifact_urn=f"{target.kind}:{target.slug}",
+            artifact_urn=_artifact_urn_for_target(target),
             artifact_kind=target.kind,  # type: ignore[arg-type]
             artifact_slug=target.slug,
             artifact_content_hash=content_hash,

--- a/src/charter/synthesizer/topic_resolver.py
+++ b/src/charter/synthesizer/topic_resolver.py
@@ -166,6 +166,17 @@ def _nearest_candidates(
     return scored[:limit]
 
 
+def _normalize_interview_section_label(label: str) -> str:
+    """Normalize user-facing interview-section selectors.
+
+    The stored section labels are underscore-delimited (`testing_philosophy`),
+    but operators naturally type hyphenated forms (`testing-philosophy`).
+    Normalize both to the canonical underscore form for matching and error
+    suggestions without changing the persisted provenance keys.
+    """
+    return label.strip().replace("-", "_").replace(" ", "_")
+
+
 # ---------------------------------------------------------------------------
 # Resolution helpers
 # ---------------------------------------------------------------------------
@@ -254,13 +265,18 @@ def _resolve_interview_section(
     raw (exact, case-sensitive match).  Returns None if raw is not in the
     known interview section set.
     """
-    if raw not in interview_sections:
+    normalized_sections = {
+        _normalize_interview_section_label(section): section for section in interview_sections
+    }
+    normalized_raw = _normalize_interview_section_label(raw)
+    canonical_section = normalized_sections.get(normalized_raw)
+    if canonical_section is None:
         return None
 
     matched: list[SynthesisTarget] = [
         artifact
         for artifact in project_artifacts
-        if artifact.source_section == raw
+        if artifact.source_section == canonical_section
     ]
     return matched
 
@@ -354,10 +370,14 @@ def resolve(
         attempted_forms.append("interview_section")
         section_results = _resolve_interview_section(raw, project_artifacts, interview_sections)
         if section_results is not None:
+            normalized_sections = {
+                _normalize_interview_section_label(section): section for section in interview_sections
+            }
+            matched_value = normalized_sections[_normalize_interview_section_label(raw)]
             return ResolvedTopic(
                 targets=section_results,
                 matched_form="interview_section",
-                matched_value=raw,
+                matched_value=matched_value,
             )
 
     # No hit — collect candidates and raise structured error

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -198,6 +198,54 @@ def _run_neutrality_gate(
             )
 
 
+def stage_and_validate(
+    request: SynthesisRequest,
+    staging_dir: StagingDir,
+    results: list[tuple[Mapping[str, Any], ProvenanceEntry]],
+    validation_callback: Callable[[StagingDir], None],
+) -> list[str]:
+    """Write staged files and run the full pre-promote validation stack.
+
+    This is the truthful implementation for CLI ``--dry-run``: all artifact
+    bodies and provenance sidecars are materialized in the staging tree, the
+    project DRG overlay is emitted via ``validation_callback``, and the
+    neutrality gate scans the exact staged bytes that a real promote would use.
+
+    No live-tree ``os.replace`` calls occur here.
+
+    Returns
+    -------
+    list[str]
+        Stable ``kind:slug`` selectors for the staged artifact set.
+    """
+    staged_artifacts: list[str] = []
+
+    for body, prov in results:
+        kind = prov.artifact_kind
+        slug = prov.artifact_slug
+        artifact_id: str | None = None
+        if kind == "directive":
+            artifact_id = prov.artifact_urn.split(":", 1)[1]
+
+        filename = _artifact_filename(kind, slug, artifact_id)
+        yaml_bytes = canonical_yaml(body)
+
+        staged_content_path = staging_dir.path_for_content(kind, filename)
+        staging_dir.guard.write_bytes(
+            staged_content_path,
+            yaml_bytes,
+            caller="write_pipeline.stage_and_validate[content]",
+        )
+
+        staged_prov_path = staging_dir.path_for_provenance(kind, slug)
+        dump_provenance(prov, staged_prov_path, staging_dir.guard)
+        staged_artifacts.append(f"{kind}:{slug}")
+
+    validation_callback(staging_dir)
+    _run_neutrality_gate(staging_dir, results, request.evidence)
+    return staged_artifacts
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------

--- a/src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-charter-doctrine/SKILL.md
@@ -128,48 +128,51 @@ The interview fields map to target artifact kinds:
 For each synthesis target, derive: `kind`, `slug` (kebab-case, project-specific),
 `title`, and `body` (the full artifact content as YAML matching the shipped schema).
 
-### Step 4 — Write the doctrine YAML to `.kittify/doctrine/`
+### Step 4 — Write the doctrine YAML to `.kittify/charter/generated/`
 
-Project-local doctrine lives at `.kittify/doctrine/<kind>/<slug>.yaml`.
+The harness writes artifact inputs here; `spec-kitty charter synthesize`
+validates, stages, and promotes them into the live doctrine tree.
 
 ```
-.kittify/doctrine/
-  directive/
-    <project-slug>.yaml    ← your generated directive
-  tactic/
-    <project-slug>.yaml    ← your generated tactic (if any)
-  styleguide/
-    <project-slug>.yaml    ← your generated styleguide (if any)
+.kittify/charter/generated/
+  directives/
+    <NNN>-<slug>.directive.yaml
+  tactics/
+    <slug>.tactic.yaml
+  styleguides/
+    <slug>.styleguide.yaml
 ```
 
 Use the shipped artifact YAML structure as your template. Make the content
 **specific to the project** based on the interview answers. Do not write
 generic filler.
 
-### Step 5 — Validate each artifact against the schema
+### Step 5 — Run the full validation stack without promoting
 
 ```bash
-spec-kitty doctrine validate --kind directive .kittify/doctrine/directive/<slug>.yaml
-spec-kitty doctrine validate --kind tactic .kittify/doctrine/tactic/<slug>.yaml
-spec-kitty doctrine validate --kind styleguide .kittify/doctrine/styleguide/<slug>.yaml
+spec-kitty charter synthesize --dry-run
 ```
 
-Fix any schema errors before proceeding.
+This is a real stage-and-validate pass. It writes the agent-authored artifacts
+into the staging tree, runs schema validation, project DRG validation, and the
+neutrality gate, then wipes the staging directory on success.
 
-### Step 6 — Run the DRG validation
+### Step 6 — Promote the validated artifact set
 
 ```bash
-spec-kitty charter synthesize --validate-only
+spec-kitty charter synthesize
 ```
 
-This runs the project DRG validation and neutrality gate without generating
-anything new. It confirms your written artifacts are coherent.
+By default this reads from `.kittify/charter/generated/` via the generated
+adapter and promotes the validated outputs into:
+- `.kittify/doctrine/` for artifact content and project `graph.yaml`
+- `.kittify/charter/provenance/` plus `synthesis-manifest.yaml` for bookkeeping
 
-### Step 7 — Commit the doctrine artifacts
+### Step 7 — Commit the promoted charter synthesis state
 
 ```bash
-git add .kittify/doctrine/
-git commit -m "feat(charter): synthesize project-local doctrine from interview"
+git add .kittify/doctrine/ .kittify/charter/provenance/ .kittify/charter/synthesis-manifest.yaml
+git commit -m "feat(charter): promote project-local doctrine from generated inputs"
 ```
 
 ---

--- a/src/specify_cli/cli/commands/charter.py
+++ b/src/specify_cli/cli/commands/charter.py
@@ -516,6 +516,7 @@ def _build_synthesis_request(
 
     from charter.interview import read_interview_answers
     from charter.synthesizer.fixture_adapter import FixtureAdapter
+    from charter.synthesizer.generated_artifact_adapter import GeneratedArtifactAdapter
     from charter.synthesizer.request import SynthesisRequest, SynthesisTarget
 
     answers_path = _interview_path(repo_root)
@@ -575,12 +576,14 @@ def _build_synthesis_request(
         evidence=evidence,
     )
 
-    if adapter_name == "fixture":
+    if adapter_name == "generated":
+        adapter_obj = GeneratedArtifactAdapter(repo_root=repo_root)
+    elif adapter_name == "fixture":
         adapter_obj = FixtureAdapter()
     else:
         raise TaskCliError(
             f"Unknown adapter '{adapter_name}'. "
-            "Only '--adapter fixture' is supported. "
+            "Supported adapters are '--adapter generated' and '--adapter fixture'. "
             "Doctrine generation is performed by the LLM harness (Claude Code, Codex, "
             "Cursor, etc.) via the spec-kitty-charter-doctrine skill. "
             "spec-kitty never calls an LLM itself."
@@ -589,12 +592,125 @@ def _build_synthesis_request(
     return request, adapter_obj
 
 
+def _collect_evidence_result(
+    repo_root: Path,
+    *,
+    skip_code_evidence: bool,
+    skip_corpus: bool,
+) -> Any:
+    from charter.evidence.orchestrator import EvidenceOrchestrator, load_url_list_from_config
+
+    url_list = load_url_list_from_config(repo_root)
+    orchestrator = EvidenceOrchestrator(
+        repo_root=repo_root,
+        url_list=url_list,
+        skip_code=skip_code_evidence,
+        skip_corpus=skip_corpus,
+    )
+    return orchestrator.collect()
+
+
+def _build_synthesis_validation_callback(request: Any) -> Any:
+    from doctrine.drg.models import DRGGraph
+    from importlib.metadata import version as pkg_version
+
+    from charter.synthesizer.interview_mapping import resolve_sections
+    from charter.synthesizer.orchestrator import _shipped_drg_from_snapshot
+    from charter.synthesizer.project_drg import emit_project_layer, persist as persist_project_graph
+    from charter.synthesizer.targets import build_targets, detect_duplicates, order_targets
+    from charter.synthesizer.validation_gate import validate as validate_project_graph
+
+    spec_kitty_version = pkg_version("spec-kitty-cli")
+    shipped_drg = DRGGraph.model_validate(_shipped_drg_from_snapshot(request.drg_snapshot))
+    sections = resolve_sections(dict(request.interview_snapshot))
+    targets = build_targets(
+        interview_snapshot=dict(request.interview_snapshot),
+        mappings=sections,
+        drg_snapshot=dict(request.drg_snapshot),
+    )
+    targets = order_targets(targets)
+    detect_duplicates(targets)
+    if not targets:
+        targets = [request.target]
+
+    def _validation_callback(staged_dir: Any) -> None:
+        project_graph = emit_project_layer(
+            targets=targets,
+            spec_kitty_version=spec_kitty_version,
+            shipped_drg=shipped_drg,
+        )
+        persist_project_graph(project_graph, staged_dir.root, staged_dir.guard)
+        validate_project_graph(staged_dir.root, shipped_drg)
+
+    return _validation_callback
+
+
+def _run_synthesis_dry_run(
+    request: Any,
+    syn_adapter: Any,
+    repo_root: Path,
+) -> list[str]:
+    from charter.synthesizer.staging import StagingDir
+    from charter.synthesizer.synthesize_pipeline import run_all
+    from charter.synthesizer.write_pipeline import stage_and_validate
+
+    results = run_all(request, adapter=syn_adapter)
+    validation_callback = _build_synthesis_validation_callback(request)
+
+    with StagingDir.create(repo_root, request.run_id) as staging_dir:
+        staged_artifacts = stage_and_validate(
+            request,
+            staging_dir,
+            results,
+            validation_callback,
+        )
+        staging_dir.wipe()
+
+    return staged_artifacts
+
+
+def _list_resynthesis_topics(
+    request: Any,
+    repo_root: Path,
+) -> dict[str, list[str]]:
+    from charter.synthesizer.resynthesize_pipeline import (
+        _load_merged_drg,
+        _load_project_artifacts_from_provenance,
+    )
+
+    project_artifacts = _load_project_artifacts_from_provenance(repo_root)
+    merged_drg = _load_merged_drg(repo_root, request)
+    interview_sections = sorted(str(section) for section in request.interview_snapshot)
+
+    artifact_topics = []
+    for artifact in project_artifacts:
+        selector = artifact.urn if artifact.kind == "directive" else f"{artifact.kind}:{artifact.slug}"
+        artifact_topics.append(selector)
+
+    drg_topics: list[str] = []
+    for node in merged_drg.get("nodes", []):
+        if isinstance(node, dict):
+            urn = node.get("urn")
+            if isinstance(urn, str) and urn:
+                drg_topics.append(urn)
+
+    return {
+        "project_artifacts": sorted(dict.fromkeys(artifact_topics)),
+        "drg_urns": sorted(dict.fromkeys(drg_topics)),
+        "interview_sections": interview_sections,
+        "interview_section_aliases": sorted(section.replace("_", "-") for section in interview_sections),
+    }
+
+
 @app.command("synthesize")
 def charter_synthesize(
     adapter: str = typer.Option(
-        "fixture",
+        "generated",
         "--adapter",
-        help="Adapter to use. Only 'fixture' is supported (offline/testing).",
+        help=(
+            "Adapter to use. 'generated' (default) validates agent-authored YAML under "
+            ".kittify/charter/generated/. 'fixture' is offline/testing only."
+        ),
     ),
     dry_run: bool = typer.Option(
         False,
@@ -629,15 +745,18 @@ def charter_synthesize(
 
     Examples
     --------
+    Validate + promote generated artifacts written by the harness::
+
+        spec-kitty charter synthesize
+
     Validate + promote with fixture adapter (offline/testing)::
 
         spec-kitty charter synthesize --adapter fixture
 
-    Dry-run (stage only, no write)::
+    Dry-run (stage + validate, no promote)::
 
-        spec-kitty charter synthesize --adapter fixture --dry-run
+        spec-kitty charter synthesize --dry-run
     """
-    from charter.evidence.orchestrator import EvidenceOrchestrator, load_url_list_from_config
     from charter.synthesizer.errors import NeutralityGateViolation, SynthesisError, render_error_panel
 
     err_console = Console(stderr=True)
@@ -646,14 +765,11 @@ def charter_synthesize(
         repo_root = find_repo_root()
 
         # Collect evidence before building the synthesis request
-        url_list = load_url_list_from_config(repo_root)
-        orchestrator = EvidenceOrchestrator(
-            repo_root=repo_root,
-            url_list=url_list,
-            skip_code=skip_code_evidence,
+        evidence_result = _collect_evidence_result(
+            repo_root,
+            skip_code_evidence=skip_code_evidence,
             skip_corpus=skip_corpus,
         )
-        evidence_result = orchestrator.collect()
         for warning in evidence_result.warnings:
             console.print(f"[yellow]\u26a0 {warning}[/yellow]")
 
@@ -681,24 +797,18 @@ def charter_synthesize(
         request, syn_adapter = _build_synthesis_request(repo_root, adapter, evidence=evidence_result.bundle)
 
         if dry_run:
-            # Dry-run: stage but do not promote
-            from charter.synthesizer.synthesize_pipeline import run_all
-
-            results = run_all(request, adapter=syn_adapter)
-
-            staged_files: list[str] = []
-            for _body, prov in results:
-                staged_files.append(f"{prov.artifact_kind}:{prov.artifact_slug}")
+            staged_files = _run_synthesis_dry_run(request, syn_adapter, repo_root)
 
             if json_output:
                 print(json.dumps({
                     "result": "dry_run",
                     "staged_artifacts": staged_files,
                     "artifact_count": len(staged_files),
+                    "validated": True,
                 }, indent=2))
                 return
 
-            console.print("[yellow]Dry-run:[/yellow] synthesis staged (not promoted)")
+            console.print("[yellow]Dry-run:[/yellow] synthesis staged and validated (not promoted)")
             for f in staged_files:
                 console.print(f"  [dim]staged:[/dim] {f}")
             return
@@ -743,9 +853,9 @@ def charter_synthesize(
 
 
 @app.command("resynthesize")
-def charter_resynthesize(
-    topic: str = typer.Option(
-        ...,
+def charter_resynthesize(  # noqa: C901
+    topic: str | None = typer.Option(
+        None,
         "--topic",
         help=(
             "Structured topic selector: "
@@ -754,10 +864,28 @@ def charter_resynthesize(
             "or <interview-section-label>."
         ),
     ),
+    list_topics: bool = typer.Option(
+        False,
+        "--list-topics",
+        help="List valid structured topic selectors and exit.",
+    ),
     adapter: str = typer.Option(
-        "fixture",
+        "generated",
         "--adapter",
-        help="Adapter to use. Only 'fixture' is supported (offline/testing).",
+        help=(
+            "Adapter to use. 'generated' (default) validates agent-authored YAML under "
+            ".kittify/charter/generated/. 'fixture' is offline/testing only."
+        ),
+    ),
+    skip_code_evidence: bool = typer.Option(
+        False,
+        "--skip-code-evidence",
+        help="Skip code-reading evidence collection.",
+    ),
+    skip_corpus: bool = typer.Option(
+        False,
+        "--skip-corpus",
+        help="Skip best-practice corpus loading.",
     ),
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
 ) -> None:
@@ -777,11 +905,11 @@ def charter_resynthesize(
     --------
     Resynthesize a single tactic::
 
-        spec-kitty charter resynthesize --topic tactic:how-we-apply-directive-003 --adapter fixture
+        spec-kitty charter resynthesize --topic tactic:how-we-apply-directive-003
 
     Resynthesize all artifacts referencing a shipped directive::
 
-        spec-kitty charter resynthesize --topic directive:DIRECTIVE_003 --adapter fixture
+        spec-kitty charter resynthesize --topic directive:DIRECTIVE_003
     """
     from charter.synthesizer.errors import (
         SynthesisError,
@@ -795,7 +923,46 @@ def charter_resynthesize(
 
     try:
         repo_root = find_repo_root()
-        request, syn_adapter = _build_synthesis_request(repo_root, adapter)
+        evidence_result = _collect_evidence_result(
+            repo_root,
+            skip_code_evidence=skip_code_evidence,
+            skip_corpus=skip_corpus,
+        )
+        for warning in evidence_result.warnings:
+            console.print(f"[yellow]\u26a0 {warning}[/yellow]")
+
+        request, syn_adapter = _build_synthesis_request(repo_root, adapter, evidence=evidence_result.bundle)
+
+        if list_topics:
+            topics = _list_resynthesis_topics(request, repo_root)
+            if json_output:
+                print(json.dumps({
+                    "result": "success",
+                    "topics": topics,
+                }, indent=2))
+                return
+
+            if not any(topics.values()):
+                console.print("[yellow]No topic selectors available yet.[/yellow]")
+                return
+
+            if topics["project_artifacts"]:
+                console.print("[bold]Project artifact selectors[/bold]")
+                for selector in topics["project_artifacts"]:
+                    console.print(f"  {selector}")
+            if topics["drg_urns"]:
+                console.print("[bold]DRG URNs[/bold]")
+                for selector in topics["drg_urns"]:
+                    console.print(f"  {selector}")
+            if topics["interview_sections"]:
+                console.print("[bold]Interview sections[/bold]")
+                for selector in topics["interview_sections"]:
+                    alias = selector.replace("_", "-")
+                    console.print(f"  {selector}  [dim](alias: {alias})[/dim]")
+            return
+
+        if topic is None:
+            raise TaskCliError("Pass --topic <selector> or use --list-topics.")
 
         from charter.synthesizer.resynthesize_pipeline import run as resynthesize_run
 

--- a/tests/agent/cli/commands/test_charter_resynthesize_cli.py
+++ b/tests/agent/cli/commands/test_charter_resynthesize_cli.py
@@ -1,7 +1,8 @@
 """CLI tests for 'spec-kitty charter resynthesize' (T032).
 
 Happy path:
-  - Resolved selector writes bounded change; output reports regenerated artifacts.
+  - Default generated adapter writes bounded change; output reports regenerated artifacts.
+  - --list-topics shows the valid selector surface.
   - --json returns valid JSON with result="success" or "noop".
 
 Error paths:
@@ -102,6 +103,7 @@ class TestResynthesizeHelp:
         assert result.exit_code == 0
         plain = _plain_output(result.output)
         assert "--topic" in plain
+        assert "--list-topics" in plain
         assert "--adapter" in plain
 
     def test_synthesize_help(self) -> None:
@@ -121,21 +123,18 @@ class TestResynthesizeHappyPath:
         _write_interview_answers(tmp_path)
         mock_result = _make_mock_result()
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                return_value=mock_result,
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "tactic:how-we-apply-directive-003",
-                        "--adapter",
-                        "fixture",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            return_value=mock_result,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "tactic:how-we-apply-directive-003",
+                ],
+            )
 
         assert result.exit_code == 0, f"Expected exit 0: {result.output}"
         assert "how-we-apply-directive-003" in result.output or "Resynthesis" in result.output
@@ -145,22 +144,19 @@ class TestResynthesizeHappyPath:
         _write_interview_answers(tmp_path)
         mock_result = _make_mock_result()
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                return_value=mock_result,
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "tactic:how-we-apply-directive-003",
-                        "--adapter",
-                        "fixture",
-                        "--json",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            return_value=mock_result,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "tactic:how-we-apply-directive-003",
+                    "--json",
+                ],
+            )
 
         assert result.exit_code == 0, f"Expected exit 0: {result.output}"
         data = json.loads(result.output)
@@ -174,21 +170,18 @@ class TestResynthesizeHappyPath:
         _write_interview_answers(tmp_path)
         mock_result = _make_mock_result(is_noop=True, matched_form="drg_urn")
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                return_value=mock_result,
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "paradigm:evidence-first",
-                        "--adapter",
-                        "fixture",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            return_value=mock_result,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "paradigm:evidence-first",
+                ],
+            )
 
         assert result.exit_code == 0, f"Expected exit 0: {result.output}"
         assert "noop" in result.output.lower() or "No-op" in result.output
@@ -198,27 +191,44 @@ class TestResynthesizeHappyPath:
         _write_interview_answers(tmp_path)
         mock_result = _make_mock_result(is_noop=True, matched_form="drg_urn")
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                return_value=mock_result,
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "paradigm:evidence-first",
-                        "--adapter",
-                        "fixture",
-                        "--json",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            return_value=mock_result,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "paradigm:evidence-first",
+                    "--json",
+                ],
+            )
 
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["result"] == "noop"
         assert data["targets_count"] == 0
+
+    def test_list_topics_json_output(self, tmp_path: Path) -> None:
+        """--list-topics returns the available selector sets."""
+        _write_interview_answers(tmp_path)
+
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "specify_cli.cli.commands.charter._list_resynthesis_topics",
+            return_value={
+                "project_artifacts": ["directive:PROJECT_001"],
+                "drg_urns": ["directive:DIRECTIVE_003"],
+                "interview_sections": ["testing_philosophy"],
+                "interview_section_aliases": ["testing-philosophy"],
+            },
+        ):
+            result = runner.invoke(app, ["resynthesize", "--list-topics", "--json"])
+
+        assert result.exit_code == 0, f"Expected exit 0: {result.output}"
+        data = json.loads(result.output)
+        assert data["result"] == "success"
+        assert data["topics"]["project_artifacts"] == ["directive:PROJECT_001"]
 
 
 # ---------------------------------------------------------------------------
@@ -233,25 +243,22 @@ class TestResynthesizeErrorPaths:
 
         from charter.synthesizer.errors import TopicSelectorUnresolvedError
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                side_effect=TopicSelectorUnresolvedError(
-                    raw="bogus:nonexistent",
-                    candidates=("tactic:how-we-apply-directive-003 (distance=5)",),
-                    attempted_forms=("kind_slug", "drg_urn"),
-                ),
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "bogus:nonexistent",
-                        "--adapter",
-                        "fixture",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            side_effect=TopicSelectorUnresolvedError(
+                raw="bogus:nonexistent",
+                candidates=("tactic:how-we-apply-directive-003 (distance=5)",),
+                attempted_forms=("kind_slug", "drg_urn"),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "bogus:nonexistent",
+                ],
+            )
 
         # Exit code 2 is the contract (contracts/topic-selector.md §2.2)
         assert result.exit_code == 2, (
@@ -264,25 +271,24 @@ class TestResynthesizeErrorPaths:
 
         from charter.synthesizer.errors import TopicSelectorUnresolvedError
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                side_effect=TopicSelectorUnresolvedError(
-                    raw="bogus:nonexistent",
-                    candidates=(),
-                    attempted_forms=("kind_slug", "drg_urn"),
-                ),
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "bogus:nonexistent",
-                        "--adapter",
-                        "fixture",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            side_effect=TopicSelectorUnresolvedError(
+                raw="bogus:nonexistent",
+                candidates=(),
+                attempted_forms=("kind_slug", "drg_urn"),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "bogus:nonexistent",
+                    "--adapter",
+                    "fixture",
+                ],
+            )
 
         assert result.exit_code == 2
         # Panel title should contain the unresolved topic string
@@ -297,25 +303,24 @@ class TestResynthesizeErrorPaths:
 
         doctrine_dir = tmp_path / ".kittify" / "doctrine"
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                side_effect=TopicSelectorUnresolvedError(
-                    raw="bogus:nonexistent",
-                    candidates=(),
-                    attempted_forms=("kind_slug", "drg_urn"),
-                ),
-            ):
-                runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "bogus:nonexistent",
-                        "--adapter",
-                        "fixture",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            side_effect=TopicSelectorUnresolvedError(
+                raw="bogus:nonexistent",
+                candidates=(),
+                attempted_forms=("kind_slug", "drg_urn"),
+            ),
+        ):
+            runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "bogus:nonexistent",
+                    "--adapter",
+                    "fixture",
+                ],
+            )
 
         # doctrine dir should not have been created by the error path
         assert not doctrine_dir.exists(), (
@@ -341,21 +346,20 @@ class TestResynthesizeErrorPaths:
         """No prior manifest → FileNotFoundError → exit 1."""
         _write_interview_answers(tmp_path)
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            with patch(
-                "charter.synthesizer.resynthesize_pipeline.run",
-                side_effect=FileNotFoundError("No prior synthesis manifest"),
-            ):
-                result = runner.invoke(
-                    app,
-                    [
-                        "resynthesize",
-                        "--topic",
-                        "tactic:how-we-apply-directive-003",
-                        "--adapter",
-                        "fixture",
-                    ],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "charter.synthesizer.resynthesize_pipeline.run",
+            side_effect=FileNotFoundError("No prior synthesis manifest"),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "resynthesize",
+                    "--topic",
+                    "tactic:how-we-apply-directive-003",
+                    "--adapter",
+                    "fixture",
+                ],
+            )
 
         assert result.exit_code == 1, f"Expected exit 1: {result.output}"
 

--- a/tests/agent/cli/commands/test_charter_synthesize_cli.py
+++ b/tests/agent/cli/commands/test_charter_synthesize_cli.py
@@ -1,8 +1,9 @@
 """CLI tests for 'spec-kitty charter synthesize' (T032).
 
 Happy path:
-  - --adapter fixture runs synthesis and emits manifest info.
-  - --dry-run doesn't promote (prints staged artifacts only).
+  - default generated adapter runs synthesis and emits manifest info.
+  - --adapter fixture remains available for deterministic testing.
+  - --dry-run stages and validates without promoting.
   - --json returns valid JSON.
 
 Error paths:
@@ -75,12 +76,29 @@ class TestSynthesizeHappyPath:
         assert "--adapter" in plain
         assert "--dry-run" in plain
 
-    def test_synthesize_fixture_adapter(self, tmp_path: Path) -> None:
-        """--adapter fixture runs synthesis and reports success."""
+    def test_synthesize_generated_default_adapter(self, tmp_path: Path) -> None:
+        """Default adapter is the generated-artifact path, not fixture."""
         _write_interview_answers(tmp_path)
 
         with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            # Mock the synthesize call to avoid fixture-hash mismatches in CLI context
+            mock_result = MagicMock()
+            mock_result.target_kind = "directive"
+            mock_result.target_slug = "mission-type-scope-directive"
+            mock_result.inputs_hash = "abc123"
+            mock_result.effective_adapter_id = "generated"
+            mock_result.effective_adapter_version = "1.0.0"
+
+            with patch("charter.synthesizer.synthesize", return_value=mock_result):
+                result = runner.invoke(app, ["synthesize"])
+
+        assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}: {result.output}"
+        assert "synthesis complete" in result.output.lower() or "Charter synthesis" in result.output
+
+    def test_synthesize_fixture_adapter(self, tmp_path: Path) -> None:
+        """--adapter fixture remains supported for offline regression runs."""
+        _write_interview_answers(tmp_path)
+
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
             mock_result = MagicMock()
             mock_result.target_kind = "directive"
             mock_result.target_slug = "mission-type-scope-directive"
@@ -92,29 +110,20 @@ class TestSynthesizeHappyPath:
                 result = runner.invoke(app, ["synthesize", "--adapter", "fixture"])
 
         assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}: {result.output}"
-        assert "synthesis complete" in result.output.lower() or "Charter synthesis" in result.output
 
     def test_synthesize_fixture_dry_run(self, tmp_path: Path) -> None:
-        """--dry-run stages but does not promote; output contains 'Dry-run'."""
+        """--dry-run stages and validates but does not promote."""
         _write_interview_answers(tmp_path)
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            # Mock run_all to return a simple result
-            mock_prov = MagicMock()
-            mock_prov.artifact_kind = "directive"
-            mock_prov.artifact_slug = "test-directive"
-            mock_body = {"id": "PROJECT_001", "title": "Test"}
-
-            with patch(
-                "charter.synthesizer.synthesize_pipeline.run_all",
-                return_value=[(mock_body, mock_prov)],
-            ):
-                result = runner.invoke(
-                    app, ["synthesize", "--adapter", "fixture", "--dry-run"]
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "specify_cli.cli.commands.charter._run_synthesis_dry_run",
+            return_value=["directive:test-directive"],
+        ):
+            result = runner.invoke(app, ["synthesize", "--dry-run"])
 
         assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}: {result.output}"
         assert "Dry-run" in result.output or "dry" in result.output.lower()
+        assert "validated" in result.output.lower()
 
     def test_synthesize_json_output(self, tmp_path: Path) -> None:
         """--json returns valid JSON with a 'result' key."""
@@ -138,27 +147,23 @@ class TestSynthesizeHappyPath:
         assert data["result"] in {"success", "dry_run"}
 
     def test_synthesize_dry_run_json(self, tmp_path: Path) -> None:
-        """--dry-run --json returns JSON with staged_artifacts."""
+        """--dry-run --json returns staged artifacts and validated=true."""
         _write_interview_answers(tmp_path)
 
-        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            mock_prov = MagicMock()
-            mock_prov.artifact_kind = "directive"
-            mock_prov.artifact_slug = "test-directive"
-
-            with patch(
-                "charter.synthesizer.synthesize_pipeline.run_all",
-                return_value=[({}, mock_prov)],
-            ):
-                result = runner.invoke(
-                    app,
-                    ["synthesize", "--adapter", "fixture", "--dry-run", "--json"],
-                )
+        with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
+            "specify_cli.cli.commands.charter._run_synthesis_dry_run",
+            return_value=["directive:test-directive"],
+        ):
+            result = runner.invoke(
+                app,
+                ["synthesize", "--dry-run", "--json"],
+            )
 
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["result"] == "dry_run"
         assert "staged_artifacts" in data
+        assert data["validated"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +176,7 @@ class TestSynthesizeErrorPaths:
         """No interview answers → exit 1 with error message."""
         # tmp_path has no interview answers
         with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
-            result = runner.invoke(app, ["synthesize", "--adapter", "fixture"])
+            result = runner.invoke(app, ["synthesize"])
 
         assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}: {result.output}"
 

--- a/tests/charter/synthesizer/test_generated_artifact_adapter.py
+++ b/tests/charter/synthesizer/test_generated_artifact_adapter.py
@@ -1,0 +1,156 @@
+"""Tests for the harness-owned generated artifact adapter and evidence roundtrips."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from charter.synthesizer.errors import (
+    GeneratedArtifactLoadError,
+    GeneratedArtifactMissingError,
+)
+from charter.synthesizer.evidence import CodeSignals, CorpusEntry, CorpusSnapshot, EvidenceBundle
+from charter.synthesizer.generated_artifact_adapter import GeneratedArtifactAdapter
+from charter.synthesizer.provenance import load_yaml as load_provenance
+from charter.synthesizer.request import SynthesisRequest, SynthesisTarget, _evidence_to_jsonable
+from charter.synthesizer.resynthesize_pipeline import run as resynthesize_run
+from charter.synthesizer.orchestrator import synthesize
+
+
+VALID_DIRECTIVE_BODY = {
+    "id": "PROJECT_001",
+    "schema_version": "1.0",
+    "title": "Mission Scope Directive",
+    "intent": "Capture project mission scope for governance synthesis tests.",
+    "enforcement": "required",
+}
+
+
+def _directive_request(evidence: EvidenceBundle | None = None) -> SynthesisRequest:
+    target = SynthesisTarget(
+        kind="directive",
+        slug="mission-type-scope-directive",
+        title="Mission Type Scope Directive",
+        artifact_id="PROJECT_001",
+        source_section="mission_type",
+    )
+    return SynthesisRequest(
+        target=target,
+        interview_snapshot={},
+        doctrine_snapshot={"directives": {}, "tactics": {}, "styleguides": {}},
+        drg_snapshot={"nodes": [], "edges": [], "schema_version": "1"},
+        run_id="01KTESTGENERATEDARTIFACT0001",
+        evidence=evidence,
+    )
+
+
+def _generated_directive_path(repo_root: Path) -> Path:
+    return (
+        repo_root
+        / ".kittify"
+        / "charter"
+        / "generated"
+        / "directives"
+        / "001-mission-type-scope-directive.directive.yaml"
+    )
+
+
+def _write_generated_directive(repo_root: Path, body: dict[str, object]) -> Path:
+    path = _generated_directive_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    import ruamel.yaml
+
+    yaml = ruamel.yaml.YAML()
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.dump(body, fh)
+    return path
+
+
+def _evidence_hash(bundle: EvidenceBundle) -> str:
+    raw = json.dumps(_evidence_to_jsonable(bundle), sort_keys=True, ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def test_generated_adapter_missing_file_raises(tmp_path: Path) -> None:
+    request = _directive_request()
+    adapter = GeneratedArtifactAdapter(repo_root=tmp_path)
+
+    with pytest.raises(GeneratedArtifactMissingError) as exc_info:
+        adapter.generate(request)
+
+    assert "001-mission-type-scope-directive.directive.yaml" in exc_info.value.expected_path
+
+
+def test_generated_adapter_rejects_identity_mismatch(tmp_path: Path) -> None:
+    request = _directive_request()
+    adapter = GeneratedArtifactAdapter(repo_root=tmp_path)
+    body = dict(VALID_DIRECTIVE_BODY)
+    body["id"] = "PROJECT_999"
+    _write_generated_directive(tmp_path, body)
+
+    with pytest.raises(GeneratedArtifactLoadError) as exc_info:
+        adapter.generate(request)
+
+    assert "artifact id mismatch" in str(exc_info.value)
+
+
+def test_evidence_hash_survives_synthesize_and_resynthesize_roundtrip(tmp_path: Path) -> None:
+    evidence = EvidenceBundle(
+        code_signals=CodeSignals(
+            stack_id="python",
+            primary_language="python",
+            frameworks=("django",),
+            test_frameworks=("pytest",),
+            scope_tag="python",
+            representative_files=("src/app.py",),
+            detected_at="2026-04-19T00:00:00+00:00",
+        ),
+        url_list=("https://example.com/governance",),
+        corpus_snapshot=CorpusSnapshot(
+            profile_key="python",
+            snapshot_id="python-v1.0.0",
+            entries=(
+                CorpusEntry(
+                    topic="testing",
+                    guidance="Prefer fast deterministic tests.",
+                    tags=("python", "testing"),
+                ),
+            ),
+            loaded_at="2026-04-19T00:00:00+00:00",
+        ),
+        collected_at="2026-04-19T00:00:00+00:00",
+    )
+    expected_hash = _evidence_hash(evidence)
+
+    request = _directive_request(evidence=evidence)
+    adapter = GeneratedArtifactAdapter(repo_root=tmp_path)
+    _write_generated_directive(tmp_path, VALID_DIRECTIVE_BODY)
+
+    synthesize(request, adapter=adapter, repo_root=tmp_path)
+
+    prov_path = (
+        tmp_path
+        / ".kittify"
+        / "charter"
+        / "provenance"
+        / "directive-mission-type-scope-directive.yaml"
+    )
+    first_prov = load_provenance(prov_path)
+    assert first_prov.artifact_urn == "directive:PROJECT_001"
+    assert first_prov.evidence_bundle_hash == expected_hash
+    assert first_prov.corpus_snapshot_id == "python-v1.0.0"
+
+    resynthesize_run(
+        request=request,
+        adapter=adapter,
+        topic="directive:PROJECT_001",
+        repo_root=tmp_path,
+    )
+
+    second_prov = load_provenance(prov_path)
+    assert second_prov.artifact_urn == "directive:PROJECT_001"
+    assert second_prov.evidence_bundle_hash == expected_hash
+    assert second_prov.corpus_snapshot_id == "python-v1.0.0"

--- a/tests/charter/synthesizer/test_orchestrator_resynthesize.py
+++ b/tests/charter/synthesizer/test_orchestrator_resynthesize.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 from typing import Any
-from collections.abc import Mapping
 
 import pytest
 
@@ -26,17 +25,13 @@ from charter.synthesizer import (
     SynthesisTarget,
     synthesize,
 )
-from charter.synthesizer.errors import ProjectDRGValidationError, TopicSelectorUnresolvedError
+from charter.synthesizer.errors import ProjectDRGValidationError
 from charter.synthesizer.manifest import (
     MANIFEST_PATH,
     SynthesisManifest,
     load_yaml as load_manifest,
 )
-from charter.synthesizer.resynthesize_pipeline import (
-    ResynthesisResult,
-    run as resynthesize_run,
-)
-from charter.synthesizer.synthesize_pipeline import canonical_yaml
+from charter.synthesizer.resynthesize_pipeline import run as resynthesize_run
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +165,30 @@ class TestPriorSynthesisBaseline:
 
 
 class TestUs3KindSlug:
+    def test_resynthesize_single_directive_by_project_id(
+        self,
+        base_request: SynthesisRequest,
+        adapter: FixtureAdapter,
+        repo_with_prior_synthesis: Path,
+    ) -> None:
+        """directive:PROJECT_001 resolves back to the synthesized project directive."""
+        repo = repo_with_prior_synthesis
+
+        result = resynthesize_run(
+            request=base_request,
+            adapter=adapter,
+            topic="directive:PROJECT_001",
+            repo_root=repo,
+        )
+
+        assert not result.is_noop
+        assert result.resolved_topic.matched_form == "kind_slug"
+        assert len(result.resolved_topic.targets) == 1
+        target = result.resolved_topic.targets[0]
+        assert target.kind == "directive"
+        assert target.artifact_id == "PROJECT_001"
+        assert target.slug == "mission-type-scope-directive"
+
     def test_resynthesize_single_tactic_by_kind_slug(
         self,
         base_request: SynthesisRequest,
@@ -178,8 +197,6 @@ class TestUs3KindSlug:
     ) -> None:
         """US-3: tactic:how-we-apply-directive-003 → only that artifact regenerated."""
         repo = repo_with_prior_synthesis
-        prior_manifest = load_manifest(repo / MANIFEST_PATH)
-        prior_hashes = _artifact_hashes_from_manifest(repo, prior_manifest)
 
         result = resynthesize_run(
             request=base_request,
@@ -289,7 +306,6 @@ class TestUs2DrgUrn:
     ) -> None:
         """US-2: directive:DIRECTIVE_003 → multiple artifacts referencing that URN."""
         repo = repo_with_prior_synthesis
-        prior_manifest = load_manifest(repo / MANIFEST_PATH)
 
         result = resynthesize_run(
             request=base_request,

--- a/tests/charter/synthesizer/test_orchestrator_synthesize.py
+++ b/tests/charter/synthesizer/test_orchestrator_synthesize.py
@@ -168,10 +168,14 @@ class TestRunAllTupleCount:
         full_request: SynthesisRequest,
         adapter: FixtureAdapter,
     ) -> None:
-        """ProvenanceEntry.artifact_urn equals f'{kind}:{artifact_id or slug}'."""
+        """ProvenanceEntry.artifact_urn uses artifact_id for directives, slug otherwise."""
         results = run_all(full_request, adapter=adapter)
-        for _, prov in results:
-            expected_urn = f"{prov.artifact_kind}:{prov.artifact_slug}"
+        for body, prov in results:
+            expected_urn = (
+                f"{prov.artifact_kind}:{body['id']}"
+                if prov.artifact_kind == "directive"
+                else f"{prov.artifact_kind}:{prov.artifact_slug}"
+            )
             assert prov.artifact_urn == expected_urn, (
                 f"Expected urn '{expected_urn}', got '{prov.artifact_urn}'"
             )
@@ -241,7 +245,7 @@ class TestIdempotency:
         results_b = run_all(full_request, adapter=adapter)
 
         assert len(results_a) == len(results_b)
-        for (_, prov_a), (_, prov_b) in zip(results_a, results_b):
+        for (_, prov_a), (_, prov_b) in zip(results_a, results_b, strict=True):
             assert prov_a.inputs_hash == prov_b.inputs_hash, (
                 f"inputs_hash diverged for {prov_a.artifact_urn}: "
                 f"{prov_a.inputs_hash!r} != {prov_b.inputs_hash!r}"
@@ -256,7 +260,7 @@ class TestIdempotency:
         results_a = run_all(full_request, adapter=adapter)
         results_b = run_all(full_request, adapter=adapter)
 
-        for (_, prov_a), (_, prov_b) in zip(results_a, results_b):
+        for (_, prov_a), (_, prov_b) in zip(results_a, results_b, strict=True):
             assert prov_a.artifact_content_hash == prov_b.artifact_content_hash, (
                 f"artifact_content_hash diverged for {prov_a.artifact_urn}: "
                 f"{prov_a.artifact_content_hash!r} != {prov_b.artifact_content_hash!r}"
@@ -298,7 +302,7 @@ class TestIdempotency:
         results_b = run_all(req_b, adapter=adapter)
 
         assert len(results_a) == len(results_b)
-        for (_, prov_a), (_, prov_b) in zip(results_a, results_b):
+        for (_, prov_a), (_, prov_b) in zip(results_a, results_b, strict=True):
             assert prov_a.inputs_hash == prov_b.inputs_hash
             assert prov_a.artifact_content_hash == prov_b.artifact_content_hash
 

--- a/tests/charter/synthesizer/test_topic_resolver.py
+++ b/tests/charter/synthesizer/test_topic_resolver.py
@@ -20,7 +20,7 @@ import pytest
 
 from charter.synthesizer.errors import TopicSelectorUnresolvedError
 from charter.synthesizer.request import SynthesisTarget
-from charter.synthesizer.topic_resolver import ResolvedTopic, resolve
+from charter.synthesizer.topic_resolver import resolve
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +264,17 @@ class TestTier3InterviewSection:
         assert "how-we-apply-directive-003" in slugs
         assert "python-testing-style" in slugs
         assert "mission-scope" not in slugs  # mission_type section, not testing_philosophy
+
+    def test_hyphenated_section_alias_resolves_to_canonical_section(
+        self, all_artifacts, merged_drg, interview_sections
+    ) -> None:
+        """testing-philosophy is normalized to testing_philosophy for operator UX."""
+        result = resolve("testing-philosophy", all_artifacts, merged_drg, interview_sections)
+        assert result.matched_form == "interview_section"
+        assert result.matched_value == "testing_philosophy"
+        slugs = {t.slug for t in result.targets}
+        assert "how-we-apply-directive-003" in slugs
+        assert "python-testing-style" in slugs
 
     def test_section_hit_with_no_artifacts(
         self, all_artifacts, merged_drg, interview_sections


### PR DESCRIPTION
## Summary
**Charter synthesis**
- add a generated-artifact adapter so harness-authored doctrine YAML in `.kittify/charter/generated/` can flow through the existing schema, provenance, neutrality, and promotion pipeline without an in-process model adapter
- fix directive provenance to use canonical artifact URNs, preserve evidence during bounded resynthesis, and make `charter synthesize --dry-run` perform real staging and validation
- tighten the CLI and topic UX with generated adapter defaults, `--list-topics`, and normalized interview-section selectors, backed by new regression coverage

**Docs and operator guidance**
- update the charter doctrine skill, Phase 3 spec docs, completion metadata, and changelog to describe the harness-owned generated-artifact workflow after the Anthropic adapter removal

## Test Coverage
All new code paths have test coverage.

Tests: `pytest -q tests/charter/synthesizer tests/charter/evidence tests/charter/test_phase3_integration.py tests/agent/cli/commands/test_charter_synthesize_cli.py tests/agent/cli/commands/test_charter_resynthesize_cli.py` → `387 passed`

## Pre-Landing Review
Resolved the charter review findings that prompted this branch:
- directive provenance identity broke directive roundtrips and resynthesis selection
- bounded resynthesis dropped evidence collected during initial synthesis
- `--dry-run` claimed validation without staging or validation work
- resynthesis topic UX advertised selectors the resolver could not actually match

## Design Review
No frontend files changed, design review skipped.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
No plan file detected.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] `ruff check src/charter/synthesizer/generated_artifact_adapter.py src/charter/synthesizer/errors.py src/charter/synthesizer/resynthesize_pipeline.py src/charter/synthesizer/synthesize_pipeline.py src/charter/synthesizer/topic_resolver.py src/charter/synthesizer/write_pipeline.py src/specify_cli/cli/commands/charter.py tests/charter/synthesizer/test_generated_artifact_adapter.py tests/charter/synthesizer/test_orchestrator_resynthesize.py tests/charter/synthesizer/test_orchestrator_synthesize.py tests/charter/synthesizer/test_topic_resolver.py tests/agent/cli/commands/test_charter_resynthesize_cli.py tests/agent/cli/commands/test_charter_synthesize_cli.py`
- [x] `pytest -q tests/charter/synthesizer tests/charter/evidence tests/charter/test_phase3_integration.py tests/agent/cli/commands/test_charter_synthesize_cli.py tests/agent/cli/commands/test_charter_resynthesize_cli.py`

🤖 Generated with [OpenAI Codex](https://openai.com/codex)