### PR TITLE
ci: speed up windows and release-readiness workflows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -6,8 +6,55 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect Windows-critical changes
+    runs-on: ubuntu-latest
+    outputs:
+      windows_critical: ${{ steps.filter.outputs.windows_critical }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            windows_critical:
+              - '.github/workflows/ci-windows.yml'
+              - 'pyproject.toml'
+              - 'pytest.ini'
+              - 'tests/conftest.py'
+              - 'tests/auth/secure_storage/test_file_fallback_windows_root.py'
+              - 'tests/cli/test_agent_status_messaging.py'
+              - 'tests/cli/test_migrate_cmd_messaging.py'
+              - 'tests/core/test_worktree_symlink_fallback.py'
+              - 'tests/kernel/test_paths_unified_windows_root.py'
+              - 'tests/mission/test_active_mission_handle_windows.py'
+              - 'tests/paths/test_windows_migrate.py'
+              - 'tests/policy/test_hook_installer_execution.py'
+              - 'tests/regressions/test_issue_101_utf8_startup.py'
+              - 'tests/regressions/test_issue_105_hook_python_lookup.py'
+              - 'tests/regressions/test_issue_71_dashboard_empty.py'
+              - 'tests/runtime/test_home_unit.py'
+              - 'tests/sync/test_daemon_windows_paths.py'
+              - 'tests/sync/test_issue_586_windows_import.py'
+              - 'tests/tracker/test_credentials_windows_paths.py'
+              - 'src/kernel/**'
+              - 'src/specify_cli/__init__.py'
+              - 'src/specify_cli/auth/**'
+              - 'src/specify_cli/cli/**'
+              - 'src/specify_cli/context/**'
+              - 'src/specify_cli/core/**'
+              - 'src/specify_cli/dashboard/**'
+              - 'src/specify_cli/encoding.py'
+              - 'src/specify_cli/paths/**'
+              - 'src/specify_cli/policy/**'
+              - 'src/specify_cli/runtime/**'
+              - 'src/specify_cli/sync/**'
+              - 'src/specify_cli/tracker/**'
+
   windows-critical:
     name: Windows critical (pipx, pytest -m windows_ci)
+    needs: [changes]
+    if: needs.changes.outputs.windows_critical == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     env:
@@ -17,9 +64,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install pipx
         shell: bash

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -37,19 +37,11 @@ jobs:
               - 'tests/sync/test_daemon_windows_paths.py'
               - 'tests/sync/test_issue_586_windows_import.py'
               - 'tests/tracker/test_credentials_windows_paths.py'
+              # Keep this intentionally coarse: the Windows-marked CLI tests
+              # exercise the root app import path, which can pull in modules
+              # across the full source tree.
               - 'src/kernel/**'
-              - 'src/specify_cli/__init__.py'
-              - 'src/specify_cli/auth/**'
-              - 'src/specify_cli/cli/**'
-              - 'src/specify_cli/context/**'
-              - 'src/specify_cli/core/**'
-              - 'src/specify_cli/dashboard/**'
-              - 'src/specify_cli/encoding.py'
-              - 'src/specify_cli/paths/**'
-              - 'src/specify_cli/policy/**'
-              - 'src/specify_cli/runtime/**'
-              - 'src/specify_cli/sync/**'
-              - 'src/specify_cli/tracker/**'
+              - 'src/specify_cli/**'
 
   windows-critical:
     name: Windows critical (pipx, pytest -m windows_ci)

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -95,9 +95,17 @@ jobs:
           EOF
           python verify_isolation.py
 
-      - name: Run tests
+      - name: Run release workflow tests
+        if: github.event_name == 'pull_request'
         run: |
-          echo "::group::Running test suite"
+          echo "::group::Running targeted release test suite"
+          python -m pytest -v --import-mode=importlib tests/release
+          echo "::endgroup::"
+
+      - name: Run full non-Windows suite
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "::group::Running full test suite"
           # Exclude windows_ci tests — they run on the native windows-latest job (ci-windows.yml).
           python -m pytest -v --import-mode=importlib -m "not windows_ci"
           echo "::endgroup::"
@@ -191,7 +199,7 @@ jobs:
             echo "- Version is properly bumped" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog entry exists and is populated" >> $GITHUB_STEP_SUMMARY
             echo "- Version progression is monotonic" >> $GITHUB_STEP_SUMMARY
-            echo "- Tests pass" >> $GITHUB_STEP_SUMMARY
+            echo "- Release validation tests pass" >> $GITHUB_STEP_SUMMARY
             echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
             echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
             echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -95,6 +95,16 @@ jobs:
           EOF
           python verify_isolation.py
 
+      - name: Detect release metadata changes
+        if: github.event_name == 'pull_request'
+        id: metadata_changes
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            release_metadata:
+              - 'pyproject.toml'
+              - 'CHANGELOG.md'
+
       - name: Run release workflow tests
         if: github.event_name == 'pull_request'
         run: |
@@ -111,6 +121,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Validate release metadata
+        if: github.event_name != 'pull_request' || steps.metadata_changes.outputs.release_metadata == 'true'
         id: validate
         continue-on-error: true
         run: |
@@ -203,6 +214,16 @@ jobs:
             echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
             echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
             echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.metadata_changes.outputs.release_metadata }}" != "true" ]]; then
+            echo "✅ **Release workflow checks passed**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Release metadata validation was skipped because this pull request does not modify \`pyproject.toml\` or \`CHANGELOG.md\`." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This branch is ready to merge from a release-readiness workflow perspective:" >> $GITHUB_STEP_SUMMARY
+            echo "- Targeted release workflow tests pass" >> $GITHUB_STEP_SUMMARY
+            echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
+            echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
+            echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ **Readiness checks failed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -220,7 +241,7 @@ jobs:
           fi
 
       - name: Fail if validation failed
-        if: steps.validate.outcome != 'success'
+        if: (github.event_name != 'pull_request' || steps.metadata_changes.outputs.release_metadata == 'true') && steps.validate.outcome != 'success'
         run: |
           echo "::error::Release readiness checks failed. Review the validation output and job summary for details."
           exit 1


### PR DESCRIPTION
## Summary
- gate the native Windows workflow behind a cheap change-detection job and add pip caching
- keep the Windows suite scoped to the source and test surfaces actually covered by `windows_ci`
- run `tests/release` on release-readiness pull requests while keeping the broader non-Windows suite for scheduled and manual runs

## Testing
- `.venv/bin/python -m pytest -v --import-mode=importlib tests/release`
