### PR TITLE
fix(tracker): persist project_slug post-bind + add auth whoami

### DIFF
--- a/src/specify_cli/cli/commands/_auth_whoami.py
+++ b/src/specify_cli/cli/commands/_auth_whoami.py
@@ -1,0 +1,28 @@
+"""Implementation of ``spec-kitty auth whoami``.
+
+Prints the authenticated user's email on stdout and exits 0.
+Prints nothing and exits 1 if not authenticated or session is expired.
+
+Designed for machine consumption — canary preflight scripts read the first
+non-empty output line as the identity token.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from specify_cli.auth import get_token_manager
+
+
+def whoami_impl() -> None:
+    """Print the current user's email and exit 0, or exit 1 if not authenticated."""
+    tm = get_token_manager()
+    session = tm.get_current_session()
+
+    if session is None or session.is_refresh_token_expired():
+        raise typer.Exit(1)
+
+    print(session.email)
+
+
+__all__ = ["whoami_impl"]

--- a/src/specify_cli/cli/commands/auth.py
+++ b/src/specify_cli/cli/commands/auth.py
@@ -89,4 +89,12 @@ def status() -> None:
     status_impl()
 
 
+@app.command()
+def whoami() -> None:
+    """Print the authenticated user's email and exit 0, or exit 1 if not authenticated."""
+    from specify_cli.cli.commands._auth_whoami import whoami_impl
+
+    whoami_impl()
+
+
 __all__ = ["app"]

--- a/src/specify_cli/tracker/discovery.py
+++ b/src/specify_cli/tracker/discovery.py
@@ -84,6 +84,7 @@ class BindResult:
     provider: str
     provider_context: dict[str, str]
     bound_at: str
+    project_slug: str | None = None
 
     @classmethod
     def from_api(cls, data: dict[str, Any]) -> BindResult:
@@ -93,6 +94,7 @@ class BindResult:
             provider=data["provider"],
             provider_context=data.get("provider_context", {}),
             bound_at=data["bound_at"],
+            project_slug=data.get("project_slug") or None,
         )
 
 

--- a/src/specify_cli/tracker/saas_service.py
+++ b/src/specify_cli/tracker/saas_service.py
@@ -248,13 +248,15 @@ class SaaSTrackerService:
         binding_ref: str,
         display_label: str | None,
         provider_context: dict[str, str] | None,
+        project_slug: str | None = None,
     ) -> None:
         """Write binding config to disk and update in-memory state."""
         same_provider = self._config.provider == provider
+        resolved_slug = project_slug or (self._config.project_slug if same_provider else None)
         updated = TrackerProjectConfig(
             provider=provider,
             binding_ref=binding_ref,
-            project_slug=self._config.project_slug if same_provider else None,
+            project_slug=resolved_slug,
             display_label=(
                 display_label
                 if display_label is not None
@@ -297,6 +299,7 @@ class SaaSTrackerService:
             raise
         self._persist_binding(
             provider, result.binding_ref, result.display_label, result.provider_context,
+            project_slug=result.project_slug,
         )
         return result
 


### PR DESCRIPTION
## Summary

- **fix(tracker): persist project_slug from bind response to config** — After a successful `tracker bind`, the `project_slug` was written empty to `.kittify/config.yaml` because the SaaS CLI adapter never returned it. The CLI now reads `project_slug` from the bind response and persists it directly, instead of conditionally preserving the old config value. Fixes saas#78.
- **feat(auth): add `auth whoami` command** — Exits 0 and prints the authenticated email on stdout; exits 1 if unauthenticated or expired. Removes the fragile `auth status` fallback in the live Linear canary preflight. Closes #681.

## Changes

- `src/specify_cli/tracker/discovery.py` — added `project_slug: str | None` field to `BindResult`
- `src/specify_cli/tracker/saas_service.py` — `_persist_binding` accepts and uses `project_slug` from bind result
- `src/specify_cli/cli/commands/_auth_whoami.py` — new file
- `src/specify_cli/cli/commands/auth.py` — register `whoami` command

## Test plan

- [ ] `spec-kitty tracker bind` followed by `cat .kittify/config.yaml` shows non-empty `project_slug`
- [ ] `spec-kitty auth whoami` exits 0 and prints email when authenticated
- [ ] `spec-kitty auth whoami` exits 1 when not authenticated
- [ ] All existing sync/tracker tests pass (`pytest tests/sync/ tests/tracker/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)