### PR TITLE
Harden Charter synthesis manifest path validation

### DIFF
--- a/kitty-specs/charter-p7-release-closure-01KQF9B9/mission-review-report.md
+++ b/kitty-specs/charter-p7-release-closure-01KQF9B9/mission-review-report.md
@@ -76,23 +76,23 @@ Gate 4 failure does not block the overall verdict when the only affected FR is a
 
 ## Risk Findings
 
-### RISK-1: `_assert_bundle_compatible_bundle` leaks Rich text to stdout in `--json` mode (pre-existing, not a regression)
+### RISK-1: Incompatible bundle failures leaked Rich text to stdout in `--json` mode — RESOLVED
 
 **Type**: BOUNDARY-CONDITION
-**Severity**: LOW (pre-existing; only fires for bundles with an incompatible `metadata.yaml` schema version)
-**Location**: `src/specify_cli/cli/commands/charter_bundle.py:245–255` (unchanged by this mission)
+**Severity**: RESOLVED in commit `5a6e0737`
+**Location**: `src/specify_cli/cli/commands/charter_bundle.py` (`_bundle_compatibility_error` and unified JSON exit gate)
 **Trigger condition**: `charter bundle validate --json` invoked on a bundle whose `metadata.yaml` carries a schema version that `check_bundle_compatibility()` rejects.
 
-**Analysis**: `_assert_bundle_compatible_bundle(charter_dir, console)` passes `console = Console()` (stdout) and calls `console.print(f"[red]Error:[/red] {result.message}")` before raising `typer.Exit(code=1)`. When `--json` is active, this leaks a Rich-formatted line to stdout before the JSON envelope — violating FR-006 for this specific code path. WP01 fixed the sidecar-path stdout leak (the mission's target) but did not fix the pre-existing compatibility-check path. The git diff confirms this line is unchanged since the baseline `a9d8cab2`. No test exercises this path with `--json`, so no regression was introduced by this mission. Recommend a follow-up fix to redirect the compatibility error to `err_console` (stderr) when `json_output` is True.
+**Analysis**: The old early-exit compatibility helper printed to stdout before raising. It has been replaced by `_bundle_compatibility_error()`, which returns the message so the main validation command can include it in the parseable JSON envelope and exit through the same gate as other failures. `test_validate_json_is_strict_on_incompatible_bundle` now covers this path.
 
-### RISK-2: `manifest_hash` self-integrity is stored but never verified
+### RISK-2: `manifest_hash` self-integrity gap — RESOLVED
 
 **Type**: BOUNDARY-CONDITION
-**Severity**: LOW (explicitly accepted as out-of-scope; documented in test helper comments)
-**Location**: `src/charter/synthesizer/manifest.py:verify()` (not changed by this mission)
-**Trigger condition**: A synthesis manifest whose `manifest_hash` field is tampered with passes `validate_synthesis_state()` as long as per-artifact `content_hash` values match.
+**Severity**: RESOLVED in commit `5a6e0737`
+**Location**: `src/charter/synthesizer/manifest.py:verify_manifest_hash()` and `src/charter/bundle.py:_check_manifest_integrity()`
+**Trigger condition**: A synthesis manifest whose `manifest_hash` field is tampered with while per-artifact `content_hash` values still match.
 
-**Analysis**: `SynthesisManifest` carries a `manifest_hash` field (SHA-256 of all other fields), but `verify()` only cross-checks per-artifact `content_hash` against on-disk artifact bytes. The manifest self-hash is cosmetic from validation's perspective. The `_add_synthesis_manifest` test helper uses `"c" * 64` as a dummy `manifest_hash` and passes; this is documented explicitly as in-scope ("verify() does not check manifest_hash"). Per C-002 the accepted audit-linkage design was not to be reopened. Recommend a follow-up mission to wire manifest self-hash verification if the threat model requires it.
+**Analysis**: `verify_manifest_hash()` now recomputes SHA-256 over the canonical manifest fields excluding `manifest_hash` and `_check_manifest_integrity()` reports a structured error on mismatch. CLI and direct validator regressions cover tampered self-hash failures.
 
 ---
 
@@ -108,7 +108,7 @@ None introduced by this mission. The diff adds no `except Exception: return ""` 
 |---------|----------|------------|----------------|
 | No new subprocess calls | — | — | None |
 | No `shell=True` | — | — | None |
-| No new file path operations without anchoring | — | — | None |
+| Manifest-listed paths are anchored | `src/charter/synthesizer/manifest.py` | Path traversal / local file read | Manifest artifact paths must stay under `.kittify/doctrine`; provenance paths must stay under `.kittify/charter/provenance`; symlink escapes are rejected. |
 | No `type: ignore` or `noqa` added | — | — | None |
 | No new HTTP/network calls | — | — | None |
 
@@ -118,7 +118,7 @@ The diff is clean from a security perspective. The only existing subprocess call
 
 ## Contract Compliance Note
 
-The `contracts/validate-json-output.md` file uses `"manifest": { "...": "existing shape unchanged" }` as a documentation placeholder in its JSON examples. The actual implementation emits no `"manifest"` key — the real shape has `tracked_files`, `derived_files`, `gitignore`, `out_of_scope_files`, etc. This is a documentation-only drift (the placeholder is misleading) that does not affect runtime behavior. The test `test_validate_json_shape_matches_contract` is the authoritative contract surface and does not require a `"manifest"` key.
+The `contracts/validate-json-output.md` examples now use the real envelope keys emitted by the implementation (`tracked_files`, `derived_files`, `gitignore`, `out_of_scope_files`, `warnings`, and `synthesis_state`) instead of the stale placeholder `"manifest"` key. The test `test_validate_json_shape_matches_contract` remains the executable contract guard.
 
 ---
 
@@ -130,10 +130,10 @@ The `contracts/validate-json-output.md` file uses `"manifest": { "...": "existin
 
 All nine code-level FRs (FR-001 through FR-009) are adequately tested and correctly implemented. The diff is minimal (59 lines in the CLI module, 289 lines of new tests), architecturally clean, and introduces no security issues or silent failure modes. Gate 1 (contract) and Gate 2 (architectural) pass. Gate 3 is an environmental exception with no code implication. Gate 4 fails solely because FR-010 (GitHub issue hygiene) was not assigned to a WP — not because of any runtime defect.
 
-FR-010 is being remediated as part of this review's follow-up actions (GitHub issues #515 and #469). RISK-1 (`_assert_bundle_compatible_bundle` stdout leak in `--json` mode for incompatible bundles) is pre-existing and out of this mission's scope; it does not affect the two fixed blockers.
+FR-010 is a post-merge hygiene action for GitHub issues #515 and #469. RISK-1 and RISK-2 were both remediated in commit `5a6e0737` and now have regression coverage.
 
 ### Open items (non-blocking)
 
-1. **RISK-1** ✅ **RESOLVED** (commit `5a6e0737`): `_assert_bundle_compatible_bundle` now passes `err_console` when `json_output` is True.
+1. **RISK-1** ✅ **RESOLVED** (commit `5a6e0737`): incompatible-bundle errors now flow through `_bundle_compatibility_error()` and the unified JSON exit gate.
 2. **RISK-2** ✅ **RESOLVED** (commit `5a6e0737`): `verify_manifest_hash()` added to `synthesizer/manifest.py` and wired into `_check_manifest_integrity()`; tests updated to compute real manifest hashes and cover the mismatch failure path.
-3. **Documentation**: Update `contracts/validate-json-output.md` to replace the `"manifest"` placeholder with the actual key names used by the implementation.
+3. **Documentation** ✅ **RESOLVED**: `contracts/validate-json-output.md` now shows the actual key names used by the implementation.

--- a/kitty-specs/charter-p7-release-closure-01KQF9B9/tasks.md
+++ b/kitty-specs/charter-p7-release-closure-01KQF9B9/tasks.md
@@ -117,5 +117,4 @@ WP01 (validate_synthesis_state must be wired before tests can pass).
 
 ### Risks
 
-- Fixture helpers must create `synthesis-manifest.yaml` with real `content_hash` values so the valid-bundle test passes.
-- `manifest_hash` integrity check in `validate_synthesis_state()` uses `content_hash` per artifact, not a single top-level hash — test fixtures must match that structure exactly.
+- Fixture helpers must create `synthesis-manifest.yaml` with real `content_hash` and `manifest_hash` values so the valid-bundle test passes; corrupt fixture variants should target only the field under test.

--- a/kitty-specs/charter-p7-release-closure-01KQF9B9/tasks/WP02-regression-tests.md
+++ b/kitty-specs/charter-p7-release-closure-01KQF9B9/tasks/WP02-regression-tests.md
@@ -154,11 +154,9 @@ def _add_synthesis_manifest(
     When corrupt_hash=True, tampers with the stored content_hash after dumping so that
     verify_manifest raises on the per-artifact content_hash mismatch (FR-003).
 
-    NOTE: validate_synthesis_state() → _check_manifest_integrity() → verify_manifest()
-    only checks per-artifact content_hash values. The manifest self-hash field
-    (manifest_hash) is NOT verified by the current implementation. T010 therefore tests
-    per-artifact content_hash mismatch only; manifest self-hash verification is out of
-    scope for this mission.
+    NOTE: validate_synthesis_state() → _check_manifest_integrity() verifies both
+    per-artifact content_hash values and the manifest self-hash. T010 targets the
+    per-artifact mismatch path; the self-hash mismatch path has its own regression.
     """
     from charter.synthesizer.manifest import SynthesisManifest, dump_manifest  # noqa: PLC0415
 
@@ -258,7 +256,7 @@ def test_validate_fails_when_sidecar_references_missing_artifact(
 
 **Purpose**: Synthesis manifest exists with a per-artifact `content_hash` that does not match on-disk bytes → validation fails (FR-003).
 
-**Scope note**: `validate_synthesis_state()` → `_check_manifest_integrity()` → `verify_manifest()` checks **per-artifact `content_hash` values only**. The manifest self-hash field (`manifest_hash`) is not verified by the current implementation. This test covers the per-artifact content_hash mismatch path; manifest self-hash verification is explicitly out of scope for this mission.
+**Scope note**: `validate_synthesis_state()` → `_check_manifest_integrity()` checks both per-artifact `content_hash` values and the manifest self-hash. This test covers the per-artifact content_hash mismatch path; manifest self-hash mismatch is covered by the dedicated RISK-2 remediation regression.
 
 ```python
 def test_validate_fails_on_manifest_content_hash_mismatch(

--- a/src/charter/synthesizer/manifest.py
+++ b/src/charter/synthesizer/manifest.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
 # Canonical location of the synthesis manifest.
 MANIFEST_PATH = Path(".kittify/charter/synthesis-manifest.yaml")
+_ARTIFACT_PATH_PREFIX = Path(".kittify/doctrine")
+_PROVENANCE_PATH_PREFIX = Path(".kittify/charter/provenance")
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +182,36 @@ def verify_manifest_hash(manifest: SynthesisManifest) -> None:
         )
 
 
+def _validate_manifest_path(raw_path: str, *, field_name: str, required_prefix: Path) -> Path:
+    """Return a safe repo-relative manifest path under ``required_prefix``."""
+    path = Path(raw_path.replace("\\", "/"))
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(
+            f"{field_name} must be repo-relative and stay under "
+            f"{required_prefix.as_posix()}: {raw_path}"
+        )
+    try:
+        path.relative_to(required_prefix)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be under {required_prefix.as_posix()}: {raw_path}"
+        ) from exc
+    return path
+
+
+def _resolve_under_repo(repo_root: Path, rel_path: Path, *, field_name: str) -> Path:
+    """Resolve ``rel_path`` and fail if symlinks escape ``repo_root``."""
+    repo_resolved = repo_root.resolve(strict=False)
+    resolved = (repo_root / rel_path).resolve(strict=False)
+    try:
+        resolved.relative_to(repo_resolved)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} resolves outside repository root: {rel_path.as_posix()}"
+        ) from exc
+    return resolved
+
+
 def verify(manifest: SynthesisManifest, repo_root: Path) -> None:
     """Verify that every artifact listed in the manifest exists with matching hash.
 
@@ -201,7 +233,21 @@ def verify(manifest: SynthesisManifest, repo_root: Path) -> None:
     """
     manifest_path = str(MANIFEST_PATH)
     for entry in manifest.artifacts:
-        artifact_path = repo_root / entry.path
+        artifact_rel = _validate_manifest_path(
+            entry.path,
+            field_name="manifest artifact path",
+            required_prefix=_ARTIFACT_PATH_PREFIX,
+        )
+        _validate_manifest_path(
+            entry.provenance_path,
+            field_name="manifest provenance path",
+            required_prefix=_PROVENANCE_PATH_PREFIX,
+        )
+        artifact_path = _resolve_under_repo(
+            repo_root,
+            artifact_rel,
+            field_name="manifest artifact path",
+        )
         if not artifact_path.exists():
             raise ManifestIntegrityError(
                 manifest_path=manifest_path,

--- a/tests/charter/synthesizer/test_bundle_validate_extension.py
+++ b/tests/charter/synthesizer/test_bundle_validate_extension.py
@@ -355,6 +355,37 @@ def test_manifest_without_doctrine_tree_is_not_legacy(tmp_path: Path) -> None:
     assert any("could not load synthesis manifest" in error.lower() for error in result.errors)
 
 
+def test_manifest_absolute_artifact_path_fails_closed(tmp_path: Path) -> None:
+    """A manifest cannot make validation read artifacts outside the repo root."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.tactic.yaml"
+    outside.write_bytes(_tactic_body("outside"))
+    content_hash = hashlib.sha256(outside.read_bytes()).hexdigest()
+
+    guard = PathGuard(repo, extra_allowed_prefixes=[repo])
+    manifest = _make_v2_manifest(
+        artifacts=[
+            ManifestArtifactEntry(
+                kind="tactic",
+                slug="outside",
+                path=str(outside),
+                provenance_path=".kittify/charter/provenance/tactic-outside.yaml",
+                content_hash=content_hash,
+            )
+        ],
+    )
+    manifest_path = repo / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    dump_manifest(manifest, manifest_path, guard)
+
+    result = validate_synthesis_state(repo)
+
+    assert result.synthesis_state_present
+    assert not result.passed
+    assert any("repo-relative" in error for error in result.errors), result.errors
+
+
 # ---------------------------------------------------------------------------
 # Stale .failed/ staging dirs produce warnings
 # ---------------------------------------------------------------------------

--- a/tests/charter/synthesizer/test_manifest.py
+++ b/tests/charter/synthesizer/test_manifest.py
@@ -85,6 +85,32 @@ def _make_manifest(run_id: str = "01KPE222TESTRUNID0000000001") -> SynthesisMani
     )
 
 
+def _make_manifest_for_artifacts(
+    artifacts: list[ManifestArtifactEntry],
+    run_id: str = "01KPE222TESTRUNID0000000001",
+) -> SynthesisManifest:
+    data_without_hash = {
+        "schema_version": "2",
+        "mission_id": None,
+        "created_at": "2026-04-17T12:00:00+00:00",
+        "run_id": run_id,
+        "adapter_id": "fixture",
+        "adapter_version": "1.0.0",
+        "synthesizer_version": "3.2.0a5",
+        "artifacts": [a.model_dump(mode="python") for a in artifacts],
+    }
+    manifest_hash = hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()
+    return SynthesisManifest(
+        created_at="2026-04-17T12:00:00+00:00",
+        run_id=run_id,
+        adapter_id="fixture",
+        adapter_version="1.0.0",
+        synthesizer_version="3.2.0a5",
+        manifest_hash=manifest_hash,
+        artifacts=artifacts,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -304,6 +330,89 @@ def test_verify_raises_on_missing_artifact(tmp_path: Path) -> None:
         verify(manifest, tmp_path)
 
 
+def test_verify_rejects_absolute_artifact_path(tmp_path: Path) -> None:
+    """Manifest verification must not read absolute paths outside the repo."""
+    outside = tmp_path / "outside.tactic.yaml"
+    outside.write_bytes(b"id: outside\n")
+    manifest = _make_manifest_for_artifacts(
+        [
+            ManifestArtifactEntry(
+                kind="tactic",
+                slug="outside",
+                path=str(outside),
+                provenance_path=".kittify/charter/provenance/tactic-outside.yaml",
+                content_hash=hashlib.sha256(outside.read_bytes()).hexdigest(),
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="repo-relative"):
+        verify(manifest, tmp_path / "repo")
+
+
+def test_verify_rejects_traversal_artifact_path(tmp_path: Path) -> None:
+    """Manifest artifact paths must stay within .kittify/doctrine."""
+    manifest = _make_manifest_for_artifacts(
+        [
+            ManifestArtifactEntry(
+                kind="tactic",
+                slug="escape",
+                path=".kittify/doctrine/../charter/provenance/tactic-escape.yaml",
+                provenance_path=".kittify/charter/provenance/tactic-escape.yaml",
+                content_hash="a" * 64,
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="repo-relative"):
+        verify(manifest, tmp_path)
+
+
+def test_verify_rejects_provenance_path_outside_provenance_tree(tmp_path: Path) -> None:
+    """Manifest provenance paths must stay within .kittify/charter/provenance."""
+    artifact_rel = ".kittify/doctrine/tactics/my-tactic.tactic.yaml"
+    artifact_path = tmp_path / artifact_rel
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_bytes(b"id: my-tactic\n")
+    manifest = _make_manifest_for_artifacts(
+        [
+            ManifestArtifactEntry(
+                kind="tactic",
+                slug="my-tactic",
+                path=artifact_rel,
+                provenance_path=".kittify/charter/../doctrine/tactic-my-tactic.yaml",
+                content_hash=hashlib.sha256(artifact_path.read_bytes()).hexdigest(),
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="repo-relative"):
+        verify(manifest, tmp_path)
+
+
+def test_verify_accepts_manifest_paths_with_windows_separators(tmp_path: Path) -> None:
+    """Windows-written manifest paths are normalized before validation."""
+    artifact_rel = ".kittify/doctrine/tactics/windows-path.tactic.yaml"
+    artifact_path = tmp_path / artifact_rel
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_bytes(b"id: windows-path\n")
+    manifest = _make_manifest_for_artifacts(
+        [
+            ManifestArtifactEntry(
+                kind="tactic",
+                slug="windows-path",
+                path=artifact_rel.replace("/", "\\"),
+                provenance_path=".kittify/charter/provenance/tactic-windows-path.yaml".replace(
+                    "/", "\\"
+                ),
+                content_hash=hashlib.sha256(artifact_path.read_bytes()).hexdigest(),
+            )
+        ]
+    )
+
+    verify(manifest, tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # Ordering (deterministic)
 # ---------------------------------------------------------------------------
@@ -383,7 +492,6 @@ def test_manifest_hash_validates(tmp_path: Path, guard: PathGuard) -> None:
 
 def test_manifest_synthesizer_version_empty_raises() -> None:
     """SynthesisManifest with synthesizer_version='' must raise ValidationError."""
-    artifacts: list[ManifestArtifactEntry] = []
     data_without_hash = {
         "schema_version": "2",
         "mission_id": None,

--- a/tests/charter/test_bundle_validate_cli.py
+++ b/tests/charter/test_bundle_validate_cli.py
@@ -472,10 +472,9 @@ def test_validate_fails_on_manifest_content_hash_mismatch(
 ) -> None:
     """FR-003: mismatched synthesis manifest per-artifact content_hash must fail.
 
-    validate_synthesis_state() → _check_manifest_integrity() → verify() checks
-    per-artifact content_hash values only. Manifest self-hash (manifest_hash field)
-    is not verified by the current implementation; this test covers the
-    per-artifact mismatch path.
+    validate_synthesis_state() → _check_manifest_integrity() checks both
+    per-artifact content_hash values and the manifest self-hash. This test covers
+    the per-artifact mismatch path; a separate regression covers manifest_hash.
     """
     artifact_content = "# directive content\n"
     _add_doctrine_artifact(


### PR DESCRIPTION
## Summary
- Follow-up to #914 after review found the public bundle validator trusted manifest-listed paths too broadly.
- Require synthesis manifest artifact paths to be repo-relative under `.kittify/doctrine` and provenance paths under `.kittify/charter/provenance`.
- Normalize Windows path separators, reject absolute/traversal paths, and fail symlink escapes before reading artifact bytes.
- Clean up stale mission-review/task notes that still described manifest self-hash verification as out of scope.

## Related
- Follow-up to #914
- Phase 7: #469
- WP7.3 provenance sidecar hardening: #515

## Validation
- `uv run ruff check src/charter/bundle.py src/charter/synthesizer/manifest.py src/specify_cli/cli/commands/charter_bundle.py tests/charter/synthesizer/test_manifest.py tests/charter/synthesizer/test_bundle_validate_extension.py tests/charter/test_bundle_validate_cli.py`
- `uv run pytest tests/charter/synthesizer/test_manifest.py tests/charter/synthesizer/test_bundle_validate_extension.py tests/charter/test_bundle_validate_cli.py -q` (53 passed)
- `uv run pytest tests/charter -q` (719 passed, 1 skipped)
- `uv run pytest tests/specify_cli/cli/commands/test_charter_status_provenance.py tests/doctrine/test_versioning.py tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py -q` (57 passed)
- `uv run mypy --strict src/charter/synthesizer/manifest.py` (passed)

## Note
- `uv run mypy --strict src/charter/bundle.py src/charter/synthesizer/manifest.py src/specify_cli/cli/commands/charter_bundle.py` remains blocked by existing missing `jsonschema` stubs in doctrine validation modules.