### PR TITLE
Select safe SonarCloud follow-ups from #699 and #748

### DIFF
--- a/src/charter/synthesizer/artifact_naming.py
+++ b/src/charter/synthesizer/artifact_naming.py
@@ -1,0 +1,59 @@
+"""Helpers for artifact filenames and doctrine subdirectories.
+
+These helpers intentionally avoid regex backtracking so they remain safe when
+fed arbitrary artifact IDs from external inputs or persisted manifests.
+"""
+
+from __future__ import annotations
+
+
+def extract_directive_number(artifact_id: str | None) -> str:
+    """Return the numeric directive segment from an artifact ID.
+
+    Valid directive IDs contain an uppercase prefix followed by ``_`` and one or
+    more digits, for example ``PROJECT_001``. When no such segment is present,
+    the safe fallback is ``"000"``.
+    """
+    if not artifact_id:
+        return "000"
+
+    length = len(artifact_id)
+    index = 0
+    while index < length:
+        start = index
+        while index < length and artifact_id[index].isupper():
+            index += 1
+        if index == start or index >= length or artifact_id[index] != "_":
+            index = start + 1
+            continue
+
+        digits_start = index + 1
+        digits_end = digits_start
+        while digits_end < length and artifact_id[digits_end].isdigit():
+            digits_end += 1
+        if digits_end > digits_start:
+            return artifact_id[digits_start:digits_end].zfill(3)
+
+        index = digits_start
+
+    return "000"
+
+
+def artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> str:
+    """Return the repository-glob-matching filename for an artifact."""
+    if kind == "directive":
+        return f"{extract_directive_number(artifact_id)}-{slug}.directive.yaml"
+    if kind == "tactic":
+        return f"{slug}.tactic.yaml"
+    if kind == "styleguide":
+        return f"{slug}.styleguide.yaml"
+    raise ValueError(f"Unknown artifact kind: {kind!r}")
+
+
+def doctrine_kind_subdir(kind: str) -> str:
+    """Return the doctrine subdirectory name for a given artifact kind."""
+    return {
+        "directive": "directives",
+        "tactic": "tactics",
+        "styleguide": "styleguides",
+    }[kind]

--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -39,6 +39,7 @@ from typing import Any
 from doctrine.drg.loader import load_graph
 from doctrine.drg.models import DRGEdge, DRGGraph, DRGNode
 
+from .artifact_naming import artifact_filename, doctrine_kind_subdir
 from .manifest import (
     MANIFEST_PATH,
     ManifestArtifactEntry,
@@ -117,29 +118,7 @@ def _rewrite_manifest(
         The merged manifest (not yet written to disk; caller does the write).
     """
     import hashlib
-    import re
     from datetime import UTC, datetime
-
-    # Filename helper (mirrors write_pipeline._artifact_filename)
-    _DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
-
-    def _filename(kind: str, slug: str, artifact_id: str | None) -> str:
-        if kind == "directive":
-            nnn = "000"
-            if artifact_id:
-                m = _DIRECTIVE_NUM_RE.search(artifact_id)
-                if m:
-                    nnn = m.group(1).zfill(3)
-            return f"{nnn}-{slug}.directive.yaml"
-        elif kind == "tactic":
-            return f"{slug}.tactic.yaml"
-        elif kind == "styleguide":
-            return f"{slug}.styleguide.yaml"
-        else:
-            raise ValueError(f"Unknown artifact kind: {kind!r}")
-
-    def _doctrine_subdir(kind: str) -> str:
-        return {"directive": "directives", "tactic": "tactics", "styleguide": "styleguides"}[kind]
 
     # Build a key → new ManifestArtifactEntry dict for regenerated artifacts
     new_entries_by_key: dict[tuple[str, str], ManifestArtifactEntry] = {}
@@ -153,11 +132,11 @@ def _rewrite_manifest(
         if kind == "directive":
             artifact_id = prov.artifact_urn.split(":", 1)[1]
 
-        filename = _filename(kind, slug, artifact_id)
+        filename = artifact_filename(kind, slug, artifact_id)
         yaml_bytes = canonical_yaml(body)
         content_hash = hashlib.sha256(yaml_bytes).hexdigest()
 
-        rel_content = f".kittify/doctrine/{_doctrine_subdir(kind)}/{filename}"
+        rel_content = f".kittify/doctrine/{doctrine_kind_subdir(kind)}/{filename}"
         rel_prov = f".kittify/charter/provenance/{kind}-{slug}.yaml"
 
         new_entries_by_key[(kind, slug)] = ManifestArtifactEntry(

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -30,12 +30,12 @@ All filesystem writes go through ``PathGuard`` (FR-016).
 from __future__ import annotations
 
 import hashlib
-import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
+from .artifact_naming import artifact_filename, doctrine_kind_subdir
 from .errors import NeutralityGateViolation, StagingPromoteError
 from .evidence import EvidenceBundle
 from .manifest import (
@@ -54,8 +54,6 @@ from .synthesize_pipeline import ProvenanceEntry, canonical_yaml
 # Filename helpers (data-model §E-2 "Filename rule")
 # ---------------------------------------------------------------------------
 
-_DIRECTIVE_NUM_RE = re.compile(r"[A-Z]+_(\d+)")
-
 
 def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> str:
     """Return the repository-glob-matching filename for an artifact.
@@ -66,28 +64,12 @@ def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> 
     - tactic:    ``<slug>.tactic.yaml``
     - styleguide: ``<slug>.styleguide.yaml``
     """
-    if kind == "directive":
-        nnn = "000"
-        if artifact_id:
-            m = _DIRECTIVE_NUM_RE.search(artifact_id)
-            if m:
-                nnn = m.group(1).zfill(3)
-        return f"{nnn}-{slug}.directive.yaml"
-    elif kind == "tactic":
-        return f"{slug}.tactic.yaml"
-    elif kind == "styleguide":
-        return f"{slug}.styleguide.yaml"
-    else:
-        raise ValueError(f"Unknown artifact kind: {kind!r}")
+    return artifact_filename(kind, slug, artifact_id)
 
 
 def _doctrine_kind_subdir(kind: str) -> str:
     """Return the doctrine subdirectory name for a given artifact kind."""
-    return {
-        "directive": "directives",
-        "tactic": "tactics",
-        "styleguide": "styleguides",
-    }[kind]
+    return doctrine_kind_subdir(kind)
 
 
 def _compute_content_hash(yaml_bytes: bytes) -> str:

--- a/src/specify_cli/auth/session.py
+++ b/src/specify_cli/auth/session.py
@@ -69,7 +69,7 @@ def pick_default_team_id(teams: list[Team]) -> str:
 def get_private_team_id(teams: list[Team]) -> str | None:
     """Return the user's Private Teamspace id when one is present."""
     for team in teams:
-        if team.is_private_teamspace:
+        if bool(getattr(team, "is_private_teamspace", False)):
             return team.id
     return None
 

--- a/src/specify_cli/invocation/propagator.py
+++ b/src/specify_cli/invocation/propagator.py
@@ -36,6 +36,8 @@
 from __future__ import annotations
 
 import atexit
+import asyncio
+import contextlib
 import json
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -48,6 +50,13 @@ logger = logging.getLogger(__name__)
 
 PROPAGATION_ERRORS_PATH = ".kittify/events/propagation-errors.jsonl"
 _ATEXIT_TIMEOUT_SECONDS = 5.0
+_PENDING_SEND_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _track_send_task(task: asyncio.Task[Any]) -> None:
+    """Retain scheduled send tasks until completion to avoid premature GC."""
+    _PENDING_SEND_TASKS.add(task)
+    task.add_done_callback(_PENDING_SEND_TASKS.discard)
 
 
 def _get_saas_client(repo_root: Path) -> Any | None:  # noqa: ARG001
@@ -116,14 +125,11 @@ def _propagate_one(record: InvocationRecord, repo_root: Path) -> None:
                 "completed_at": record.completed_at,
             }
 
-        # Mirror emitter.py _route_event() asyncio pattern (lines 993-1000):
-        import asyncio  # noqa: PLC0415
-
         try:
             loop = asyncio.get_event_loop()
             if loop.is_running():
                 # Already inside a running loop (rare in CLI threads, but safe)
-                asyncio.ensure_future(client.send_event(event_dict))
+                _track_send_task(asyncio.create_task(client.send_event(event_dict)))
             else:
                 loop.run_until_complete(client.send_event(event_dict))
         except RuntimeError:
@@ -147,7 +153,7 @@ def _log_propagation_error(
             "invocation_id": record.invocation_id,
             "event": record.event,
             "error": error,
-            "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "at": datetime.datetime.now(datetime.UTC).isoformat(),
         }
         with error_log.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")
@@ -186,7 +192,5 @@ class InvocationSaaSPropagator:
         Python's process-exit machinery imposes its own timeout, so threads
         that have not finished by then are abandoned (acceptable behaviour).
         """
-        try:
+        with contextlib.suppress(Exception):
             self._executor.shutdown(wait=True, cancel_futures=False)
-        except Exception:  # noqa: BLE001
-            pass  # Shutdown must never raise

--- a/src/specify_cli/sync/background.py
+++ b/src/specify_cli/sync/background.py
@@ -41,6 +41,21 @@ logger = logging.getLogger(__name__)
 _STOP_SYNC_TIMEOUT_SECONDS = 5
 
 
+def _safe_optional_queue_size(queue_obj: object | None) -> int:
+    """Best-effort queue size lookup that tolerates missing attrs and test doubles."""
+    if queue_obj is None:
+        return 0
+    try:
+        raw = queue_obj.size()
+    except Exception:
+        return 0
+
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _fetch_access_token_sync() -> str | None:
     """Fetch a valid access token from the TokenManager (sync bridge).
 
@@ -158,9 +173,7 @@ class BackgroundSyncService:
         # Best-effort final sync with a bounded timeout so atexit never
         # hangs the process.  Events stay in the durable queue and will
         # be drained on the next daemon tick.
-        body_queue_has_work = (
-            self._body_queue is not None and self._body_queue.size() > 0
-        )
+        body_queue_has_work = _safe_optional_queue_size(self._body_queue) > 0
         if self.queue.size() > 0 or body_queue_has_work:
             sync_thread = threading.Thread(
                 target=self._guarded_final_sync, daemon=True,
@@ -223,9 +236,7 @@ class BackgroundSyncService:
         """Timer callback: sync if queue is non-empty, then reschedule."""
         if not self._running:
             return
-        body_queue_has_work = (
-            self._body_queue is not None and self._body_queue.size() > 0
-        )
+        body_queue_has_work = _safe_optional_queue_size(self._body_queue) > 0
         if self.queue.size() > 0 or body_queue_has_work:
             self._perform_sync()
         self._schedule_next_sync()

--- a/src/specify_cli/sync/runtime.py
+++ b/src/specify_cli/sync/runtime.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 from specify_cli.core.paths import locate_project_root
 
 from .feature_flags import is_saas_sync_enabled, saas_sync_disabled_message
@@ -64,11 +66,39 @@ def _auto_start_enabled() -> bool:
     project_root = locate_project_root(Path.cwd())
     if project_root is None:
         return True
+
+    project_setting = _read_project_auto_start(project_root)
+    if project_setting is not None:
+        return project_setting
+
     try:
         return is_sync_enabled_for_checkout(project_root)
     except Exception as e:
         logger.debug(f"Could not resolve sync routing config: {e}")
         return True
+
+
+def _read_project_auto_start(project_root: Path) -> bool | None:
+    """Read the legacy project-local ``sync.auto_start`` flag when present."""
+    config_path = project_root / ".kittify" / "config.yaml"
+    if not config_path.exists():
+        return None
+
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("Could not read project sync config from %s: %s", config_path, exc)
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    sync_section = raw.get("sync")
+    if not isinstance(sync_section, dict):
+        return None
+
+    auto_start = sync_section.get("auto_start")
+    return auto_start if isinstance(auto_start, bool) else None
 
 
 @dataclass

--- a/tests/charter/synthesizer/test_write_pipeline.py
+++ b/tests/charter/synthesizer/test_write_pipeline.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from charter.synthesizer.errors import NeutralityGateViolation
+from charter.synthesizer.artifact_naming import artifact_filename, extract_directive_number
 from charter.synthesizer.write_pipeline import _is_generic_scoped
 
 
@@ -61,6 +62,28 @@ def _staged_neutral_generic(tmp_path: Path) -> Path:
         "  Fast tests should run frequently; slow tests in CI.\n"
     )
     return staged_dir
+
+
+# ---------------------------------------------------------------------------
+# artifact_naming tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_directive_number_returns_padded_digits() -> None:
+    assert extract_directive_number("PROJECT_7") == "007"
+
+
+def test_extract_directive_number_falls_back_for_malformed_ids() -> None:
+    assert extract_directive_number("project_007") == "000"
+    assert extract_directive_number("PROJECT_") == "000"
+    assert extract_directive_number(None) == "000"
+
+
+def test_artifact_filename_builds_directive_filename_without_regex() -> None:
+    assert (
+        artifact_filename("directive", "mission-type-scope-directive", "PROJECT_001")
+        == "001-mission-type-scope-directive.directive.yaml"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -182,15 +205,7 @@ def _make_staging_dir_with_artifact(
     urn = f"{kind}:{effective_artifact_id}"
 
     # Write content to staged location
-    if kind == "directive":
-        import re
-        m = re.search(r"\d+", effective_artifact_id)
-        nnn = m.group(0).zfill(3) if m else "000"
-        filename = f"{nnn}-{slug}.directive.yaml"
-    elif kind == "tactic":
-        filename = f"{slug}.tactic.yaml"
-    else:
-        filename = f"{slug}.styleguide.yaml"
+    filename = artifact_filename(kind, slug, effective_artifact_id)
 
     staged_path = stage.path_for_content(kind, filename)
     staged_path.write_text(content)

--- a/tests/specify_cli/invocation/test_propagator.py
+++ b/tests/specify_cli/invocation/test_propagator.py
@@ -19,6 +19,7 @@ import pytest
 
 from specify_cli.invocation.propagator import (
     InvocationSaaSPropagator,
+    _PENDING_SEND_TASKS,
     _log_propagation_error,
     _propagate_one,
 )
@@ -126,6 +127,31 @@ def test_propagator_sends_invocation_id_in_event_dict(tmp_path: pytest.TempPathF
     assert len(captured) == 1
     assert captured[0]["invocation_id"] == record.invocation_id
     assert captured[0]["event_type"] == "ProfileInvocationStarted"
+
+
+def test_propagator_tracks_tasks_until_completion(tmp_path: pytest.TempPathFactory) -> None:
+    """Running-loop sends stay referenced until the async task completes."""
+    record = make_started_record()
+    captured: list[dict[str, object]] = []
+
+    class MockClient:
+        async def send_event(self, event_dict: dict[str, object]) -> None:
+            captured.append(event_dict)
+
+    async def exercise() -> None:
+        with patch(
+            "specify_cli.invocation.propagator._get_saas_client",
+            return_value=MockClient(),
+        ):
+            _propagate_one(record, tmp_path)
+            assert len(_PENDING_SEND_TASKS) == 1
+            await asyncio.gather(*tuple(_PENDING_SEND_TASKS))
+            await asyncio.sleep(0)
+
+    asyncio.run(exercise())
+
+    assert not _PENDING_SEND_TASKS
+    assert captured[0]["invocation_id"] == record.invocation_id
 
 
 def test_propagator_error_log_never_raises_on_disk_full(tmp_path: pytest.TempPathFactory) -> None:

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -940,6 +940,7 @@ class TestSaasFanOut:
             to_lane="in_progress",
             actor="test-actor",
             mission_slug="034-test-feature",
+            mission_id=None,
             policy_metadata=None,
             ensure_daemon=True,
         )

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -582,7 +582,6 @@ class TestDoneEvidence:
 
     def test_done_without_evidence_rejected(self, feature_dir: Path):
         """Transition to done without evidence is rejected."""
-        from specify_cli.status.models import ReviewResult
 
         # Move through the pipeline: planned → claimed → in_progress → for_review → in_review
         emit_status_transition(TransitionRequest(

--- a/tests/status/test_sync_lane_mapping.py
+++ b/tests/status/test_sync_lane_mapping.py
@@ -81,6 +81,7 @@ class TestCanonicalFanOut:
             to_lane=str(to_lane),
             actor="test-actor",
             mission_slug="039-test-feature",
+            mission_id=None,
             policy_metadata=None,
             ensure_daemon=True,
         )


### PR DESCRIPTION
## Summary
- cherry-pick the worthwhile SonarCloud follow-ups from #699 and #748 onto current `main`
- keep the charter filename helper consolidation and the sync/runtime regression fixes
- add focused regression coverage for running-loop propagation retention and keep touched tests lint-clean

## Review outcome
- Included from `#699`: shared artifact filename helper and coverage
- Included from `#748`: sync runtime/background/propagator fixes plus status assertion updates
- Rejected from `#747`: the anchored directive-id regex narrows valid semantic IDs like `RISK_APPETITE_003` to `000`, which is a real behavior regression

## Validation
- `pytest tests/charter/synthesizer/test_write_pipeline.py tests/charter/synthesizer/test_orchestrator_resynthesize.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest tests/sync/test_runtime.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest tests/specify_cli/invocation/test_propagator.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest tests/status/test_emit.py -q -k "done_without_evidence_rejected or saas_called_when_available"`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest tests/status/test_sync_lane_mapping.py -q -k fan_out_passes_canonical_lanes_directly`
- `ruff check src/charter/synthesizer/artifact_naming.py src/charter/synthesizer/resynthesize_pipeline.py src/charter/synthesizer/write_pipeline.py src/specify_cli/auth/session.py src/specify_cli/invocation/propagator.py src/specify_cli/sync/background.py src/specify_cli/sync/runtime.py tests/charter/synthesizer/test_write_pipeline.py tests/specify_cli/invocation/test_propagator.py tests/status/test_emit.py tests/status/test_sync_lane_mapping.py`
