### PR TITLE
fix: clear stale auth after refresh invalid_grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `requests` floor to `>=2.33.0` (CVE-2026-25645).
 - Bump `pytest` floor to `>=9.0.3` (CVE-2025-71176).
 - Pin `pygments>=2.20.0` explicitly to resolve CVE-2026-4539 in the transitive dependency pulled in via `rich`.
+- `auth refresh` now treats `HTTP 401` responses with `invalid_grant` or `session_invalid` error codes identically to `HTTP 400`, and clears the locally stored session on server-side refresh rejection so `auth status` no longer reports stale credentials as authenticated.
 
 ### Removed
 

--- a/src/specify_cli/auth/flows/refresh.py
+++ b/src/specify_cli/auth/flows/refresh.py
@@ -13,12 +13,13 @@ is absent. The CLI NEVER hardcodes a TTL.
 
 Error semantics (feature 080, spec §7.2):
 
-- SaaS returns ``400 invalid_grant`` → :class:`RefreshTokenExpiredError`.
-  The refresh token is invalid or expired; the user must re-run
-  ``spec-kitty auth login``.
-- SaaS returns ``400 session_invalid`` → :class:`SessionInvalidError`. The
-  server has administratively invalidated this session; ``TokenManager``
-  clears local state and the user must re-login.
+- SaaS returns ``400`` or ``401`` with ``invalid_grant`` →
+  :class:`RefreshTokenExpiredError`. The refresh token is invalid or expired;
+  the user must re-run ``spec-kitty auth login``.
+- SaaS returns ``400`` or ``401`` with ``session_invalid`` →
+  :class:`SessionInvalidError`. The server has administratively invalidated
+  this session; ``TokenManager`` clears local state and the user must
+  re-login.
 - Any other HTTP error → :class:`TokenRefreshError`.
 - Transport-level failures → :class:`NetworkError`.
 """
@@ -64,9 +65,10 @@ class TokenRefreshFlow:
 
         Raises:
             RefreshTokenExpiredError: The SaaS rejected the refresh token
-                (``400 invalid_grant``). The user must re-run ``auth login``.
+                (``400/401 invalid_grant``). The user must re-run
+                ``auth login``.
             SessionInvalidError: The SaaS reports the session has been
-                invalidated server-side (``400 session_invalid``).
+                invalidated server-side (``400/401 session_invalid``).
             TokenRefreshError: Any other HTTP failure during refresh.
             NetworkError: Transport-level failure (DNS, connect, timeout).
         """
@@ -93,7 +95,7 @@ class TokenRefreshFlow:
                 ) from exc
             return self._update_session(session, tokens)
 
-        if response.status_code == 400:
+        if response.status_code in {400, 401}:
             try:
                 body = response.json()
             except ValueError:

--- a/src/specify_cli/auth/token_manager.py
+++ b/src/specify_cli/auth/token_manager.py
@@ -162,6 +162,12 @@ class TokenManager:
             flow = TokenRefreshFlow()
             try:
                 updated = await flow.refresh(self._session)
+            except RefreshTokenExpiredError:
+                # The server rejected the stored refresh token. Clear the
+                # local session so follow-up status/diagnostics do not report
+                # stale credentials as still authenticated.
+                self.clear_session()
+                raise
             except SessionInvalidError:
                 # Server-side invalidation: clear local state and propagate.
                 self.clear_session()

--- a/tests/auth/test_refresh_flow.py
+++ b/tests/auth/test_refresh_flow.py
@@ -258,7 +258,8 @@ class TestRefreshTTLAmendment:
 class TestRefreshErrors:
 
     @pytest.mark.asyncio
-    async def test_invalid_grant_raises_expired(self):
+    @pytest.mark.parametrize("status_code", [400, 401])
+    async def test_invalid_grant_raises_expired(self, status_code):
         flow = TokenRefreshFlow()
         session = _make_session()
 
@@ -266,14 +267,15 @@ class TestRefreshErrors:
             mock_client = AsyncMock()
             mock_cls.return_value.__aenter__.return_value = mock_client
             mock_client.post.return_value = _mock_httpx_response(
-                400, {"error": "invalid_grant"}
+                status_code, {"error": "invalid_grant"}
             )
 
             with pytest.raises(RefreshTokenExpiredError):
                 await flow.refresh(session)
 
     @pytest.mark.asyncio
-    async def test_session_invalid_raises_session_invalid(self):
+    @pytest.mark.parametrize("status_code", [400, 401])
+    async def test_session_invalid_raises_session_invalid(self, status_code):
         flow = TokenRefreshFlow()
         session = _make_session()
 
@@ -281,7 +283,7 @@ class TestRefreshErrors:
             mock_client = AsyncMock()
             mock_cls.return_value.__aenter__.return_value = mock_client
             mock_client.post.return_value = _mock_httpx_response(
-                400, {"error": "session_invalid"}
+                status_code, {"error": "session_invalid"}
             )
 
             with pytest.raises(SessionInvalidError):

--- a/tests/auth/test_refresh_flow.py
+++ b/tests/auth/test_refresh_flow.py
@@ -290,7 +290,8 @@ class TestRefreshErrors:
                 await flow.refresh(session)
 
     @pytest.mark.asyncio
-    async def test_unknown_400_error_raises_token_refresh_error(self):
+    @pytest.mark.parametrize("status_code", [400, 401])
+    async def test_unknown_error_raises_token_refresh_error(self, status_code):
         flow = TokenRefreshFlow()
         session = _make_session()
 
@@ -298,7 +299,7 @@ class TestRefreshErrors:
             mock_client = AsyncMock()
             mock_cls.return_value.__aenter__.return_value = mock_client
             mock_client.post.return_value = _mock_httpx_response(
-                400, {"error": "mystery"}, text="mystery error"
+                status_code, {"error": "mystery"}, text="mystery error"
             )
 
             with pytest.raises(TokenRefreshError):

--- a/tests/auth/test_token_manager.py
+++ b/tests/auth/test_token_manager.py
@@ -96,6 +96,7 @@ class FakeRefreshFlow:
     call_count = 0
     delay_seconds: float = 0.05
     raise_session_invalid: bool = False
+    raise_refresh_expired: bool = False
 
     def __init__(self) -> None:
         # Instance counter so each test starts clean.
@@ -104,6 +105,8 @@ class FakeRefreshFlow:
     async def refresh(self, session: StoredSession) -> StoredSession:
         FakeRefreshFlow.call_count += 1
         await asyncio.sleep(FakeRefreshFlow.delay_seconds)
+        if FakeRefreshFlow.raise_refresh_expired:
+            raise RefreshTokenExpiredError("refresh token invalid")
         if FakeRefreshFlow.raise_session_invalid:
             raise SessionInvalidError("server says no")
         # Return a brand-new session with a fresh access token and a non-expired window.
@@ -131,6 +134,7 @@ def install_fake_refresh_flow(monkeypatch):
     """Install ``specify_cli.auth.flows.refresh`` as a fake module in sys.modules."""
     FakeRefreshFlow.call_count = 0
     FakeRefreshFlow.raise_session_invalid = False
+    FakeRefreshFlow.raise_refresh_expired = False
     FakeRefreshFlow.delay_seconds = 0.05
 
     flows_pkg = types.ModuleType("specify_cli.auth.flows")
@@ -262,7 +266,8 @@ async def test_get_access_token_refreshes_within_buffer_window(install_fake_refr
 async def test_refresh_if_needed_raises_when_refresh_token_expired(
     install_fake_refresh_flow,
 ):
-    tm = TokenManager(FakeStorage())
+    storage = FakeStorage()
+    tm = TokenManager(storage)
     tm.set_session(
         _make_session(
             access_expires_in=-1,
@@ -273,6 +278,24 @@ async def test_refresh_if_needed_raises_when_refresh_token_expired(
         await tm.refresh_if_needed()
     # No network call was made.
     assert install_fake_refresh_flow.call_count == 0
+    # Locally-known expiry is not stale state; keep the session loaded so
+    # status commands can still explain why re-login is required.
+    assert tm.get_current_session() is not None
+    assert storage.deletes == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_needed_clears_session_on_server_invalid_grant(
+    install_fake_refresh_flow,
+):
+    install_fake_refresh_flow.raise_refresh_expired = True
+    storage = FakeStorage()
+    tm = TokenManager(storage)
+    tm.set_session(_make_session(access_expires_in=-1))
+    with pytest.raises(RefreshTokenExpiredError):
+        await tm.refresh_if_needed()
+    assert tm.get_current_session() is None
+    assert storage.deletes >= 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- treat both 400 and 401 refresh responses with `invalid_grant` or `session_invalid` as first-class auth refresh failures
- clear the locally stored session when the server rejects the stored refresh token, so `auth status` does not keep reporting stale credentials as authenticated
- add tests for 401 refresh failures and for local session clearing on terminal server-side refresh rejection

## Testing
- pytest -q tests/auth/test_refresh_flow.py tests/auth/test_token_manager.py
- pytest -q tests/auth/test_http_transport.py