### PR TITLE
Prepare 3.2.0a6 release notes for Charter closure

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0a5
+  version: 3.2.0a6
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `charter bundle validate --json` now fail-closes on incomplete Charter
-  synthesis state while preserving strict JSON stdout. Sidecar-only bundles,
-  manifest-only bundles, incompatible bundle versions, missing provenance
-  sidecars, dangling sidecar references, and synthesis manifest integrity
-  failures all produce parseable failure envelopes with actionable
-  `synthesis_state` details (#914, closes the final Phase 7 release gap for
-  #469/#515).
-
 ### Removed
 
-## [3.2.0a6] — Tranche 2 (bug-only)
+## [3.2.0a6] - 2026-04-30
 
 Tranche 2 of the 3.2.0a6 release is a bug-only sweep that restores the
 documented fresh-project golden path (`init` → charter `setup`/`generate`/
@@ -37,6 +29,13 @@ runtime dependencies were introduced.
 
 ### Fixed
 
+- `charter bundle validate --json` now fail-closes on incomplete Charter
+  synthesis state while preserving strict JSON stdout. Sidecar-only bundles,
+  manifest-only bundles, incompatible bundle versions, missing provenance
+  sidecars, dangling sidecar references, and synthesis manifest integrity
+  failures all produce parseable failure envelopes with actionable
+  `synthesis_state` details (#914, closes the final Phase 7 release gap for
+  #469/#515).
 - Stamp `schema_version` and a `schema_capabilities` block in
   `.kittify/metadata.yaml` on `spec-kitty init` so a fresh project no
   longer requires hand-edits before subsequent CLI commands; existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `charter bundle validate --json` now fail-closes on incomplete Charter
+  synthesis state while preserving strict JSON stdout. Sidecar-only bundles,
+  manifest-only bundles, incompatible bundle versions, missing provenance
+  sidecars, dangling sidecar references, and synthesis manifest integrity
+  failures all produce parseable failure envelopes with actionable
+  `synthesis_state` details (#914, closes the final Phase 7 release gap for
+  #469/#515).
+
 ### Removed
 
 ## [3.2.0a6] — Tranche 2 (bug-only)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0a5"
+version = "3.2.0a6"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0a5"
+version = "3.2.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary\n- Bumps the package/repo metadata from 3.2.0a5 to 3.2.0a6.\n- Moves the Charter Phase 7 final validation closure note into the 3.2.0a6 changelog section.\n- Updates uv.lock so release metadata stays coherent.\n\n## Validation\n- git diff --check\n- uv run ruff check CHANGELOG.md\n- uv run pytest tests/release/test_validate_release.py tests/release/test_validate_changelog_entry.py tests/release/test_validate_metadata_yaml_sync.py -q\n- python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'\n- uv lock --check