### PR TITLE
Strengthen specify discovery gate

### DIFF
--- a/src/doctrine/mission_step_contracts/shipped/specify.step-contract.yaml
+++ b/src/doctrine/mission_step_contracts/shipped/specify.step-contract.yaml
@@ -15,7 +15,9 @@ steps:
         optional: true
 
   - id: capture_intent
-    description: Capture the feature description and user intent
+    description: >
+      Conduct or verify the human discovery interview, then capture confirmed
+      user intent
     delegates_to:
       kind: directive
       candidates:

--- a/src/specify_cli/missions/software-dev/command-templates/specify.md
+++ b/src/specify_cli/missions/software-dev/command-templates/specify.md
@@ -62,6 +62,24 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Primary Invariant: What Are We Building?
+
+This workflow answers "What are we building?" before it creates artifacts. The
+raw invocation text is only a starting point for discovery, not the final truth.
+
+Before `mission create`, before writing `spec.md`, and before committing
+anything, you **MUST** have one of these:
+
+- A completed discovery interview with an acknowledged Intent Summary.
+- A brief-intake summary and extracted requirement set explicitly confirmed by
+  the user.
+- An explicit user instruction to minimize or skip discovery; even then, record
+  the minimal confirmed scenario and assumptions in the Intent Summary.
+
+For non-trivial work, the confirmed Intent Summary must cover the primary actor,
+trigger, desired outcome, one rule or invariant, and any canonical domain term
+or boundary that materially affects the work.
+
 ## Branch Strategy Confirmation (MANDATORY)
 
 Before discovery, resolve branch intent through the Python helper, not by probing git directly:
@@ -167,7 +185,7 @@ Check in priority order:
    | Partial (goal statement only) | 4–5 questions |
    | Empty / missing | Proceed to normal Discovery Gate below |
 
-5. **Show the extracted requirement set.** Present the full FR/NFR/C table to the user: "I extracted X functional requirements and Y non-functional requirements. Does this look right?" Wait for one round of confirmation. The user may correct or supplement before you write the spec.
+5. **Show the extracted requirement set.** Present the full FR/NFR/C table to the user: "I extracted X functional requirements and Y non-functional requirements. Does this look right?" Wait for one round of confirmation. This confirmation is the discovery gate for brief-intake mode; do not write or commit `spec.md` before it happens unless the user explicitly asks to minimize or skip discovery. The user may correct or supplement before you write the spec.
 
 6. **Write spec.md normally.** Apply the same quality checklist and readiness gate as standard specify. Brief-intake mode does NOT lower the quality bar — spec.md must still pass all validation items.
 
@@ -238,7 +256,7 @@ Before asking **any** interview question during this command, you MUST:
 
 ## Discovery Gate (mandatory)
 
-Before running any scripts or writing to disk you **must** conduct a structured discovery interview.
+Before running `mission create`, writing `spec.md`, committing, or otherwise creating planning artifacts, you **must** conduct or verify a structured discovery interview.
 
 - **Scope proportionality (CRITICAL)**: FIRST, gauge the inherent complexity of the request:
   - **Trivial/Test Features** (hello world, simple pages, proof-of-concept): Ask 1-2 questions maximum, then proceed. Examples: "a simple hello world page", "tic-tac-toe game", "basic contact form"

--- a/tests/doctrine/mission_step_contracts/test_shipped_contracts.py
+++ b/tests/doctrine/mission_step_contracts/test_shipped_contracts.py
@@ -133,6 +133,8 @@ class TestSpecifyContractStructure:
     def test_capture_intent_includes_examples_directive(self, contract: MissionStepContract) -> None:
         capture_intent = next((s for s in contract.steps if s.id == "capture_intent"), None)
         assert capture_intent is not None
+        assert "human discovery interview" in capture_intent.description
+        assert "confirmed user intent" in capture_intent.description
         assert capture_intent.delegates_to is not None
         assert capture_intent.delegates_to.kind == ArtifactKind.DIRECTIVE
         assert "037-living-documentation-sync" in capture_intent.delegates_to.candidates

--- a/tests/missions/test_specify_creates_requirements_checklist.py
+++ b/tests/missions/test_specify_creates_requirements_checklist.py
@@ -57,6 +57,36 @@ def test_specify_template_creates_requirements_checklist() -> None:
     )
 
 
+def test_specify_template_blocks_artifacts_until_intent_confirmed() -> None:
+    """`specify.md` must keep discovery before artifact creation.
+
+    The `/spec-kitty.specify` flow is prompt-driven for agent hosts. This static
+    check protects the instruction that prevents agents from skipping the user
+    interview and calling `mission create` before confirming intent.
+    """
+    assert SPECIFY_TEMPLATE.exists(), (
+        f"Source template missing: {SPECIFY_TEMPLATE}.\n"
+        "The software-dev /spec-kitty.specify template is the canonical "
+        "owner of the discovery gate."
+    )
+    text = SPECIFY_TEMPLATE.read_text(encoding="utf-8")
+    required_phrases = [
+        'This workflow answers "What are we building?"',
+        "Before `mission create`, before writing `spec.md`, and before committing",
+        "A completed discovery interview with an acknowledged Intent Summary.",
+        "A brief-intake summary and extracted requirement set explicitly confirmed",
+        "primary actor",
+        "one rule or invariant",
+        "canonical domain term",
+    ]
+    for phrase in required_phrases:
+        assert phrase in text, (
+            f"specify.md no longer contains the discovery-gate phrase: {phrase!r}. "
+            "Do not weaken /spec-kitty.specify's interview-first invariant "
+            "without an explicit migration plan."
+        )
+
+
 def test_software_dev_mission_declares_checklists_directory() -> None:
     """`mission.yaml` must list `checklists/` as an optional artifact.
 


### PR DESCRIPTION
## Summary
- Add a top-level specify invariant that artifacts must wait until the user interview or brief confirmation establishes what is being built.
- Tighten brief-intake and discovery-gate wording so confirmation is the explicit gate before writing or committing spec.md.
- Update the specify step contract to describe human discovery verification, with static regression coverage for prompt and contract drift.

## Tests
- uv run --extra test pytest tests/missions/test_specify_creates_requirements_checklist.py tests/doctrine/mission_step_contracts/test_shipped_contracts.py -q
- uv run --extra test pytest tests/prompts/test_prompt_fragment_rendering.py tests/specify_cli/mission_step_contracts/test_software_dev_composition.py -q