### PR TITLE
Fix post-merge E2E template-root resolution

### DIFF
--- a/src/kernel/paths.py
+++ b/src/kernel/paths.py
@@ -73,11 +73,35 @@ def get_package_asset_root() -> Path:
     Raises:
         FileNotFoundError: If no valid asset root can be found.
     """
+    def _looks_like_missions_root(path: Path) -> bool:
+        if path.name == "missions":
+            return True
+        for mission_name in ("software-dev", "documentation", "research", "plan"):
+            mission_dir = path / mission_name
+            if (mission_dir / "mission.yaml").is_file() or (mission_dir / "mission-runtime.yaml").is_file():
+                return True
+        return False
+
+    def _resolve_env_root(root: Path) -> Path:
+        candidates = (
+            root,
+            root / "missions",
+            root / "src" / "doctrine" / "missions",
+            root / "src" / "specify_cli" / "missions",
+        )
+        for candidate in candidates:
+            if candidate.is_dir() and _looks_like_missions_root(candidate):
+                return candidate
+        raise FileNotFoundError(
+            "SPEC_KITTY_TEMPLATE_ROOT does not contain mission assets: "
+            f"{root}. Expected a missions directory or a Spec Kitty checkout root."
+        )
+
     # CI/testing override
     if env_root := os.environ.get("SPEC_KITTY_TEMPLATE_ROOT"):
         root = Path(env_root)
         if root.is_dir():
-            return root
+            return _resolve_env_root(root)
         raise FileNotFoundError(f"SPEC_KITTY_TEMPLATE_ROOT path does not exist: {env_root}")
 
     # Canonical location: doctrine.missions

--- a/src/kernel/paths.py
+++ b/src/kernel/paths.py
@@ -80,6 +80,8 @@ def get_package_asset_root() -> Path:
             mission_dir = path / mission_name
             if (mission_dir / "mission.yaml").is_file() or (mission_dir / "mission-runtime.yaml").is_file():
                 return True
+            if (mission_dir / "command-templates").is_dir():
+                return True
         return False
 
     def _resolve_env_root(root: Path) -> Path:

--- a/src/specify_cli/runtime/home.py
+++ b/src/specify_cli/runtime/home.py
@@ -41,12 +41,45 @@ def get_kittify_home() -> Path:
     return Path.home() / ".kittify"
 
 
+def _looks_like_missions_root(path: Path) -> bool:
+    """Return True when ``path`` can serve as a mission asset root."""
+    if path.name == "missions":
+        return True
+    for mission_name in ("software-dev", "documentation", "research", "plan"):
+        mission_dir = path / mission_name
+        if (mission_dir / "mission.yaml").is_file() or (mission_dir / "mission-runtime.yaml").is_file():
+            return True
+    return False
+
+
+def _resolve_env_package_asset_root(root: Path) -> Path:
+    """Normalize ``SPEC_KITTY_TEMPLATE_ROOT`` to the bundled missions directory.
+
+    Development docs and tests point ``SPEC_KITTY_TEMPLATE_ROOT`` at the
+    checkout root. Runtime asset resolution needs the missions directory under
+    that checkout, not the checkout root itself.
+    """
+    candidates = (
+        root,
+        root / "missions",
+        root / "src" / "specify_cli" / "missions",
+        root / "src" / "doctrine" / "missions",
+    )
+    for candidate in candidates:
+        if candidate.is_dir() and _looks_like_missions_root(candidate):
+            return candidate
+    raise FileNotFoundError(
+        "SPEC_KITTY_TEMPLATE_ROOT does not contain mission assets: "
+        f"{root}. Expected a missions directory or a Spec Kitty checkout root."
+    )
+
+
 def get_package_asset_root() -> Path:
     """Return the path to the package's bundled mission assets."""
     if env_root := os.environ.get("SPEC_KITTY_TEMPLATE_ROOT"):
         root = Path(env_root)
         if root.is_dir():
-            return root
+            return _resolve_env_package_asset_root(root)
         raise FileNotFoundError(f"SPEC_KITTY_TEMPLATE_ROOT path does not exist: {env_root}")
 
     try:

--- a/src/specify_cli/runtime/home.py
+++ b/src/specify_cli/runtime/home.py
@@ -49,6 +49,8 @@ def _looks_like_missions_root(path: Path) -> bool:
         mission_dir = path / mission_name
         if (mission_dir / "mission.yaml").is_file() or (mission_dir / "mission-runtime.yaml").is_file():
             return True
+        if (mission_dir / "command-templates").is_dir():
+            return True
     return False
 
 

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -21,6 +21,51 @@ from pathlib import Path
 import pytest
 
 
+SUBSTANTIVE_SPEC = """# E2E Smoke Spec
+
+## Functional Requirements
+
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | Exercise the E2E smoke workflow. | setup-plan can run against committed spec content. | proposed |
+"""
+
+
+SUBSTANTIVE_PLAN_TEMPLATE = """# Implementation Plan
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: spec-kitty-cli
+**Storage**: Filesystem fixtures
+"""
+
+
+def _prepare_setup_plan_inputs(repo: Path, feature_dir: Path) -> None:
+    """Seed committed spec/plan content that satisfies setup-plan gates."""
+    (feature_dir / "spec.md").write_text(SUBSTANTIVE_SPEC, encoding="utf-8")
+
+    template_dir = repo / ".kittify" / "templates"
+    template_dir.mkdir(parents=True, exist_ok=True)
+    (template_dir / "plan-template.md").write_text(
+        SUBSTANTIVE_PLAN_TEMPLATE,
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Seed substantive setup-plan inputs"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
 @pytest.mark.e2e
 @pytest.mark.slow
 class TestFullCLIWorkflow:
@@ -69,6 +114,7 @@ class TestFullCLIWorkflow:
         output = json.loads(result.stdout)
         feature_dir = Path(output["feature_dir"])
         mission_slug = output["mission_slug"]
+        _prepare_setup_plan_inputs(e2e_project, feature_dir)
 
         # Run setup-plan
         result = run_cli(
@@ -113,6 +159,7 @@ class TestFullCLIWorkflow:
         feature_dir = Path(create_output["feature_dir"])
         assert feature_dir.exists()
         assert (feature_dir / "spec.md").exists()
+        _prepare_setup_plan_inputs(repo, feature_dir)
 
         # === Step 2: Setup plan ===
         result = run_cli(

--- a/tests/kernel/test_paths.py
+++ b/tests/kernel/test_paths.py
@@ -151,10 +151,35 @@ class TestGetPackageAssetRoot:
 
         assert get_package_asset_root() == package_assets
 
+    def test_template_root_legacy_package_asset_root_with_mission_yaml(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A direct package asset root with mission YAML remains valid."""
+        package_assets = tmp_path / "pkg"
+        mission = package_assets / "software-dev"
+        mission.mkdir(parents=True)
+        (mission / "mission.yaml").write_text("name: software-dev\n", encoding="utf-8")
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(package_assets))
+
+        assert get_package_asset_root() == package_assets
+
     def test_template_root_env_nonexistent_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SPEC_KITTY_TEMPLATE_ROOT with invalid path raises FileNotFoundError."""
         monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", "/nonexistent/path")
         with pytest.raises(FileNotFoundError, match="SPEC_KITTY_TEMPLATE_ROOT"):
+            get_package_asset_root()
+
+    def test_template_root_existing_invalid_dir_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """SPEC_KITTY_TEMPLATE_ROOT must contain recognizable mission assets."""
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(empty_root))
+
+        with pytest.raises(FileNotFoundError, match="does not contain mission assets"):
             get_package_asset_root()
 
     def test_importlib_discovery(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/kernel/test_paths.py
+++ b/tests/kernel/test_paths.py
@@ -125,6 +125,20 @@ class TestGetPackageAssetRoot:
         monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(missions))
         assert get_package_asset_root() == missions
 
+    def test_template_root_checkout_root_normalizes_to_doctrine_missions(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A checkout root env var resolves to src/doctrine/missions."""
+        checkout = tmp_path / "spec-kitty"
+        missions = checkout / "src" / "doctrine" / "missions"
+        software_dev = missions / "software-dev"
+        software_dev.mkdir(parents=True)
+        (software_dev / "mission.yaml").write_text("name: software-dev\n", encoding="utf-8")
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(checkout))
+
+        assert get_package_asset_root() == missions
+
     def test_template_root_env_nonexistent_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SPEC_KITTY_TEMPLATE_ROOT with invalid path raises FileNotFoundError."""
         monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", "/nonexistent/path")

--- a/tests/kernel/test_paths.py
+++ b/tests/kernel/test_paths.py
@@ -139,6 +139,18 @@ class TestGetPackageAssetRoot:
 
         assert get_package_asset_root() == missions
 
+    def test_template_root_legacy_package_asset_root_with_command_templates(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A direct package asset root with command templates remains valid."""
+        package_assets = tmp_path / "pkg"
+        command_templates = package_assets / "software-dev" / "command-templates"
+        command_templates.mkdir(parents=True)
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(package_assets))
+
+        assert get_package_asset_root() == package_assets
+
     def test_template_root_env_nonexistent_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SPEC_KITTY_TEMPLATE_ROOT with invalid path raises FileNotFoundError."""
         monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", "/nonexistent/path")

--- a/tests/runtime/test_home_unit.py
+++ b/tests/runtime/test_home_unit.py
@@ -160,12 +160,37 @@ class TestGetPackageAssetRoot:
 
         assert get_package_asset_root() == package_assets
 
+    def test_template_root_legacy_package_asset_root_with_mission_yaml(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A direct package asset root with mission YAML remains valid."""
+        package_assets = tmp_path / "pkg"
+        mission = package_assets / "software-dev"
+        mission.mkdir(parents=True)
+        (mission / "mission.yaml").write_text("name: software-dev\n", encoding="utf-8")
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(package_assets))
+
+        assert get_package_asset_root() == package_assets
+
     def test_template_root_env_nonexistent_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SPEC_KITTY_TEMPLATE_ROOT with invalid path raises FileNotFoundError."""
         monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", "/nonexistent/path")
         with pytest.raises(FileNotFoundError, match="SPEC_KITTY_TEMPLATE_ROOT"):
+            get_package_asset_root()
+
+    def test_template_root_existing_invalid_dir_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """SPEC_KITTY_TEMPLATE_ROOT must contain recognizable mission assets."""
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(empty_root))
+
+        with pytest.raises(FileNotFoundError, match="does not contain mission assets"):
             get_package_asset_root()
 
     def test_importlib_discovery(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runtime/test_home_unit.py
+++ b/tests/runtime/test_home_unit.py
@@ -148,6 +148,18 @@ class TestGetPackageAssetRoot:
 
         assert get_package_asset_root() == missions
 
+    def test_template_root_legacy_package_asset_root_with_command_templates(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A direct package asset root with command templates remains valid."""
+        package_assets = tmp_path / "pkg"
+        command_templates = package_assets / "software-dev" / "command-templates"
+        command_templates.mkdir(parents=True)
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(package_assets))
+
+        assert get_package_asset_root() == package_assets
+
     def test_template_root_env_nonexistent_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/runtime/test_home_unit.py
+++ b/tests/runtime/test_home_unit.py
@@ -134,6 +134,20 @@ class TestGetPackageAssetRoot:
         result = get_package_asset_root()
         assert result == missions
 
+    def test_template_root_checkout_root_normalizes_to_runtime_missions(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A checkout root env var resolves to src/specify_cli/missions."""
+        checkout = tmp_path / "spec-kitty"
+        missions = checkout / "src" / "specify_cli" / "missions"
+        software_dev = missions / "software-dev"
+        software_dev.mkdir(parents=True)
+        (software_dev / "mission.yaml").write_text("name: software-dev\n", encoding="utf-8")
+
+        monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(checkout))
+
+        assert get_package_asset_root() == missions
+
     def test_template_root_env_nonexistent_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Normalize SPEC_KITTY_TEMPLATE_ROOT checkout roots to the bundled missions directory for runtime/package asset resolution.
- Align E2E smoke setup-plan fixtures with the substantive spec/plan gates introduced before PR #868 merged.

## Verification

- SPEC_KITTY_HOME=$(mktemp -d) SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/e2e/test_charter_epic_golden_path.py::test_charter_epic_golden_path tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_setup_plan tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_full_workflow_sequence tests/runtime/test_home_unit.py::TestGetPackageAssetRoot::test_template_root_checkout_root_normalizes_to_runtime_missions tests/kernel/test_paths.py::TestGetPackageAssetRoot::test_template_root_checkout_root_normalizes_to_doctrine_missions -q
- SPEC_KITTY_HOME=$(mktemp -d) SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/e2e/ tests/cross_cutting/ -m "not distribution and not windows_ci" -q
- uv run ruff check src/specify_cli/runtime/home.py src/kernel/paths.py tests/runtime/test_home_unit.py tests/kernel/test_paths.py tests/e2e/test_cli_smoke.py
- git diff --check