### PR TITLE
build: point spec-kitty-events dep at sibling checkout via uv.sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ build-backend = "hatchling.build"
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.uv.sources]
+spec-kitty-events = { path = "../spec-kitty-events", editable = true }
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/kernel", "src/specify_cli", "src/doctrine", "src/charter"]
 exclude = [


### PR DESCRIPTION
## Summary

- `pyproject.toml` pins `spec-kitty-events==4.0.0`, which is not published to PyPI, so any fresh `uv run` that needs to resolve dependencies fails with "no solution found". This blocks the e2e harness (`spec-kitty-end-to-end-testing`) from invoking `spec-kitty` via `uv run --directory`.
- Add a `[tool.uv.sources]` entry that redirects the pin to the sibling `../spec-kitty-events/` path (editable mode, version 4.0.0 matches). uv.sources is dev-only metadata and is ignored by pip, so PyPI consumers are unaffected.

## Test plan

- [x] Verified the e2e Scenario A test (`test_local_only_planning_interview` in spec-kitty-end-to-end-testing) now resolves `spec-kitty-events` from the sibling checkout and runs end-to-end against the real installed CLI.
- [ ] CI / PR review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)