### PR TITLE
test(intake): post-review follow-ups for --auto flag (#703)

### DIFF
--- a/tests/specify_cli/cli/commands/test_intake.py
+++ b/tests/specify_cli/cli/commands/test_intake.py
@@ -335,3 +335,27 @@ def test_auto_tty_out_of_range_number_exits_1(
 
     assert result.exit_code == 1
     assert not (tmp_path / ".kittify" / MISSION_BRIEF_FILENAME).exists()
+
+
+def test_auto_tty_zero_input_exits_1(
+    intake_app: typer.Typer, tmp_path: Path
+) -> None:
+    """TTY --auto: selection of 0 (below valid range) exits 1."""
+    _make_plan_file(tmp_path, "plan-a.md")
+    _make_plan_file(tmp_path, "plan-b.md")
+    mock_sources = [
+        ("harness-a", "agent-a", ["plan-a.md"]),
+        ("harness-b", "agent-b", ["plan-b.md"]),
+    ]
+
+    with (
+        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
+        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
+        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
+        patch("specify_cli.cli.commands.intake.sys") as mock_sys,
+    ):
+        mock_sys.stdin.isatty.return_value = True
+        result = runner.invoke(intake_app, ["--auto"], input="0\n", catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert not (tmp_path / ".kittify" / MISSION_BRIEF_FILENAME).exists()

--- a/tests/specify_cli/test_intake_sources.py
+++ b/tests/specify_cli/test_intake_sources.py
@@ -74,6 +74,24 @@ class TestScanForPlans:
         assert len(results) == 1
         assert results[0][0].name == "plan.md"
 
+    def test_directory_candidate_md_files_sorted_alphabetically(self, tmp_path: Path):
+        """Multiple .md files in a candidate directory are returned in sorted (alphabetical) order."""
+        mock_sources = [("opencode", "opencode", [".opencode/plans"])]
+        plans_dir = tmp_path / ".opencode" / "plans"
+        plans_dir.mkdir(parents=True)
+        (plans_dir / "2026-04-20-newest.md").write_text("# Newest", encoding="utf-8")
+        (plans_dir / "2026-01-01-oldest.md").write_text("# Oldest", encoding="utf-8")
+        (plans_dir / "2026-02-15-middle.md").write_text("# Middle", encoding="utf-8")
+
+        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+            results = scan_for_plans(tmp_path)
+
+        assert [r[0].name for r in results] == [
+            "2026-01-01-oldest.md",
+            "2026-02-15-middle.md",
+            "2026-04-20-newest.md",
+        ]
+
     def test_returns_multiple_matches_in_order(self, tmp_path: Path):
         mock_sources = [
             ("harness-a", "agent-a", ["plan-a.md"]),


### PR DESCRIPTION
## Summary

Follow-up fixes surfaced by `/spec-kitty-mission-review` after mission 090 merged.

- Add TTY interactive-selection tests for `--auto` multi-match path (valid selection, non-numeric input, out-of-range number)
- Rename misleading `test_directory_at_candidate_path_is_skipped` → `test_empty_directory_at_candidate_path_returns_empty`; add `test_directory_at_candidate_path_expands_md_children` and `test_non_md_files_in_directory_are_excluded` to properly exercise directory expansion
- Correct `research.md`: document directory-expansion as intended design (the original "skip directories" instruction was internally inconsistent with all 4 active `HARNESS_PLAN_SOURCES` entries being directories)
- Add "Multiple files from same directory" UX note to `docs/reference/agent-plan-artifacts.md`
- Move WP01 and WP02 to `done` (post-merge status housekeeping)

## Test plan

- [x] `pytest tests/specify_cli/test_intake_sources.py tests/specify_cli/cli/commands/test_intake.py -v` — 22 passed
- [x] `ruff check` — clean

Closes follow-up items from mission review of #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)