### PR TITLE
fix(upgrade): persist schema_version through metadata.save() and fix stale test args

### DIFF
--- a/src/specify_cli/upgrade/metadata.py
+++ b/src/specify_cli/upgrade/metadata.py
@@ -37,6 +37,7 @@ class ProjectMetadata:
     version: str
     initialized_at: datetime
     last_upgraded_at: datetime | None = None
+    schema_version: int | None = None
     python_version: str = ""
     platform: str = ""
     platform_version: str = ""
@@ -96,10 +97,17 @@ class ProjectMetadata:
         except ValueError:
             last_upgraded_at = None
 
+        raw_schema_version = spec_kitty.get("schema_version")
+        try:
+            schema_version: int | None = int(raw_schema_version) if raw_schema_version is not None else None
+        except (TypeError, ValueError):
+            schema_version = None
+
         metadata = cls(
             version=spec_kitty.get("version", "unknown"),
             initialized_at=initialized_at,
             last_upgraded_at=last_upgraded_at,
+            schema_version=schema_version,
             python_version=env.get("python_version", ""),
             platform=env.get("platform", ""),
             platform_version=env.get("platform_version", ""),
@@ -144,12 +152,16 @@ class ProjectMetadata:
         """
         metadata_path = kittify_dir / "metadata.yaml"
 
+        spec_kitty_section: dict = {
+            "version": self.version,
+            "initialized_at": self.initialized_at.isoformat(),
+            "last_upgraded_at": (self.last_upgraded_at.isoformat() if self.last_upgraded_at else None),
+        }
+        if self.schema_version is not None:
+            spec_kitty_section["schema_version"] = self.schema_version
+
         data = {
-            "spec_kitty": {
-                "version": self.version,
-                "initialized_at": self.initialized_at.isoformat(),
-                "last_upgraded_at": (self.last_upgraded_at.isoformat() if self.last_upgraded_at else None),
-            },
+            "spec_kitty": spec_kitty_section,
             "environment": {
                 "python_version": self.python_version,
                 "platform": self.platform,

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -115,6 +115,8 @@ class MigrationRunner:
             if metadata and not dry_run and metadata.version != target_version:
                 metadata.version = target_version
                 metadata.last_upgraded_at = datetime.now()
+                if REQUIRED_SCHEMA_VERSION is not None:
+                    metadata.schema_version = REQUIRED_SCHEMA_VERSION
                 metadata.save(self.kittify_dir)
 
             result.warnings.append(f"No migrations needed from {from_version} to {target_version}")
@@ -157,10 +159,8 @@ class MigrationRunner:
         if not dry_run and result.success:
             metadata.version = target_version
             metadata.last_upgraded_at = datetime.now()
-            # Schema-version-based migration: stamp the new schema_version so the
-            # gate does not block future commands.
             if REQUIRED_SCHEMA_VERSION is not None:
-                self._stamp_schema_version(self.kittify_dir, REQUIRED_SCHEMA_VERSION)
+                metadata.schema_version = REQUIRED_SCHEMA_VERSION
             metadata.save(self.kittify_dir)
 
         # Handle worktrees

--- a/tests/cross_cutting/versioning/test_upgrade_version_update.py
+++ b/tests/cross_cutting/versioning/test_upgrade_version_update.py
@@ -84,6 +84,34 @@ def test_upgrade_dry_run_does_not_update_version(tmp_path):
     assert after_dry_run.version == "0.12.0", "Dry run should not update version"
 
 
+def test_upgrade_preserves_schema_version_in_metadata(tmp_path):
+    """After upgrade, schema_version must survive the metadata.save() call.
+
+    Regression test: previously _stamp_schema_version ran before metadata.save(),
+    which overwrote the file without schema_version, leaving the project gated.
+    """
+    from specify_cli import __version__
+    from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
+
+    _init_git_repo(tmp_path)
+
+    kittify_dir = tmp_path / ".kittify"
+    kittify_dir.mkdir()
+
+    metadata = ProjectMetadata(version="0.12.0", initialized_at=datetime.fromisoformat("2026-01-01T00:00:00"))
+    metadata.save(kittify_dir)
+
+    runner = MigrationRunner(tmp_path)
+    runner.upgrade(__version__, dry_run=False, include_worktrees=False)
+
+    import yaml
+    data = yaml.safe_load((kittify_dir / "metadata.yaml").read_text())
+    assert data["spec_kitty"].get("schema_version") == REQUIRED_SCHEMA_VERSION, (
+        "schema_version must be present in metadata.yaml after upgrade; "
+        "metadata.save() must not overwrite the stamp"
+    )
+
+
 def test_cli_version_is_not_fallback():
     """Verify that CLI __version__ is not using the fallback values."""
     from specify_cli import __version__

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -473,6 +473,8 @@ def test_upgrade_no_migrations_json_includes_auto_commit_fields(
         json_output=True,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
     data = json.loads(capsys.readouterr().out.strip())
@@ -506,14 +508,13 @@ def test_upgrade_dry_run_skips_auto_commit(
         dry_run=True,
         force=True,
         target="1.0.0a1",
-        json_output=True,
+        json_output=False,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
-    data = json.loads(capsys.readouterr().out.strip())
-    assert data["auto_committed"] is False
-    assert data["auto_commit_paths"] == []
     assert safe_commit_called["called"] is False
 
 
@@ -544,6 +545,8 @@ def test_upgrade_baseline_failure_skips_auto_commit(
         json_output=True,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
     data = json.loads(capsys.readouterr().out.strip())
@@ -590,6 +593,8 @@ def test_upgrade_no_migrations_rich_output_shows_auto_commit(
         json_output=False,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
     full = "\n".join(captured_output)
@@ -628,6 +633,8 @@ def test_upgrade_no_migrations_safe_commit_failure_shows_warning(
         json_output=True,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
     data = json.loads(capsys.readouterr().out.strip())
@@ -654,6 +661,8 @@ def test_upgrade_rejects_downgrade_target_in_json_mode(
             json_output=True,
             verbose=False,
             no_worktrees=True,
+            cli=False,
+            project=False,
         )
 
     data = json.loads(capsys.readouterr().out.strip())
@@ -713,6 +722,8 @@ def test_upgrade_suppresses_auto_commit_when_manual_review_required(
         json_output=True,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
     data = json.loads(capsys.readouterr().out.strip())
@@ -769,6 +780,8 @@ def test_upgrade_auto_commits_clean_run_when_no_manual_review(
         json_output=True,
         verbose=False,
         no_worktrees=True,
+        cli=False,
+        project=False,
     )
 
     data = json.loads(capsys.readouterr().out.strip())


### PR DESCRIPTION
## Summary

Two bugs in the upgrade pipeline found during a local `spec-kitty upgrade` + `spec-kitty verify-setup` alignment run.

### Bug 1 — `schema_version` silently dropped by `ProjectMetadata.save()`

`ProjectMetadata.save()` reconstructed the YAML dict from scratch from the dataclass fields, which did not include `schema_version`. Every `save()` call therefore stripped the field that the compat gate reads, leaving the project in a gated state (`verify-setup` / any non-upgrade command blocked with exit code 4) after any migration run.

The existing workaround (`_stamp_schema_version`) called a raw-YAML patch _after_ `save()` only in the "has migrations" code path. The "no migrations" early-return path (line 112–121 of `runner.py`) called `save()` and returned without ever stamping, so projects already at the target version would also lose `schema_version` on every upgrade.

**Root cause confirmed by reproducing the regression locally**: running `spec-kitty upgrade` on a clean checkout stripped `schema_version: 3` from `.kittify/metadata.yaml`, causing `verify-setup` to block with `PROJECT_MIGRATION_NEEDED`.

**Fix:**
- Add `schema_version: int | None = None` to `ProjectMetadata` dataclass
- Round-trip it through `load()` and `save()`
- Set `metadata.schema_version = REQUIRED_SCHEMA_VERSION` in both `upgrade()` code paths before `save()` — covers both "has migrations" and "no migrations" branches
- Remove the `_stamp_schema_version` post-save workaround (no longer needed)

**Test added:** `test_upgrade_preserves_schema_version_in_metadata` in `tests/cross_cutting/versioning/test_upgrade_version_update.py` — written failing first, then fixed.

Related to the 3.2.0 stabilization work tracked in #822.

---

### Bug 2 — Stale test args: `typer.Option` is truthy in direct function calls

Eight tests in `tests/upgrade/test_upgrade_auto_commit_unit.py` called `upgrade_cmd.upgrade()` directly (bypassing the CLI) without passing the `cli=` and `project=` kwargs added in WP09 (FR-014/FR-015). `typer.Option(False, "--cli")` returns an `OptionInfo` object which evaluates to `True` in a boolean context, causing the mutual-exclusion guard (`if cli and project: raise typer.Exit(2)`) to fire for every such call.

A ninth test (`test_upgrade_dry_run_skips_auto_commit`) additionally used `dry_run=True + json_output=True`, which routes to the compat-planner JSON path (line 449: `if json_output and (project or dry_run)`) instead of the auto-commit path the test was actually verifying.

**Fix:**
- Add `cli=False, project=False` to all 8 affected direct calls
- Change the dry-run test to `json_output=False` and assert only on the `safe_commit` spy

---

## Test plan

- [x] `test_upgrade_preserves_schema_version_in_metadata` — new regression test, confirmed failing before fix
- [x] `tests/upgrade/test_upgrade_auto_commit_unit.py` — all 33 tests pass (8 were failing before)
- [x] `tests/upgrade/ tests/specify_cli/migration/ tests/cross_cutting/versioning/` — 598 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)