### PR TITLE
Fix Sonar propagator reliability bug and regex hotspots

### DIFF
--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -121,7 +121,7 @@ def _rewrite_manifest(
     from datetime import UTC, datetime
 
     # Filename helper (mirrors write_pipeline._artifact_filename)
-    _DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
+    _DIRECTIVE_NUM_RE = re.compile(r"^[A-Z]+_(\d+)$")
 
     def _filename(kind: str, slug: str, artifact_id: str | None) -> str:
         if kind == "directive":

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -54,7 +54,7 @@ from .synthesize_pipeline import ProvenanceEntry, canonical_yaml
 # Filename helpers (data-model §E-2 "Filename rule")
 # ---------------------------------------------------------------------------
 
-_DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
+_DIRECTIVE_NUM_RE = re.compile(r"^[A-Z]+_(\d+)$")
 
 
 def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> str:

--- a/src/specify_cli/invocation/propagator.py
+++ b/src/specify_cli/invocation/propagator.py
@@ -36,9 +36,11 @@
 from __future__ import annotations
 
 import atexit
+import asyncio
 import json
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -48,6 +50,14 @@ logger = logging.getLogger(__name__)
 
 PROPAGATION_ERRORS_PATH = ".kittify/events/propagation-errors.jsonl"
 _ATEXIT_TIMEOUT_SECONDS = 5.0
+_IN_FLIGHT_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _track_in_flight_task(task: asyncio.Task[Any]) -> asyncio.Task[Any]:
+    """Keep fire-and-forget tasks alive until completion."""
+    _IN_FLIGHT_TASKS.add(task)
+    task.add_done_callback(_IN_FLIGHT_TASKS.discard)
+    return task
 
 
 def _get_saas_client(repo_root: Path) -> Any | None:  # noqa: ARG001
@@ -116,14 +126,12 @@ def _propagate_one(record: InvocationRecord, repo_root: Path) -> None:
                 "completed_at": record.completed_at,
             }
 
-        # Mirror emitter.py _route_event() asyncio pattern (lines 993-1000):
-        import asyncio  # noqa: PLC0415
-
         try:
             loop = asyncio.get_event_loop()
             if loop.is_running():
                 # Already inside a running loop (rare in CLI threads, but safe)
-                asyncio.ensure_future(client.send_event(event_dict))
+                task = asyncio.ensure_future(client.send_event(event_dict))
+                _track_in_flight_task(task)
             else:
                 loop.run_until_complete(client.send_event(event_dict))
         except RuntimeError:
@@ -147,7 +155,7 @@ def _log_propagation_error(
             "invocation_id": record.invocation_id,
             "event": record.event,
             "error": error,
-            "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "at": datetime.datetime.now(datetime.UTC).isoformat(),
         }
         with error_log.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
@@ -186,7 +194,5 @@ class InvocationSaaSPropagator:
         Python's process-exit machinery imposes its own timeout, so threads
         that have not finished by then are abandoned (acceptable behaviour).
         """
-        try:
+        with suppress(Exception):
             self._executor.shutdown(wait=True, cancel_futures=False)
-        except Exception:  # noqa: BLE001
-            pass  # Shutdown must never raise

--- a/tests/specify_cli/invocation/test_propagator.py
+++ b/tests/specify_cli/invocation/test_propagator.py
@@ -19,6 +19,7 @@ import pytest
 
 from specify_cli.invocation.propagator import (
     InvocationSaaSPropagator,
+    _IN_FLIGHT_TASKS,
     _log_propagation_error,
     _propagate_one,
 )
@@ -126,6 +127,37 @@ def test_propagator_sends_invocation_id_in_event_dict(tmp_path: pytest.TempPathF
     assert len(captured) == 1
     assert captured[0]["invocation_id"] == record.invocation_id
     assert captured[0]["event_type"] == "ProfileInvocationStarted"
+
+
+def test_propagator_tracks_fire_and_forget_tasks(tmp_path: pytest.TempPathFactory) -> None:
+    """Tasks scheduled on a running loop stay referenced until completion."""
+    record = make_started_record()
+    captured: list[dict[str, object]] = []
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        async def mock_send(event_dict: dict[str, object]) -> None:
+            captured.append(event_dict)
+
+        class MockClient:
+            send_event = staticmethod(mock_send)
+
+        with patch("specify_cli.invocation.propagator._get_saas_client", return_value=MockClient()):
+            running_loop = MagicMock()
+            running_loop.is_running.return_value = True
+
+            with patch("specify_cli.invocation.propagator.asyncio.get_event_loop", return_value=running_loop):
+                _propagate_one(record, tmp_path)
+                assert len(_IN_FLIGHT_TASKS) == 1
+                loop.run_until_complete(asyncio.gather(*tuple(_IN_FLIGHT_TASKS)))
+                loop.run_until_complete(asyncio.sleep(0))
+
+        assert captured[0]["invocation_id"] == record.invocation_id
+        assert not _IN_FLIGHT_TASKS
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
 
 
 def test_propagator_error_log_never_raises_on_disk_full(tmp_path: pytest.TempPathFactory) -> None:


### PR DESCRIPTION
## Summary
- retain fire-and-forget propagation tasks until completion so asyncio tasks cannot be garbage-collected early
- add a focused propagator test that exercises the running-loop path
- tighten directive-id regexes in charter synthesizer helpers to remove Sonar regex hotspot findings without changing valid matches

## Validation
- `python -m pytest tests/specify_cli/invocation/test_propagator.py -q`
- `python -m ruff check src/specify_cli/invocation/propagator.py tests/specify_cli/invocation/test_propagator.py src/charter/synthesizer/write_pipeline.py src/charter/synthesizer/resynthesize_pipeline.py`
- `PYTHONPATH=src python - <<'PY'`

## Notes
- `tests/charter/synthesizer/test_write_pipeline.py -q` is currently blocked on this machine because the repo test fixture venv bootstrap fails while creating `.pytest_cache/spec-kitty-test-venv` via `python -m venv`/`ensurepip`.