### PR TITLE
fix: harden dashboard mission selector rendering

### DIFF
--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -296,22 +296,13 @@ function loadOverview() {
     const feature = allFeatures.find(f => f.id === currentFeature);
     if (!feature) return;
 
-    const mergeBadge = (() => {
-const meta = feature.meta || {};
-const mergedAt = meta.merged_at || meta.merge_at;
-const mergedInto = meta.merged_into || meta.merge_into || meta.merged_target;
-if (!mergedAt || !mergedInto) {
-    return '';
-}
-const date = new Date(mergedAt);
-const dateStr = Number.isNaN(date.valueOf()) ? mergedAt : date.toLocaleDateString();
-return `
-    <span class="merge-badge" title="Merged into ${escapeHtml(mergedInto)} on ${escapeHtml(dateStr)}">
-        <span class="icon">✅</span>
-        <span>merged → ${escapeHtml(mergedInto)}</span>
-    </span>
-`;
-    })();
+    const meta = feature.meta || {};
+    const mergedAt = meta.merged_at || meta.merge_at;
+    const mergedInto = meta.merged_into || meta.merge_into || meta.merged_target;
+    const mergeDate = mergedAt ? new Date(mergedAt) : null;
+    const mergeDateText = !mergeDate || Number.isNaN(mergeDate.valueOf())
+        ? mergedAt
+        : mergeDate.toLocaleDateString();
 
     const stats = feature.kanban_stats;
     const total = stats.total;
@@ -321,12 +312,6 @@ return `
         : (total > 0 ? Math.round((completed / total) * 100) : 0);
     const purposeTldr = (meta.purpose_tldr || '').trim();
     const purposeContext = (meta.purpose_context || '').trim();
-    const overviewIntro = purposeTldr
-        ? `<p style="color: #374151; font-weight: 600; margin-top: 12px;">${escapeHtml(purposeTldr)}</p>`
-        : '<p style="color: #6b7280;">View and track all artifacts for this feature</p>';
-    const overviewContext = purposeContext
-        ? `<p style="color: #6b7280; margin-top: 10px; max-width: 72ch;">${escapeHtml(purposeContext)}</p>`
-        : '';
 
     const artifacts = feature.artifacts;
     const artifactList = [
@@ -349,11 +334,12 @@ return `
         </div>
     `}).join('');
 
-    document.getElementById('overview-content').innerHTML = `
+    const overviewContent = document.getElementById('overview-content');
+    overviewContent.innerHTML = `
 <div style="margin-bottom: 30px;">
-    <h3>Mission Run: ${feature.name} ${mergeBadge}</h3>
-    ${overviewIntro}
-    ${overviewContext}
+    <h3 id="overview-title"></h3>
+    <p id="overview-intro" style="color: #6b7280;">View and track all artifacts for this feature</p>
+    <p id="overview-context" style="color: #6b7280; margin-top: 10px; max-width: 72ch; display: none;"></p>
 </div>
 
 <div class="status-summary">
@@ -385,10 +371,42 @@ return `
         </div>
 
         <h3 style="margin-top: 30px; margin-bottom: 15px; color: #1f2937;">Available Artifacts</h3>
-        <div style="display: grid; gap: 10px;">
-            ${artifactList}
-        </div>
-    `;
+    <div style="display: grid; gap: 10px;">
+        ${artifactList}
+    </div>
+`;
+
+    const titleEl = document.getElementById('overview-title');
+    titleEl.textContent = `Mission Run: ${feature.name}`;
+    if (mergedInto && mergeDateText) {
+        const badge = document.createElement('span');
+        badge.className = 'merge-badge';
+        badge.title = `Merged into ${mergedInto} on ${mergeDateText}`;
+
+        const icon = document.createElement('span');
+        icon.className = 'icon';
+        icon.textContent = '✅';
+
+        const text = document.createElement('span');
+        text.textContent = `merged → ${mergedInto}`;
+
+        badge.append(icon, text);
+        titleEl.append(' ', badge);
+    }
+
+    const introEl = document.getElementById('overview-intro');
+    if (purposeTldr) {
+        introEl.textContent = purposeTldr;
+        introEl.style.color = '#374151';
+        introEl.style.fontWeight = '600';
+        introEl.style.marginTop = '12px';
+    }
+
+    const contextEl = document.getElementById('overview-context');
+    if (purposeContext) {
+        contextEl.textContent = purposeContext;
+        contextEl.style.display = 'block';
+    }
 }
 
 function loadKanban() {
@@ -1171,9 +1189,13 @@ function updateFeatureList(features, activeFeatureId = null) {
             currentFeature = savedFeatureExists ? savedState.feature : features[0].id;
         }
 
-        select.innerHTML = features.map(f =>
-            `<option value="${f.id}" ${f.id === currentFeature ? 'selected' : ''}>${escapeHtml(getFeatureDisplayName(f))}</option>`
-        ).join('');
+        select.replaceChildren(...features.map(f => {
+            const option = document.createElement('option');
+            option.value = f.id;
+            option.textContent = getFeatureDisplayName(f);
+            option.selected = f.id === currentFeature;
+            return option;
+        }));
         select.value = currentFeature;
     }
 
@@ -1272,7 +1294,7 @@ function fetchData(isInitialLoad = false) {
             return response.json();
         })
         .then(data => {
-            const features = normalizeFeatureList(data && data.features);
+            const features = normalizeFeatureList(data?.features);
             if (!data || !Array.isArray(data.features)) {
                 console.warn('GET /api/features returned no features array; rendering an empty feature list', data);
             }

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -1189,13 +1189,15 @@ function updateFeatureList(features, activeFeatureId = null) {
             currentFeature = savedFeatureExists ? savedState.feature : features[0].id;
         }
 
-        select.replaceChildren(...features.map(f => {
+        const options = document.createDocumentFragment();
+        features.forEach(f => {
             const option = document.createElement('option');
             option.value = f.id;
             option.textContent = getFeatureDisplayName(f);
             option.selected = f.id === currentFeature;
-            return option;
-        }));
+            options.appendChild(option);
+        });
+        select.replaceChildren(options);
         select.value = currentFeature;
     }
 

--- a/tests/specify_cli/dashboard/test_dashboard_wording.py
+++ b/tests/specify_cli/dashboard/test_dashboard_wording.py
@@ -23,7 +23,7 @@ class TestUserVisibleMissionRunWording:
 
     def test_index_html_selector_label_is_mission_run(self) -> None:
         content = INDEX_HTML.read_text()
-        assert "<label>Mission Run:</label>" in content
+        assert '<label for="feature-select">Mission Run:</label>' in content
         assert "<label>Feature:</label>" not in content
 
     def test_index_html_overview_heading(self) -> None:
@@ -50,7 +50,7 @@ class TestUserVisibleMissionRunWording:
 
     def test_dashboard_js_feature_heading_renamed(self) -> None:
         content = DASHBOARD_JS.read_text()
-        assert "<h3>Mission Run: ${feature.name}" in content
+        assert "titleEl.textContent = `Mission Run: ${feature.name}`;" in content
         assert "<h3>Feature: ${feature.name}" not in content
 
     def test_dashboard_js_unknown_fallback_renamed(self) -> None:

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -8,6 +8,9 @@ from specify_cli.dashboard.templates import get_dashboard_html
 
 pytestmark = pytest.mark.fast
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_JS = REPO_ROOT / "src" / "specify_cli" / "dashboard" / "static" / "dashboard" / "dashboard.js"
+
 
 def test_dashboard_template_references_static_assets():
     html = get_dashboard_html()
@@ -39,10 +42,8 @@ def test_dashboard_javascript_has_valid_syntax():
     if shutil.which("node") is None:
         pytest.skip("node is required for dashboard.js syntax validation")
 
-    repo_root = Path(__file__).resolve().parents[2]
-    dashboard_js = repo_root / "src" / "specify_cli" / "dashboard" / "static" / "dashboard" / "dashboard.js"
     result = subprocess.run(
-        ["node", "--check", str(dashboard_js)],
+        ["node", "--check", str(DASHBOARD_JS)],
         capture_output=True,
         text=True,
         check=False,
@@ -52,10 +53,30 @@ def test_dashboard_javascript_has_valid_syntax():
 
 
 def test_dashboard_features_polling_guards_malformed_payloads():
-    repo_root = Path(__file__).resolve().parents[2]
-    dashboard_js = repo_root / "src" / "specify_cli" / "dashboard" / "static" / "dashboard" / "dashboard.js"
-    source = dashboard_js.read_text(encoding="utf-8")
+    source = DASHBOARD_JS.read_text(encoding="utf-8")
 
     assert "function normalizeFeatureList(features)" in source
     assert "Array.isArray(data.features)" in source
     assert "response.ok" in source
+
+
+def test_dashboard_overview_mission_copy_uses_text_nodes():
+    source = DASHBOARD_JS.read_text(encoding="utf-8")
+
+    assert '<h3 id="overview-title"></h3>' in source
+    assert "titleEl.textContent = `Mission Run: ${feature.name}`;" in source
+    assert "introEl.textContent = purposeTldr;" in source
+    assert "contextEl.textContent = purposeContext;" in source
+    assert "<h3>Mission Run: ${feature.name}" not in source
+    assert "${purposeTldr}</p>" not in source
+    assert "${purposeContext}</p>" not in source
+
+
+def test_dashboard_selector_options_use_dom_text_nodes():
+    source = DASHBOARD_JS.read_text(encoding="utf-8")
+
+    assert "document.createElement('option')" in source
+    assert "option.textContent = getFeatureDisplayName(f);" in source
+    assert "select.replaceChildren(options);" in source
+    assert "select.innerHTML = features.map" not in source
+    assert '<option value="${f.id}"' not in source


### PR DESCRIPTION
## Summary
- replace tainted dashboard `innerHTML` flows for mission titles and selector options with DOM-based rendering
- keep mission-run wording intact while eliminating the two open Sonar/GitHub code-scanning XSS findings in `dashboard.js`
- update wording assertions to match the safer implementation and current template markup

## Validation
- `node --check src/specify_cli/dashboard/static/dashboard/dashboard.js`
- `pytest tests/test_dashboard/test_static.py tests/test_dashboard/test_api_contract.py tests/specify_cli/dashboard/test_dashboard_wording.py -q`

## Notes
- GitHub Dependabot alert `GHSA-58qw-9mgm-455v` on transitive `pip` remains blocked upstream because GitHub still reports `first_patched_version: null`.
- The nightly Sonar run also shows hotspot review items around localhost/plaintext loopback and regex review paths; I did not suppress those here because this PR focuses on the actionable code-scanning XSS findings in the dashboard.
