### PR TITLE
[Phase 6] Add StepContractExecutor composer

### DIFF
--- a/src/specify_cli/mission_step_contracts/__init__.py
+++ b/src/specify_cli/mission_step_contracts/__init__.py
@@ -1,0 +1,19 @@
+"""Mission step contract execution support."""
+
+from specify_cli.mission_step_contracts.executor import (
+    ResolvedStepDelegation,
+    StepContractExecutionContext,
+    StepContractExecutionError,
+    StepContractExecutionResult,
+    StepContractExecutor,
+    StepContractStepResult,
+)
+
+__all__ = [
+    "ResolvedStepDelegation",
+    "StepContractExecutionContext",
+    "StepContractExecutionError",
+    "StepContractExecutionResult",
+    "StepContractExecutor",
+    "StepContractStepResult",
+]

--- a/src/specify_cli/mission_step_contracts/executor.py
+++ b/src/specify_cli/mission_step_contracts/executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 from charter._drg_helpers import load_validated_graph
 from doctrine.artifact_kinds import ArtifactKind
@@ -87,7 +88,7 @@ class StepContractStepResult:
         """Return the underlying invocation ID when this step was invoked."""
         if self.invocation_payload is None:
             return None
-        return self.invocation_payload.invocation_id
+        return cast(str, self.invocation_payload.invocation_id)
 
 
 @dataclass(frozen=True)

--- a/src/specify_cli/mission_step_contracts/executor.py
+++ b/src/specify_cli/mission_step_contracts/executor.py
@@ -1,0 +1,315 @@
+"""Step contract executor for Phase 6 mission composition.
+
+This executor is intentionally a composer, not a command runner or model
+caller. It resolves step contract delegations through the merged DRG and then
+routes each step through ``ProfileInvocationExecutor`` so the existing
+governance context, trail, and glossary chokepoint behavior remains the single
+invocation primitive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from charter._drg_helpers import load_validated_graph
+from doctrine.artifact_kinds import ArtifactKind
+from doctrine.drg.models import DRGGraph, NodeKind
+from doctrine.drg.query import ResolvedContext, resolve_context
+from doctrine.mission_step_contracts.models import MissionStep, MissionStepContract
+from doctrine.mission_step_contracts.repository import MissionStepContractRepository
+from specify_cli.invocation.executor import InvocationPayload, ProfileInvocationExecutor
+from specify_cli.invocation.modes import ModeOfWork
+
+
+_ARTIFACT_TO_NODE_KIND: dict[ArtifactKind, NodeKind] = {
+    ArtifactKind.DIRECTIVE: NodeKind.DIRECTIVE,
+    ArtifactKind.TACTIC: NodeKind.TACTIC,
+    ArtifactKind.PARADIGM: NodeKind.PARADIGM,
+    ArtifactKind.STYLEGUIDE: NodeKind.STYLEGUIDE,
+    ArtifactKind.TOOLGUIDE: NodeKind.TOOLGUIDE,
+    ArtifactKind.PROCEDURE: NodeKind.PROCEDURE,
+    ArtifactKind.AGENT_PROFILE: NodeKind.AGENT_PROFILE,
+}
+
+_ACTION_PROFILE_DEFAULTS: dict[tuple[str, str], str] = {
+    ("software-dev", "specify"): "researcher-robbie",
+    ("software-dev", "plan"): "architect-alphonso",
+    ("software-dev", "implement"): "implementer-ivan",
+    ("software-dev", "review"): "reviewer-renata",
+}
+
+
+class StepContractExecutionError(RuntimeError):
+    """Raised when a step contract run cannot be composed."""
+
+
+@dataclass(frozen=True)
+class StepContractExecutionContext:
+    """Minimal context needed to execute a mission step contract."""
+
+    repo_root: Path
+    mission: str
+    action: str
+    actor: str = "unknown"
+    profile_hint: str | None = None
+    request_text: str | None = None
+    mode_of_work: ModeOfWork | None = None
+    resolution_depth: int = 2
+
+
+@dataclass(frozen=True)
+class ResolvedStepDelegation:
+    """A delegation candidate selected through merged DRG resolution."""
+
+    kind: ArtifactKind
+    candidate: str
+    urn: str
+    label: str | None = None
+
+
+@dataclass(frozen=True)
+class StepContractStepResult:
+    """Structured result for one composed step invocation."""
+
+    step_id: str
+    sequence: int
+    description: str
+    command: str | None
+    command_declared: bool
+    guidance: str | None
+    resolved_delegations: tuple[ResolvedStepDelegation, ...] = field(default_factory=tuple)
+    unresolved_candidates: tuple[str, ...] = field(default_factory=tuple)
+    invocation_payload: InvocationPayload | None = None
+
+    @property
+    def invocation_id(self) -> str | None:
+        """Return the underlying invocation ID when this step was invoked."""
+        if self.invocation_payload is None:
+            return None
+        return self.invocation_payload.invocation_id
+
+
+@dataclass(frozen=True)
+class StepContractExecutionResult:
+    """Structured result for a complete step contract run."""
+
+    contract_id: str
+    mission: str
+    action: str
+    profile_hint: str
+    resolution_source: str
+    steps: tuple[StepContractStepResult, ...]
+
+    @property
+    def invocation_ids(self) -> tuple[str, ...]:
+        """Return all invocation IDs emitted by the composed run."""
+        ids: list[str] = []
+        for step in self.steps:
+            invocation_id = step.invocation_id
+            if invocation_id is not None:
+                ids.append(invocation_id)
+        return tuple(ids)
+
+
+class StepContractExecutor:
+    """Execute mission step contracts by composing profile invocations."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        contract_repository: MissionStepContractRepository | None = None,
+        invocation_executor: ProfileInvocationExecutor | None = None,
+        graph: DRGGraph | None = None,
+    ) -> None:
+        self._repo_root = repo_root
+        self._contracts = contract_repository or MissionStepContractRepository(
+            project_dir=repo_root / ".kittify" / "doctrine" / "mission_step_contracts"
+        )
+        self._invocation_executor = invocation_executor or ProfileInvocationExecutor(repo_root)
+        self._graph = graph
+
+    def execute(
+        self,
+        context: StepContractExecutionContext,
+        contract: MissionStepContract | None = None,
+    ) -> StepContractExecutionResult:
+        """Execute a contract's steps in order through ``ProfileInvocationExecutor``."""
+        selected_contract = contract or self._contracts.get_by_action(context.mission, context.action)
+        if selected_contract is None:
+            raise StepContractExecutionError(
+                f"No step contract found for mission/action {context.mission}/{context.action}"
+            )
+
+        profile_hint = self._resolve_profile_hint(context, selected_contract)
+        graph = self._graph or load_validated_graph(context.repo_root)
+        action_urn = f"action:{selected_contract.mission}/{selected_contract.action}"
+        action_context = resolve_context(graph, action_urn, depth=context.resolution_depth)
+
+        step_results: list[StepContractStepResult] = []
+        for sequence, step in enumerate(selected_contract.steps, start=1):
+            resolved, unresolved = self._resolve_step_delegations(
+                graph=graph,
+                action_context=action_context,
+                step=step,
+            )
+            payload = self._invocation_executor.invoke(
+                self._build_request_text(
+                    contract=selected_contract,
+                    context=context,
+                    step=step,
+                    resolved_delegations=resolved,
+                    unresolved_candidates=unresolved,
+                ),
+                profile_hint=profile_hint,
+                actor=context.actor,
+                mode_of_work=context.mode_of_work,
+            )
+            step_results.append(
+                StepContractStepResult(
+                    step_id=step.id,
+                    sequence=sequence,
+                    description=step.description,
+                    command=step.command,
+                    command_declared=step.command is not None,
+                    guidance=step.guidance,
+                    resolved_delegations=tuple(resolved),
+                    unresolved_candidates=tuple(unresolved),
+                    invocation_payload=payload,
+                )
+            )
+
+        return StepContractExecutionResult(
+            contract_id=selected_contract.id,
+            mission=selected_contract.mission,
+            action=selected_contract.action,
+            profile_hint=profile_hint,
+            resolution_source="merged_drg",
+            steps=tuple(step_results),
+        )
+
+    def _resolve_profile_hint(
+        self,
+        context: StepContractExecutionContext,
+        contract: MissionStepContract,
+    ) -> str:
+        if context.profile_hint:
+            return context.profile_hint
+        default = _ACTION_PROFILE_DEFAULTS.get((contract.mission, contract.action))
+        if default is not None:
+            return default
+        raise StepContractExecutionError(
+            "profile_hint is required when no action default exists for "
+            f"{contract.mission}/{contract.action}"
+        )
+
+    def _resolve_step_delegations(
+        self,
+        *,
+        graph: DRGGraph,
+        action_context: ResolvedContext,
+        step: MissionStep,
+    ) -> tuple[list[ResolvedStepDelegation], list[str]]:
+        if step.delegates_to is None:
+            return [], []
+
+        kind = step.delegates_to.kind
+        resolved: list[ResolvedStepDelegation] = []
+        unresolved: list[str] = []
+        selected_urns = action_context.artifact_urns
+
+        for candidate in step.delegates_to.candidates:
+            urn = self._candidate_urn(graph, kind, candidate)
+            if urn is None or urn not in selected_urns:
+                unresolved.append(candidate)
+                continue
+            node = graph.get_node(urn)
+            resolved.append(
+                ResolvedStepDelegation(
+                    kind=kind,
+                    candidate=candidate,
+                    urn=urn,
+                    label=node.label if node is not None else None,
+                )
+            )
+        return resolved, unresolved
+
+    def _candidate_urn(
+        self,
+        graph: DRGGraph,
+        kind: ArtifactKind,
+        candidate: str,
+    ) -> str | None:
+        node_kind = _ARTIFACT_TO_NODE_KIND.get(kind)
+        if node_kind is None:
+            return None
+
+        direct = f"{kind.value}:{candidate}"
+        direct_node = graph.get_node(direct)
+        if direct_node is not None and direct_node.kind == node_kind:
+            return direct
+
+        directive_urn = self._directive_candidate_urn(candidate) if kind == ArtifactKind.DIRECTIVE else None
+        if directive_urn is not None:
+            directive_node = graph.get_node(directive_urn)
+            if directive_node is not None and directive_node.kind == node_kind:
+                return directive_urn
+
+        matches = [
+            node.urn
+            for node in graph.nodes
+            if node.kind == node_kind and node.urn.split(":", 1)[1] == candidate
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    @staticmethod
+    def _directive_candidate_urn(candidate: str) -> str | None:
+        numeric = ""
+        for char in candidate:
+            if not char.isdigit():
+                break
+            numeric += char
+        if not numeric:
+            return None
+        return f"directive:DIRECTIVE_{numeric.zfill(3)}"
+
+    def _build_request_text(
+        self,
+        *,
+        contract: MissionStepContract,
+        context: StepContractExecutionContext,
+        step: MissionStep,
+        resolved_delegations: list[ResolvedStepDelegation],
+        unresolved_candidates: list[str],
+    ) -> str:
+        lines = [
+            f"Execute mission step contract {contract.id} ({contract.mission}/{contract.action}).",
+            f"Step {step.id}: {step.description}",
+        ]
+        if context.request_text:
+            lines.append(f"Run request: {context.request_text}")
+        if step.command:
+            lines.append(f"Declared command: {step.command}")
+            lines.append("Command status: declared only; the host/operator owns execution.")
+        if resolved_delegations:
+            joined = ", ".join(delegation.urn for delegation in resolved_delegations)
+            lines.append(f"Resolved delegations: {joined}")
+        if unresolved_candidates:
+            joined = ", ".join(unresolved_candidates)
+            lines.append(f"Unresolved delegation candidates: {joined}")
+        if step.guidance:
+            lines.append(f"Step guidance: {step.guidance}")
+        return "\n".join(lines)
+
+
+__all__ = [
+    "ResolvedStepDelegation",
+    "StepContractExecutionContext",
+    "StepContractExecutionError",
+    "StepContractExecutionResult",
+    "StepContractExecutor",
+    "StepContractStepResult",
+]

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -1,0 +1,285 @@
+"""Tests for StepContractExecutor composition over ProfileInvocationExecutor."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from ruamel.yaml import YAML
+
+from doctrine.mission_step_contracts.repository import MissionStepContractRepository
+from specify_cli.invocation.writer import EVENTS_DIR
+from specify_cli.mission_step_contracts.executor import (
+    StepContractExecutionContext,
+    StepContractExecutionError,
+    StepContractExecutor,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    yaml = YAML()
+    yaml.default_flow_style = False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.dump(data, fh)
+
+
+def _setup_fixture_profiles(repo_root: Path) -> None:
+    profiles_dir = repo_root / ".kittify" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    fixtures = Path(__file__).parents[1] / "invocation" / "fixtures" / "profiles"
+    for yaml_file in fixtures.glob("*.agent.yaml"):
+        shutil.copy(yaml_file, profiles_dir / yaml_file.name)
+
+
+def _write_project_graph(repo_root: Path) -> None:
+    _write_yaml(
+        repo_root / ".kittify" / "doctrine" / "graph.yaml",
+        {
+            "schema_version": "1.0",
+            "generated_at": "2026-04-24T00:00:00Z",
+            "generated_by": "test",
+            "nodes": [
+                {
+                    "urn": "action:fixture/composer",
+                    "kind": "action",
+                    "label": "Fixture composer action",
+                },
+                {"urn": "tactic:delegated-alpha", "kind": "tactic", "label": "Alpha"},
+                {"urn": "tactic:delegated-beta", "kind": "tactic", "label": "Beta"},
+                {"urn": "tactic:delegated-gamma", "kind": "tactic", "label": "Gamma"},
+                {"urn": "tactic:not-selected", "kind": "tactic", "label": "Not selected"},
+                {
+                    "urn": "action:fixture/directive-composer",
+                    "kind": "action",
+                    "label": "Fixture directive composer action",
+                },
+                {
+                    "urn": "directive:DIRECTIVE_030",
+                    "kind": "directive",
+                    "label": "Test and Typecheck Quality Gate",
+                },
+            ],
+            "edges": [
+                {
+                    "source": "action:fixture/composer",
+                    "target": "tactic:delegated-alpha",
+                    "relation": "scope",
+                },
+                {
+                    "source": "action:fixture/composer",
+                    "target": "tactic:delegated-beta",
+                    "relation": "scope",
+                },
+                {
+                    "source": "action:fixture/composer",
+                    "target": "tactic:delegated-gamma",
+                    "relation": "scope",
+                },
+                {
+                    "source": "action:fixture/directive-composer",
+                    "target": "directive:DIRECTIVE_030",
+                    "relation": "scope",
+                },
+            ],
+        },
+    )
+
+
+def _write_fixture_contract(shipped_dir: Path) -> None:
+    _write_yaml(
+        shipped_dir / "fixture.step-contract.yaml",
+        {
+            "schema_version": "1.0",
+            "id": "fixture-composer",
+            "mission": "fixture",
+            "action": "composer",
+            "steps": [
+                {
+                    "id": "alpha",
+                    "description": "Run alpha delegation",
+                    "delegates_to": {
+                        "kind": "tactic",
+                        "candidates": ["delegated-alpha", "not-selected"],
+                    },
+                },
+                {
+                    "id": "beta",
+                    "description": "Run beta delegation",
+                    "delegates_to": {
+                        "kind": "tactic",
+                        "candidates": ["delegated-beta"],
+                    },
+                },
+                {
+                    "id": "gamma",
+                    "description": "Run gamma delegation",
+                    "delegates_to": {
+                        "kind": "tactic",
+                        "candidates": ["delegated-gamma"],
+                    },
+                },
+            ],
+        },
+    )
+
+
+def test_three_delegated_steps_execute_end_to_end_via_profile_invocation_executor(
+    tmp_path: Path,
+) -> None:
+    """Acceptance: three delegated steps compose through invocation and merged DRG."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _setup_fixture_profiles(repo_root)
+    _write_project_graph(repo_root)
+
+    shipped_dir = tmp_path / "contracts"
+    _write_fixture_contract(shipped_dir)
+    contract_repo = MissionStepContractRepository(shipped_dir=shipped_dir)
+
+    context_result = SimpleNamespace(mode="compact", text="fixture governance context")
+    with patch("specify_cli.invocation.executor.build_charter_context", return_value=context_result):
+        result = StepContractExecutor(
+            repo_root=repo_root,
+            contract_repository=contract_repo,
+        ).execute(
+            StepContractExecutionContext(
+                repo_root=repo_root,
+                mission="fixture",
+                action="composer",
+                actor="pytest",
+                profile_hint="implementer-fixture",
+                request_text="issue #501 fixture run",
+            )
+        )
+
+    assert result.contract_id == "fixture-composer"
+    assert result.resolution_source == "merged_drg"
+    assert len(result.steps) == 3
+    assert len(result.invocation_ids) == 3
+
+    assert [step.step_id for step in result.steps] == ["alpha", "beta", "gamma"]
+    assert [step.resolved_delegations[0].urn for step in result.steps] == [
+        "tactic:delegated-alpha",
+        "tactic:delegated-beta",
+        "tactic:delegated-gamma",
+    ]
+    assert result.steps[0].unresolved_candidates == ("not-selected",)
+    assert all(step.invocation_payload is not None for step in result.steps)
+
+    jsonl_files = sorted((repo_root / EVENTS_DIR).glob("*.jsonl"))
+    assert len(jsonl_files) == 3
+
+
+def test_command_step_is_declared_not_shell_executed(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _setup_fixture_profiles(repo_root)
+    _write_project_graph(repo_root)
+
+    contract = {
+        "schema_version": "1.0",
+        "id": "command-contract",
+        "mission": "fixture",
+        "action": "composer",
+        "steps": [
+            {
+                "id": "status_transition",
+                "description": "Move status",
+                "command": "spec-kitty agent tasks move-task WP1 --to for_review",
+            }
+        ],
+    }
+    shipped_dir = tmp_path / "contracts"
+    _write_yaml(shipped_dir / "command.step-contract.yaml", contract)
+
+    context_result = SimpleNamespace(mode="compact", text="fixture governance context")
+    with patch("specify_cli.invocation.executor.build_charter_context", return_value=context_result):
+        result = StepContractExecutor(
+            repo_root=repo_root,
+            contract_repository=MissionStepContractRepository(shipped_dir=shipped_dir),
+        ).execute(
+            StepContractExecutionContext(
+                repo_root=repo_root,
+                mission="fixture",
+                action="composer",
+                actor="pytest",
+                profile_hint="implementer-fixture",
+            )
+        )
+
+    step = result.steps[0]
+    assert step.command_declared is True
+    assert step.command == "spec-kitty agent tasks move-task WP1 --to for_review"
+    assert step.resolved_delegations == ()
+    assert len(result.invocation_ids) == 1
+
+
+def test_directive_slug_candidate_resolves_to_drg_urn(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _setup_fixture_profiles(repo_root)
+    _write_project_graph(repo_root)
+
+    contract = {
+        "schema_version": "1.0",
+        "id": "directive-contract",
+        "mission": "fixture",
+        "action": "directive-composer",
+        "steps": [
+            {
+                "id": "quality_gate",
+                "description": "Run quality gate",
+                "delegates_to": {
+                    "kind": "directive",
+                    "candidates": ["030-test-and-typecheck-quality-gate"],
+                },
+            }
+        ],
+    }
+    shipped_dir = tmp_path / "contracts"
+    _write_yaml(shipped_dir / "directive.step-contract.yaml", contract)
+
+    context_result = SimpleNamespace(mode="compact", text="fixture governance context")
+    with patch("specify_cli.invocation.executor.build_charter_context", return_value=context_result):
+        result = StepContractExecutor(
+            repo_root=repo_root,
+            contract_repository=MissionStepContractRepository(shipped_dir=shipped_dir),
+        ).execute(
+            StepContractExecutionContext(
+                repo_root=repo_root,
+                mission="fixture",
+                action="directive-composer",
+                actor="pytest",
+                profile_hint="implementer-fixture",
+            )
+        )
+
+    assert result.steps[0].resolved_delegations[0].urn == "directive:DIRECTIVE_030"
+    assert result.steps[0].unresolved_candidates == ()
+
+
+def test_profile_hint_required_when_no_action_default_exists(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_project_graph(repo_root)
+    shipped_dir = tmp_path / "contracts"
+    _write_fixture_contract(shipped_dir)
+
+    with pytest.raises(StepContractExecutionError, match="profile_hint is required"):
+        StepContractExecutor(
+            repo_root=repo_root,
+            contract_repository=MissionStepContractRepository(shipped_dir=shipped_dir),
+        ).execute(
+            StepContractExecutionContext(
+                repo_root=repo_root,
+                mission="fixture",
+                action="composer",
+            )
+        )

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -22,7 +23,7 @@ from specify_cli.mission_step_contracts.executor import (
 pytestmark = pytest.mark.fast
 
 
-def _write_yaml(path: Path, data: dict) -> None:
+def _write_yaml(path: Path, data: Mapping[str, object]) -> None:
     yaml = YAML()
     yaml.default_flow_style = False
     path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Closes #501.

Adds a library-first `StepContractExecutor` in `specify_cli.mission_step_contracts` that:

- loads mission/action step contracts via `MissionStepContractRepository`
- executes steps in contract order
- resolves `delegates_to` candidates through the merged DRG action context (`load_validated_graph` + `resolve_context`)
- composes each step through the existing non-LLM `ProfileInvocationExecutor`
- returns structured per-step results with invocation payloads, resolved delegations, unresolved candidates, and declared command metadata
- represents command steps as declared host/operator work without shell execution

## Acceptance proof

The new fixture-driven executor tests cover:

- a three-step delegated contract executing end-to-end through `ProfileInvocationExecutor`
- delegation selection through a project DRG overlay merged with shipped DRG
- directive slug candidates like `030-test-and-typecheck-quality-gate` resolving to canonical DRG URNs like `directive:DIRECTIVE_030`
- command steps being declared, not executed by Spec Kitty
- explicit profile binding for non-default mission/action contracts

## Deliberately left for follow-up work

- #503: no live rewrite of the `software-dev` mission runtime to step-contract execution
- #505: no custom mission loading implementation
- #507/#506/#508/#509: no retrospective facilitator, retrospective schema, synthesis handoff, or lifecycle gating
- #534: no `spec-kitty explain` scope pulled in

## Verification

Ran with the available system Python 3.14 because `uv run` is blocked in this fresh checkout by missing Python 3.13.12 from `.python-version`.

Passing:

- `python -m pytest tests/specify_cli/mission_step_contracts/test_executor.py -q`
- `python -m pytest tests/doctrine/mission_step_contracts tests/specify_cli/mission_step_contracts/test_executor.py -q`
- `python -m pytest tests/specify_cli/invocation/test_executor.py tests/specify_cli/invocation/test_executor_glossary.py tests/specify_cli/invocation/test_invocation_e2e.py -q`
- `python -m pytest tests/architectural/test_layer_rules.py -q`
- `python -m ruff check src/specify_cli/mission_step_contracts tests/specify_cli/mission_step_contracts`

Known baseline/environment issue observed while checking the broader requested invocation suite:

- `python -m pytest tests/specify_cli/invocation -q` currently reports 216 passed / 15 failed under Python 3.14, with failures in pre-existing router/record/CLI expectations (`Role.value`, `mode_of_work` record shape, CLI mock signature). The targeted invocation executor/e2e tests above pass.
