### PR TITLE
docs: prepare 3.2.0a5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ runtime dependencies were introduced.
 
 ### Fixed
 
+- CLI auth now consumes the server Tranche 2 contract end to end: logout posts refresh tokens to `/oauth/revoke`, local credential cleanup failures are reported truthfully, refresh handles benign 409 replay without resubmitting a spent token, and `auth doctor --server` checks `/api/v1/session-status` with safe re-authentication guidance (#902).
 - Fix `spec-kitty upgrade` silently leaving projects in PROJECT_MIGRATION_NEEDED state by stamping `schema_version` after metadata save (#705, WP01).
 - `spec-kitty init` in a non-git directory now prints an actionable "run `git init`" message (#636, WP05).
 - Suppress misleading "shutdown / final-sync" red error lines after a successful `spec-kitty agent mission create --json` payload (#735, WP06).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 ---
 
-## 🚀 What You Get on `main` (`3.2.0a4`)
+## 🚀 What You Get on `main` (`3.2.0a5`)
 
 | Capability | What Spec Kitty provides |
 |------------|--------------------------|
@@ -107,7 +107,7 @@ graph LR
 
 **Current stable release line:** `v3.1.x` (current stable release: `3.1.6` on GitHub Releases and PyPI)
 
-**Current `main` development version:** `3.2.0a4`
+**Current `main` development version:** `3.2.0a5`
 
 **Current `main` highlights:**
 - **Brief-first and ticket-first intake** — `spec-kitty intake` ingests external plans into `.kittify/mission-brief.md`, and `spec-kitty mission create --from-ticket <provider:KEY>` seeds tracker context before `/spec-kitty.specify`
@@ -130,13 +130,13 @@ graph LR
 
 ## 📌 Release Channels
 
-Spec Kitty currently ships stable `3.1.x` releases while `main` carries the active `3.2.0a4` prerelease/dev line.
+Spec Kitty currently ships stable `3.1.x` releases while `main` carries the active `3.2.0a5` prerelease/dev line.
 The former `1.x` line is deprecated and lives on `1.x-maintenance` for maintenance-only fixes.
 
 | Source | Version | Status | Install |
 |--------|---------|--------|---------|
 | **PyPI / GitHub Releases** | **3.1.6** | Current stable line | `pip install spec-kitty-cli` |
-| **main** | **3.2.0a4** | Active prerelease / development line | Install from a source checkout or a published prerelease tag |
+| **main** | **3.2.0a5** | Active prerelease / development line | Install from a source checkout or a published prerelease tag |
 | **1.x-maintenance** | **1.x** | Deprecated, maintenance-only | Install from a pinned maintenance tag or source checkout |
 
 **For users:** install the stable line from PyPI with `pip install spec-kitty-cli`.


### PR DESCRIPTION
## Summary
- update release-facing README version from 3.2.0a4 to 3.2.0a5
- add AUTH Tranche 2.5 contract-consumption notes to the 3.2.0a5 changelog

## Validation
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- git diff --check