### PR TITLE
Release 3.2.0a7

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0a6
+  version: 3.2.0a7
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.2.0a7] - 2026-05-01
+
+3.2.0a7 is a focused prerelease that bounds WebSocket sync startup and
+shutdown behavior. Short-lived agent commands now fail over to batch sync
+instead of hanging indefinitely when a local sync socket accepts the
+connection but never emits the initial snapshot.
+
+### Fixed
+
+- WebSocket sync startup now has bounded open, initial snapshot, and close
+  deadlines so `spec-kitty agent mission setup-plan` and other short-lived
+  commands degrade to batch sync instead of blocking forever on a stalled
+  sync socket (#936).
+
+### Internal
+
+- Added regression coverage for a WebSocket connection that never sends the
+  initial snapshot and for shutdown paths where the close handshake stalls.
+- Aligned existing Bandit suppressions in touched sync/readiness callsites so
+  local and CI security scans recognize the intended safe dynamic SQL and
+  localhost URL patterns.
+
 ## [3.2.0a6] - 2026-04-30
 
 3.2.0a6 is a prerelease hardening sweep that restores the documented
@@ -1345,6 +1367,7 @@ All fixes include comprehensive test coverage (54+ new tests) and maintain backw
   - **Errors handled**: TimeoutExpired (>10s git commands), general exceptions with warning
 
 ### Added
+
 - Git commit validation for "done" status transitions - prevents completing WPs with uncommitted changes
 - Empty branch detection in merge-base creation - warns when dependencies have no commits
 - Git commit workflow section in documentation mission template (consistency with software-dev/research)
@@ -1352,11 +1375,13 @@ All fixes include comprehensive test coverage (54+ new tests) and maintain backw
 - Migration to add commit workflow section to existing projects (`m_0_13_5_add_commit_workflow_to_templates.py`)
 
 ### Changed
+
 - `move-task --to done` now validates git status (same checks as "for_review")
 - Use `--force` flag to bypass validation (not recommended)
 - Warning messages in multi-parent merge now output to stderr instead of stdout (preserves JSON output integrity)
 
 ### Fixed (Non-Critical)
+
 - WP agents can no longer mark tasks as "done" without committing implementation files
 - Multi-parent merge-bases no longer silently accept empty dependency branches
 - Documentation mission now instructs agents to commit work before review
@@ -1418,7 +1443,7 @@ All fixes include comprehensive test coverage (54+ new tests) and maintain backw
   - Unit tests: `test_implement_validation.py` (11 tests)
   - Integration tests: `test_agent_command_wrappers.py` (11 tests)
 - Added `TestMigrationRegistryCompleteness` test (prevents 0.13.2-style release blocker)
-  - Verifies all m_*.py migration files are imported in __init__.py
+  - Verifies all `m_*.py` migration files are imported in `__init__.py`
   - Prevents silent bugs where migrations exist but never run
 - Added integration tests for merge with untracked branches
 - Added unit tests for `has_tracking_branch()` function
@@ -1840,9 +1865,9 @@ The migration will remove mission-specific constitution directories:
   - `signal.SIGKILL` and `signal.SIGTERM` don't exist on Windows
   - Added `psutil>=5.9.0` dependency for cross-platform process management
   - Refactored `src/specify_cli/dashboard/lifecycle.py`:
-    * `os.kill(pid, 0)` → `psutil.Process(pid).is_running()`
-    * `signal.SIGKILL` → `psutil.Process(pid).kill()` (6 locations)
-    * `signal.SIGTERM` → `psutil.Process(pid).terminate()` with timeout
+    - `os.kill(pid, 0)` → `psutil.Process(pid).is_running()`
+    - `signal.SIGKILL` → `psutil.Process(pid).kill()` (6 locations)
+    - `signal.SIGTERM` → `psutil.Process(pid).terminate()` with timeout
   - Added proper exception handling (NoSuchProcess, AccessDenied, TimeoutExpired)
   - Dashboard now starts, serves HTML, and stops cleanly on Windows 10/11
   - All 41 dashboard tests passing

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Spec Kitty addresses this with repository-native artifacts, work package workflo
 
 ---
 
-## 🚀 What You Get on `main` (`3.2.0a6`)
+## 🚀 What You Get on `main` (`3.2.0a7`)
 
 | Capability | What Spec Kitty provides |
 |------------|--------------------------|
@@ -107,7 +107,7 @@ graph LR
 
 **Current stable release line:** `v3.1.x` (current stable release: `3.1.8` on GitHub Releases and PyPI)
 
-**Current `main` development version:** `3.2.0a6`
+**Current `main` development version:** `3.2.0a7`
 
 **Current `main` highlights:**
 - **Brief-first and ticket-first intake** — `spec-kitty intake` ingests external plans into `.kittify/mission-brief.md`, and `spec-kitty mission create --from-ticket <provider:KEY>` seeds tracker context before `/spec-kitty.specify`
@@ -130,18 +130,18 @@ graph LR
 
 ## 📌 Release Channels
 
-Spec Kitty currently ships stable `3.1.x` releases while `main` carries the active `3.2.0a6` prerelease/dev line.
+Spec Kitty currently ships stable `3.1.x` releases while `main` carries the active `3.2.0a7` prerelease/dev line.
 The former `1.x` line is deprecated and lives on `1.x-maintenance` for maintenance-only fixes.
 
 | Source | Version | Status | Install |
 |--------|---------|--------|---------|
 | **PyPI / GitHub Releases** | **3.1.8** | Current stable line | `pip install spec-kitty-cli` |
-| **main** | **3.2.0a6** | Active prerelease / development line | Install from a source checkout or a published prerelease tag |
+| **main** | **3.2.0a7** | Active prerelease / development line | Install from a source checkout or a published prerelease tag |
 | **1.x-maintenance** | **1.x** | Deprecated, maintenance-only | Install from a pinned maintenance tag or source checkout |
 
 **For users:** install the stable line from PyPI with `pip install spec-kitty-cli`.
 **For testers following `main`:** use a source checkout or published prerelease builds to get the intake, profile-invocation, hosted tracker-read, and Teamspace-routing work that is newer than stable `3.1.x`.
-After `3.2.0a6` is published, testers can install the exact prerelease with `pip install "spec-kitty-cli==3.2.0a6"` or opt into prereleases with `pip install --pre spec-kitty-cli`.
+After `3.2.0a7` is published, testers can install the exact prerelease with `pip install "spec-kitty-cli==3.2.0a7"` or opt into prereleases with `pip install --pre spec-kitty-cli`.
 **For existing 3.0.x users:** upgrade to `3.1.x` and run `spec-kitty upgrade` in each project — the charter rename, mission identity, and prompt-neutrality migrations remain automatic.
 **For existing 1.x or 2.x users:** migrate to `3.1.x`; `1.x-maintenance` is maintenance-only and will no longer publish new PyPI releases.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0a6"
+version = "3.2.0a7"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0a6"
+version = "3.2.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Bump spec-kitty-cli to 3.2.0a7 and keep .kittify metadata/uv.lock in sync
- Add 3.2.0a7 release notes for the WebSocket startup/shutdown timeout fix from #936
- Update README prerelease track references to 3.2.0a7

## Local verification
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv run python scripts/release/validate_release.py --mode tag --tag v3.2.0a7 --tag-pattern 'v*.*.*'
- uv run --extra test python -m pytest -v --import-mode=importlib tests/release
- npx --yes markdownlint-cli2@0.18.1 --config .markdownlint-cli2.jsonc README.md CHANGELOG.md
- uv lock --check
- uv run python -m build
- uv run --with twine python -m twine check dist/*
- uv run python scripts/release/check_shared_package_drift.py
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli