### PR TITLE
Fix auth doctor daemon reset

### DIFF
--- a/src/specify_cli/cli/commands/_auth_doctor.py
+++ b/src/specify_cli/cli/commands/_auth_doctor.py
@@ -64,6 +64,7 @@ from specify_cli.sync.daemon import (
     DAEMON_STATE_FILE,
     SyncDaemonStatus,
     get_sync_daemon_status,
+    stop_sync_daemon,
 )
 from specify_cli.sync.orphan_sweep import (
     OrphanDaemon,
@@ -396,7 +397,7 @@ def _compute_findings(
         rollout_enabled = bool(is_saas_sync_enabled())
     except Exception:
         rollout_enabled = False
-    if rollout_enabled and (daemon is None or not daemon.active):
+    if rollout_enabled and daemon is None:
         findings.append(
             Finding(
                 id="F-005",
@@ -404,6 +405,16 @@ def _compute_findings(
                 summary="Daemon not running; next CLI command will start it.",
                 remediation_command=None,
                 remediation_description=None,
+            )
+        )
+    elif rollout_enabled and not daemon.active:
+        findings.append(
+            Finding(
+                id="F-005",
+                severity="info",
+                summary="Recorded daemon is not healthy; reset it or let the next remote command restart it.",
+                remediation_command="spec-kitty auth doctor --reset",
+                remediation_description="Clear unhealthy daemon metadata and stop any recorded daemon process.",
             )
         )
 
@@ -798,14 +809,23 @@ def doctor_impl(
     repair_messages: list[str] = []
 
     if reset:
+        repaired = False
         if any(f.id == "F-002" for f in report.findings):
             sweep = sweep_orphans(list(report.orphans))
             repair_messages.append(
                 f"--reset: {len(sweep.swept)} orphan(s) swept, "
                 f"{len(sweep.failed)} failed."
             )
+            repaired = True
             report = assemble_report(stuck_threshold_s=stuck_threshold)
-        else:
+
+        if report.daemon is not None and not report.daemon.active:
+            _stopped, message = stop_sync_daemon()
+            repair_messages.append(f"--reset: {message}")
+            repaired = True
+            report = assemble_report(stuck_threshold_s=stuck_threshold)
+
+        if not repaired:
             repair_messages.append("--reset: no orphans detected; no-op.")
 
     if unstick_lock:

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -797,8 +797,10 @@ def stop_sync_daemon(timeout: float = 5.0) -> tuple[bool, str]:
         return False, "Sync daemon metadata was invalid and has been cleared."
 
     if not _check_sync_daemon_health(port, token):
-        DAEMON_STATE_FILE.unlink(missing_ok=True)
-        return False, "Sync daemon was already stopped. Metadata has been cleared."
+        _kill_and_cleanup(pid)
+        if pid is None:
+            return True, "Unhealthy sync daemon metadata has been cleared."
+        return True, "Unhealthy sync daemon process stopped. Metadata has been cleared."
 
     _stop_daemon_by_http(url or f"http://127.0.0.1:{port}", token)
 

--- a/src/specify_cli/sync/orphan_sweep.py
+++ b/src/specify_cli/sync/orphan_sweep.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import socket
+import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -60,10 +61,10 @@ _PORT_POLL_INTERVAL_S: float = 0.05
 class OrphanDaemon:
     """A Spec Kitty sync daemon listening on a port other than the recorded singleton.
 
-    ``pid`` is ``None`` when ``psutil.net_connections`` raises ``AccessDenied``
-    (common on macOS without elevated privileges). Sweep can still attempt
-    HTTP shutdown without a PID, but escalation to ``terminate``/``kill``
-    is recorded as a failure in that case.
+    ``pid`` is ``None`` when neither ``psutil.net_connections`` nor the
+    platform fallback can identify the listener. Sweep can still attempt HTTP
+    shutdown without a PID, but escalation to ``terminate``/``kill`` is recorded
+    as a failure in that case.
     """
 
     port: int
@@ -135,17 +136,17 @@ def _is_spec_kitty_daemon(payload: dict[str, Any]) -> bool:
 def _lookup_listening_pid(port: int) -> int | None:
     """Return the PID of the process listening on ``127.0.0.1:port``, or ``None``.
 
-    Uses ``psutil.net_connections(kind="tcp")`` and filters for
-    ``laddr.port == port`` and ``status == "LISTEN"``. May raise
-    ``AccessDenied`` on macOS without elevated privileges; in that case
-    ``None`` is returned and the caller treats the orphan as PID-less.
+    Uses ``psutil.net_connections(kind="tcp")`` first and falls back to
+    ``lsof`` when psutil cannot expose listener ownership. macOS frequently
+    withholds PIDs from ``psutil.net_connections`` for subprocess sockets, while
+    ``lsof`` can still resolve the listener owned by the current user.
     """
     try:
         conns = psutil.net_connections(kind="tcp")
     except psutil.AccessDenied:
-        return None
+        return _lookup_listening_pid_with_lsof(port)
     except (psutil.Error, OSError):
-        return None
+        return _lookup_listening_pid_with_lsof(port)
 
     for conn in conns:
         laddr = getattr(conn, "laddr", None)
@@ -159,9 +160,39 @@ def _lookup_listening_pid(port: int) -> int | None:
             continue
         pid = conn.pid
         if pid is None:
-            return None
+            return _lookup_listening_pid_with_lsof(port)
         return int(pid)
 
+    return _lookup_listening_pid_with_lsof(port)
+
+
+def _lookup_listening_pid_with_lsof(port: int) -> int | None:
+    """Resolve a local listener PID with ``lsof`` when psutil cannot.
+
+    The port value is an integer drawn from the fixed Spec Kitty daemon range,
+    so it is safe to pass as an argument without shell interpolation.
+    """
+    try:
+        result = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=0.75,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        try:
+            pid = int(line.strip())
+        except ValueError:
+            continue
+        if pid > 0:
+            return pid
     return None
 
 

--- a/tests/auth/test_auth_doctor_repair.py
+++ b/tests/auth/test_auth_doctor_repair.py
@@ -73,6 +73,7 @@ def _patch_state(
     lock_path: Path,
     lock_record: LockRecord | None = None,
     daemon_state_exists: bool = False,
+    daemon_status: SyncDaemonStatus | None = None,
     orphans: list[OrphanDaemon] | None = None,
 ) -> None:
     """Wire ``_auth_doctor``'s upstream calls to deterministic fakes.
@@ -98,8 +99,10 @@ def _patch_state(
     monkeypatch.setattr(
         _auth_doctor, "DAEMON_STATE_FILE", _FakeStateFile(daemon_state_exists)
     )
+    if daemon_status is None:
+        daemon_status = SyncDaemonStatus(healthy=False)
     monkeypatch.setattr(
-        _auth_doctor, "get_sync_daemon_status", lambda: SyncDaemonStatus(healthy=False)
+        _auth_doctor, "get_sync_daemon_status", lambda: daemon_status
     )
     monkeypatch.setattr(
         _auth_doctor, "enumerate_orphans", lambda: list(orphans or [])
@@ -187,6 +190,35 @@ def test_reset_noop_when_no_orphans(
     )
 
     assert sweep_called == []
+    assert exit_code == 0
+
+
+def test_reset_repairs_recorded_unhealthy_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Recorded-but-unhealthy singleton daemon is repaired by ``--reset``."""
+    session = _make_session()
+    stop_calls: list[None] = []
+
+    def fake_stop_sync_daemon() -> tuple[bool, str]:
+        stop_calls.append(None)
+        return True, "Unhealthy sync daemon process stopped. Metadata has been cleared."
+
+    monkeypatch.setattr(_auth_doctor, "stop_sync_daemon", fake_stop_sync_daemon)
+    _patch_state(
+        monkeypatch,
+        session=session,
+        lock_path=tmp_path / "auth" / "refresh.lock",
+        daemon_state_exists=True,
+        daemon_status=SyncDaemonStatus(healthy=False, port=9402, pid=12835),
+        orphans=[],
+    )
+
+    exit_code = doctor_impl(
+        json_output=True, reset=True, unstick_lock=False, stuck_threshold=60.0
+    )
+
+    assert stop_calls == [None]
     assert exit_code == 0
 
 

--- a/tests/auth/test_auth_doctor_report.py
+++ b/tests/auth/test_auth_doctor_report.py
@@ -370,6 +370,31 @@ def test_renders_recorded_unhealthy_daemon(monkeypatch: pytest.MonkeyPatch) -> N
     assert "12345" in rendered
 
 
+def test_unhealthy_daemon_finding_points_to_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rollout-enabled unhealthy singleton should tell users to run ``--reset``."""
+    session = _make_session(
+        refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30)
+    )
+    daemon_status = SyncDaemonStatus(
+        healthy=False, port=9402, pid=12835
+    )
+    _patch_state(
+        monkeypatch,
+        session=session,
+        daemon_status=daemon_status,
+        daemon_state_exists=True,
+        rollout_enabled=True,
+    )
+
+    report = assemble_report()
+
+    finding = next(f for f in report.findings if f.id == "F-005")
+    assert "not healthy" in finding.summary
+    assert finding.remediation_command == "spec-kitty auth doctor --reset"
+
+
 def test_nfs_holder_finding(monkeypatch: pytest.MonkeyPatch) -> None:
     """F-007 fires when the lock holder host differs from the local hostname."""
     session = _make_session(

--- a/tests/sync/test_daemon.py
+++ b/tests/sync/test_daemon.py
@@ -495,6 +495,34 @@ def test_get_sync_daemon_status_reads_health_metadata(monkeypatch, tmp_path):
     assert status.package_version == daemon._get_package_version()
 
 
+def test_stop_sync_daemon_clears_unhealthy_recorded_process(monkeypatch, tmp_path):
+    """stop/reset should kill the recorded PID even when health is already bad."""
+    daemon_file = tmp_path / "sync-daemon"
+    monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", daemon_file)
+    daemon._write_daemon_file(
+        daemon_file, "http://127.0.0.1:9402", 9402, "stale-token", 12835
+    )
+    monkeypatch.setattr(daemon, "_check_sync_daemon_health", lambda *a, **kw: False)
+
+    killed: list[int] = []
+
+    class FakeProcess:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+        def kill(self) -> None:
+            killed.append(self.pid)
+
+    monkeypatch.setattr(daemon.psutil, "Process", FakeProcess)
+
+    stopped, message = daemon.stop_sync_daemon()
+
+    assert stopped is True
+    assert killed == [12835]
+    assert not daemon_file.exists()
+    assert "Unhealthy sync daemon process stopped" in message
+
+
 def test_get_package_version_queries_distribution_name_in_pyproject():
     """Regression: ``_get_package_version`` must query the actual installed
     distribution name (``spec-kitty-cli`` per ``pyproject.toml``).

--- a/tests/sync/test_orphan_sweep.py
+++ b/tests/sync/test_orphan_sweep.py
@@ -194,6 +194,23 @@ _TEST_PORT_START = 9425
 _TEST_PORT_END = 9450  # exclusive
 
 
+def test_lookup_listening_pid_falls_back_to_lsof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """macOS can hide listener PIDs from psutil; lsof should recover them."""
+
+    def fake_net_connections(*_args: Any, **_kwargs: Any) -> list[Any]:
+        raise psutil.AccessDenied(pid=None)
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 0, stdout="12345\n", stderr="")
+
+    monkeypatch.setattr(orphan_sweep.psutil, "net_connections", fake_net_connections)
+    monkeypatch.setattr(orphan_sweep.subprocess, "run", fake_run)
+
+    assert orphan_sweep._lookup_listening_pid(9401) == 12345
+
+
 @pytest.fixture
 def harness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[_DaemonHarness]:
     """Provide a harness with an isolated DAEMON_STATE_FILE and narrowed scan range."""


### PR DESCRIPTION
## Summary
- make `auth doctor --reset` repair recorded-but-unhealthy singleton daemon metadata/processes
- point the rollout-enabled unhealthy daemon finding at `auth doctor --reset`
- add an `lsof` fallback so macOS orphan sweep can resolve listener PIDs when psutil cannot

## Tests
- `uv run pytest tests/sync/test_orphan_sweep.py tests/sync/test_daemon.py tests/auth/test_auth_doctor_repair.py tests/auth/test_auth_doctor_report.py -q`

## Notes
- Reproduces the observed state where `--reset` reported orphan sweep failures for PID-less daemon ports and left `recorded but not healthy` singleton metadata behind.