### PR TITLE
fix: address fresh sonar dashboard and runtime findings

### DIFF
--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -440,30 +440,44 @@ def _render_human(envelope: dict[str, Any]) -> None:
     if envelope.get("result") == "success":
         title = "Mission Run Started"
         border = "green"
-        body = Text()
-        body.append(f"mission_key:  {envelope.get('mission_key')}\n")
-        body.append(f"mission_slug: {envelope.get('mission_slug')}\n")
-        mission_id = envelope.get("mission_id")
-        if mission_id:
-            body.append(f"mission_id:   {mission_id}\n")
-        body.append(f"feature_dir:  {envelope.get('feature_dir')}\n")
-        body.append(f"run_dir:      {envelope.get('run_dir')}")
+        body = _build_success_body(envelope)
     else:
         title = str(envelope.get("error_code") or "ERROR")
         border = "red"
-        body = Text(str(envelope.get("message") or ""))
-        details = envelope.get("details") or {}
-        if isinstance(details, dict):
-            for key, value in details.items():
-                body.append(f"\n  {key}: {value}")
+        body = _build_error_body(envelope)
 
-    for warn in envelope.get("warnings", []) or []:
-        if isinstance(warn, dict):
-            body.append(
-                f"\n[warn] {warn.get('code', '')}: {warn.get('message', '')}"
-            )
+    _append_warning_lines(body, envelope.get("warnings"))
 
     console.print(Panel(body, title=title, border_style=border))
+
+
+def _build_success_body(envelope: dict[str, Any]) -> Text:
+    body = Text()
+    body.append(f"mission_key:  {envelope.get('mission_key')}\n")
+    body.append(f"mission_slug: {envelope.get('mission_slug')}\n")
+    mission_id = envelope.get("mission_id")
+    if mission_id:
+        body.append(f"mission_id:   {mission_id}\n")
+    body.append(f"feature_dir:  {envelope.get('feature_dir')}\n")
+    body.append(f"run_dir:      {envelope.get('run_dir')}")
+    return body
+
+
+def _build_error_body(envelope: dict[str, Any]) -> Text:
+    body = Text(str(envelope.get("message") or ""))
+    details = envelope.get("details") or {}
+    if not isinstance(details, dict):
+        return body
+    for key, value in details.items():
+        body.append(f"\n  {key}: {value}")
+    return body
+
+
+def _append_warning_lines(body: Text, warnings: Any) -> None:
+    for warn in warnings or []:
+        if not isinstance(warn, dict):
+            continue
+        body.append(f"\n[warn] {warn.get('code', '')}: {warn.get('message', '')}")
 
 
 @app.command("switch", deprecated=True)

--- a/src/specify_cli/next/_internal_runtime/discovery.py
+++ b/src/specify_cli/next/_internal_runtime/discovery.py
@@ -20,6 +20,12 @@ from specify_cli.next._internal_runtime.schema import (
     load_mission_template_file,
 )
 
+_CONFIG_FILENAME = "config.yaml"
+_KITTIFY_DIRNAME = ".kittify"
+_MISSION_FILENAME = "mission.yaml"
+_MISSIONS_DIRNAME = "missions"
+_OVERRIDES_DIRNAME = "overrides"
+
 
 # ---------------------------------------------------------------------------
 # Reserved built-in mission keys (R-002)
@@ -132,7 +138,7 @@ def _collect_from_manifest(pack_root: Path) -> list[Path]:
 def _scan_root(root: Path) -> list[Path]:
     candidates: list[Path] = []
 
-    if root.is_file() and root.name == "mission.yaml":
+    if root.is_file() and root.name == _MISSION_FILENAME:
         return [root]
 
     if not root.exists() or not root.is_dir():
@@ -142,18 +148,19 @@ def _scan_root(root: Path) -> list[Path]:
     candidates.extend(_collect_from_manifest(root))
 
     # Legacy/common mission-root layout: <root>/<mission_key>/mission.yaml
-    for mission_file in sorted(root.glob("*/mission.yaml")):
+    for mission_file in sorted(root.glob(f"*/{_MISSION_FILENAME}")):
         candidates.append(mission_file)
 
     # Canonical pack layout.
-    missions_dir = root / "missions"
+    missions_dir = root / _MISSIONS_DIRNAME
     if missions_dir.is_dir():
-        for mission_file in sorted(missions_dir.glob("*/mission.yaml")):
+        for mission_file in sorted(missions_dir.glob(f"*/{_MISSION_FILENAME}")):
             candidates.append(mission_file)
 
     # Direct mission root fallback.
-    if (root / "mission.yaml").exists():
-        candidates.append(root / "mission.yaml")
+    direct_mission = root / _MISSION_FILENAME
+    if direct_mission.exists():
+        candidates.append(direct_mission)
 
     # De-duplicate while preserving order.
     seen: set[Path] = set()
@@ -168,7 +175,7 @@ def _scan_root(root: Path) -> list[Path]:
 
 
 def _project_config_pack_paths(project_dir: Path) -> list[Path]:
-    config_file = project_dir / ".kittify" / "config.yaml"
+    config_file = project_dir / _KITTIFY_DIRNAME / _CONFIG_FILENAME
     if not config_file.exists():
         return []
     with open(config_file, encoding="utf-8") as handle:
@@ -204,15 +211,15 @@ def _build_tiers(context: DiscoveryContext) -> list[tuple[str, str, list[Path]]]
         tiers.append(
             (
                 "project_override",
-                str(project_dir / ".kittify" / "overrides" / "missions"),
-                [project_dir / ".kittify" / "overrides" / "missions"],
+                str(project_dir / _KITTIFY_DIRNAME / _OVERRIDES_DIRNAME / _MISSIONS_DIRNAME),
+                [project_dir / _KITTIFY_DIRNAME / _OVERRIDES_DIRNAME / _MISSIONS_DIRNAME],
             )
         )
         tiers.append(
             (
                 "project_legacy",
-                str(project_dir / ".kittify" / "missions"),
-                [project_dir / ".kittify" / "missions"],
+                str(project_dir / _KITTIFY_DIRNAME / _MISSIONS_DIRNAME),
+                [project_dir / _KITTIFY_DIRNAME / _MISSIONS_DIRNAME],
             )
         )
 
@@ -228,7 +235,7 @@ def _build_tiers(context: DiscoveryContext) -> list[tuple[str, str, list[Path]]]
         tiers.append(
             (
                 "project_config",
-                str(project_dir / ".kittify" / "config.yaml"),
+                str(project_dir / _KITTIFY_DIRNAME / _CONFIG_FILENAME),
                 _project_config_pack_paths(project_dir),
             )
         )

--- a/src/specify_cli/runtime/__init__.py
+++ b/src/specify_cli/runtime/__init__.py
@@ -9,22 +9,28 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
+_BOOTSTRAP_MODULE = "specify_cli.runtime.bootstrap"
+_HOME_MODULE = "specify_cli.runtime.home"
+_MIGRATE_MODULE = "specify_cli.runtime.migrate"
+_RESOLVER_MODULE = "specify_cli.runtime.resolver"
+_SHOW_ORIGIN_MODULE = "specify_cli.runtime.show_origin"
+
 _EXPORT_MODULES = {
-    "AssetDisposition": "specify_cli.runtime.migrate",
-    "MigrationReport": "specify_cli.runtime.migrate",
-    "OriginEntry": "specify_cli.runtime.show_origin",
-    "ResolutionResult": "specify_cli.runtime.resolver",
-    "ResolutionTier": "specify_cli.runtime.resolver",
-    "check_version_pin": "specify_cli.runtime.bootstrap",
-    "classify_asset": "specify_cli.runtime.migrate",
-    "collect_origins": "specify_cli.runtime.show_origin",
-    "ensure_runtime": "specify_cli.runtime.bootstrap",
-    "execute_migration": "specify_cli.runtime.migrate",
-    "get_kittify_home": "specify_cli.runtime.home",
-    "get_package_asset_root": "specify_cli.runtime.home",
-    "resolve_command": "specify_cli.runtime.resolver",
-    "resolve_mission": "specify_cli.runtime.resolver",
-    "resolve_template": "specify_cli.runtime.resolver",
+    "AssetDisposition": _MIGRATE_MODULE,
+    "MigrationReport": _MIGRATE_MODULE,
+    "OriginEntry": _SHOW_ORIGIN_MODULE,
+    "ResolutionResult": _RESOLVER_MODULE,
+    "ResolutionTier": _RESOLVER_MODULE,
+    "check_version_pin": _BOOTSTRAP_MODULE,
+    "classify_asset": _MIGRATE_MODULE,
+    "collect_origins": _SHOW_ORIGIN_MODULE,
+    "ensure_runtime": _BOOTSTRAP_MODULE,
+    "execute_migration": _MIGRATE_MODULE,
+    "get_kittify_home": _HOME_MODULE,
+    "get_package_asset_root": _HOME_MODULE,
+    "resolve_command": _RESOLVER_MODULE,
+    "resolve_mission": _RESOLVER_MODULE,
+    "resolve_template": _RESOLVER_MODULE,
 }
 
 

--- a/src/specify_cli/state_contract.py
+++ b/src/specify_cli/state_contract.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
+_NEXT_INTERNAL_RUNTIME_OWNER = "next/_internal_runtime"
+
 
 # ---------------------------------------------------------------------------
 # T001 -- State Enums
@@ -171,7 +173,7 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         format=StateFormat.JSON,
         authority=AuthorityClass.LOCAL_RUNTIME,
         git_class=GitClass.IGNORED,
-        owner_module="next/_internal_runtime",
+        owner_module=_NEXT_INTERNAL_RUNTIME_OWNER,
         creation_trigger="mission run start",
     ),
     StateSurface(
@@ -181,7 +183,7 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         format=StateFormat.JSONL,
         authority=AuthorityClass.LOCAL_RUNTIME,
         git_class=GitClass.IGNORED,
-        owner_module="next/_internal_runtime",
+        owner_module=_NEXT_INTERNAL_RUNTIME_OWNER,
         creation_trigger="mission run events",
     ),
     StateSurface(
@@ -191,7 +193,7 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         format=StateFormat.YAML,
         authority=AuthorityClass.LOCAL_RUNTIME,
         git_class=GitClass.IGNORED,
-        owner_module="next/_internal_runtime",
+        owner_module=_NEXT_INTERNAL_RUNTIME_OWNER,
         creation_trigger="mission run start",
     ),
     StateSurface(

--- a/tests/runtime/test_package_exports.py
+++ b/tests/runtime/test_package_exports.py
@@ -1,0 +1,17 @@
+"""Tests for lazy exports from specify_cli.runtime."""
+
+from __future__ import annotations
+
+import pytest
+
+import specify_cli.runtime as runtime_pkg
+
+
+def test_runtime_lazy_exports_resolve_symbols() -> None:
+    assert runtime_pkg.resolve_template is not None
+    assert runtime_pkg.get_kittify_home is not None
+
+
+def test_runtime_unknown_export_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        getattr(runtime_pkg, "definitely_missing_export")

--- a/tests/specify_cli/cli/commands/test_mission_type_rendering.py
+++ b/tests/specify_cli/cli/commands/test_mission_type_rendering.py
@@ -1,0 +1,50 @@
+"""Rendering tests for mission-type command envelopes."""
+
+from __future__ import annotations
+
+from rich.panel import Panel
+
+from specify_cli.cli.commands import mission_type
+
+
+def test_render_human_success_includes_warning(monkeypatch) -> None:
+    captured: list[Panel] = []
+    monkeypatch.setattr(mission_type.console, "print", lambda panel: captured.append(panel))
+
+    mission_type._render_human(
+        {
+            "result": "success",
+            "mission_key": "software-dev",
+            "mission_slug": "123-demo",
+            "mission_id": "m-1",
+            "feature_dir": "/tmp/feature",
+            "run_dir": "/tmp/run",
+            "warnings": [{"code": "W1", "message": "Heads up"}],
+        }
+    )
+
+    assert len(captured) == 1
+    panel = captured[0]
+    assert panel.title == "Mission Run Started"
+    assert "mission_key:  software-dev" in str(panel.renderable)
+    assert "[warn] W1: Heads up" in str(panel.renderable)
+
+
+def test_render_human_error_includes_details(monkeypatch) -> None:
+    captured: list[Panel] = []
+    monkeypatch.setattr(mission_type.console, "print", lambda panel: captured.append(panel))
+
+    mission_type._render_human(
+        {
+            "result": "error",
+            "error_code": "BROKEN",
+            "message": "Nope",
+            "details": {"path": "/tmp/demo"},
+        }
+    )
+
+    assert len(captured) == 1
+    panel = captured[0]
+    assert panel.title == "BROKEN"
+    assert "Nope" in str(panel.renderable)
+    assert "path: /tmp/demo" in str(panel.renderable)

--- a/tests/test_dashboard/test_templates.py
+++ b/tests/test_dashboard/test_templates.py
@@ -1,0 +1,21 @@
+"""Template-level tests for the dashboard shell."""
+
+from __future__ import annotations
+
+from specify_cli.dashboard.templates import get_dashboard_html
+
+
+def test_dashboard_glossary_interactions_use_native_links() -> None:
+    html = get_dashboard_html()
+
+    assert '<a class="sidebar-item" href="/glossary" title="Glossary">' in html
+    assert (
+        '<a class="content-card content-card-link" id="glossary-tile" '
+        'href="/glossary" style="margin-top: 16px;">'
+    ) in html
+
+
+def test_dashboard_html_injects_safe_mission_context() -> None:
+    html = get_dashboard_html(mission_context={"mission": "</script>"})
+
+    assert 'window.__INITIAL_MISSION__ = {"mission": "\\u003c/script\\u003e"};' in html


### PR DESCRIPTION
## Summary
- preserve the dashboard keyboard-accessibility fix on all clickable navigation tiles and the glossary tile
- address additional fresh SonarCloud findings in runtime-related modules by reducing duplicated literals and shaving a small new complexity regression
- add focused regression tests for dashboard template accessibility, runtime lazy exports, and mission-type envelope rendering

## Investigation notes
- GitHub code-scanning alerts: none open
- GitHub Dependabot alerts: 1 open alert for `pip` via `uv.lock`
- That `pip` alert is currently upstream-blocked for in-repo remediation: GitHub flags `<= 26.0.1`, and the advisory currently lists no patched version
- Latest scheduled `CI Quality` run on `main` was run `24949054213` on 2026-04-26 and failed SonarCloud quality gate after a successful scan
- Actionable code issues addressed here:
  - new dashboard reliability/accessibility bugs from clickable `div` elements without keyboard activation
  - fresh Sonar maintainability issues in `runtime/__init__.py`, `state_contract.py`, `next/_internal_runtime/discovery.py`, and `cli/commands/mission_type.py`
- Remaining nightly Sonar gate items are not fully code-fixable in this patch:
  - `new_security_hotspots_reviewed = 0%` is a Sonar review-state item
  - `new_coverage = 56.5%` reflects broader `main` new-code coverage debt outside this patch slice

## Validation
- `python -m pytest tests/specify_cli/dashboard/test_dashboard_wording.py tests/test_dashboard/test_templates.py tests/runtime/test_package_exports.py tests/specify_cli/cli/commands/test_mission_type_rendering.py tests/specify_cli/test_state_contract.py tests/next/test_internal_runtime_coverage.py -q`
- Result: `185 passed`
