### PR TITLE
fix: address sonar security follow-ups

### DIFF
--- a/src/specify_cli/auth/refresh_transaction.py
+++ b/src/specify_cli/auth/refresh_transaction.py
@@ -103,7 +103,8 @@ class RefreshRejectionCause(StrEnum):
     behaviour for ``auth/transport.py``).
     """
 
-    REFRESH_TOKEN_EXPIRED = "refresh_token_expired"  # noqa: S105 — outcome label, not a credential
+    # `refresh_token_expired` is an enum label surfaced to callers, not a secret.
+    REFRESH_TOKEN_EXPIRED = "refresh_token_expired"  # noqa: S105
     SESSION_INVALID = "session_invalid"
 
 

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -172,6 +172,30 @@ def read_events_raw(feature_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+def _should_skip_status_event(obj: dict[str, Any]) -> bool:
+    """Return True for non-lane events that intentionally share the JSONL file."""
+    event_name = obj.get("event_name")
+    if isinstance(event_name, str) and event_name.startswith("retrospective."):
+        return True
+
+    # Why: Skip mission-level events (DecisionPointOpened,
+    # DecisionPointResolved, DecisionPointDeferred,
+    # DecisionPointCanceled, DecisionPointWidened, and any future
+    # event-type written by a non-status-emitter subsystem) that
+    # share status.events.jsonl with lane-transition events.
+    # Two cooperating subsystems write to this file with incompatible
+    # schemas: the status emitter writes lane-transition events
+    # (carrying wp_id, from_lane, to_lane), while the Decision Moment
+    # Protocol writes mission-level events that carry a top-level
+    # `event_type` field instead. Discriminating on event_type
+    # PRESENCE (not a specific value allowlist) is future-proof AND
+    # preserves the existing fail-loud contract for malformed
+    # lane-transition events: a corrupted lane event missing wp_id
+    # but ALSO missing event_type still hits StatusEvent.from_dict
+    # below and raises as today. See FR-010.
+    return "event_type" in obj
+
+
 def read_events(feature_dir: Path) -> list[StatusEvent]:
     """Read and deserialize StatusEvent objects from the events file.
 
@@ -200,26 +224,7 @@ def read_events(feature_dir: Path) -> list[StatusEvent]:
                 obj = json.loads(stripped)
             except json.JSONDecodeError as exc:
                 raise StoreError(f"Invalid JSON on line {line_number}: {exc}") from exc
-            event_name = obj.get("event_name")
-            if isinstance(event_name, str) and event_name.startswith("retrospective."):
-                continue
-
-            # Why: Skip mission-level events (DecisionPointOpened,
-            # DecisionPointResolved, DecisionPointDeferred,
-            # DecisionPointCanceled, DecisionPointWidened, and any future
-            # event-type written by a non-status-emitter subsystem) that
-            # share status.events.jsonl with lane-transition events.
-            # Two cooperating subsystems write to this file with incompatible
-            # schemas: the status emitter writes lane-transition events
-            # (carrying wp_id, from_lane, to_lane), while the Decision Moment
-            # Protocol writes mission-level events that carry a top-level
-            # `event_type` field instead. Discriminating on event_type
-            # PRESENCE (not a specific value allowlist) is future-proof AND
-            # preserves the existing fail-loud contract for malformed
-            # lane-transition events: a corrupted lane event missing wp_id
-            # but ALSO missing event_type still hits StatusEvent.from_dict
-            # below and raises as today. See FR-010.
-            if "event_type" in obj:
+            if _should_skip_status_event(obj):
                 continue
 
             try:

--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -13,6 +13,7 @@ import random
 from contextlib import suppress
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlparse
 
 import websockets
 from websockets import ConnectionClosed
@@ -154,11 +155,7 @@ class WebSocketClient:
                 "WebSocket provisioning returned an incomplete bundle."
             )
 
-        # Normalize ws_url scheme (provisioning returns https/http; WS needs wss/ws).
-        if ws_url.startswith("https://"):
-            ws_url = "wss://" + ws_url[len("https://") :]
-        elif ws_url.startswith("http://"):
-            ws_url = "ws://" + ws_url[len("http://") :]
+        ws_url = self._normalize_ws_url(ws_url)
 
         # Token-in-query-string, matching the SaaS contract for ephemeral ws tokens.
         separator = "&" if "?" in ws_url else "?"
@@ -259,6 +256,24 @@ class WebSocketClient:
     def reset_reconnect_attempts(self):
         """Reset the reconnection attempt counter"""
         self.reconnect_attempts = 0
+
+    @staticmethod
+    def _normalize_ws_url(ws_url: str) -> str:
+        """Convert provisioned HTTP(S) URLs to WS(S), rejecting insecure remote hosts."""
+        if ws_url.startswith("wss://") or ws_url.startswith("ws://"):
+            return ws_url
+        if ws_url.startswith("https://"):
+            return "wss://" + ws_url[len("https://") :]
+        if ws_url.startswith("http://"):
+            host = (urlparse(ws_url).hostname or "").lower()
+            if host not in {"127.0.0.1", "localhost", "::1"}:
+                raise AuthenticationError(
+                    "Refusing insecure WebSocket provisioning URL outside loopback."
+                )
+            return "ws://" + ws_url[len("http://") :]
+        raise AuthenticationError(
+            f"Unsupported WebSocket provisioning URL scheme: {ws_url!r}"
+        )
 
     def get_reconnect_delay(self, attempt: int) -> float:
         """

--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -260,7 +260,14 @@ class WebSocketClient:
     @staticmethod
     def _normalize_ws_url(ws_url: str) -> str:
         """Convert provisioned HTTP(S) URLs to WS(S), rejecting insecure remote hosts."""
-        if ws_url.startswith("wss://") or ws_url.startswith("ws://"):
+        if ws_url.startswith("wss://"):
+            return ws_url
+        if ws_url.startswith("ws://"):
+            host = (urlparse(ws_url).hostname or "").lower()
+            if host not in {"127.0.0.1", "localhost", "::1"}:
+                raise AuthenticationError(
+                    "Refusing insecure WebSocket provisioning URL outside loopback."
+                )
             return ws_url
         if ws_url.startswith("https://"):
             return "wss://" + ws_url[len("https://") :]

--- a/src/specify_cli/sync/orphan_sweep.py
+++ b/src/specify_cli/sync/orphan_sweep.py
@@ -204,9 +204,16 @@ def _http_shutdown_no_token(port: int) -> None:
     try:
         # nosec B310 — request URL is 127.0.0.1 in the reserved daemon range.
         with urllib.request.urlopen(request, timeout=1.0):
-            pass
+            return
     except Exception:
-        pass
+        return
+
+
+def _port_closed_after_process_disappeared(port: int) -> tuple[bool, str | None]:
+    """Handle races where the process exits between discovery and escalation."""
+    if _wait_for_port_close(port, timeout_s=_TERMINATE_WAIT_S):
+        return True, None
+    return False, "process_gone_but_port_still_listening"
 
 
 # ---------------------------------------------------------------------------
@@ -301,9 +308,7 @@ def _sweep_one(orphan: OrphanDaemon) -> tuple[bool, str | None]:
     except psutil.NoSuchProcess:
         # Process vanished between health-probe and now; the port may already
         # be free (race with self-retirement tick).
-        if _wait_for_port_close(orphan.port, timeout_s=_TERMINATE_WAIT_S):
-            return True, None
-        return False, "process_gone_but_port_still_listening"
+        return _port_closed_after_process_disappeared(orphan.port)
     except psutil.AccessDenied:
         return False, "access_denied_opening_process"
 
@@ -311,9 +316,7 @@ def _sweep_one(orphan: OrphanDaemon) -> tuple[bool, str | None]:
     try:
         proc.terminate()
     except psutil.NoSuchProcess:
-        if _wait_for_port_close(orphan.port, timeout_s=_TERMINATE_WAIT_S):
-            return True, None
-        return False, "process_gone_but_port_still_listening"
+        return _port_closed_after_process_disappeared(orphan.port)
     except psutil.AccessDenied:
         return False, "access_denied_on_terminate"
 
@@ -324,9 +327,7 @@ def _sweep_one(orphan: OrphanDaemon) -> tuple[bool, str | None]:
     try:
         proc.kill()
     except psutil.NoSuchProcess:
-        if _wait_for_port_close(orphan.port, timeout_s=_KILL_WAIT_S):
-            return True, None
-        return False, "process_gone_but_port_still_listening"
+        return _port_closed_after_process_disappeared(orphan.port)
     except psutil.AccessDenied:
         return False, "access_denied_on_kill"
 

--- a/tests/sync/test_client_integration.py
+++ b/tests/sync/test_client_integration.py
@@ -139,3 +139,21 @@ async def test_send_event_when_not_connected():
 
     with pytest.raises(ConnectionError, match="Not connected to server"):
         await client.send_event({"type": "test"})
+
+
+def test_normalize_ws_url_converts_https_and_loopback_http():
+    """Provisioned HTTPS URLs become WSS; loopback HTTP remains allowed for local dev."""
+    assert (
+        WebSocketClient._normalize_ws_url("https://spec-kitty-dev.fly.dev/ws")
+        == "wss://spec-kitty-dev.fly.dev/ws"
+    )
+    assert (
+        WebSocketClient._normalize_ws_url("http://127.0.0.1:9400/ws")
+        == "ws://127.0.0.1:9400/ws"
+    )
+
+
+def test_normalize_ws_url_rejects_insecure_remote_http():
+    """Remote HTTP endpoints must not be downgraded to plaintext WS."""
+    with pytest.raises(Exception, match="Refusing insecure WebSocket provisioning URL"):
+        WebSocketClient._normalize_ws_url("http://spec-kitty-dev.fly.dev/ws")

--- a/tests/sync/test_client_integration.py
+++ b/tests/sync/test_client_integration.py
@@ -151,9 +151,15 @@ def test_normalize_ws_url_converts_https_and_loopback_http():
         WebSocketClient._normalize_ws_url("http://127.0.0.1:9400/ws")
         == "ws://127.0.0.1:9400/ws"
     )
+    assert (
+        WebSocketClient._normalize_ws_url("ws://localhost:9400/ws")
+        == "ws://localhost:9400/ws"
+    )
 
 
-def test_normalize_ws_url_rejects_insecure_remote_http():
-    """Remote HTTP endpoints must not be downgraded to plaintext WS."""
+def test_normalize_ws_url_rejects_insecure_remote_plaintext():
+    """Remote plaintext endpoints must not receive the ephemeral WS token."""
     with pytest.raises(Exception, match="Refusing insecure WebSocket provisioning URL"):
         WebSocketClient._normalize_ws_url("http://spec-kitty-dev.fly.dev/ws")
+    with pytest.raises(Exception, match="Refusing insecure WebSocket provisioning URL"):
+        WebSocketClient._normalize_ws_url("ws://spec-kitty-dev.fly.dev/ws")


### PR DESCRIPTION
## Summary
- tighten WebSocket URL normalization so insecure `http://` provisioning URLs are only allowed for loopback hosts and remote plaintext URLs are rejected
- extract status-event skipping into a helper and clean up small Sonar findings in `refresh_transaction` and `orphan_sweep`
- add regression tests for the WebSocket URL normalization behavior

## Validation
- `ruff check src/specify_cli/auth/refresh_transaction.py src/specify_cli/status/store.py src/specify_cli/sync/orphan_sweep.py src/specify_cli/sync/client.py tests/sync/test_client_integration.py`
- `pytest tests/sync/test_client_integration.py tests/sync/test_reconnection.py tests/status/test_store.py tests/status/test_read_events_tolerates_decision_events.py -q`

## Investigation notes
- Open GitHub code-scanning alerts: none.
- Open Dependabot alert: `pip` in `uv.lock` is flagged by `GHSA-58qw-9mgm-455v` / `CVE-2026-3219`, but GitHub currently reports no patched version (`first_patched_version: null`), so there is no safe lockfile update to apply yet.
- SonarCloud nightly run on `main` was `25092675545` (2026-04-29 05:34 UTC). Its failure came from the Sonar quality gate, not from repo lint/security jobs.
- Full `tests/sync/test_orphan_sweep.py` failed locally before reaching the touched logic because its helper daemons never bound their test ports in this environment.
