### PR TITLE
fix: address Sonar cleanup findings

### DIFF
--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -50,6 +50,11 @@ from .request import SynthesisRequest
 from .staging import StagingDir
 from .synthesize_pipeline import ProvenanceEntry, _get_synthesizer_version, canonical_yaml
 
+_KITTIFY_DIRNAME = ".kittify"
+_DOCTRINE_DIRNAME = "doctrine"
+_CHARTER_DIRNAME = "charter"
+_PROVENANCE_DIRNAME = "provenance"
+
 
 # ---------------------------------------------------------------------------
 # Typed staged-artifact entry (WP02 — Charter Contract Cleanup Tranche 1)
@@ -157,8 +162,8 @@ def compute_written_artifacts(
         filename = artifact_filename(kind, slug, artifact_id)
         live_path = (
             repo_root
-            / ".kittify"
-            / "doctrine"
+            / _KITTIFY_DIRNAME
+            / _DOCTRINE_DIRNAME
             / doctrine_kind_subdir(kind)
             / filename
         )
@@ -450,12 +455,12 @@ def promote(
     # Ensure destination directories exist.
     for kind_subdir in ("directives", "tactics", "styleguides"):
         guard.mkdir(
-            repo_root / ".kittify" / "doctrine" / kind_subdir,
+            repo_root / _KITTIFY_DIRNAME / _DOCTRINE_DIRNAME / kind_subdir,
             caller="write_pipeline.promote[mkdir-doctrine]",
         )
 
     guard.mkdir(
-        repo_root / ".kittify" / "charter" / "provenance",
+        repo_root / _KITTIFY_DIRNAME / _CHARTER_DIRNAME / _PROVENANCE_DIRNAME,
         caller="write_pipeline.promote[mkdir-provenance]",
     )
 
@@ -474,12 +479,24 @@ def promote(
 
             # Content: staging → .kittify/doctrine/<kind-subdir>/<filename>
             staged_content = staging_dir.path_for_content(kind, filename)
-            live_content = repo_root / ".kittify" / "doctrine" / _doctrine_kind_subdir(kind) / filename
+            live_content = (
+                repo_root
+                / _KITTIFY_DIRNAME
+                / _DOCTRINE_DIRNAME
+                / _doctrine_kind_subdir(kind)
+                / filename
+            )
             guard.replace(staged_content, live_content, caller="write_pipeline.promote[content-replace]")
 
             # Provenance: staging → .kittify/charter/provenance/<kind>-<slug>.yaml
             staged_prov = staging_dir.path_for_provenance(kind, slug)
-            live_prov = repo_root / ".kittify" / "charter" / "provenance" / f"{kind}-{slug}.yaml"
+            live_prov = (
+                repo_root
+                / _KITTIFY_DIRNAME
+                / _CHARTER_DIRNAME
+                / _PROVENANCE_DIRNAME
+                / f"{kind}-{slug}.yaml"
+            )
             guard.replace(staged_prov, live_prov, caller="write_pipeline.promote[prov-replace]")
 
             rel_content = str(live_content.relative_to(repo_root))
@@ -498,7 +515,7 @@ def promote(
         # Check for a staged DRG overlay graph and promote it
         staged_graph = staging_dir.root / "doctrine" / "graph.yaml"
         if staged_graph.exists():
-            live_graph = repo_root / ".kittify" / "doctrine" / "graph.yaml"
+            live_graph = repo_root / _KITTIFY_DIRNAME / _DOCTRINE_DIRNAME / "graph.yaml"
             guard.replace(staged_graph, live_graph, caller="write_pipeline.promote[graph-replace]")
 
     except Exception as exc:

--- a/src/doctrine/versioning.py
+++ b/src/doctrine/versioning.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
-from typing import Callable
 
 from ruamel.yaml import YAML
 
@@ -190,6 +190,7 @@ def get_bundle_schema_version(charter_dir: Path) -> int | None:
 
 # Maps from_version → migration_function
 _MIGRATIONS: dict[int, Callable[[Path, bool], MigrationResult]] = {}
+PRE_PHASE7_MIGRATION_SENTINEL = "(pre-phase7-migration)"
 
 
 def _register_migration(
@@ -257,17 +258,17 @@ def migrate_v1_to_v2(bundle_root: Path, dry_run: bool = False) -> MigrationResul
                 continue  # Already migrated — skip (idempotent).
 
             # Add missing v2 fields using sentinel values where needed.
-            data.setdefault("synthesizer_version", "(pre-phase7-migration)")
-            data.setdefault("synthesis_run_id", "(pre-phase7-migration)")
+            data.setdefault("synthesizer_version", PRE_PHASE7_MIGRATION_SENTINEL)
+            data.setdefault("synthesis_run_id", PRE_PHASE7_MIGRATION_SENTINEL)
 
             if "produced_at" not in data:
                 try:
                     mtime = sidecar_path.stat().st_mtime
                     data["produced_at"] = datetime.fromtimestamp(
-                        mtime, tz=timezone.utc
+                        mtime, tz=UTC
                     ).isoformat()
                 except OSError:
-                    data["produced_at"] = "(pre-phase7-migration)"
+                    data["produced_at"] = PRE_PHASE7_MIGRATION_SENTINEL
 
             if "source_input_ids" not in data:
                 data["source_input_ids"] = list(data.get("source_urns", []))
@@ -302,7 +303,7 @@ def migrate_v1_to_v2(bundle_root: Path, dry_run: bool = False) -> MigrationResul
             manifest_data = None
 
         if isinstance(manifest_data, dict) and manifest_data.get("schema_version") != "2":
-            manifest_data.setdefault("synthesizer_version", "(pre-phase7-migration)")
+            manifest_data.setdefault("synthesizer_version", PRE_PHASE7_MIGRATION_SENTINEL)
 
             # Compute manifest_hash over all fields except manifest_hash itself.
             fields_for_hash = {

--- a/src/specify_cli/agent_utils/status.py
+++ b/src/specify_cli/agent_utils/status.py
@@ -26,6 +26,12 @@ from specify_cli.task_utils import extract_scalar, split_frontmatter
 console = Console()
 
 
+def _review_cycle_number(path: Path) -> int:
+    """Return the numeric review-cycle suffix for sorting review artifacts."""
+    match = re.search(r"review-cycle-(\d+)\.md", path.name)
+    return int(match.group(1)) if match else 0
+
+
 def _get_wp_review_verdict(wp_dir: Path) -> str | None:
     """Return the verdict from the latest review-cycle-N.md in wp_dir, or None.
 
@@ -35,7 +41,7 @@ def _get_wp_review_verdict(wp_dir: Path) -> str | None:
     """
     cycles = sorted(
         wp_dir.glob("review-cycle-*.md"),
-        key=lambda p: int(m.group(1)) if (m := re.search(r"review-cycle-(\d+)\.md", p.name)) else 0,
+        key=_review_cycle_number,
     )
     if not cycles:
         return None

--- a/src/specify_cli/cli/commands/_auth_doctor.py
+++ b/src/specify_cli/cli/commands/_auth_doctor.py
@@ -680,9 +680,9 @@ def render_report(report: DoctorReport, console: Console, *, show_server_hint: b
         table.add_column("Package version")
         for orphan in report.orphans:
             table.add_row(
-                str(orphan.pid) if orphan.pid is not None else "(unknown)",
+                str(orphan.pid) if orphan.pid is not None else UNKNOWN_DISPLAY,
                 str(orphan.port),
-                orphan.package_version or "(unknown)",
+                orphan.package_version or UNKNOWN_DISPLAY,
             )
         console.print(table)
     console.print()
@@ -778,6 +778,9 @@ def _finding_to_dict(finding: Finding) -> dict[str, Any]:
     return payload
 
 
+UNKNOWN_DISPLAY = "(unknown)"
+
+
 # ---------------------------------------------------------------------------
 # Orchestration entry point (T027)
 # ---------------------------------------------------------------------------
@@ -867,7 +870,7 @@ def doctor_impl(
     if server and server_status is not None:
         console.print("[bold]Server Session[/bold]")
         if server_status.active:
-            sid = server_status.session_id or "(unknown)"
+            sid = server_status.session_id or UNKNOWN_DISPLAY
             console.print(f"  Status:  [green]active[/green] (session: {sid})")
         else:
             reason = server_status.error or "unknown"

--- a/src/specify_cli/cli/commands/_auth_logout.py
+++ b/src/specify_cli/cli/commands/_auth_logout.py
@@ -65,7 +65,7 @@ async def logout_impl(*, force: bool) -> None:
         # Try to revoke the refresh token server-side. Any failure is
         # reported to the user but does NOT block local cleanup below.
         try:
-            saas_url = get_saas_base_url()  # noqa: F841 — validates config
+            get_saas_base_url()
         except ConfigurationError as exc:
             console.print(
                 f"[yellow]! Cannot reach SaaS (config error): {exc}. "

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -114,6 +114,12 @@ _VALID_VERDICTS: frozenset[str] = frozenset(
 )
 
 
+def _review_cycle_number(path: Path) -> int:
+    """Return the numeric review-cycle suffix for sorting review artifacts."""
+    match = re.search(r"review-cycle-(\d+)\.md", path.name)
+    return int(match.group(1)) if match else 0
+
+
 def _get_latest_review_cycle_verdict(wp_dir: Path) -> tuple[str | None, Path | None]:
     """Return (verdict_value, artifact_path) for the latest review-cycle-N.md.
 
@@ -130,7 +136,7 @@ def _get_latest_review_cycle_verdict(wp_dir: Path) -> tuple[str | None, Path | N
     """
     cycles = sorted(
         wp_dir.glob("review-cycle-*.md"),
-        key=lambda p: int(m.group(1)) if (m := re.search(r"review-cycle-(\d+)\.md", p.name)) else 0,
+        key=_review_cycle_number,
     )
     if not cycles:
         return None, None

--- a/src/specify_cli/cli/commands/charter.py
+++ b/src/specify_cli/cli/commands/charter.py
@@ -26,6 +26,7 @@ from charter.sync import ensure_charter_bundle_fresh
 from doctrine.versioning import check_bundle_compatibility, get_bundle_schema_version
 
 logger = logging.getLogger(__name__)
+METADATA_FILENAME = "metadata.yaml"
 
 app = typer.Typer(
     name="charter",
@@ -133,7 +134,7 @@ def _collect_charter_sync_status(repo_root: Path) -> dict[str, Any]:
         )
         charter_path = _resolve_charter_path(canonical_root)
         output_dir = charter_path.parent
-        metadata_path = output_dir / "metadata.yaml"
+        metadata_path = output_dir / METADATA_FILENAME
 
         stale, current_hash, stored_hash = is_stale(charter_path, metadata_path)
 
@@ -141,7 +142,7 @@ def _collect_charter_sync_status(repo_root: Path) -> dict[str, Any]:
         for filename in [
             "governance.yaml",
             "directives.yaml",
-            "metadata.yaml",
+            METADATA_FILENAME,
             "references.yaml",
         ]:
             file_path = output_dir / filename
@@ -1539,7 +1540,7 @@ def status(  # noqa: C901
     try:
         repo_root = find_repo_root()
         charter_dir = repo_root / ".kittify" / "charter"
-        if (charter_dir / "metadata.yaml").exists():
+        if (charter_dir / METADATA_FILENAME).exists():
             _assert_bundle_compatible(charter_dir)
         payload = {
             "result": "success",
@@ -2739,7 +2740,7 @@ def charter_resynthesize(  # noqa: C901
     try:
         repo_root = find_repo_root()
         charter_dir = repo_root / ".kittify" / "charter"
-        if (charter_dir / "metadata.yaml").exists():
+        if (charter_dir / METADATA_FILENAME).exists():
             _assert_bundle_compatible(charter_dir)
         evidence_result = _collect_evidence_result(
             repo_root,

--- a/src/specify_cli/cli/commands/charter_bundle.py
+++ b/src/specify_cli/cli/commands/charter_bundle.py
@@ -42,6 +42,10 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+_KITTIFY_DIRNAME = ".kittify"
+_CHARTER_DIR = (_KITTIFY_DIRNAME, "charter")
+_PROVENANCE_DIR = (*_CHARTER_DIR, "provenance")
+
 
 @app.callback()
 def _bundle_callback() -> None:
@@ -84,7 +88,7 @@ def _enumerate_out_of_scope_files(
     ``references.yaml`` and ``context-state.json`` are preserved; all other
     undeclared files fall through to a generic warning.
     """
-    charter_dir = canonical_root / ".kittify" / "charter"
+    charter_dir = canonical_root.joinpath(*_CHARTER_DIR)
     if not charter_dir.is_dir():
         return [], []
 
@@ -259,7 +263,7 @@ def _collect_provenance_validation_errors(canonical_root: Path) -> list[str]:
     """Return provenance validation errors for sidecars and manifest references."""
     yaml_loader = _YAML(typ="safe")
     sidecar_errors: list[str] = []
-    provenance_dir = canonical_root / ".kittify" / "charter" / "provenance"
+    provenance_dir = canonical_root.joinpath(*_PROVENANCE_DIR)
 
     if provenance_dir.exists():
         for sidecar_path in sorted(provenance_dir.glob("*.yaml")):
@@ -278,7 +282,7 @@ def _collect_provenance_validation_errors(canonical_root: Path) -> list[str]:
             except ValidationError as e:
                 sidecar_errors.append(f"{sidecar_path.name}: {e}")
 
-    manifest_path = canonical_root / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    manifest_path = canonical_root.joinpath(*_CHARTER_DIR, "synthesis-manifest.yaml")
     if not manifest_path.exists():
         return sidecar_errors
 
@@ -336,7 +340,7 @@ def validate(
 
     # FR-009: Incompatible bundles fail validation, but --json still emits the
     # same parseable envelope as other public validation failures.
-    charter_dir = canonical_root / ".kittify" / "charter"
+    charter_dir = canonical_root.joinpath(*_CHARTER_DIR)
     compatibility_error: str | None = None
     if (charter_dir / "metadata.yaml").exists():
         compatibility_error = _bundle_compatibility_error(charter_dir)

--- a/src/specify_cli/cli/commands/charter_bundle.py
+++ b/src/specify_cli/cli/commands/charter_bundle.py
@@ -278,8 +278,8 @@ def _collect_provenance_validation_errors(canonical_root: Path) -> list[str]:
                 )
                 continue
             try:
-                ProvenanceEntry(**raw)
-            except ValidationError as e:
+                ProvenanceEntry.model_validate(raw)
+            except (TypeError, ValidationError) as e:
                 sidecar_errors.append(f"{sidecar_path.name}: {e}")
 
     manifest_path = canonical_root.joinpath(*_CHARTER_DIR, "synthesis-manifest.yaml")

--- a/src/specify_cli/cli/commands/review.py
+++ b/src/specify_cli/cli/commands/review.py
@@ -41,8 +41,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
 from typing import Annotated
 
 import typer
@@ -50,6 +49,8 @@ import typer
 from specify_cli.cli.selector_resolution import resolve_mission_handle
 from specify_cli.status.reducer import materialize
 from specify_cli.task_utils import TaskCliError, find_repo_root
+
+_IDENTIFIER_CHARCLASS = r"\w"
 
 
 def review_mission(
@@ -156,7 +157,7 @@ def review_mission(
                 current_file = line[6:]
             elif line.startswith("+") and not line.startswith("+++"):
                 m = re.match(
-                    r"^\+\s*(def|class)\s+([A-Za-z][A-Za-z0-9_]*)\s*[\(:]",
+                    rf"^\+\s*(def|class)\s+([A-Za-z]{_IDENTIFIER_CHARCLASS}*)\s*[\(:]",
                     line,
                 )
                 if m and not m.group(2).startswith("_"):
@@ -246,7 +247,7 @@ def review_mission(
     else:
         verdict = "pass"
 
-    reviewed_at = datetime.now(timezone.utc).isoformat()
+    reviewed_at = datetime.now(UTC).isoformat()
     report_lines = [
         "---",
         f"verdict: {verdict}",
@@ -280,9 +281,12 @@ def review_mission(
     # ------------------------------------------------------------------
     # Summary output
     # ------------------------------------------------------------------
-    verdict_color = (
-        "green" if verdict == "pass" else ("yellow" if verdict == "pass_with_notes" else "red")
-    )
+    if verdict == "pass":
+        verdict_color = "green"
+    elif verdict == "pass_with_notes":
+        verdict_color = "yellow"
+    else:
+        verdict_color = "red"
     console.print(
         f"\nVerdict: [{verdict_color}]{verdict}[/{verdict_color}]  ({len(findings)} finding(s))"
     )

--- a/tests/auth/test_auth_doctor_report.py
+++ b/tests/auth/test_auth_doctor_report.py
@@ -751,6 +751,44 @@ def test_doctor_impl_server_true_renders_active(
     assert exit_code == 0
 
 
+def test_doctor_impl_server_true_renders_unknown_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _make_session(
+        refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30)
+    )
+    _patch_state(monkeypatch, session=session)
+
+    fake_status = ServerSessionStatus(active=True, session_id=None)
+
+    import asyncio
+
+    def _fake_run(coro):  # type: ignore[no-untyped-def]
+        coro.close()
+        return fake_status
+
+    monkeypatch.setattr(asyncio, "run", _fake_run)
+
+    buf = io.StringIO()
+    monkeypatch.setattr(
+        _auth_doctor,
+        "console",
+        Console(file=buf, width=120, record=False, force_terminal=False),
+    )
+
+    exit_code = doctor_impl(
+        json_output=False,
+        reset=False,
+        unstick_lock=False,
+        stuck_threshold=60.0,
+        server=True,
+    )
+
+    output = buf.getvalue()
+    assert "(unknown)" in output
+    assert exit_code == 0
+
+
 def test_doctor_impl_server_true_renders_reauthenticate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/auth/test_auth_doctor_report.py
+++ b/tests/auth/test_auth_doctor_report.py
@@ -38,6 +38,8 @@ from specify_cli.cli.commands._auth_doctor import (
     render_report,
     render_report_json,
 )
+
+pytestmark = pytest.mark.fast
 from specify_cli.core.file_lock import LockRecord
 from specify_cli.sync.daemon import SyncDaemonStatus
 from specify_cli.sync.orphan_sweep import OrphanDaemon

--- a/tests/charter/test_bundle_validate_cli.py
+++ b/tests/charter/test_bundle_validate_cli.py
@@ -262,6 +262,24 @@ def test_validate_reports_out_of_scope_files_as_warnings(
     assert len(payload["warnings"]) >= 2
 
 
+def test_enumerate_out_of_scope_files_without_charter_dir_returns_empty(
+    tmp_path: Path,
+) -> None:
+    out_of_scope, warnings = charter_bundle._enumerate_out_of_scope_files(  # type: ignore[attr-defined]
+        tmp_path,
+        charter_bundle.CANONICAL_MANIFEST,
+    )
+    assert out_of_scope == []
+    assert warnings == []
+
+
+def test_collect_provenance_validation_errors_without_manifest_returns_empty(
+    tmp_path: Path,
+) -> None:
+    errors = charter_bundle._collect_provenance_validation_errors(tmp_path)  # type: ignore[attr-defined]
+    assert errors == []
+
+
 def test_validate_fails_on_missing_tracked_file(compliant_repo: Path) -> None:
     (compliant_repo / _TRACKED).unlink()
     result = _invoke_validate_json()
@@ -616,6 +634,20 @@ def test_validate_passes_complete_v2_bundle(compliant_repo: Path) -> None:
     assert ss["passed"] is True
     assert ss["errors"] == []
     assert payload["errors"] == []
+
+
+def test_validate_reports_provenance_yaml_parse_error(
+    compliant_repo: Path,
+) -> None:
+    sidecar = compliant_repo / ".kittify" / "charter" / "provenance" / "broken.yaml"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(":\n", encoding="utf-8")
+
+    result = runner.invoke(charter_bundle.app, ["validate", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert any("broken.yaml" in error for error in payload["errors"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/commands/test_auth_logout.py
+++ b/tests/cli/commands/test_auth_logout.py
@@ -31,6 +31,8 @@ from specify_cli.auth.flows.revoke import RevokeOutcome
 from specify_cli.auth.session import StoredSession, Team
 from specify_cli.cli.commands.auth import app
 
+pytestmark = pytest.mark.fast
+
 
 runner = CliRunner()
 

--- a/tests/doctrine/test_versioning.py
+++ b/tests/doctrine/test_versioning.py
@@ -19,6 +19,51 @@ from doctrine.versioning import (
 )
 
 
+def _write_v1_bundle(bundle_root: Path) -> Path:
+    provenance_dir = bundle_root / "provenance"
+    provenance_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_root / "metadata.yaml").write_text(
+        "timestamp_utc: 2026-01-01T00:00:00Z\n",
+        encoding="utf-8",
+    )
+    (provenance_dir / "directive-use-prs.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: '1'",
+                "artifact_urn: drg:directive:directive-use-prs",
+                "artifact_kind: directive",
+                "artifact_slug: directive-use-prs",
+                f"artifact_content_hash: {'a' * 64}",
+                f"inputs_hash: {'b' * 64}",
+                "adapter_id: fixture",
+                "adapter_version: 1.0.0",
+                "generated_at: '2026-01-01T00:00:00Z'",
+                "source_section: review_policy",
+                "source_urns:",
+                "  - drg:directive:DIR-001",
+                "corpus_snapshot_id: null",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (bundle_root / "synthesis-manifest.yaml").write_text(
+        "\n".join(
+            [
+                "schema_version: '1'",
+                "created_at: '2026-01-01T00:00:00Z'",
+                "run_id: '01TEST000000000000000000001'",
+                "adapter_id: fixture",
+                "adapter_version: 1.0.0",
+                "artifacts: []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return provenance_dir / "directive-use-prs.yaml"
+
+
 # ---------------------------------------------------------------------------
 # Constants sanity check
 # ---------------------------------------------------------------------------
@@ -268,6 +313,44 @@ def test_run_migration_v1_returns_migration_result(tmp_path: Path) -> None:
     assert result.to_version == 2
     assert result.errors == []
     assert any("metadata.yaml" in change for change in result.changes_made)
+
+
+def test_run_migration_v1_backfills_manifest_and_sidecar_fields(tmp_path: Path) -> None:
+    _write_v1_bundle(tmp_path)
+
+    result = run_migration(1, tmp_path)
+
+    assert result.errors == []
+    manifest = (tmp_path / "synthesis-manifest.yaml").read_text(encoding="utf-8")
+    sidecar = (tmp_path / "provenance" / "directive-use-prs.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "synthesizer_version: (pre-phase7-migration)" in manifest
+    assert "synthesizer_version: (pre-phase7-migration)" in sidecar
+    assert "synthesis_run_id: (pre-phase7-migration)" in sidecar
+    assert "source_input_ids:" in sidecar
+
+
+def test_run_migration_v1_uses_sentinel_when_sidecar_stat_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_sidecar = _write_v1_bundle(tmp_path)
+    original_stat = Path.stat
+
+    def _patched_stat(path: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if path == target_sidecar:
+            raise OSError("stat blocked for test")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _patched_stat)
+
+    result = run_migration(1, tmp_path)
+
+    assert result.errors == []
+    sidecar = (tmp_path / "provenance" / "directive-use-prs.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "produced_at: (pre-phase7-migration)" in sidecar
 
 
 # ---------------------------------------------------------------------------

--- a/tests/doctrine/test_versioning.py
+++ b/tests/doctrine/test_versioning.py
@@ -18,6 +18,8 @@ from doctrine.versioning import (
     run_migration,
 )
 
+pytestmark = pytest.mark.fast
+
 
 def _write_v1_bundle(bundle_root: Path) -> Path:
     provenance_dir = bundle_root / "provenance"

--- a/tests/specify_cli/cli/commands/test_charter_resynthesize.py
+++ b/tests/specify_cli/cli/commands/test_charter_resynthesize.py
@@ -1,0 +1,146 @@
+"""Targeted CLI coverage for ``spec-kitty charter resynthesize``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import charter as charter_module
+from specify_cli.cli.commands.charter import app as charter_app
+
+
+runner = CliRunner()
+
+
+@dataclass
+class _EvidenceResult:
+    bundle: object
+    warnings: list[str]
+
+
+def test_resynthesize_list_topics_checks_bundle_compatibility(
+    tmp_path: Path, monkeypatch
+) -> None:
+    charter_dir = tmp_path / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True, exist_ok=True)
+    (charter_dir / "metadata.yaml").write_text(
+        "bundle_schema_version: 2\n", encoding="utf-8"
+    )
+
+    compatibility_calls: list[Path] = []
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter.find_repo_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._assert_bundle_compatible",
+        lambda path: compatibility_calls.append(path),
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._collect_evidence_result",
+        lambda *args, **kwargs: _EvidenceResult(bundle={"bundle": True}, warnings=[]),
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._build_synthesis_request",
+        lambda *args, **kwargs: ({"request": True}, object()),
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._list_resynthesis_topics",
+        lambda *args, **kwargs: {"directive": ["directive:PROJECT_001"]},
+    )
+
+    result = runner.invoke(charter_app, ["resynthesize", "--list-topics", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert compatibility_calls == [charter_dir]
+    assert '"directive:PROJECT_001"' in result.output
+
+
+def test_status_list_checks_bundle_compatibility(
+    tmp_path: Path, monkeypatch
+) -> None:
+    charter_dir = tmp_path / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True, exist_ok=True)
+    (charter_dir / "metadata.yaml").write_text(
+        "bundle_schema_version: 2\n", encoding="utf-8"
+    )
+
+    compatibility_calls: list[Path] = []
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter.find_repo_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._assert_bundle_compatible",
+        lambda path: compatibility_calls.append(path),
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._collect_charter_sync_status",
+        lambda repo_root: {"repo_root": str(repo_root)},
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.charter._collect_synthesis_status",
+        lambda repo_root, include_provenance=False: {"present": False},
+    )
+
+    result = runner.invoke(charter_app, ["status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert compatibility_calls == [charter_dir]
+
+
+def test_collect_charter_sync_status_passes_metadata_path_to_stale_check(
+    tmp_path: Path, monkeypatch
+) -> None:
+    charter_dir = tmp_path / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True, exist_ok=True)
+    (charter_dir / "charter.md").write_text("# Charter\n", encoding="utf-8")
+    (charter_dir / "governance.yaml").write_text("governance: true\n", encoding="utf-8")
+    (charter_dir / "directives.yaml").write_text("directives: []\n", encoding="utf-8")
+    metadata_path = charter_dir / "metadata.yaml"
+    metadata_path.write_text("bundle_schema_version: 2\n", encoding="utf-8")
+
+    seen_metadata_paths: list[Path] = []
+
+    monkeypatch.setattr(
+        charter_module,
+        "ensure_charter_bundle_fresh",
+        lambda repo_root: SimpleNamespace(canonical_root=tmp_path),
+    )
+    monkeypatch.setattr(
+        "charter.hasher.is_stale",
+        lambda charter_path, path: (
+            seen_metadata_paths.append(path) or False,
+            "current",
+            "stored",
+        ),
+    )
+
+    from specify_cli.glossary import entity_pages as entity_pages_module
+
+    class _FakeRenderer:
+        def __init__(self, repo_root: Path) -> None:
+            self.repo_root = repo_root
+
+        def generate_all(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        entity_pages_module,
+        "GlossaryEntityPageRenderer",
+        _FakeRenderer,
+    )
+    monkeypatch.setattr(
+        "ruamel.yaml.YAML.load",
+        lambda self, text: {"timestamp_utc": "2026-01-01T00:00:00Z"},
+    )
+
+    status = charter_module._collect_charter_sync_status(tmp_path)
+
+    assert seen_metadata_paths == [metadata_path]
+    assert status["charter_path"] == ".kittify/charter/charter.md"

--- a/tests/specify_cli/cli/commands/test_charter_resynthesize.py
+++ b/tests/specify_cli/cli/commands/test_charter_resynthesize.py
@@ -6,10 +6,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands import charter as charter_module
 from specify_cli.cli.commands.charter import app as charter_app
+
+pytestmark = pytest.mark.fast
 
 
 runner = CliRunner()

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -266,3 +266,50 @@ def _make_mock_resolved(feature_dir: Path) -> object:
         feature_dir=feature_dir,
         mid8=_MISSION_ID[:8],
     )
+
+
+def test_review_passes_with_notes_when_dead_code_scan_finds_symbol(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root, feature_dir = _setup_fixture(
+        tmp_path,
+        {"WP01": "done"},
+        baseline_merge_commit="abc123",
+    )
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+    _mock_resolved = _make_mock_resolved(feature_dir)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.resolve_mission_handle",
+        lambda handle, repo_root: _mock_resolved,
+    )
+
+    from types import SimpleNamespace
+
+    def _fake_run(cmd, cwd=None, capture_output=False, text=False):  # type: ignore[no-untyped-def]
+        if cmd[:2] == ["git", "diff"]:
+            return SimpleNamespace(
+                stdout="+++ b/src/pkg/example.py\n+def PublicSymbol():\n",
+                returncode=0,
+            )
+        if cmd[:3] == ["grep", "-r", "--include=*.py"]:
+            return SimpleNamespace(stdout="", returncode=1)
+        if cmd[:2] == ["grep", "-rn"]:
+            return SimpleNamespace(stdout="", returncode=1)
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("specify_cli.cli.commands.review.subprocess.run", _fake_run)
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG])
+
+    assert result.exit_code == 0, result.output
+    report_path = feature_dir / "mission-review-report.md"
+    content = report_path.read_text(encoding="utf-8")
+    assert "verdict: pass_with_notes" in content
+    assert "dead_code" in content


### PR DESCRIPTION
## Summary
- replace walrus-in-argument-list sorting helpers in agent status/task review-cycle scanners
- remove unused locals and centralize repeated Sonar-flagged literals in auth, charter, write-pipeline, and versioning code
- simplify review command regex/color handling without changing behavior

## Validation
- `pytest tests/cli/commands/test_auth_logout.py tests/auth/test_auth_doctor_report.py tests/auth/test_auth_doctor_offline.py tests/agent/test_agent_utils_status.py tests/specify_cli/agent_utils/test_status.py tests/specify_cli/cli/commands/agent/test_tasks.py tests/specify_cli/cli/commands/test_charter.py tests/charter/test_bundle_validate_cli.py tests/doctrine/test_versioning.py tests/charter/synthesizer/test_write_pipeline.py tests/specify_cli/cli/commands/test_review.py -q`

## Notes
- GitHub code-scanning alerts: none open.
- Dependabot alert `GHSA-58qw-9mgm-455v` for transitive `pip` remains non-actionable because GitHub still reports `first_patched_version: null`.
- SonarCloud quality gate on `main` is currently failing on `new_coverage` and `new_security_hotspots_reviewed`; the security-hotspot portion is review-state in SonarCloud, not something this PR can change in code.
- I also checked the `next` test slice locally. Those failures reproduced independently of this diff in this fresh `/tmp` clone, including a readonly sync-queue DB path in `tests/next/test_next_command_integration.py`.
