### PR TITLE
Add curated Matt Pocock skill doctrine

### DIFF
--- a/src/doctrine/drg/migration/extractor.py
+++ b/src/doctrine/drg/migration/extractor.py
@@ -33,11 +33,12 @@ _KIND_MAP: dict[str, NodeKind] = {
     "toolguide": NodeKind.TOOLGUIDE,
     "procedure": NodeKind.PROCEDURE,
     "agent_profile": NodeKind.AGENT_PROFILE,
+    "template": NodeKind.TEMPLATE,
     "action": NodeKind.ACTION,
 }
 
 # Reference types that are NOT DRG node kinds (skipped during extraction).
-_SKIP_REF_TYPES: frozenset[str] = frozenset({"template"})
+_SKIP_REF_TYPES: frozenset[str] = frozenset()
 
 
 def _ensure_node(
@@ -78,14 +79,14 @@ def _kind_for_type(ref_type: str) -> NodeKind | None:
 
 
 # ---------------------------------------------------------------------------
-# T012: Artifact walker (directives, tactics, paradigms)
+# T012: Artifact walker (directives, tactics, paradigms, procedures)
 # ---------------------------------------------------------------------------
 
 
-def extract_artifact_edges(
+def extract_artifact_edges(  # noqa: C901
     doctrine_root: Path,
 ) -> tuple[list[DRGNode], list[DRGEdge]]:
-    """Walk shipped directives, tactics, and paradigms; return (nodes, edges).
+    """Walk shipped directives, tactics, paradigms, and procedures; return (nodes, edges).
 
     Every inline reference field is converted to a typed DRG edge.
     Nodes are deduplicated by URN.
@@ -272,6 +273,36 @@ def extract_artifact_edges(
                         target=tgt_urn,
                         relation=Relation.REPLACES,
                         reason=opp.get("reason"),
+                    )
+                )
+
+    # --- Procedures ---
+    procedures_dir = doctrine_root / "procedures" / "shipped"
+    if procedures_dir.is_dir():
+        for path in sorted(procedures_dir.glob("*.procedure.yaml")):
+            data = _load_yaml(path)
+            if data is None:
+                continue
+            procedure_id = data.get("id", "")
+            procedure_name = data.get("name", "")
+            src_urn = artifact_to_urn("procedure", procedure_id)
+            _ensure_node(nodes_by_urn, src_urn, NodeKind.PROCEDURE, procedure_name)
+
+            for ref in data.get("references", []) or []:
+                ref_type = ref.get("type", "")
+                ref_id = ref.get("id", "")
+                if not ref_type or not ref_id:
+                    continue
+                tgt_kind = _kind_for_type(ref_type)
+                if tgt_kind is None:
+                    continue
+                tgt_urn = artifact_to_urn(ref_type, ref_id)
+                _ensure_node(nodes_by_urn, tgt_urn, tgt_kind)
+                _add_edge(
+                    DRGEdge(
+                        source=src_urn,
+                        target=tgt_urn,
+                        relation=_relation_for_ref_type(ref_type),
                     )
                 )
 

--- a/src/doctrine/drg/models.py
+++ b/src/doctrine/drg/models.py
@@ -37,6 +37,7 @@ class NodeKind(StrEnum):
     TOOLGUIDE = "toolguide"
     PROCEDURE = "procedure"
     AGENT_PROFILE = "agent_profile"
+    TEMPLATE = "template"
     ACTION = "action"
     GLOSSARY_SCOPE = "glossary_scope"
     GLOSSARY = "glossary"           # URN prefix: "glossary:<id>"

--- a/src/doctrine/drg/query.py
+++ b/src/doctrine/drg/query.py
@@ -149,6 +149,7 @@ class ResolveTransitiveRefsResult:
     toolguides: list[str] = field(default_factory=list)
     procedures: list[str] = field(default_factory=list)
     agent_profiles: list[str] = field(default_factory=list)
+    templates: list[str] = field(default_factory=list)
     # Edges whose target URN was not found in the graph, stored as
     # ``(source_urn, target_urn)``. Always ``[]`` when the input graph has
     # passed :func:`doctrine.drg.validator.assert_valid`, since the validator
@@ -232,5 +233,6 @@ def resolve_transitive_refs(
         toolguides=buckets[NodeKind.TOOLGUIDE],
         procedures=buckets[NodeKind.PROCEDURE],
         agent_profiles=buckets[NodeKind.AGENT_PROFILE],
+        templates=buckets[NodeKind.TEMPLATE],
         unresolved=unresolved,
     )

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -112,15 +112,24 @@ nodes:
   label: C4 Incremental Detail Modeling
 - urn: paradigm:code-is-the-documentation
   kind: paradigm
+- urn: paradigm:deep-module-design
+  kind: paradigm
+  label: Deep Module Design
 - urn: paradigm:domain-driven-design
   kind: paradigm
   label: Domain-Driven Design
 - urn: paradigm:specification-by-example
   kind: paradigm
   label: Specification by Example
+- urn: procedure:disciplined-defect-diagnosis
+  kind: procedure
+  label: Disciplined Defect Diagnosis
 - urn: procedure:documentation-gap-prioritization
   kind: procedure
   label: Documentation Gap Prioritization
+- urn: procedure:domain-aware-decision-interview
+  kind: procedure
+  label: Domain-Aware Decision Interview
 - urn: procedure:drill-down-documentation
   kind: procedure
   label: Drill-Down Documentation
@@ -130,6 +139,9 @@ nodes:
 - urn: procedure:example-mapping-workshop
   kind: procedure
   label: Example Mapping Workshop
+- urn: procedure:issue-triage-state-machine
+  kind: procedure
+  label: Issue Triage State Machine
 - urn: procedure:migrate-project-guidance-to-spec-kitty-charter
   kind: procedure
   label: Migrate Project Guidance to Spec Kitty Charter
@@ -145,6 +157,9 @@ nodes:
 - urn: styleguide:aggregate-design-rules
   kind: styleguide
   label: Aggregate Design Rules
+- urn: styleguide:deployable-skill-authoring
+  kind: styleguide
+  label: Deployable Skill Authoring Styleguide
 - urn: styleguide:kitty-glossary-writing
   kind: styleguide
   label: Kitty Glossary Writing Styleguide
@@ -187,6 +202,9 @@ nodes:
 - urn: tactic:black-box-integration-testing
   kind: tactic
   label: Black-Box Integration Testing
+- urn: tactic:bug-fixing-checklist
+  kind: tactic
+  label: Bug-Fixing Checklist
 - urn: tactic:bounded-context-canvas-fill
   kind: tactic
   label: Bounded Context Canvas Fill
@@ -216,6 +234,9 @@ nodes:
   label: Cross-Cutting State via Store
 - urn: tactic:database-driven-design
   kind: tactic
+- urn: tactic:deepening-opportunity-assessment
+  kind: tactic
+  label: Deepening Opportunity Assessment
 - urn: tactic:decision-marker-capture
   kind: tactic
   label: Decision Marker Capture
@@ -240,6 +261,9 @@ nodes:
 - urn: tactic:input-validation-fail-fast
   kind: tactic
   label: Input Validation with Fail-Fast Feedback
+- urn: tactic:interface-variation-design
+  kind: tactic
+  label: Interface Variation Design
 - urn: tactic:language-driven-design
   kind: tactic
   label: Language-Driven Design
@@ -353,6 +377,45 @@ nodes:
 - urn: tactic:zombies-tdd
   kind: tactic
   label: ZOMBIES TDD
+- urn: template:agent-brief-template
+  kind: template
+  label: Agent Brief Template
+- urn: template:ammerse-analysis-template
+  kind: template
+  label: AMMERSE Analysis Template
+- urn: template:bounded-context-canvas-template
+  kind: template
+  label: Bounded Context Canvas Template
+- urn: template:c4-component-mermaid-template
+  kind: template
+  label: C4 Component Mermaid Template
+- urn: template:c4-container-mermaid-template
+  kind: template
+  label: C4 Container Mermaid Template
+- urn: template:c4-context-mermaid-template
+  kind: template
+  label: C4 Context Mermaid Template
+- urn: template:glossary-template
+  kind: template
+  label: Glossary Template
+- urn: template:lightweight-prestudy-template
+  kind: template
+  label: Lightweight Prestudy Template
+- urn: template:out-of-scope-record-template
+  kind: template
+  label: Out-of-Scope Record Template
+- urn: template:quality-attribute-assessment-template
+  kind: template
+  label: Quality Attribute Assessment Template
+- urn: template:risk-identification-assessment-template
+  kind: template
+  label: Risk Identification Assessment Template
+- urn: template:stakeholder-persona-template
+  kind: template
+  label: Stakeholder Persona Template
+- urn: template:system-context-canvas-template
+  kind: template
+  label: System Context Canvas Template
 - urn: toolguide:contextive
   kind: toolguide
   label: Contextive
@@ -533,6 +596,12 @@ edges:
   target: tactic:adr-drafting-workflow
   relation: scope
 - source: action:software-dev/plan
+  target: tactic:deepening-opportunity-assessment
+  relation: scope
+- source: action:software-dev/plan
+  target: tactic:interface-variation-design
+  relation: scope
+- source: action:software-dev/plan
   target: tactic:premortem-risk-identification
   relation: scope
 - source: action:software-dev/plan
@@ -540,6 +609,9 @@ edges:
   relation: scope
 - source: action:software-dev/plan
   target: tactic:requirements-validation-workflow
+  relation: scope
+- source: action:software-dev/plan
+  target: procedure:domain-aware-decision-interview
   relation: scope
 - source: action:software-dev/review
   target: directive:DIRECTIVE_010
@@ -606,6 +678,9 @@ edges:
   relation: scope
 - source: action:software-dev/tasks
   target: tactic:requirements-validation-workflow
+  relation: scope
+- source: action:software-dev/tasks
+  target: procedure:issue-triage-state-machine
   relation: scope
 - source: action:research/scoping
   target: directive:DIRECTIVE_003
@@ -894,6 +969,23 @@ edges:
   reason: "A single all-in-one architecture diagram conflates audiences and abstraction
     levels, producing a poster that nobody can review in a reasonable time. C4 explicitly
     separates concerns into distinct levels.\n"
+- source: paradigm:deep-module-design
+  target: directive:DIRECTIVE_001
+  relation: requires
+- source: paradigm:deep-module-design
+  target: directive:DIRECTIVE_024
+  relation: requires
+- source: paradigm:deep-module-design
+  target: directive:DIRECTIVE_030
+  relation: requires
+- source: paradigm:deep-module-design
+  target: tactic:deepening-opportunity-assessment
+  relation: suggests
+  when: Use to determine whether a shallow design should be deepened.
+- source: paradigm:deep-module-design
+  target: tactic:interface-variation-design
+  relation: suggests
+  when: Use to compare candidate interfaces for a deep module.
 - source: paradigm:domain-driven-design
   target: directive:DIRECTIVE_001
   relation: requires
@@ -1379,6 +1471,130 @@ edges:
 - source: toolguide:python-mutation-tools
   target: styleguide:mutation-aware-test-design
   relation: requires
+
+# ---------------------------------------------------------------------------
+# Template reference edges — templates are first-class DRG nodes so procedure
+# and tactic references can resolve through the graph instead of being skipped.
+# ---------------------------------------------------------------------------
+- source: tactic:ammerse-impact-analysis
+  target: template:ammerse-analysis-template
+  relation: suggests
+- source: tactic:bounded-context-canvas-fill
+  target: template:bounded-context-canvas-template
+  relation: suggests
+- source: tactic:bounded-context-canvas-fill
+  target: template:glossary-template
+  relation: suggests
+- source: tactic:c4-zoom-in-architecture-documentation
+  target: template:c4-context-mermaid-template
+  relation: suggests
+- source: tactic:c4-zoom-in-architecture-documentation
+  target: template:c4-container-mermaid-template
+  relation: suggests
+- source: tactic:c4-zoom-in-architecture-documentation
+  target: template:c4-component-mermaid-template
+  relation: suggests
+- source: tactic:premortem-risk-identification
+  target: template:risk-identification-assessment-template
+  relation: suggests
+- source: tactic:problem-decomposition
+  target: template:lightweight-prestudy-template
+  relation: suggests
+- source: tactic:stakeholder-alignment
+  target: template:stakeholder-persona-template
+  relation: suggests
+- source: tactic:stakeholder-alignment
+  target: template:system-context-canvas-template
+  relation: suggests
+- source: procedure:situational-assessment
+  target: template:system-context-canvas-template
+  relation: suggests
+- source: procedure:situational-assessment
+  target: template:lightweight-prestudy-template
+  relation: suggests
+- source: procedure:situational-assessment
+  target: template:quality-attribute-assessment-template
+  relation: suggests
+- source: procedure:situational-assessment
+  target: template:ammerse-analysis-template
+  relation: suggests
+
+# ---------------------------------------------------------------------------
+# Curated Matt Pocock skill-pattern doctrine.
+# Upstream: https://github.com/mattpocock/skills/tree/49cec7be019bc408e87b77670f3d442f536da254
+# ---------------------------------------------------------------------------
+- source: procedure:disciplined-defect-diagnosis
+  target: directive:DIRECTIVE_030
+  relation: requires
+- source: procedure:disciplined-defect-diagnosis
+  target: procedure:test-first-bug-fixing
+  relation: suggests
+- source: procedure:disciplined-defect-diagnosis
+  target: tactic:bug-fixing-checklist
+  relation: suggests
+- source: procedure:disciplined-defect-diagnosis
+  target: tactic:testing-select-appropriate-level
+  relation: suggests
+- source: procedure:domain-aware-decision-interview
+  target: tactic:glossary-curation-interview
+  relation: suggests
+- source: procedure:domain-aware-decision-interview
+  target: tactic:language-driven-design
+  relation: suggests
+- source: procedure:domain-aware-decision-interview
+  target: tactic:adr-drafting-workflow
+  relation: suggests
+- source: procedure:domain-aware-decision-interview
+  target: procedure:situational-assessment
+  relation: suggests
+- source: procedure:issue-triage-state-machine
+  target: template:agent-brief-template
+  relation: suggests
+- source: procedure:issue-triage-state-machine
+  target: template:out-of-scope-record-template
+  relation: suggests
+- source: procedure:issue-triage-state-machine
+  target: procedure:disciplined-defect-diagnosis
+  relation: suggests
+- source: procedure:issue-triage-state-machine
+  target: procedure:test-first-bug-fixing
+  relation: suggests
+- source: procedure:issue-triage-state-machine
+  target: tactic:requirements-validation-workflow
+  relation: suggests
+- source: tactic:deepening-opportunity-assessment
+  target: paradigm:deep-module-design
+  relation: suggests
+- source: tactic:deepening-opportunity-assessment
+  target: tactic:easy-to-change
+  relation: suggests
+- source: tactic:deepening-opportunity-assessment
+  target: tactic:locality-of-change
+  relation: suggests
+- source: tactic:deepening-opportunity-assessment
+  target: procedure:refactoring
+  relation: suggests
+- source: tactic:interface-variation-design
+  target: paradigm:deep-module-design
+  relation: suggests
+- source: tactic:interface-variation-design
+  target: tactic:deepening-opportunity-assessment
+  relation: suggests
+- source: tactic:interface-variation-design
+  target: tactic:traceable-decisions
+  relation: suggests
+- source: styleguide:deployable-skill-authoring
+  target: directive:DIRECTIVE_037
+  relation: suggests
+- source: agent_profile:architect-alphonso
+  target: tactic:deepening-opportunity-assessment
+  relation: suggests
+- source: agent_profile:architect-alphonso
+  target: tactic:interface-variation-design
+  relation: suggests
+- source: agent_profile:curator-carla
+  target: styleguide:deployable-skill-authoring
+  relation: suggests
 # ---------------------------------------------------------------------------
 # Agent profile nodes — specialisation hierarchy and doctrine context wiring
 # ---------------------------------------------------------------------------

--- a/src/doctrine/missions/software-dev/actions/plan/index.yaml
+++ b/src/doctrine/missions/software-dev/actions/plan/index.yaml
@@ -5,6 +5,9 @@ directives:
 tactics:
   - requirements-validation-workflow
   - adr-drafting-workflow
+  - deepening-opportunity-assessment
+  - interface-variation-design
 styleguides: []
 toolguides: []
-procedures: []
+procedures:
+  - domain-aware-decision-interview

--- a/src/doctrine/missions/software-dev/actions/tasks/index.yaml
+++ b/src/doctrine/missions/software-dev/actions/tasks/index.yaml
@@ -9,4 +9,5 @@ tactics:
   - requirements-validation-workflow
 styleguides: []
 toolguides: []
-procedures: []
+procedures:
+  - issue-triage-state-machine

--- a/src/doctrine/paradigms/shipped/deep-module-design.paradigm.yaml
+++ b/src/doctrine/paradigms/shipped/deep-module-design.paradigm.yaml
@@ -1,0 +1,14 @@
+schema_version: "1.0"
+id: deep-module-design
+name: Deep Module Design
+summary: >
+  Shape modules so a small, stable interface gives callers high leverage over a
+  substantial implementation. The interface includes every fact a caller must
+  know to use the module correctly: names, types, invariants, ordering, error
+  modes, configuration, and performance expectations. Deep modules improve
+  locality because changes, bugs, and knowledge concentrate behind the interface
+  instead of spreading across callers and tests.
+directive_refs:
+  - DIRECTIVE_001
+  - DIRECTIVE_024
+  - DIRECTIVE_030

--- a/src/doctrine/procedures/shipped/disciplined-defect-diagnosis.procedure.yaml
+++ b/src/doctrine/procedures/shipped/disciplined-defect-diagnosis.procedure.yaml
@@ -1,0 +1,107 @@
+schema_version: "1.0"
+id: disciplined-defect-diagnosis
+name: Disciplined Defect Diagnosis
+purpose: >
+  Diagnose hard bugs and performance regressions by first constructing a fast,
+  trustworthy feedback loop, then testing ranked hypotheses with targeted
+  instrumentation before applying a regression-tested fix. This procedure fills
+  the gap before test-first bug fixing: it is for turning an unclear report into
+  a reproducible, falsifiable, and cleanly verified defect.
+entry_condition: >
+  A bug report, failing behavior, intermittent failure, or performance regression
+  exists, but the root cause is not yet proven and the current reproduction path
+  is missing, slow, flaky, or too broad to guide a fix.
+exit_condition: >
+  The original user-described failure no longer reproduces, a correct-seam
+  regression test or documented seam gap exists, temporary instrumentation has
+  been removed, and the winning hypothesis is recorded in the commit, PR, or
+  work-package closeout.
+steps:
+  - title: Build the feedback loop first
+    actor: agent
+    description: >
+      Spend disproportionate effort creating the fastest deterministic pass/fail
+      signal that reaches the defect. Prefer a failing test, CLI fixture, HTTP
+      script, headless browser script, replayed trace, throwaway harness,
+      property loop, bisection harness, differential loop, or structured
+      human-in-the-loop script, in that order. If the bug is nondeterministic,
+      raise the reproduction rate enough to debug before looking for a fix.
+    on_failure: >
+      Stop and request the missing artifact, environment, trace, log, or
+      permission for temporary instrumentation instead of hypothesizing from
+      code inspection alone.
+  - title: Reproduce the reported failure
+    actor: agent
+    description: >
+      Run the loop until it produces the failure mode the user described. Capture
+      the exact symptom, error, wrong output, timing regression, or state change.
+      Do not proceed if the loop shows only a nearby or different failure.
+    on_failure: >
+      Revise the loop or narrow the report; fixing the wrong failure creates
+      false confidence.
+  - title: Rank falsifiable hypotheses
+    actor: agent
+    description: >
+      Generate three to five ranked hypotheses before testing any one of them.
+      Each hypothesis must state a prediction: if this is the cause, then a
+      specific probe or variable change will make the failure disappear, move, or
+      become worse.
+  - title: Instrument one prediction at a time
+    actor: agent
+    description: >
+      Use the least noisy probe that distinguishes the ranked hypotheses:
+      debugger or REPL inspection first, then targeted logs, metrics, query plans,
+      profilers, or trace markers. Tag every temporary log or probe with a unique
+      prefix so cleanup can be verified mechanically. For performance regressions,
+      establish a baseline and measure before changing code.
+    on_failure: >
+      If a probe cannot falsify a hypothesis, discard or sharpen the hypothesis.
+  - title: Minimize and lock the defect
+    actor: agent
+    description: >
+      Convert the smallest reproduction that still exercises the real bug pattern
+      into a failing regression test at the correct seam. The seam must match how
+      the defect occurs in production or in the caller path; a too-shallow test is
+      a documented architecture finding, not a substitute for coverage.
+  - title: Apply the smallest verified fix
+    actor: agent
+    description: >
+      Make the minimal production change that makes the regression test pass.
+      Re-run the original broad feedback loop after the minimized test passes so
+      the fix is proven against the user's scenario, not only the reduced case.
+  - title: Clean up and record the learning
+    actor: agent
+    description: >
+      Remove all tagged debug instrumentation and throwaway harnesses, rerun the
+      relevant gates, and record the confirmed root cause plus the hypothesis that
+      proved correct. If diagnosis exposed a missing test seam or architectural
+      tangle, open follow-up work after the fix is verified.
+anti_patterns:
+  - name: Fixing without a feedback loop
+    description: "Changing production code before a repeatable signal exists turns debugging into guessing."
+  - name: Logging everything
+    description: "Broad untagged logging creates noise, hides the discriminating signal, and leaves cleanup debt."
+  - name: Single-hypothesis anchoring
+    description: "Testing the first plausible explanation anchors the diagnosis and misses cheaper disconfirming probes."
+  - name: Wrong-failure reproduction
+    description: "A loop that fails for a nearby setup error or different behavior validates the wrong fix."
+  - name: Leaving debug artifacts behind
+    description: "Temporary logs, harnesses, trace files, and flags must either be deleted or promoted into named diagnostics."
+references:
+  - type: procedure
+    id: test-first-bug-fixing
+    reason: Once the defect is minimized, the fix follows the test-first bug-fixing procedure.
+  - type: tactic
+    id: bug-fixing-checklist
+    reason: The checklist supplies the focused red-green discipline for the regression-test phase.
+  - type: tactic
+    id: testing-select-appropriate-level
+    reason: Test level selection identifies the correct seam for the regression test.
+  - type: directive
+    id: DIRECTIVE_030
+    reason: The fix is not complete until relevant quality gates pass.
+notes: >
+  Adapted from the mattpocock/skills diagnose workflow at commit
+  49cec7be019bc408e87b77670f3d442f536da254. The upstream skill is a host
+  workflow; this artifact preserves the reusable diagnostic procedure without
+  copying host-specific mechanics into doctrine.

--- a/src/doctrine/procedures/shipped/domain-aware-decision-interview.procedure.yaml
+++ b/src/doctrine/procedures/shipped/domain-aware-decision-interview.procedure.yaml
@@ -1,0 +1,87 @@
+schema_version: "1.0"
+id: domain-aware-decision-interview
+name: Domain-Aware Decision Interview
+purpose: >
+  Stress-test a plan or design through a one-question-at-a-time interview that
+  uses project glossary, charter, doctrine, ADRs, and code evidence as the
+  shared source of truth. The procedure resolves the decision tree without
+  over-interviewing and records durable terminology or decision updates only
+  when they have long-term value.
+entry_condition: >
+  A plan, design, interface, issue, or work-package direction is proposed but
+  contains unresolved terminology, hidden assumptions, trade-offs, or domain
+  boundary questions.
+exit_condition: >
+  The relevant decision branches are resolved, remaining unknowns are explicit,
+  glossary or decision updates have been recorded when warranted, and the plan
+  can move to specification, tasking, implementation, or rejection with clear
+  rationale.
+steps:
+  - title: Load local language and decisions
+    actor: agent
+    description: >
+      Read the relevant project glossary, charter selections, doctrine context,
+      ADRs, and nearby design docs before asking questions. If the answer can be
+      discovered from repository evidence, inspect that evidence instead of
+      asking the human.
+  - title: Ask one decision question at a time
+    actor: agent
+    description: >
+      Walk the decision tree one branch at a time. Each question should include a
+      recommended answer and the reason for that recommendation. Wait for the
+      human's response before opening the next branch.
+  - title: Challenge vocabulary conflicts immediately
+    actor: agent
+    description: >
+      When a term conflicts with the glossary or is overloaded, pause to resolve
+      it. Ask whether the user means the existing canonical term, a distinct new
+      concept, or a boundary between contexts.
+  - title: Probe with concrete scenarios
+    actor: agent
+    description: >
+      Convert vague claims into specific examples that test boundaries, lifecycle
+      rules, failure paths, and ownership. Prefer examples involving real actors,
+      states, and transitions over abstract discussion.
+  - title: Cross-check claims against code and docs
+    actor: agent
+    description: >
+      If the human states how the system works, verify whether code, tests, ADRs,
+      or existing specs agree. Surface contradictions as decision points rather
+      than silently accepting either side.
+  - title: Record durable outcomes inline
+    actor: agent
+    description: >
+      Propose a glossary update when a canonical term is created or clarified.
+      Propose a decision record only when the choice is hard to reverse,
+      surprising without context, and the result of a real trade-off.
+  - title: Close with resolved branches and residual questions
+    actor: agent
+    description: >
+      Summarize decisions, rejected alternatives, updated terminology, open
+      questions, and the next artifact that should consume the result.
+anti_patterns:
+  - name: Over-interviewing
+    description: "Asking questions whose answers are already present in code, tests, docs, or the current plan wastes human attention."
+  - name: Terminology policing
+    description: "Correcting words without structural or domain impact creates friction without improving understanding."
+  - name: Premature decision records
+    description: "Recording reversible, obvious, or non-trade-off choices bloats decision history."
+  - name: Batch questioning
+    description: "Asking many questions at once prevents the interview from adapting to resolved dependencies."
+references:
+  - type: tactic
+    id: glossary-curation-interview
+    reason: Use when the interview resolves a new or ambiguous domain term.
+  - type: tactic
+    id: language-driven-design
+    reason: Use for detecting architectural significance in terminology conflicts.
+  - type: tactic
+    id: adr-drafting-workflow
+    reason: Use when the interview crystallizes a durable architectural decision.
+  - type: procedure
+    id: situational-assessment
+    reason: Use when the interview reveals that the broader context is not yet understood.
+notes: >
+  Adapted from the mattpocock/skills grill-with-docs and grill-me workflows at
+  commit 49cec7be019bc408e87b77670f3d442f536da254. Spec Kitty uses its glossary,
+  DRG, charter, and ADR surfaces rather than the upstream CONTEXT.md convention.

--- a/src/doctrine/procedures/shipped/issue-triage-state-machine.procedure.yaml
+++ b/src/doctrine/procedures/shipped/issue-triage-state-machine.procedure.yaml
@@ -1,0 +1,89 @@
+schema_version: "1.0"
+id: issue-triage-state-machine
+name: Issue Triage State Machine
+purpose: >
+  Triage incoming bugs and enhancements into a single current state, preserving
+  durable handoff context for agents and durable rejection context for future
+  maintainers. The procedure is tracker-neutral: GitHub labels are one possible
+  carrier, but the invariant is a category plus exactly one workflow state.
+entry_condition: >
+  An incoming issue, support report, feature request, or bug report needs
+  classification before it can be planned, delegated, rejected, or sent back for
+  more information.
+exit_condition: >
+  The issue has one category, one state, and a durable record appropriate to
+  that state: questions for the reporter, an agent brief, a human handoff, or an
+  out-of-scope decision record.
+steps:
+  - title: Read the whole issue history
+    actor: agent
+    description: >
+      Load the issue body, comments, labels or tracker status, prior triage
+      notes, reporter context, and any existing out-of-scope records for similar
+      concepts. Do not classify from the title alone.
+  - title: Enforce one category and one state
+    actor: agent
+    description: >
+      Assign one category such as bug or enhancement and one state such as
+      needs-triage, needs-info, ready-for-agent, ready-for-human, or wontfix.
+      If existing tracker labels conflict, surface the conflict before making
+      changes.
+  - title: Reproduce or bound bugs
+    actor: agent
+    description: >
+      For bug reports, attempt to reproduce the behavior or identify the missing
+      reproduction detail before moving the issue to ready-for-agent. A confirmed
+      reproduction should feed the agent brief; an underspecified report should
+      move to needs-info with specific questions.
+  - title: Create a durable agent brief for delegated work
+    actor: agent
+    description: >
+      When the issue is ready for an autonomous agent, write a brief that
+      describes current behavior, desired behavior, key interfaces or contracts,
+      acceptance criteria, and out-of-scope boundaries. Avoid file paths, line
+      numbers, and step-by-step implementation instructions that will go stale.
+  - title: Route human-only work explicitly
+    actor: agent
+    description: >
+      If the issue requires product judgment, external credentials, manual
+      validation, or unresolved design choices, mark it ready for a human and
+      summarize what is known plus why it should not be delegated yet.
+  - title: Preserve rejected enhancement decisions
+    actor: agent
+    description: >
+      For rejected enhancements, create or update an out-of-scope record keyed
+      by concept. Capture the decision, durable rationale, and prior requests so
+      future similar issues can be recognized without relying on memory.
+  - title: Resume from prior triage state
+    actor: agent
+    description: >
+      When a reporter replies or a maintainer reopens discussion, continue from
+      the prior triage notes rather than re-asking resolved questions.
+anti_patterns:
+  - name: Multiple active state labels
+    description: "Conflicting states make ownership and next action ambiguous."
+  - name: Implementation-coupled briefs
+    description: "Briefs that mention line numbers or current file paths decay quickly and constrain agents unnecessarily."
+  - name: Vague needs-info questions
+    description: "Questions like 'please provide more detail' do not help the reporter unblock triage."
+  - name: Memory-only rejection
+    description: "Closing an enhancement without a persistent concept record causes future duplicate requests to be relitigated."
+references:
+  - type: template
+    id: agent-brief-template
+    reason: Use when moving an issue to ready-for-agent.
+  - type: template
+    id: out-of-scope-record-template
+    reason: Use when rejecting an enhancement as out of scope.
+  - type: procedure
+    id: disciplined-defect-diagnosis
+    reason: Use for bug reports that need diagnosis before they are ready for implementation.
+  - type: procedure
+    id: test-first-bug-fixing
+    reason: Use once a bug is reproducible and ready for a fix.
+  - type: tactic
+    id: requirements-validation-workflow
+    reason: Use to validate enhancement claims and acceptance criteria before delegation.
+notes: >
+  Adapted from the mattpocock/skills github-triage, qa, and triage-issue
+  workflows at commit 49cec7be019bc408e87b77670f3d442f536da254.

--- a/src/doctrine/styleguides/shipped/deployable-skill-authoring.styleguide.yaml
+++ b/src/doctrine/styleguides/shipped/deployable-skill-authoring.styleguide.yaml
@@ -1,0 +1,61 @@
+schema_version: "1.0"
+id: deployable-skill-authoring
+title: Deployable Skill Authoring Styleguide
+scope: docs
+principles:
+  - "A skill description is a routing contract: it must name what the skill does and the concrete triggers that should cause an agent to load it."
+  - "Keep SKILL.md focused on the common path. Move rare, long, or provider-specific detail into references, scripts, or assets."
+  - "Prefer deterministic scripts for repeatable validation, formatting, extraction, or setup work instead of asking agents to regenerate shell logic from prose."
+  - "Use stable, project-owned terminology so the same skill can be distributed across supported host surfaces without rewriting its concepts."
+  - "Review skills as executable governance: check trigger precision, context size, source authority, failure handling, and host portability."
+patterns:
+  - name: Trigger-rich description
+    description: >
+      The frontmatter description should include the capability and concrete
+      activation cues. It must help an agent distinguish this skill from nearby
+      skills before reading the body.
+    bad_example: |
+      description: Helps with planning.
+    good_example: |
+      description: Turn approved specifications into dependency-aware work packages. Use when the user asks to create tasks, split a plan into WPs, or prepare implementation slices.
+  - name: Progressive disclosure package
+    description: >
+      Put the happy-path workflow in SKILL.md. Put rarely needed matrices,
+      provider-specific details, long examples, and recovery references in files
+      under references/ so the agent loads them only when needed.
+    bad_example: |
+      SKILL.md contains every supported host command, every historical failure,
+      and every migration detail in one long document.
+    good_example: |
+      SKILL.md gives the workflow and links to references/agent-path-matrix.md
+      only when the task touches host-specific install paths.
+  - name: Scripted deterministic operation
+    description: >
+      If a step is mechanical and must be repeated exactly, package a script
+      beside the skill and document when to run it.
+    bad_example: |
+      Ask the agent to hand-write a JSON merger every time the skill installs a hook.
+    good_example: |
+      Provide scripts/merge_settings.py and have SKILL.md call it with explicit inputs.
+anti_patterns:
+  - name: Ambiguous trigger surface
+    description: "A vague description causes agents to load the skill for unrelated tasks or miss it when it is needed."
+    bad_example: "Use this skill for projects."
+    good_example: "Use this skill when working on Spec Kitty missions, runtime, tracker, hub, website, mobile, SaaS, or tests."
+  - name: Context dump skill
+    description: "A skill that loads all reference material up front defeats progressive disclosure and crowds out task-specific context."
+    bad_example: "Read every file in references/ before starting."
+    good_example: "Read only the reference that matches the current host or workflow branch."
+  - name: Host-specific assumptions
+    description: "A deployable skill should not silently assume one agent product's paths, commands, or tool names when Spec Kitty distributes it across multiple hosts."
+    bad_example: "Always edit .claude/settings.json."
+    good_example: "Resolve the active host surface first, then edit the host-specific settings file if that host supports one."
+  - name: Unsourced operating rule
+    description: "A skill that encodes policy without pointing to doctrine, charter, ADR, or project source makes governance hard to audit."
+    bad_example: "Never use feature flags here."
+    good_example: "Apply DIRECTIVE_024 and ADR-2026-04-11 before adding a new flag."
+quality_test: "Can a new maintainer read the skill description and know when it triggers, then read only SKILL.md to complete the common workflow without loading unrelated provider detail?"
+references:
+  - "src/doctrine/skills/README.md"
+  - "docs/host-surface-parity.md"
+  - "architecture/adrs/2026-04-14-2-agent-skills-renderer-for-codex-and-vibe.md"

--- a/src/doctrine/tactics/shipped/architecture/deepening-opportunity-assessment.tactic.yaml
+++ b/src/doctrine/tactics/shipped/architecture/deepening-opportunity-assessment.tactic.yaml
@@ -1,0 +1,73 @@
+schema_version: "1.0"
+id: deepening-opportunity-assessment
+name: Deepening Opportunity Assessment
+purpose: >
+  Identify whether a shallow cluster of modules should be deepened into a
+  higher-leverage module with a smaller, more stable interface. The assessment
+  focuses on real caller friction, test seam quality, dependency shape, and
+  locality of future changes rather than on abstract cleanliness.
+steps:
+  - title: Name the caller friction
+    description: >
+      Identify where understanding or changing one concept requires bouncing
+      through many small modules, repeating setup in tests, or coordinating edits
+      across callers. Use domain language for the concept being hidden and
+      architecture language for the module/interface being evaluated.
+    examples:
+      - "Changing tracker binding behavior requires edits in CLI parsing, auth lookup, SaaS client construction, and tests that duplicate the same setup."
+  - title: Apply the deletion test
+    description: >
+      Imagine deleting the suspected module. If complexity disappears, it was a
+      pass-through. If the same rules and ordering constraints reappear across
+      multiple callers, the module was earning its keep or should be deepened.
+    examples:
+      - "Deleting a two-line wrapper removes no caller knowledge; deleting a cohesive auth session facade would force every caller to know token refresh ordering."
+  - title: Define the real interface
+    description: >
+      List everything callers must know: entry points, invariants, ordering,
+      errors, idempotency, configuration, performance, and observable effects.
+      A module is shallow when that interface is nearly as complex as the
+      implementation it hides.
+  - title: Classify dependency shape
+    description: >
+      Mark dependencies as in-process, local-substitutable, remote-owned, or
+      true external. In-process logic can be merged directly. Local-substitutable
+      dependencies need local test stand-ins. Remote-owned services need a port
+      with production and test adapters. True external systems need injected
+      adapters or mocks at the external seam.
+  - title: Verify seam legitimacy
+    description: >
+      Do not introduce a seam just because a class or interface could exist. A
+      single adapter is usually a hypothetical seam; two justified adapters,
+      commonly production plus test, indicate a real seam.
+  - title: Choose the smallest deepening step
+    description: >
+      Recommend the smallest change that increases leverage and locality:
+      combine pass-through helpers, move repeated rules behind an existing
+      interface, or introduce a port only when dependency variation is real.
+failure_modes:
+  - "Counting implementation lines instead of caller leverage."
+  - "Introducing a port for a dependency with only one real adapter."
+  - "Treating every extracted helper as a module that deserves its own interface."
+  - "Deepening without evidence of repeated caller or test friction."
+  - "Moving complexity into a generic abstraction whose vocabulary no longer matches the domain."
+references:
+  - name: Deep Module Design
+    type: paradigm
+    id: deep-module-design
+    when: This tactic operationalizes the paradigm's interface-leverage model.
+  - name: Easy-to-Change Design Review
+    type: tactic
+    id: easy-to-change
+    when: Use after identifying a candidate to test whether deepening improves future change cost.
+  - name: Locality of Change Assessment
+    type: tactic
+    id: locality-of-change
+    when: Use to require evidence that the added structure solves an observed locality problem.
+  - name: Refactoring
+    type: procedure
+    id: refactoring
+    when: Use when the selected deepening is an internal behavior-preserving restructuring.
+notes: >
+  Adapted from the mattpocock/skills improve-codebase-architecture workflow at
+  commit 49cec7be019bc408e87b77670f3d442f536da254.

--- a/src/doctrine/tactics/shipped/architecture/interface-variation-design.tactic.yaml
+++ b/src/doctrine/tactics/shipped/architecture/interface-variation-design.tactic.yaml
@@ -1,0 +1,59 @@
+schema_version: "1.0"
+id: interface-variation-design
+name: Interface Variation Design
+purpose: >
+  Explore materially different interface shapes before committing to a deepened
+  module design. The tactic reduces first-idea bias by comparing interfaces on
+  leverage, locality, misuse resistance, dependency strategy, and how naturally
+  behavior can be tested through the same surface callers use.
+steps:
+  - title: Frame the design constraints
+    description: >
+      State the module's responsibility, caller groups, invariants, error modes,
+      dependency categories, and performance expectations. This frame is not a
+      proposal; it is the shared problem space every alternative must satisfy.
+  - title: Generate distinct interface options
+    description: >
+      Produce at least three materially different designs. Vary the design force
+      on purpose: smallest surface, most flexible surface, common-case-optimized
+      surface, and ports/adapters surface when cross-seam dependencies are real.
+    examples:
+      - "Option A has one command method. Option B exposes a lifecycle object. Option C optimizes the common caller with defaults and hides retries."
+  - title: Show caller usage before implementation detail
+    description: >
+      For each option, write a caller-facing usage example and name what the
+      implementation hides. If usage is hard to explain, the interface is already
+      leaking too much knowledge.
+  - title: Compare depth and misuse resistance
+    description: >
+      Compare how much behavior callers get per fact they must learn, how errors
+      are constrained, how ordering is enforced, and how difficult the interface
+      is to misuse. Prefer the design that removes caller knowledge rather than
+      merely moving code.
+  - title: Select or synthesize the strongest interface
+    description: >
+      Choose a design or hybrid and record the trade-off. If the decision is
+      hard to reverse, surprising without context, and based on real alternatives,
+      record it as a decision artifact.
+failure_modes:
+  - "Producing three versions of the same first idea."
+  - "Comparing implementation effort before comparing caller leverage."
+  - "Ignoring error modes, ordering constraints, or performance expectations."
+  - "Optimizing for maximum flexibility without a current caller need."
+  - "Choosing an interface that cannot be tested without reaching past it."
+references:
+  - name: Deep Module Design
+    type: paradigm
+    id: deep-module-design
+    when: Interface options are evaluated by the paradigm's depth and leverage criteria.
+  - name: Deepening Opportunity Assessment
+    type: tactic
+    id: deepening-opportunity-assessment
+    when: Run first to confirm that a real deepening opportunity exists.
+  - name: Traceable Decisions
+    type: tactic
+    id: traceable-decisions
+    when: Record the selected interface when the trade-off is durable and non-obvious.
+notes: >
+  Adapted from the mattpocock/skills interface design workflows at commit
+  49cec7be019bc408e87b77670f3d442f536da254.

--- a/src/doctrine/templates/README.md
+++ b/src/doctrine/templates/README.md
@@ -12,6 +12,7 @@ missions.
 | `command-templates/` | Prompt files for `/spec-kitty.*` slash commands |
 | `sets/` | Named bundles grouping related templates for coordinated deployment |
 | `structure/` | Structural mapping templates (REPO_MAP, SURFACES) for repository orientation |
+| `triage/` | Issue triage interaction templates (agent briefs, out-of-scope records) |
 
 ## Top-Level Templates
 

--- a/src/doctrine/templates/triage/agent-brief-template.md
+++ b/src/doctrine/templates/triage/agent-brief-template.md
@@ -1,0 +1,35 @@
+# Agent Brief
+
+**Category:** {bug | enhancement}
+**Summary:** {one-line description of the delegated work}
+
+## Current Behavior
+
+{Describe what happens now. For bugs, describe the broken behavior. For
+enhancements, describe the status quo that the feature builds on.}
+
+## Desired Behavior
+
+{Describe the observable behavior after the work is complete, including relevant
+edge cases, error cases, and degraded states.}
+
+## Key Contracts
+
+- `{ContractName}`: {what must change or remain true}
+- `{InterfaceName}`: {caller-visible behavior, input/output shape, or invariant}
+
+## Acceptance Criteria
+
+- [ ] {Specific, independently verifiable criterion}
+- [ ] {Specific, independently verifiable criterion}
+- [ ] {Relevant tests or quality gates pass}
+
+## Out of Scope
+
+- {Adjacent work that must not be included}
+- {Implementation path that should not be assumed}
+
+## Notes
+
+{Optional context from triage. Avoid file paths and line numbers unless the
+path itself is the public contract being changed.}

--- a/src/doctrine/templates/triage/out-of-scope-record-template.md
+++ b/src/doctrine/templates/triage/out-of-scope-record-template.md
@@ -1,0 +1,18 @@
+# {Concept Name}
+
+## Decision
+
+{State the rejected enhancement or concept in one sentence.}
+
+## Why This Is Out Of Scope
+
+{Explain the durable reason. Prefer product scope, architectural constraint,
+strategic direction, or maintenance cost over temporary capacity arguments.}
+
+## Prior Requests
+
+- {tracker reference}: {short title or summary}
+
+## Reconsideration Trigger
+
+{Describe what would need to change for this decision to be revisited.}

--- a/src/specify_cli/mission_step_contracts/executor.py
+++ b/src/specify_cli/mission_step_contracts/executor.py
@@ -30,6 +30,7 @@ _ARTIFACT_TO_NODE_KIND: dict[ArtifactKind, NodeKind] = {
     ArtifactKind.TOOLGUIDE: NodeKind.TOOLGUIDE,
     ArtifactKind.PROCEDURE: NodeKind.PROCEDURE,
     ArtifactKind.AGENT_PROFILE: NodeKind.AGENT_PROFILE,
+    ArtifactKind.TEMPLATE: NodeKind.TEMPLATE,
 }
 
 # FR-008 / Phase 6 #505: this table is for built-in missions ONLY.

--- a/tests/doctrine/drg/migration/test_extractor.py
+++ b/tests/doctrine/drg/migration/test_extractor.py
@@ -23,7 +23,7 @@ from doctrine.drg.migration.extractor import (
     extract_artifact_edges,
     generate_graph,
 )
-from doctrine.drg.models import DRGGraph, NodeKind, Relation
+from doctrine.drg.models import NodeKind, Relation
 from doctrine.drg.validator import validate_graph
 
 # Path to the shipped doctrine root inside the repo.
@@ -32,7 +32,7 @@ DOCTRINE_ROOT: Path = Path(__file__).resolve().parents[4] / "src" / "doctrine"
 _yaml = YAML(typ="safe")
 
 
-def _count_inline_refs(doctrine_root: Path) -> int:
+def _count_inline_refs(doctrine_root: Path) -> int:  # noqa: C901
     """Count every inline reference field entry across all shipped artifacts.
 
     This mirrors the extraction logic but only counts -- used for the T017
@@ -81,6 +81,17 @@ def _count_inline_refs(doctrine_root: Path) -> int:
             total += len(data.get("directive_refs", []) or [])
             for opp in data.get("opposed_by", []) or []:
                 if opp.get("type", "") not in _SKIP_REF_TYPES:
+                    total += 1
+
+    # Procedures
+    procedures_dir = doctrine_root / "procedures" / "shipped"
+    if procedures_dir.is_dir():
+        for path in sorted(procedures_dir.glob("*.procedure.yaml")):
+            data = _yaml.load(path)
+            if not data:
+                continue
+            for ref in data.get("references", []) or []:
+                if ref.get("type", "") not in _SKIP_REF_TYPES:
                     total += 1
 
     # Action indices
@@ -179,6 +190,20 @@ class TestExtractArtifactEdges:
         targets = {e.target for e in pd_suggests}
         assert "tactic:eisenhower-prioritisation" in targets
 
+    def test_procedure_template_references_produce_template_edges(self) -> None:
+        """Procedure template references should be represented in the DRG."""
+        _, edges = extract_artifact_edges(DOCTRINE_ROOT)
+        issue_triage_suggests = [
+            e
+            for e in edges
+            if e.source == "procedure:issue-triage-state-machine"
+            and e.relation == Relation.SUGGESTS
+        ]
+
+        targets = {e.target for e in issue_triage_suggests}
+        assert "template:agent-brief-template" in targets
+        assert "template:out-of-scope-record-template" in targets
+
     def test_walks_all_shipped_directives(self) -> None:
         nodes, _ = extract_artifact_edges(DOCTRINE_ROOT)
         directive_count = len(
@@ -256,14 +281,14 @@ class TestExtractActionEdges:
         # specify has 2 directives + 1 tactic = 3 scope edges
         assert len(specify_edges) == 3
 
-    def test_tasks_action_has_six_refs(self) -> None:
-        """The new tasks action index should produce 6 scope edges."""
+    def test_tasks_action_has_seven_refs(self) -> None:
+        """The tasks action index should produce 7 scope edges."""
         _, edges = extract_action_edges(DOCTRINE_ROOT)
         tasks_edges = [
             e for e in edges
             if e.source == "action:software-dev/tasks"
         ]
-        assert len(tasks_edges) == 6
+        assert len(tasks_edges) == 7
 
     def test_nonexistent_doctrine_root(self) -> None:
         nodes, edges = extract_action_edges(Path("/nonexistent"))

--- a/tests/doctrine/drg/test_resolve_transitive_refs.py
+++ b/tests/doctrine/drg/test_resolve_transitive_refs.py
@@ -18,9 +18,7 @@ Covers all 7 contract dimensions from
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -214,6 +212,7 @@ def test_bucketing_by_kind_and_prefix_stripping() -> None:
             ("toolguide:TG1", NodeKind.TOOLGUIDE),
             ("procedure:PR1", NodeKind.PROCEDURE),
             ("agent_profile:AP1", NodeKind.AGENT_PROFILE),
+            ("template:TPL1", NodeKind.TEMPLATE),
         ],
         edges=[
             ("directive:D1", "tactic:T1", Relation.REQUIRES),
@@ -222,6 +221,7 @@ def test_bucketing_by_kind_and_prefix_stripping() -> None:
             ("directive:D1", "toolguide:TG1", Relation.REQUIRES),
             ("directive:D1", "procedure:PR1", Relation.REQUIRES),
             ("directive:D1", "agent_profile:AP1", Relation.REQUIRES),
+            ("directive:D1", "template:TPL1", Relation.REQUIRES),
         ],
     )
     assert_valid(graph)
@@ -238,6 +238,7 @@ def test_bucketing_by_kind_and_prefix_stripping() -> None:
     assert result.toolguides == ["TG1"]
     assert result.procedures == ["PR1"]
     assert result.agent_profiles == ["AP1"]
+    assert result.templates == ["TPL1"]
     assert result.is_complete
 
 

--- a/tests/doctrine/test_mattpocock_skill_doctrine.py
+++ b/tests/doctrine/test_mattpocock_skill_doctrine.py
@@ -1,0 +1,105 @@
+"""Regression tests for curated Matt Pocock skill doctrine imports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+import pytest
+
+from doctrine.drg.loader import load_graph, merge_layers
+from doctrine.drg.models import NodeKind, Relation
+from doctrine.drg.query import resolve_transitive_refs
+from doctrine.drg.validator import assert_valid
+from doctrine.missions import MissionTemplateRepository
+
+pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCTRINE_ROOT = REPO_ROOT / "src" / "doctrine"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_curated_doctrine_artifacts_exist_with_expected_kinds() -> None:
+    expected_paths = [
+        "procedures/shipped/disciplined-defect-diagnosis.procedure.yaml",
+        "paradigms/shipped/deep-module-design.paradigm.yaml",
+        "tactics/shipped/architecture/deepening-opportunity-assessment.tactic.yaml",
+        "tactics/shipped/architecture/interface-variation-design.tactic.yaml",
+        "procedures/shipped/domain-aware-decision-interview.procedure.yaml",
+        "procedures/shipped/issue-triage-state-machine.procedure.yaml",
+        "styleguides/shipped/deployable-skill-authoring.styleguide.yaml",
+        "templates/triage/agent-brief-template.md",
+        "templates/triage/out-of-scope-record-template.md",
+    ]
+
+    missing = [relative for relative in expected_paths if not (DOCTRINE_ROOT / relative).exists()]
+    assert missing == []
+
+    assert _load_yaml(DOCTRINE_ROOT / expected_paths[0])["id"] == "disciplined-defect-diagnosis"
+    assert _load_yaml(DOCTRINE_ROOT / expected_paths[1])["id"] == "deep-module-design"
+    assert _load_yaml(DOCTRINE_ROOT / expected_paths[6])["id"] == "deployable-skill-authoring"
+
+
+def test_shipped_graph_links_curated_artifacts_and_templates() -> None:
+    graph = merge_layers(load_graph(DOCTRINE_ROOT / "graph.yaml"), None)
+    assert_valid(graph)
+
+    expected_nodes = {
+        "procedure:disciplined-defect-diagnosis": NodeKind.PROCEDURE,
+        "paradigm:deep-module-design": NodeKind.PARADIGM,
+        "tactic:deepening-opportunity-assessment": NodeKind.TACTIC,
+        "tactic:interface-variation-design": NodeKind.TACTIC,
+        "procedure:domain-aware-decision-interview": NodeKind.PROCEDURE,
+        "procedure:issue-triage-state-machine": NodeKind.PROCEDURE,
+        "styleguide:deployable-skill-authoring": NodeKind.STYLEGUIDE,
+        "template:agent-brief-template": NodeKind.TEMPLATE,
+        "template:out-of-scope-record-template": NodeKind.TEMPLATE,
+    }
+
+    for urn, kind in expected_nodes.items():
+        node = graph.get_node(urn)
+        assert node is not None, urn
+        assert node.kind is kind
+
+    result = resolve_transitive_refs(
+        graph,
+        start_urns={"procedure:issue-triage-state-machine"},
+        relations={Relation.REQUIRES, Relation.SUGGESTS},
+        max_depth=1,
+    )
+    assert result.templates == ["agent-brief-template", "out-of-scope-record-template"]
+    assert "disciplined-defect-diagnosis" in result.procedures
+
+
+def test_software_dev_action_indexes_expose_design_and_triage_doctrine() -> None:
+    repo = MissionTemplateRepository.default()
+
+    plan_index = repo.get_action_index("software-dev", "plan")
+    assert plan_index is not None
+    assert "deepening-opportunity-assessment" in plan_index.parsed["tactics"]
+    assert "interface-variation-design" in plan_index.parsed["tactics"]
+    assert "domain-aware-decision-interview" in plan_index.parsed["procedures"]
+
+    tasks_index = repo.get_action_index("software-dev", "tasks")
+    assert tasks_index is not None
+    assert "issue-triage-state-machine" in tasks_index.parsed["procedures"]
+
+
+def test_diagnosis_procedure_preserves_hypothesis_and_feedback_loop_discipline() -> None:
+    procedure = _load_yaml(
+        DOCTRINE_ROOT / "procedures" / "shipped" / "disciplined-defect-diagnosis.procedure.yaml"
+    )
+
+    step_text = "\n".join(step["title"] + " " + step.get("description", "") for step in procedure["steps"])
+    assert "feedback loop" in step_text
+    assert "hypotheses" in step_text
+    assert "tag" in step_text
+    assert "regression test" in step_text
+    assert any(pattern["name"] == "Fixing without a feedback loop" for pattern in procedure["anti_patterns"])


### PR DESCRIPTION
## Summary

This PR implements the curated doctrine import from the Matt Pocock skills review. It does not vendor upstream skills wholesale; it decomposes the unique, durable patterns into Spec Kitty doctrine artifacts and wires them into the DRG/action-index surfaces.

Upstream snapshot reviewed: https://github.com/mattpocock/skills/tree/49cec7be019bc408e87b77670f3d442f536da254

## Upstream sources used

- `diagnose`: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/engineering/diagnose/SKILL.md
- `improve-codebase-architecture`: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/engineering/improve-codebase-architecture/SKILL.md
- Deepening guide: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/engineering/improve-codebase-architecture/DEEPENING.md
- Interface design guide: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/engineering/improve-codebase-architecture/INTERFACE-DESIGN.md
- `grill-with-docs`: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/engineering/grill-with-docs/SKILL.md
- `github-triage`: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/engineering/github-triage/SKILL.md
- `write-a-skill`: https://github.com/mattpocock/skills/blob/49cec7be019bc408e87b77670f3d442f536da254/skills/productivity/write-a-skill/SKILL.md

## Changes

- Adds `disciplined-defect-diagnosis`, `domain-aware-decision-interview`, and `issue-triage-state-machine` procedures.
- Adds `deep-module-design` paradigm plus `deepening-opportunity-assessment` and `interface-variation-design` tactics.
- Adds `deployable-skill-authoring` styleguide for Spec Kitty skill authoring quality.
- Adds triage templates for durable agent briefs and out-of-scope records.
- Promotes `template` to a first-class DRG node kind and teaches the DRG extractor to preserve procedure/template references.
- Wires the new doctrine into `graph.yaml` and scoped action indexes for software-dev plan/tasks.
- Adds regression coverage for the imported doctrine, template bucketing, extractor behavior, and action-index exposure.

## Notes

`disciplined-defect-diagnosis` is intentionally not injected into the generic implement action index because the source issue calls for bug/debug contexts only; there is no bug-specific built-in action index yet. It is linked through issue triage and the DRG so it can be surfaced where a bug report actually needs diagnosis.

## Tests

- `uv run ruff check src/doctrine/drg/migration/extractor.py src/doctrine/drg/models.py src/doctrine/drg/query.py src/specify_cli/mission_step_contracts/executor.py tests/doctrine/drg/migration/test_extractor.py tests/doctrine/drg/test_resolve_transitive_refs.py tests/doctrine/test_mattpocock_skill_doctrine.py`
- `uv run pytest tests/doctrine/test_mattpocock_skill_doctrine.py tests/doctrine/drg/test_resolve_transitive_refs.py::test_bucketing_by_kind_and_prefix_stripping tests/doctrine/drg/migration/test_extractor.py::TestExtractArtifactEdges::test_procedure_template_references_produce_template_edges tests/doctrine/drg/migration/test_extractor.py::TestExtractActionEdges::test_tasks_action_has_seven_refs tests/doctrine/drg/migration/test_extractor.py::TestGenerateGraph::test_generates_valid_graph tests/doctrine/drg/migration/test_extractor.py::TestEdgeCountCompleteness::test_edge_count_gte_inline_refs tests/doctrine/drg/test_shipped_graph_valid.py tests/doctrine/test_tactic_compliance.py tests/doctrine/test_procedure_consistency.py tests/doctrine/test_artifact_compliance.py tests/doctrine/missions/test_action_indexes.py` (`423 passed`)
- `uv run pytest tests/doctrine/drg/migration/test_extractor.py tests/doctrine/drg/test_resolve_transitive_refs.py` (`48 passed`)

Refs #856
Closes #857
Closes #858
Closes #859
Closes #860
Closes #861
