### PR TITLE
fix docs pages charter build

### DIFF
--- a/docs/explanation/toc.yml
+++ b/docs/explanation/toc.yml
@@ -20,7 +20,7 @@
   href: multi-agent-orchestration.md
 - name: Runtime Loop
   href: runtime-loop.md
-- name: Understanding Charter: Synthesis, DRG, and Governed Context
+- name: "Understanding Charter: Synthesis, DRG, and Governed Context"
   href: charter-synthesis-drg.md
 - name: Understanding Governed Profile Invocation
   href: governed-profile-invocation.md

--- a/docs/how-to/setup-governance.md
+++ b/docs/how-to/setup-governance.md
@@ -260,17 +260,20 @@ If you edit `charter.md` but forget to sync, agents will work with outdated poli
 Set up governance for a new project from scratch:
 
 ```bash
-# 1. Run the interview
-spec-kitty charter interview \
+# 1. Create the Spec Kitty project scaffold
+uv run spec-kitty init --ai claude --non-interactive
+
+# 2. Run the interview
+uv run spec-kitty charter interview \
   --profile comprehensive
 
-# 2. Generate charter and extracted config
-spec-kitty charter generate --from-interview --json
+# 3. Generate charter and extracted config
+uv run spec-kitty charter generate --from-interview --json
 
-# 3. Verify everything is in sync
-spec-kitty charter status --json
+# 4. Verify everything is in sync
+uv run spec-kitty charter status --json
 
-# 4. Start working -- governance context loads automatically
+# 5. Start working -- governance context loads automatically
 uv run spec-kitty specify "Build user authentication module"
 ```
 

--- a/docs/tutorials/charter-governed-workflow.md
+++ b/docs/tutorials/charter-governed-workflow.md
@@ -18,16 +18,31 @@ policy-backed context on every action.
 
 - Spec Kitty 3.x installed — verify with `uv run spec-kitty --version`
 - A git repository (new or existing). Charter requires a git working tree.
+- A Spec Kitty project scaffold. For a fresh repository, run `uv run spec-kitty init --ai claude --non-interactive` before the Charter interview.
 - Optional: a Spec Kitty account if you want SaaS sync enabled. Steps that require SaaS sync are
   labeled with a note.
 
 ---
 
-## Step 1: Initialize governance
+## Step 1: Initialize Spec Kitty and governance
 
-The first step captures your project's policy decisions and generates the charter bundle.
+The first step creates the Spec Kitty project scaffold, captures your project's policy decisions,
+and generates the charter bundle.
 
-### 1a. Run the interview
+### 1a. Initialize the project scaffold
+
+If this is a fresh git repository, initialize Spec Kitty first:
+
+```bash
+uv run spec-kitty init --ai claude --non-interactive
+```
+
+`init` creates `.kittify/config.yaml`, agent command templates, and ignore files. It is
+idempotent, so rerunning it in an already-initialized project exits cleanly. Use the agent key
+that matches your workflow; this tutorial uses `claude` because the later `next` examples use
+`--agent claude`.
+
+### 1b. Run the interview
 
 The interview collects your project's policy decisions and saves them as structured answers. Use
 the minimal profile to start; upgrade to comprehensive later if needed.
@@ -46,7 +61,7 @@ saved to `.kittify/charter/interview/answers.yaml`.
 
 This step is interactive when you omit `--defaults`. Follow the prompts to describe your project.
 
-### 1b. Generate the charter bundle
+### 1c. Generate the charter bundle
 
 Generate `charter.md` and all derived governance files from your interview answers:
 
@@ -148,11 +163,15 @@ First, create a mission to work on (if you don't have one already):
 uv run spec-kitty specify my-first-feature
 ```
 
+The command returns a `mission_slug` such as `my-first-feature-01KQEE5E`. Use that full slug
+for `spec-kitty next`; the short feature name alone is not enough once Spec Kitty has appended
+the mission identity suffix.
+
 Then drive the mission using `spec-kitty next`. The `--agent` flag identifies the agent name used
-for the issued action; `--mission` identifies the mission by its slug:
+for the issued action; `--mission` identifies the mission by its full slug:
 
 ```bash
-uv run spec-kitty next --agent claude --mission my-first-feature --json
+uv run spec-kitty next --agent claude --mission my-first-feature-01KQEE5E --json
 ```
 
 In query mode (when `--result` is omitted), `next` reads and prints the current mission state
@@ -161,7 +180,7 @@ without advancing it. This is useful to see what step is next before acting.
 To advance the mission after completing a step, pass `--result`:
 
 ```bash
-uv run spec-kitty next --agent claude --mission my-first-feature --result success --json
+uv run spec-kitty next --agent claude --mission my-first-feature-01KQEE5E --result success --json
 ```
 
 The runtime resolves the next step from the mission's state machine, builds the governed prompt

--- a/kitty-specs/charter-end-user-docs-828-01KQCSYD/checklists/validation-report.md
+++ b/kitty-specs/charter-end-user-docs-828-01KQCSYD/checklists/validation-report.md
@@ -117,44 +117,55 @@ The `accept` step in the runtime yaml is administrative and is intentionally omi
 
 **Result**: PASS
 
-**Temp dir**: `/private/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/tmp.oJonzxwiby`
+**Temp dir**: `/tmp/spec-kitty-docs-tutorial-iOe23F`
+
+**Command surface**: used `uv --project /Users/robert/spec-kitty-dev/spec-kitty-docs-pages-fix-20260430 run spec-kitty ...` from the temp project so the source checkout was not used as the command working directory.
 
 **Commands run**:
 ```bash
-mkdir my-test-project && cd my-test-project
 git init
 git config user.email "test@test.com"
 git config user.name "Test"
-uv run spec-kitty --version
-# Output: spec-kitty-cli version 3.2.0a5
+uv --project "$REPO" run spec-kitty init --ai claude --non-interactive
+uv --project "$REPO" run spec-kitty charter interview --profile minimal --defaults --json
+uv --project "$REPO" run spec-kitty charter generate --from-interview --json
+uv --project "$REPO" run spec-kitty charter lint
+uv --project "$REPO" run spec-kitty charter bundle validate --json
+uv --project "$REPO" run spec-kitty charter status --json
+uv --project "$REPO" run spec-kitty charter synthesize --dry-run --json
+uv --project "$REPO" run spec-kitty charter synthesize --json
+uv --project "$REPO" run spec-kitty charter status --json
+uv --project "$REPO" run spec-kitty specify my-first-feature --json
+MISSION_SLUG="$(parse mission_slug from specify JSON)"
+uv --project "$REPO" run spec-kitty next --agent claude --mission "$MISSION_SLUG" --json
+uv --project "$REPO" run spec-kitty next --agent claude --mission "$MISSION_SLUG" --result success --json
+uv --project "$REPO" run spec-kitty retrospect summary --json
 ```
 
-**CLI output**: `spec-kitty-cli version 3.2.0a5` — CLI accessible and functional from isolated temp directory.
+**Evidence**:
+- `charter bundle validate --json` returned `result: success` and `bundle_compliant: true`.
+- `charter synthesize --dry-run --json` returned `result: dry_run`, `adapter.id: fresh-seed`, and `written_artifacts[0].path: .kittify/doctrine/PROVENANCE.md`.
+- `charter synthesize --json` returned `result: success` and wrote `.kittify/doctrine/PROVENANCE.md`.
+- `specify my-first-feature --json` returned `mission_slug: my-first-feature-01KQEE76`.
+- `next --agent claude --mission my-first-feature-01KQEE76 --json` returned `mission_type: software-dev`, `mission_state: not_started`, and `preview_step: discovery`.
+- `next --agent claude --mission my-first-feature-01KQEE76 --result success --json` returned `kind: step`, `action: research`, `step_id: discovery`, and a non-empty `prompt_file`.
+- `retrospect summary --json` returned `command: retrospect.summary` and `mission_count: 0`, which is expected for a fresh project with no completed missions.
 
-**Source repo clean after**: yes — only pre-existing snapshot file modified (not part of WP03 work).
+**Source repo clean after**: yes — source checkout status was unchanged by the temp-project smoke run.
 
 ---
 
-## Check 6: setup-governance Smoke-test (NFR-002)
+## Check 6: DocFX Build
 
 **Result**: PASS
 
-**Temp dir**: `/private/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/tmp.uun4u49hdq`
-
-**Commands run**:
+**Command run**:
 ```bash
-mkdir test-project && cd test-project
-git init
-git config user.email "test@test.com"
-git config user.name "Test"
-uv run spec-kitty charter --help | head -5
-# Output: Usage: spec-kitty charter [OPTIONS] COMMAND [ARGS]...
-#          Charter management commands
+cd docs
+docfx docfx.json
 ```
 
-**CLI output**: `charter --help` accessible and shows expected output from isolated temp directory.
-
-**Source repo clean after**: yes — only pre-existing snapshot file modified (not part of WP03 work).
+**Result**: build succeeded with 48 warnings and 0 errors. The warnings are pre-existing invalid `~/...` file-link warnings outside this follow-up fix; the previous blocking `InvalidTocFile` error in `docs/explanation/toc.yml` is resolved.
 
 ---
 
@@ -167,8 +178,8 @@ uv run spec-kitty charter --help | head -5
 | 3. CLI flag accuracy | PASS |
 | 4. Phase accuracy | PASS |
 | 5. Tutorial smoke-test | PASS |
-| 6. setup-governance smoke-test | PASS |
+| 6. DocFX build | PASS |
 
 **Overall**: PASS
 
-No fixes required during T009 triage. All six checks passed on first run. No product bugs encountered.
+Follow-up validation on 2026-04-30 resolved the DocFX TOC build blocker and replaced the earlier shallow tutorial smoke with an executable fresh-project Charter spine.


### PR DESCRIPTION
## Summary
- Quote the Charter explanation TOC title so DocFX can parse the TOC
- Add the missing `spec-kitty init` step and full mission slug guidance to the Charter tutorial/setup docs
- Replace shallow validation notes with an executable fresh-project Charter smoke and DocFX build evidence

## Validation
- `uv run pytest tests/docs/ -q` -> 375 passed
- `cd docs && docfx docfx.json` -> build succeeded with 48 pre-existing invalid-link warnings and 0 errors
- Fresh-project tutorial smoke ran `init`, `charter interview`, `generate`, `lint`, `bundle validate`, `synthesize --dry-run`, `synthesize`, `specify`, `next`, and `retrospect summary` via `uv --project ...` from `/tmp` without source checkout mutation

Fixes the Pages build regression introduced by #886.
