### PR TITLE
fix: release 3.1.8 dashboard and OpenCode hotfixes

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.1.7
+  version: 3.1.8
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-09T16:23:40.925198'
 environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.8] - 2026-04-29
+
+### Fixed
+
+- Dashboard feature polling now tolerates `/api/features` error or malformed
+  payloads without crashing on an undefined `features` array, so the UI no
+  longer gets stuck on loading when feature scanning fails.
+- OpenCode global command installation now targets OpenCode's config command
+  directory, honoring `OPENCODE_CONFIG_DIR` and `XDG_CONFIG_HOME` before
+  falling back to `~/.config/opencode/commands`.
+
 ## [3.1.7] - 2026-04-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.1.7"
+version = "3.1.8"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -1086,7 +1086,12 @@ function getFeatureDisplayName(feature) {
     return feature.display_name || feature.name || feature.id || 'Unknown feature';
 }
 
+function normalizeFeatureList(features) {
+    return Array.isArray(features) ? features : [];
+}
+
 function updateFeatureList(features, activeFeatureId = null) {
+    features = normalizeFeatureList(features);
     allFeatures = features;
     const selectContainer = document.getElementById('feature-selector-container');
     const select = document.getElementById('feature-select');
@@ -1218,7 +1223,8 @@ function updateFeatureList(features, activeFeatureId = null) {
 function updateFeatureListSilent(features) {
     // Same as updateFeatureList but doesn't reload the current page
     // Used during polling to avoid resetting user's view
-    const oldFeature = allFeatures.find(f => f.id === currentFeature);
+    features = normalizeFeatureList(features);
+    const oldFeature = normalizeFeatureList(allFeatures).find(f => f.id === currentFeature);
     allFeatures = features;
     const feature = features.find(f => f.id === currentFeature);
 
@@ -1245,13 +1251,28 @@ function fetchData(isInitialLoad = false) {
         return;
     }
     fetch('/api/features')
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                return response.json()
+                    .catch(() => ({}))
+                    .then(errorData => {
+                        const detail = errorData.detail || errorData.error || response.statusText;
+                        throw new Error(`GET /api/features failed (${response.status}): ${detail}`);
+                    });
+            }
+            return response.json();
+        })
         .then(data => {
+            const features = normalizeFeatureList(data && data.features);
+            if (!data || !Array.isArray(data.features)) {
+                console.warn('GET /api/features returned no features array; rendering an empty feature list', data);
+            }
+
             // Use full update on initial load, silent update on polls
             if (isInitialLoad) {
-                updateFeatureList(data.features, data.active_feature_id || null);
+                updateFeatureList(features, data?.active_feature_id || null);
             } else {
-                updateFeatureListSilent(data.features);
+                updateFeatureListSilent(features);
             }
 
             // Refresh kanban board if currently viewing it
@@ -1261,11 +1282,11 @@ function fetchData(isInitialLoad = false) {
 
             document.getElementById('last-update').textContent = new Date().toLocaleTimeString();
 
-            if (data.project_path) {
+            if (data?.project_path) {
                 projectPathDisplay = data.project_path;
             }
 
-            if (data.active_worktree) {
+            if (data?.active_worktree) {
                 activeWorktreeDisplay = data.active_worktree;
             } else {
                 activeWorktreeDisplay = '';
@@ -1275,7 +1296,13 @@ function fetchData(isInitialLoad = false) {
             computeFeatureWorktreeStatus(currentFeatureObj || null);
             updateTreeInfo();
         })
-        .catch(error => console.error('Error fetching data:', error));
+        .catch(error => {
+            console.error('Error fetching data:', error);
+            if (isInitialLoad) {
+                updateFeatureList([], null);
+                document.getElementById('last-update').textContent = 'Load failed';
+            }
+        });
 }
 
 // Initial fetch

--- a/src/specify_cli/runtime/agent_commands.py
+++ b/src/specify_cli/runtime/agent_commands.py
@@ -41,13 +41,26 @@ def get_global_command_dir(agent_key: str) -> Path:
     """Return the user-global command directory for *agent_key*.
 
     Mirrors the project-local ``AGENT_COMMAND_CONFIG[agent_key]["dir"]`` path
-    beneath the user's home directory.  For example::
+    beneath the user's home directory unless the agent has a documented
+    user-global config root.  For example::
 
         "claude" → ~/.claude/commands/
         "gemini" → ~/.gemini/commands/
         "copilot" → ~/.github/prompts/
+        "opencode" → ~/.config/opencode/commands/
     """
     from specify_cli.core.config import AGENT_COMMAND_CONFIG
+
+    if agent_key == "opencode":
+        custom_config_dir = os.environ.get("OPENCODE_CONFIG_DIR")
+        if custom_config_dir:
+            return Path(custom_config_dir).expanduser() / "commands"
+
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+        if xdg_config_home:
+            return Path(xdg_config_home).expanduser() / "opencode" / "commands"
+
+        return Path.home() / ".config" / "opencode" / "commands"
 
     config = AGENT_COMMAND_CONFIG[agent_key]
     return Path.home() / config["dir"]

--- a/tests/agent/cli/commands/test_agent_config.py
+++ b/tests/agent/cli/commands/test_agent_config.py
@@ -27,13 +27,15 @@ def fake_global_command_dirs(tmp_path, monkeypatch):
     global_root = tmp_path / "global-home"
 
     def _fake_global_command_dir(agent_key: str):
+        if agent_key == "opencode":
+            return global_root / ".config" / "opencode" / "commands"
         return global_root / AGENT_COMMAND_CONFIG[agent_key]["dir"]
 
     monkeypatch.setattr(
         "specify_cli.cli.commands.agent.config.get_global_command_dir",
         _fake_global_command_dir,
     )
-    (global_root / ".opencode" / "command").mkdir(parents=True)
+    (global_root / ".config" / "opencode" / "commands").mkdir(parents=True)
     return global_root
 
 
@@ -72,7 +74,7 @@ class TestListCommand:
 
             assert result.exit_code == 0
             assert "opencode" in result.stdout
-            assert ".opencode/command/" in _unwrapped_output(result.stdout)
+            assert ".config/opencode/commands/" in _unwrapped_output(result.stdout)
             assert "✓" in result.stdout  # opencode exists
 
     def test_list_uses_global_command_root_after_init(self, tmp_path):
@@ -86,7 +88,7 @@ class TestListCommand:
 
             assert result.exit_code == 0
             assert "✓ opencode" in result.stdout
-            assert ".opencode/command/" in _unwrapped_output(result.stdout)
+            assert ".config/opencode/commands/" in _unwrapped_output(result.stdout)
             assert "(global)" in result.stdout
             assert not (tmp_path / ".opencode").exists()
 

--- a/tests/specify_cli/runtime/test_agent_commands_routing.py
+++ b/tests/specify_cli/runtime/test_agent_commands_routing.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 
 
 from specify_cli.core.config import AGENT_COMMAND_CONFIG
-from specify_cli.runtime.agent_commands import _sync_agent_commands
+from specify_cli.runtime.agent_commands import _sync_agent_commands, get_global_command_dir
 
 
 # ---------------------------------------------------------------------------
@@ -71,3 +71,19 @@ def test_claude_still_routes_to_command_files(tmp_path: Path) -> None:
         _sync_agent_commands("claude", tmp_path, "sh")
 
     mock_install.assert_not_called()
+
+
+def test_opencode_global_commands_use_xdg_config_home(tmp_path: Path, monkeypatch) -> None:
+    """OpenCode loads global commands from its config root, not ``~/.opencode``."""
+    monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+    assert get_global_command_dir("opencode") == tmp_path / "xdg-config" / "opencode" / "commands"
+
+
+def test_opencode_global_commands_respect_custom_config_dir(tmp_path: Path, monkeypatch) -> None:
+    """OpenCode's documented custom config directory should be honored."""
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path / "custom-opencode"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+    assert get_global_command_dir("opencode") == tmp_path / "custom-opencode" / "commands"

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -49,3 +49,13 @@ def test_dashboard_javascript_has_valid_syntax():
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_dashboard_features_polling_guards_malformed_payloads():
+    repo_root = Path(__file__).resolve().parents[2]
+    dashboard_js = repo_root / "src" / "specify_cli" / "dashboard" / "static" / "dashboard" / "dashboard.js"
+    source = dashboard_js.read_text(encoding="utf-8")
+
+    assert "function normalizeFeatureList(features)" in source
+    assert "Array.isArray(data.features)" in source
+    assert "response.ok" in source


### PR DESCRIPTION
## Summary
- harden dashboard /api/features loading so malformed/error payloads do not crash polling
- install OpenCode global commands into OpenCode's config command directory with OPENCODE_CONFIG_DIR/XDG_CONFIG_HOME support
- prepare 3.1.8 release metadata

## Base
This PR intentionally targets release/3.1.7, not main. 3.1.8 must be v3.1.7 plus these hotfixes only.

## Local verification
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- uv run pytest tests/test_dashboard/test_static.py tests/specify_cli/runtime/test_agent_commands_routing.py tests/agent/cli/commands/test_agent_config.py
- node --check src/specify_cli/dashboard/static/dashboard/dashboard.js
- uv run ruff check src/specify_cli/runtime/agent_commands.py tests/specify_cli/runtime/test_agent_commands_routing.py tests/agent/cli/commands/test_agent_config.py tests/test_dashboard/test_static.py
- uv run --with build --with twine python -m build --outdir <tmpdir>
- uv run --with twine twine check <tmpdir>/*