### PR TITLE
Fix Sonar regex hotspot in charter artifact naming

### DIFF
--- a/src/charter/synthesizer/artifact_naming.py
+++ b/src/charter/synthesizer/artifact_naming.py
@@ -1,0 +1,59 @@
+"""Helpers for artifact filenames and doctrine subdirectories.
+
+These helpers intentionally avoid regex backtracking so they remain safe when
+fed arbitrary artifact IDs from external inputs or persisted manifests.
+"""
+
+from __future__ import annotations
+
+
+def extract_directive_number(artifact_id: str | None) -> str:
+    """Return the numeric directive segment from an artifact ID.
+
+    Valid directive IDs contain an uppercase prefix followed by ``_`` and one or
+    more digits, for example ``PROJECT_001``. When no such segment is present,
+    the safe fallback is ``"000"``.
+    """
+    if not artifact_id:
+        return "000"
+
+    length = len(artifact_id)
+    index = 0
+    while index < length:
+        start = index
+        while index < length and artifact_id[index].isupper():
+            index += 1
+        if index == start or index >= length or artifact_id[index] != "_":
+            index = start + 1
+            continue
+
+        digits_start = index + 1
+        digits_end = digits_start
+        while digits_end < length and artifact_id[digits_end].isdigit():
+            digits_end += 1
+        if digits_end > digits_start:
+            return artifact_id[digits_start:digits_end].zfill(3)
+
+        index = digits_start
+
+    return "000"
+
+
+def artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> str:
+    """Return the repository-glob-matching filename for an artifact."""
+    if kind == "directive":
+        return f"{extract_directive_number(artifact_id)}-{slug}.directive.yaml"
+    if kind == "tactic":
+        return f"{slug}.tactic.yaml"
+    if kind == "styleguide":
+        return f"{slug}.styleguide.yaml"
+    raise ValueError(f"Unknown artifact kind: {kind!r}")
+
+
+def doctrine_kind_subdir(kind: str) -> str:
+    """Return the doctrine subdirectory name for a given artifact kind."""
+    return {
+        "directive": "directives",
+        "tactic": "tactics",
+        "styleguide": "styleguides",
+    }[kind]

--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -39,6 +39,7 @@ from typing import Any
 from doctrine.drg.loader import load_graph
 from doctrine.drg.models import DRGEdge, DRGGraph, DRGNode
 
+from .artifact_naming import artifact_filename, doctrine_kind_subdir
 from .manifest import (
     MANIFEST_PATH,
     ManifestArtifactEntry,
@@ -117,29 +118,7 @@ def _rewrite_manifest(
         The merged manifest (not yet written to disk; caller does the write).
     """
     import hashlib
-    import re
     from datetime import UTC, datetime
-
-    # Filename helper (mirrors write_pipeline._artifact_filename)
-    _DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
-
-    def _filename(kind: str, slug: str, artifact_id: str | None) -> str:
-        if kind == "directive":
-            nnn = "000"
-            if artifact_id:
-                m = _DIRECTIVE_NUM_RE.search(artifact_id)
-                if m:
-                    nnn = m.group(1).zfill(3)
-            return f"{nnn}-{slug}.directive.yaml"
-        elif kind == "tactic":
-            return f"{slug}.tactic.yaml"
-        elif kind == "styleguide":
-            return f"{slug}.styleguide.yaml"
-        else:
-            raise ValueError(f"Unknown artifact kind: {kind!r}")
-
-    def _doctrine_subdir(kind: str) -> str:
-        return {"directive": "directives", "tactic": "tactics", "styleguide": "styleguides"}[kind]
 
     # Build a key → new ManifestArtifactEntry dict for regenerated artifacts
     new_entries_by_key: dict[tuple[str, str], ManifestArtifactEntry] = {}
@@ -153,11 +132,11 @@ def _rewrite_manifest(
         if kind == "directive":
             artifact_id = prov.artifact_urn.split(":", 1)[1]
 
-        filename = _filename(kind, slug, artifact_id)
+        filename = artifact_filename(kind, slug, artifact_id)
         yaml_bytes = canonical_yaml(body)
         content_hash = hashlib.sha256(yaml_bytes).hexdigest()
 
-        rel_content = f".kittify/doctrine/{_doctrine_subdir(kind)}/{filename}"
+        rel_content = f".kittify/doctrine/{doctrine_kind_subdir(kind)}/{filename}"
         rel_prov = f".kittify/charter/provenance/{kind}-{slug}.yaml"
 
         new_entries_by_key[(kind, slug)] = ManifestArtifactEntry(

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -30,12 +30,12 @@ All filesystem writes go through ``PathGuard`` (FR-016).
 from __future__ import annotations
 
 import hashlib
-import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
+from .artifact_naming import artifact_filename, doctrine_kind_subdir
 from .errors import NeutralityGateViolation, StagingPromoteError
 from .evidence import EvidenceBundle
 from .manifest import (
@@ -54,8 +54,6 @@ from .synthesize_pipeline import ProvenanceEntry, canonical_yaml
 # Filename helpers (data-model §E-2 "Filename rule")
 # ---------------------------------------------------------------------------
 
-_DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
-
 
 def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> str:
     """Return the repository-glob-matching filename for an artifact.
@@ -66,28 +64,12 @@ def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> 
     - tactic:    ``<slug>.tactic.yaml``
     - styleguide: ``<slug>.styleguide.yaml``
     """
-    if kind == "directive":
-        nnn = "000"
-        if artifact_id:
-            m = _DIRECTIVE_NUM_RE.search(artifact_id)
-            if m:
-                nnn = m.group(1).zfill(3)
-        return f"{nnn}-{slug}.directive.yaml"
-    elif kind == "tactic":
-        return f"{slug}.tactic.yaml"
-    elif kind == "styleguide":
-        return f"{slug}.styleguide.yaml"
-    else:
-        raise ValueError(f"Unknown artifact kind: {kind!r}")
+    return artifact_filename(kind, slug, artifact_id)
 
 
 def _doctrine_kind_subdir(kind: str) -> str:
     """Return the doctrine subdirectory name for a given artifact kind."""
-    return {
-        "directive": "directives",
-        "tactic": "tactics",
-        "styleguide": "styleguides",
-    }[kind]
+    return doctrine_kind_subdir(kind)
 
 
 def _compute_content_hash(yaml_bytes: bytes) -> str:

--- a/tests/charter/synthesizer/test_write_pipeline.py
+++ b/tests/charter/synthesizer/test_write_pipeline.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from charter.synthesizer.errors import NeutralityGateViolation
+from charter.synthesizer.artifact_naming import artifact_filename, extract_directive_number
 from charter.synthesizer.write_pipeline import _is_generic_scoped
 
 
@@ -61,6 +62,28 @@ def _staged_neutral_generic(tmp_path: Path) -> Path:
         "  Fast tests should run frequently; slow tests in CI.\n"
     )
     return staged_dir
+
+
+# ---------------------------------------------------------------------------
+# artifact_naming tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_directive_number_returns_padded_digits() -> None:
+    assert extract_directive_number("PROJECT_7") == "007"
+
+
+def test_extract_directive_number_falls_back_for_malformed_ids() -> None:
+    assert extract_directive_number("project_007") == "000"
+    assert extract_directive_number("PROJECT_") == "000"
+    assert extract_directive_number(None) == "000"
+
+
+def test_artifact_filename_builds_directive_filename_without_regex() -> None:
+    assert (
+        artifact_filename("directive", "mission-type-scope-directive", "PROJECT_001")
+        == "001-mission-type-scope-directive.directive.yaml"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +186,7 @@ def _make_staging_dir_with_artifact(
     slug: str,
     content: str,
     artifact_id: str | None = None,
-) -> "tuple[object, object]":
+) -> tuple[object, object]:
     """Create a StagingDir and a matching ProvenanceEntry for testing the gate."""
     import hashlib
 
@@ -182,15 +205,7 @@ def _make_staging_dir_with_artifact(
     urn = f"{kind}:{effective_artifact_id}"
 
     # Write content to staged location
-    if kind == "directive":
-        import re
-        m = re.search(r"\d+", effective_artifact_id)
-        nnn = m.group(0).zfill(3) if m else "000"
-        filename = f"{nnn}-{slug}.directive.yaml"
-    elif kind == "tactic":
-        filename = f"{slug}.tactic.yaml"
-    else:
-        filename = f"{slug}.styleguide.yaml"
+    filename = artifact_filename(kind, slug, effective_artifact_id)
 
     staged_path = stage.path_for_content(kind, filename)
     staged_path.write_text(content)


### PR DESCRIPTION
## Summary
- replace duplicated directive filename regex parsing with a shared non-regex helper
- reuse the helper from both charter write/resynthesis pipelines
- add focused tests for directive number extraction and filename fallback behavior

## Validation
- pytest tests/charter/synthesizer/test_write_pipeline.py -q -o cache_dir=/tmp/spec-kitty-pytest-cache-write
- pytest tests/charter/synthesizer/test_orchestrator_resynthesize.py -q -o cache_dir=/tmp/spec-kitty-pytest-cache-resynth
- ruff check src/charter/synthesizer/write_pipeline.py src/charter/synthesizer/resynthesize_pipeline.py src/charter/synthesizer/artifact_naming.py tests/charter/synthesizer/test_write_pipeline.py

## Sonar / security context
- GitHub Dependabot alerts: 0 open
- GitHub code scanning alerts: 0 open
- Nightly CI on main (run 24649856884, 2026-04-20) failed in SonarCloud due to new-code coverage and unreviewed security hotspots
- This PR addresses the two actionable regex-based Sonar hotspots in code; it does not suppress findings
