### PR TITLE
Forward-port 3.1.6 bulk-edit hotfix and maintainer charter rule

### DIFF
--- a/.kittify/charter/charter.md
+++ b/.kittify/charter/charter.md
@@ -1,7 +1,7 @@
 # Spec Kitty Charter
 
 > Created: 2026-01-27
-> Version: 1.1.0
+> Version: 1.1.1
 
 ## Purpose
 
@@ -198,6 +198,26 @@ The 1.x/2.x branch split was originally documented in [ADR-12: Two-Branch Strate
 - **Public APIs:** Docstrings with parameter types and return values
 - **Breaking changes:** Update migration guide in docs/
 - **Architecture decisions:** Capture in ADRs (architecture/decisions/)
+
+---
+
+## User Customization Preservation
+
+### Ownership Boundaries for Mutating Flows
+
+- This section governs **Spec Kitty development itself**. It is a maintainer rule for the Spec Kitty codebase and release process; it is not a substitute for end-user project charters, which users generate for their own repositories.
+- Package-owned mutation flows (`init`, `upgrade`, install/remove/sync commands, shipped-asset refresh, and migrations) must treat user-authored custom commands, custom skills, and project overrides as **user-owned assets** by default.
+- No mutating flow may overwrite, delete, rename, or chmod a user-owned customization unless the exact path is explicitly package-managed or manifest-tracked.
+- Name-based heuristics alone are not sufficient proof of package ownership. Historical broad matching of `spec-kitty.*` command names has created a real risk of clobbering user-authored slash commands that were never shipped by Spec Kitty.
+- When package-managed files share a directory with user-authored files, cleanup and migration logic must scope destructive changes only to known package-owned paths and leave unknown or third-party files untouched.
+- If ownership cannot be proven from manifest data or an explicit managed-path contract, the safe behavior is to preserve the file and emit a warning instead of deleting or rewriting it.
+
+### Proof Trail
+
+- `src/specify_cli/runtime/merge.py` already encodes the intended ownership model for runtime assets: package-managed paths may be refreshed, while user-owned data must be preserved.
+- `src/specify_cli/skills/command_installer.py` already codifies the same boundary for shared skills roots: third-party paths under `.agents/skills/` are never touched unless they are manifest-owned.
+- `src/specify_cli/upgrade/migrations/m_3_1_2_globalize_commands.py` is the motivating hazard: broad `spec-kitty.*` filename matching can incorrectly classify user-authored custom slash commands as shipped assets and remove them.
+- Any future migration, installer, or cleanup path that mutates user-visible command or skill directories must document its ownership proof and show why it cannot hit custom user files.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `spec-kitty charter synthesize` and `spec-kitty charter resynthesize` now default to the generated-artifact adapter. `--adapter fixture` remains available only for deterministic offline regression runs.
 - `spec-kitty charter synthesize --dry-run` is now a real stage-and-validate pass: it writes the staged artifact set, runs project DRG validation and neutrality gating, and only skips the final promote step.
+- Release pipeline now generates and attaches a CycloneDX SBOM (`sbom.cdx.json`) to every GitHub Release. The SBOM is an environment-snapshot of the fully resolved dependency tree at build time, making it straightforward for enterprise users to ingest the inventory into tools like Dependency-Track for continuous CVE monitoring without rescanning the package themselves.
 
 ### Fixed
 
@@ -27,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bounded resynthesis now preserves evidence inputs end-to-end, so regenerated provenance entries keep the correct `evidence_bundle_hash` and `corpus_snapshot_id`.
 - Generated-artifact synthesis errors now point to the exact expected file path and exact expected artifact id, which makes harness handoff mistakes easier to diagnose.
 - Charter neutrality lint now scans mission `templates/` directories in addition to `command-templates/`, so banned terms in generic mission prompt files are caught by the default repo scan (#653 tripwire).
+- Bump `requests` floor to `>=2.33.0` (CVE-2026-25645).
+- Bump `pytest` floor to `>=9.0.3` (CVE-2025-71176).
+- Pin `pygments>=2.20.0` explicitly to resolve CVE-2026-4539 in the transitive dependency pulled in via `rich`.
 
 ### Removed
 
@@ -42,23 +46,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [architecture/2.x/05_ownership_map.md](architecture/2.x/05_ownership_map.md) for the full
   charter slice entry and the reference exemplar pattern. Closes #611.
 
-## [3.1.6] - 2026-04-17
+## [3.1.6] - 2026-04-20
 
-### Security
+### Fixed
 
-- Bump `requests` floor to `>=2.33.0` (CVE-2026-25645).
-- Bump `pytest` floor to `>=9.0.3` (CVE-2025-71176).
-- Pin `pygments>=2.20.0` explicitly to resolve CVE-2026-4539 in the
-  transitive dependency pulled in via `rich`.
+- `spec-kitty agent action implement` now exposes and forwards
+  `--acknowledge-not-bulk-edit` to the underlying workspace-allocation command,
+  allowing non-bulk-edit missions to suppress false-positive bulk-edit inference
+  warnings during workspace creation.
 
-### Changed
+### Docs
 
-- Release pipeline now generates and attaches a CycloneDX SBOM
-  (`sbom.cdx.json`) to every GitHub Release. The SBOM is an
-  environment-snapshot of the fully resolved dependency tree at build
-  time, making it straightforward for enterprise users to ingest the
-  inventory into tools like Dependency-Track for continuous CVE
-  monitoring without rescanning the package themselves.
+- Spec Kitty's internal maintainer charter now records the ownership boundary
+  for user-authored custom commands, custom skills, and project overrides, with
+  an explicit proof trail showing that package-owned mutation flows must preserve
+  files whose ownership is not proven by managed-path or manifest data.
 
 ## [3.1.5] - 2026-04-16
 

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -464,6 +464,13 @@ def implement(
             ),
         ),
     ] = False,
+    acknowledge_not_bulk_edit: Annotated[
+        bool,
+        typer.Option(
+            "--acknowledge-not-bulk-edit",
+            help="Suppress the bulk-edit inference warning when spec language resembles a bulk edit but the mission is not one.",
+        ),
+    ] = False,
 ) -> None:
     """Display work package prompt with implementation instructions.
 
@@ -565,7 +572,13 @@ def implement(
 
             print(f"Creating workspace for {normalized_wp_id}...")
             try:
-                top_level_implement(wp_id=normalized_wp_id, mission=mission_slug, json_output=False, recover=False)
+                top_level_implement(
+                    wp_id=normalized_wp_id,
+                    mission=mission_slug,
+                    json_output=False,
+                    recover=False,
+                    acknowledge_not_bulk_edit=acknowledge_not_bulk_edit,
+                )
             except typer.Exit:
                 # Worktree creation failed - propagate error
                 raise

--- a/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
+++ b/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
@@ -3,17 +3,28 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.agent.mission import app
+from specify_cli.cli.commands.agent import workflow
 from specify_cli.merge.config import MergeStrategy
 
 pytestmark = pytest.mark.fast
 
 runner = CliRunner()
+
+
+def _workspace(exists: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        exists=exists,
+        worktree_path=Path("/tmp/spec-kitty-test-worktree"),
+        resolution_kind="repo_root",
+    )
 
 
 @patch("specify_cli.cli.commands.agent.mission.top_level_accept")
@@ -79,4 +90,89 @@ def test_agent_mission_merge_passes_explicit_wrapper_defaults(
         abort=False,
         context_token=None,
         keep_workspace=False,
+    )
+
+
+@patch("specify_cli.cli.commands.agent.workflow.top_level_implement")
+@patch("specify_cli.cli.commands.agent.workflow.resolve_workspace_for_wp")
+@patch("specify_cli.cli.commands.agent.workflow.locate_work_package")
+@patch("specify_cli.cli.commands.agent.workflow._ensure_target_branch_checked_out")
+@patch("specify_cli.cli.commands.agent.workflow.get_main_repo_root")
+@patch("specify_cli.cli.commands.agent.workflow.locate_project_root")
+@patch("specify_cli.cli.commands.agent.workflow._find_mission_slug")
+def test_agent_action_implement_passes_acknowledge_default_false(
+    mock_find_mission_slug: MagicMock,
+    mock_locate_project_root: MagicMock,
+    mock_get_main_repo_root: MagicMock,
+    mock_ensure_target_branch_checked_out: MagicMock,
+    mock_locate_work_package: MagicMock,
+    mock_resolve_workspace_for_wp: MagicMock,
+    mock_top_level_implement: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Wrapper must forward the default acknowledgement value explicitly."""
+
+    mock_find_mission_slug.return_value = "demo-mission"
+    mock_locate_project_root.return_value = tmp_path
+    mock_get_main_repo_root.return_value = tmp_path
+    mock_ensure_target_branch_checked_out.return_value = (tmp_path, "main")
+    mock_locate_work_package.return_value = SimpleNamespace(path=tmp_path / "wp01.md")
+    mock_resolve_workspace_for_wp.return_value = _workspace(exists=False)
+    mock_top_level_implement.side_effect = RuntimeError("stop after delegation")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        workflow.implement(wp_id="WP01", mission="demo-mission", agent="claude")
+
+    assert exc_info.value.exit_code == 1
+    mock_top_level_implement.assert_called_once_with(
+        wp_id="WP01",
+        mission="demo-mission",
+        json_output=False,
+        recover=False,
+        acknowledge_not_bulk_edit=False,
+    )
+
+
+@patch("specify_cli.cli.commands.agent.workflow.top_level_implement")
+@patch("specify_cli.cli.commands.agent.workflow.resolve_workspace_for_wp")
+@patch("specify_cli.cli.commands.agent.workflow.locate_work_package")
+@patch("specify_cli.cli.commands.agent.workflow._ensure_target_branch_checked_out")
+@patch("specify_cli.cli.commands.agent.workflow.get_main_repo_root")
+@patch("specify_cli.cli.commands.agent.workflow.locate_project_root")
+@patch("specify_cli.cli.commands.agent.workflow._find_mission_slug")
+def test_agent_action_implement_passes_acknowledge_true_when_requested(
+    mock_find_mission_slug: MagicMock,
+    mock_locate_project_root: MagicMock,
+    mock_get_main_repo_root: MagicMock,
+    mock_ensure_target_branch_checked_out: MagicMock,
+    mock_locate_work_package: MagicMock,
+    mock_resolve_workspace_for_wp: MagicMock,
+    mock_top_level_implement: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Wrapper must forward the explicit acknowledgement override."""
+
+    mock_find_mission_slug.return_value = "demo-mission"
+    mock_locate_project_root.return_value = tmp_path
+    mock_get_main_repo_root.return_value = tmp_path
+    mock_ensure_target_branch_checked_out.return_value = (tmp_path, "main")
+    mock_locate_work_package.return_value = SimpleNamespace(path=tmp_path / "wp01.md")
+    mock_resolve_workspace_for_wp.return_value = _workspace(exists=False)
+    mock_top_level_implement.side_effect = RuntimeError("stop after delegation")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        workflow.implement(
+            wp_id="WP01",
+            mission="demo-mission",
+            agent="claude",
+            acknowledge_not_bulk_edit=True,
+        )
+
+    assert exc_info.value.exit_code == 1
+    mock_top_level_implement.assert_called_once_with(
+        wp_id="WP01",
+        mission="demo-mission",
+        json_output=False,
+        recover=False,
+        acknowledge_not_bulk_edit=True,
     )

--- a/tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py
+++ b/tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py
@@ -66,7 +66,7 @@ def test_implement_help_advertises_acknowledge_flag() -> None:
     )
     # The option's help string should be present so users know what it does.
     normalized_help = " ".join(result.output.lower().split())
-    assert "inference warning" in normalized_help, (
+    assert "inference" in normalized_help and "warning" in normalized_help, (
         "Help text for --acknowledge-not-bulk-edit must describe the "
         "inference-warning suppression behavior; current output:\n" + result.output
     )
@@ -86,7 +86,7 @@ def test_agent_action_implement_help_advertises_acknowledge_flag() -> None:
         "current output:\n" + result.output
     )
     normalized_help = " ".join(result.output.lower().split())
-    assert "inference warning" in normalized_help, (
+    assert "inference" in normalized_help and "warning" in normalized_help, (
         "Wrapper help text for --acknowledge-not-bulk-edit must describe the "
         "inference-warning suppression behavior; current output:\n" + result.output
     )

--- a/tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py
+++ b/tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py
@@ -65,7 +65,8 @@ def test_implement_help_advertises_acknowledge_flag() -> None:
         "discover it; current output:\n" + result.output
     )
     # The option's help string should be present so users know what it does.
-    assert "inference warning" in result.output.lower(), (
+    normalized_help = " ".join(result.output.lower().split())
+    assert "inference warning" in normalized_help, (
         "Help text for --acknowledge-not-bulk-edit must describe the "
         "inference-warning suppression behavior; current output:\n" + result.output
     )
@@ -84,7 +85,8 @@ def test_agent_action_implement_help_advertises_acknowledge_flag() -> None:
         "agent action implement help must advertise --acknowledge-not-bulk-edit; "
         "current output:\n" + result.output
     )
-    assert "inference warning" in result.output.lower(), (
+    normalized_help = " ".join(result.output.lower().split())
+    assert "inference warning" in normalized_help, (
         "Wrapper help text for --acknowledge-not-bulk-edit must describe the "
         "inference-warning suppression behavior; current output:\n" + result.output
     )

--- a/tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py
+++ b/tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typer.testing import CliRunner
 
+from specify_cli.cli.commands.agent.workflow import app as agent_action_app
 from specify_cli.cli.commands.implement import implement as implement_fn
 
 
@@ -66,5 +67,24 @@ def test_implement_help_advertises_acknowledge_flag() -> None:
     # The option's help string should be present so users know what it does.
     assert "inference warning" in result.output.lower(), (
         "Help text for --acknowledge-not-bulk-edit must describe the "
+        "inference-warning suppression behavior; current output:\n" + result.output
+    )
+
+
+def test_agent_action_implement_help_advertises_acknowledge_flag() -> None:
+    """The wrapper help text must expose the same acknowledgement override."""
+    runner = CliRunner(env={"COLUMNS": "200", "TERM": "dumb"})
+    result = runner.invoke(agent_action_app, ["implement", "--help"], terminal_width=200)
+
+    assert result.exit_code == 0, f"help invocation failed: {result.output}"
+    assert (
+        "--acknowledge-not-bulk-edit" in result.output
+        or "--acknowledge-not-bulk" in result.output
+    ), (
+        "agent action implement help must advertise --acknowledge-not-bulk-edit; "
+        "current output:\n" + result.output
+    )
+    assert "inference warning" in result.output.lower(), (
+        "Wrapper help text for --acknowledge-not-bulk-edit must describe the "
         "inference-warning suppression behavior; current output:\n" + result.output
     )


### PR DESCRIPTION
## Summary
- cherry-pick the `3.1.6` hotfix that exposes `--acknowledge-not-bulk-edit` on `spec-kitty agent action implement`
- carry forward the internal Spec Kitty maintainer charter rule protecting user custom commands, skills, and overrides from package-owned mutation flows
- reconcile `main`'s changelog so the hotfix notes live under `3.1.6` and the unrelated security/SBOM bullets return to `Unreleased`

## Notes
- the charter update is repo-internal maintainer governance only; it does not seed or replace end-user project charters
- this PR intentionally excludes the hotfix branch version bumps and release-bookkeeping changes
