### PR TITLE
fix: extend charter neutrality lint to mission templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Directive provenance now records canonical URNs (`directive:PROJECT_<NNN>`) instead of slug-based placeholders, which restores correct directive filenames, provenance reload, and `directive:PROJECT_<NNN>` resynthesis.
 - Bounded resynthesis now preserves evidence inputs end-to-end, so regenerated provenance entries keep the correct `evidence_bundle_hash` and `corpus_snapshot_id`.
 - Generated-artifact synthesis errors now point to the exact expected file path and exact expected artifact id, which makes harness handoff mistakes easier to diagnose.
+- Charter neutrality lint now scans mission `templates/` directories in addition to `command-templates/`, so banned terms in generic mission prompt files are caught by the default repo scan (#653 tripwire).
 
 ### Removed
 

--- a/src/charter/neutrality/lint.py
+++ b/src/charter/neutrality/lint.py
@@ -59,9 +59,7 @@ class NeutralityLintResult:
 
 _YAML = YAML(typ="safe")
 
-_SCANNABLE_SUFFIXES: frozenset[str] = frozenset(
-    {".md", ".yaml", ".yml", ".txt", ".j2"}
-)
+_SCANNABLE_SUFFIXES: frozenset[str] = frozenset({".md", ".yaml", ".yml", ".txt", ".j2"})
 # Segment names that disqualify a file (checked against each path component, not the full path)
 _SKIP_SEGMENTS: frozenset[str] = frozenset({"__pycache__", ".worktrees"})
 # Suffix-level skips (applied to the filename)
@@ -94,9 +92,7 @@ def _load_banned_terms(path: Path) -> list[_CompiledTerm]:
             try:
                 compiled = re.compile(pattern, re.MULTILINE)
             except re.error as exc:
-                raise ValueError(
-                    f"Banned term {term_id!r} has invalid regex pattern {pattern!r}: {exc}"
-                ) from exc
+                raise ValueError(f"Banned term {term_id!r} has invalid regex pattern {pattern!r}: {exc}") from exc
         terms.append(_CompiledTerm(term_id=term_id, kind=kind, pattern=pattern, compiled=compiled))
     return terms
 
@@ -233,10 +229,7 @@ def _scan_regex_matches(
 ) -> list[BannedTermHit]:
     """Return all regex matches for one term on one line."""
     assert term.compiled is not None
-    return [
-        _make_hit(repo_relative, lineno, match.start() + 1, term, match.group(0))
-        for match in term.compiled.finditer(line_text)
-    ]
+    return [_make_hit(repo_relative, lineno, match.start() + 1, term, match.group(0)) for match in term.compiled.finditer(line_text)]
 
 
 def _scan_line(

--- a/src/charter/neutrality/lint.py
+++ b/src/charter/neutrality/lint.py
@@ -288,7 +288,7 @@ def _iter_charter_scan_roots(charter_root: Path) -> list[Path]:
 
 
 def _iter_mission_scan_roots(missions_root: Path) -> list[Path]:
-    """Return mission command-template and mission.yaml scan roots."""
+    """Return mission prompt/template and mission.yaml scan roots."""
     if not missions_root.exists():
         return []
 
@@ -297,9 +297,12 @@ def _iter_mission_scan_roots(missions_root: Path) -> list[Path]:
         if not mission_dir.is_dir():
             continue
         command_templates = mission_dir / "command-templates"
+        templates = mission_dir / "templates"
         mission_manifest = mission_dir / "mission.yaml"
         if command_templates.exists():
             roots.append(command_templates)
+        if templates.exists():
+            roots.append(templates)
         if mission_manifest.exists():
             roots.append(mission_manifest)
     return roots

--- a/tests/charter/test_neutrality_lint.py
+++ b/tests/charter/test_neutrality_lint.py
@@ -99,6 +99,34 @@ def test_fault_injection_catches_regression(tmp_path: Path) -> None:
     )
 
 
+def test_default_scan_roots_include_mission_templates(tmp_path: Path) -> None:
+    """Mission ``templates/`` directories must be scanned by default.
+
+    The current repo ships many generic mission prompt files under
+    ``src/specify_cli/missions/*/templates/`` rather than only under
+    ``command-templates/``. A banned term appearing there must therefore be
+    caught by the default repo scan.
+    """
+    mission_templates = tmp_path / "src" / "specify_cli" / "missions" / "research" / "templates"
+    mission_templates.mkdir(parents=True)
+    (mission_templates / "plan-template.md").write_text(
+        "Generic mission guidance that accidentally tells the user to run pytest.\n",
+        encoding="utf-8",
+    )
+
+    empty_allowlist = tmp_path / "allow.yaml"
+    empty_allowlist.write_text("schema_version: '1'\npaths: []\n", encoding="utf-8")
+
+    result = run_neutrality_lint(
+        repo_root=tmp_path,
+        allowlist_path=empty_allowlist,
+    )
+    assert not result.passed
+    assert any(hit.term_id == "PY-001" for hit in result.hits), (
+        f"Expected PY-001 ('pytest') hit from mission templates; got hits={result.hits}"
+    )
+
+
 def test_fault_injection_respects_allowlist(tmp_path: Path) -> None:
     """An allowlisted file must NOT produce a hit even when it contains a banned term.
 

--- a/tests/charter/test_neutrality_lint.py
+++ b/tests/charter/test_neutrality_lint.py
@@ -28,10 +28,7 @@ def _format_failure(result: NeutralityLintResult) -> str:
     """
     lines: list[str] = ["Neutrality lint failed.", "", "HITS:"]
     for hit in result.hits:
-        lines.append(
-            f"  {hit.file}:{hit.line}:{hit.column} — "
-            f"term_id={hit.term_id} matched={hit.match!r}"
-        )
+        lines.append(f"  {hit.file}:{hit.line}:{hit.column} — term_id={hit.term_id} matched={hit.match!r}")
     if result.stale_allowlist_entries:
         lines.append("")
         lines.append("STALE ALLOWLIST ENTRIES:")
@@ -94,9 +91,7 @@ def test_fault_injection_catches_regression(tmp_path: Path) -> None:
         allowlist_path=empty_allowlist,
     )
     assert not result.passed
-    assert any(hit.term_id == "PY-001" for hit in result.hits), (
-        f"Expected PY-001 ('pytest') hit; got hits={result.hits}"
-    )
+    assert any(hit.term_id == "PY-001" for hit in result.hits), f"Expected PY-001 ('pytest') hit; got hits={result.hits}"
 
 
 def test_default_scan_roots_include_mission_templates(tmp_path: Path) -> None:
@@ -122,9 +117,33 @@ def test_default_scan_roots_include_mission_templates(tmp_path: Path) -> None:
         allowlist_path=empty_allowlist,
     )
     assert not result.passed
-    assert any(hit.term_id == "PY-001" for hit in result.hits), (
-        f"Expected PY-001 ('pytest') hit from mission templates; got hits={result.hits}"
-    )
+    assert any(hit.term_id == "PY-001" for hit in result.hits), f"Expected PY-001 ('pytest') hit from mission templates; got hits={result.hits}"
+
+
+def test_default_scan_roots_include_both_mission_template_dirs(tmp_path: Path) -> None:
+    """Both ``command-templates/`` and ``templates/`` are scanned when they coexist.
+
+    A mission directory may ship both directories at the same time.  A refactor
+    that makes the two branches mutually exclusive would produce a false-negative
+    in either direction — this test locks in that both are live.
+    """
+    mission_dir = tmp_path / "src" / "specify_cli" / "missions" / "research"
+    command_templates = mission_dir / "command-templates"
+    templates = mission_dir / "templates"
+    command_templates.mkdir(parents=True)
+    templates.mkdir(parents=True)
+
+    (command_templates / "cmd.md").write_text("Run pytest to validate.\n", encoding="utf-8")
+    (templates / "tpl.md").write_text("Generic guidance: invoke pytest here.\n", encoding="utf-8")
+
+    empty_allowlist = tmp_path / "allow.yaml"
+    empty_allowlist.write_text("schema_version: '1'\npaths: []\n", encoding="utf-8")
+
+    result = run_neutrality_lint(repo_root=tmp_path, allowlist_path=empty_allowlist)
+    assert not result.passed
+    hit_files = {str(h.file) for h in result.hits}
+    assert any("command-templates" in f for f in hit_files), f"Expected a PY-001 hit from command-templates/; got hit_files={hit_files}"
+    assert any("command-templates" not in f and "templates" in f for f in hit_files), f"Expected a PY-001 hit from templates/; got hit_files={hit_files}"
 
 
 def test_fault_injection_respects_allowlist(tmp_path: Path) -> None:
@@ -170,11 +189,7 @@ def test_stale_allowlist_entry_is_reported(tmp_path: Path) -> None:
 
     allowlist = tmp_path / "allow.yaml"
     allowlist.write_text(
-        "schema_version: '1'\n"
-        "paths:\n"
-        "  - path: src/doctrine/does-not-exist.md\n"
-        "    rationale: Intentionally stale for test.\n"
-        "    added_in: '3.2.0'\n",
+        "schema_version: '1'\npaths:\n  - path: src/doctrine/does-not-exist.md\n    rationale: Intentionally stale for test.\n    added_in: '3.2.0'\n",
         encoding="utf-8",
     )
 
@@ -196,11 +211,7 @@ def test_glob_allowlist_matches_files(tmp_path: Path) -> None:
 
     allowlist = tmp_path / "allow.yaml"
     allowlist.write_text(
-        "schema_version: '1'\n"
-        "paths:\n"
-        "  - path: src/doctrine/python-scoped/*.md\n"
-        "    rationale: Glob-scoped to a python directory.\n"
-        "    added_in: '3.2.0'\n",
+        "schema_version: '1'\npaths:\n  - path: src/doctrine/python-scoped/*.md\n    rationale: Glob-scoped to a python directory.\n    added_in: '3.2.0'\n",
         encoding="utf-8",
     )
 
@@ -209,10 +220,7 @@ def test_glob_allowlist_matches_files(tmp_path: Path) -> None:
         scan_roots=[tmp_path / "src" / "doctrine"],
         allowlist_path=allowlist,
     )
-    assert result.passed, (
-        f"Expected glob allowlist to suppress all hits; got hits={result.hits} "
-        f"stale={result.stale_allowlist_entries}"
-    )
+    assert result.passed, f"Expected glob allowlist to suppress all hits; got hits={result.hits} stale={result.stale_allowlist_entries}"
 
 
 def test_regex_term_reports_accurate_column(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- scan mission `templates/` directories in the charter neutrality lint, not just `command-templates/`
- add a regression test proving a banned term in a generic mission template is caught by the default scan
- keep the #653 neutrality closeout grounded in an actual shipped tripwire, not only a one-time audit

## Testing
- `pytest -q tests/charter/test_neutrality_lint.py`
- `ruff check src/charter/neutrality/lint.py tests/charter/test_neutrality_lint.py`
