### PR TITLE
Fix agent config handling for global command roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`constraints.txt`** — the file existed solely to paper over a transitive pin conflict with the retired `spec-kitty-runtime` package and is no longer needed.
 
+### Fixed
+
+- `spec-kitty agent config list/status` now checks global command roots for slash-command agents instead of reporting missing project-local command directories after `init`.
+- `spec-kitty agent config add/sync --create-missing` no longer recreates retired project-local command directories for globally managed slash-command agents.
+- `spec-kitty agent config remove/sync` now removes only the managed command surface for project-local agent directories, preserving unrelated files such as `.github/workflows/`.
+
 ### Added — Documentation mission composition rewrite (#502, #461, Phase 6 WP6.4)
 
 - Documentation mission now runs on the StepContractExecutor composition substrate, mirroring research (#504) and software-dev (#503). The runtime resolves the new composed step contracts ahead of the legacy `mission.yaml` workflow via the existing `_resolve_runtime_template_in_root` precedence — no loader changes were required.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 | **Charter and compatibility governance** | Harness-owned charter synthesis, provenance reporting, `charter bundle validate`, `charter resynthesize --list-topics`, and `doctor shim-registry` |
 | **Review resilience** | Persisted versioned review artifacts, focused fix prompts, dirty-state classification, and arbiter checklists |
 | **Execution resilience** | Interrupted merge recovery (`merge --resume`), crash recovery (`implement --recover`), stale-claim diagnostics, sparse-checkout repair, and stricter release validation |
-| **Multi-agent support** | 15 AI integrations: 13 project-local slash/prompt surfaces plus Codex CLI and Mistral Vibe via shared Agent Skills |
+| **Multi-agent support** | 15 AI integrations: 13 user-global slash/prompt surfaces plus Codex CLI and Mistral Vibe via shared Agent Skills |
 
 <p align="center">
     <a href="#-getting-started-complete-workflow">Quick Start</a> •
@@ -116,7 +116,7 @@ graph LR
 - **Charter synthesis is harness-owned and inspectable** — generated-artifact adapters, `charter status --provenance`, `charter resynthesize --list-topics`, bundle validation, and stronger neutrality rules make synthesis auditable
 - **Compatibility and release governance are stricter** — `doctor shim-registry`, mutation-testing guidance, shared-package drift checks, SBOM-attached prereleases, and safer publish validation harden upgrades and releases
 - **Review and runtime recovery keep improving** — sparse-checkout defenses, offline/auth refresh fixes, provider-aware tracker readiness, action-routing hardening, and post-merge fixes to the profile-invocation flow reduce recovery work
-- **15 AI integrations are supported** — 13 project-local slash/prompt surfaces plus Codex CLI and Mistral Vibe via shared Agent Skills, with Kiro fully documented and legacy `q` retained for compatibility
+- **15 AI integrations are supported** — 13 user-global slash/prompt surfaces plus Codex CLI and Mistral Vibe via shared Agent Skills, with Kiro fully documented and legacy `q` retained for compatibility
 
 **Jump to:**
 [Getting Started](#-getting-started-complete-workflow) •
@@ -305,7 +305,7 @@ spec-kitty dashboard  # Opens http://localhost:3000-5000
 ```
 
 **What just happened:**
-- ✅ Created project-local command or prompt files for the selected integrations, or shared Agent Skills under `.agents/skills/` for Codex / Vibe
+- ✅ Registered selected integrations; slash/prompt commands are installed globally, while Codex / Vibe use shared Agent Skills under `.agents/skills/`
 - ✅ Created `.kittify/` with templates, scripts, and mission scaffolding
 - ✅ Prepared the project for verification, mission creation, and on-demand dashboard use
 - ✅ Wrote project files only — `spec-kitty init` does not initialize Git for you
@@ -748,7 +748,7 @@ Browse our [examples directory](https://github.com/Priivacy-ai/spec-kitty/tree/m
 
 ## 🤖 Supported AI Tools
 
-Spec Kitty integrates with 15 AI tools. Thirteen tools receive project-local **slash commands or prompt files** written to an agent-specific directory (for example `.claude/commands/` or `.kiro/prompts/`). Two tools — Codex CLI and Mistral Vibe — use the **Agent Skills** pipeline: Spec Kitty installs shared skills under `.agents/skills/spec-kitty.<command>/`, and Vibe also registers that shared root through project-local `.vibe/config.toml` `skill_paths`.
+Spec Kitty integrates with 15 AI tools. Thirteen tools receive user-global **slash commands or prompt files** written to an agent-specific directory (for example `~/.claude/commands/` or `~/.kiro/prompts/`). Two tools — Codex CLI and Mistral Vibe — use the **Agent Skills** pipeline: Spec Kitty installs shared skills under `.agents/skills/spec-kitty.<command>/`, and Vibe also registers that shared root through project-local `.vibe/config.toml` `skill_paths`.
 
 | Tool                                                      | Support | Notes                                             |
 |-----------------------------------------------------------|---------|---------------------------------------------------|

--- a/docs/how-to/manage-agents.md
+++ b/docs/how-to/manage-agents.md
@@ -8,7 +8,7 @@ Spec-kitty supports 12 AI agents, including Claude Code, GitHub Codex, Google Ge
 
 This guide applies after you've run `spec-kitty init` and want to change which agents are active in your project. For initial setup, see the [Getting Started](../tutorials/getting-started.md) guide.
 
-Agent configuration is managed through `.kittify/config.yaml` and the `spec-kitty agent config` command family. The config file acts as the single source of truth - agent directories on your filesystem are derived from this configuration. This ensures migrations respect your agent selections and prevents unwanted directory recreation.
+Agent configuration is managed through `.kittify/config.yaml` and the `spec-kitty agent config` command family. The config file acts as the single source of truth for which agents are active in the project. Slash-command agents use user-global command roots such as `~/.opencode/command/`; Codex and Vibe use project-local command skills under `.agents/skills/`.
 
 This guide shows you how to add agents to enable multi-agent workflows, remove agents you don't use, list configured agents, check sync status, and synchronize your filesystem with the config file.
 
@@ -47,7 +47,7 @@ Before using agent config commands, ensure:
 
 `.kittify/config.yaml` is the single source of truth for agent configuration. All agent management commands read from and write to this file, and the filesystem is automatically synchronized to match it.
 
-This means agent directories on your filesystem (like `.claude/commands/` or `.codex/prompts/`) are derived from the config file. When you add an agent using `spec-kitty agent config add`, the command creates the directory and updates the config. When you remove an agent, the directory is deleted and the config is updated.
+This means the config records active agents, while the command surface depends on the agent class. For slash-command agents such as Claude, Gemini, OpenCode, and Kiro, commands are installed globally at CLI startup. When you add one of these agents using `spec-kitty agent config add`, the command updates the config and points at the global command root. For Codex and Vibe, Spec Kitty writes project-local command skills under `.agents/skills/`.
 
 Do not manually edit agent directories or config.yaml directly - use the `spec-kitty agent config` commands instead. This ensures consistency and prevents sync issues.
 
@@ -63,14 +63,14 @@ agents:
     - opencode
 ```
 
-The `available` field contains a list of active agent keys. Each key corresponds to a specific directory:
-- `claude` → `.claude/commands/`
-- `codex` → `.codex/prompts/`
-- `opencode` → `.opencode/command/`
+The `available` field contains a list of active agent keys. Each key corresponds to a managed command surface:
+- `claude` → `~/.claude/commands/` (global)
+- `codex` → `.agents/skills/spec-kitty.<command>/` (project-local Agent Skills)
+- `opencode` → `~/.opencode/command/` (global)
 
-When you run `spec-kitty agent config add` or `remove`, this list is automatically updated. Each configured agent has a directory containing slash command templates (like `spec-kitty.specify.md`, `spec-kitty.plan.md`, etc.).
+When you run `spec-kitty agent config add` or `remove`, this list is automatically updated. Global slash-command files are refreshed by normal CLI startup; Codex and Vibe command skills are managed inside the project.
 
-Agent directories are created and removed automatically by CLI commands. You should never need to manually create or delete these directories.
+Managed command surfaces are created and refreshed by CLI commands. You should never need to manually create or delete them.
 
 > **Why This Matters**: In spec-kitty 0.11.x and earlier, users could manually delete agent directories, but migrations would recreate them. Starting in 0.12.0, migrations respect `config.yaml` - if an agent is not listed in `available`, its directory stays deleted. See [Upgrading to 0.12.0](install-and-upgrade.md) for details.
 
@@ -89,8 +89,8 @@ spec-kitty agent config list
 The output shows two sections: configured agents and available agents you can add.
 
 Configured agents display a status indicator:
-- ✓ = Agent directory exists on filesystem
-- ⚠ = Configured in config.yaml but directory is missing (rare, indicates sync issue)
+- ✓ = Managed command surface exists
+- ⚠ = Configured in config.yaml but the managed command surface is missing
 
 Available agents show which agents you can add to your project.
 
@@ -98,8 +98,8 @@ Example output:
 
 ```
 Configured agents:
-  ✓ opencode (.opencode/command/)
-  ✓ claude (.claude/commands/)
+  ✓ opencode (~/.opencode/command/ (global))
+  ✓ claude (~/.claude/commands/ (global))
 
 Available but not configured:
   - codex
@@ -116,10 +116,10 @@ Available but not configured:
 
 Use `list` to:
 - See which agents are active in your project
-- Check if configured agents have directories on filesystem
+- Check if configured agents have their managed command surfaces
 - Discover available agents you can add
 
-**Troubleshooting**: If you see ⚠ next to a configured agent, the directory is missing from filesystem. Run `spec-kitty agent config sync --create-missing` to restore it.
+**Troubleshooting**: If you see ⚠ next to a configured slash-command agent, run any `spec-kitty` command to refresh global commands. For Codex or Vibe, run `spec-kitty agent config add <agent>` again or `spec-kitty upgrade`.
 
 ## Adding Agents
 
@@ -142,16 +142,16 @@ spec-kitty agent config add codex gemini cursor
 ```
 
 When you add an agent, spec-kitty:
-1. Creates the agent directory (e.g., `.claude/commands/`)
-2. Copies slash command templates to the directory
+1. Registers slash-command agents against their global command root
+2. Installs project-local command skills for Codex and Vibe
 3. Adds the agent key to `.kittify/config.yaml` under `agents.available`
 4. Displays success message for each agent added
 
 Example output:
 
 ```
-✓ Added .claude/commands/
-✓ Added .codex/prompts/
+✓ Registered claude (global commands at ~/.claude/commands/)
+✓ Registered codex (11 command skills in .agents/skills/)
 Updated .kittify/config.yaml
 ```
 
@@ -304,18 +304,11 @@ Example output:
 ```
 Agent Key  Directory                Configured  Exists  Status
 ──────────────────────────────────────────────────────────────────
-claude     .claude/commands/        ✓           ✓       OK
-codex      .codex/prompts/          ✗           ✓       Orphaned
-gemini     .gemini/commands/        ✓           ✗       Missing
-cursor     .cursor/commands/        ✗           ✗       Not used
-qwen       .qwen/commands/          ✗           ✗       Not used
-opencode   .opencode/command/       ✓           ✓       OK
-windsurf   .windsurf/workflows/     ✗           ✗       Not used
-kilocode   .kilocode/workflows/     ✗           ✗       Not used
-roo        .roo/commands/           ✗           ✗       Not used
-copilot    .github/prompts/         ✗           ✗       Not used
-auggie     .augment/commands/       ✗           ✗       Not used
-q          .amazonq/prompts/        ✗           ✗       Not used
+claude     ~/.claude/commands/ (global)      ✓  ✓  OK
+codex      .agents/skills/ (project skills)  ✗  ✓  Orphaned
+gemini     ~/.gemini/commands/ (global)      ✓  ✗  Missing
+cursor     ~/.cursor/commands/ (global)      ✗  ✗  Not used
+opencode   ~/.opencode/command/ (global)     ✓  ✓  OK
 
 ⚠ Found 1 orphaned directory
 Run 'spec-kitty agent config sync --remove-orphaned' to clean up
@@ -336,10 +329,10 @@ Use `status` to:
 spec-kitty agent config sync --remove-orphaned
 ```
 
-**Missing directories** (yellow "Missing" status):
+**Missing managed surfaces** (yellow "Missing" status):
 
 ```bash
-# Restore missing configured agents
+# Re-check global command roots and restore supported project-local skill roots
 spec-kitty agent config sync --create-missing
 ```
 
@@ -365,23 +358,23 @@ spec-kitty agent config sync
 - Does NOT create missing directories
 - Reports actions taken or "No changes needed"
 
-### Create Missing Configured Agents
+### Check Missing Configured Agents
 
-To restore directories for configured agents that are missing from filesystem:
+To check configured agents whose managed command surface is missing:
 
 ```bash
 spec-kitty agent config sync --create-missing
 ```
 
 **What this does**:
-- Creates directories for agents in `config.yaml` but missing from filesystem
-- Copies slash command templates to each created directory
+- Reports global command roots for slash-command agents
+- Creates/restores supported project-local skill roots where applicable
 - Also removes orphaned directories (default behavior)
 
 **Example output**:
 
 ```
-✓ Created .claude/commands/
+✓ Global commands present for claude at ~/.claude/commands/
 ✓ Removed orphaned .gemini/
 ```
 
@@ -395,7 +388,7 @@ spec-kitty agent config sync --keep-orphaned
 
 **What this does**:
 - Does NOT remove orphaned directories
-- Still creates missing directories if `--create-missing` is used
+- Still checks missing managed surfaces if `--create-missing` is used
 
 **Use case**: You have agent directories not in config.yaml but want to keep them (rare).
 
@@ -417,7 +410,7 @@ To fully sync filesystem with config (create missing AND remove orphaned):
 spec-kitty agent config sync --create-missing --remove-orphaned
 ```
 
-This ensures filesystem exactly matches `config.yaml`.
+This removes orphaned project-local command directories and verifies configured managed surfaces.
 
 ### When Filesystem Matches Config
 
@@ -432,11 +425,11 @@ No changes needed - filesystem matches config
 **After manual directory deletion** (not recommended, but happens):
 
 ```bash
-# You manually deleted .gemini/ but forgot to update config.yaml
+# The global command root for gemini is missing
 spec-kitty agent config status
 # Shows "Missing" status for gemini
 
-# Option 1: Restore directory
+# Option 1: Re-run any spec-kitty command to refresh global commands, then check again
 spec-kitty agent config sync --create-missing
 
 # Option 2: Remove from config properly

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -689,7 +689,7 @@ Manage project AI agent configuration (add, remove, list agents).
 spec-kitty agent config [OPTIONS] COMMAND [ARGS]...
 ```
 
-**Description**: The `config` subcommand provides tools for managing which AI agents are active in your project. Agent configuration is stored in `.kittify/config.yaml` and controls which agent directories are present on the filesystem.
+**Description**: The `config` subcommand provides tools for managing which AI agents are active in your project. Agent configuration is stored in `.kittify/config.yaml`; slash-command agents use user-global command roots, while Codex and Vibe use project-local command skills under `.agents/skills/`.
 
 **Subcommands**:
 
@@ -727,8 +727,8 @@ Lists agents currently configured in your project (from `.kittify/config.yaml`) 
 
 Two sections:
 - **Configured agents**: Agents in `config.yaml` with status indicators:
-  - ✓ (green) - Directory exists
-  - ⚠ (yellow) - Configured but directory missing
+  - ✓ (green) - Managed command surface exists
+  - ⚠ (yellow) - Configured but managed command surface missing
 - **Available but not configured**: Agents you can add
 
 **Examples**:
@@ -741,8 +741,8 @@ spec-kitty agent config list
 Example output:
 ```
 Configured agents:
-  ✓ opencode (.opencode/command/)
-  ✓ claude (.claude/commands/)
+  ✓ opencode (~/.opencode/command/ (global))
+  ✓ claude (~/.claude/commands/ (global))
 
 Available but not configured:
   - codex
@@ -762,7 +762,7 @@ spec-kitty agent config add <agent1> [agent2] [agent3] ...
 
 **Description**:
 
-Adds specified agents to your project by creating agent directories, copying slash command templates, and updating `.kittify/config.yaml`.
+Adds specified agents to your project by registering slash-command agents against their global command roots, installing Codex/Vibe command skills where applicable, and updating `.kittify/config.yaml`.
 
 **Arguments**:
 
@@ -772,14 +772,14 @@ Adds specified agents to your project by creating agent directories, copying sla
 
 **Output**:
 
-- Success: `✓ Added <agent-dir>/<subdir>/` for each agent
+- Success: `✓ Registered <agent>` for slash-command agents or `✓ Registered <agent> (... command skills in .agents/skills/)` for skill-based agents
 - Already configured: `Already configured: <agent>` (informational, not an error)
 - Error: `Error: Invalid agent keys: <keys>` with list of valid keys
 
 **Side Effects**:
 
-- Creates agent directory (e.g., `.claude/commands/`)
-- Copies slash command templates from mission templates
+- Uses the global command root for slash-command agents (e.g., `~/.claude/commands/`)
+- Creates project-local command skills for Codex and Vibe
 - Adds agent key to `.kittify/config.yaml` under `agents.available`
 
 **Examples**:
@@ -796,9 +796,9 @@ spec-kitty agent config add codex gemini cursor
 
 Example output:
 ```
-✓ Added .codex/prompts/
-✓ Added .gemini/commands/
-✓ Added .cursor/commands/
+✓ Registered codex (11 command skills in .agents/skills/)
+✓ Registered gemini (global commands at ~/.gemini/commands/)
+✓ Registered cursor (global commands at ~/.cursor/commands/)
 Updated .kittify/config.yaml
 ```
 
@@ -906,9 +906,9 @@ Rich table with columns:
 - **Status**: Colored status indicator
 
 **Status values**:
-- `[green]OK[/green]`: Configured and directory exists (normal state)
-- `[yellow]Missing[/yellow]`: Configured but directory doesn't exist (needs sync)
-- `[red]Orphaned[/red]`: Directory exists but not configured (should be cleaned up)
+- `[green]OK[/green]`: Configured and managed command surface exists (normal state)
+- `[yellow]Missing[/yellow]`: Configured but managed command surface doesn't exist
+- `[red]Orphaned[/red]`: Project-local directory exists but is not configured (should be cleaned up)
 - `[dim]Not used[/dim]`: Neither configured nor present (available to add)
 
 **Actionable message**: If orphaned directories detected, shows: `"Run 'spec-kitty agent config sync --remove-orphaned' to clean up"`
@@ -924,11 +924,11 @@ Example output:
 ```
 Agent Key  Directory                Configured  Exists  Status
 ──────────────────────────────────────────────────────────────────
-claude     .claude/commands/        ✓           ✓       OK
-codex      .codex/prompts/          ✗           ✓       Orphaned
-gemini     .gemini/commands/        ✓           ✗       Missing
-cursor     .cursor/commands/        ✗           ✗       Not used
-qwen       .qwen/commands/          ✓           ✓       OK
+claude     ~/.claude/commands/ (global)      ✓  ✓  OK
+codex      .agents/skills/ (project skills)  ✗  ✓  Orphaned
+gemini     ~/.gemini/commands/ (global)      ✓  ✗  Missing
+cursor     ~/.cursor/commands/ (global)      ✗  ✗  Not used
+qwen       ~/.qwen/commands/ (global)        ✓  ✓  OK
 ...
 
 ⚠ Found 1 orphaned directory
@@ -946,26 +946,26 @@ spec-kitty agent config sync [OPTIONS]
 
 **Description**:
 
-Automatically aligns filesystem with `.kittify/config.yaml` by creating missing directories and/or removing orphaned directories.
+Automatically aligns filesystem with `.kittify/config.yaml` by checking configured managed command surfaces and/or removing orphaned project-local directories.
 
 **Arguments**: None
 
 **Options**:
 
-- `--create-missing`: Create directories for configured agents that are missing from filesystem (default: False)
+- `--create-missing`: Check configured managed command surfaces and restore supported project-local skill roots (default: False)
 - `--remove-orphaned` / `--keep-orphaned`: Remove orphaned directories (directories present but not configured). Default: `--remove-orphaned` (True)
 
 **Default behavior** (no flags): Removes orphaned directories only. Does NOT create missing directories.
 
 **Output**:
 
-- Creating: `✓ Created <agent-dir>/<subdir>/`
+- Present global commands: `✓ Global commands present for <agent> at <global-dir>/`
 - Removing: `✓ Removed orphaned <agent-dir>/`
 - No changes: `No changes needed - filesystem matches config`
 
 **Side Effects**:
 
-- Creates agent directories with slash command templates (if `--create-missing`)
+- Checks global command roots or creates supported project-local skill roots (if `--create-missing`)
 - Deletes orphaned agent directories (if `--remove-orphaned`, default)
 
 **Examples**:
@@ -992,7 +992,7 @@ spec-kitty agent config sync --keep-orphaned
 
 Example output:
 ```
-✓ Created .claude/commands/
+✓ Global commands present for claude at ~/.claude/commands/
 ✓ Removed orphaned .gemini/
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -270,24 +270,24 @@ VCS Backend: git
 
 ## Agent Configuration
 
-Spec Kitty supports 12 AI agents across different platforms. Agent configuration is stored in `.kittify/config.yaml` and can be managed via CLI commands.
+Spec Kitty supports AI agents across different platforms. Agent configuration is stored in `.kittify/config.yaml` and can be managed via CLI commands. Slash-command agents use user-global command roots; Codex and Vibe use project-local command skills under `.agents/skills/`.
 
 ### Supported Agents
 
-| Agent Key | Directory | Platform |
-|-----------|-----------|----------|
-| `claude` | `.claude/commands/` | Claude (Anthropic) |
-| `copilot` | `.github/prompts/` | GitHub Copilot |
-| `gemini` | `.gemini/commands/` | Google Gemini |
-| `cursor` | `.cursor/commands/` | Cursor AI |
-| `qwen` | `.qwen/commands/` | Qwen Code |
-| `opencode` | `.opencode/command/` | OpenCode |
-| `windsurf` | `.windsurf/workflows/` | Windsurf |
-| `codex` | `.codex/prompts/` | GitHub Codex |
-| `kilocode` | `.kilocode/workflows/` | Kilocode |
-| `auggie` | `.augment/commands/` | Augment Code |
-| `roo` | `.roo/commands/` | Roo Cline |
-| `q` | `.amazonq/prompts/` | Amazon Q |
+| Agent Key | Managed Surface | Platform |
+|-----------|-----------------|----------|
+| `claude` | `~/.claude/commands/` | Claude (Anthropic) |
+| `copilot` | `~/.github/prompts/` | GitHub Copilot |
+| `gemini` | `~/.gemini/commands/` | Google Gemini |
+| `cursor` | `~/.cursor/commands/` | Cursor AI |
+| `qwen` | `~/.qwen/commands/` | Qwen Code |
+| `opencode` | `~/.opencode/command/` | OpenCode |
+| `windsurf` | `~/.windsurf/workflows/` | Windsurf |
+| `codex` | `.agents/skills/spec-kitty.<command>/` | Codex CLI |
+| `kilocode` | `~/.kilocode/workflows/` | Kilocode |
+| `auggie` | `~/.augment/commands/` | Augment Code |
+| `roo` | `~/.roo/commands/` | Roo Cline |
+| `q` | `~/.amazonq/prompts/` | Amazon Q |
 
 ### Configuration File
 
@@ -309,7 +309,9 @@ agents:
 Starting in spec-kitty 0.12.0, agent configuration follows a config-driven model where `.kittify/config.yaml` is the single source of truth for which agents are active in your project.
 
 **Key principles**:
-- Agent directories on filesystem (e.g., `.claude/commands/`) are derived from `config.yaml`
+- Active agents are derived from `config.yaml`
+- Slash-command files are installed globally at CLI startup
+- Codex and Vibe command skills are project-local under `.agents/skills/`
 - Migrations respect `config.yaml` - only process configured agents
 - Use `spec-kitty agent config` commands to manage agents (not manual editing)
 
@@ -343,8 +345,8 @@ spec-kitty agent config list
 Output:
 ```
 Configured agents:
-  ✓ opencode (.opencode/command/)
-  ✓ claude (.claude/commands/)
+  ✓ opencode (~/.opencode/command/ (global))
+  ✓ claude (~/.claude/commands/ (global))
 
 Available but not configured:
   - codex, copilot, gemini, ...
@@ -357,8 +359,8 @@ spec-kitty agent config add claude codex
 ```
 
 This command:
-1. Creates agent directories (`.claude/commands/`, `.codex/prompts/`)
-2. Copies slash command templates from mission templates
+1. Registers slash-command agents against their global command roots
+2. Installs project-local command skills for Codex and Vibe
 3. Updates `config.yaml` to include new agents
 
 #### Remove Agents
@@ -381,8 +383,8 @@ spec-kitty agent config status
 ```
 
 Shows a table of all agents with their status:
-- **OK**: Configured and directory exists
-- **Missing**: Configured but directory doesn't exist
+- **OK**: Configured and managed command surface exists
+- **Missing**: Configured but managed command surface doesn't exist
 - **Orphaned**: Directory exists but not configured
 - **Not used**: Neither configured nor present
 
@@ -391,9 +393,9 @@ Example output:
 ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
 ┃ Agent Key ┃ Directory           ┃ Configured ┃ Exists ┃ Status   ┃
 ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
-│ opencode  │ .opencode/command   │     ✓      │   ✓    │ OK       │
-│ claude    │ .claude/commands    │     ✓      │   ✓    │ OK       │
-│ codex     │ .codex/prompts      │     ✗      │   ✓    │ Orphaned │
+│ opencode  │ ~/.opencode/command/ (global)     │ ✓ │ ✓ │ OK       │
+│ claude    │ ~/.claude/commands/ (global)      │ ✓ │ ✓ │ OK       │
+│ codex     │ .agents/skills/ (project skills)  │ ✗ │ ✓ │ Orphaned │
 └───────────┴─────────────────────┴────────────┴────────┴──────────┘
 
 ⚠ 1 orphaned directory found (present but not configured)
@@ -407,7 +409,7 @@ spec-kitty agent config sync
 
 Synchronizes filesystem with `config.yaml`:
 - By default, removes orphaned directories (present but not configured)
-- Use `--create-missing` to create directories for configured agents
+- Use `--create-missing` to check configured managed surfaces and restore supported project-local skill roots
 - Use `--keep-orphaned` to keep orphaned directories
 
 **Examples:**

--- a/docs/reference/supported-agents.md
+++ b/docs/reference/supported-agents.md
@@ -1,28 +1,28 @@
 # Supported AI Agents Reference
 
-Spec Kitty currently exposes **13 slash-command agent surfaces**. This page documents the agents that get project command directories such as `.claude/commands/` or `.codex/prompts/`.
+Spec Kitty currently exposes **13 slash-command agent surfaces**. This page documents the agents that get user-global command directories such as `~/.claude/commands/` or `~/.opencode/command/`.
 
-Related assistant integrations such as `vibe` use shared skill roots rather than project slash-command directories, so they are intentionally out of scope for this specific table.
+Related assistant integrations such as Codex CLI and Vibe use shared skill roots rather than slash-command directories, so they are intentionally out of scope for this specific table.
 
 ---
 
 ## Agent Overview
 
-| Agent | Directory | Commands Subdirectory | Slash Commands |
-|-------|-----------|----------------------|----------------|
-| Claude Code | `.claude/` | `commands/` | `/spec-kitty.*` |
-| GitHub Copilot | `.github/` | `prompts/` | `/spec-kitty.*` |
-| Google Gemini | `.gemini/` | `commands/` | `/spec-kitty.*` |
-| Cursor | `.cursor/` | `commands/` | `/spec-kitty.*` |
-| Qwen Code | `.qwen/` | `commands/` | `/spec-kitty.*` |
-| OpenCode | `.opencode/` | `command/` | `/spec-kitty.*` |
-| Windsurf | `.windsurf/` | `workflows/` | `/spec-kitty.*` |
-| GitHub Codex | `.codex/` | `prompts/` | `/spec-kitty.*` |
-| Kilocode | `.kilocode/` | `workflows/` | `/spec-kitty.*` |
-| Augment Code | `.augment/` | `commands/` | `/spec-kitty.*` |
-| Roo Cline | `.roo/` | `commands/` | `/spec-kitty.*` |
-| Amazon Q (legacy) | `.amazonq/` | `prompts/` | `/spec-kitty.*` |
-| Kiro | `.kiro/` | `prompts/` | `/spec-kitty.*` |
+| Agent | Global Directory | Commands Subdirectory | Slash Commands |
+|-------|------------------|----------------------|----------------|
+| Claude Code | `~/.claude/` | `commands/` | `/spec-kitty.*` |
+| GitHub Copilot | `~/.github/` | `prompts/` | `/spec-kitty.*` |
+| Google Gemini | `~/.gemini/` | `commands/` | `/spec-kitty.*` |
+| Cursor | `~/.cursor/` | `commands/` | `/spec-kitty.*` |
+| Qwen Code | `~/.qwen/` | `commands/` | `/spec-kitty.*` |
+| OpenCode | `~/.opencode/` | `command/` | `/spec-kitty.*` |
+| Windsurf | `~/.windsurf/` | `workflows/` | `/spec-kitty.*` |
+| Google Antigravity | `~/.agent/` | `workflows/` | `/spec-kitty.*` |
+| Kilocode | `~/.kilocode/` | `workflows/` | `/spec-kitty.*` |
+| Augment Code | `~/.augment/` | `commands/` | `/spec-kitty.*` |
+| Roo Cline | `~/.roo/` | `commands/` | `/spec-kitty.*` |
+| Amazon Q (legacy) | `~/.amazonq/` | `prompts/` | `/spec-kitty.*` |
+| Kiro | `~/.kiro/` | `prompts/` | `/spec-kitty.*` |
 
 ---
 
@@ -296,7 +296,7 @@ spec-kitty init my-project --ai claude,codex
 spec-kitty init my-project --ai claude,copilot,gemini,cursor,qwen,opencode,windsurf,codex,kilocode,augment,roo,q
 ```
 
-This creates command directories for all specified agents, allowing team members to use their preferred tool.
+This registers all specified agents, allowing team members to use their preferred tool. Slash-command files are installed in user-global agent roots at CLI startup.
 
 ---
 
@@ -305,17 +305,11 @@ This creates command directories for all specified agents, allowing team members
 To add agent support to an existing project:
 
 ```bash
-# Upgrade regenerates all agent directories
+# Upgrade refreshes global command files and project-local skill packages
 spec-kitty upgrade
 ```
 
-Or manually create the directory structure:
-
-```bash
-mkdir -p .cursor/commands
-# Copy command files from another agent
-cp .claude/commands/*.md .cursor/commands/
-```
+For project configuration, use `spec-kitty agent config add <agent>` rather than manually copying command files.
 
 ---
 
@@ -360,9 +354,9 @@ See [Slash Commands](slash-commands.md) for complete documentation.
 
 ### Slash commands not appearing
 
-1. Verify the agent directory exists:
+1. Verify the global agent directory exists:
    ```bash
-   ls -la .claude/commands/
+   ls -la ~/.claude/commands/
    ```
 
 2. Regenerate commands:

--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import List
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
+from specify_cli.core.config import AGENT_COMMAND_CONFIG
 from specify_cli.core.agent_config import (
     load_agent_config,
     save_agent_config,
     AgentConfig,
     AgentConfigError,
 )
+from specify_cli.runtime.agent_commands import get_global_command_dir
 from specify_cli.upgrade.migrations.m_0_9_1_complete_lane_migration import (
     AGENT_DIR_TO_KEY,
     CompleteLaneMigration,
@@ -35,6 +36,82 @@ KEY_TO_AGENT_DIR = {
     for agent_dir, subdir in CompleteLaneMigration.AGENT_DIRS
     if agent_dir in AGENT_DIR_TO_KEY
 }
+SKILL_ONLY_AGENTS = {"codex", "vibe"}
+GLOBAL_COMMAND_AGENTS = frozenset(AGENT_COMMAND_CONFIG)
+VALID_AGENTS = set(AGENT_DIR_TO_KEY.values()) | SKILL_ONLY_AGENTS
+
+
+def _display_path(path: Path) -> str:
+    """Render paths compactly for CLI output."""
+    try:
+        rel = path.relative_to(Path.home())
+        label = f"~/{rel.as_posix()}"
+    except ValueError:
+        label = path.as_posix()
+    return label.rstrip("/") + "/"
+
+
+def _agent_location(repo_root: Path, agent_key: str) -> tuple[Path | None, str, bool]:
+    """Return the managed command/skill location for an agent."""
+    if agent_key in GLOBAL_COMMAND_AGENTS:
+        path = get_global_command_dir(agent_key)
+        return path, f"{_display_path(path)} (global)", path.exists()
+
+    if agent_key in SKILL_ONLY_AGENTS:
+        path = repo_root / ".agents" / "skills"
+        return path, ".agents/skills/ (project skills)", path.exists()
+
+    agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
+    if agent_dir_info:
+        agent_dir, subdir = agent_dir_info
+        path = repo_root / agent_dir / subdir
+        return path, f"{agent_dir}/{subdir}/", path.exists()
+
+    return None, "unknown agent", False
+
+
+def _project_agent_root(repo_root: Path, agent_key: str) -> Path | None:
+    """Return the legacy project-local root for command-layer agents."""
+    agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
+    if agent_dir_info is None:
+        return None
+    agent_root, _ = agent_dir_info
+    return repo_root / agent_root
+
+
+def _project_agent_surface(repo_root: Path, agent_key: str) -> tuple[Path, Path, str] | None:
+    """Return root, managed surface, and display label for a project agent."""
+    agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
+    if agent_dir_info is None:
+        return None
+    agent_root, subdir = agent_dir_info
+    root = repo_root / agent_root
+    return root, root / subdir, f"{agent_root}/{subdir}/"
+
+
+def _remove_project_agent_surface(repo_root: Path, agent_key: str) -> tuple[bool, str]:
+    """Remove only the managed command surface for an agent."""
+    paths = _project_agent_surface(repo_root, agent_key)
+    if paths is None:
+        return False, f"Unknown agent: {agent_key}"
+
+    root, surface, label = paths
+    if not surface.exists():
+        return False, f"{label} already removed"
+
+    try:
+        if surface.is_dir():
+            shutil.rmtree(surface)
+        else:
+            surface.unlink()
+
+        try:
+            root.rmdir()
+            return True, f"Removed {root.name}/"
+        except OSError:
+            return True, f"Removed {label}"
+    except OSError as exc:
+        return False, f"Failed to remove {label}: {exc}"
 
 
 def _load_config_or_exit(repo_root: Path) -> AgentConfig:
@@ -43,6 +120,130 @@ def _load_config_or_exit(repo_root: Path) -> AgentConfig:
     except AgentConfigError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1)
+
+
+def _register_skill_agent(repo_root: Path, config: AgentConfig, agent_key: str) -> tuple[bool, str | None]:
+    """Install command skills for Codex/Vibe and update config."""
+    from specify_cli.skills import command_installer  # noqa: PLC0415
+    from specify_cli.skills.vibe_config import ensure_project_skill_path  # noqa: PLC0415
+
+    try:
+        report = command_installer.install(repo_root, agent_key)
+        if agent_key == "vibe":
+            ensure_project_skill_path(repo_root)
+        installed = len(report.added) + len(report.reused_shared)
+        config.available.append(agent_key)
+        console.print(
+            f"[green]✓[/green] Registered {agent_key} "
+            f"({installed} command skills in .agents/skills/)"
+        )
+        return True, None
+    except Exception as exc:
+        return False, f"Failed to install {agent_key} skills: {exc}"
+
+
+def _register_global_command_agent(config: AgentConfig, agent_key: str) -> None:
+    """Register a slash-command agent whose command files are global."""
+    global_dir = get_global_command_dir(agent_key)
+    config.available.append(agent_key)
+    console.print(
+        f"[green]✓[/green] Registered {agent_key} "
+        f"(global commands at {_display_path(global_dir)})"
+    )
+
+
+def _create_project_agent_dir(repo_root: Path, config: AgentConfig, agent_key: str) -> tuple[bool, str | None]:
+    """Fallback for legacy project-local command agents."""
+    agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
+    if not agent_dir_info:
+        return False, f"Unknown agent: {agent_key}"
+
+    agent_root, subdir = agent_dir_info
+    agent_dir = repo_root / agent_root / subdir
+
+    try:
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        missions_dir = repo_root / ".kittify" / "missions" / "software-dev" / "command-templates"
+
+        if missions_dir.exists():
+            for template_file in missions_dir.glob("*.md"):
+                dest_file = agent_dir / f"spec-kitty.{template_file.name}"
+                shutil.copy2(template_file, dest_file)
+
+        config.available.append(agent_key)
+        console.print(f"[green]✓[/green] Added {agent_root}/{subdir}/")
+        return True, None
+    except OSError as exc:
+        return False, f"Failed to create {agent_root}/{subdir}/: {exc}"
+
+
+def _remove_orphaned_agent_dirs(repo_root: Path, config: AgentConfig) -> bool:
+    """Remove project-local command dirs for agents not in config."""
+    console.print("[cyan]Checking for orphaned directories...[/cyan]")
+    changes_made = False
+    all_agent_keys = set(AGENT_DIR_TO_KEY.values())
+    orphaned = [
+        key
+        for key in all_agent_keys
+        if key not in config.available
+        and (surface := _project_agent_surface(repo_root, key)) is not None
+        and surface[1].exists()
+    ]
+
+    for agent_key in orphaned:
+        removed, message = _remove_project_agent_surface(repo_root, agent_key)
+        if removed:
+            removed_label = message.removeprefix("Removed ")
+            console.print(f"  [green]✓[/green] Removed orphaned {removed_label}")
+            changes_made = True
+        else:
+            console.print(f"  [red]✗[/red] {message}")
+
+    return changes_made
+
+
+def _check_or_create_configured_agent_dirs(repo_root: Path, config: AgentConfig) -> bool:
+    """Check configured managed surfaces and create legacy local dirs if needed."""
+    console.print("\n[cyan]Checking for missing directories...[/cyan]")
+    changes_made = False
+    missions_dir = repo_root / ".kittify" / "missions" / "software-dev" / "command-templates"
+
+    for agent_key in config.available:
+        if agent_key in GLOBAL_COMMAND_AGENTS:
+            global_dir = get_global_command_dir(agent_key)
+            if global_dir.exists():
+                console.print(
+                    f"  [green]✓[/green] Global commands present for {agent_key} at {_display_path(global_dir)}"
+                )
+            else:
+                console.print(
+                    f"  [yellow]⚠[/yellow] Global commands missing for {agent_key} at {_display_path(global_dir)}"
+                )
+            continue
+
+        agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
+        if not agent_dir_info:
+            console.print(f"  [yellow]⚠[/yellow] Unknown agent: {agent_key}")
+            continue
+
+        agent_root, subdir = agent_dir_info
+        agent_dir = repo_root / agent_root / subdir
+        if agent_dir.exists():
+            continue
+
+        try:
+            agent_dir.mkdir(parents=True, exist_ok=True)
+            if missions_dir.exists():
+                for template_file in missions_dir.glob("*.md"):
+                    dest_file = agent_dir / f"spec-kitty.{template_file.name}"
+                    shutil.copy2(template_file, dest_file)
+
+            console.print(f"  [green]✓[/green] Created {agent_root}/{subdir}/")
+            changes_made = True
+        except OSError as exc:
+            console.print(f"  [red]✗[/red] Failed to create {agent_root}/{subdir}/: {exc}")
+
+    return changes_made
 
 
 @app.command(name="list")
@@ -65,14 +266,9 @@ def list_agents():
     # Display configured agents
     console.print("[cyan]Configured agents:[/cyan]")
     for agent_key in config.available:
-        agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
-        if agent_dir_info:
-            agent_dir, subdir = agent_dir_info
-            agent_path = repo_root / agent_dir / subdir
-            status = "✓" if agent_path.exists() else "⚠"
-            console.print(f"  {status} {agent_key} ({agent_dir}/{subdir}/)")
-        else:
-            console.print(f"  ✗ {agent_key} (unknown agent)")
+        _, location, exists = _agent_location(repo_root, agent_key)
+        status = "✓" if exists else "⚠"
+        console.print(f"  {status} {agent_key} ({location})")
 
     # Show auto-commit setting
     auto_commit_label = "[green]enabled[/green]" if config.auto_commit else "[yellow]disabled[/yellow]"
@@ -82,7 +278,7 @@ def list_agents():
         console.print("[dim]  Override per-command with --auto-commit flag.[/dim]")
 
     # Show available but not configured
-    all_agent_keys = set(AGENT_DIR_TO_KEY.values())
+    all_agent_keys = VALID_AGENTS
     not_configured = all_agent_keys - set(config.available)
 
     if not_configured:
@@ -113,12 +309,10 @@ def add_agents(
 
     # Validate agent keys — command-layer agents come from AGENT_DIR_TO_KEY;
     # skill-only agents (codex, vibe) have their own installer path.
-    _SKILL_ONLY_AGENTS = {"codex", "vibe"}
-    _valid_agents = set(AGENT_DIR_TO_KEY.values()) | _SKILL_ONLY_AGENTS
-    invalid = [a for a in agents if a not in _valid_agents]
+    invalid = [a for a in agents if a not in VALID_AGENTS]
     if invalid:
         console.print(f"[red]Error:[/red] Invalid agent keys: {', '.join(invalid)}")
-        console.print(f"\nValid agents: {', '.join(sorted(_valid_agents))}")
+        console.print(f"\nValid agents: {', '.join(sorted(VALID_AGENTS))}")
         raise typer.Exit(1)
 
     added = []
@@ -131,55 +325,24 @@ def add_agents(
             already_configured.append(agent_key)
             continue
 
-        if agent_key in _SKILL_ONLY_AGENTS:
-            # Skill-only agents (codex, vibe) receive Spec Kitty's slash commands
-            # as Agent Skills packages rendered into .agents/skills/.
-            from specify_cli.skills import command_installer  # noqa: PLC0415
-            from specify_cli.skills.vibe_config import ensure_project_skill_path  # noqa: PLC0415
-
-            try:
-                report = command_installer.install(repo_root, agent_key)
-                if agent_key == "vibe":
-                    ensure_project_skill_path(repo_root)
-                installed = len(report.added) + len(report.reused_shared)
+        if agent_key in SKILL_ONLY_AGENTS:
+            ok, error = _register_skill_agent(repo_root, config, agent_key)
+            if ok:
                 added.append(agent_key)
-                config.available.append(agent_key)
-                console.print(
-                    f"[green]✓[/green] Registered {agent_key} "
-                    f"({installed} command skills in .agents/skills/)"
-                )
-            except Exception as exc:
-                errors.append(f"Failed to install {agent_key} skills: {exc}")
+            elif error:
+                errors.append(error)
             continue
 
-        # Get directory for this agent
-        agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
-        if not agent_dir_info:
-            errors.append(f"Unknown agent: {agent_key}")
-            continue
-
-        agent_root, subdir = agent_dir_info
-        agent_dir = repo_root / agent_root / subdir
-
-        # Create directory structure
-        try:
-            agent_dir.mkdir(parents=True, exist_ok=True)
-
-            # Generate templates for this agent
-            # Copy from mission templates
-            missions_dir = repo_root / ".kittify" / "missions" / "software-dev" / "command-templates"
-
-            if missions_dir.exists():
-                for template_file in missions_dir.glob("*.md"):
-                    dest_file = agent_dir / f"spec-kitty.{template_file.name}"
-                    shutil.copy2(template_file, dest_file)
-
+        if agent_key in GLOBAL_COMMAND_AGENTS:
+            _register_global_command_agent(config, agent_key)
             added.append(agent_key)
-            config.available.append(agent_key)
-            console.print(f"[green]✓[/green] Added {agent_root}/{subdir}/")
+            continue
 
-        except OSError as e:
-            errors.append(f"Failed to create {agent_root}/{subdir}/: {e}")
+        ok, error = _create_project_agent_dir(repo_root, config, agent_key)
+        if ok:
+            added.append(agent_key)
+        elif error:
+            errors.append(error)
 
     # Save updated config
     if added:
@@ -223,15 +386,14 @@ def remove_agents(
 
     # Validate agent keys — command-layer agents come from AGENT_DIR_TO_KEY;
     # skill-only agents (codex, vibe) have their own installer path.
-    _SKILL_ONLY_AGENTS = {"codex", "vibe"}
-    _valid_agents = set(AGENT_DIR_TO_KEY.values()) | _SKILL_ONLY_AGENTS
-    invalid = [a for a in agents if a not in _valid_agents]
+    invalid = [a for a in agents if a not in VALID_AGENTS]
     if invalid:
         console.print(f"[red]Error:[/red] Invalid agent keys: {', '.join(invalid)}")
-        console.print(f"\nValid agents: {', '.join(sorted(_valid_agents))}")
+        console.print(f"\nValid agents: {', '.join(sorted(VALID_AGENTS))}")
         raise typer.Exit(1)
 
     removed = []
+    removed_from_config = []
     errors = []
 
     for agent_key in agents:
@@ -246,36 +408,25 @@ def remove_agents(
             # Update config (unless --keep-config)
             if not keep_config and agent_key in config.available:
                 config.available.remove(agent_key)
+                removed_from_config.append(agent_key)
             continue
 
-        # Get directory for this agent
-        agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
-        if not agent_dir_info:
-            errors.append(f"Unknown agent: {agent_key}")
-            continue
-
-        agent_root, subdir = agent_dir_info
-
-        # Delete directory
-        agent_path = repo_root / agent_root
-        if agent_path.exists():
-            try:
-                shutil.rmtree(agent_path)
-                removed.append(agent_key)
-                console.print(f"[green]✓[/green] Removed {agent_root}/")
-            except OSError as e:
-                errors.append(f"Failed to remove {agent_root}/: {e}")
+        surface_removed, message = _remove_project_agent_surface(repo_root, agent_key)
+        if surface_removed:
+            removed.append(agent_key)
+            console.print(f"[green]✓[/green] {message}")
         else:
-            console.print(f"[dim]• {agent_root}/ already removed[/dim]")
+            console.print(f"[dim]• {message}[/dim]")
 
         # Update config (unless --keep-config)
         if not keep_config and agent_key in config.available:
             config.available.remove(agent_key)
+            removed_from_config.append(agent_key)
 
     # Save updated config
-    if not keep_config and (removed or any(a in config.available for a in agents)):
+    if not keep_config and removed_from_config:
         save_agent_config(repo_root, config)
-        console.print(f"\n[cyan]Updated config.yaml:[/cyan] removed {', '.join(removed)}")
+        console.print(f"\n[cyan]Updated config.yaml:[/cyan] removed {', '.join(removed_from_config)}")
 
     if errors:
         console.print("\n[yellow]Warnings:[/yellow]")
@@ -309,29 +460,27 @@ def agent_status():
     table.add_column("Exists", justify="center")
     table.add_column("Status")
 
-    all_agent_keys = sorted(AGENT_DIR_TO_KEY.values())
+    all_agent_keys = sorted(VALID_AGENTS)
 
     for agent_key in all_agent_keys:
-        agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
-        if not agent_dir_info:
-            continue
-
-        agent_root, subdir = agent_dir_info
-        agent_path = repo_root / agent_root / subdir
-
+        _, location, exists_bool = _agent_location(repo_root, agent_key)
         configured = "✓" if agent_key in config.available else "✗"
-        exists = "✓" if agent_path.exists() else "✗"
+        exists = "✓" if exists_bool else "✗"
 
-        if agent_key in config.available and agent_path.exists():
+        if agent_key in config.available and exists_bool:
             status = "[green]OK[/green]"
-        elif agent_key in config.available and not agent_path.exists():
+        elif agent_key in config.available and not exists_bool:
             status = "[yellow]Missing[/yellow]"
-        elif agent_key not in config.available and agent_path.exists():
+        elif (
+            agent_key not in config.available
+            and (surface := _project_agent_surface(repo_root, agent_key)) is not None
+            and surface[1].exists()
+        ):
             status = "[red]Orphaned[/red]"
         else:
             status = "[dim]Not used[/dim]"
 
-        table.add_row(agent_key, f"{agent_root}/{subdir}", configured, exists, status)
+        table.add_row(agent_key, location, configured, exists, status)
 
     console.print(table)
 
@@ -339,7 +488,9 @@ def agent_status():
     orphaned = [
         key
         for key in all_agent_keys
-        if key not in config.available and (repo_root / KEY_TO_AGENT_DIR[key][0]).exists()
+        if key not in config.available
+        and (surface := _project_agent_surface(repo_root, key)) is not None
+        and surface[1].exists()
     ]
 
     if orphaned:
@@ -381,53 +532,11 @@ def sync_agents(
 
     # Remove orphaned directories
     if remove_orphaned:
-        console.print("[cyan]Checking for orphaned directories...[/cyan]")
-        all_agent_keys = set(AGENT_DIR_TO_KEY.values())
-        orphaned = [
-            key
-            for key in all_agent_keys
-            if key not in config.available and (repo_root / KEY_TO_AGENT_DIR[key][0]).exists()
-        ]
-
-        for agent_key in orphaned:
-            agent_root, _ = KEY_TO_AGENT_DIR[agent_key]
-            agent_path = repo_root / agent_root
-
-            try:
-                shutil.rmtree(agent_path)
-                console.print(f"  [green]✓[/green] Removed orphaned {agent_root}/")
-                changes_made = True
-            except OSError as e:
-                console.print(f"  [red]✗[/red] Failed to remove {agent_root}/: {e}")
+        changes_made = _remove_orphaned_agent_dirs(repo_root, config) or changes_made
 
     # Create missing directories
     if create_missing:
-        console.print("\n[cyan]Checking for missing directories...[/cyan]")
-        missions_dir = repo_root / ".kittify" / "missions" / "software-dev" / "command-templates"
-
-        for agent_key in config.available:
-            agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
-            if not agent_dir_info:
-                console.print(f"  [yellow]⚠[/yellow] Unknown agent: {agent_key}")
-                continue
-
-            agent_root, subdir = agent_dir_info
-            agent_dir = repo_root / agent_root / subdir
-
-            if not agent_dir.exists():
-                try:
-                    agent_dir.mkdir(parents=True, exist_ok=True)
-
-                    # Copy templates if available
-                    if missions_dir.exists():
-                        for template_file in missions_dir.glob("*.md"):
-                            dest_file = agent_dir / f"spec-kitty.{template_file.name}"
-                            shutil.copy2(template_file, dest_file)
-
-                    console.print(f"  [green]✓[/green] Created {agent_root}/{subdir}/")
-                    changes_made = True
-                except OSError as e:
-                    console.print(f"  [red]✗[/red] Failed to create {agent_root}/{subdir}/: {e}")
+        changes_made = _check_or_create_configured_agent_dirs(repo_root, config) or changes_made
 
     if not changes_made:
         console.print("[dim]No changes needed - filesystem matches config[/dim]")

--- a/tests/agent/cli/commands/test_agent_config.py
+++ b/tests/agent/cli/commands/test_agent_config.py
@@ -8,11 +8,28 @@ import pytest
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.agent.config import app
+from specify_cli.core.config import AGENT_COMMAND_CONFIG
 from specify_cli.core.agent_config import save_agent_config
 
 pytestmark = pytest.mark.fast
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def fake_global_command_dirs(tmp_path, monkeypatch):
+    """Keep global command checks isolated from the developer's home directory."""
+    global_root = tmp_path / "global-home"
+
+    def _fake_global_command_dir(agent_key: str):
+        return global_root / AGENT_COMMAND_CONFIG[agent_key]["dir"]
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.agent.config.get_global_command_dir",
+        _fake_global_command_dir,
+    )
+    (global_root / ".opencode" / "command").mkdir(parents=True)
+    return global_root
 
 
 @pytest.fixture
@@ -53,6 +70,21 @@ class TestListCommand:
             assert ".opencode/command/" in result.stdout
             assert "✓" in result.stdout  # opencode exists
 
+    def test_list_uses_global_command_root_after_init(self, tmp_path):
+        """A fresh 3.1.x project has config but no project-local command dir."""
+        kittify = tmp_path / ".kittify"
+        kittify.mkdir()
+        (kittify / "config.yaml").write_text("agents:\n  available:\n    - opencode\n")
+
+        with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+            result = runner.invoke(app, ["list"])
+
+            assert result.exit_code == 0
+            assert "✓ opencode" in result.stdout
+            assert ".opencode/command/" in result.stdout
+            assert "(global)" in result.stdout
+            assert not (tmp_path / ".opencode").exists()
+
     def test_list_no_agents_configured(self, tmp_path):
         """Test listing when no agents are configured."""
         kittify = tmp_path / ".kittify"
@@ -79,16 +111,17 @@ class TestAddCommand:
     """Tests for 'spec-kitty agent config add' command."""
 
     def test_add_single_agent(self, mock_project):
-        """Test adding a single agent."""
+        """Adding a slash-command agent registers global commands without local dirs."""
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=mock_project):
             result = runner.invoke(app, ["add", "claude"])
 
             assert result.exit_code == 0
-            assert "Added .claude/commands/" in result.stdout
+            assert "Registered claude" in result.stdout
+            assert "global commands" in result.stdout
             assert "Updated config.yaml" in result.stdout
 
-            # Verify directory was created
-            assert (mock_project / ".claude" / "commands").exists()
+            # Slash-command files are global in 3.1.x, not project-local.
+            assert not (mock_project / ".claude").exists()
 
             # Verify config was updated
             config_file = mock_project / ".kittify" / "config.yaml"
@@ -101,12 +134,12 @@ class TestAddCommand:
             result = runner.invoke(app, ["add", "claude", "codex"])
 
             assert result.exit_code == 0
-            assert "Added .claude/commands/" in result.stdout
+            assert "Registered claude" in result.stdout
             assert "Registered codex" in result.stdout
             assert ".agents/skills/" in result.stdout
 
-            # Verify both directories were created
-            assert (mock_project / ".claude" / "commands").exists()
+            # Claude is globally managed; Codex uses project-local command skills.
+            assert not (mock_project / ".claude").exists()
             assert (mock_project / ".agents" / "skills").exists()
 
     def test_add_already_configured_agent(self, mock_project):
@@ -126,17 +159,15 @@ class TestAddCommand:
             assert "Invalid agent keys: invalid-agent" in result.stdout
             assert "Valid agents:" in result.stdout
 
-    def test_add_creates_templates(self, mock_project):
-        """Test that adding an agent copies templates."""
+    def test_add_does_not_create_project_command_templates(self, mock_project):
+        """Adding a global command agent must not recreate local command files."""
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=mock_project):
             result = runner.invoke(app, ["add", "claude"])
 
             assert result.exit_code == 0
 
-            # Verify templates were copied
             claude_dir = mock_project / ".claude" / "commands"
-            assert (claude_dir / "spec-kitty.implement.md").exists()
-            assert (claude_dir / "spec-kitty.review.md").exists()
+            assert not claude_dir.exists()
 
 
 class TestRemoveCommand:
@@ -187,6 +218,10 @@ class TestRemoveCommand:
 
             assert result.exit_code == 0
             assert "already removed" in result.stdout.lower()
+            assert "Updated config.yaml" in result.stdout
+
+            config = load_agent_config(mock_project)
+            assert "gemini" not in config.available
 
     def test_remove_with_keep_config(self, mock_project):
         """Test removing agent with --keep-config flag."""
@@ -202,6 +237,26 @@ class TestRemoveCommand:
             from specify_cli.core.agent_config import load_agent_config
             config = load_agent_config(mock_project)
             assert "opencode" in config.available
+
+    def test_remove_copilot_preserves_github_workflows(self, tmp_path):
+        """Removing Copilot must not delete unrelated .github content."""
+        kittify = tmp_path / ".kittify"
+        kittify.mkdir()
+        (kittify / "config.yaml").write_text("agents:\n  available:\n    - copilot\n")
+        workflows = tmp_path / ".github" / "workflows"
+        prompts = tmp_path / ".github" / "prompts"
+        workflows.mkdir(parents=True)
+        prompts.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: ci\n")
+        (prompts / "spec-kitty.example.prompt.md").write_text("# prompt\n")
+
+        with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+            result = runner.invoke(app, ["remove", "copilot"])
+
+            assert result.exit_code == 0
+            assert "Removed .github/prompts/" in result.stdout
+            assert not prompts.exists()
+            assert (workflows / "ci.yml").exists()
 
 
 class TestStatusCommand:
@@ -225,6 +280,22 @@ class TestStatusCommand:
             assert result.exit_code == 0
             # opencode is configured and present
             assert "OK" in result.stdout
+
+    def test_status_uses_global_command_root_after_init(self, tmp_path):
+        """Configured global command agents should not be missing after init."""
+        kittify = tmp_path / ".kittify"
+        kittify.mkdir()
+        (kittify / "config.yaml").write_text("agents:\n  available:\n    - opencode\n")
+
+        with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+            result = runner.invoke(app, ["status"])
+
+            assert result.exit_code == 0
+            assert "opencode" in result.stdout
+            assert "global" in result.stdout
+            assert "OK" in result.stdout
+            assert "Missing" not in result.stdout
+            assert not (tmp_path / ".opencode").exists()
 
     def test_status_shows_orphaned(self, mock_project):
         """Test status shows orphaned agents (present but not configured)."""
@@ -258,6 +329,26 @@ class TestSyncCommand:
             assert "Removed orphaned .claude/" in result.stdout
             assert not (mock_project / ".claude").exists()
 
+    def test_sync_removes_only_copilot_prompts(self, tmp_path):
+        """Orphan cleanup must preserve unrelated .github files."""
+        kittify = tmp_path / ".kittify"
+        kittify.mkdir()
+        (kittify / "config.yaml").write_text("agents:\n  available: []\n")
+        workflows = tmp_path / ".github" / "workflows"
+        prompts = tmp_path / ".github" / "prompts"
+        workflows.mkdir(parents=True)
+        prompts.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: ci\n")
+        (prompts / "spec-kitty.example.prompt.md").write_text("# prompt\n")
+
+        with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+            result = runner.invoke(app, ["sync"])
+
+            assert result.exit_code == 0
+            assert "Removed orphaned .github/prompts/" in result.stdout
+            assert not prompts.exists()
+            assert (workflows / "ci.yml").exists()
+
     def test_sync_keep_orphaned(self, mock_project):
         """Test sync with --keep-orphaned flag."""
         # Create orphaned claude directory (if not exists)
@@ -272,8 +363,8 @@ class TestSyncCommand:
             # Should not remove claude
             assert (mock_project / ".claude" / "commands").exists()
 
-    def test_sync_create_missing(self, mock_project):
-        """Test sync creates missing directories with --create-missing."""
+    def test_sync_create_missing_skips_global_command_dirs(self, mock_project):
+        """Sync should not recreate retired project-local command directories."""
         # Add gemini to config but don't create directory
         from specify_cli.core.agent_config import load_agent_config
 
@@ -285,8 +376,8 @@ class TestSyncCommand:
             result = runner.invoke(app, ["sync", "--create-missing"])
 
             assert result.exit_code == 0
-            assert "Created .gemini/commands/" in result.stdout
-            assert (mock_project / ".gemini" / "commands").exists()
+            assert "Global commands missing for gemini" in result.stdout
+            assert not (mock_project / ".gemini").exists()
 
     def test_sync_no_changes_needed(self, tmp_path):
         """Test sync when filesystem already matches config."""
@@ -312,8 +403,8 @@ class TestSyncCommand:
 class TestAgentKeyMapping:
     """Tests for agent key to directory mapping."""
 
-    def test_special_agent_keys(self, mock_project):
-        """Test that special agent keys map correctly."""
+    def test_special_agent_keys_register_global_commands(self, mock_project):
+        """Special command-layer agent keys still register without local dirs."""
         # copilot -> .github
         # auggie -> .augment
         # q -> .amazonq
@@ -322,14 +413,17 @@ class TestAgentKeyMapping:
             # Test copilot (maps to .github)
             result = runner.invoke(app, ["add", "copilot"])
             assert result.exit_code == 0
-            assert (mock_project / ".github" / "prompts").exists()
+            assert "Registered copilot" in result.stdout
+            assert not (mock_project / ".github" / "prompts").exists()
 
             # Test auggie (maps to .augment)
             result = runner.invoke(app, ["add", "auggie"])
             assert result.exit_code == 0
-            assert (mock_project / ".augment" / "commands").exists()
+            assert "Registered auggie" in result.stdout
+            assert not (mock_project / ".augment" / "commands").exists()
 
             # Test q (maps to .amazonq)
             result = runner.invoke(app, ["add", "q"])
             assert result.exit_code == 0
-            assert (mock_project / ".amazonq" / "prompts").exists()
+            assert "Registered q" in result.stdout
+            assert not (mock_project / ".amazonq" / "prompts").exists()

--- a/tests/agent/cli/commands/test_agent_config.py
+++ b/tests/agent/cli/commands/test_agent_config.py
@@ -16,6 +16,11 @@ pytestmark = pytest.mark.fast
 runner = CliRunner()
 
 
+def _unwrapped_output(output: str) -> str:
+    """Normalize Rich line wrapping in CLI output assertions."""
+    return output.replace("\n", "")
+
+
 @pytest.fixture(autouse=True)
 def fake_global_command_dirs(tmp_path, monkeypatch):
     """Keep global command checks isolated from the developer's home directory."""
@@ -67,7 +72,7 @@ class TestListCommand:
 
             assert result.exit_code == 0
             assert "opencode" in result.stdout
-            assert ".opencode/command/" in result.stdout
+            assert ".opencode/command/" in _unwrapped_output(result.stdout)
             assert "✓" in result.stdout  # opencode exists
 
     def test_list_uses_global_command_root_after_init(self, tmp_path):
@@ -81,7 +86,7 @@ class TestListCommand:
 
             assert result.exit_code == 0
             assert "✓ opencode" in result.stdout
-            assert ".opencode/command/" in result.stdout
+            assert ".opencode/command/" in _unwrapped_output(result.stdout)
             assert "(global)" in result.stdout
             assert not (tmp_path / ".opencode").exists()
 


### PR DESCRIPTION
## Summary
- make `agent config list/status` report global command roots for slash-command agents
- stop `agent config add` and `sync --create-missing` from recreating retired project-local command directories
- constrain remove/sync cleanup to the managed command surface so `.github/workflows/` and other unrelated files are preserved
- update docs for the global command-root model

Closes #816.
Closes #817.
Closes #818.

## Tests
- `uv run ruff check src/specify_cli/cli/commands/agent/config.py tests/agent/cli/commands/test_agent_config.py`
- `uv run pytest tests/agent/cli/commands/test_agent_config.py tests/runtime/test_global_runtime_convergence_unit.py tests/specify_cli/shims/test_direct_commands.py -q`
- isolated CLI smoke for `init --ai claude,opencode`, `agent config list`, and `agent config sync --create-missing`