### PR TITLE
fix(status): split --agent colon-string into AgentAssignment fields

### DIFF
--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -19,6 +19,19 @@ guardrails for bulk operations.
 allocated by `spec-kitty agent action implement WPxx --agent <name>`. Do NOT modify files outside
 your `owned_files` boundaries.
 
+**Agent identity flags** — pass these to `spec-kitty agent action implement` and `spec-kitty next`
+to fully populate `AgentAssignment` without relying on colon-concatenation:
+
+| Flag | Maps to | Example |
+|------|---------|---------|
+| `--tool <id>` | `AgentAssignment.tool` | `--tool claude` |
+| `--profile <id>` | `AgentAssignment.model` | `--profile claude-sonnet-4-6` |
+| `--profile-id <id>` | `AgentAssignment.profile_id` | `--profile-id python-pedro` |
+| `--role <role>` | `AgentAssignment.role` | `--role implementer` |
+
+Omitting `--profile-id` defaults to `generic-agent`.
+The shorthand colon format `--agent tool:model:profile_id:role` is also accepted.
+
 **In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input

--- a/src/specify_cli/missions/software-dev/command-templates/review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/review.md
@@ -19,6 +19,19 @@ compliance with any applicable guardrails (e.g., bulk edit occurrence maps).
 allocated by `spec-kitty agent action review WPxx --agent <name>`. Do NOT modify files outside
 your `owned_files` boundaries.
 
+**Agent identity flags** — pass these to `spec-kitty agent action review` and `spec-kitty next`
+to fully populate `AgentAssignment` without relying on colon-concatenation:
+
+| Flag | Maps to | Example |
+|------|---------|---------|
+| `--tool <id>` | `AgentAssignment.tool` | `--tool claude` |
+| `--profile <id>` | `AgentAssignment.model` | `--profile claude-opus-4-7` |
+| `--profile-id <id>` | `AgentAssignment.profile_id` | `--profile-id reviewer-renata` |
+| `--role <role>` | `AgentAssignment.role` | `--role reviewer` |
+
+Omitting `--profile-id` defaults to `generic-agent`.
+The shorthand colon format `--agent tool:model:profile_id:role` is also accepted.
+
 **In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
 
 ## User Input

--- a/src/specify_cli/status/wp_metadata.py
+++ b/src/specify_cli/status/wp_metadata.py
@@ -21,6 +21,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from specify_cli.status.models import AgentAssignment, Lane
 
 
+_DEFAULT_PROFILE = "generic-agent"
+
+
 def _resolve_agent_fallback(
     model: str | None,
     agent_profile: str | None,
@@ -30,7 +33,7 @@ def _resolve_agent_fallback(
     return AgentAssignment(
         tool="unknown",
         model=model or "unknown-model",
-        profile_id=agent_profile or None,
+        profile_id=agent_profile or _DEFAULT_PROFILE,
         role=role or None,
     )
 
@@ -40,19 +43,40 @@ def _resolve_agent_from_assignment(agent: AgentAssignment) -> AgentAssignment:
     return agent
 
 
+def _parse_agent_string(value: str) -> tuple[str, str | None, str | None, str | None]:
+    """Split a colon-separated agent string into (tool, model, profile_id, role).
+
+    Wire format: <tool>[:<model>[:<profile_id>[:<role>]]]
+    Unspecified trailing parts are returned as None.
+    """
+    parts = value.split(":", 3)
+    tool = parts[0]
+    model = parts[1] if len(parts) > 1 else None
+    profile_id = parts[2] if len(parts) > 2 else None
+    role = parts[3] if len(parts) > 3 else None
+    return tool, model, profile_id, role
+
+
 def _resolve_agent_from_string(
-    tool: str,
+    value: str,
     model: str | None,
     agent_profile: str | None,
     role: str | None,
 ) -> AgentAssignment:
-    """Resolve agent metadata when the agent field is a non-empty string."""
+    """Resolve agent metadata when the agent field is a non-empty string.
+
+    If the string contains colons it is treated as a wire-format
+    ``tool:model:profile_id:role`` tuple; unspecified trailing parts
+    fall back to the separate frontmatter fields or the module defaults.
+    A plain string without colons is used as-is for ``tool``.
+    """
+    parsed_tool, parsed_model, parsed_profile, parsed_role = _parse_agent_string(value)
     fallback = _resolve_agent_fallback(model, agent_profile, role)
     return AgentAssignment(
-        tool=tool,
-        model=fallback.model,
-        profile_id=fallback.profile_id,
-        role=fallback.role,
+        tool=parsed_tool,
+        model=parsed_model or fallback.model,
+        profile_id=parsed_profile or fallback.profile_id,
+        role=parsed_role or fallback.role,
     )
 
 

--- a/tests/specify_cli/cli/commands/agent/test_workflow.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow.py
@@ -35,7 +35,7 @@ def test_resolved_agent_string_agent():
     assignment = meta.resolved_agent()
     assert assignment.tool == "claude"
     assert assignment.model == "claude-opus-4-6"
-    assert assignment.profile_id is None
+    assert assignment.profile_id == "generic-agent"
     assert assignment.role is None
 
 

--- a/tests/specify_cli/status/test_agent_assignment.py
+++ b/tests/specify_cli/status/test_agent_assignment.py
@@ -100,7 +100,7 @@ class TestStringAgent:
         result = wp.resolved_agent()
         assert result.tool == "claude"
         assert result.model == "claude-opus-4-6"
-        assert result.profile_id is None
+        assert result.profile_id == "generic-agent"
         assert result.role is None
 
     def test_string_agent_no_model_falls_back_to_unknown_model(self) -> None:
@@ -184,7 +184,7 @@ class TestNoneAgent:
         result = wp.resolved_agent()
         assert result.tool == "unknown"
         assert result.model == "unknown-model"
-        assert result.profile_id is None
+        assert result.profile_id == "generic-agent"
         assert result.role is None
 
 

--- a/tests/specify_cli/status/test_agent_colon_format.py
+++ b/tests/specify_cli/status/test_agent_colon_format.py
@@ -194,10 +194,16 @@ class TestReviewTemplateDocumentsDecomposedFlags:
 
 
 class TestImplementSkillDocumentsDecomposedFlags:
-    """Generated spec-kitty.implement SKILL.md must mention specific flags."""
+    """Generated spec-kitty.implement SKILL.md must mention specific flags.
+
+    Skipped when the skill file is absent — it is gitignored and only present
+    after ``spec-kitty upgrade`` has been run locally.
+    """
 
     @pytest.mark.parametrize("flag", _DECOMPOSED_FLAGS)
     def test_implement_skill_mentions_flag(self, flag: str) -> None:
+        if not _SKILL_IMPLEMENT.exists():
+            pytest.skip("spec-kitty.implement SKILL.md not installed (run spec-kitty upgrade)")
         content = _SKILL_IMPLEMENT.read_text(encoding="utf-8")
         assert flag in content, (
             f"spec-kitty.implement/SKILL.md does not document {flag!r}"
@@ -205,10 +211,16 @@ class TestImplementSkillDocumentsDecomposedFlags:
 
 
 class TestReviewSkillDocumentsDecomposedFlags:
-    """Generated spec-kitty.review SKILL.md must mention specific flags."""
+    """Generated spec-kitty.review SKILL.md must mention specific flags.
+
+    Skipped when the skill file is absent — it is gitignored and only present
+    after ``spec-kitty upgrade`` has been run locally.
+    """
 
     @pytest.mark.parametrize("flag", _DECOMPOSED_FLAGS)
     def test_review_skill_mentions_flag(self, flag: str) -> None:
+        if not _SKILL_REVIEW.exists():
+            pytest.skip("spec-kitty.review SKILL.md not installed (run spec-kitty upgrade)")
         content = _SKILL_REVIEW.read_text(encoding="utf-8")
         assert flag in content, (
             f"spec-kitty.review/SKILL.md does not document {flag!r}"

--- a/tests/specify_cli/status/test_agent_colon_format.py
+++ b/tests/specify_cli/status/test_agent_colon_format.py
@@ -1,0 +1,215 @@
+"""Tests for --agent colon-split format and template/skill flag documentation.
+
+These tests are EXPECTED TO FAIL in their current state:
+
+1. resolved_agent() does not split colon-separated strings — the full string
+   "claude:opus-4-7:reviewer:reviewer" is used as the tool name verbatim
+   instead of being parsed into (tool, model, profile_id, role).
+
+2. The command templates and skill files only document ``--agent <name>``
+   and do not mention the decomposed flags ``--profile``, ``--tool``,
+   ``--profile-id``, or ``--role``.
+
+Observed in the wild: every WP in the latest mission carries
+  agent: "claude:opus-4-7:reviewer:reviewer"
+which is already in the intended colon-split format, but the production
+code silently discards the model/profile/role parts.
+
+Fix targets:
+  src/specify_cli/status/wp_metadata.py  — _resolve_agent_from_string()
+  src/specify_cli/missions/software-dev/command-templates/implement.md
+  src/specify_cli/missions/software-dev/command-templates/review.md
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.status.models import AgentAssignment
+from specify_cli.status.wp_metadata import WPMetadata
+
+pytestmark = pytest.mark.fast
+
+_REPO_ROOT = Path(__file__).parents[3]
+_IMPLEMENT_TEMPLATE = _REPO_ROOT / "src/specify_cli/missions/software-dev/command-templates/implement.md"
+_REVIEW_TEMPLATE = _REPO_ROOT / "src/specify_cli/missions/software-dev/command-templates/review.md"
+_SKILL_IMPLEMENT = _REPO_ROOT / ".agents/skills/spec-kitty.implement/SKILL.md"
+_SKILL_REVIEW = _REPO_ROOT / ".agents/skills/spec-kitty.review/SKILL.md"
+
+
+# ─────────────────────────────────────────────────────────────
+# Part 1: resolved_agent() colon-split parsing
+# ─────────────────────────────────────────────────────────────
+
+
+class TestResolvedAgentColonSplit:
+    """--agent colon-separated string must be split into AgentAssignment parts.
+
+    Expected wire format:  <tool>:<model>:<profile_id>:<role>
+    All parts after <tool> are optional (trailing omission only).
+
+    Regression: every WP in stability-and-hygiene-hardening-2026-04-01KQ4ARB
+    stores  agent: "claude:opus-4-7:reviewer:reviewer"  — the production code
+    currently returns tool="claude:opus-4-7:reviewer:reviewer" (the unsplit
+    string) which is incorrect.
+    """
+
+    def test_four_parts_map_to_all_assignment_fields(self) -> None:
+        meta = WPMetadata(work_package_id="WP01", agent="claude:opus-4-7:reviewer:reviewer")
+
+        result = meta.resolved_agent()
+
+        assert result.tool == "claude"
+        assert result.model == "opus-4-7"
+        assert result.profile_id == "reviewer"
+        assert result.role == "reviewer"
+
+    def test_three_parts_leave_role_as_none(self) -> None:
+        meta = WPMetadata(work_package_id="WP01", agent="claude:opus-4-7:python-pedro")
+
+        result = meta.resolved_agent()
+
+        assert result.tool == "claude"
+        assert result.model == "opus-4-7"
+        assert result.profile_id == "python-pedro"
+        assert result.role is None
+
+    def test_two_parts_default_profile_to_generic_agent(self) -> None:
+        """When profile is omitted from the agent string, profile_id defaults to 'generic-agent'."""
+        meta = WPMetadata(work_package_id="WP01", agent="claude:opus-4-7")
+
+        result = meta.resolved_agent()
+
+        assert result.tool == "claude"
+        assert result.model == "opus-4-7"
+        assert result.profile_id == "generic-agent"
+        assert result.role is None
+
+    def test_single_part_defaults_profile_to_generic_agent(self) -> None:
+        """Backward-compat: a bare tool name (no colon) still defaults profile to 'generic-agent'."""
+        meta = WPMetadata(work_package_id="WP01", agent="claude", model="opus-4-7")
+
+        result = meta.resolved_agent()
+
+        assert result.tool == "claude"
+        assert result.model == "opus-4-7"
+        assert result.profile_id == "generic-agent"
+
+    def test_tool_field_contains_no_colons_after_split(self) -> None:
+        """Splitting must strip the model/profile/role from the tool name."""
+        meta = WPMetadata(work_package_id="WP01", agent="claude:opus-4-7:reviewer:reviewer")
+
+        result = meta.resolved_agent()
+
+        assert ":" not in result.tool
+
+    def test_result_is_agent_assignment_instance(self) -> None:
+        meta = WPMetadata(work_package_id="WP01", agent="claude:opus-4-7:reviewer:reviewer")
+
+        result = meta.resolved_agent()
+
+        assert isinstance(result, AgentAssignment)
+
+    def test_latest_mission_wp_format_roundtrips_correctly(self) -> None:
+        """Regression for the exact agent string observed in the latest mission WPs.
+
+        All WPs in stability-and-hygiene-hardening-2026-04-01KQ4ARB carry:
+          agent: "claude:opus-4-7:reviewer:reviewer"
+        """
+        meta = WPMetadata(work_package_id="WP07", agent="claude:opus-4-7:reviewer:reviewer")
+
+        result = meta.resolved_agent()
+
+        assert result == AgentAssignment(
+            tool="claude",
+            model="opus-4-7",
+            profile_id="reviewer",
+            role="reviewer",
+        )
+
+    def test_colon_split_model_takes_precedence_over_standalone_model_field(self) -> None:
+        """Model encoded in the agent string wins over the separate model field."""
+        meta = WPMetadata(
+            work_package_id="WP01",
+            agent="claude:sonnet-4-6:python-pedro:implementer",
+            model="haiku",  # should be overridden by the split model
+        )
+
+        result = meta.resolved_agent()
+
+        assert result.model == "sonnet-4-6"
+
+    def test_four_parts_with_profile_and_no_role_variant(self) -> None:
+        meta = WPMetadata(work_package_id="WP01", agent="codex:o1:implementer-ivan:implementer")
+
+        result = meta.resolved_agent()
+
+        assert result.tool == "codex"
+        assert result.model == "o1"
+        assert result.profile_id == "implementer-ivan"
+        assert result.role == "implementer"
+
+
+# ─────────────────────────────────────────────────────────────
+# Part 2: Source templates document the decomposed flags
+# ─────────────────────────────────────────────────────────────
+
+_DECOMPOSED_FLAGS = ["--profile", "--tool", "--profile-id", "--role"]
+
+
+class TestImplementTemplateDocumentsDecomposedFlags:
+    """Source implement template must instruct agents to use specific flags.
+
+    Currently the template only documents ``--agent <name>``.  It should
+    also document ``--profile``, ``--tool``, ``--profile-id``, and ``--role``
+    so agents know how to populate all AgentAssignment fields.
+    """
+
+    @pytest.mark.parametrize("flag", _DECOMPOSED_FLAGS)
+    def test_implement_template_mentions_flag(self, flag: str) -> None:
+        content = _IMPLEMENT_TEMPLATE.read_text(encoding="utf-8")
+        assert flag in content, (
+            f"implement.md does not document {flag!r} — agents cannot populate "
+            f"AgentAssignment.{flag.lstrip('-').replace('-', '_')}"
+        )
+
+
+class TestReviewTemplateDocumentsDecomposedFlags:
+    """Source review template must instruct agents to use specific flags."""
+
+    @pytest.mark.parametrize("flag", _DECOMPOSED_FLAGS)
+    def test_review_template_mentions_flag(self, flag: str) -> None:
+        content = _REVIEW_TEMPLATE.read_text(encoding="utf-8")
+        assert flag in content, (
+            f"review.md does not document {flag!r} — agents cannot populate "
+            f"AgentAssignment.{flag.lstrip('-').replace('-', '_')}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────
+# Part 3: Generated Skill files document the decomposed flags
+# ─────────────────────────────────────────────────────────────
+
+
+class TestImplementSkillDocumentsDecomposedFlags:
+    """Generated spec-kitty.implement SKILL.md must mention specific flags."""
+
+    @pytest.mark.parametrize("flag", _DECOMPOSED_FLAGS)
+    def test_implement_skill_mentions_flag(self, flag: str) -> None:
+        content = _SKILL_IMPLEMENT.read_text(encoding="utf-8")
+        assert flag in content, (
+            f"spec-kitty.implement/SKILL.md does not document {flag!r}"
+        )
+
+
+class TestReviewSkillDocumentsDecomposedFlags:
+    """Generated spec-kitty.review SKILL.md must mention specific flags."""
+
+    @pytest.mark.parametrize("flag", _DECOMPOSED_FLAGS)
+    def test_review_skill_mentions_flag(self, flag: str) -> None:
+        content = _SKILL_REVIEW.read_text(encoding="utf-8")
+        assert flag in content, (
+            f"spec-kitty.review/SKILL.md does not document {flag!r}"
+        )


### PR DESCRIPTION
Closes #833
Part of #822

## Summary

- `_resolve_agent_from_string` now parses the wire format `tool:model:profile_id:role` instead of using the whole string as `tool`
- `_resolve_agent_fallback` defaults `profile_id` to `"generic-agent"` instead of `None`
- Source command templates (`implement.md`, `review.md`) document the decomposed flags `--tool`, `--profile`, `--profile-id`, `--role`

## Test plan

- [ ] Regression tests committed first (TDD) — all 24 were failing before the fix
- [ ] 121/121 tests pass after fix
- [ ] Pre-existing `test_resolved_agent_string_agent` updated: `profile_id is None` → `profile_id == "generic-agent"`
- [ ] Skill file tests skip gracefully when `.agents/skills/` is absent (gitignored; only present after `spec-kitty upgrade`)
- [ ] Worktrees cleaned up; no stale worktree registrations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)