### PR TITLE
test: keep e2e fixtures schema-compatible

### DIFF
--- a/tests/cross_cutting/test_gitignore_isolation_integration.py
+++ b/tests/cross_cutting/test_gitignore_isolation_integration.py
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.git_repo
 
 
 def _write_compatible_project_metadata(repo_root: Path) -> None:
+    """Write the current project schema; these tests do not exercise migrations."""
     capabilities = "\n".join(
         f"    - {capability}"
         for capability in SCHEMA_CAPABILITIES[MAX_SUPPORTED_SCHEMA]


### PR DESCRIPTION
## Summary
- documents the schema-compatible metadata helper used by e2e/cross-cutting fixtures
- keeps latest main movement on the PR-shaped path required by Protect Main after the direct CI hotfix

## Verification
- uv run ruff check tests/e2e/conftest.py tests/cross_cutting/test_gitignore_isolation_integration.py
- uv run pytest tests/e2e/test_cli_smoke.py tests/cross_cutting/test_gitignore_isolation_integration.py -q
- uv run pytest tests/e2e/ tests/cross_cutting/ -m "not distribution and not windows_ci" -q