### PR TITLE
fix: address nightly Sonar reliability findings

### DIFF
--- a/src/specify_cli/compat/safety.py
+++ b/src/specify_cli/compat/safety.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 
 class Safety(StrEnum):
@@ -64,11 +64,7 @@ class _InvocationProtocol(Protocol):
         ...
 
 
-if TYPE_CHECKING:
-    # Only imported for type annotations; never executed at runtime.
-    _Invocation = _InvocationProtocol
-else:
-    _Invocation = _InvocationProtocol
+_Invocation = _InvocationProtocol
 
 # Public type alias — used by callers that want to register a predicate.
 SafetyPredicate = Callable[[_InvocationProtocol], Safety]

--- a/src/specify_cli/next/runtime_bridge.py
+++ b/src/specify_cli/next/runtime_bridge.py
@@ -706,11 +706,11 @@ def _check_composed_action_guard(  # noqa: C901
         # produces a non-empty failures list, which the dispatch surface
         # propagates as a structured error with no run-state advancement.
         if action == "scoping":
-            if not (feature_dir / "spec.md").is_file():
-                failures.append("Required artifact missing: spec.md")
+            if not (feature_dir / SPEC_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=SPEC_ARTIFACT))
         elif action == "methodology":
-            if not (feature_dir / "plan.md").is_file():
-                failures.append("Required artifact missing: plan.md")
+            if not (feature_dir / PLAN_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=PLAN_ARTIFACT))
         elif action == "gathering":
             if not (feature_dir / "source-register.csv").is_file():
                 failures.append("Required artifact missing: source-register.csv")
@@ -732,14 +732,14 @@ def _check_composed_action_guard(  # noqa: C901
 
     if mission == "documentation":
         if action == "discover":
-            if not (feature_dir / "spec.md").is_file():
-                failures.append("Required artifact missing: spec.md")
+            if not (feature_dir / SPEC_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=SPEC_ARTIFACT))
         elif action == "audit":
             if not (feature_dir / "gap-analysis.md").is_file():
                 failures.append("Required artifact missing: gap-analysis.md")
         elif action == "design":
-            if not (feature_dir / "plan.md").is_file():
-                failures.append("Required artifact missing: plan.md")
+            if not (feature_dir / PLAN_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=PLAN_ARTIFACT))
         elif action == "generate":
             if not _has_generated_docs(feature_dir):
                 failures.append(
@@ -759,25 +759,25 @@ def _check_composed_action_guard(  # noqa: C901
         return failures
 
     if action == "specify":
-        if not (feature_dir / "spec.md").exists():
-            failures.append("Required artifact missing: spec.md")
+        if not (feature_dir / SPEC_ARTIFACT).exists():
+            failures.append(MISSING_ARTIFACT_MESSAGE.format(name=SPEC_ARTIFACT))
 
     elif action == "plan":
-        if not (feature_dir / "plan.md").exists():
-            failures.append("Required artifact missing: plan.md")
+        if not (feature_dir / PLAN_ARTIFACT).exists():
+            failures.append(MISSING_ARTIFACT_MESSAGE.format(name=PLAN_ARTIFACT))
 
     elif action == "tasks":
         if legacy_step_id == "tasks_outline":
             # After tasks_outline the user is expected to have produced
             # tasks.md. WP files and dependencies come in later substeps.
-            if not (feature_dir / "tasks.md").exists():
-                failures.append("Required artifact missing: tasks.md")
+            if not (feature_dir / TASKS_ARTIFACT).exists():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=TASKS_ARTIFACT))
         elif legacy_step_id == "tasks_packages":
             # After tasks_packages: tasks.md AND >=1 WP file. Dependencies
             # are not yet expected — finalize-tasks adds them in the next
             # substep.
-            if not (feature_dir / "tasks.md").exists():
-                failures.append("Required artifact missing: tasks.md")
+            if not (feature_dir / TASKS_ARTIFACT).exists():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=TASKS_ARTIFACT))
             tasks_dir = feature_dir / "tasks"
             if not tasks_dir.is_dir() or not list(tasks_dir.glob("WP*.md")):
                 failures.append("Required: at least one tasks/WP*.md file")
@@ -786,8 +786,8 @@ def _check_composed_action_guard(  # noqa: C901
             # (legacy_step_id is None): demand the full terminal state.
             # Union of legacy tasks_outline + tasks_packages + tasks_finalize
             # checks; no weakening of assertions.
-            if not (feature_dir / "tasks.md").exists():
-                failures.append("Required artifact missing: tasks.md")
+            if not (feature_dir / TASKS_ARTIFACT).exists():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=TASKS_ARTIFACT))
             tasks_dir = feature_dir / "tasks"
             if not tasks_dir.is_dir() or not list(tasks_dir.glob("WP*.md")):
                 failures.append("Required: at least one tasks/WP*.md file")


### PR DESCRIPTION
## Summary
- remove the dead TYPE_CHECKING branch in compat safety classification so the new-code reliability issue on main is resolved
- reuse existing runtime bridge artifact constants for composed guard checks to clear the new literal-duplication findings introduced in the latest nightly Sonar analysis
- validate with focused pytest coverage for safety classification and runtime guard composition paths

## Validation
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/specify_cli/compat/test_safety.py tests/specify_cli/next/test_runtime_bridge_documentation_composition.py tests/specify_cli/next/test_runtime_bridge_research_composition.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/specify_cli/next/test_runtime_bridge_composition.py -k "tasks_outline or tasks_packages or tasks_finalize or test_specify_guard or test_plan_guard or task_guard or collapsed_on_tasks_outline or missing_spec or missing_plan"`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/architectural/test_safety_registry_completeness.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run ruff check --select F401,F821,E9 src/specify_cli/compat/safety.py src/specify_cli/next/runtime_bridge.py`

## Notes
- GitHub code scanning currently reports no open alerts.
- The open Dependabot alert is `GHSA-58qw-9mgm-455v` on transitive `pip` in `uv.lock`; there is still no upstream patched version published, so there is no repo-side version bump to apply yet.
- The nightly SonarCloud gate on `main` also remains blocked by `new_coverage` and `new_security_hotspots_reviewed`; those are not directly fixable by this code patch alone.