### PR TITLE
fix: address small SonarCloud findings in charter tooling

### DIFF
--- a/src/charter/evidence/code_reader.py
+++ b/src/charter/evidence/code_reader.py
@@ -36,6 +36,9 @@ EXCLUDED_DIRS: frozenset[str] = frozenset(
 )
 
 # Indicator file → language (order matters for resolution when multiple found)
+PACKAGE_JSON = "package.json"
+
+
 LANGUAGE_INDICATORS: dict[str, str] = {
     "pyproject.toml": "python",
     "setup.py": "python",
@@ -48,7 +51,7 @@ LANGUAGE_INDICATORS: dict[str, str] = {
     "Gemfile": "ruby",
     "composer.json": "php",
     # package.json is handled separately (js vs ts disambiguation)
-    "package.json": "javascript",
+    PACKAGE_JSON: "javascript",
 }
 
 FRAMEWORK_INDICATORS: dict[str, str] = {
@@ -268,7 +271,7 @@ class CodeReadingCollector:
     ) -> str:
         """Return the primary language string."""
         # TypeScript takes precedence over JavaScript when tsconfig.json present
-        if "package.json" in indicator_files:
+        if PACKAGE_JSON in indicator_files:
             if "tsconfig.json" in indicator_files:
                 return "typescript"
             # Majority-extension heuristic
@@ -279,7 +282,7 @@ class CodeReadingCollector:
 
         # Check remaining language indicators in priority order
         for indicator, lang in LANGUAGE_INDICATORS.items():
-            if indicator == "package.json":
+            if indicator == PACKAGE_JSON:
                 continue  # handled above
             if indicator in indicator_files:
                 return lang

--- a/src/charter/synthesizer/request.py
+++ b/src/charter/synthesizer/request.py
@@ -147,7 +147,7 @@ class SynthesisRequest:
 def _to_jsonable(obj: Any) -> Any:
     """Recursively convert an object to a JSON-serializable form with sorted keys."""
     if isinstance(obj, dict):
-        return {k: _to_jsonable(v) for k in sorted(obj.keys()) for _ in [None] if (v := obj[k]) is not None or True}
+        return {k: _to_jsonable(obj[k]) for k in sorted(obj.keys())}
     if isinstance(obj, (list, tuple)):
         return [_to_jsonable(v) for v in obj]
     # Stable representation for float — avoid locale-sensitive formatting

--- a/src/charter/synthesizer/staging.py
+++ b/src/charter/synthesizer/staging.py
@@ -236,7 +236,7 @@ class StagingDir:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool:
+    ) -> bool | None:
         if exc_type is not None:
             # Unhandled exception — preserve staging as .failed/
             cause = f"{exc_type.__name__}: {exc_val}"
@@ -244,7 +244,7 @@ class StagingDir:
             # Re-raise the original exception (return False suppresses nothing)
             return False
         # Success path — caller must call wipe() explicitly after promote.
-        return False
+        return None
 
 
 __all__ = ["StagingDir"]

--- a/src/specify_cli/cli/commands/advise.py
+++ b/src/specify_cli/cli/commands/advise.py
@@ -116,7 +116,6 @@ def _run_invoke(
     entry_command: str = "advise",
 ) -> None:
     """Shared implementation for advise and ask commands."""
-    from specify_cli.invocation.modes import ModeOfWork
     repo_root = _get_repo_root()
     executor = _build_executor(repo_root)
     mode = derive_mode(entry_command)
@@ -189,6 +188,53 @@ profile_invocation_app = typer.Typer(
 )
 
 
+def _handle_complete_already_closed(
+    invocation_id: str,
+    *,
+    json_output: bool,
+) -> None:
+    msg: dict[str, str] = {"warning": "already_closed", "invocation_id": invocation_id}
+    if json_output:
+        typer.echo(json.dumps(msg))
+    else:
+        console.print(
+            f"[yellow]Warning:[/yellow] Invocation {invocation_id} is already closed."
+        )
+    raise typer.Exit(0) from None
+
+
+def _render_complete_response(
+    *,
+    invocation_id: str,
+    outcome: str | None,
+    evidence_ref: str | None,
+    artifact: list[str] | None,
+    commit: str | None,
+    repo_root: Path,
+    json_output: bool,
+) -> None:
+    if json_output:
+        response = {
+            "result": "success",
+            "invocation_id": invocation_id,
+            "outcome": outcome,
+            "evidence_ref": evidence_ref,
+            "artifact_links": [normalise_ref(a, repo_root) for a in (artifact or [])],
+            "commit_link": commit,
+        }
+        typer.echo(json.dumps(response, indent=2))
+        return
+
+    console.print(f"[green]✓[/green] Invocation [bold]{invocation_id}[/bold] closed.")
+    if outcome:
+        console.print(f"  Outcome: {outcome}")
+    if artifact:
+        for item in artifact:
+            console.print(f"  Artifact: {normalise_ref(item, repo_root)}")
+    if commit:
+        console.print(f"  Commit: {commit}")
+
+
 @profile_invocation_app.command("complete")
 def complete_invocation(
     invocation_id: str = typer.Option(
@@ -230,41 +276,22 @@ def complete_invocation(
             commit_sha=commit,
         )
     except InvalidModeForEvidenceError as e:
-        console.print(
-            f"[red]Error:[/red] {e}"
-        )
+        console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(2) from e
     except AlreadyClosedError:
-        msg: dict[str, str] = {"warning": "already_closed", "invocation_id": invocation_id}
-        if json_output:
-            typer.echo(json.dumps(msg))
-        else:
-            console.print(
-                f"[yellow]Warning:[/yellow] Invocation {invocation_id} is already closed."
-            )
-        raise typer.Exit(0) from None
+        _handle_complete_already_closed(invocation_id, json_output=json_output)
     except Exception as e:
         typer.echo(
             json.dumps({"error": "complete_failed", "message": str(e)}), err=True
         )
         raise typer.Exit(1) from e
 
-    if json_output:
-        response = {
-            "result": "success",
-            "invocation_id": invocation_id,
-            "outcome": outcome,
-            "evidence_ref": completed.evidence_ref,
-            "artifact_links": [normalise_ref(a, repo_root) for a in (artifact or [])],
-            "commit_link": commit,
-        }
-        typer.echo(json.dumps(response, indent=2))
-    else:
-        console.print(f"[green]✓[/green] Invocation [bold]{invocation_id}[/bold] closed.")
-        if outcome:
-            console.print(f"  Outcome: {outcome}")
-        if artifact:
-            for a in artifact:
-                console.print(f"  Artifact: {normalise_ref(a, repo_root)}")
-        if commit:
-            console.print(f"  Commit: {commit}")
+    _render_complete_response(
+        invocation_id=invocation_id,
+        outcome=outcome,
+        evidence_ref=completed.evidence_ref,
+        artifact=artifact,
+        commit=commit,
+        repo_root=repo_root,
+        json_output=json_output,
+    )

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -251,40 +251,13 @@ class ProfileInvocationExecutor:
         )
 
         # Step 4: Promote to Tier 2 evidence artifact if --evidence was supplied (existing behaviour).
-        if evidence_ref is not None:
-            evidence_path = Path(evidence_ref)
-            candidate_path: Path | None = None
-            if not evidence_path.is_absolute():
-                repo_root = self._repo_root.resolve()
-                resolved_relative_path = (repo_root / evidence_path).resolve()
-                if resolved_relative_path.is_relative_to(repo_root):
-                    candidate_path = resolved_relative_path
-            else:
-                # Absolute paths are the operator's explicit choice.
-                candidate_path = evidence_path
-            try:
-                content = (
-                    candidate_path.read_text(encoding="utf-8")
-                    if candidate_path is not None
-                    else evidence_ref
-                )
-            except OSError:
-                content = evidence_ref  # fallback: treat the value as inline content
-            evidence_base_dir = self._repo_root / ".kittify" / "evidence"
-            promote_to_evidence(completed, evidence_base_dir, content)
+        self._promote_evidence_if_requested(completed, evidence_ref)
 
         # Step 5 (NEW): Append artifact_link events (FR-007).
-        for raw_ref in artifact_refs or []:
-            normalised = normalise_ref(raw_ref, self._repo_root)
-            self._writer.append_correlation_link(
-                invocation_id, kind="artifact", ref=normalised,
-            )
+        self._append_artifact_links(invocation_id, artifact_refs)
 
         # Step 6 (NEW): Append commit_link event (FR-007).
-        if commit_sha is not None:
-            self._writer.append_correlation_link(
-                invocation_id, sha=commit_sha,
-            )
+        self._append_commit_link(invocation_id, commit_sha)
 
         # Step 7: Propagate completed event (non-blocking, best-effort; existing behaviour).
         # Correlation events (artifact_link, commit_link) are locally written by
@@ -299,6 +272,57 @@ class ProfileInvocationExecutor:
             self._propagator.submit(completed)
 
         return completed
+
+    def _promote_evidence_if_requested(
+        self,
+        completed: InvocationRecord,
+        evidence_ref: str | None,
+    ) -> None:
+        if evidence_ref is None:
+            return
+        content = self._resolve_evidence_content(evidence_ref)
+        evidence_base_dir = self._repo_root / ".kittify" / "evidence"
+        promote_to_evidence(completed, evidence_base_dir, content)
+
+    def _resolve_evidence_content(self, evidence_ref: str) -> str:
+        candidate_path = self._resolve_evidence_path(evidence_ref)
+        try:
+            return (
+                candidate_path.read_text(encoding="utf-8")
+                if candidate_path is not None
+                else evidence_ref
+            )
+        except OSError:
+            return evidence_ref
+
+    def _resolve_evidence_path(self, evidence_ref: str) -> Path | None:
+        evidence_path = Path(evidence_ref)
+        if evidence_path.is_absolute():
+            return evidence_path
+
+        repo_root = self._repo_root.resolve()
+        resolved_relative_path = (repo_root / evidence_path).resolve()
+        if resolved_relative_path.is_relative_to(repo_root):
+            return resolved_relative_path
+        return None
+
+    def _append_artifact_links(
+        self,
+        invocation_id: str,
+        artifact_refs: list[str] | None,
+    ) -> None:
+        for raw_ref in artifact_refs or []:
+            normalised = normalise_ref(raw_ref, self._repo_root)
+            self._writer.append_correlation_link(
+                invocation_id,
+                kind="artifact",
+                ref=normalised,
+            )
+
+    def _append_commit_link(self, invocation_id: str, commit_sha: str | None) -> None:
+        if commit_sha is None:
+            return
+        self._writer.append_correlation_link(invocation_id, sha=commit_sha)
 
     def _read_started_mode(self, invocation_id: str) -> ModeOfWork | None:
         """Read mode_of_work from the started event. Returns None for pre-mission records

--- a/src/specify_cli/invocation/propagator.py
+++ b/src/specify_cli/invocation/propagator.py
@@ -119,68 +119,15 @@ def _propagate_one(record: InvocationRecord, repo_root: Path) -> None:
         return  # No SaaS token / client not connected → no-op, no log
 
     # 3. Policy lookup (read-only, never raises, never blocks).
-    raw_event = record.event
-    try:
-        event_kind = EventKind(raw_event)
-    except ValueError:
-        # Unknown event kind (e.g., future EventKind added before table extended).
-        # Use STARTED as the conservative fallback so resolve_projection returns
-        # _DEFAULT_RULE (project=True), which preserves existing behaviour.
-        event_kind = EventKind.STARTED
-
-    raw_mode = getattr(record, "mode_of_work", None)
-    mode: ModeOfWork | None
-    if raw_mode:
-        try:
-            mode = ModeOfWork(raw_mode)
-        except ValueError:
-            # Malformed mode_of_work on the record. Treat as None (legacy) rather than
-            # crashing the background propagation thread silently.
-            mode = None
-    else:
-        mode = None
+    event_kind = _coerce_event_kind(record.event)
+    mode = _coerce_mode(getattr(record, "mode_of_work", None))
     rule = resolve_projection(mode, event_kind)
     if not rule.project:
         return  # Policy says no projection for this (mode, event) pair.
 
     try:
-        if record.event == "started":
-            event_dict: dict[str, object] = {
-                "event_type": "ProfileInvocationStarted",
-                "invocation_id": record.invocation_id,
-                "profile_id": record.profile_id,
-                "action": record.action,
-                "governance_context_hash": record.governance_context_hash,
-                "actor": record.actor,
-                "started_at": record.started_at,
-            }
-            # Gate request_text inclusion on policy (advisory mode omits body).
-            if rule.include_request_text:
-                event_dict["request_text"] = record.request_text
-            # Additively include mode_of_work when present (WP06 additive field).
-            if mode is not None:
-                event_dict["mode_of_work"] = mode.value
-        else:  # completed
-            event_dict = {
-                "event_type": "ProfileInvocationCompleted",
-                "invocation_id": record.invocation_id,
-                "outcome": record.outcome,
-                "completed_at": record.completed_at,
-            }
-            # Gate evidence_ref inclusion on policy (advisory/query modes omit it).
-            if rule.include_evidence_ref:
-                event_dict["evidence_ref"] = record.evidence_ref
-
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # Already inside a running loop (rare in CLI threads, but safe)
-                _track_send_task(asyncio.create_task(client.send_event(event_dict)))
-            else:
-                loop.run_until_complete(client.send_event(event_dict))
-        except RuntimeError:
-            # No current event loop (background thread with no loop) → create one
-            asyncio.run(client.send_event(event_dict))
+        event_dict = _build_event_dict(record, rule, mode)
+        _send_event(client, event_dict)
 
     except Exception as exc:  # noqa: BLE001
         _log_propagation_error(repo_root, record, str(exc))
@@ -196,6 +143,83 @@ def _propagate_one(record: InvocationRecord, repo_root: Path) -> None:
     #       event_type_map = {"artifact_link": "ProfileInvocationArtifactLink",
     #                         "commit_link": "ProfileInvocationCommitLink"}
     #       ...and consult rule.project before calling client.send_event.
+
+
+def _coerce_event_kind(raw_event: str) -> EventKind:
+    try:
+        return EventKind(raw_event)
+    except ValueError:
+        # Unknown event kind (e.g., future EventKind added before table extended).
+        # Use STARTED as the conservative fallback so resolve_projection returns
+        # _DEFAULT_RULE (project=True), which preserves existing behaviour.
+        return EventKind.STARTED
+
+
+def _coerce_mode(raw_mode: str | None) -> ModeOfWork | None:
+    if not raw_mode:
+        return None
+    try:
+        return ModeOfWork(raw_mode)
+    except ValueError:
+        # Malformed mode_of_work on the record. Treat as None (legacy) rather than
+        # crashing the background propagation thread silently.
+        return None
+
+
+def _build_event_dict(
+    record: InvocationRecord,
+    rule: Any,
+    mode: ModeOfWork | None,
+) -> dict[str, object]:
+    if record.event == "started":
+        return _build_started_event_dict(record, rule, mode)
+    return _build_completed_event_dict(record, rule)
+
+
+def _build_started_event_dict(
+    record: InvocationRecord,
+    rule: Any,
+    mode: ModeOfWork | None,
+) -> dict[str, object]:
+    event_dict: dict[str, object] = {
+        "event_type": "ProfileInvocationStarted",
+        "invocation_id": record.invocation_id,
+        "profile_id": record.profile_id,
+        "action": record.action,
+        "governance_context_hash": record.governance_context_hash,
+        "actor": record.actor,
+        "started_at": record.started_at,
+    }
+    if rule.include_request_text:
+        event_dict["request_text"] = record.request_text
+    if mode is not None:
+        event_dict["mode_of_work"] = mode.value
+    return event_dict
+
+
+def _build_completed_event_dict(record: InvocationRecord, rule: Any) -> dict[str, object]:
+    event_dict: dict[str, object] = {
+        "event_type": "ProfileInvocationCompleted",
+        "invocation_id": record.invocation_id,
+        "outcome": record.outcome,
+        "completed_at": record.completed_at,
+    }
+    if rule.include_evidence_ref:
+        event_dict["evidence_ref"] = record.evidence_ref
+    return event_dict
+
+
+def _send_event(client: Any, event_dict: dict[str, object]) -> None:
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # Already inside a running loop (rare in CLI threads, but safe)
+            _track_send_task(asyncio.create_task(client.send_event(event_dict)))
+            return
+        loop.run_until_complete(client.send_event(event_dict))
+    except RuntimeError:
+        # No current event loop (background thread with no loop) → create one
+        asyncio.run(client.send_event(event_dict))
 
 
 def _log_propagation_error(

--- a/tests/charter/synthesizer/test_staging_atomicity.py
+++ b/tests/charter/synthesizer/test_staging_atomicity.py
@@ -135,9 +135,14 @@ def test_context_manager_on_exception_routes_to_failed(tmp_path: Path) -> None:
 def test_context_manager_on_success_does_not_auto_wipe(tmp_path: Path) -> None:
     """Context manager on success does NOT wipe staging — caller must call wipe()."""
     stage = StagingDir.create(tmp_path, RUN_ID)
-    with stage:
-        pass  # No exception
+    result = stage.__enter__()
+    try:
+        pass
+    finally:
+        exit_result = stage.__exit__(None, None, None)
     # Staging dir should still exist (caller is responsible for wipe after promote)
+    assert result is stage
+    assert exit_result is None
     assert stage.root.exists()
 
 


### PR DESCRIPTION
## Summary
- simplify the request hash JSON normalization path to remove the constant-condition Sonar finding
- make `StagingDir.__exit__` return `None` on the success path while preserving context-manager semantics
- replace repeated `package.json` literals with a shared constant in code reader detection
- split invocation completion/propagation helpers to remove new Sonar cognitive-complexity hotspots in `advise`, `executor`, and `propagator`

## Validation
- `pytest tests/charter/synthesizer/test_request.py`
- `pytest tests/charter/synthesizer/test_staging_atomicity.py`
- `pytest --noconftest tests/charter/evidence/test_code_reader.py`
- `pytest tests/specify_cli/invocation/test_executor.py tests/specify_cli/invocation/test_propagator.py tests/specify_cli/invocation/test_propagator_policy.py tests/charter/synthesizer/test_request.py tests/charter/synthesizer/test_staging_atomicity.py --noconftest tests/charter/evidence/test_code_reader.py`
- `ruff check src/specify_cli/cli/commands/advise.py src/specify_cli/invocation/executor.py src/specify_cli/invocation/propagator.py`

## Notes
- GitHub Dependabot alerts: none open as of 2026-04-23.
- GitHub code-scanning alerts: none open as of 2026-04-23.
- The nightly `main` SonarCloud failure on 2026-04-23 05:11 UTC is currently driven by `new_coverage` (44.9%) and `new_security_hotspots_reviewed` (0%), not by open GitHub security alerts.
- The normal `tests/charter/evidence/test_code_reader.py` invocation currently trips the repo-wide venv bootstrap in `tests/conftest.py` (`python -m venv ... ensurepip` failure), so I used `--noconftest` for that direct unit slice.
- `tests/specify_cli/invocation/cli/test_advise.py` still hits the repo runtime bootstrap lock path (`/Users/robert/.kittify/cache/.update.lock`) under `CliRunner` in this sandboxed run, so I validated the touched invocation code via executor/propagator suites plus direct command-path compilation instead.
