### PR TITLE
fix: address mission-093 post-merge review findings

### DIFF
--- a/.agents/skills/spec-kitty.advise/SKILL.md
+++ b/.agents/skills/spec-kitty.advise/SKILL.md
@@ -31,6 +31,20 @@ Response fields:
 | `governance_context_available` | boolean | `false` when charter has not been synthesised |
 | `router_confidence` | string or null | Routing confidence score (auto-routing only) |
 
+### Governance context injection
+
+After calling `advise`, `ask`, or `do`, the response includes a `governance_context_text` field.
+
+**You must inject this text into your working context before executing the task.**
+
+Steps:
+1. Read `governance_context_text` from the JSON response.
+2. Add the text to the beginning of your task execution context. Treat it as binding governance: follow any directives, constraints, and guidelines it contains when generating code, plans, or analyses.
+3. If `governance_context_available` is `false`, note it to the user ("governance context unavailable — run `spec-kitty charter synthesize` to build the DRG") but proceed with the task. The invocation trail is still recorded.
+4. After completing the task, close the record (see "Close the record" below).
+
+The `governance_context_hash` field in the response is a checksum of the context used. It is stored in the invocation record for provenance.
+
 ### Close the record
 ```bash
 spec-kitty profile-invocation complete \

--- a/.kittify/command-skills-manifest.json
+++ b/.kittify/command-skills-manifest.json
@@ -4,6 +4,15 @@
       "agents": [
         "codex"
       ],
+      "content_hash": "3f76a5ec6458923400cbfaf1435eca489fa2327a4f939b1a9d2e2baa68429a64",
+      "installed_at": "2026-04-22T00:00:00+00:00",
+      "path": ".agents/skills/spec-kitty.advise/SKILL.md",
+      "spec_kitty_version": "3.2.0"
+    },
+    {
+      "agents": [
+        "codex"
+      ],
       "content_hash": "a9896884095113bf1385847e5b7959bb3d33e8d97bfe6754ec6b0b4eba23bf9a",
       "installed_at": "2026-04-19T12:40:14.220282+00:00",
       "path": ".agents/skills/spec-kitty.analyze/SKILL.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased - 3.2.0]
 
+## [3.2.0a5] - 2026-04-22
+
+### Added
+
+- `docs/trail-model.md`: Formal operator documentation for the Phase 4 trail contract,
+  mode-of-work taxonomy, tier promotion rules, SaaS projection policy, intake positioning,
+  and explain deferral (WP04).
+- "Governance context injection" section in `.agents/skills/spec-kitty.advise/SKILL.md`
+  for Codex/Vibe hosts, enabling Tier 1 trail recording without host-side SaaS auth (WP03).
+- "Standalone invocations (outside missions)" section in
+  `src/doctrine/skills/spec-kitty-runtime-next/SKILL.md` for Claude Code and gstack hosts,
+  covering when to open an invocation record outside the mission workflow (WP04).
+- End-to-end invocation integration tests in
+  `tests/specify_cli/invocation/test_invocation_e2e.py` covering Tier 1 JSONL write,
+  complete-event append, local-only list read, and sync-gate suppression (WP05).
+
+### Fixed
+
+- `propagator.py` (`_propagate_one`): Invocation events are now suppressed when
+  `effective_sync_enabled = False`, even when the user is authenticated. Previously,
+  sync-disabled checkouts could still emit SaaS events if a WebSocket client was
+  connected (WP01).
+- `executor.complete_invocation` now calls `promote_to_evidence()` when the
+  `--evidence` flag is supplied, enabling correct Tier 2 artifact promotion (WP03).
+
+### Changed
+
+- Issue #496: Priority-surface slice complete in 3.2.x (Claude Code via
+  `spec-kitty-runtime-next` doctrine skill, Codex CLI via SKILL.md governance context
+  injection). Remaining 9 surfaces tracked in #496 for a follow-on patch or Phase 5.
+- Issue #534: `spec-kitty explain` explicitly deferred to Phase 5 (requires DRG
+  glossary addressability, issue #499). A partial implementation without glossary
+  citations would be misleading.
+
 ## [3.2.0a4] - 2026-04-21
 
 ### Added

--- a/docs/trail-model.md
+++ b/docs/trail-model.md
@@ -1,0 +1,106 @@
+# Trail Model
+
+*Operator reference for the Phase 4 runtime consumption baseline.*
+
+## Overview
+
+Every profile invocation in Spec Kitty — whether triggered by `advise`, `ask`, or `do` — leaves an auditable trail. The trail serves three purposes:
+
+1. **Local accountability**: operators can reconstruct what happened on any checkout without SaaS connectivity.
+2. **SaaS coherence**: the dashboard timeline shows the same history as the local audit log.
+3. **Governance provenance**: downstream retrospective and doctrine work can reference specific invocations.
+
+## Minimal Viable Trail
+
+**One JSONL file per invocation, written locally before the executor returns.**
+
+Every `advise`, `ask`, and `do` call writes a `started` event to:
+
+```
+.kittify/events/profile-invocations/{invocation_id}.jsonl
+```
+
+When `spec-kitty profile-invocation complete` is called, a `completed` event is appended to the same file.
+
+This is the unconditional minimum — it is always written, regardless of SaaS connectivity, charter state, or sync configuration. The data model is defined in `src/specify_cli/invocation/record.py`.
+
+## Mode-of-Work Taxonomy
+
+Every invocation belongs to one of four work modes. The mode determines which optional trail tiers are eligible — it does not override the mandatory Tier 1 rule.
+
+| Mode | Description | Example actions | Tier 2 eligible | Tier 3 eligible |
+|------|-------------|-----------------|-----------------|-----------------|
+| `advisory` | Pure routing/context advisory, no durable output | `advise` | No | No |
+| `task_execution` | Produces a checkable output (code change, review, test run) | `ask`, `do` (non-mission) | Yes (caller-triggered) | No |
+| `mission_step` | One step in a governed mission workflow | `specify`, `plan`, `tasks`, `merge`, `accept` | Yes (caller-triggered) | Yes |
+| `query` | Read-only, no execution | `profiles list`, `invocations list` | No | No |
+
+Mode-of-work is a documentation-level taxonomy in 3.2. Runtime enforcement and automatic mode detection are deferred to Phase 5.
+
+## Trail Tiers
+
+### Tier 1 — Every Invocation (mandatory)
+
+Written unconditionally before the executor returns.
+
+- **Storage**: `.kittify/events/profile-invocations/{invocation_id}.jsonl`
+- **Content**: Two JSONL lines — a `started` event and (after completion) a `completed` event.
+- **When**: All `advise`, `ask`, and `do` invocations.
+
+### Tier 2 — Evidence Artifact (optional, caller-triggered)
+
+Created when the caller explicitly flags that the invocation produced checkable output.
+
+- **Trigger**: Caller sets `--evidence-ref <description>` on `spec-kitty profile-invocation complete`.
+- **Storage**: `.kittify/evidence/{invocation_id}/evidence.md` and `.kittify/evidence/{invocation_id}/record.json`
+- **When**: `task_execution` and `mission_step` modes only.
+
+### Tier 3 — Durable Project State (optional, action-driven)
+
+Promotion to `kitty-specs/` or doctrine artifacts only when the invocation changes project-domain state.
+
+- **Trigger**: Action is in `TIER_3_ACTIONS` — `{specify, plan, tasks, merge, accept}`.
+- **Storage**: `kitty-specs/{mission_slug}/` — existing spec/plan/tasks/status files.
+- **When**: `mission_step` mode only.
+
+### Promotion Rules
+
+```
+Tier 1 always written
+  |
+  +-- If caller sets evidence_ref --> Tier 2 artifact created
+  |
+  +-- If action in TIER_3_ACTIONS --> Tier 3 artifacts produced by workflow
+```
+
+## SaaS Projection
+
+Projection is conditional on `CheckoutSyncRouting.effective_sync_enabled`. When sync is disabled for a checkout, no events are emitted to SaaS — even if the user is authenticated.
+
+| Item | Projection behaviour |
+|------|---------------------|
+| Tier 1 started/completed pairs | Projected to SaaS timeline view |
+| Advisory-only (`mode=advisory`) | Minimal timeline entry, no body upload |
+| Tier 2 evidence artifacts | Local only in 3.2. Not uploaded to SaaS. |
+| Tier 3 `kitty-specs/` artifacts | Referenced in SaaS dossier via mission linkage; bodies not bulk-uploaded in 3.2 |
+
+Projection is additive. Events accumulate; there is no deletion, replay-based overwrite, or idempotency-key gating in 3.2.
+
+## Retention and Redaction
+
+| Field | Treatment |
+|-------|-----------|
+| `request_text` | Retained as-written in local JSONL. No automatic redaction in 3.2. |
+| `governance_context_hash` | First 16 hex chars of SHA-256 only. Full governance context is never persisted. |
+| JSONL files | Persist indefinitely unless the operator purges `.kittify/events/`. |
+| SaaS propagation | Additive. No delete-on-disable in 3.2. |
+
+Propagation failures are written to `.kittify/events/propagation-errors.jsonl` and never affect the CLI exit code.
+
+## `spec-kitty intake` — Not a Profile Invocation
+
+`spec-kitty intake` ingests a plan document into `.kittify/mission-brief.md` for use by `/spec-kitty.specify` brief-intake mode. It is **not** a profile invocation and produces no `InvocationRecord`. The governed trail begins when the host calls `spec-kitty advise`, `ask`, or `do` — not when the user stages a brief.
+
+## `spec-kitty explain` — Deferred to Phase 5
+
+`spec-kitty explain` (issue #534) is not part of this release. It requires Phase 5 DRG glossary addressability to produce fully-cited answers. A partial implementation without glossary citations would be misleading.

--- a/docs/trail-model.md
+++ b/docs/trail-model.md
@@ -51,7 +51,7 @@ Written unconditionally before the executor returns.
 
 Created when the caller explicitly flags that the invocation produced checkable output.
 
-- **Trigger**: Caller sets `--evidence-ref <description>` on `spec-kitty profile-invocation complete`.
+- **Trigger**: Caller sets `--evidence <path>` on `spec-kitty profile-invocation complete`.
 - **Storage**: `.kittify/evidence/{invocation_id}/evidence.md` and `.kittify/evidence/{invocation_id}/record.json`
 - **When**: `task_execution` and `mission_step` modes only.
 

--- a/kitty-specs/phase-4-trail-host-surface-closeout-01KPSXD2/meta.json
+++ b/kitty-specs/phase-4-trail-host-surface-closeout-01KPSXD2/meta.json
@@ -1,0 +1,12 @@
+{
+  "created_at": "2026-04-22T06:17:55.233560+00:00",
+  "friendly_name": "Phase 4 Trail and Host-Surface Closeout",
+  "mission_id": "01KPSXD2MH6JXN5F48ZWAYC47J",
+  "mission_number": 93,
+  "mission_slug": "phase-4-trail-host-surface-closeout-01KPSXD2",
+  "mission_type": "software-dev",
+  "slug": "phase-4-trail-host-surface-closeout-01KPSXD2",
+  "source_description": "Phase 4 closeout: harden the landed runtime-consumption baseline so charter/doctrine is operationally coherent across host surfaces, local audit trail, and SaaS projection. Covers trail contract formalization (#701), host-surface rollout (#496), intake positioning, sync-boundary validation, and explicit explain deferral (#534). Release gate for 3.2 before Phase 5/6/7.",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
@@ -508,6 +508,58 @@ for null before acting; treat null as blocked.
 
 ---
 
+## Standalone Invocations (Outside Missions)
+
+Not all governed work happens inside an active mission. When a user asks for help with a task that has no active `spec-kitty next` loop — a code review, a quick implementation, an ad-hoc analysis — you should still invoke Spec Kitty's governance layer via the profile invocation surface.
+
+Spec Kitty never spawns a parallel LLM call. You are the host; Spec Kitty routes, assembles governance context, and records the trail.
+
+### When to use which command
+
+| Situation | Command |
+|-----------|---------|
+| Request is clear, profile unknown | `spec-kitty do "<request>" --json` |
+| Request is clear, profile known | `spec-kitty ask <profile> "<request>" --json` |
+| Need routing decision only (no implementation) | `spec-kitty advise "<request>" --json` |
+
+### The governance injection loop
+
+1. **Get context**:
+   ```bash
+   spec-kitty do "implement the login handler" --json
+   # or:
+   spec-kitty ask pedro "review WP05" --json
+   ```
+   Response includes `invocation_id`, `governance_context_text`, and `governance_context_available`.
+
+2. **Inject governance**:
+   Read `governance_context_text` and treat it as binding governance context for your task. Follow any directives and constraints it contains.
+   If `governance_context_available` is `false`, note this to the user but proceed with the task.
+
+3. **Execute**:
+   Do the work. Generate the code, analysis, or plan.
+
+4. **Close the record**:
+   ```bash
+   spec-kitty profile-invocation complete \
+     --invocation-id <invocation_id> \
+     --outcome done
+   ```
+   Use `failed` or `abandoned` as appropriate.
+
+### Trail produced
+
+Every standalone invocation writes a Tier 1 JSONL file to:
+```
+.kittify/events/profile-invocations/<invocation_id>.jsonl
+```
+
+Viewable at any time with `spec-kitty invocations list --json`. No SaaS connection required.
+
+For full CLI surface documentation, see `.agents/skills/spec-kitty.advise/SKILL.md`.
+
+---
+
 ## References
 
 - `references/runtime-result-taxonomy.md` -- Decision kinds, output fields, and precedence rules

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -19,7 +19,7 @@ import ulid as _ulid_mod  # matches codebase pattern: status/emit.py, core/missi
 from charter.context import build_charter_context
 from specify_cli.invocation.errors import InvocationWriteError, ProfileNotFoundError
 from specify_cli.invocation.propagator import InvocationSaaSPropagator
-from specify_cli.invocation.record import InvocationRecord
+from specify_cli.invocation.record import InvocationRecord, promote_to_evidence
 from specify_cli.invocation.registry import ProfileRegistry
 from specify_cli.invocation.router import ActionRouter, RouterDecision  # WP02: router implemented
 from specify_cli.invocation.writer import InvocationWriter
@@ -186,6 +186,15 @@ class ProfileInvocationExecutor:
             outcome=outcome,
             evidence_ref=evidence_ref,
         )
+        # Promote to Tier 2 evidence artifact if --evidence was supplied
+        if evidence_ref is not None:
+            evidence_path = Path(evidence_ref)
+            try:
+                content = evidence_path.read_text(encoding="utf-8")
+            except OSError:
+                content = evidence_ref  # fallback: treat the value as inline content
+            evidence_base_dir = self._repo_root / ".kittify" / "evidence"
+            promote_to_evidence(completed, evidence_base_dir, content)
         # Propagate completed event (non-blocking, best-effort)
         if self._propagator is not None:
             self._propagator.submit(completed)

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -189,6 +189,11 @@ class ProfileInvocationExecutor:
         # Promote to Tier 2 evidence artifact if --evidence was supplied
         if evidence_ref is not None:
             evidence_path = Path(evidence_ref)
+            if not evidence_path.is_absolute():
+                # Anchor relative paths to the project root to prevent directory
+                # traversal (e.g. ../../etc/passwd). Absolute paths are the
+                # operator's explicit choice and pass through unchanged.
+                evidence_path = (self._repo_root / evidence_path).resolve()
             try:
                 content = evidence_path.read_text(encoding="utf-8")
             except OSError:

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -189,13 +189,21 @@ class ProfileInvocationExecutor:
         # Promote to Tier 2 evidence artifact if --evidence was supplied
         if evidence_ref is not None:
             evidence_path = Path(evidence_ref)
+            candidate_path: Path | None = None
             if not evidence_path.is_absolute():
-                # Anchor relative paths to the project root to prevent directory
-                # traversal (e.g. ../../etc/passwd). Absolute paths are the
-                # operator's explicit choice and pass through unchanged.
-                evidence_path = (self._repo_root / evidence_path).resolve()
+                repo_root = self._repo_root.resolve()
+                resolved_relative_path = (repo_root / evidence_path).resolve()
+                if resolved_relative_path.is_relative_to(repo_root):
+                    candidate_path = resolved_relative_path
+            else:
+                # Absolute paths are the operator's explicit choice.
+                candidate_path = evidence_path
             try:
-                content = evidence_path.read_text(encoding="utf-8")
+                content = (
+                    candidate_path.read_text(encoding="utf-8")
+                    if candidate_path is not None
+                    else evidence_ref
+                )
             except OSError:
                 content = evidence_ref  # fallback: treat the value as inline content
             evidence_base_dir = self._repo_root / ".kittify" / "evidence"

--- a/src/specify_cli/invocation/propagator.py
+++ b/src/specify_cli/invocation/propagator.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Any
 
 from specify_cli.invocation.record import InvocationRecord
+from specify_cli.sync.routing import resolve_checkout_sync_routing
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,10 @@ def _propagate_one(record: InvocationRecord, repo_root: Path) -> None:
     It is NOT synchronous and does NOT accept an idempotency_key kwarg.
     Call pattern mirrors src/specify_cli/sync/emitter.py lines 993-1000.
     """
+    routing = resolve_checkout_sync_routing(repo_root)
+    if routing is not None and not routing.effective_sync_enabled:
+        return  # Sync explicitly disabled for this checkout → no-op
+
     client = _get_saas_client(repo_root)
     if client is None:
         return  # No SaaS token / client not connected → no-op, no log

--- a/tests/migration/test_normalize_mission_lifecycle_cli.py
+++ b/tests/migration/test_normalize_mission_lifecycle_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -47,7 +48,7 @@ def test_help_flag() -> None:
     result = runner.invoke(migrate_app, ["normalize-lifecycle", "--help"])
 
     assert result.exit_code == 0
-    plain = result.output
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
     assert "normalize-lifecycle" in plain
     assert "--dry-run" in plain
     assert "--json" in plain

--- a/tests/specify_cli/cli/commands/test_selector_resolution.py
+++ b/tests/specify_cli/cli/commands/test_selector_resolution.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 from pathlib import Path
+from types import ModuleType
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -401,6 +403,9 @@ def test_agent_mission_create_canonical_succeeds(tmp_path: Path) -> None:
             feature_dir=feature_dir,
             target_branch="main",
             current_branch="main",
+            origin_binding_attempted=False,
+            origin_binding_succeeded=False,
+            origin_binding_error=None,
         )
 
     with (
@@ -438,6 +443,9 @@ def test_agent_mission_create_alias_succeeds_with_warning(
             feature_dir=feature_dir,
             target_branch="main",
             current_branch="main",
+            origin_binding_attempted=False,
+            origin_binding_succeeded=False,
+            origin_binding_error=None,
         )
 
     with (
@@ -479,9 +487,13 @@ def test_next_step_canonical_selector_passes_mission_slug(
             run_id=None,
         )
 
+    fake_runtime_bridge = ModuleType("specify_cli.next.runtime_bridge")
+    fake_runtime_bridge.query_current_state = _fake_query
+    fake_runtime_bridge.QueryModeValidationError = RuntimeError
+
     with (
         patch("specify_cli.cli.commands.next_cmd.locate_project_root", return_value=tmp_path),
-        patch("specify_cli.next.runtime_bridge.query_current_state", side_effect=_fake_query),
+        patch.dict(sys.modules, {"specify_cli.next.runtime_bridge": fake_runtime_bridge}),
     ):
         next_step.__wrapped__(
             agent="codex",
@@ -515,9 +527,13 @@ def test_next_step_alias_selector_warns_and_passes_mission_slug(
             run_id=None,
         )
 
+    fake_runtime_bridge = ModuleType("specify_cli.next.runtime_bridge")
+    fake_runtime_bridge.query_current_state = _fake_query
+    fake_runtime_bridge.QueryModeValidationError = RuntimeError
+
     with (
         patch("specify_cli.cli.commands.next_cmd.locate_project_root", return_value=tmp_path),
-        patch("specify_cli.next.runtime_bridge.query_current_state", side_effect=_fake_query),
+        patch.dict(sys.modules, {"specify_cli.next.runtime_bridge": fake_runtime_bridge}),
     ):
         next_step.__wrapped__(
             agent="codex",

--- a/tests/specify_cli/invocation/test_evidence_promotion.py
+++ b/tests/specify_cli/invocation/test_evidence_promotion.py
@@ -95,3 +95,20 @@ def test_complete_with_nonexistent_evidence_path_uses_inline_content(tmp_path: P
     evidence_dir = tmp_path / ".kittify" / "evidence" / invocation_id
     assert evidence_dir.exists()
     assert "all tests passed" in (evidence_dir / "evidence.md").read_text()
+
+
+def test_complete_with_relative_escape_path_uses_inline_content(tmp_path: Path) -> None:
+    """Relative evidence paths must stay inside repo_root after resolution."""
+    outside_file = tmp_path.parent / f"{tmp_path.name}-outside.md"
+    outside_file.write_text("top secret outside repo", encoding="utf-8")
+    executor, invocation_id = _make_executor_with_started_record(tmp_path)
+
+    executor.complete_invocation(
+        invocation_id=invocation_id,
+        outcome="done",
+        evidence_ref=f"../{outside_file.name}",
+    )
+
+    evidence_dir = tmp_path / ".kittify" / "evidence" / invocation_id
+    promoted_content = (evidence_dir / "evidence.md").read_text(encoding="utf-8")
+    assert promoted_content == f"../{outside_file.name}"

--- a/tests/specify_cli/invocation/test_evidence_promotion.py
+++ b/tests/specify_cli/invocation/test_evidence_promotion.py
@@ -1,0 +1,97 @@
+"""Tests for evidence artifact promotion (Tier 2) via complete_invocation()."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from specify_cli.invocation.executor import ProfileInvocationExecutor
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "profiles"
+
+_COMPACT_CTX = MagicMock()
+_COMPACT_CTX.mode = "compact"
+_COMPACT_CTX.text = "test governance context"
+
+
+def _setup_project(tmp_path: Path) -> Path:
+    """Create a minimal project with fixture profiles."""
+    profiles_dir = tmp_path / ".kittify" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    for yaml_file in FIXTURES_DIR.glob("*.agent.yaml"):
+        shutil.copy(yaml_file, profiles_dir / yaml_file.name)
+    (tmp_path / ".kittify" / "events" / "profile-invocations").mkdir(parents=True)
+    return tmp_path
+
+
+def _make_executor_with_started_record(
+    tmp_path: Path,
+) -> tuple[ProfileInvocationExecutor, str]:
+    """Create an executor and start an invocation; return (executor, invocation_id)."""
+    project = _setup_project(tmp_path)
+    with patch(
+        "specify_cli.invocation.executor.build_charter_context",
+        return_value=_COMPACT_CTX,
+    ):
+        executor = ProfileInvocationExecutor(project)
+        profiles = list(executor._registry.list_all())
+        if not profiles:
+            pytest.skip("No fixture profiles available")
+        profile = profiles[0]
+        payload = executor.invoke(
+            request_text="test evidence request",
+            profile_hint=profile.profile_id,
+            actor="claude",
+        )
+    return executor, payload.invocation_id
+
+
+def test_complete_with_evidence_creates_tier2_directory(tmp_path: Path) -> None:
+    """complete_invocation with evidence_ref must create the Tier 2 evidence directory."""
+    evidence_file = tmp_path / "test_evidence.md"
+    evidence_file.write_text("## Test Evidence\n\nAll assertions passed.", encoding="utf-8")
+
+    executor, invocation_id = _make_executor_with_started_record(tmp_path)
+
+    executor.complete_invocation(
+        invocation_id=invocation_id,
+        outcome="done",
+        evidence_ref=str(evidence_file),
+    )
+
+    evidence_dir = tmp_path / ".kittify" / "evidence" / invocation_id
+    assert evidence_dir.exists(), f"Tier 2 directory not created at {evidence_dir}"
+    assert (evidence_dir / "evidence.md").exists()
+    assert (evidence_dir / "record.json").exists()
+    assert "All assertions passed." in (evidence_dir / "evidence.md").read_text()
+
+
+def test_complete_without_evidence_skips_tier2(tmp_path: Path) -> None:
+    """complete_invocation without evidence_ref must NOT create any evidence directory."""
+    executor, invocation_id = _make_executor_with_started_record(tmp_path)
+
+    executor.complete_invocation(invocation_id=invocation_id, outcome="done")
+
+    evidence_dir = tmp_path / ".kittify" / "evidence"
+    # Either dir doesn't exist, or exists but is empty
+    if evidence_dir.exists():
+        assert not list(evidence_dir.iterdir()), "Unexpected evidence directory created"
+
+
+def test_complete_with_nonexistent_evidence_path_uses_inline_content(tmp_path: Path) -> None:
+    """When evidence_ref is not a valid file path, use it as inline content."""
+    executor, invocation_id = _make_executor_with_started_record(tmp_path)
+
+    executor.complete_invocation(
+        invocation_id=invocation_id,
+        outcome="done",
+        evidence_ref="all tests passed: 42/42",  # a label, not a path
+    )
+
+    evidence_dir = tmp_path / ".kittify" / "evidence" / invocation_id
+    assert evidence_dir.exists()
+    assert "all tests passed" in (evidence_dir / "evidence.md").read_text()

--- a/tests/specify_cli/invocation/test_invocation_e2e.py
+++ b/tests/specify_cli/invocation/test_invocation_e2e.py
@@ -25,9 +25,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from specify_cli.invocation.executor import ProfileInvocationExecutor
-from specify_cli.invocation.propagator import InvocationSaaSPropagator, _propagate_one
 from specify_cli.invocation.record import InvocationRecord
-from specify_cli.invocation.writer import EVENTS_DIR, InvocationWriter
+from specify_cli.invocation.writer import EVENTS_DIR
 from specify_cli.sync.routing import CheckoutSyncRouting
 
 
@@ -234,6 +233,10 @@ def test_sync_disabled_no_saas_events(tmp_path: Path) -> None:
     - _get_saas_client is NOT called when effective_sync_enabled=False
     - Local JSONL file is still written (Tier 1 trail is mandatory regardless of sync)
     """
+    # Integrated test: executor.invoke() is called with sync disabled.
+    # Verifies both properties in a single, unbroken execution path:
+    # (a) _get_saas_client is never called (sync gate fires inside _propagate_one)
+    # (b) the JSONL file is written by the executor, not manually
     project = _setup_minimal_project(tmp_path)
 
     disabled_routing = CheckoutSyncRouting(
@@ -247,8 +250,6 @@ def test_sync_disabled_no_saas_events(tmp_path: Path) -> None:
         effective_sync_enabled=False,
     )
 
-    record = _make_started_record()
-
     with patch(
         "specify_cli.invocation.propagator.resolve_checkout_sync_routing",
         return_value=disabled_routing,
@@ -256,19 +257,25 @@ def test_sync_disabled_no_saas_events(tmp_path: Path) -> None:
         with patch(
             "specify_cli.invocation.propagator._get_saas_client",
         ) as mock_client:
-            _propagate_one(record, project)
+            with patch(
+                "specify_cli.invocation.executor.build_charter_context",
+                return_value=_COMPACT_CTX,
+            ):
+                executor = ProfileInvocationExecutor(project)
+                payload = executor.invoke(
+                    "implement the feature",
+                    profile_hint="implementer-fixture",
+                )
+
+            # (a) SaaS client was never called — sync gate suppressed emission
             mock_client.assert_not_called()
 
-    # The local JSONL must still exist — write it directly (Tier 1 is mandatory,
-    # independently of the propagator).  The propagator is best-effort SaaS sync;
-    # the writer is mandatory.  We write directly here to confirm the writer path
-    # is independent of the propagator gate.
-    writer = InvocationWriter(project)
-    writer.write_started(record)
-
+    # (b) Local JSONL written by the executor (not manually) — Tier 1 is mandatory
     events_dir = project / EVENTS_DIR
-    jsonl_files = list(events_dir.glob("*.jsonl"))
-    assert len(jsonl_files) >= 1, (
-        "Expected local JSONL to exist after write_started; "
-        f"found {len(jsonl_files)} files in {events_dir}"
+    expected_file = events_dir / f"{payload.invocation_id}.jsonl"
+    assert expected_file.exists(), (
+        f"Expected executor to write JSONL at {expected_file}; file not found"
     )
+    import json as _json
+    lines = [ln for ln in expected_file.read_text().splitlines() if ln.strip()]
+    assert len(lines) >= 1 and _json.loads(lines[0])["event"] == "started"

--- a/tests/specify_cli/invocation/test_invocation_e2e.py
+++ b/tests/specify_cli/invocation/test_invocation_e2e.py
@@ -1,0 +1,274 @@
+"""End-to-end invocation tests (WP05 T018–T021).
+
+Tests exercise the advise/execute loop at the executor level (bypassing the CLI
+layer for reliability) to verify:
+
+- T018: A `started` JSONL record is written with a 26-char ULID invocation_id.
+- T019: `complete_invocation` appends a `completed` event with the correct outcome.
+- T020: `invocations list` reads from local JSONL without SaaS connectivity.
+- T021: When `effective_sync_enabled=False`, `_get_saas_client` is never called
+         but the local JSONL is still written.
+
+Implementation note: Tests use the executor/writer/propagator directly rather
+than CliRunner to avoid CLI routing complexity (ActionRouter requires profiles).
+The acceptance criteria only require the *behaviour* to be verified, not that it
+goes through the full CLI layer.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from specify_cli.invocation.executor import ProfileInvocationExecutor
+from specify_cli.invocation.propagator import InvocationSaaSPropagator, _propagate_one
+from specify_cli.invocation.record import InvocationRecord
+from specify_cli.invocation.writer import EVENTS_DIR, InvocationWriter
+from specify_cli.sync.routing import CheckoutSyncRouting
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "profiles"
+
+_COMPACT_CTX = MagicMock()
+_COMPACT_CTX.mode = "compact"
+_COMPACT_CTX.text = "compact governance context"
+
+_MISSING_CTX = MagicMock()
+_MISSING_CTX.mode = "missing"
+_MISSING_CTX.text = ""
+
+
+def _setup_minimal_project(tmp_path: Path) -> Path:
+    """Create a minimal project structure for invocation tests.
+
+    Copies fixture profiles into .kittify/profiles/ so that ProfileRegistry
+    can resolve them.  Also creates the events directory pre-emptively so
+    directory-existence checks in tests do not require a prior write.
+    """
+    profiles_dir = tmp_path / ".kittify" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    for yaml_file in FIXTURES_DIR.glob("*.agent.yaml"):
+        shutil.copy(yaml_file, profiles_dir / yaml_file.name)
+
+    events_dir = tmp_path / EVENTS_DIR
+    events_dir.mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _make_started_record(invocation_id: str = "01KPQRX2EVGMRVB4Q1JQBAZJV3") -> InvocationRecord:
+    """Create a minimal started record for direct writer/propagator tests."""
+    return InvocationRecord(
+        event="started",
+        invocation_id=invocation_id,
+        profile_id="implementer-fixture",
+        action="implement",
+        request_text="test request",
+        started_at="2026-04-22T06:00:00Z",
+    )
+
+
+# ---------------------------------------------------------------------------
+# T018 — test_advise_writes_tier1_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_advise_writes_tier1_jsonl(tmp_path: Path) -> None:
+    """Running the executor must write a `started` JSONL record (Tier 1 audit trail).
+
+    Verifies:
+    - At least one JSONL file is created in .kittify/events/profile-invocations/
+    - First line event == "started"
+    - invocation_id is present and is 26 characters (ULID)
+    """
+    project = _setup_minimal_project(tmp_path)
+
+    with patch(
+        "specify_cli.invocation.executor.build_charter_context",
+        return_value=_COMPACT_CTX,
+    ):
+        executor = ProfileInvocationExecutor(project)
+        payload = executor.invoke("implement the feature", profile_hint="implementer-fixture")
+
+    events_dir = project / EVENTS_DIR
+    jsonl_files = list(events_dir.glob("*.jsonl"))
+    assert len(jsonl_files) >= 1, f"No JSONL files found in {events_dir}"
+
+    # The file is named after the invocation_id
+    expected_file = events_dir / f"{payload.invocation_id}.jsonl"
+    assert expected_file.exists(), f"Expected JSONL file {expected_file} not found"
+
+    lines = [ln for ln in expected_file.read_text().splitlines() if ln.strip()]
+    assert len(lines) >= 1, "JSONL file is empty"
+
+    started = json.loads(lines[0])
+    assert started["event"] == "started", f"Expected event='started', got {started['event']!r}"
+    assert "invocation_id" in started, "invocation_id missing from started record"
+    assert len(started["invocation_id"]) == 26, (
+        f"Expected 26-char ULID, got {len(started['invocation_id'])!r}-char "
+        f"{started['invocation_id']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T019 — test_complete_writes_completed_event
+# ---------------------------------------------------------------------------
+
+
+def test_complete_writes_completed_event(tmp_path: Path) -> None:
+    """After calling complete_invocation, the JSONL must have a `completed` event.
+
+    Verifies:
+    - JSONL file has exactly 2 lines (started + completed)
+    - Second line event == "completed", outcome == "done"
+    - invocation_id matches across both records
+    """
+    project = _setup_minimal_project(tmp_path)
+
+    # Step 1: Start invocation
+    with patch(
+        "specify_cli.invocation.executor.build_charter_context",
+        return_value=_COMPACT_CTX,
+    ):
+        executor = ProfileInvocationExecutor(project)
+        payload = executor.invoke("implement the feature", profile_hint="implementer-fixture")
+
+    invocation_id = payload.invocation_id
+
+    # Step 2: Complete invocation
+    with patch(
+        "specify_cli.invocation.executor.build_charter_context",
+        return_value=_COMPACT_CTX,
+    ):
+        completed_record = executor.complete_invocation(
+            invocation_id=invocation_id,
+            outcome="done",
+        )
+
+    # Step 3: Verify JSONL has started + completed
+    events_dir = project / EVENTS_DIR
+    jsonl_file = events_dir / f"{invocation_id}.jsonl"
+    assert jsonl_file.exists(), f"JSONL file {jsonl_file} not found"
+
+    lines = [ln for ln in jsonl_file.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 2, f"Expected 2 lines (started + completed), got {len(lines)}"
+
+    completed = json.loads(lines[1])
+    assert completed["event"] == "completed", (
+        f"Expected event='completed', got {completed['event']!r}"
+    )
+    assert completed["outcome"] == "done", (
+        f"Expected outcome='done', got {completed['outcome']!r}"
+    )
+    assert completed["invocation_id"] == invocation_id, (
+        f"invocation_id mismatch: {completed['invocation_id']!r} != {invocation_id!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T020 — test_invocations_list_reads_local_only
+# ---------------------------------------------------------------------------
+
+
+def test_invocations_list_reads_local_only(tmp_path: Path) -> None:
+    """invocations list must return records from local JSONL without SaaS connectivity.
+
+    Verifies (FR-012/AC-012):
+    - A manually-written JSONL file in the events dir is returned by _iter_records
+    - No SaaS call is required — the read path is purely local
+    """
+    from specify_cli.cli.commands.invocations_cmd import _iter_records
+
+    project = _setup_minimal_project(tmp_path)
+    events_dir = project / EVENTS_DIR
+
+    # Write a JSONL file directly to simulate a prior invocation
+    test_id = "01KPQRX2EVGMRVB4Q1JQBAZJV4"
+    jsonl = events_dir / f"{test_id}.jsonl"
+    started_record = {
+        "event": "started",
+        "invocation_id": test_id,
+        "profile_id": "implementer-fixture",
+        "action": "implement",
+        "request_text": "test local read",
+        "governance_context_hash": "abc123",
+        "governance_context_available": True,
+        "actor": "claude",
+        "router_confidence": None,
+        "started_at": "2026-04-22T06:00:00Z",
+        "completed_at": None,
+        "outcome": None,
+        "evidence_ref": None,
+    }
+    jsonl.write_text(json.dumps(started_record) + "\n", encoding="utf-8")
+
+    # _iter_records reads local JSONL with no SaaS access
+    # Patch resolve_checkout_sync_routing to ensure no SaaS lookup is attempted
+    with patch("specify_cli.invocation.propagator.resolve_checkout_sync_routing") as mock_routing:
+        records = list(_iter_records(events_dir, profile_filter=None, limit=100, repo_root=project))
+        # SaaS routing is NOT called by the read path — assert it was never invoked
+        mock_routing.assert_not_called()
+
+    assert any(r.get("invocation_id") == test_id for r in records), (
+        f"Expected invocation_id={test_id!r} in list output; got: "
+        f"{[r.get('invocation_id') for r in records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T021 — test_sync_disabled_no_saas_events
+# ---------------------------------------------------------------------------
+
+
+def test_sync_disabled_no_saas_events(tmp_path: Path) -> None:
+    """Sync-disabled checkout: local JSONL is written, SaaS client is never called.
+
+    Verifies (AC-004):
+    - _get_saas_client is NOT called when effective_sync_enabled=False
+    - Local JSONL file is still written (Tier 1 trail is mandatory regardless of sync)
+    """
+    project = _setup_minimal_project(tmp_path)
+
+    disabled_routing = CheckoutSyncRouting(
+        repo_root=project,
+        project_uuid="test-uuid",
+        project_slug="test-slug",
+        build_id=None,
+        repo_slug="test-repo",
+        local_sync_enabled=False,
+        repo_default_sync_enabled=None,
+        effective_sync_enabled=False,
+    )
+
+    record = _make_started_record()
+
+    with patch(
+        "specify_cli.invocation.propagator.resolve_checkout_sync_routing",
+        return_value=disabled_routing,
+    ):
+        with patch(
+            "specify_cli.invocation.propagator._get_saas_client",
+        ) as mock_client:
+            _propagate_one(record, project)
+            mock_client.assert_not_called()
+
+    # The local JSONL must still exist — write it directly (Tier 1 is mandatory,
+    # independently of the propagator).  The propagator is best-effort SaaS sync;
+    # the writer is mandatory.  We write directly here to confirm the writer path
+    # is independent of the propagator gate.
+    writer = InvocationWriter(project)
+    writer.write_started(record)
+
+    events_dir = project / EVENTS_DIR
+    jsonl_files = list(events_dir.glob("*.jsonl"))
+    assert len(jsonl_files) >= 1, (
+        "Expected local JSONL to exist after write_started; "
+        f"found {len(jsonl_files)} files in {events_dir}"
+    )

--- a/tests/specify_cli/invocation/test_propagator_sync_gate.py
+++ b/tests/specify_cli/invocation/test_propagator_sync_gate.py
@@ -1,0 +1,114 @@
+"""Tests for the effective_sync_enabled gate in _propagate_one() (WP01).
+
+Verifies:
+- When sync is disabled, _get_saas_client is never called (T002)
+- When sync is enabled, _get_saas_client is called (T003)
+- A SaaS client exception does not propagate out of _propagate_one (T004)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from specify_cli.invocation.propagator import _propagate_one
+from specify_cli.invocation.record import InvocationRecord
+from specify_cli.sync.routing import CheckoutSyncRouting
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_started_record() -> InvocationRecord:
+    return InvocationRecord(
+        event="started",
+        invocation_id="01HXYZABCDEFGHIJKLMNOPQRST",
+        profile_id="test-profile",
+        action="implement",
+        started_at="2026-04-22T06:00:00Z",
+    )
+
+
+def _make_routing(*, effective_sync_enabled: bool) -> CheckoutSyncRouting:
+    return CheckoutSyncRouting(
+        repo_root=Path("/fake/repo"),
+        project_uuid="fake-uuid",
+        project_slug="fake-slug",
+        build_id=None,
+        repo_slug="fake-repo",
+        local_sync_enabled=not effective_sync_enabled,
+        repo_default_sync_enabled=None,
+        effective_sync_enabled=effective_sync_enabled,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T002 — sync disabled suppresses SaaS emit
+# ---------------------------------------------------------------------------
+
+
+def test_local_sync_disabled_suppresses_saas_emit(tmp_path: Path) -> None:
+    """When sync is explicitly disabled, _propagate_one must return before touching SaaS client."""
+    routing = _make_routing(effective_sync_enabled=False)
+    record = _make_started_record()
+
+    with patch(
+        "specify_cli.invocation.propagator.resolve_checkout_sync_routing",
+        return_value=routing,
+    ) as mock_routing:
+        with patch(
+            "specify_cli.invocation.propagator._get_saas_client",
+        ) as mock_client:
+            _propagate_one(record, tmp_path)
+            mock_routing.assert_called_once_with(tmp_path)
+            mock_client.assert_not_called()  # key assertion
+
+
+# ---------------------------------------------------------------------------
+# T003 — sync enabled proceeds to auth gate
+# ---------------------------------------------------------------------------
+
+
+def test_local_sync_enabled_proceeds_to_auth_gate(tmp_path: Path) -> None:
+    """When sync is enabled, _propagate_one proceeds to the SaaS client check."""
+    routing = _make_routing(effective_sync_enabled=True)
+    record = _make_started_record()
+
+    with patch(
+        "specify_cli.invocation.propagator.resolve_checkout_sync_routing",
+        return_value=routing,
+    ):
+        with patch(
+            "specify_cli.invocation.propagator._get_saas_client",
+            return_value=None,  # auth not connected → returns None, no emit, but gate was reached
+        ) as mock_client:
+            _propagate_one(record, tmp_path)
+            mock_client.assert_called_once_with(tmp_path)  # key: gate was NOT hit
+
+
+# ---------------------------------------------------------------------------
+# T004 — SaaS exception does not raise
+# ---------------------------------------------------------------------------
+
+
+def test_saas_exception_does_not_raise(tmp_path: Path) -> None:
+    """SaaS client raising an exception must not propagate out of _propagate_one."""
+    routing = _make_routing(effective_sync_enabled=True)
+    record = _make_started_record()
+    mock_client = MagicMock()
+    mock_client.send_event = MagicMock(side_effect=RuntimeError("network timeout"))
+
+    with patch(
+        "specify_cli.invocation.propagator.resolve_checkout_sync_routing",
+        return_value=routing,
+    ):
+        with patch(
+            "specify_cli.invocation.propagator._get_saas_client",
+            return_value=mock_client,
+        ):
+            # Must not raise
+            _propagate_one(record, tmp_path)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/charter.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/charter.prompt.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/plan.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/plan.prompt.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/charter.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/charter.toml
@@ -129,6 +129,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/plan.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/plan.toml
@@ -103,11 +103,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -117,7 +126,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -180,8 +189,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -194,6 +203,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -201,6 +211,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -219,10 +231,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -158,11 +158,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -172,8 +185,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -340,14 +354,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/charter.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/charter.toml
@@ -129,6 +129,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/plan.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/plan.toml
@@ -103,11 +103,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -117,7 +126,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -180,8 +189,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -194,6 +203,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -201,6 +211,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -219,10 +231,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
@@ -158,11 +158,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -172,8 +185,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -340,14 +354,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/charter.md
@@ -130,6 +130,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/plan.md
@@ -104,11 +104,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -118,7 +127,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -181,8 +190,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -195,6 +204,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -202,6 +212,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -220,10 +232,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
@@ -159,11 +159,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -173,8 +186,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -341,14 +355,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
@@ -127,6 +127,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
@@ -101,11 +101,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -115,7 +124,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -178,8 +187,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -192,6 +201,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -199,6 +209,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -217,10 +229,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -156,11 +156,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -170,8 +183,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -338,14 +352,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
@@ -127,6 +127,14 @@ Use this for normal `/spec-kitty.charter` runs.
    - The LLM is responsible for structuring and normalizing the user's answers
      into the interview schema later. The user should only have to answer the
      substance of the question.
+   - If the project uses dense business or domain language, ask one lightweight
+     terminology question: which terms must stay precise across docs, specs,
+     and code, and which overloaded terms or synonyms should be avoided. Fold
+     that signal into existing documentation/review/risk answers rather than
+     inventing new interview schema fields.
+   - If failure modes differ materially, ask which kind of failure would be
+     most costly (for example wrong behavior, privacy breach, downtime, data
+     loss) and use that answer to sharpen risk boundaries and review policy.
    - If examples are needed, keep them conceptual and brief; do not imply that
      the user must mirror the example format.
    - Match interview depth to project complexity and the user's stated

--- a/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
@@ -101,11 +101,20 @@ Before executing any scripts or generating artifacts you must interrogate the sp
   - **Complex Features** (new subsystems, multi-component features): Ask 3-5 questions covering architecture, NFRs, integrations
   - **Platform/Critical Features** (core infrastructure, security, payments): Full interrogation with 5+ questions
 
+- **Scenario-to-design handoff**: For non-trivial features, anchor planning
+  questions in the concrete user flows from the spec rather than generic
+  architecture preferences.
+
+- **Domain rule follow-through**: When the spec implies approvals, lifecycle
+  states, irreversible operations, or business-critical validations, ask 1-2
+  targeted questions about invariants, transitions, atomicity, and externally
+  visible events or integrations. Skip this for trivial features.
+
 - **User signals to reduce questioning**: If the user says "use defaults", "just make it simple", "skip to implementation", "vanilla HTML/CSS/JS" - recognize these as signals to minimize planning questions and use standard approaches.
 
 - **First response rule**:
   - For TRIVIAL features: Ask ONE tech stack question, then if answer is simple (e.g., "vanilla HTML"), proceed directly to plan generation
-  - For other features: Ask a single architecture question and end with `WAITING_FOR_PLANNING_INPUT`
+  - For other features: Ask a single architecture question tied to the riskiest scenario, rule, or lifecycle constraint and end with `WAITING_FOR_PLANNING_INPUT`
 
 - If the user has not provided plan context, keep interrogating with one question at a time.
 
@@ -115,7 +124,7 @@ Planning requirements (scale to complexity):
 
 1. Maintain a **Planning Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for platform-level). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, standard practices are acceptable (vanilla HTML, simple file structure, no build tools). Only probe if the user's request suggests otherwise.
-3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm.
+3. When you have sufficient context for the scope, summarize into an **Engineering Alignment** note and confirm. Include invariant, state-transition, or event assumptions when they materially affect the design.
 4. If user explicitly asks to skip questions or use defaults, acknowledge and proceed with best practices for that feature type.
 
 ## Bulk-Edit Check (if applicable)
@@ -178,8 +187,8 @@ If the mission is not a bulk edit, skip this step.
    - Update Technical Context with explicit statements from the user or discovery research; mark `[NEEDS CLARIFICATION: …]` only when the user deliberately postpones a decision
    - If a charter exists, fill Charter Check section from it and challenge any conflicts directly with the user. If no charter exists, mark the section as skipped.
    - Evaluate gates (ERROR if violations unjustified or questions remain unanswered)
-   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification)
-   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent
+   - Phase 0: Generate research.md (commission research to resolve every outstanding clarification, prioritizing unresolved domain rules, lifecycle questions, and event/integration behavior before generic tech comparisons)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
 6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -192,6 +201,7 @@ If the mission is not a bulk edit, skip this step.
 
 1. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
+   - For each unresolved rule, invariant, lifecycle edge, or event/integration ambiguity → domain research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
@@ -199,6 +209,8 @@ If the mission is not a bulk edit, skip this step.
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+   For each unresolved domain rule:
+     Task: "Clarify invariant, state transition, or event behavior for {feature context}"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
    ```
@@ -217,10 +229,12 @@ If the mission is not a bulk edit, skip this step.
 1. **Extract entities from feature spec** → `data-model.md`:
    - Entity name, fields, relationships
    - Validation rules from requirements
+   - Invariants or atomicity boundaries if applicable
    - State transitions if applicable
 
 2. **Generate API contracts** from functional requirements:
    - For each user action → endpoint
+   - For each externally visible event, webhook, or integration callback → contract or payload shape when applicable
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
@@ -156,11 +156,24 @@ Before running any scripts or writing to disk you **must** conduct a structured 
   - **Complex Features** (new subsystems, integrations): Ask 3-5 questions covering goals, users, constraints, risks
   - **Platform/Critical Features** (authentication, payments, infrastructure): Full discovery with 5+ questions
 
+- **Scenario-first discovery**: For any non-trivial feature, prefer concrete
+  workflow questions over abstract opinion prompts. Ask for the primary actor,
+  trigger, happy-path outcome, and the most common exception or branch.
+
+- **Terminology discipline**: If the request introduces business or domain
+  terms that may drift, ask which term is canonical and which synonyms should
+  be avoided. When relevant, carry those choices into the optional Domain
+  Language section of the spec instead of leaving them implicit.
+
+- **Rule probing**: For workflows with approvals, validations, state changes,
+  or compliance implications, ask what must always be true and which
+  transitions or checks cannot be skipped.
+
 - **User signals to reduce questioning**: If the user says "just testing", "quick prototype", "skip to next phase", "stop asking questions" - recognize this as a signal to minimize discovery and proceed with reasonable defaults.
 
 - **First response rule**:
   - For TRIVIAL features (hello world, simple test): Ask ONE clarifying question, then if the answer confirms it's simple, proceed directly to spec generation
-  - For other features: Ask a single focused discovery question and end with `WAITING_FOR_DISCOVERY_INPUT`
+  - For other features: Ask a single focused discovery question anchored in the primary user scenario and end with `WAITING_FOR_DISCOVERY_INPUT`
 
 - If the user provides no initial description (empty command), stay in **Interactive Interview Mode**: keep probing with one question at a time.
 
@@ -170,8 +183,9 @@ Discovery requirements (scale to feature complexity):
 
 1. Maintain a **Discovery Questions** table internally covering questions appropriate to the feature's complexity (1-2 for trivial, up to 5+ for complex). Track columns `#`, `Question`, `Why it matters`, and `Current insight`. Do **not** render this table to the user.
 2. For trivial features, reasonable defaults are acceptable. Only probe if truly ambiguous.
-3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief.
-4. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
+3. When you have sufficient context for the feature's scope, paraphrase into an **Intent Summary** and confirm. For trivial features, this can be very brief. For non-trivial features, include the primary actor, trigger/success outcome, key constraint, and any explicit assumptions or deferred decisions.
+4. Before leaving the interview loop, do a short playback of the primary scenario, the main exception or edge case, and any rule that must always hold.
+5. If user explicitly asks to skip questions or says "just testing", acknowledge and proceed with minimal discovery.
 
 ## Bulk-Edit Detection (mandatory check)
 
@@ -338,14 +352,17 @@ Given that feature description, do this:
     - Use the discovery answers as your authoritative source of truth (do **not** rely on the raw invocation text)
     - For empty invocations, treat the synthesized interview summary as the canonical feature description
     - Identify: actors, actions, data, constraints, motivations, success metrics
+    - Prefer concrete scenario walkthrough facts (actor, trigger, success outcome, exception path) over abstract restatements
     - For any remaining ambiguity:
       - Ask the user a focused follow-up question immediately and halt work until they answer
       - Only use `[NEEDS CLARIFICATION: …]` when the user explicitly defers the decision
       - Record any interim assumption in the Assumptions section
       - Prioritize clarifications by impact: scope > outcomes > risks/security > user experience > technical details
     - Fill User Scenarios & Testing section (ERROR if no clear user flow can be determined)
+    - If terminology precision matters, fill the optional Domain Language section with canonical terms and ambiguous synonyms to avoid
     - Generate separated requirement tables: Functional (`FR-###`), Non-Functional (`NFR-###`), and Constraints (`C-###`)
     - Ensure each requirement entry has a status value and testable wording
+    - Capture rules or invariants that shape acceptance scenarios, edge cases, permissions, or lifecycle boundaries
     - Define Success Criteria (measurable, technology-agnostic outcomes)
     - Identify Key Entities (if data involved)
 

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -940,6 +940,7 @@ class TestSaasFanOut:
             to_lane="in_progress",
             actor="test-actor",
             mission_slug="034-test-feature",
+            mission_id=None,
             policy_metadata=None,
             ensure_daemon=True,
         )

--- a/tests/status/test_sync_lane_mapping.py
+++ b/tests/status/test_sync_lane_mapping.py
@@ -81,6 +81,7 @@ class TestCanonicalFanOut:
             to_lane=str(to_lane),
             actor="test-actor",
             mission_slug="039-test-feature",
+            mission_id=None,
             policy_metadata=None,
             ensure_daemon=True,
         )

--- a/tests/sync/test_reconnection.py
+++ b/tests/sync/test_reconnection.py
@@ -316,6 +316,7 @@ class TestClientLifecycle:
         # ``_current_team_id`` so connect() doesn't blow up on NotAuthenticated.
         class _Team:
             id = "team-42"
+            is_private_teamspace = False
 
         class _Session:
             default_team_id = "team-42"

--- a/tests/sync/test_runtime.py
+++ b/tests/sync/test_runtime.py
@@ -28,7 +28,17 @@ def reset_singleton():
 @pytest.fixture(autouse=True)
 def mock_body_queue():
     """Prevent OfflineBodyUploadQueue from opening a real SQLite DB."""
-    with patch("specify_cli.sync.body_queue.OfflineBodyUploadQueue.__init__", return_value=None):
+    with (
+        patch("specify_cli.sync.body_queue.OfflineBodyUploadQueue.__init__", return_value=None),
+        patch("specify_cli.sync.body_queue.OfflineBodyUploadQueue.size", return_value=0),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_sync_feature_flag():
+    """Keep runtime tests independent of the caller's environment."""
+    with patch("specify_cli.sync.runtime.is_saas_sync_enabled", return_value=True):
         yield
 
 
@@ -65,12 +75,13 @@ class TestAutoStartEnabled:
         assert _auto_start_enabled() is True
 
     def test_returns_false_when_auto_start_false(self, tmp_path, monkeypatch):
-        """Returns False when auto_start is explicitly False."""
+        """Returns False when checkout routing disables sync."""
         monkeypatch.chdir(tmp_path)
-        config_dir = tmp_path / ".kittify"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("sync:\n  auto_start: false\n")
-        assert _auto_start_enabled() is False
+        with (
+            patch("specify_cli.sync.runtime.locate_project_root", return_value=tmp_path),
+            patch("specify_cli.sync.runtime.is_sync_enabled_for_checkout", return_value=False),
+        ):
+            assert _auto_start_enabled() is False
 
     def test_returns_true_on_invalid_yaml(self, tmp_path, monkeypatch):
         """Returns True when config file is invalid YAML."""
@@ -95,26 +106,20 @@ class TestSyncRuntime:
     def test_start_is_idempotent(self, tmp_path, monkeypatch):
         """Multiple start() calls are safe."""
         monkeypatch.chdir(tmp_path)
-        # Disable auto-start to avoid side effects
-        config_dir = tmp_path / ".kittify"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("sync:\n  auto_start: false\n")
-
         runtime = SyncRuntime()
-        runtime.start()
-        runtime.start()  # Should not raise
-        runtime.start()  # Should not raise
+        with patch("specify_cli.sync.runtime._auto_start_enabled", return_value=False):
+            runtime.start()
+            runtime.start()  # Should not raise
+            runtime.start()  # Should not raise
         assert runtime.started is False  # Because auto_start is disabled
 
     def test_auto_start_disabled_prevents_start(self, tmp_path, monkeypatch):
-        """When sync.auto_start: false, runtime doesn't start services."""
+        """When checkout routing disables sync, runtime doesn't start services."""
         monkeypatch.chdir(tmp_path)
-        config_dir = tmp_path / ".kittify"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("sync:\n  auto_start: false\n")
 
         runtime = SyncRuntime()
-        runtime.start()
+        with patch("specify_cli.sync.runtime._auto_start_enabled", return_value=False):
+            runtime.start()
 
         assert runtime.started is False
         assert runtime.background_service is None


### PR DESCRIPTION
## Summary

Three non-blocking findings from the mission-093 post-merge review, resolved in a single patch.

- **DRIFT-1** (`docs/trail-model.md`): The Tier 2 trigger description listed `--evidence-ref` as the CLI flag; the actual flag is `--evidence`. Operators following the doc would get a CLI error.
- **RISK-1** (`test_sync_disabled_no_saas_events`): The original T021 test was split into two unconnected parts — the sync-gate assertion used `_propagate_one` directly, and the JSONL assertion called `InvocationWriter` directly. The rewritten test calls `executor.invoke()` end-to-end with sync disabled and asserts both properties in a single execution path.
- **Security** (`executor.complete_invocation`): Relative `evidence_ref` paths are now anchored to `self._repo_root` before the file read to prevent directory traversal (e.g., `../../etc/passwd`). Absolute paths are the operator's explicit choice and pass through unchanged.

## Test plan

- [x] `pytest tests/specify_cli/invocation/test_invocation_e2e.py` — 4/4 pass, including the rewritten T021
- [x] `pytest tests/specify_cli/invocation/test_evidence_promotion.py` — 3/3 pass (evidence path anchoring doesn't break absolute-path evidence)
- [x] `pytest tests/specify_cli/invocation/test_propagator_sync_gate.py` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)