### PR TITLE
fix: harden intake brief write paths

### DIFF
--- a/src/specify_cli/intake/brief_writer.py
+++ b/src/specify_cli/intake/brief_writer.py
@@ -16,7 +16,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from .errors import IntakeError, IntakeRootInconsistentError
+from .errors import (
+    IntakeError,
+    IntakePathEscapeError,
+    IntakeRootInconsistentError,
+)
 
 
 def _validate_root_consistency(scanner_root: Path, writer_root: Path) -> None:
@@ -39,6 +43,20 @@ def _validate_root_consistency(scanner_root: Path, writer_root: Path) -> None:
             scanner_root=s_resolved,
             writer_root=w_resolved,
         )
+
+
+def _validate_target_within_root(root: Path, candidate: Path) -> Path:
+    """Return the resolved candidate when it stays inside ``root``."""
+    resolved_root = Path(root).resolve(strict=False)
+    resolved_candidate = Path(candidate).resolve(strict=False)
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise IntakePathEscapeError(
+            candidate=resolved_candidate,
+            intake_root=resolved_root,
+        ) from exc
+    return resolved_candidate
 
 
 class CrossFilesystemWriteError(IntakeError):
@@ -172,6 +190,8 @@ def write_brief_atomic(
     crashed predecessors never collide on the same temp filename.
     """
     _validate_root_consistency(scanner_root, writer_root)
+    _validate_target_within_root(writer_root, brief_path)
+    _validate_target_within_root(writer_root, source_path)
     # Source first so brief.md remains the canonical "commit marker"
     # for the pair. The reader treats source-without-brief as no brief.
     atomic_write_text(source_path, source_yaml, allow_cross_fs=allow_cross_fs)

--- a/src/specify_cli/mission_brief.py
+++ b/src/specify_cli/mission_brief.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
-from specify_cli.intake.brief_writer import atomic_write_text
+from specify_cli.intake.brief_writer import write_brief_atomic
 from specify_cli.intake.errors import (
     IntakeFileMissingError,
     IntakeFileUnreadableError,
@@ -106,8 +106,15 @@ def write_mission_brief(
     # writes are rejected unless explicitly allowed in config.yaml.
     allow_cross_fs = load_allow_cross_fs(repo_root)
     source_yaml = yaml.safe_dump(source_data, default_flow_style=False)
-    atomic_write_text(brief_path, brief_text, allow_cross_fs=allow_cross_fs)
-    atomic_write_text(source_path, source_yaml, allow_cross_fs=allow_cross_fs)
+    write_brief_atomic(
+        scanner_root=repo_root,
+        writer_root=repo_root,
+        brief_path=brief_path,
+        brief_text=brief_text,
+        source_path=source_path,
+        source_yaml=source_yaml,
+        allow_cross_fs=allow_cross_fs,
+    )
 
     return brief_path, source_path
 

--- a/tests/specify_cli/test_mission_brief_resilient_write.py
+++ b/tests/specify_cli/test_mission_brief_resilient_write.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 import pytest
 import yaml
 from pathlib import Path
-from specify_cli.mission_brief import write_mission_brief, MISSION_BRIEF_FILENAME, BRIEF_SOURCE_FILENAME
+from specify_cli.mission_brief import (
+    BRIEF_SOURCE_FILENAME,
+    MISSION_BRIEF_FILENAME,
+    read_brief_source,
+    read_mission_brief,
+    write_mission_brief,
+)
 
 
 def test_write_mission_brief_success(tmp_path):
@@ -67,10 +73,13 @@ def test_write_mission_brief_pre_replace_crash_leaves_no_final_files(tmp_path, m
     with pytest.raises(OSError):
         write_mission_brief(tmp_path, "# Test", "test.md")
     kittify = tmp_path / ".kittify"
-    # The brief landed (first replace succeeded) but the source did not.
-    # The atomic-write contract: ``target`` is either fully written or
-    # absent; tmp files are cleaned up on failure.
-    assert not (kittify / BRIEF_SOURCE_FILENAME).exists()
+    # Source lands first and brief.md is the commit marker. A crash during
+    # the second rename leaves source.yaml on disk, but the reader surface
+    # still treats that state as "no brief".
+    assert (kittify / BRIEF_SOURCE_FILENAME).exists()
+    assert not (kittify / MISSION_BRIEF_FILENAME).exists()
+    assert read_mission_brief(tmp_path) is None
+    assert read_brief_source(tmp_path) is None
     # No .tmp leftovers from either write.
     assert not list(kittify.glob("*.tmp"))
 

--- a/tests/unit/intake/test_root_consistency.py
+++ b/tests/unit/intake/test_root_consistency.py
@@ -9,7 +9,7 @@ from specify_cli.intake.brief_writer import (
     _validate_root_consistency,
     write_brief_atomic,
 )
-from specify_cli.intake.errors import IntakeRootInconsistentError
+from specify_cli.intake.errors import IntakePathEscapeError, IntakeRootInconsistentError
 
 
 pytestmark = [pytest.mark.fast]
@@ -76,3 +76,21 @@ def test_write_brief_atomic_succeeds_when_roots_match(tmp_path):
 
     assert brief_path.read_text(encoding="utf-8") == "# brief"
     assert source_path.read_text(encoding="utf-8") == "source_file: x\n"
+
+
+def test_write_brief_atomic_rejects_paths_outside_root(tmp_path):
+    root = tmp_path / "intake-root"
+    root.mkdir()
+    escaped = tmp_path / "escaped-brief.md"
+
+    with pytest.raises(IntakePathEscapeError):
+        write_brief_atomic(
+            scanner_root=root,
+            writer_root=root,
+            brief_path=escaped,
+            brief_text="# brief",
+            source_path=root / ".kittify" / "brief-source.yaml",
+            source_yaml="source_file: x\n",
+        )
+
+    assert not escaped.exists()


### PR DESCRIPTION
## Summary
- route mission brief writes through `write_brief_atomic()` so intake writes always go through root consistency validation
- reject brief/source targets that resolve outside the repo root before any file write occurs
- add regression coverage for escaped targets and the crash-between-renames reader contract

## Validation
- python3 -m pytest tests/unit/intake/test_root_consistency.py tests/specify_cli/test_brief_pair_atomicity.py tests/specify_cli/test_mission_brief_resilient_write.py -q
- python3 -m pytest tests/cli/test_mission_brief.py tests/specify_cli/cli/commands/test_intake.py -q

## Remaining findings investigated
- Dependabot alert https://github.com/Priivacy-ai/spec-kitty/security/dependabot/2 remains upstream-only because GitHub still reports no patched `pip` release for the vulnerable range
- SonarCloud `new_security_hotspots_reviewed = 0%` is review-state only, not fixable in this code patch
- SonarCloud `new_coverage` on `main` remains broader than this intake slice, but this patch adds focused coverage for the changed path