### PR TITLE
fix: address nightly SonarCloud safety follow-ups

### DIFF
--- a/src/specify_cli/compat/safety.py
+++ b/src/specify_cli/compat/safety.py
@@ -145,11 +145,11 @@ def classify(invocation: _InvocationProtocol) -> Safety:
     - Found with ``None`` value → ``Safety.SAFE``.
     - Found with callable → call the predicate; any exception → ``Safety.UNSAFE``.
     """
-    predicate = SAFETY_REGISTRY.get(invocation.command_path)
-
-    if predicate is None and invocation.command_path not in SAFETY_REGISTRY:
-        # Key was absent (get() returned default None for missing keys)
+    if invocation.command_path not in SAFETY_REGISTRY:
+        # Missing registry entries must fail closed.
         return Safety.UNSAFE
+
+    predicate = SAFETY_REGISTRY[invocation.command_path]
 
     if predicate is None:
         # Key present, value explicitly None → always safe
@@ -158,7 +158,7 @@ def classify(invocation: _InvocationProtocol) -> Safety:
     # Key present with a callable predicate
     try:
         return predicate(invocation)
-    except Exception:  # noqa: BLE001 — defensive, any exception → UNSAFE
+    except Exception:  # noqa: BLE001 - defensive: any exception -> UNSAFE
         return Safety.UNSAFE
 
 

--- a/src/specify_cli/doctrine_synthesizer/apply.py
+++ b/src/specify_cli/doctrine_synthesizer/apply.py
@@ -186,8 +186,8 @@ def _assert_within(base: Path, target: Path) -> Path:
 def _apply_add_glossary_term(
     payload: AddGlossaryTermPayload,
     repo_root: Path,
-    proposal: Proposal,
-    actor: ActorRef,
+    _proposal: Proposal,
+    _actor: ActorRef,
 ) -> tuple[str, str]:
     """Apply an add_glossary_term proposal.
 
@@ -219,8 +219,8 @@ def _apply_add_glossary_term(
 def _apply_update_glossary_term(
     payload: UpdateGlossaryTermPayload,
     repo_root: Path,
-    proposal: Proposal,
-    actor: ActorRef,
+    _proposal: Proposal,
+    _actor: ActorRef,
 ) -> tuple[str, str]:
     """Apply an update_glossary_term proposal (same storage as add)."""
     term_key = payload.term_key
@@ -246,7 +246,7 @@ def _apply_flag_not_helpful(
     payload: FlagNotHelpfulPayload,
     repo_root: Path,
     proposal: Proposal,
-    actor: ActorRef,
+    _actor: ActorRef,
 ) -> tuple[str, str]:
     """Apply a flag_not_helpful proposal.
 
@@ -277,8 +277,8 @@ def _apply_flag_not_helpful(
 def _apply_add_edge(
     payload: AddEdgePayload,
     repo_root: Path,
-    proposal: Proposal,
-    actor: ActorRef,
+    _proposal: Proposal,
+    _actor: ActorRef,
 ) -> tuple[str, str]:
     """Apply an add_edge proposal.
 
@@ -315,8 +315,8 @@ def _apply_add_edge(
 def _apply_rewire_edge(
     payload: RewireEdgePayload,
     repo_root: Path,
-    proposal: Proposal,
-    actor: ActorRef,
+    _proposal: Proposal,
+    _actor: ActorRef,
 ) -> tuple[str, str]:
     """Apply a rewire_edge proposal.
 
@@ -357,8 +357,8 @@ def _apply_rewire_edge(
 def _apply_synthesize(
     payload: SynthesizeDirectivePayload | SynthesizeTacticPayload | SynthesizeProcedurePayload,
     repo_root: Path,
-    proposal: Proposal,
-    actor: ActorRef,
+    _proposal: Proposal,
+    _actor: ActorRef,
 ) -> tuple[str, str]:
     """Apply a synthesize_* proposal.
 

--- a/src/specify_cli/next/runtime_bridge.py
+++ b/src/specify_cli/next/runtime_bridge.py
@@ -305,6 +305,7 @@ def _should_advance_wp_step(step_id: str, feature_dir: Path) -> bool:
 SPEC_ARTIFACT = "spec.md"
 PLAN_ARTIFACT = "plan.md"
 TASKS_ARTIFACT = "tasks.md"
+STATE_FILE = "state.json"
 TASKS_GLOB = "WP*.md"
 MISSING_ARTIFACT_MESSAGE = "Required artifact missing: {name}"
 MISSING_TASK_FILES_MESSAGE = f"Required: at least one tasks/{TASKS_GLOB} file"
@@ -706,11 +707,11 @@ def _check_composed_action_guard(  # noqa: C901
         # produces a non-empty failures list, which the dispatch surface
         # propagates as a structured error with no run-state advancement.
         if action == "scoping":
-            if not (feature_dir / "spec.md").is_file():
-                failures.append("Required artifact missing: spec.md")
+            if not (feature_dir / SPEC_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=SPEC_ARTIFACT))
         elif action == "methodology":
-            if not (feature_dir / "plan.md").is_file():
-                failures.append("Required artifact missing: plan.md")
+            if not (feature_dir / PLAN_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=PLAN_ARTIFACT))
         elif action == "gathering":
             if not (feature_dir / "source-register.csv").is_file():
                 failures.append("Required artifact missing: source-register.csv")
@@ -732,14 +733,14 @@ def _check_composed_action_guard(  # noqa: C901
 
     if mission == "documentation":
         if action == "discover":
-            if not (feature_dir / "spec.md").is_file():
-                failures.append("Required artifact missing: spec.md")
+            if not (feature_dir / SPEC_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=SPEC_ARTIFACT))
         elif action == "audit":
             if not (feature_dir / "gap-analysis.md").is_file():
                 failures.append("Required artifact missing: gap-analysis.md")
         elif action == "design":
-            if not (feature_dir / "plan.md").is_file():
-                failures.append("Required artifact missing: plan.md")
+            if not (feature_dir / PLAN_ARTIFACT).is_file():
+                failures.append(MISSING_ARTIFACT_MESSAGE.format(name=PLAN_ARTIFACT))
         elif action == "generate":
             if not _has_generated_docs(feature_dir):
                 failures.append(
@@ -1323,7 +1324,7 @@ def _existing_run_ref(
 
     entry = index[mission_slug]
     run_dir = Path(entry["run_dir"])
-    if not (run_dir / "state.json").exists():
+    if not (run_dir / STATE_FILE).exists():
         return None
 
     stored_mission_type = entry.get("mission_type") or entry.get("mission_key") or mission_type
@@ -1382,7 +1383,7 @@ def get_or_start_run(
     if mission_slug in index:
         entry = index[mission_slug]
         run_dir = Path(entry["run_dir"])
-        if (run_dir / "state.json").exists():
+        if (run_dir / STATE_FILE).exists():
             stored_mission_type = entry.get("mission_type") or entry.get("mission_key") or mission_type
             return _build_run_ref(
                 run_id=entry["run_id"],
@@ -1768,7 +1769,7 @@ def decide_next_via_runtime(
 
     if retrospective_enabled:
         run_dir = Path(run_ref.run_dir)
-        state_path = run_dir / "state.json"
+        state_path = run_dir / STATE_FILE
         events_path = run_dir / "run.events.jsonl"
         try:
             pre_state_bytes = state_path.read_bytes() if state_path.exists() else None
@@ -1845,7 +1846,7 @@ def decide_next_via_runtime(
             run_dir = Path(run_ref.run_dir)
             if pre_state_bytes is not None:
                 try:
-                    (run_dir / "state.json").write_bytes(pre_state_bytes)
+                    (run_dir / STATE_FILE).write_bytes(pre_state_bytes)
                 except OSError as restore_exc:
                     logger.error(
                         "rollback of state.json failed after gate block: %s",


### PR DESCRIPTION
## Summary
- fix the new Sonar reliability bug in `specify_cli.compat.safety.classify()` by making the fail-closed path explicit
- replace repeated runtime artifact literals with shared constants and normalize nearby guard messages
- remove recent low-signal Sonar findings in doctrine synthesizer helpers by marking intentionally unused helper parameters

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/compat/test_safety.py tests/specify_cli/next/test_runtime_bridge.py`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run ruff check src/specify_cli/compat/safety.py src/specify_cli/doctrine_synthesizer/apply.py --select ARG,BLE,F,E`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run ruff check src/specify_cli/next/runtime_bridge.py --select F,E`

## Notes
- GitHub code scanning is currently clean.
- The open Dependabot alert for transitive `pip` (`GHSA-58qw-9mgm-455v` / `CVE-2026-3219`) still has no patched upstream version available in `uv.lock`, so there is no repo-side version bump to apply yet.
- SonarCloud nightly `main` still has outstanding quality-gate pressure from low new-code coverage and unreviewed security hotspots beyond this patch scope.