### PR TITLE
fix: consume upstream retrospective event registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     # src/specify_cli/next/_internal_runtime/ (see WP01 of mission
     # shared-package-boundary-cutover-01KQ22DS), and absence is enforced by
     # tests/architectural/test_pyproject_shape.py.
-    "spec-kitty-events>=4.0.0,<5.0.0",
+    "spec-kitty-events>=4.1.0,<5.0.0",
     "spec-kitty-tracker>=0.4,<0.5",
     "websockets>=12.0",  # WebSocket client for sync protocol
     "toml>=0.10.2",  # Config file parsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     # src/specify_cli/next/_internal_runtime/ (see WP01 of mission
     # shared-package-boundary-cutover-01KQ22DS), and absence is enforced by
     # tests/architectural/test_pyproject_shape.py.
-    "spec-kitty-events>=4.1.0,<5.0.0",
+    "spec-kitty-events>=4.0.0,<5.0.0",
     "spec-kitty-tracker>=0.4,<0.5",
     "websockets>=12.0",  # WebSocket client for sync protocol
     "toml>=0.10.2",  # Config file parsing

--- a/src/specify_cli/retrospective/events.py
+++ b/src/specify_cli/retrospective/events.py
@@ -2,8 +2,8 @@
 
 The event-name registry is imported from ``spec_kitty_events`` when the 4.1+
 surface is installed. A local fallback keeps the CLI importable if a downstream
-test harness temporarily supplies an older package, but packaged installs pin
-the upstream 4.1+ registry.
+test harness or package index temporarily supplies an older package; the
+project lock pins the upstream 4.1+ registry for development and CI.
 
 Source-of-truth: kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md
 """

--- a/src/specify_cli/retrospective/events.py
+++ b/src/specify_cli/retrospective/events.py
@@ -1,8 +1,9 @@
 """Pydantic v2 payload models for retrospective runtime events.
 
 The event-name registry is imported from ``spec_kitty_events`` when the 4.1+
-surface is installed. A local fallback keeps the CLI compatible with the
-currently pinned 4.0.x package until the release pin is advanced.
+surface is installed. A local fallback keeps the CLI importable if a downstream
+test harness temporarily supplies an older package, but packaged installs pin
+the upstream 4.1+ registry.
 
 Source-of-truth: kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md
 """

--- a/src/specify_cli/retrospective/events.py
+++ b/src/specify_cli/retrospective/events.py
@@ -1,10 +1,8 @@
-"""Pydantic v2 payload models for the eight retrospective events (local definitions).
+"""Pydantic v2 payload models for retrospective runtime events.
 
-These models are defined locally per the Q4-C cutover plan. They will be replaced
-by imports from the upstream ``spec_kitty_events`` package when that release ships.
-
-# TODO: Replace local definitions with upstream imports once the spec_kitty_events
-# package is released. Tracking issue: <TODO: WP12 issue link>
+The event-name registry is imported from ``spec_kitty_events`` when the 4.1+
+surface is installed. A local fallback keeps the CLI compatible with the
+currently pinned 4.0.x package until the release pin is advanced.
 
 Source-of-truth: kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md
 """
@@ -13,9 +11,10 @@ from __future__ import annotations
 
 import json
 import logging
+from importlib import import_module
 from datetime import datetime, UTC
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 import ulid as _ulid_mod
 from pydantic import BaseModel, ConfigDict
@@ -24,11 +23,20 @@ from specify_cli.retrospective.schema import ActorRef, Mode
 
 logger = logging.getLogger(__name__)
 
+try:
+    _upstream_retrospective = import_module("spec_kitty_events.retrospective")
+    _UPSTREAM_RETROSPECTIVE_EVENT_NAMES = cast(
+        "frozenset[str] | None",
+        getattr(_upstream_retrospective, "RETROSPECTIVE_EVENT_NAMES", None),
+    )
+except ImportError:  # pragma: no cover - exercised only with pre-4.1 package pins
+    _UPSTREAM_RETROSPECTIVE_EVENT_NAMES = None
+
 # ---------------------------------------------------------------------------
 # Stable event name registry
 # ---------------------------------------------------------------------------
 
-RETROSPECTIVE_EVENT_NAMES: frozenset[str] = frozenset(
+_LOCAL_RETROSPECTIVE_EVENT_NAMES: frozenset[str] = frozenset(
     [
         "retrospective.requested",
         "retrospective.started",
@@ -39,6 +47,10 @@ RETROSPECTIVE_EVENT_NAMES: frozenset[str] = frozenset(
         "retrospective.proposal.applied",
         "retrospective.proposal.rejected",
     ]
+)
+
+RETROSPECTIVE_EVENT_NAMES: frozenset[str] = (
+    _UPSTREAM_RETROSPECTIVE_EVENT_NAMES or _LOCAL_RETROSPECTIVE_EVENT_NAMES
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/snapshots/spec-kitty-events-4.1.0.json
+++ b/tests/contract/snapshots/spec-kitty-events-4.1.0.json
@@ -1,0 +1,160 @@
+{
+  "envelope_class": "spec_kitty_events.models.Event",
+  "field_names": [
+    "aggregate_id",
+    "build_id",
+    "causation_id",
+    "correlation_id",
+    "data_tier",
+    "event_id",
+    "event_type",
+    "lamport_clock",
+    "node_id",
+    "payload",
+    "project_slug",
+    "project_uuid",
+    "schema_version",
+    "timestamp"
+  ],
+  "package": "spec-kitty-events",
+  "required_fields": [
+    "aggregate_id",
+    "build_id",
+    "correlation_id",
+    "event_id",
+    "event_type",
+    "lamport_clock",
+    "node_id",
+    "project_uuid",
+    "timestamp"
+  ],
+  "resolved_version": "4.1.0",
+  "schema": {
+    "description": "Immutable event with causal metadata for distributed conflict detection.",
+    "properties": {
+      "aggregate_id": {
+        "description": "Identifier of the entity this event modifies",
+        "minLength": 1,
+        "title": "Aggregate Id",
+        "type": "string"
+      },
+      "build_id": {
+        "description": "Canonical checkout or worktree identity that produced this event",
+        "minLength": 1,
+        "title": "Build Id",
+        "type": "string"
+      },
+      "causation_id": {
+        "anyOf": [
+          {
+            "maxLength": 36,
+            "minLength": 26,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Event ID of the parent event (26-char ULID or UUID accepted, None for root events)",
+        "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$|^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        "title": "Causation Id"
+      },
+      "correlation_id": {
+        "description": "Correlation identifier (26-char ULID or UUID accepted)",
+        "maxLength": 36,
+        "minLength": 26,
+        "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$|^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        "title": "Correlation Id",
+        "type": "string"
+      },
+      "data_tier": {
+        "default": 0,
+        "description": "Progressive data sharing tier (0=local, 4=telemetry)",
+        "maximum": 4,
+        "minimum": 0,
+        "title": "Data Tier",
+        "type": "integer"
+      },
+      "event_id": {
+        "description": "Unique event identifier (26-char ULID or UUID accepted)",
+        "maxLength": 36,
+        "minLength": 26,
+        "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$|^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        "title": "Event Id",
+        "type": "string"
+      },
+      "event_type": {
+        "description": "Event type identifier (e.g., 'WPStatusChanged', 'TagAdded')",
+        "minLength": 1,
+        "title": "Event Type",
+        "type": "string"
+      },
+      "lamport_clock": {
+        "description": "Lamport logical clock value (monotonically increasing)",
+        "minimum": 0,
+        "title": "Lamport Clock",
+        "type": "integer"
+      },
+      "node_id": {
+        "description": "Required causal emitter identity used for Lamport ordering and deterministic tie-breaking",
+        "minLength": 1,
+        "title": "Node Id",
+        "type": "string"
+      },
+      "payload": {
+        "additionalProperties": true,
+        "description": "Event-specific data (opaque to library)",
+        "title": "Payload",
+        "type": "object"
+      },
+      "project_slug": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Human-readable project identifier (optional)",
+        "title": "Project Slug"
+      },
+      "project_uuid": {
+        "description": "UUID of the project this event belongs to",
+        "format": "uuid",
+        "title": "Project Uuid",
+        "type": "string"
+      },
+      "schema_version": {
+        "default": "3.0.0",
+        "description": "Envelope schema version (semver)",
+        "pattern": "^\\d+\\.\\d+\\.\\d+$",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "timestamp": {
+        "description": "Wall-clock timestamp (human-readable, not used for ordering)",
+        "format": "date-time",
+        "title": "Timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "event_id",
+      "event_type",
+      "aggregate_id",
+      "timestamp",
+      "build_id",
+      "node_id",
+      "lamport_clock",
+      "project_uuid",
+      "correlation_id"
+    ],
+    "title": "Event",
+    "type": "object"
+  },
+  "schema_title": "Event",
+  "version_source": "uv.lock"
+}

--- a/tests/retrospective/test_events_shapes.py
+++ b/tests/retrospective/test_events_shapes.py
@@ -299,10 +299,26 @@ class TestRetroEventNames:
             "retrospective.proposal.applied",
             "retrospective.proposal.rejected",
         }
-        assert RETROSPECTIVE_EVENT_NAMES == expected
+        assert expected == RETROSPECTIVE_EVENT_NAMES
 
     def test_is_frozenset(self) -> None:
         assert isinstance(RETROSPECTIVE_EVENT_NAMES, frozenset)
+
+    def test_matches_upstream_registry_when_available(self) -> None:
+        try:
+            from spec_kitty_events import retrospective as upstream_retrospective
+        except ImportError:  # pragma: no cover - dependency is required in normal installs
+            pytest.skip("spec_kitty_events is not importable")
+
+        upstream_names = getattr(
+            upstream_retrospective,
+            "RETROSPECTIVE_EVENT_NAMES",
+            None,
+        )
+        if upstream_names is None:
+            pytest.skip("spec_kitty_events package is older than retrospective 4.1")
+
+        assert upstream_names == RETROSPECTIVE_EVENT_NAMES
 
     def test_no_collision_with_lane_values(self) -> None:
         """Retrospective event names must not overlap with 9-lane state values."""

--- a/uv.lock
+++ b/uv.lock
@@ -2155,7 +2155,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.3.3" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.4.0" },
-    { name = "spec-kitty-events", specifier = ">=4.1.0,<5.0.0" },
+    { name = "spec-kitty-events", specifier = ">=4.0.0,<5.0.0" },
     { name = "spec-kitty-tracker", specifier = ">=0.4,<0.5" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "transitions", specifier = ">=0.9.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2155,7 +2155,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.3.3" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.4.0" },
-    { name = "spec-kitty-events", specifier = ">=4.0.0,<5.0.0" },
+    { name = "spec-kitty-events", specifier = ">=4.1.0,<5.0.0" },
     { name = "spec-kitty-tracker", specifier = ">=0.4,<0.5" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "transitions", specifier = ">=0.9.2" },
@@ -2171,15 +2171,15 @@ requires-dist = [
 
 [[package]]
 name = "spec-kitty-events"
-version = "4.0.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-ulid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/4d/05b3aeb413f8221302354ebb589376c6709b9197e966142bb22f2ddde342/spec_kitty_events-4.0.0.tar.gz", hash = "sha256:9f372cf2b092c10e4fa423e7523262255b9ebb7e5c0013093ba7ca0011e71559", size = 186079 }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/25/9ecedbeceed104e382f62a74a1419b511fa57f21ca512c81763c12eb6f70/spec_kitty_events-4.1.0.tar.gz", hash = "sha256:f30fc368d880a52f009808f38df6003cdf1b3ad96d576dd0ceecfdaed1c0a915", size = 190704 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/18/20965a5f2fca18ccc467911f901b67ab41e955ef52adef59ac38c182827a/spec_kitty_events-4.0.0-py3-none-any.whl", hash = "sha256:b906a34cdec5f06d0723a787f7ed7c4b8c36ee9c78740411946bc037e90deebb", size = 286208 },
+    { url = "https://files.pythonhosted.org/packages/40/82/1063eef992c4b4dd5ed404bc87d769965346fa56aa1faef646557b699e4e/spec_kitty_events-4.1.0-py3-none-any.whl", hash = "sha256:3520685f5e0259d6c2fe1cc75a3a531f13ed7236a18052427b2855157842ef12", size = 299111 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Consume the upstream retrospective event registry from spec-kitty-events 4.1.0 while keeping the local runtime event writer surface stable.
- Keep wheel metadata compatible with spec-kitty-events 4.0.x so clean installs survive stale package indexes; pin development/CI through uv.lock to the released 4.1.0 wheel.
- Add the resolved-version event envelope snapshot for 4.1.0 and regression coverage that compares the local registry against upstream when available.

## Verification
- spec-kitty-events PR #17 merged and v4.1.0 published to PyPI.
- uv lock --check
- uv run pytest tests/contract/test_events_envelope_matches_resolved_version.py tests/contract/test_cross_repo_consumers.py tests/contract/spec_kitty_events_consumer/test_consumer_contract.py tests/retrospective/test_events_shapes.py tests/retrospective/test_reducer_integration.py -q
- uv run pytest tests/retrospective tests/doctrine_synthesizer tests/next/test_retrospective_terminus_wiring.py tests/architectural/test_pyproject_shape.py -q
- uv run ruff check src/specify_cli/retrospective/events.py tests/retrospective/test_events_shapes.py tests/contract/test_events_envelope_matches_resolved_version.py tests/contract/test_cross_repo_consumers.py
- uv run mypy --strict src/specify_cli/retrospective/events.py tests/retrospective/test_events_shapes.py tests/contract/test_events_envelope_matches_resolved_version.py tests/contract/test_cross_repo_consumers.py