### PR TITLE
feat(tasks-packages): parallel WP file generation via sub-agents

### DIFF
--- a/.kittify/overrides/missions/software-dev/command-templates/tasks-packages.md
+++ b/.kittify/overrides/missions/software-dev/command-templates/tasks-packages.md
@@ -34,35 +34,92 @@ Run `spec-kitty agent mission check-prerequisites --json --paths-only --include-
 Read `mission_dir/tasks.md` — this must already exist from the previous step.
 Parse the work package definitions, subtask lists, and dependencies.
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `tasks.md`:
+Parse all WP definitions from `tasks.md`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `mission_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `mission_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `mission_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `mission_dir/tasks/planned/`, `mission_dir/tasks/doing/`, or ANY lane subdirectories
 
-**For each WP**:
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `mission_dir/tasks/WP01-create-html-page.md`
-4. Use the bundled task prompt template (`.kittify/missions/software-dev/templates/task-prompt-template.md`)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `lane: "planned"`, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `Requirement Refs` line in `tasks.md`
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
-7. Update `tasks.md` to reference the prompt filename
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+---
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Lane status is tracked ONLY in the `lane:` frontmatter field, NOT by directory location.
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file, then update `tasks.md` to reference it, and
+return the filename and final line count.
+
+**Mission directory**: `{mission_dir}` (absolute path)
+**Write to**: `{mission_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from tasks.md):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}` (from tasks.md "Depends on" line)
+- requirement_refs: `{requirement_refs}` (from tasks.md "Requirement Refs" line)
+- subtasks: `{subtask_list}` (T-ids listed under this WP)
+
+**Read for context** (all from `mission_dir`):
+- `tasks.md` (required — full WP definition, subtask list, dependencies)
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+lane: "planned"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtask_list}
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command (pick one):
+- No dependencies: `spec-kitty implement {wp_id}`
+- With dependencies: `spec-kitty implement {wp_id} --base {first_dep}`
+
+After writing the file, update `tasks.md` to reference the prompt filename on the
+WP's line (e.g., append `→ tasks/{wp_id}-{slug}.md`).
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `tasks.md` during sub-agent dispatch — each sub-agent updates its
+own reference, or collect all and update once after all complete.
 
 ### 4. Include Dependencies in Frontmatter
 
@@ -86,11 +143,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
+After all sub-agents complete, verify each generated prompt:
 
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/.kittify/overrides/missions/software-dev/command-templates/tasks-packages.md
+++ b/.kittify/overrides/missions/software-dev/command-templates/tasks-packages.md
@@ -55,8 +55,7 @@ start the next group.
 ---
 
 You are writing a single Work Package prompt file for the spec-kitty planning
-pipeline. Write exactly one file, then update `tasks.md` to reference it, and
-return the filename and final line count.
+pipeline. Write exactly one file and return the filename and final line count.
 
 **Mission directory**: `{mission_dir}` (absolute path)
 **Write to**: `{mission_dir}/tasks/{wp_id}-{slug}.md`
@@ -104,22 +103,20 @@ Include the implementation command (pick one):
 - No dependencies: `spec-kitty implement {wp_id}`
 - With dependencies: `spec-kitty implement {wp_id} --base {first_dep}`
 
-After writing the file, update `tasks.md` to reference the prompt filename on the
-WP's line (e.g., append `→ tasks/{wp_id}-{slug}.md`).
-
 Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
 If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
 should be split` callout at the top.
 
 ---
 
-**After all sub-agents confirm completion**, proceed to Step 4.
+**After all sub-agents confirm completion**, update `tasks.md` once to reference
+each generated prompt file, then proceed to Step 4.
 
 **Fallback — if your host does not support sub-agents**: Generate all WP files
 sequentially and issue all Write tool calls in a single batched response.
 
-Do NOT update `tasks.md` during sub-agent dispatch — each sub-agent updates its
-own reference, or collect all and update once after all complete.
+Do NOT update `tasks.md` during sub-agent dispatch — collect prompt filenames
+from sub-agent results, then update `tasks.md` once after all complete.
 
 ### 4. Include Dependencies in Frontmatter
 

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
@@ -58,41 +58,95 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "code_change"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -145,10 +199,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-packages.md
@@ -89,6 +89,7 @@ pipeline. Write exactly one file and return the filename and final line count.
 - title: `{title}`
 - dependencies: `{dependencies}`
 - owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
 - requirement_refs: `{requirement_refs}`
 - subtasks: `{subtasks}`
 
@@ -109,7 +110,7 @@ requirement_refs: {requirement_refs}
 subtasks: {subtasks}
 owned_files: {owned_files}
 authoritative_surface: "{longest common path prefix of owned_files}"
-execution_mode: "code_change"
+execution_mode: "{execution_mode}"
 ---
 ```
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-packages.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-packages.prompt.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-packages.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-packages.toml
@@ -59,41 +59,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -146,10 +201,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-packages.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-packages.toml
@@ -59,41 +59,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -146,10 +201,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-packages.md
@@ -60,41 +60,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -147,10 +202,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
@@ -59,41 +59,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -146,10 +201,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
@@ -59,41 +59,96 @@ work_packages:
     prompt_file: null     # fill in this step
 ```
 
-### 3. Generate Prompt Files
+### 3. Generate Prompt Files in Parallel
 
-For each work package defined in `wps.yaml`:
+Parse all WP definitions from `wps.yaml`. Each WP prompt file is independent —
+dispatch one sub-agent per WP in a **single message** so they run concurrently
+rather than generating all WP content in one serial response.
 
-**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/` directory, NOT in subdirectories!
+**CRITICAL PATH RULE**: All WP files MUST be created in a FLAT `feature_dir/tasks/`
+directory, NOT in subdirectories!
 
 - Correct: `feature_dir/tasks/WPxx-slug.md` (flat, no subdirectories)
 - WRONG: `feature_dir/tasks/planned/`, `feature_dir/tasks/doing/`, or ANY status subdirectories
 
-**For each WP**:
-1. Derive a kebab-case slug from the title
-2. Filename: `WPxx-slug.md` (e.g., `WP01-create-html-page.md`)
-3. Full path: `feature_dir/tasks/WP01-create-html-page.md`
-4. Follow the WP prompt template structure below (**do NOT write instructions to read a template file from `.kittify/`**)
-5. Include frontmatter with:
-   - `work_package_id`, `subtasks` array, `dependencies`, history entry
-   - `requirement_refs` array from the WP's `requirement_refs` in `wps.yaml`
-   - `owned_files`, `authoritative_surface`, `execution_mode` (required ownership fields)
-6. Include in body:
-   - Objective, context, detailed guidance per subtask
-   - Test strategy (only if requested)
-   - Definition of Done, risks, reviewer guidance
+**Batching for large missions**: If there are more than 6 WPs, dispatch in groups
+of 4. Send all agents in a group in one message, wait for all to complete, then
+start the next group.
 
-**TARGET PROMPT SIZE**: 200-500 lines per WP (3-7 subtasks)
-**MAXIMUM PROMPT SIZE**: 700 lines per WP (10 subtasks max)
-**If prompts are >700 lines**: Split the WP — it's too large
+**Sub-agent prompt** (send one per WP, all dispatched simultaneously in one message):
 
-**IMPORTANT**: All WP files live in flat `tasks/` directory. Status is managed via `status.events.jsonl`, not by directory location or frontmatter fields.
+---
+
+You are writing a single Work Package prompt file for the spec-kitty planning
+pipeline. Write exactly one file and return the filename and final line count.
+
+**Feature directory**: `{feature_dir}` (absolute path)
+**Write to**: `{feature_dir}/tasks/{wp_id}-{slug}.md`
+
+**Work Package** (from wps.yaml):
+- id: `{wp_id}`
+- title: `{title}`
+- dependencies: `{dependencies}`
+- owned_files: `{owned_files}`
+- execution_mode: derive from `owned_files` (`planning_artifact` for kitty-specs/docs-only WPs, otherwise `code_change`)
+- requirement_refs: `{requirement_refs}`
+- subtasks: `{subtasks}`
+
+**Read for context** (all from `feature_dir`):
+- `plan.md` (required — tech architecture, stack)
+- `spec.md` (required — user stories, acceptance criteria)
+- `data-model.md`, `research.md` (read if present)
+
+**Write the WP prompt file with this structure:**
+
+Frontmatter:
+```yaml
+---
+work_package_id: "{wp_id}"
+title: "{title}"
+dependencies: {dependencies}
+requirement_refs: {requirement_refs}
+subtasks: {subtasks}
+owned_files: {owned_files}
+authoritative_surface: "{longest common path prefix of owned_files}"
+execution_mode: "{execution_mode}"
+---
+```
+
+Body sections (in order):
+1. `## Objective` — 1–3 sentence goal
+2. `## Context` — why this WP exists, what depends on it, key design decisions from plan.md
+3. `### Subtask {T-id}: {name}` — one section per subtask, ~60 lines each:
+   - **Purpose**: what this subtask accomplishes
+   - **Steps**: numbered, with specific file paths and implementation details
+   - **Files**: what to create/modify, approximate size
+   - **Validation**: how to verify it works
+4. `## Definition of Done` — verifiable checklist covering all subtasks
+5. `## Risks` — known risks and mitigations
+6. `## Reviewer Guidance` — what reviewers should focus on
+
+Include the implementation command: `spec-kitty agent action implement {wp_id} --agent <name>`
+
+Sizing: target 200–500 lines (3–7 subtasks), maximum 700 lines (10 subtasks).
+If >700 lines would be needed: write the file anyway but add a `> NOTE: This WP
+should be split` callout at the top.
+
+---
+
+**After all sub-agents confirm completion**, proceed to Step 4.
+
+**Fallback — if your host does not support sub-agents**: Generate all WP files
+sequentially and issue all Write tool calls in a single batched response.
+
+Do NOT update `wps.yaml` during sub-agent dispatch — collect all confirmations,
+then update once in Step 4.
 
 ### 4. Update `wps.yaml` With Per-WP Details
 
-After generating each WP prompt file, update the corresponding entry in `wps.yaml`
-to fill in `owned_files`, `requirement_refs`, `subtasks`, and `prompt_file`.
-Write the updated `wps.yaml` back to disk after each WP is generated (or
-accumulate changes and write once at the end).
+After all sub-agents have confirmed completion, update `wps.yaml` once with all
+per-WP details collected from sub-agent results: `owned_files`, `requirement_refs`,
+`subtasks`, and `prompt_file` for every WP. Write the updated `wps.yaml` in a
+single write.
 
 **Critical rule**: Do NOT modify a `dependencies` field that is already present in
 `wps.yaml` — even if it is empty (`[]`). It is authoritative. Only populate
@@ -146,10 +201,11 @@ Include the correct implementation command:
 
 ### 5. Self-Check
 
-After generating each prompt:
-- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ SPLIT
-- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ SPLIT
-- Can implement in one session? ✓ | Multiple sessions needed? ❌ SPLIT
+After all sub-agents complete, verify each generated prompt:
+- Subtask count: 3-7? ✓ | 8-10? ⚠️ | 11+? ❌ needs splitting
+- Estimated lines: 200-500? ✓ | 500-700? ⚠️ | 700+? ❌ needs splitting
+- owned_files glob patterns non-overlapping across all WPs? ✓
+- Can implement in one session? ✓ | Multiple sessions needed? ❌ needs splitting
 
 ## Output
 


### PR DESCRIPTION
## Summary

- **Source template** (`src/specify_cli/missions/software-dev/command-templates/tasks-packages.md`, 3.2.0): Step 3 restructured from a serial \"for each WP\" loop to parallel sub-agent dispatch. The template now embeds a complete sub-agent prompt template (WP definition, file target, context doc references, frontmatter schema, body structure, sizing constraints). Batching guidance added for missions >6 WPs (groups of 4). Fallback for hosts without sub-agent support. Step 4 (wps.yaml update) now explicitly runs after all sub-agents complete.
- **Dogfood override** (`.kittify/overrides/missions/software-dev/command-templates/tasks-packages.md`, 0.12.0+): same parallel dispatch pattern adapted for the older `tasks.md` input format.

**Why this matters:** The `tasks-packages` step is the bottleneck in the planning phase. Each WP prompt file (200-500 lines) is generated serially in a single LLM response. For a 12-WP mission that's 3,600-6,000 lines of output end-to-end. The WP files are fully independent (different paths, no cross-dependencies during generation), so dispatching sub-agents in parallel cuts wall-clock time by ~2x for 4-WP missions and ~3-4x for 12-WP missions.

**No Python changes** — the bottleneck is LLM token generation time, and the fix is instructional (teach the orchestrating agent to use parallel sub-agents).

## Test plan
- [ ] Run `/spec-kitty.tasks-outline` on a mission with ≥4 WPs to produce `wps.yaml`
- [ ] Run `/spec-kitty.tasks-packages` and verify sub-agents fire concurrently (Claude Code shows multiple Agent tool calls in one message)
- [ ] Verify all `tasks/WP*.md` files created with correct frontmatter (`work_package_id`, `dependencies`, `owned_files`, `authoritative_surface`, `execution_mode`)
- [ ] Run `spec-kitty agent mission finalize-tasks --json` — should pass with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)