### PR TITLE
Port #855 follow-up fixes after #864

### DIFF
--- a/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
@@ -366,7 +366,7 @@ See `references/runtime-result-taxonomy.md` for the complete taxonomy.
 
 | Kind | Next Action |
 |------|-------------|
-| `step` | Check `prompt_file` is not null, then read and execute |
+| `step` | Read and execute `prompt_file` (always non-empty and resolvable on disk) |
 | `decision_required` | Answer with `--answer` and `--decision-id` |
 | `blocked` | Read `reason` + `guard_failures`, resolve blockers |
 | `terminal` | Run `/spec-kitty.accept` for final validation |
@@ -374,10 +374,12 @@ See `references/runtime-result-taxonomy.md` for the complete taxonomy.
 **Always check `guard_failures`** — this field may appear on any decision kind,
 not just `blocked`.
 
-**Always check `prompt_file` before acting on a `step` decision.** If it is
-`null`, the runtime could not generate a prompt for this step (known issue
-#336). Treat a null `prompt_file` as a blocked state — do not attempt to
-execute without a prompt.
+**`prompt_file` contract on `kind: step`.** Issued steps always carry a
+non-empty `prompt_file` whose path resolves to an existing file on disk. If
+the runtime cannot resolve a prompt template, the response is `kind: blocked`
+with a non-empty `reason` (and an optional machine-readable code such as
+`no_prompt_template`). There is no third state — no agent loop should ever
+observe a `kind: step` with `prompt_file == null`.
 
 **Always check `progress` for completion.** If `progress.done_wps` equals
 `progress.total_wps` but `kind` is not `terminal`, the mission is actually
@@ -450,10 +452,9 @@ while [ "$KIND" = "step" ] || [ "$KIND" = "decision_required" ]; do
   if [ "$KIND" = "step" ]; then
     PROMPT=$(echo "$DECISION" | jq -r '.prompt_file')
 
-    # Workaround #336: treat null prompt as blocked
-    if [ "$PROMPT" = "null" ] || [ -z "$PROMPT" ]; then
-      break  # Cannot execute without a prompt
-    fi
+    # Contract (post-#336 fix): kind=step always carries a non-empty
+    # prompt_file resolvable on disk. If a prompt cannot be resolved the
+    # runtime emits kind=blocked with a populated reason instead.
 
     # Read and execute the prompt...
     RESULT="success"  # or "failed" or "blocked"
@@ -501,10 +502,11 @@ runtime run state, it creates a new run starting at `discovery` instead of
 recognizing the mission is complete. **Workaround:** Check
 `progress.done_wps == progress.total_wps` as a secondary completion signal.
 
-**#336 — `prompt_file` can be `null` on `step` decisions.** Some steps
-(e.g., `discovery`) lack command templates, so the runtime returns a step
-decision with no prompt to execute. **Workaround:** Check `prompt_file`
-for null before acting; treat null as blocked.
+**#336 — fixed.** `prompt_file` is always non-empty and resolvable on disk
+on `kind: step` decisions. When no prompt is available the runtime now emits
+a structured `kind: blocked` decision with a non-empty `reason` (and an
+optional `blocker_code` such as `no_prompt_template`). Agent loops no longer
+need to defensively null-check `prompt_file`.
 
 ---
 

--- a/src/specify_cli/cli/commands/charter.py
+++ b/src/specify_cli/cli/commands/charter.py
@@ -20,6 +20,7 @@ from specify_cli.cli.selector_resolution import resolve_selector
 from specify_cli.decisions import service as _dm_service
 from specify_cli.decisions.models import OriginFlow as _DmOriginFlow
 from specify_cli.decisions.service import DecisionError as _DecisionError
+from specify_cli.diagnostics import mark_invocation_succeeded
 from specify_cli.tasks_support import TaskCliError, find_repo_root
 from charter.sync import ensure_charter_bundle_fresh
 
@@ -1849,11 +1850,87 @@ def _build_synthesis_validation_callback(request: Any) -> Any:
     return _validation_callback
 
 
+def _read_written_artifacts_from_manifest(repo_root: Path) -> list[dict[str, str]]:
+    """Read manifest entries for the strict synthesize success envelope."""
+    try:
+        from charter.synthesizer.manifest import MANIFEST_PATH, load_yaml as _load_manifest
+    except Exception:
+        return []
+    manifest_path = repo_root / MANIFEST_PATH
+    if not manifest_path.exists():
+        return []
+    try:
+        manifest = _load_manifest(manifest_path)
+    except Exception:
+        return []
+    return [{"path": entry.path, "kind": entry.kind} for entry in manifest.artifacts]
+
+
+def _provenance_to_planned_artifacts(
+    results: list[tuple[Any, Any]],
+) -> list[dict[str, str]]:
+    """Convert synthesis provenance entries into planned doctrine paths."""
+    from charter.synthesizer.artifact_naming import (
+        artifact_filename,
+        doctrine_kind_subdir,
+    )
+
+    planned: list[dict[str, str]] = []
+    for _body, prov in results:
+        kind = prov.artifact_kind
+        slug = prov.artifact_slug
+        artifact_id: str | None = None
+        if kind == "directive":
+            artifact_id = prov.artifact_urn.split(":", 1)[1]
+        try:
+            filename = artifact_filename(kind, slug, artifact_id)
+            subdir = doctrine_kind_subdir(kind)
+        except Exception:  # noqa: S112
+            continue
+        planned.append(
+            {
+                "path": f".kittify/doctrine/{subdir}/{filename}",
+                "kind": kind,
+            }
+        )
+    return planned
+
+
+def _staged_to_planned_artifacts(staged_files: list[str]) -> list[dict[str, str]]:
+    """Convert legacy staged ``kind:slug`` selectors to planned artifacts."""
+    from charter.synthesizer.artifact_naming import (
+        artifact_filename,
+        doctrine_kind_subdir,
+    )
+
+    planned: list[dict[str, str]] = []
+    for selector in staged_files:
+        if ":" not in selector:
+            continue
+        kind, slug = selector.split(":", 1)
+        artifact_id: str | None = None
+        if kind == "directive":
+            artifact_id = "PROJECT_000"
+        try:
+            filename = artifact_filename(kind, slug, artifact_id)
+            subdir = doctrine_kind_subdir(kind)
+        except Exception:  # noqa: S112
+            continue
+        planned.append(
+            {
+                "path": f".kittify/doctrine/{subdir}/{filename}",
+                "kind": kind,
+            }
+        )
+    return planned
+
+
 def _run_synthesis_dry_run(
     request: Any,
     syn_adapter: Any,
     repo_root: Path,
-) -> list[str]:
+) -> list[dict[str, str]]:
+    """Stage + validate without promoting, returning typed planned artifacts."""
     from charter.synthesizer.staging import StagingDir
     from charter.synthesizer.synthesize_pipeline import run_all
     from charter.synthesizer.write_pipeline import stage_and_validate
@@ -1862,7 +1939,7 @@ def _run_synthesis_dry_run(
     validation_callback = _build_synthesis_validation_callback(request)
 
     with StagingDir.create(repo_root, request.run_id) as staging_dir:
-        staged_artifacts = stage_and_validate(
+        stage_and_validate(
             request,
             staging_dir,
             results,
@@ -1870,7 +1947,7 @@ def _run_synthesis_dry_run(
         )
         staging_dir.wipe()
 
-    return staged_artifacts
+    return _provenance_to_planned_artifacts(results)
 
 
 def _list_resynthesis_topics(
@@ -2004,7 +2081,7 @@ def _planned_fresh_doctrine_paths(repo_root: Path) -> list[str]:
 
 
 @app.command("synthesize")
-def charter_synthesize(
+def charter_synthesize(  # noqa: C901
     adapter: str = typer.Option(
         "generated",
         "--adapter",
@@ -2167,8 +2244,9 @@ def charter_synthesize(
             skip_code_evidence=skip_code_evidence,
             skip_corpus=skip_corpus,
         )
-        for warning in evidence_result.warnings:
-            console.print(f"[yellow]\u26a0 {warning}[/yellow]")
+        if not json_output:
+            for warning in evidence_result.warnings:
+                console.print(f"[yellow]\u26a0 {warning}[/yellow]")
 
         if dry_run_evidence:
             bundle = evidence_result.bundle
@@ -2194,20 +2272,26 @@ def charter_synthesize(
         request, syn_adapter = _build_synthesis_request(repo_root, adapter, evidence=evidence_result.bundle)
 
         if dry_run:
-            staged_files = _run_synthesis_dry_run(request, syn_adapter, repo_root)
+            planned_artifacts = _run_synthesis_dry_run(request, syn_adapter, repo_root)
 
             if json_output:
                 print(json.dumps({
-                    "result": "dry_run",
-                    "staged_artifacts": staged_files,
-                    "artifact_count": len(staged_files),
-                    "validated": True,
+                    "result": "success",
+                    "adapter": adapter,
+                    "planned_artifacts": planned_artifacts,
+                    "warnings": [
+                        {"code": "evidence_warning", "message": w}
+                        for w in evidence_result.warnings
+                    ],
                 }, indent=2))
+                mark_invocation_succeeded()
                 return
 
             console.print("[yellow]Dry-run:[/yellow] synthesis staged and validated (not promoted)")
-            for f in staged_files:
-                console.print(f"  [dim]staged:[/dim] {f}")
+            for entry in planned_artifacts:
+                console.print(
+                    f"  [dim]staged:[/dim] {entry.get('kind', '?')} -> {entry.get('path', '?')}"
+                )
             return
 
         from charter.synthesizer import synthesize
@@ -2215,14 +2299,22 @@ def charter_synthesize(
         result = synthesize(request, adapter=syn_adapter, repo_root=repo_root)
 
         if json_output:
+            written_artifacts = _read_written_artifacts_from_manifest(repo_root)
             print(json.dumps({
                 "result": "success",
+                "adapter": result.effective_adapter_id,
+                "written_artifacts": written_artifacts,
                 "target_kind": result.target_kind,
                 "target_slug": result.target_slug,
                 "inputs_hash": result.inputs_hash,
                 "adapter_id": result.effective_adapter_id,
                 "adapter_version": result.effective_adapter_version,
+                "warnings": [
+                    {"code": "evidence_warning", "message": w}
+                    for w in evidence_result.warnings
+                ],
             }, indent=2))
+            mark_invocation_succeeded()
             return
 
         console.print("[green]Charter synthesis complete[/green]")

--- a/src/specify_cli/next/decision.py
+++ b/src/specify_cli/next/decision.py
@@ -461,7 +461,43 @@ def _build_prompt_safe(
     repo_root: Path,
     mission_type: str,
 ) -> str | None:
-    """Build prompt, returning None on failure instead of raising."""
+    """Build prompt, returning None on failure instead of raising.
+
+    .. deprecated::
+        Prefer :func:`_build_prompt_or_error` which surfaces the underlying
+        exception text so callers can emit a structured ``blocked`` decision
+        with a populated ``reason`` (WP06 / FR-006 / FR-013).
+    """
+    path, _err = _build_prompt_or_error(
+        action=action,
+        feature_dir=feature_dir,
+        mission_slug=mission_slug,
+        wp_id=wp_id,
+        agent=agent,
+        repo_root=repo_root,
+        mission_type=mission_type,
+    )
+    return path
+
+
+def _build_prompt_or_error(
+    action: str,
+    feature_dir: Path,
+    mission_slug: str,
+    wp_id: str | None,
+    agent: str,
+    repo_root: Path,
+    mission_type: str,
+) -> tuple[str | None, str | None]:
+    """Build prompt, returning ``(path, None)`` on success or ``(None, error)``.
+
+    The ``error`` message is suitable for embedding in a ``blocked`` decision's
+    ``reason`` so callers can avoid emitting a ``kind=step`` decision with a
+    null/missing ``prompt_file`` (WP06 / FR-006 / FR-013).
+
+    The path is also verified to exist on disk; if ``build_prompt`` returned a
+    path that does not resolve, ``error`` is populated and ``path`` is ``None``.
+    """
     try:
         from specify_cli.next.prompt_builder import build_prompt
 
@@ -475,6 +511,20 @@ def _build_prompt_safe(
                 repo_root=repo_root,
                 mission_type=mission_type,
             )
-        return str(prompt_path)
-    except Exception:
-        return None
+        path_str = str(prompt_path)
+        try:
+            if not Path(path_str).exists():
+                return None, (
+                    f"prompt template did not materialize on disk for action "
+                    f"'{action}' (path={path_str})"
+                )
+        except OSError as exc:
+            return None, (
+                f"prompt template path is not stat-able for action '{action}': {exc}"
+            )
+        return path_str, None
+    except Exception as exc:
+        return None, (
+            f"prompt resolution failed for action '{action}': "
+            f"{type(exc).__name__}: {exc}"
+        )

--- a/src/specify_cli/next/runtime_bridge.py
+++ b/src/specify_cli/next/runtime_bridge.py
@@ -49,6 +49,7 @@ from specify_cli.status.wp_state import wp_state_for
 from specify_cli.next.decision import (
     Decision,
     DecisionKind,
+    _build_prompt_or_error,
     _build_prompt_safe,
     _compute_wp_progress,
     _state_to_action,
@@ -1422,7 +1423,7 @@ def get_or_start_run(
 # ---------------------------------------------------------------------------
 
 
-def decide_next_via_runtime(
+def decide_next_via_runtime(  # noqa: C901
     agent: str,
     mission_slug: str,
     result: str,
@@ -1568,9 +1569,11 @@ def decide_next_via_runtime(
                 repo_root,
                 mission_type,
             )
-            prompt_file = (
-                _build_prompt_safe(
-                    action or current_step_id,
+            prompt_file: str | None = None
+            prompt_error: str | None = None
+            if action:
+                prompt_file, prompt_error = _build_prompt_or_error(
+                    action,
                     feature_dir,
                     mission_slug,
                     wp_id,
@@ -1578,9 +1581,31 @@ def decide_next_via_runtime(
                     repo_root,
                     mission_type,
                 )
-                if action
-                else None
-            )
+            else:
+                prompt_error = (
+                    f"no action mapped for step '{current_step_id}'; cannot resolve prompt"
+                )
+            if prompt_file is None:
+                # WP06 (FR-006/FR-013): never issue kind=step with prompt_file=None.
+                # When a prompt cannot be resolved, surface a structured blocked
+                # decision so callers can stop, not partial-execute.
+                return Decision(
+                    kind=DecisionKind.blocked,
+                    agent=agent,
+                    mission_slug=mission_slug,
+                    mission=mission_type,
+                    mission_state=current_step_id,
+                    timestamp=now,
+                    reason=prompt_error or "no_prompt_template",
+                    action=action,
+                    wp_id=wp_id,
+                    workspace_path=workspace_path,
+                    guard_failures=guard_failures,
+                    progress=progress,
+                    origin=origin,
+                    run_id=run_ref.run_id,
+                    step_id=current_step_id,
+                )
             return Decision(
                 kind=DecisionKind.step,
                 agent=agent,
@@ -2115,7 +2140,7 @@ def _build_wp_iteration_decision(
             step_id=step_id,
         )
 
-    prompt_file = _build_prompt_safe(
+    prompt_file, prompt_error = _build_prompt_or_error(
         action,
         feature_dir,
         mission_slug,
@@ -2124,6 +2149,27 @@ def _build_wp_iteration_decision(
         repo_root,
         mission_type,
     )
+    if prompt_file is None:
+        # WP06 (FR-006/FR-013): kind=step decisions must always carry a
+        # non-empty resolvable prompt_file. When prompt resolution fails,
+        # surface a structured blocked decision instead of a partial step.
+        return Decision(
+            kind=DecisionKind.blocked,
+            agent=agent,
+            mission_slug=mission_slug,
+            mission=mission_type,
+            mission_state=step_id,
+            timestamp=timestamp,
+            reason=prompt_error or "no_prompt_template",
+            action=action,
+            wp_id=wp_id,
+            workspace_path=workspace_path,
+            guard_failures=guard_failures or [],
+            progress=progress,
+            origin=origin,
+            run_id=run_ref.run_id,
+            step_id=step_id,
+        )
 
     return Decision(
         kind=DecisionKind.step,
@@ -2249,7 +2295,7 @@ def _map_runtime_decision(
                 run_id=run_id,
                 step_id=step_id,
             )
-        prompt_file = _build_prompt_safe(
+        prompt_file, prompt_error = _build_prompt_or_error(
             action,
             feature_dir,
             mission_slug,
@@ -2258,6 +2304,25 @@ def _map_runtime_decision(
             repo_root,
             mission_type,
         )
+        if prompt_file is None:
+            # WP06 (FR-006/FR-013): kind=step requires a resolvable prompt;
+            # fall through to blocked when one cannot be built.
+            return Decision(
+                kind=DecisionKind.blocked,
+                agent=agent,
+                mission_slug=mission_slug,
+                mission=mission_type,
+                mission_state=step_id,
+                timestamp=timestamp,
+                reason=prompt_error or "no_prompt_template",
+                action=action,
+                wp_id=wp_id,
+                workspace_path=workspace_path,
+                progress=progress,
+                origin=origin,
+                run_id=run_id,
+                step_id=step_id,
+            )
         return Decision(
             kind=DecisionKind.step,
             agent=agent,
@@ -2283,8 +2348,10 @@ def _map_runtime_decision(
         repo_root,
         mission_type,
     )
-    prompt_file = (
-        _build_prompt_safe(
+    prompt_file: str | None = None
+    prompt_error: str | None = None
+    if action or step_id:
+        prompt_file, prompt_error = _build_prompt_or_error(
             action or step_id or "unknown",
             feature_dir,
             mission_slug,
@@ -2293,9 +2360,27 @@ def _map_runtime_decision(
             repo_root,
             mission_type,
         )
-        if action or step_id
-        else None
-    )
+    else:
+        prompt_error = "no action and no step_id; cannot resolve prompt"
+    if prompt_file is None:
+        # WP06 (FR-006/FR-013): emit a structured blocked decision rather than
+        # an issued step that has no resolvable prompt.
+        return Decision(
+            kind=DecisionKind.blocked,
+            agent=agent,
+            mission_slug=mission_slug,
+            mission=mission_type,
+            mission_state=step_id or "unknown",
+            timestamp=timestamp,
+            reason=prompt_error or "no_prompt_template",
+            action=action or step_id,
+            wp_id=wp_id,
+            workspace_path=workspace_path,
+            progress=progress,
+            origin=origin,
+            run_id=run_id,
+            step_id=step_id,
+        )
 
     return Decision(
         kind=DecisionKind.step,

--- a/src/specify_cli/upgrade/migrations/m_3_2_5_fix_prompt_file_workaround.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_5_fix_prompt_file_workaround.py
@@ -1,0 +1,103 @@
+"""Migration: remove the ``prompt_file == null`` workaround text from the
+runtime-next skill (issues #336 / #844).
+
+After WP06 of mission ``charter-e2e-hardening-tranche-2-01KQ9NVQ`` the
+runtime guarantees that every ``kind: step`` decision carries a non-empty
+``prompt_file`` resolvable on disk; otherwise it emits a structured
+``kind: blocked`` decision with a populated ``reason``. The SKILL.md text
+that previously instructed agents to defensively null-check ``prompt_file``
+is now stale and removed from the source.
+
+This migration mirrors :mod:`m_2_1_2_fix_runtime_next_skill` and uses the
+shared :func:`find_skill_files` helper to refresh every installed copy of
+``spec-kitty-runtime-next/SKILL.md`` across all known agent skill roots.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+from ..registry import MigrationRegistry
+from ..skill_update import file_contains_any, find_skill_files
+from .base import BaseMigration, MigrationResult
+
+_SKILL_NAME = "spec-kitty-runtime-next"
+
+# Match the pre-WP06 markers that we just removed from the canonical SKILL.md.
+# Any installed copy still containing one of these strings is stale.
+_OLD_MARKERS = [
+    "Check `prompt_file` is not null, then read and execute",
+    "Workaround #336: treat null prompt as blocked",
+    "#336 — `prompt_file` can be `null` on `step` decisions",
+    "Treat a null `prompt_file` as a blocked state",
+]
+
+
+@MigrationRegistry.register
+class FixPromptFileWorkaroundMigration(BaseMigration):
+    """Refresh runtime-next SKILL.md copies after the WP06 contract change."""
+
+    migration_id = "3.2.5_fix_prompt_file_workaround"
+    description = (
+        "Remove `prompt_file == null` workaround text from runtime-next skill; "
+        "kind=step now always carries a resolvable prompt_file (#336 / #844)."
+    )
+    target_version = "3.2.5"
+
+    def detect(self, project_path: Path) -> bool:
+        return any(
+            file_contains_any(info.path, _OLD_MARKERS)
+            for info in find_skill_files(project_path, _SKILL_NAME, ["SKILL.md"])
+        )
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:  # noqa: ARG002
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        changes: list[str] = []
+        errors: list[str] = []
+
+        try:
+            doctrine_root = files("doctrine")
+            canonical_path = doctrine_root.joinpath(
+                "skills", _SKILL_NAME, "SKILL.md"
+            )
+            new_content = canonical_path.read_text(encoding="utf-8")
+        except Exception:
+            fallback = (
+                Path(__file__).resolve().parents[3]
+                / "doctrine"
+                / "skills"
+                / _SKILL_NAME
+                / "SKILL.md"
+            )
+            if fallback.is_file():
+                new_content = fallback.read_text(encoding="utf-8")
+            else:
+                return MigrationResult(
+                    success=False,
+                    errors=["Cannot locate canonical SKILL.md for runtime-next"],
+                )
+
+        for info in find_skill_files(project_path, _SKILL_NAME, ["SKILL.md"]):
+            if not file_contains_any(info.path, _OLD_MARKERS):
+                continue
+            rel = str(info.path.relative_to(project_path))
+            if dry_run:
+                changes.append(f"Would replace {rel}")
+            else:
+                try:
+                    info.path.write_text(new_content, encoding="utf-8")
+                    changes.append(f"Replaced {rel}")
+                except OSError as exc:
+                    errors.append(f"Failed to write {rel}: {exc}")
+
+        if not changes and not errors:
+            changes.append("All runtime-next skill files already up to date")
+
+        return MigrationResult(
+            success=len(errors) == 0,
+            changes_made=changes,
+            errors=errors,
+        )

--- a/tests/agent/cli/commands/test_charter_synthesize_cli.py
+++ b/tests/agent/cli/commands/test_charter_synthesize_cli.py
@@ -117,7 +117,12 @@ class TestSynthesizeHappyPath:
 
         with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
             "specify_cli.cli.commands.charter._run_synthesis_dry_run",
-            return_value=["directive:test-directive"],
+            return_value=[
+                {
+                    "path": ".kittify/doctrine/directives/001-test-directive.directive.yaml",
+                    "kind": "directive",
+                }
+            ],
         ):
             result = runner.invoke(app, ["synthesize", "--dry-run"])
 
@@ -137,22 +142,42 @@ class TestSynthesizeHappyPath:
             mock_result.effective_adapter_id = "fixture"
             mock_result.effective_adapter_version = "1.0.0"
 
-            with patch("charter.synthesizer.synthesize", return_value=mock_result):
+            with patch("charter.synthesizer.synthesize", return_value=mock_result), patch(
+                "specify_cli.cli.commands.charter._read_written_artifacts_from_manifest",
+                return_value=[
+                    {
+                        "path": ".kittify/doctrine/directives/001-test.directive.yaml",
+                        "kind": "directive",
+                    }
+                ],
+            ):
                 result = runner.invoke(
                     app, ["synthesize", "--adapter", "fixture", "--json"]
                 )
 
         assert result.exit_code == 0, f"Expected exit 0: {result.output}"
         data = json.loads(result.output)
-        assert data["result"] in {"success", "dry_run"}
+        assert data["result"] == "success"
+        assert data["adapter"] == "fixture"
+        assert data["written_artifacts"] == [
+            {
+                "path": ".kittify/doctrine/directives/001-test.directive.yaml",
+                "kind": "directive",
+            }
+        ]
 
     def test_synthesize_dry_run_json(self, tmp_path: Path) -> None:
-        """--dry-run --json returns staged artifacts and validated=true."""
+        """--dry-run --json returns the strict planned-artifacts envelope."""
         _write_interview_answers(tmp_path)
 
         with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path), patch(
             "specify_cli.cli.commands.charter._run_synthesis_dry_run",
-            return_value=["directive:test-directive"],
+            return_value=[
+                {
+                    "path": ".kittify/doctrine/directives/001-test-directive.directive.yaml",
+                    "kind": "directive",
+                }
+            ],
         ):
             result = runner.invoke(
                 app,
@@ -161,9 +186,40 @@ class TestSynthesizeHappyPath:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["result"] == "dry_run"
-        assert "staged_artifacts" in data
-        assert data["validated"] is True
+        assert data["result"] == "success"
+        assert data["adapter"] == "generated"
+        assert data["planned_artifacts"] == [
+            {
+                "path": ".kittify/doctrine/directives/001-test-directive.directive.yaml",
+                "kind": "directive",
+            }
+        ]
+
+    def test_dry_run_planned_path_uses_provenance_artifact_id(self) -> None:
+        """Dry-run paths use the real directive id, not a PROJECT_000 fallback."""
+        from types import SimpleNamespace
+
+        from specify_cli.cli.commands.charter import _provenance_to_planned_artifacts
+
+        planned = _provenance_to_planned_artifacts(
+            [
+                (
+                    {},
+                    SimpleNamespace(
+                        artifact_kind="directive",
+                        artifact_slug="mission-type-scope-directive",
+                        artifact_urn="directive:PROJECT_001",
+                    ),
+                )
+            ]
+        )
+
+        assert planned == [
+            {
+                "path": ".kittify/doctrine/directives/001-mission-type-scope-directive.directive.yaml",
+                "kind": "directive",
+            }
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/next/test_next_command_integration.py
+++ b/tests/next/test_next_command_integration.py
@@ -89,6 +89,23 @@ def _write_runtime_input_mission(repo_root: Path, mission_type: str) -> None:
         ),
         encoding="utf-8",
     )
+    _write_command_templates(repo_root, ["collect_input", "execute"])
+
+
+def _write_command_templates(repo_root: Path, action_names: list[str]) -> None:
+    """Create minimal command templates for synthetic runtime steps.
+
+    The next runtime now guarantees that emitted ``kind=step`` decisions carry
+    a resolvable prompt file. Integration fixtures that expect runnable custom
+    steps must therefore provide command templates in the resolver override tier.
+    """
+    template_dir = repo_root / ".kittify" / "overrides" / "command-templates"
+    template_dir.mkdir(parents=True, exist_ok=True)
+    for action in action_names:
+        (template_dir / f"{action}.md").write_text(
+            f"# {action}\n\nRun the synthetic {action} step for this integration test.\n",
+            encoding="utf-8",
+        )
 
 
 def _write_invalid_runtime_mission(repo_root: Path, mission_type: str) -> None:
@@ -429,6 +446,7 @@ class TestNextCommandKnownBlockedMissions:
             mission_slug="043-plan-feature",
             mission_type="plan",
         )
+        _write_command_templates(repo_root, ["specify"])
 
         from specify_cli.next.decision import decide_next
 
@@ -442,6 +460,7 @@ class TestNextCommandKnownBlockedMissions:
             mission_slug="044-docs-feature",
             mission_type="documentation",
         )
+        _write_command_templates(repo_root, ["discover"])
 
         from specify_cli.next.decision import decide_next
 

--- a/tests/next/test_prompt_file_invariant.py
+++ b/tests/next/test_prompt_file_invariant.py
@@ -1,0 +1,402 @@
+"""WP06 — `next --json` prompt_file resolvability invariant.
+
+This module exercises the contract locked by
+``contracts/next-issue.json``: when ``spec-kitty next --json`` issues a step
+(``kind == DecisionKind.step``), the issued decision MUST carry a non-empty
+``prompt_file`` whose path resolves to an existing file on disk. When no
+prompt is resolvable, the runtime MUST emit a structured ``blocked`` decision
+with a populated ``reason`` instead of a partial step.
+
+Tests target the two `_build_prompt_or_error` consumers in
+``runtime_bridge.py`` plus the helper itself in ``decision.py``. We exercise
+the legacy DAG path (`_handle_query_or_step`) via the bridge function
+``_map_runtime_decision`` because a full subprocess loop requires a working
+runtime stack with a frozen template; the unit-level coverage here proves
+the invariant holds for every code path that converts a runtime
+``NextDecision`` into a CLI ``Decision``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.next.decision import (
+    Decision,
+    DecisionKind,
+    _build_prompt_or_error,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# _build_prompt_or_error — direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPromptOrError:
+    """The helper underpins the invariant — verify both branches end-to-end."""
+
+    def test_returns_path_when_prompt_exists(self, tmp_path: Path) -> None:
+        prompt_path = tmp_path / "prompt.md"
+        prompt_path.write_text("# prompt\n", encoding="utf-8")
+
+        with patch(
+            "specify_cli.next.prompt_builder.build_prompt",
+            return_value=(None, prompt_path),
+        ):
+            path, error = _build_prompt_or_error(
+                action="implement",
+                feature_dir=tmp_path,
+                mission_slug="042-test",
+                wp_id="WP01",
+                agent="claude",
+                repo_root=tmp_path,
+                mission_type="software-dev",
+            )
+
+        assert path == str(prompt_path)
+        assert error is None
+        assert os.path.exists(path)
+
+    def test_returns_error_when_build_raises(self, tmp_path: Path) -> None:
+        with patch(
+            "specify_cli.next.prompt_builder.build_prompt",
+            side_effect=FileNotFoundError("no template for 'discovery'"),
+        ):
+            path, error = _build_prompt_or_error(
+                action="discovery",
+                feature_dir=tmp_path,
+                mission_slug="042-test",
+                wp_id=None,
+                agent="claude",
+                repo_root=tmp_path,
+                mission_type="software-dev",
+            )
+
+        assert path is None
+        assert error is not None
+        assert "discovery" in error
+        assert "FileNotFoundError" in error
+
+    def test_returns_error_when_path_missing_on_disk(self, tmp_path: Path) -> None:
+        # build_prompt returns a path but the file does not exist.
+        ghost = tmp_path / "ghost.md"
+        with patch(
+            "specify_cli.next.prompt_builder.build_prompt",
+            return_value=(None, ghost),
+        ):
+            path, error = _build_prompt_or_error(
+                action="implement",
+                feature_dir=tmp_path,
+                mission_slug="042-test",
+                wp_id="WP01",
+                agent="claude",
+                repo_root=tmp_path,
+                mission_type="software-dev",
+            )
+
+        assert path is None
+        assert error is not None
+        assert "did not materialize" in error
+
+    def test_returns_error_when_path_stat_raises_oserror(
+        self, tmp_path: Path
+    ) -> None:
+        """Exercise decision.py:521-522 — Path.exists() OSError branch.
+
+        On some platforms Path.exists() can raise OSError (PermissionError,
+        ENAMETOOLONG, broken symlinks under restrictive filesystems). The
+        helper MUST surface a structured `not stat-able` error rather than
+        propagate the exception.
+        """
+        ghost = tmp_path / "ghost.md"
+        with (
+            patch(
+                "specify_cli.next.prompt_builder.build_prompt",
+                return_value=(None, ghost),
+            ),
+            # Cover the `except OSError` branch in
+            # `_build_prompt_or_error`. Path.exists() is called inside the
+            # try/except — we patch the class method to raise OSError so the
+            # second `except` block executes.
+            patch(
+                "pathlib.Path.exists",
+                side_effect=PermissionError("EACCES"),
+            ),
+        ):
+            path, error = _build_prompt_or_error(
+                action="implement",
+                feature_dir=tmp_path,
+                mission_slug="042-test",
+                wp_id="WP01",
+                agent="claude",
+                repo_root=tmp_path,
+                mission_type="software-dev",
+            )
+
+        assert path is None
+        assert error is not None
+        assert "not stat-able" in error
+        assert "implement" in error
+
+
+# ---------------------------------------------------------------------------
+# _map_runtime_decision — every step kind goes through this surface
+# ---------------------------------------------------------------------------
+
+
+def _runtime_decision(
+    *,
+    kind: str = "step",
+    step_id: str = "discovery",
+    run_id: str = "run-001",
+    decision_id: str | None = None,
+    question: str | None = None,
+    options: list[str] | None = None,
+    input_key: str | None = None,
+    reason: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        kind=kind,
+        step_id=step_id,
+        run_id=run_id,
+        decision_id=decision_id,
+        question=question,
+        options=options,
+        input_key=input_key,
+        reason=reason,
+    )
+
+
+@pytest.mark.parametrize(
+    "step_id",
+    [
+        "discovery",
+        "research",
+        "documentation",
+        "scoping",
+        "methodology",
+        "gathering",
+        "synthesis",
+        "output",
+    ],
+)
+def test_issued_step_always_has_resolvable_prompt(tmp_path: Path, step_id: str) -> None:
+    """For every public step kind, an issued decision must satisfy the contract."""
+    from specify_cli.next.runtime_bridge import _map_runtime_decision
+
+    prompt_path = tmp_path / f"{step_id}-prompt.md"
+    prompt_path.write_text(f"# prompt for {step_id}\n", encoding="utf-8")
+
+    with (
+        patch(
+            "specify_cli.next.runtime_bridge._state_to_action",
+            return_value=(step_id, None, None),
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._is_wp_iteration_step",
+            return_value=False,
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._build_prompt_or_error",
+            return_value=(str(prompt_path), None),
+        ),
+    ):
+        decision: Decision = _map_runtime_decision(
+            decision=_runtime_decision(step_id=step_id),
+            agent="claude",
+            mission_slug="042-test",
+            mission_type="software-dev",
+            repo_root=tmp_path,
+            feature_dir=tmp_path,
+            timestamp="2026-04-28T00:00:00+00:00",
+            progress=None,
+            origin={},
+        )
+
+    assert decision.kind == DecisionKind.step
+    # Contract: issued steps MUST carry a non-empty resolvable prompt_file.
+    assert decision.prompt_file is not None
+    assert decision.prompt_file != ""
+    assert os.path.exists(decision.prompt_file)
+
+
+@pytest.mark.parametrize("step_id", ["discovery", "research", "documentation"])
+def test_unresolvable_prompt_yields_structured_blocked(tmp_path: Path, step_id: str) -> None:
+    """When prompt resolution fails, the response MUST be `blocked` with a non-empty `reason`."""
+    from specify_cli.next.runtime_bridge import _map_runtime_decision
+
+    error_msg = (
+        f"prompt resolution failed for action '{step_id}': "
+        f"FileNotFoundError: no template"
+    )
+    with (
+        patch(
+            "specify_cli.next.runtime_bridge._state_to_action",
+            return_value=(step_id, None, None),
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._is_wp_iteration_step",
+            return_value=False,
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._build_prompt_or_error",
+            return_value=(None, error_msg),
+        ),
+    ):
+        decision: Decision = _map_runtime_decision(
+            decision=_runtime_decision(step_id=step_id),
+            agent="claude",
+            mission_slug="042-test",
+            mission_type="software-dev",
+            repo_root=tmp_path,
+            feature_dir=tmp_path,
+            timestamp="2026-04-28T00:00:00+00:00",
+            progress=None,
+            origin={},
+        )
+
+    assert decision.kind == DecisionKind.blocked
+    assert decision.reason is not None
+    assert decision.reason != ""
+    assert step_id in decision.reason
+    # prompt_file must NOT be set on a blocked decision when no prompt was resolvable.
+    assert decision.prompt_file is None
+
+
+@pytest.mark.parametrize("step_id", ["implement", "review"])
+def test_wp_iteration_step_invariant_holds(tmp_path: Path, step_id: str) -> None:
+    """Composed WP-iteration steps (implement/review) must satisfy the invariant too."""
+    from specify_cli.next.runtime_bridge import _map_runtime_decision
+
+    prompt_path = tmp_path / f"{step_id}-prompt.md"
+    prompt_path.write_text(f"# prompt for {step_id}\n", encoding="utf-8")
+
+    with (
+        patch(
+            "specify_cli.next.runtime_bridge._state_to_action",
+            return_value=(step_id, "WP01", str(tmp_path / ".worktrees" / "lane-a")),
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._is_wp_iteration_step",
+            return_value=True,
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._build_prompt_or_error",
+            return_value=(str(prompt_path), None),
+        ),
+    ):
+        decision = _map_runtime_decision(
+            decision=_runtime_decision(step_id=step_id),
+            agent="claude",
+            mission_slug="042-test",
+            mission_type="software-dev",
+            repo_root=tmp_path,
+            feature_dir=tmp_path,
+            timestamp="2026-04-28T00:00:00+00:00",
+            progress=None,
+            origin={},
+        )
+
+    assert decision.kind == DecisionKind.step
+    assert decision.prompt_file is not None
+    assert os.path.exists(decision.prompt_file)
+
+
+@pytest.mark.parametrize("step_id", ["implement", "review"])
+def test_wp_iteration_step_blocked_when_prompt_unresolvable(tmp_path: Path, step_id: str) -> None:
+    """WP-iteration steps must also fall through to blocked when prompts fail."""
+    from specify_cli.next.runtime_bridge import _map_runtime_decision
+
+    with (
+        patch(
+            "specify_cli.next.runtime_bridge._state_to_action",
+            return_value=(step_id, "WP01", str(tmp_path / ".worktrees" / "lane-a")),
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._is_wp_iteration_step",
+            return_value=True,
+        ),
+        patch(
+            "specify_cli.next.runtime_bridge._build_prompt_or_error",
+            return_value=(None, f"prompt resolution failed for action '{step_id}'"),
+        ),
+    ):
+        decision = _map_runtime_decision(
+            decision=_runtime_decision(step_id=step_id),
+            agent="claude",
+            mission_slug="042-test",
+            mission_type="software-dev",
+            repo_root=tmp_path,
+            feature_dir=tmp_path,
+            timestamp="2026-04-28T00:00:00+00:00",
+            progress=None,
+            origin={},
+        )
+
+    assert decision.kind == DecisionKind.blocked
+    assert decision.reason is not None
+    assert decision.reason != ""
+    assert step_id in decision.reason
+    assert decision.prompt_file is None
+
+
+def test_third_state_does_not_exist(tmp_path: Path) -> None:
+    """Negative test: there is no `kind=step` decision with a null prompt_file.
+
+    This codifies the WP06 invariant in a single shot — across both branches
+    of `_map_runtime_decision`'s step handler, the only outcomes are
+    (issued + resolvable prompt) or (blocked + non-empty reason).
+    """
+    from specify_cli.next.runtime_bridge import _map_runtime_decision
+
+    for prompt_outcome in [
+        (None, "prompt resolution failed for action 'discovery': FileNotFoundError: x"),
+    ]:
+        with (
+            patch(
+                "specify_cli.next.runtime_bridge._state_to_action",
+                return_value=("discovery", None, None),
+            ),
+            patch(
+                "specify_cli.next.runtime_bridge._is_wp_iteration_step",
+                return_value=False,
+            ),
+            patch(
+                "specify_cli.next.runtime_bridge._build_prompt_or_error",
+                return_value=prompt_outcome,
+            ),
+        ):
+            decision = _map_runtime_decision(
+                decision=_runtime_decision(step_id="discovery"),
+                agent="claude",
+                mission_slug="042-test",
+                mission_type="software-dev",
+                repo_root=tmp_path,
+                feature_dir=tmp_path,
+                timestamp="2026-04-28T00:00:00+00:00",
+                progress=None,
+                origin={},
+            )
+
+        # Forbidden combination: issued step with no resolvable prompt.
+        is_issued_step = decision.kind == DecisionKind.step
+        has_resolvable_prompt = (
+            decision.prompt_file is not None
+            and decision.prompt_file != ""
+            and os.path.exists(decision.prompt_file)
+        )
+        if is_issued_step:
+            assert has_resolvable_prompt, (
+                f"WP06 invariant violated: kind={decision.kind!r}, "
+                f"prompt_file={decision.prompt_file!r}"
+            )
+        else:
+            assert decision.kind == DecisionKind.blocked
+            assert decision.reason

--- a/tests/next/test_query_mode_unit.py
+++ b/tests/next/test_query_mode_unit.py
@@ -254,9 +254,12 @@ class TestBuildPromptSafe:
     def test_build_prompt_safe_suppresses_stdout_noise(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         from specify_cli.next.decision import _build_prompt_safe
 
+        prompt_path = tmp_path / "prompt.md"
+        prompt_path.write_text("# prompt\n", encoding="utf-8")
+
         def noisy_build_prompt(**_kwargs):
             print("noisy stdout")
-            return None, tmp_path / "prompt.md"
+            return None, prompt_path
 
         with patch("specify_cli.next.prompt_builder.build_prompt", side_effect=noisy_build_prompt):
             result = _build_prompt_safe(
@@ -269,7 +272,7 @@ class TestBuildPromptSafe:
                 mission_type="software-dev",
             )
 
-        assert result == str(tmp_path / "prompt.md")
+        assert result == str(prompt_path)
         captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""

--- a/tests/next/test_runtime_bridge_blocked_paths.py
+++ b/tests/next/test_runtime_bridge_blocked_paths.py
@@ -1,0 +1,338 @@
+"""Targeted coverage for the structured-blocked emit branches in
+``runtime_bridge.py`` (PR #855 follow-up — diff-coverage fill).
+
+The CI diff-coverage gate flagged the following lines uncovered by the WP06
+prompt-file-invariant tests:
+
+- ``runtime_bridge.py:1565-1609`` — legacy DAG path guard failures: when
+  ``current_step_id`` has a guard failure on a non-WP step, the runtime
+  must build a structured ``blocked`` decision (with the resolvable prompt
+  attached when one is available, or with the prompt-resolution error
+  threaded into the reason when not).
+- ``runtime_bridge.py:2156`` — ``_build_wp_iteration_decision`` with a
+  prompt-resolution error must yield a structured ``blocked`` instead of a
+  partial step.
+- ``runtime_bridge.py:2364`` — ``_map_runtime_decision`` non-WP step branch
+  with neither ``action`` nor ``step_id`` mapped must short-circuit to a
+  structured ``blocked`` with a populated reason (no template lookup).
+
+The existing `test_prompt_file_invariant.py` covers the contract surface
+but doesn't drive these specific lines because it stubs ``_state_to_action``
+to always return a usable action. Here we drive the branches directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.next.decision import DecisionKind
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# 2156 — _build_wp_iteration_decision blocked when prompt unresolvable
+# ---------------------------------------------------------------------------
+
+
+def _runtime_decision(**overrides: object) -> SimpleNamespace:
+    base: dict[str, object] = {
+        "kind": "step",
+        "step_id": "implement",
+        "run_id": "run-001",
+        "decision_id": None,
+        "question": None,
+        "options": None,
+        "input_key": None,
+        "reason": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestWPIterationDecisionBlockedBranch:
+    """runtime_bridge.py:2152-2172 (`_build_wp_iteration_decision` blocked path)."""
+
+    def test_wp_iteration_blocked_when_prompt_unresolvable_with_guard_failures(
+        self, tmp_path: Path
+    ) -> None:
+        """Direct unit-level call to `_build_wp_iteration_decision`.
+
+        Ensures the blocked branch (line 2156-2172) fires when the helper
+        returns a non-empty error and `guard_failures` is supplied. The
+        resulting Decision must:
+          - kind == blocked
+          - reason == prompt_error
+          - guard_failures forwarded (not dropped)
+          - prompt_file is None
+        """
+        from specify_cli.next.runtime_bridge import _build_wp_iteration_decision
+
+        run_ref = SimpleNamespace(run_id="run-blocked-01")
+
+        with (
+            patch(
+                "specify_cli.next.runtime_bridge._state_to_action",
+                return_value=("implement", "WP01", str(tmp_path / ".worktrees" / "lane-a")),
+            ),
+            patch(
+                "specify_cli.next.runtime_bridge._build_prompt_or_error",
+                return_value=(None, "prompt resolution failed for action 'implement'"),
+            ),
+        ):
+            decision = _build_wp_iteration_decision(
+                step_id="implement",
+                agent="claude",
+                mission_slug="042-test",
+                mission_type="software-dev",
+                feature_dir=tmp_path,
+                repo_root=tmp_path,
+                timestamp="2026-04-28T00:00:00+00:00",
+                progress=None,
+                origin={},
+                run_ref=run_ref,
+                guard_failures=["pre-existing guard"],
+            )
+
+        assert decision.kind == DecisionKind.blocked
+        assert decision.reason
+        assert "prompt resolution failed" in decision.reason
+        assert decision.prompt_file is None
+        assert decision.guard_failures == ["pre-existing guard"]
+        assert decision.action == "implement"
+        assert decision.wp_id == "WP01"
+
+
+# ---------------------------------------------------------------------------
+# 2364 — _map_runtime_decision non-WP step with neither action nor step_id
+# ---------------------------------------------------------------------------
+
+
+class TestMapRuntimeDecisionNoActionNoStepId:
+    """runtime_bridge.py:2363-2364 (no-action AND no-step_id branch)."""
+
+    def test_map_runtime_decision_emits_blocked_when_no_action_and_no_step_id(
+        self, tmp_path: Path
+    ) -> None:
+        """Drive the `else` branch on line 2363-2364.
+
+        Pre-condition: `_state_to_action` returns (None, None, None) AND
+        `decision.step_id` is None. The map function must NOT attempt to
+        resolve a prompt (prompt_error is set inline) and must emit a
+        blocked decision.
+        """
+        from specify_cli.next.runtime_bridge import _map_runtime_decision
+
+        with (
+            patch(
+                "specify_cli.next.runtime_bridge._state_to_action",
+                return_value=(None, None, None),
+            ),
+            patch(
+                "specify_cli.next.runtime_bridge._is_wp_iteration_step",
+                return_value=False,
+            ),
+        ):
+            # step_id=None forces the `if action or step_id` guard to fall
+            # through to the `else` branch on line 2363.
+            decision = _map_runtime_decision(
+                decision=_runtime_decision(step_id=None),
+                agent="claude",
+                mission_slug="042-test",
+                mission_type="software-dev",
+                repo_root=tmp_path,
+                feature_dir=tmp_path,
+                timestamp="2026-04-28T00:00:00+00:00",
+                progress=None,
+                origin={},
+            )
+
+        assert decision.kind == DecisionKind.blocked
+        assert decision.reason
+        assert "no action and no step_id" in decision.reason
+        assert decision.prompt_file is None
+
+
+# ---------------------------------------------------------------------------
+# 1565-1609 — legacy DAG path: non-WP step + guard failures + prompt branch
+# ---------------------------------------------------------------------------
+
+
+class TestDecideNextViaRuntimeGuardFailureBlocked:
+    """runtime_bridge.py:1561-1608 (`decide_next_via_runtime` guard branch).
+
+    When ``result == "success"``, the current step is NOT a WP iteration step,
+    and ``_check_cli_guards`` returns a non-empty list, the runtime MUST
+    surface a structured blocked decision with the prompt either attached
+    (when resolvable) or threaded into the reason (when not).
+    """
+
+    def _build_minimal_feature_dir(self, tmp_path: Path, mission_slug: str) -> Path:
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        feature_dir.mkdir(parents=True, exist_ok=True)
+        # Minimal meta so get_mission_type doesn't blow up.
+        (feature_dir / "meta.json").write_text(
+            '{"mission_type": "software-dev"}',
+            encoding="utf-8",
+        )
+        return feature_dir
+
+    def test_guard_failure_on_non_wp_step_yields_blocked_with_prompt_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Lines 1561-1609 — the prompt-error branch of the guard handler.
+
+        Drives the branch where ``_state_to_action`` returns a usable
+        ``action`` and ``_build_prompt_or_error`` returns ``(None, error)``.
+        The decision must be ``blocked`` with the prompt error in
+        ``reason``.
+        """
+        from specify_cli.next import runtime_bridge as rb
+
+        mission_slug = "042-test"
+        self._build_minimal_feature_dir(tmp_path, mission_slug)
+
+        # Stub helpers to drive the exact branch with no real runtime engine.
+        run_ref = SimpleNamespace(run_id="run-guard-01", run_dir=str(tmp_path / "run"))
+        snapshot = SimpleNamespace(issued_step_id="specify")
+
+        with (
+            patch.object(rb, "get_mission_type", return_value="software-dev"),
+            patch.object(rb, "SyncRuntimeEventEmitter") as sync_cls,
+            patch.object(rb, "get_or_start_run", return_value=run_ref),
+            patch.object(rb, "_compute_wp_progress", return_value=None),
+            patch.object(rb, "_check_cli_guards", return_value=["specify_guard_failure"]),
+            patch.object(rb, "_is_wp_iteration_step", return_value=False),
+            patch.object(rb, "_state_to_action", return_value=("specify", None, None)),
+            patch.object(
+                rb,
+                "_build_prompt_or_error",
+                return_value=(None, "prompt resolution failed for action 'specify'"),
+            ),
+            patch(
+                "specify_cli.next._internal_runtime.engine._read_snapshot",
+                return_value=snapshot,
+            ),
+        ):
+            sync_cls.for_feature.return_value = SimpleNamespace(
+                seed_from_snapshot=lambda *_a, **_k: None
+            )
+            decision = rb.decide_next_via_runtime(
+                agent="claude",
+                mission_slug=mission_slug,
+                result="success",
+                repo_root=tmp_path,
+            )
+
+        assert decision.kind == DecisionKind.blocked
+        assert decision.reason
+        assert "prompt resolution failed" in decision.reason
+        assert decision.guard_failures == ["specify_guard_failure"]
+        assert decision.action == "specify"
+        assert decision.prompt_file is None
+
+    def test_guard_failure_on_non_wp_step_with_resolvable_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        """Lines 1561-1609 — the prompt-attached branch (line 1609+).
+
+        Same setup as above but with a resolvable prompt: the decision is
+        still blocked (because guards failed), but it MUST carry the
+        resolvable ``prompt_file`` rather than a prompt-error reason.
+        """
+        from specify_cli.next import runtime_bridge as rb
+
+        mission_slug = "042-test"
+        self._build_minimal_feature_dir(tmp_path, mission_slug)
+
+        prompt_path = tmp_path / "specify-prompt.md"
+        prompt_path.write_text("# specify\n", encoding="utf-8")
+
+        run_ref = SimpleNamespace(run_id="run-guard-02", run_dir=str(tmp_path / "run"))
+        snapshot = SimpleNamespace(issued_step_id="specify")
+
+        with (
+            patch.object(rb, "get_mission_type", return_value="software-dev"),
+            patch.object(rb, "SyncRuntimeEventEmitter") as sync_cls,
+            patch.object(rb, "get_or_start_run", return_value=run_ref),
+            patch.object(rb, "_compute_wp_progress", return_value=None),
+            patch.object(rb, "_check_cli_guards", return_value=["specify_guard_failure"]),
+            patch.object(rb, "_is_wp_iteration_step", return_value=False),
+            patch.object(rb, "_state_to_action", return_value=("specify", None, None)),
+            patch.object(
+                rb,
+                "_build_prompt_or_error",
+                return_value=(str(prompt_path), None),
+            ),
+            patch(
+                "specify_cli.next._internal_runtime.engine._read_snapshot",
+                return_value=snapshot,
+            ),
+        ):
+            sync_cls.for_feature.return_value = SimpleNamespace(
+                seed_from_snapshot=lambda *_a, **_k: None
+            )
+            decision = rb.decide_next_via_runtime(
+                agent="claude",
+                mission_slug=mission_slug,
+                result="success",
+                repo_root=tmp_path,
+            )
+
+        # When guards fail but the prompt is resolvable, the decision is
+        # still structured (blocked OR step depending on policy). The
+        # critical contract is: guard_failures are surfaced, and any
+        # `prompt_file` attached must point to a real file.
+        assert decision.guard_failures == ["specify_guard_failure"]
+        if decision.prompt_file is not None:
+            assert Path(decision.prompt_file).exists()
+
+    def test_guard_failure_on_non_wp_step_no_action_mapped(
+        self, tmp_path: Path
+    ) -> None:
+        """Lines 1584-1587 — `_state_to_action` returns (None, ...) branch.
+
+        When no action can be mapped for the current step, the helper
+        composes the prompt-error reason inline (`no action mapped for
+        step ...`) without invoking `_build_prompt_or_error`.
+        """
+        from specify_cli.next import runtime_bridge as rb
+
+        mission_slug = "042-test"
+        self._build_minimal_feature_dir(tmp_path, mission_slug)
+
+        run_ref = SimpleNamespace(run_id="run-guard-03", run_dir=str(tmp_path / "run"))
+        snapshot = SimpleNamespace(issued_step_id="exotic-step")
+
+        with (
+            patch.object(rb, "get_mission_type", return_value="software-dev"),
+            patch.object(rb, "SyncRuntimeEventEmitter") as sync_cls,
+            patch.object(rb, "get_or_start_run", return_value=run_ref),
+            patch.object(rb, "_compute_wp_progress", return_value=None),
+            patch.object(rb, "_check_cli_guards", return_value=["exotic_guard_failure"]),
+            patch.object(rb, "_is_wp_iteration_step", return_value=False),
+            patch.object(rb, "_state_to_action", return_value=(None, None, None)),
+            patch(
+                "specify_cli.next._internal_runtime.engine._read_snapshot",
+                return_value=snapshot,
+            ),
+        ):
+            sync_cls.for_feature.return_value = SimpleNamespace(
+                seed_from_snapshot=lambda *_a, **_k: None
+            )
+            decision = rb.decide_next_via_runtime(
+                agent="claude",
+                mission_slug=mission_slug,
+                result="success",
+                repo_root=tmp_path,
+            )
+
+        assert decision.kind == DecisionKind.blocked
+        assert decision.reason
+        assert "no action mapped" in decision.reason
+        assert decision.guard_failures == ["exotic_guard_failure"]
+        assert decision.prompt_file is None


### PR DESCRIPTION
## Summary

Follow-up after PR #864 landed as the winning branch over PR #855. This ports the useful #855 leftovers onto current main without replaying the competing branch wholesale:

- enforce the next --json prompt-file invariant: kind=step now requires a resolvable prompt_file; unresolved prompts become structured blocked decisions
- update the runtime-next skill and add an upgrade migration to remove stale prompt_file == null workaround guidance
- tighten charter synthesize --json envelopes: warnings stay inside JSON, dry-run emits typed planned_artifacts, success emits adapter and manifest-derived written_artifacts
- update next integration fixtures to provide command templates when they intentionally expect runnable synthetic/custom steps

## Verification

- uv run pytest tests/agent/cli/commands/test_charter_synthesize_cli.py tests/integration/test_charter_synthesize_fresh.py tests/next/test_prompt_file_invariant.py tests/next/test_runtime_bridge_blocked_paths.py tests/next/test_query_mode_unit.py -q
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/integration/test_json_envelope_strict.py -q
- uv run pytest tests/upgrade/test_auto_discovery.py -q
- uv run pytest tests/next/test_next_command_integration.py -q
- uv run ruff check tests/next/test_next_command_integration.py src/specify_cli/cli/commands/charter.py src/specify_cli/next/decision.py src/specify_cli/next/runtime_bridge.py src/specify_cli/upgrade/migrations/m_3_2_5_fix_prompt_file_workaround.py tests/agent/cli/commands/test_charter_synthesize_cli.py tests/next/test_prompt_file_invariant.py tests/next/test_runtime_bridge_blocked_paths.py

Note: full-file ruff on tests/next/test_query_mode_unit.py still reports pre-existing F841/SIM117 issues unrelated to this patch; the focused tests above pass.