### PR TITLE
fix(sync): bound websocket startup and shutdown

### DIFF
--- a/src/specify_cli/saas/readiness.py
+++ b/src/specify_cli/saas/readiness.py
@@ -182,7 +182,7 @@ def _probe_reachability(server_url: str, timeout_s: float = 2.0) -> bool:
     """
     try:
         req = urllib.request.Request(server_url, method="HEAD")
-        with urllib.request.urlopen(req, timeout=timeout_s):  # noqa: S310
+        with urllib.request.urlopen(req, timeout=timeout_s):  # noqa: S310  # nosec B310
             return True
     except Exception:  # noqa: BLE001
         return False

--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -10,6 +10,7 @@ state directly.
 import asyncio
 import json
 import random
+import sys
 from contextlib import suppress
 from collections.abc import Callable
 from typing import Any
@@ -63,6 +64,9 @@ class WebSocketClient:
     BASE_DELAY_SECONDS = 0.5  # 500ms
     MAX_DELAY_SECONDS = 30.0
     JITTER_RANGE = 1.0  # +/- 1 second
+    OPEN_TIMEOUT_SECONDS = 5.0
+    INITIAL_SNAPSHOT_TIMEOUT_SECONDS = 5.0
+    CLOSE_TIMEOUT_SECONDS = 2.0
 
     def __init__(
         self,
@@ -166,12 +170,17 @@ class WebSocketClient:
                 uri,
                 ping_interval=None,  # We handle heartbeat manually
                 ping_timeout=None,
+                open_timeout=self.OPEN_TIMEOUT_SECONDS,
+                close_timeout=self.CLOSE_TIMEOUT_SECONDS,
             )
             self.connected = True
             self.status = ConnectionStatus.CONNECTED
 
             # Receive initial snapshot
-            await self._receive_snapshot()
+            await asyncio.wait_for(
+                self._receive_snapshot(),
+                timeout=self.INITIAL_SNAPSHOT_TIMEOUT_SECONDS,
+            )
 
             # Start message listener
             self._listen_task = asyncio.create_task(self._listen())
@@ -187,7 +196,17 @@ class WebSocketClient:
             self.connected = False
             self.status = ConnectionStatus.OFFLINE
             raise
+        except TimeoutError:
+            await self._close_after_failed_connect()
+            print(
+                "Warning: WebSocket connection timed out; events will be queued for batch sync.",
+                file=sys.stderr,
+            )
+            self.connected = False
+            self.status = ConnectionStatus.BATCH_MODE
+            raise
         except Exception as e:
+            await self._close_after_failed_connect()
             self.connected = False
             self.status = ConnectionStatus.OFFLINE
             print(f"❌ Connection failed: {e}")
@@ -195,6 +214,7 @@ class WebSocketClient:
 
     async def disconnect(self):
         """Close WebSocket connection"""
+        had_ws = self.ws is not None
         if self._listen_task:
             self._listen_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -202,11 +222,28 @@ class WebSocketClient:
             self._listen_task = None
 
         if self.ws:
-            await self.ws.close()
-            self.ws = None
-            self.connected = False
-            self.status = ConnectionStatus.OFFLINE
+            with suppress(Exception):
+                await asyncio.wait_for(
+                    self.ws.close(),
+                    timeout=self.CLOSE_TIMEOUT_SECONDS,
+                )
+        self.ws = None
+        self.connected = False
+        self.status = ConnectionStatus.OFFLINE
+        if had_ws:
             print("Disconnected from sync server")
+
+    async def _close_after_failed_connect(self) -> None:
+        """Best-effort cleanup when connect fails after a socket was opened."""
+        ws = self.ws
+        self.ws = None
+        if ws is None:
+            return
+        with suppress(Exception):
+            await asyncio.wait_for(
+                ws.close(),
+                timeout=self.CLOSE_TIMEOUT_SECONDS,
+            )
 
     async def reconnect(self) -> bool:
         """

--- a/src/specify_cli/sync/orphan_sweep.py
+++ b/src/specify_cli/sync/orphan_sweep.py
@@ -110,8 +110,7 @@ def _probe_health(port: int) -> dict[str, Any] | None:
     """Issue ``GET /api/health`` and return the parsed JSON dict, or ``None`` on any failure."""
     url = f"http://127.0.0.1:{port}/api/health"
     try:
-        # nosec B310 — URL is always 127.0.0.1 in the reserved daemon range.
-        with urllib.request.urlopen(url, timeout=_HEALTH_PROBE_TIMEOUT_S) as response:
+        with urllib.request.urlopen(url, timeout=_HEALTH_PROBE_TIMEOUT_S) as response:  # nosec B310 - URL is always 127.0.0.1 in the reserved daemon range.
             if response.status != 200:
                 return None
             payload = response.read()
@@ -233,8 +232,7 @@ def _http_shutdown_no_token(port: int) -> None:
         method="POST",
     )
     try:
-        # nosec B310 — request URL is 127.0.0.1 in the reserved daemon range.
-        with urllib.request.urlopen(request, timeout=1.0):
+        with urllib.request.urlopen(request, timeout=1.0):  # nosec B310 - request URL is 127.0.0.1 in the reserved daemon range.
             return
     except Exception:
         return

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -736,7 +736,7 @@ class OfflineQueue:
         try:
             placeholders = ",".join("?" * len(event_ids))
             conn.execute(
-                f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only
+                f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only  # nosec B608
                 event_ids,
             )
             conn.commit()
@@ -757,7 +757,7 @@ class OfflineQueue:
         try:
             placeholders = ",".join("?" * len(event_ids))
             conn.execute(
-                f"UPDATE queue SET retry_count = retry_count + 1 WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only
+                f"UPDATE queue SET retry_count = retry_count + 1 WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only  # nosec B608
                 event_ids,
             )
             conn.commit()
@@ -814,7 +814,7 @@ class OfflineQueue:
 
             placeholders = ",".join("?" * len(matching_ids))
             conn.execute(
-                f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only
+                f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only  # nosec B608
                 matching_ids,
             )
             conn.commit()
@@ -846,13 +846,13 @@ class OfflineQueue:
             if synced_or_duplicate:
                 placeholders = ",".join("?" * len(synced_or_duplicate))
                 conn.execute(
-                    f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only
+                    f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only  # nosec B608
                     synced_or_duplicate,
                 )
             if rejected:
                 placeholders = ",".join("?" * len(rejected))
                 conn.execute(
-                    f"UPDATE queue SET retry_count = retry_count + 1 WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only
+                    f"UPDATE queue SET retry_count = retry_count + 1 WHERE event_id IN ({placeholders})",  # noqa: S608 - placeholders are count-derived only  # nosec B608
                     rejected,
                 )
             conn.commit()

--- a/tests/sync/test_reconnection.py
+++ b/tests/sync/test_reconnection.py
@@ -297,6 +297,27 @@ class _FakeWebSocket:
         raise StopAsyncIteration
 
 
+class _NeverSnapshotWebSocket(_FakeWebSocket):
+    """Websocket stub that accepts the upgrade but never sends a snapshot."""
+
+    def __init__(self):
+        self.closed = False
+
+    async def recv(self):
+        await asyncio.sleep(60)
+        return '{"type":"snapshot","work_packages":[]}'
+
+    async def close(self):
+        self.closed = True
+
+
+class _StalledCloseWebSocket(_FakeWebSocket):
+    """Websocket stub whose close handshake never completes."""
+
+    async def close(self):
+        await asyncio.sleep(60)
+
+
 class TestClientLifecycle:
     """Tests for connect/disconnect task lifecycle hygiene."""
 
@@ -364,3 +385,63 @@ class TestClientLifecycle:
                 and getattr(t.get_coro(), "__qualname__", "") == "WebSocketClient._listen"
             ]
             assert leaked_listeners == []
+
+    @pytest.mark.asyncio
+    async def test_connect_times_out_when_initial_snapshot_never_arrives(self, monkeypatch):
+        """A stalled initial recv must not keep short-lived CLI calls alive."""
+        client = WebSocketClient()
+        client.INITIAL_SNAPSHOT_TIMEOUT_SECONDS = 0.01
+        client.CLOSE_TIMEOUT_SECONDS = 0.01
+        fake_ws = _NeverSnapshotWebSocket()
+
+        class _Team:
+            id = "team-42"
+            is_private_teamspace = False
+
+        class _Session:
+            default_team_id = "team-42"
+            teams = [_Team()]
+
+        class _TM:
+            def get_current_session(self):
+                return _Session()
+
+        async def fake_provision(_team_id):
+            return {
+                "ws_url": "https://example.test/ws",
+                "ws_token": "provisioned-token",
+                "expires_in": 60,
+            }
+
+        async def fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        monkeypatch.setattr("specify_cli.sync.client.get_token_manager", lambda: _TM())
+        monkeypatch.setattr("specify_cli.sync.client.provision_ws_token", fake_provision)
+        monkeypatch.setattr("specify_cli.sync.client.is_saas_sync_enabled", lambda: True)
+
+        with (
+            patch("specify_cli.sync.client.websockets.connect", side_effect=fake_connect),
+            pytest.raises(TimeoutError),
+        ):
+            await client.connect()
+
+        assert fake_ws.closed is True
+        assert client.ws is None
+        assert client.connected is False
+        assert client.get_status() == ConnectionStatus.BATCH_MODE
+
+    @pytest.mark.asyncio
+    async def test_disconnect_bounds_stalled_close_handshake(self):
+        """A stuck websocket close handshake must not block process shutdown."""
+        client = WebSocketClient()
+        client.CLOSE_TIMEOUT_SECONDS = 0.01
+        client.ws = _StalledCloseWebSocket()
+        client.connected = True
+        client.status = ConnectionStatus.CONNECTED
+
+        await client.disconnect()
+
+        assert client.ws is None
+        assert client.connected is False
+        assert client.get_status() == ConnectionStatus.OFFLINE


### PR DESCRIPTION
## Summary

- Add bounded WebSocket open, initial snapshot, and close deadlines so sync startup cannot hold short-lived CLI commands forever.
- Clean up partially opened sockets on failed startup and degrade timed-out connections to batch sync.
- Add regressions for a stalled initial snapshot and stalled close handshake.
- Record the fix in the Unreleased changelog and clean up markdownlint issues that were already present in the touched changelog file.

Closes #936.

## Local verification

- `uv run pytest tests/sync/test_reconnection.py tests/sync/test_client_integration.py -q`
- `uv run pytest tests/sync/ -m "fast and not windows_ci" -q --tb=short --cov=src/specify_cli/sync --cov-report=xml:/tmp/coverage-fast-sync.xml`
- `uv run ruff check src/specify_cli/sync/client.py tests/sync/test_reconnection.py`
- `uv run python scripts/generate_contextive_glossaries.py check`
- `uv run python scripts/check_patch_targets.py`
- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint-cli2.jsonc CHANGELOG.md`
- `uv run bandit -r src/ --severity-level medium --confidence-level medium`
