### PR TITLE
Fix idempotent implementation start lifecycle

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -3014,7 +3014,7 @@ def status(
 
         # Rich table output
         # Group by lane
-        by_lane = {Lane.PLANNED: [], Lane.IN_PROGRESS: [], Lane.IN_REVIEW: [], Lane.FOR_REVIEW: [], Lane.APPROVED: [], Lane.DONE: []}
+        by_lane = {lane: [] for lane in Lane}
         for wp in work_packages:
             lane = wp["lane"]
             if lane in by_lane:
@@ -3053,7 +3053,7 @@ def status(
         # Calculate metrics
         total = len(work_packages)
         done_count = len(by_lane[Lane.DONE])
-        in_progress = len(by_lane[Lane.IN_PROGRESS]) + len(by_lane[Lane.IN_REVIEW]) + len(by_lane[Lane.FOR_REVIEW])
+        in_progress = len(by_lane[Lane.CLAIMED]) + len(by_lane[Lane.IN_PROGRESS]) + len(by_lane[Lane.IN_REVIEW]) + len(by_lane[Lane.FOR_REVIEW])
         planned_count = len(by_lane[Lane.PLANNED])
         progress_pct = round(compute_weighted_progress(_st_snapshot).percentage, 1) if _st_snapshot else 0
 
@@ -3081,8 +3081,12 @@ def status(
         console.print()
 
         # Kanban board table
-        # Fold in_review WPs into the "Doing" column with a review marker
-        display_in_progress = list(by_lane[Lane.IN_PROGRESS])
+        # Fold claimed and in_review WPs into the "Doing" column with markers.
+        display_in_progress = []
+        for wp in by_lane[Lane.CLAIMED]:
+            wp["_display_claimed"] = True
+            display_in_progress.append(wp)
+        display_in_progress.extend(by_lane[Lane.IN_PROGRESS])
         for wp in by_lane.get(Lane.IN_REVIEW, []):
             wp["_display_in_review"] = True
             display_in_progress.append(wp)
@@ -3122,6 +3126,8 @@ def status(
                         cell = f"[red]⚠️ {display_id}[/red]\n{title_truncated}"
                     elif wp.get("_stall_label"):
                         cell = f"[yellow]⚠ {display_id} (review)[/yellow]\n{title_truncated}"
+                    elif wp.get("_display_claimed"):
+                        cell = f"[blue]{display_id} (claimed)[/blue]\n{title_truncated}"
                     elif wp.get("_display_in_review"):
                         cell = f"[bright_cyan]{display_id} (review)[/bright_cyan]\n{title_truncated}"
                     else:
@@ -3134,7 +3140,7 @@ def status(
         # Add count row
         table.add_row(
             f"[bold]{len(by_lane[Lane.PLANNED])} WPs[/bold]",
-            f"[bold]{len(by_lane[Lane.IN_PROGRESS])} WPs[/bold]",
+            f"[bold]{len(display_in_progress)} WPs[/bold]",
             f"[bold]{len(by_lane[Lane.FOR_REVIEW])} WPs[/bold]",
             f"[bold]{len(by_lane[Lane.APPROVED])} WPs[/bold]",
             f"[bold]{len(by_lane[Lane.DONE])} WPs[/bold]",
@@ -3195,6 +3201,14 @@ def status(
                     f"  • {marker}{wp['id']} - {wp['title']}"
                     "  [bold yellow]⚠ review artifact: verdict=rejected[/bold yellow]"
                 )
+            console.print()
+
+        if by_lane[Lane.CLAIMED]:
+            console.print("[bold blue]🔄 Claimed (shown in Doing column):[/bold blue]")
+            for wp in by_lane[Lane.CLAIMED]:
+                marker = _get_hic_marker(wp.get("agent_profile"), main_repo_root, repo=profile_repo)
+                agent = wp.get("agent", "unknown")
+                console.print(f"  • {marker}{wp['id']} - {wp['title']} [dim](agent: {agent})[/dim]")
             console.print()
 
         if by_lane[Lane.IN_PROGRESS]:

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -53,6 +53,7 @@ from specify_cli.core.paths import get_main_repo_root, is_worktree_context, loca
 from specify_cli.core.utils import write_text_within_directory
 from specify_cli.git import safe_commit
 from specify_cli.mission import get_deliverables_path, get_mission_type
+from specify_cli.status.locking import feature_status_lock
 from specify_cli.status.models import AgentAssignment, Lane
 from specify_cli.status.work_package_lifecycle import (
     WorkPackageClaimConflict,
@@ -1455,53 +1456,54 @@ def review(
             # Capture current shell PID
             shell_pid = str(os.getppid())  # Parent process ID (the shell running this command)
 
-            try:
-                start_review_status(
-                    feature_dir=feature_dir,
-                    mission_slug=mission_slug,
-                    wp_id=normalized_wp_id,
-                    actor=agent,
-                    review_ref="action-review-claim",
-                    workspace_context=f"action-review:{main_repo_root}",
-                    execution_mode=status_execution_mode,
-                    repo_root=main_repo_root,
+            with feature_status_lock(main_repo_root, mission_slug):
+                try:
+                    start_review_status(
+                        feature_dir=feature_dir,
+                        mission_slug=mission_slug,
+                        wp_id=normalized_wp_id,
+                        actor=agent,
+                        review_ref="action-review-claim",
+                        workspace_context=f"action-review:{main_repo_root}",
+                        execution_mode=status_execution_mode,
+                        repo_root=main_repo_root,
+                    )
+                except WorkPackageClaimConflict as exc:
+                    print(f"Error: {exc}")
+                    raise typer.Exit(1) from exc
+                except WorkPackageStartRejected as exc:
+                    print(f"Error: {exc}")
+                    raise typer.Exit(1) from exc
+
+                # Post-emit: apply operational metadata fields to WP file (lane is event-log-only)
+                wp_content = wp.path.read_text(encoding="utf-8-sig")
+                updated_front, updated_body, updated_padding = split_frontmatter(wp_content)
+                updated_front = set_scalar(updated_front, "agent", agent)
+                updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
+
+                # Build history entry (no lane= segment; event log is sole lane authority)
+                timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+                history_entry = f"- {timestamp} – {agent} – shell_pid={shell_pid} – Started review via action command"
+
+                # Add history entry to body
+                updated_body = append_activity_log(updated_body, history_entry)
+
+                # Build and write updated document
+                updated_doc = build_document(updated_front, updated_body, updated_padding)
+                write_text_within_directory(wp.path, updated_doc, root=main_repo_root, encoding="utf-8")
+
+                # Atomic commit: WP file + all status artifacts (#211, #212)
+                actual_wp_path = wp.path.resolve()
+                status_artifacts = _collect_status_artifacts(feature_dir)
+                commit_success = safe_commit(
+                    repo_path=main_repo_root,
+                    files_to_commit=[actual_wp_path] + status_artifacts,
+                    commit_message=f"chore: Start {normalized_wp_id} review [{agent}]",
+                    allow_empty=True,  # OK if already in this state
                 )
-            except WorkPackageClaimConflict as exc:
-                print(f"Error: {exc}")
-                raise typer.Exit(1) from exc
-            except WorkPackageStartRejected as exc:
-                print(f"Error: {exc}")
-                raise typer.Exit(1) from exc
-
-            # Post-emit: apply operational metadata fields to WP file (lane is event-log-only)
-            wp_content = wp.path.read_text(encoding="utf-8-sig")
-            updated_front, updated_body, updated_padding = split_frontmatter(wp_content)
-            updated_front = set_scalar(updated_front, "agent", agent)
-            updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
-
-            # Build history entry (no lane= segment; event log is sole lane authority)
-            timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-            history_entry = f"- {timestamp} – {agent} – shell_pid={shell_pid} – Started review via action command"
-
-            # Add history entry to body
-            updated_body = append_activity_log(updated_body, history_entry)
-
-            # Build and write updated document
-            updated_doc = build_document(updated_front, updated_body, updated_padding)
-            write_text_within_directory(wp.path, updated_doc, root=main_repo_root, encoding="utf-8")
-
-            # Atomic commit: WP file + all status artifacts (#211, #212)
-            actual_wp_path = wp.path.resolve()
-            status_artifacts = _collect_status_artifacts(feature_dir)
-            commit_success = safe_commit(
-                repo_path=main_repo_root,
-                files_to_commit=[actual_wp_path] + status_artifacts,
-                commit_message=f"chore: Start {normalized_wp_id} review [{agent}]",
-                allow_empty=True,  # OK if already in this state
-            )
-            if not commit_success:
-                print(f"Error: Failed to commit workflow status update for {normalized_wp_id}. Review claim aborted.")
-                raise typer.Exit(1)
+                if not commit_success:
+                    print(f"Error: Failed to commit workflow status update for {normalized_wp_id}. Review claim aborted.")
+                    raise typer.Exit(1)
 
             print(f"✓ Claimed {normalized_wp_id} for review (agent: {agent}, PID: {shell_pid}, target: {target_branch})")
 

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -53,9 +53,13 @@ from specify_cli.core.paths import get_main_repo_root, is_worktree_context, loca
 from specify_cli.core.utils import write_text_within_directory
 from specify_cli.git import safe_commit
 from specify_cli.mission import get_deliverables_path, get_mission_type
-from specify_cli.status.emit import emit_status_transition
-from specify_cli.status.locking import feature_status_lock
-from specify_cli.status.models import AgentAssignment, Lane, TransitionRequest
+from specify_cli.status.models import AgentAssignment, Lane
+from specify_cli.status.work_package_lifecycle import (
+    WorkPackageClaimConflict,
+    WorkPackageStartRejected,
+    start_implementation_status,
+    start_review_status,
+)
 from specify_cli.status.wp_metadata import read_wp_frontmatter
 from specify_cli.task_utils import (
     append_activity_log,
@@ -628,6 +632,7 @@ def implement(
                     json_output=False,
                     recover=False,
                     acknowledge_not_bulk_edit=acknowledge_not_bulk_edit,
+                    actor=agent,
                 )
             except typer.Exit:
                 # Worktree creation failed - propagate error
@@ -687,7 +692,7 @@ def implement(
             print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
             raise typer.Exit(1)
 
-        if current_lane != Lane.IN_PROGRESS or needs_agent_assignment:
+        if current_lane != Lane.IN_PROGRESS or needs_agent_assignment or agent:
             # Require --agent parameter to track who is working
             if not agent:
                 if current_lane == Lane.IN_PROGRESS and not needs_agent_assignment:
@@ -702,7 +707,7 @@ def implement(
                     print("This tracks WHO is working on the WP (prevents abandoned tasks).")
                     raise typer.Exit(1)
 
-            from datetime import datetime, timezone
+            from datetime import datetime
             import os
 
             review_workspace = resolve_workspace_for_wp(main_repo_root, mission_slug, normalized_wp_id)
@@ -711,57 +716,25 @@ def implement(
             # Capture current shell PID
             shell_pid = str(os.getppid())  # Parent process ID (the shell running this command)
 
-            # Emit status events (canonical lane authority)
-            # Must follow allowed transitions: planned→claimed→in_progress
             try:
-                from specify_cli.status.emit import emit_status_transition
-                from specify_cli.status.models import TransitionRequest
-
                 _impl_feature_dir = main_repo_root / "kitty-specs" / mission_slug
                 _actor = agent or "unknown"
-
-                if current_lane == Lane.PLANNED or current_lane == Lane.CANCELED:
-                    # Two-step: planned→claimed, claimed→in_progress
-                    emit_status_transition(TransitionRequest(
-                        feature_dir=_impl_feature_dir,
-                        mission_slug=mission_slug,
-                        wp_id=normalized_wp_id,
-                        to_lane=Lane.CLAIMED,
-                        actor=_actor,
-                        execution_mode=status_execution_mode,
-                    ))
-                    emit_status_transition(TransitionRequest(
-                        feature_dir=_impl_feature_dir,
-                        mission_slug=mission_slug,
-                        wp_id=normalized_wp_id,
-                        to_lane=Lane.IN_PROGRESS,
-                        actor=_actor,
-                        execution_mode=status_execution_mode,
-                    ))
-                elif current_lane == Lane.CLAIMED:
-                    emit_status_transition(TransitionRequest(
-                        feature_dir=_impl_feature_dir,
-                        mission_slug=mission_slug,
-                        wp_id=normalized_wp_id,
-                        to_lane=Lane.IN_PROGRESS,
-                        actor=_actor,
-                        execution_mode=status_execution_mode,
-                    ))
-                elif current_lane in (Lane.FOR_REVIEW, Lane.APPROVED):
-                    # Re-implementing after review — force back to in_progress
-                    emit_status_transition(TransitionRequest(
-                        feature_dir=_impl_feature_dir,
-                        mission_slug=mission_slug,
-                        wp_id=normalized_wp_id,
-                        to_lane=Lane.IN_PROGRESS,
-                        actor=_actor,
-                        force=True,
-                        reason="Re-implementing after review feedback",
-                        execution_mode=status_execution_mode,
-                    ))
-                # If already in_progress, no event needed
-            except Exception as _evt_err:
-                logger.warning("Could not emit status event: %s", _evt_err)
+                start_implementation_status(
+                    feature_dir=_impl_feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=normalized_wp_id,
+                    actor=_actor,
+                    workspace_context=f"{status_execution_mode}:{workspace_path}",
+                    execution_mode=status_execution_mode,
+                    repo_root=main_repo_root,
+                    allow_rework=current_lane in {Lane.FOR_REVIEW, Lane.APPROVED, Lane.IN_REVIEW},
+                )
+            except WorkPackageClaimConflict as exc:
+                print(f"Error: {exc}")
+                raise typer.Exit(1) from exc
+            except WorkPackageStartRejected as exc:
+                print(f"Error: {exc}")
+                raise typer.Exit(1) from exc
 
             # Update operational metadata in frontmatter (NO lane — event log is sole authority)
             updated_front = wp.frontmatter
@@ -1465,7 +1438,7 @@ def review(
                 for _w in _diff_result.warnings:
                     _rich_console.print(f"[yellow]manual_review:[/] {_w}")
 
-        if current_lane not in {Lane.IN_PROGRESS, Lane.IN_REVIEW}:
+        if current_lane == Lane.FOR_REVIEW or (current_lane == Lane.IN_REVIEW and agent):
             # Require --agent parameter to track who is reviewing
             if not agent:
                 print("Error: --agent parameter required when starting review.")
@@ -1476,56 +1449,59 @@ def review(
                 print("This tracks WHO is reviewing the WP (prevents abandoned reviews).")
                 raise typer.Exit(1)
 
-            from datetime import datetime, timezone
+            from datetime import datetime
             import os
 
             # Capture current shell PID
             shell_pid = str(os.getppid())  # Parent process ID (the shell running this command)
 
-            with feature_status_lock(main_repo_root, mission_slug):
-                # Emit the actual for_review -> in_review transition
-                emit_status_transition(TransitionRequest(
+            try:
+                start_review_status(
                     feature_dir=feature_dir,
                     mission_slug=mission_slug,
                     wp_id=normalized_wp_id,
-                    to_lane=Lane.IN_REVIEW,
                     actor=agent,
-                    reason="Started review via action command",
                     review_ref="action-review-claim",
                     workspace_context=f"action-review:{main_repo_root}",
                     execution_mode=status_execution_mode,
                     repo_root=main_repo_root,
-                ))
-
-                # Post-emit: apply operational metadata fields to WP file (lane is event-log-only)
-                wp_content = wp.path.read_text(encoding="utf-8-sig")
-                updated_front, updated_body, updated_padding = split_frontmatter(wp_content)
-                updated_front = set_scalar(updated_front, "agent", agent)
-                updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
-
-                # Build history entry (no lane= segment; event log is sole lane authority)
-                timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-                history_entry = f"- {timestamp} – {agent} – shell_pid={shell_pid} – Started review via action command"
-
-                # Add history entry to body
-                updated_body = append_activity_log(updated_body, history_entry)
-
-                # Build and write updated document
-                updated_doc = build_document(updated_front, updated_body, updated_padding)
-                write_text_within_directory(wp.path, updated_doc, root=main_repo_root, encoding="utf-8")
-
-                # Atomic commit: WP file + all status artifacts (#211, #212)
-                actual_wp_path = wp.path.resolve()
-                status_artifacts = _collect_status_artifacts(feature_dir)
-                commit_success = safe_commit(
-                    repo_path=main_repo_root,
-                    files_to_commit=[actual_wp_path] + status_artifacts,
-                    commit_message=f"chore: Start {normalized_wp_id} review [{agent}]",
-                    allow_empty=True,  # OK if already in this state
                 )
-                if not commit_success:
-                    print(f"Error: Failed to commit workflow status update for {normalized_wp_id}. Review claim aborted.")
-                    raise typer.Exit(1)
+            except WorkPackageClaimConflict as exc:
+                print(f"Error: {exc}")
+                raise typer.Exit(1) from exc
+            except WorkPackageStartRejected as exc:
+                print(f"Error: {exc}")
+                raise typer.Exit(1) from exc
+
+            # Post-emit: apply operational metadata fields to WP file (lane is event-log-only)
+            wp_content = wp.path.read_text(encoding="utf-8-sig")
+            updated_front, updated_body, updated_padding = split_frontmatter(wp_content)
+            updated_front = set_scalar(updated_front, "agent", agent)
+            updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
+
+            # Build history entry (no lane= segment; event log is sole lane authority)
+            timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            history_entry = f"- {timestamp} – {agent} – shell_pid={shell_pid} – Started review via action command"
+
+            # Add history entry to body
+            updated_body = append_activity_log(updated_body, history_entry)
+
+            # Build and write updated document
+            updated_doc = build_document(updated_front, updated_body, updated_padding)
+            write_text_within_directory(wp.path, updated_doc, root=main_repo_root, encoding="utf-8")
+
+            # Atomic commit: WP file + all status artifacts (#211, #212)
+            actual_wp_path = wp.path.resolve()
+            status_artifacts = _collect_status_artifacts(feature_dir)
+            commit_success = safe_commit(
+                repo_path=main_repo_root,
+                files_to_commit=[actual_wp_path] + status_artifacts,
+                commit_message=f"chore: Start {normalized_wp_id} review [{agent}]",
+                allow_empty=True,  # OK if already in this state
+            )
+            if not commit_success:
+                print(f"Error: Failed to commit workflow status update for {normalized_wp_id}. Review claim aborted.")
+                raise typer.Exit(1)
 
             print(f"✓ Claimed {normalized_wp_id} for review (agent: {agent}, PID: {shell_pid}, target: {target_branch})")
 

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -25,8 +25,9 @@ from specify_cli.frontmatter import FrontmatterError, update_fields
 from specify_cli.git import safe_commit
 from specify_cli.lanes.implement_support import create_lane_workspace
 from specify_cli.lanes.persistence import CorruptLanesError, MissingLanesError, require_lanes_json
-from specify_cli.status.emit import emit_status_transition
+from specify_cli.status.emit import TransitionError, emit_status_transition
 from specify_cli.status.models import Lane, TransitionRequest
+from specify_cli.status.work_package_lifecycle import WorkPackageClaimConflict, start_implementation_status
 from specify_cli.task_utils import TaskCliError, find_repo_root
 from specify_cli.workspace.context import resolve_workspace_for_wp
 from specify_cli.cli.commands.agent.tasks import _collect_status_artifacts
@@ -414,6 +415,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
             help="Suppress the bulk-edit inference warning when spec language resembles a bulk edit but the mission is not one.",
         ),
     ] = False,
+    actor: Annotated[str | None, typer.Option("--actor", hidden=True, help="Actor identity for programmatic callers")] = None,
 ) -> None:
     """Internal — allocate or reuse the lane worktree for a work package.
 
@@ -518,45 +520,13 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         raise typer.Exit(1) from exc
 
     tracker.start("create")
-    # WP03/T015/FR-014: emit `planned -> claimed -> in_progress` BEFORE
-    # any worktree allocation that could fail. If the allocator raises,
-    # we emit `in_progress -> blocked` with reason=worktree_alloc_failed
-    # so the WP never appears inactive when it actually started.
-    import os as _os
-    pre_alloc_status_emitted = False
+    effective_actor = actor or "implement-command"
+    status_result = None
+    status_execution_mode = "direct_repo" if resolved_workspace.resolution_kind == "repo_root" else "worktree"
     try:
-        current_lane = _get_wp_lane_from_event_log(feature_dir, wp_id)
-        if current_lane == Lane.PLANNED:
-            shell_pid_pre = str(_os.getppid())
-            status_execution_mode_pre = "direct_repo" if resolved_workspace.resolution_kind == "repo_root" else "worktree"
-            update_fields(wp_file, {"shell_pid": shell_pid_pre})
+        import os as _os
 
-            emit_status_transition(TransitionRequest(
-                feature_dir=feature_dir,
-                mission_slug=mission_slug,
-                wp_id=wp_id,
-                to_lane=Lane.CLAIMED,
-                actor="implement-command",
-                execution_mode=status_execution_mode_pre,
-                repo_root=repo_root,
-            ))
-            emit_status_transition(TransitionRequest(
-                feature_dir=feature_dir,
-                mission_slug=mission_slug,
-                wp_id=wp_id,
-                to_lane=Lane.IN_PROGRESS,
-                actor="implement-command",
-                execution_mode=status_execution_mode_pre,
-                repo_root=repo_root,
-            ))
-            pre_alloc_status_emitted = True
-    except Exception as _emit_exc:
-        # If the pre-alloc emit itself fails, surface but do not block
-        # alloc — the prior code already tolerated emit failures further
-        # downstream.
-        console.print(f"[yellow]Warning:[/yellow] Could not emit pre-alloc status transition: {_emit_exc}")
-
-    try:
+        update_fields(wp_file, {"shell_pid": str(_os.getppid())})
         vcs_backend = _ensure_vcs_in_meta(feature_dir, repo_root)
 
         # When --base is provided, validate the ref and build a patched
@@ -586,6 +556,24 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         )
         workspace_path = result.workspace_path
         branch_name = result.branch_name
+        status_execution_mode = result.execution_mode if isinstance(result.execution_mode, str) else status_execution_mode
+
+        try:
+            status_result = start_implementation_status(
+                feature_dir=feature_dir,
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                actor=effective_actor,
+                workspace_context=f"{status_execution_mode}:{workspace_path}",
+                execution_mode=status_execution_mode,
+                repo_root=repo_root,
+            )
+        except WorkPackageClaimConflict as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1) from exc
+        except TransitionError as exc:
+            console.print(f"[red]Error:[/red] Could not start implementation status: {exc}")
+            raise typer.Exit(1) from exc
 
         if result.lane_id is None:
             tracker.complete("create", f"Repository root: {workspace_path.relative_to(repo_root)}")
@@ -607,17 +595,16 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         tracker.error("create", f"workspace allocation failed: {exc}")
         console.print(tracker.render())
         console.print(f"\n[red]Error:[/red] Workspace allocation failed: {exc}")
-        # WP03/T015/FR-014: emit `in_progress -> blocked` so the WP does
-        # not look inactive after a worktree allocation failure.
-        if pre_alloc_status_emitted:
+        current_lane = _get_wp_lane_from_event_log(feature_dir, wp_id)
+        if current_lane in {Lane.PLANNED, Lane.CLAIMED, Lane.IN_PROGRESS}:
             try:
                 emit_status_transition(TransitionRequest(
                     feature_dir=feature_dir,
                     mission_slug=mission_slug,
                     wp_id=wp_id,
                     to_lane=Lane.BLOCKED,
-                    actor="implement-command",
-                    execution_mode="worktree",
+                    actor=effective_actor,
+                    execution_mode=status_execution_mode,
                     reason="worktree_alloc_failed",
                     policy_metadata={"evidence": str(exc)},
                     repo_root=repo_root,
@@ -629,7 +616,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         raise typer.Exit(1) from exc
 
     try:
-        if pre_alloc_status_emitted:
+        if status_result is not None and status_result.status_changed:
             commit_msg = f"chore: {wp_id} claimed for implementation"
             if auto_commit:
                 meta_file = feature_dir / "meta.json"

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -23,7 +23,7 @@ from specify_cli.text_sanitization import sanitize_file
 # distinguishes it from ``for_review`` (both have display_category "Review").
 _KANBAN_COLUMN_FOR_LANE: dict[Lane, str] = {
     Lane.PLANNED: "planned",
-    Lane.CLAIMED: "planned",
+    Lane.CLAIMED: "doing",
     Lane.IN_PROGRESS: "doing",
     Lane.FOR_REVIEW: "for_review",
     Lane.IN_REVIEW: "for_review",

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -625,94 +625,35 @@ def start_implementation(
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
 
-    from specify_cli.status.reducer import materialize
-    from specify_cli.status.emit import emit_status_transition, TransitionError
-    from specify_cli.status.models import TransitionRequest
-
-    snapshot = materialize(mission_dir)
-    wp_snapshot = snapshot.work_packages.get(wp, {})
-    current_lane = wp_snapshot.get("lane", Lane.PLANNED)
-    state = wp_state_for(current_lane)
-    last_actor = _get_last_actor(mission_dir, wp)
+    from specify_cli.status.emit import TransitionError
+    from specify_cli.status.work_package_lifecycle import WorkPackageClaimConflict, start_implementation_status
 
     workspace_path = str(main_repo_root / ".worktrees" / f"{mission}-{wp}")
     prompt_path = str(wp_path)
 
     try:
-        if state.lane == Lane.PLANNED:
-            # Composite: planned -> claimed -> in_progress
-            emit_status_transition(TransitionRequest(
-                feature_dir=mission_dir,
-                mission_slug=mission,
-                wp_id=wp,
-                to_lane=Lane.CLAIMED,
-                actor=actor,
-                policy_metadata=policy_dict,
-            ))
-            emit_status_transition(TransitionRequest(
-                feature_dir=mission_dir,
-                mission_slug=mission,
-                wp_id=wp,
-                to_lane=Lane.IN_PROGRESS,
-                actor=actor,
-                workspace_context=workspace_path,
-                execution_mode="worktree",
-                policy_metadata=policy_dict,
-            ))
-            from_lane_reported = Lane.PLANNED
-            no_op = False
-
-        elif state.lane == Lane.CLAIMED:
-            if last_actor is not None and last_actor != actor:
-                _fail(
-                    cmd,
-                    "WP_ALREADY_CLAIMED",
-                    f"WP {wp} is already claimed by '{last_actor}'",
-                    {
-                        **_mission_identity_payload(mission_dir),
-                        "claimed_by": last_actor,
-                        "requesting_actor": actor,
-                    },
-                )
-                return
-            emit_status_transition(TransitionRequest(
-                feature_dir=mission_dir,
-                mission_slug=mission,
-                wp_id=wp,
-                to_lane=Lane.IN_PROGRESS,
-                actor=actor,
-                workspace_context=workspace_path,
-                execution_mode="worktree",
-                policy_metadata=policy_dict,
-            ))
-            from_lane_reported = Lane.CLAIMED
-            no_op = False
-
-        elif state.lane == Lane.IN_PROGRESS:
-            if last_actor is not None and last_actor != actor:
-                _fail(
-                    cmd,
-                    "WP_ALREADY_CLAIMED",
-                    f"WP {wp} is already in_progress by '{last_actor}'",
-                    {
-                        **_mission_identity_payload(mission_dir),
-                        "claimed_by": last_actor,
-                        "requesting_actor": actor,
-                    },
-                )
-                return
-            # Idempotent success
-            from_lane_reported = Lane.IN_PROGRESS
-            no_op = True
-
-        else:
-            _fail(
-                cmd,
-                "TRANSITION_REJECTED",
-                f"WP {wp} is in '{current_lane}', cannot start implementation",
-            )
-            return
-
+        start_result = start_implementation_status(
+            feature_dir=mission_dir,
+            mission_slug=mission,
+            wp_id=wp,
+            actor=actor,
+            workspace_context=workspace_path,
+            execution_mode="worktree",
+            repo_root=main_repo_root,
+            policy_metadata=policy_dict,
+        )
+    except WorkPackageClaimConflict as exc:
+        _fail(
+            cmd,
+            "WP_ALREADY_CLAIMED",
+            str(exc),
+            {
+                **_mission_identity_payload(mission_dir),
+                "claimed_by": exc.claimed_by,
+                "requesting_actor": exc.requesting_actor,
+            },
+        )
+        return
     except TransitionError as exc:
         _fail(cmd, "TRANSITION_REJECTED", str(exc))
         return
@@ -720,12 +661,12 @@ def start_implementation(
     data = {
         **_mission_identity_payload(mission_dir),
         "wp_id": wp,
-        "from_lane": from_lane_reported,
+        "from_lane": start_result.from_lane,
         "to_lane": Lane.IN_PROGRESS,
         "workspace_path": workspace_path,
         "prompt_path": prompt_path,
         "policy_metadata_recorded": True,
-        "no_op": no_op,
+        "no_op": start_result.no_op,
     }
     validate_outbound_payload(data, "orchestrator_api")
     envelope = make_envelope(
@@ -773,27 +714,35 @@ def start_review(
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
 
-    from specify_cli.status.reducer import materialize
-    from specify_cli.status.emit import emit_status_transition, TransitionError
-    from specify_cli.status.models import TransitionRequest
-
-    snapshot = materialize(mission_dir)
-    wp_snapshot = snapshot.work_packages.get(wp, {})
-    from_lane = wp_snapshot.get("lane", Lane.PLANNED)
+    from specify_cli.status.emit import TransitionError
+    from specify_cli.status.work_package_lifecycle import WorkPackageClaimConflict, start_review_status
 
     prompt_path = str(wp_path)
 
     try:
-        emit_status_transition(TransitionRequest(
+        start_result = start_review_status(
             feature_dir=mission_dir,
             mission_slug=mission,
             wp_id=wp,
-            to_lane=Lane.IN_REVIEW,
             actor=actor,
             review_ref=review_ref,
+            workspace_context=f"orchestrator-api:{main_repo_root}",
             execution_mode="worktree",
+            repo_root=main_repo_root,
             policy_metadata=policy_dict,
-        ))
+        )
+    except WorkPackageClaimConflict as exc:
+        _fail(
+            cmd,
+            "WP_ALREADY_CLAIMED",
+            str(exc),
+            {
+                **_mission_identity_payload(mission_dir),
+                "claimed_by": exc.claimed_by,
+                "requesting_actor": exc.requesting_actor,
+            },
+        )
+        return
     except TransitionError as exc:
         _fail(cmd, "TRANSITION_REJECTED", str(exc))
         return
@@ -801,10 +750,11 @@ def start_review(
     data = {
         **_mission_identity_payload(mission_dir),
         "wp_id": wp,
-        "from_lane": from_lane,
+        "from_lane": start_result.from_lane,
         "to_lane": Lane.IN_REVIEW,
         "prompt_path": prompt_path,
         "policy_metadata_recorded": True,
+        "no_op": start_result.no_op,
     }
     validate_outbound_payload(data, "orchestrator_api")
     envelope = make_envelope(

--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from pathlib import Path
 from typing import Any
 
@@ -314,6 +314,7 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
         TransitionError: If the transition is invalid.
         specify_cli.status.store.StoreError: If the event log is corrupted.
     """
+    current_actor = None
     if isinstance(feature_dir, TransitionRequest):
         request = feature_dir
         mixed_legacy_args = any(
@@ -352,6 +353,7 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
         workspace_context = request.workspace_context
         subtasks_complete = request.subtasks_complete
         implementation_evidence_present = request.implementation_evidence_present
+        current_actor = request.current_actor
         execution_mode = request.execution_mode
         repo_root = request.repo_root
         policy_metadata = request.policy_metadata
@@ -434,6 +436,7 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
             review_ref=review_ref,
             evidence=done_evidence,
             review_result=review_result,
+            current_actor=current_actor,
         ),
     )
     if not ok:
@@ -488,6 +491,136 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
 
     # Step 9: Return the event
     return event
+
+
+def emit_status_transition_batch(  # noqa: C901 — composite transition orchestration mirrors the single-event pipeline
+    requests: list[TransitionRequest],
+    *,
+    ensure_sync_daemon: bool = True,
+    sync_dossier: bool = True,
+) -> list[StatusEvent]:
+    """Validate and persist a same-WP transition sequence atomically.
+
+    Composite operations such as implementation start have multiple legal lane
+    edges but one user-visible lifecycle action. This helper validates the full
+    sequence before any write, appends all events via ``append_events_atomic``,
+    materializes once, and then performs best-effort fan-out.
+    """
+    if not requests:
+        return []
+
+    first = requests[0]
+    feature_dir = first.feature_dir or first.mission_dir
+    mission_slug = first.mission_slug or first._legacy_mission_slug
+    wp_id = first.wp_id
+    if feature_dir is None or mission_slug is None or wp_id is None:
+        raise TypeError("emit_status_transition_batch requires feature_dir/mission_dir, mission_slug, and wp_id")
+
+    feature_dir = canonicalize_feature_dir(feature_dir)
+    mission_id = _load_mission_id(feature_dir)
+    from_lane: str = str(_derive_from_lane(feature_dir, wp_id))
+    built: list[tuple[StatusEvent, TransitionRequest]] = []
+    batch_started_at = datetime.now(UTC)
+
+    for request in requests:
+        request_feature_dir = request.feature_dir or request.mission_dir
+        request_mission_slug = request.mission_slug or request._legacy_mission_slug
+        if request_feature_dir is None or request_mission_slug is None or request.wp_id is None or request.to_lane is None or request.actor is None:
+            raise TypeError("Each batch transition requires feature_dir/mission_dir, mission_slug, wp_id, to_lane, and actor")
+        if canonicalize_feature_dir(request_feature_dir) != feature_dir or request_mission_slug != mission_slug or request.wp_id != wp_id:
+            raise TypeError("emit_status_transition_batch only supports one feature/mission/wp per batch")
+
+        raw_to_lane = str(request.to_lane).strip().lower()
+        resolved_lane = resolve_lane_alias(str(request.to_lane))
+
+        workspace_context = request.workspace_context
+        if workspace_context is None and not (from_lane == Lane.CLAIMED and resolved_lane == Lane.IN_PROGRESS):
+            context_root = request.repo_root if request.repo_root is not None else feature_dir
+            workspace_context = f"{request.execution_mode}:{context_root}"
+        subtasks_complete = request.subtasks_complete
+        implementation_evidence_present = request.implementation_evidence_present
+        if subtasks_complete is None and from_lane == Lane.IN_PROGRESS and resolved_lane == Lane.FOR_REVIEW:
+            subtasks_complete = _infer_subtasks_complete(feature_dir, wp_id)
+        if implementation_evidence_present is None and from_lane == Lane.IN_PROGRESS and resolved_lane == Lane.FOR_REVIEW:
+            implementation_evidence_present = _infer_implementation_evidence(feature_dir, wp_id)
+
+        if _legacy_alias_collapses_to_current_lane(raw_to_lane, resolved_lane, from_lane):
+            continue
+
+        done_evidence: DoneEvidence | None = None
+        if request.evidence is not None:
+            done_evidence = _build_done_evidence(request.evidence)
+
+        ok, error_msg = validate_transition(
+            from_lane,
+            resolved_lane,
+            GuardContext(
+                force=request.force,
+                actor=request.actor,
+                workspace_context=workspace_context,
+                subtasks_complete=subtasks_complete,
+                implementation_evidence_present=implementation_evidence_present,
+                reason=request.reason,
+                review_ref=request.review_ref,
+                evidence=done_evidence,
+                review_result=request.review_result,
+                current_actor=request.current_actor,
+            ),
+        )
+        if not ok:
+            raise TransitionError(error_msg)
+
+        event = StatusEvent(
+            event_id=_generate_ulid(),
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            from_lane=Lane(from_lane),
+            to_lane=Lane(resolved_lane),
+            at=(batch_started_at + timedelta(microseconds=len(built))).isoformat(),
+            actor=request.actor,
+            force=request.force,
+            execution_mode=request.execution_mode,
+            reason=request.reason,
+            review_ref=request.review_ref,
+            evidence=done_evidence,
+            policy_metadata=request.policy_metadata,
+            mission_id=mission_id,
+        )
+        built.append((event, request))
+        from_lane = resolved_lane
+
+    if not built:
+        return []
+
+    events = [event for event, _request in built]
+    _store.append_events_atomic(feature_dir, events)
+
+    try:
+        _reducer.materialize(feature_dir)
+    except Exception:
+        logger.warning(
+            "Materialization failed after batch ending in event %s was persisted; run 'status materialize' to recover",
+            events[-1].event_id,
+        )
+
+    for event in events:
+        _mirror_phase1_frontmatter_lane(feature_dir, event.wp_id, str(event.to_lane))
+
+    for event, request in built:
+        _saas_fan_out(
+            event,
+            mission_slug,
+            request.repo_root,
+            policy_metadata=request.policy_metadata,
+            ensure_sync_daemon=ensure_sync_daemon,
+        )
+
+    if sync_dossier:
+        repo_root = next((request.repo_root for _event, request in built if request.repo_root is not None), None)
+        if repo_root is not None:
+            fire_dossier_sync(feature_dir, mission_slug, repo_root)
+
+    return events
 
 
 def _saas_fan_out(

--- a/src/specify_cli/status/models.py
+++ b/src/specify_cli/status/models.py
@@ -370,6 +370,7 @@ class TransitionRequest:
     workspace_context: str | None = None
     subtasks_complete: bool | None = None
     implementation_evidence_present: bool | None = None
+    current_actor: str | None = None
     policy_metadata: dict[str, Any] | None = None
 
 

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -144,6 +145,35 @@ def append_event(feature_dir: Path, event: StatusEvent) -> None:
     line = json.dumps(event.to_dict(), sort_keys=True)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(line + "\n")
+
+
+def append_events_atomic(feature_dir: Path, events: list[StatusEvent]) -> None:
+    """Atomically persist a batch of StatusEvents as JSONL lines.
+
+    The existing single-event append remains the compatibility path. Composite
+    lifecycle operations use this helper so crash recovery never observes only
+    half of a logical operation such as ``planned -> claimed -> in_progress``.
+    """
+    if not events:
+        return
+
+    path = _events_path(feature_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = ""
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if existing and not existing.endswith("\n"):
+            existing += "\n"
+
+    additions = "".join(json.dumps(event.to_dict(), sort_keys=True) + "\n" for event in events)
+    tmp_path = path.with_name(f"{path.name}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        fh.write(existing)
+        fh.write(additions)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, path)
 
 
 def read_events_raw(feature_dir: Path) -> list[dict[str, Any]]:

--- a/src/specify_cli/status/work_package_lifecycle.py
+++ b/src/specify_cli/status/work_package_lifecycle.py
@@ -1,0 +1,234 @@
+"""Shared lifecycle operations for work-package starts.
+
+These helpers are the single status-facing implementation of "start work" for
+agent commands, the internal implement command, and orchestrator-api. Workspace
+creation stays with the caller; durable lane transitions live here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from specify_cli.status.emit import TransitionError, emit_status_transition, emit_status_transition_batch
+from specify_cli.status.locking import feature_status_lock
+from specify_cli.status.models import Lane, StatusEvent, TransitionRequest
+from specify_cli.status.reducer import reduce
+from specify_cli.status.store import read_events
+from specify_cli.workspace import canonicalize_feature_dir
+
+_GENERIC_IMPLEMENTATION_ACTORS = frozenset({"implement-command", "unknown"})
+
+
+class WorkPackageClaimConflict(TransitionError):
+    """Raised when another actor owns an implementation or review claim."""
+
+    def __init__(self, wp_id: str, claimed_by: str, requesting_actor: str, *, review: bool = False) -> None:
+        kind = "review" if review else "implementation"
+        super().__init__(f"WP {wp_id} is already claimed for {kind} by '{claimed_by}'")
+        self.wp_id = wp_id
+        self.claimed_by = claimed_by
+        self.requesting_actor = requesting_actor
+
+
+class WorkPackageStartRejected(TransitionError):
+    """Raised when a WP cannot be started from its current lane."""
+
+
+@dataclass(frozen=True)
+class WorkPackageStartResult:
+    """Outcome for an idempotent implementation/review start operation."""
+
+    wp_id: str
+    from_lane: Lane
+    to_lane: Lane
+    actor: str
+    events: tuple[StatusEvent, ...]
+    no_op: bool = False
+    claimed_by: str | None = None
+
+    @property
+    def status_changed(self) -> bool:
+        return bool(self.events)
+
+
+def _repo_root_for_lock(feature_dir: Path, repo_root: Path | None) -> Path:
+    if repo_root is not None:
+        return repo_root
+    if feature_dir.parent.name == "kitty-specs":
+        return feature_dir.parent.parent
+    return feature_dir
+
+
+def _actor_key(actor: object | None) -> str | None:
+    if actor is None:
+        return None
+    value = str(actor).strip()
+    return value or None
+
+
+def _actors_compatible(existing: object | None, requested: object | None, *, allow_generic_existing: bool = False) -> bool:
+    existing_key = _actor_key(existing)
+    requested_key = _actor_key(requested)
+    if existing_key is None or requested_key is None:
+        return True
+    if existing_key == requested_key:
+        return True
+    return allow_generic_existing and existing_key in _GENERIC_IMPLEMENTATION_ACTORS
+
+
+def _current_lane_and_actor(feature_dir: Path, wp_id: str) -> tuple[Lane, str | None]:
+    events = read_events(feature_dir)
+    if not events:
+        return Lane.PLANNED, None
+
+    snapshot = reduce(events)
+    state = snapshot.work_packages.get(wp_id)
+    if not state:
+        return Lane.PLANNED, None
+
+    try:
+        lane = Lane(str(state.get("lane", Lane.PLANNED)))
+    except ValueError:
+        lane = Lane.PLANNED
+    return lane, _actor_key(state.get("actor"))
+
+
+def start_implementation_status(
+    *,
+    feature_dir: Path,
+    mission_slug: str,
+    wp_id: str,
+    actor: str,
+    workspace_context: str,
+    execution_mode: str,
+    repo_root: Path | None = None,
+    policy_metadata: dict[str, Any] | None = None,
+    allow_rework: bool = False,
+    rework_reason: str = "Re-implementing after review feedback",
+) -> WorkPackageStartResult:
+    """Idempotently move a WP into ``in_progress`` for an implementation actor."""
+    feature_dir = canonicalize_feature_dir(feature_dir)
+    lock_root = _repo_root_for_lock(feature_dir, repo_root)
+
+    with feature_status_lock(lock_root, mission_slug):
+        current_lane, current_actor = _current_lane_and_actor(feature_dir, wp_id)
+
+        if current_lane == Lane.PLANNED:
+            events = emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug=mission_slug,
+                        wp_id=wp_id,
+                        to_lane=Lane.CLAIMED,
+                        actor=actor,
+                        execution_mode=execution_mode,
+                        repo_root=repo_root,
+                        policy_metadata=policy_metadata,
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug=mission_slug,
+                        wp_id=wp_id,
+                        to_lane=Lane.IN_PROGRESS,
+                        actor=actor,
+                        workspace_context=workspace_context,
+                        execution_mode=execution_mode,
+                        repo_root=repo_root,
+                        policy_metadata=policy_metadata,
+                    ),
+                ]
+            )
+            return WorkPackageStartResult(wp_id, Lane.PLANNED, Lane.IN_PROGRESS, actor, tuple(events), claimed_by=actor)
+
+        if current_lane == Lane.CLAIMED:
+            if not _actors_compatible(current_actor, actor, allow_generic_existing=True):
+                raise WorkPackageClaimConflict(wp_id, current_actor or "unknown", actor)
+            events = emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug=mission_slug,
+                        wp_id=wp_id,
+                        to_lane=Lane.IN_PROGRESS,
+                        actor=actor,
+                        workspace_context=workspace_context,
+                        execution_mode=execution_mode,
+                        repo_root=repo_root,
+                        policy_metadata=policy_metadata,
+                    )
+                ]
+            )
+            return WorkPackageStartResult(wp_id, Lane.CLAIMED, Lane.IN_PROGRESS, actor, tuple(events), claimed_by=actor)
+
+        if current_lane == Lane.IN_PROGRESS:
+            if not _actors_compatible(current_actor, actor, allow_generic_existing=True):
+                raise WorkPackageClaimConflict(wp_id, current_actor or "unknown", actor)
+            return WorkPackageStartResult(wp_id, Lane.IN_PROGRESS, Lane.IN_PROGRESS, actor, (), no_op=True, claimed_by=current_actor)
+
+        if allow_rework and current_lane in {Lane.FOR_REVIEW, Lane.APPROVED, Lane.IN_REVIEW}:
+            event = emit_status_transition(
+                TransitionRequest(
+                    feature_dir=feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=wp_id,
+                    to_lane=Lane.IN_PROGRESS,
+                    actor=actor,
+                    force=True,
+                    reason=rework_reason,
+                    workspace_context=workspace_context,
+                    execution_mode=execution_mode,
+                    repo_root=repo_root,
+                    policy_metadata=policy_metadata,
+                )
+            )
+            return WorkPackageStartResult(wp_id, current_lane, Lane.IN_PROGRESS, actor, (event,), claimed_by=actor)
+
+    raise WorkPackageStartRejected(f"WP {wp_id} is in '{current_lane}', cannot start implementation")
+
+
+def start_review_status(
+    *,
+    feature_dir: Path,
+    mission_slug: str,
+    wp_id: str,
+    actor: str,
+    workspace_context: str,
+    execution_mode: str,
+    repo_root: Path | None = None,
+    policy_metadata: dict[str, Any] | None = None,
+    review_ref: str | None = "action-review-claim",
+) -> WorkPackageStartResult:
+    """Idempotently move a WP into ``in_review`` for a reviewer actor."""
+    feature_dir = canonicalize_feature_dir(feature_dir)
+    lock_root = _repo_root_for_lock(feature_dir, repo_root)
+
+    with feature_status_lock(lock_root, mission_slug):
+        current_lane, current_actor = _current_lane_and_actor(feature_dir, wp_id)
+
+        if current_lane == Lane.FOR_REVIEW:
+            event = emit_status_transition(
+                TransitionRequest(
+                    feature_dir=feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=wp_id,
+                    to_lane=Lane.IN_REVIEW,
+                    actor=actor,
+                    reason="Started review via action command",
+                    review_ref=review_ref,
+                    workspace_context=workspace_context,
+                    execution_mode=execution_mode,
+                    repo_root=repo_root,
+                    policy_metadata=policy_metadata,
+                )
+            )
+            return WorkPackageStartResult(wp_id, Lane.FOR_REVIEW, Lane.IN_REVIEW, actor, (event,), claimed_by=actor)
+
+        if current_lane == Lane.IN_REVIEW:
+            if not _actors_compatible(current_actor, actor):
+                raise WorkPackageClaimConflict(wp_id, current_actor or "unknown", actor, review=True)
+            return WorkPackageStartResult(wp_id, Lane.IN_REVIEW, Lane.IN_REVIEW, actor, (), no_op=True, claimed_by=current_actor)
+
+    raise WorkPackageStartRejected(f"WP {wp_id} is in '{current_lane}', cannot start review")

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -1036,7 +1036,7 @@ class TestSetupPlanCommand:
         # No template created and package template unavailable
         package_templates = Mock()
         package_template = Mock()
-        package_template.exists.return_value = False
+        package_template.is_file.return_value = False
         package_templates.joinpath.return_value = package_template
         mock_files.return_value = package_templates
 

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -22,6 +22,15 @@ pytestmark = pytest.mark.git_repo
 
 runner = CliRunner()
 
+
+@pytest.fixture(autouse=True)
+def _disable_status_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    import specify_cli.status.emit as status_emit
+
+    monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
+    monkeypatch.setattr(status_emit, "fire_dossier_sync", lambda *args, **kwargs: None)
+
+
 # ── Fixtures ──────────────────────────────────────────────────────
 
 
@@ -299,6 +308,47 @@ class TestStartImplementation:
         assert data["data"]["from_lane"] == "planned"
         assert data["data"]["to_lane"] == "in_progress"
         assert data["data"]["policy_metadata_recorded"] is True
+        assert data["data"]["no_op"] is False
+        from specify_cli.status.store import read_events
+
+        events = read_events(mission_dir)
+        assert [(event.from_lane, event.to_lane) for event in events] == [
+            ("planned", "claimed"),
+            ("claimed", "in_progress"),
+        ]
+
+    def test_claimed_same_actor_resumes_to_in_progress(self, tmp_path):
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+
+        from specify_cli.status.emit import emit_status_transition
+
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP01", to_lane="claimed", actor="claude"))
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "start-implementation",
+                    "--mission",
+                    mission_slug,
+                    "--wp",
+                    "WP01",
+                    "--actor",
+                    "claude",
+                    "--policy",
+                    _valid_policy_json(),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["from_lane"] == "claimed"
+        assert data["data"]["to_lane"] == "in_progress"
         assert data["data"]["no_op"] is False
 
     def test_already_in_progress_same_actor_noop(self, tmp_path):

--- a/tests/integration/test_status_emit_on_alloc_failure.py
+++ b/tests/integration/test_status_emit_on_alloc_failure.py
@@ -1,8 +1,9 @@
-"""Integration test for FR-014 (WP03/T017).
+"""Integration test for allocation-failure status handling.
 
-Asserts that the implement runtime emits ``planned -> claimed -> in_progress``
-*before* worktree allocation, and emits ``in_progress -> blocked`` (with
-``reason=worktree_alloc_failed``) when the allocator raises.
+Asserts that the implement runtime no longer records implementation start before
+workspace allocation succeeds. If allocation fails, the WP is moved directly to
+``blocked`` with ``reason=worktree_alloc_failed`` so there is no stranded
+``claimed`` state.
 
 The test mocks ``create_lane_workspace`` to raise an OSError on first
 call and inspects ``status.events.jsonl`` to verify the event order.
@@ -22,6 +23,14 @@ from specify_cli.lanes.models import ExecutionLane, LanesManifest
 from specify_cli.lanes.persistence import write_lanes_json
 
 pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _disable_status_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    import specify_cli.status.emit as status_emit
+
+    monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
+    monkeypatch.setattr(status_emit, "fire_dossier_sync", lambda *args, **kwargs: None)
 
 
 def _create_meta(feature_dir: Path) -> Path:
@@ -87,7 +96,7 @@ def _write_wp_file(feature_dir: Path) -> Path:
     return wp_file
 
 
-def test_implement_emits_in_progress_before_alloc_and_blocked_on_failure(
+def test_implement_blocks_without_claiming_when_alloc_fails(
     tmp_path: Path,
 ) -> None:
     feature_slug = "010-alloc-failure-fixture"
@@ -131,7 +140,7 @@ def test_implement_emits_in_progress_before_alloc_and_blocked_on_failure(
         # Confirm the allocator was actually invoked.
         assert mock_alloc.called
 
-    assert events_log.exists(), "status.events.jsonl must exist after pre-alloc emit"
+    assert events_log.exists(), "status.events.jsonl must exist after alloc failure status emit"
 
     events = [
         json.loads(line)
@@ -140,19 +149,10 @@ def test_implement_emits_in_progress_before_alloc_and_blocked_on_failure(
     ]
     transitions = [(e["from_lane"], e["to_lane"]) for e in events]
 
-    # The runtime must emit planned -> claimed -> in_progress BEFORE alloc.
-    assert ("planned", "claimed") in transitions, transitions
-    assert ("claimed", "in_progress") in transitions, transitions
+    # Allocation failure should not leave an implementation claim behind.
+    assert transitions == [("planned", "blocked")]
 
-    # The runtime must emit in_progress -> blocked AFTER alloc failure.
-    assert ("in_progress", "blocked") in transitions, transitions
-
-    # Order check: the blocked event must come after the in_progress event.
-    in_progress_idx = transitions.index(("claimed", "in_progress"))
-    blocked_idx = transitions.index(("in_progress", "blocked"))
-    assert in_progress_idx < blocked_idx
-
-    blocked_event = events[blocked_idx]
+    blocked_event = events[0]
     assert blocked_event["reason"] == "worktree_alloc_failed"
     # Evidence may live under policy_metadata; either a plain "evidence"
     # string or a structured map containing one is acceptable.

--- a/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
@@ -28,7 +28,7 @@ from specify_cli.tasks_support import split_frontmatter
 pytestmark = pytest.mark.fast
 
 
-def _seed_wp_lane(feature_dir: Path, wp_id: str, lane: str) -> None:
+def _seed_wp_lane(feature_dir: Path, wp_id: str, lane: str, *, actor: str = "test") -> None:
     """Seed a WP into a specific lane in the event log."""
     _lane_alias = {"doing": "in_progress"}
     canonical_lane = _lane_alias.get(lane, lane)
@@ -39,7 +39,7 @@ def _seed_wp_lane(feature_dir: Path, wp_id: str, lane: str) -> None:
         from_lane=Lane.PLANNED,
         to_lane=Lane(canonical_lane),
         at="2026-01-01T00:00:00+00:00",
-        actor="test",
+        actor=actor,
         force=True,
         execution_mode="worktree",
     )
@@ -146,7 +146,7 @@ class TestImplementBodyNoteLaneFree:
         wp_path = tasks_dir / "WP01-test.md"
         _write_wp_file(wp_path, "WP01", lane="doing")
         # Seed canonical state as in_progress (= doing)
-        _seed_wp_lane(feature_dir, "WP01", "doing")
+        _seed_wp_lane(feature_dir, "WP01", "doing", actor="test-agent")
 
         workspace = lane_worktree_path(workflow_repo, mission_slug)
         workspace.mkdir(parents=True)

--- a/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
+++ b/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
@@ -130,6 +130,7 @@ def test_agent_action_implement_passes_acknowledge_default_false(
         json_output=False,
         recover=False,
         acknowledge_not_bulk_edit=False,
+        actor="claude",
     )
 
 
@@ -175,4 +176,5 @@ def test_agent_action_implement_passes_acknowledge_true_when_requested(
         json_output=False,
         recover=False,
         acknowledge_not_bulk_edit=True,
+        actor="claude",
     )

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -27,14 +27,16 @@ from specify_cli.status.emit import (
     _phase1_dual_write_enabled,
     _saas_fan_out,
     emit_status_transition,
+    emit_status_transition_batch,
 )
 from specify_cli.status.models import (
     DoneEvidence,
     Lane,
+    ReviewResult,
     StatusEvent,
     TransitionRequest,
 )
-from specify_cli.status.store import EVENTS_FILENAME, read_events
+from specify_cli.status.store import EVENTS_FILENAME, append_event, read_events
 
 pytestmark = pytest.mark.fast
 # ── Fixtures ──────────────────────────────────────────────────
@@ -1237,3 +1239,217 @@ class TestMergeLightweightEmit:
         mock_fanout.assert_called_once()
         assert mock_fanout.call_args.kwargs["ensure_sync_daemon"] is False
         mock_dossier.assert_not_called()
+
+
+class TestBatchEmit:
+    def test_empty_batch_returns_empty(self) -> None:
+        assert emit_status_transition_batch([]) == []
+
+    def test_batch_requires_first_request_identity(self) -> None:
+        with pytest.raises(TypeError, match="requires feature_dir"):
+            emit_status_transition_batch([TransitionRequest()])
+
+    def test_batch_requires_each_request_identity(self, feature_dir: Path) -> None:
+        with pytest.raises(TypeError, match="Each batch transition"):
+            emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="claimed",
+                        actor="agent",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                    ),
+                ]
+            )
+
+    def test_batch_rejects_mixed_work_packages(self, feature_dir: Path) -> None:
+        with pytest.raises(TypeError, match="one feature/mission/wp"):
+            emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="claimed",
+                        actor="agent",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="claimed",
+                        actor="agent",
+                    ),
+                ]
+            )
+
+    def test_batch_all_alias_collapses_returns_empty(self, feature_dir: Path) -> None:
+        append_event(
+            feature_dir,
+            StatusEvent(
+                event_id="01HXYZ0000000000000000CLPS",
+                mission_slug="034-test-feature",
+                wp_id="WP01",
+                from_lane=Lane.CLAIMED,
+                to_lane=Lane.IN_PROGRESS,
+                at="2026-02-08T12:00:00Z",
+                actor="agent",
+                force=False,
+                execution_mode="worktree",
+            ),
+        )
+
+        events = emit_status_transition_batch(
+            [
+                TransitionRequest(
+                    feature_dir=feature_dir,
+                    mission_slug="034-test-feature",
+                    wp_id="WP01",
+                    to_lane="doing",
+                    actor="agent",
+                )
+            ]
+        )
+
+        assert events == []
+        assert len(read_events(feature_dir)) == 1
+
+    def test_batch_invalid_transition_is_rejected_without_persisting(self, feature_dir: Path) -> None:
+        with pytest.raises(TransitionError, match="Illegal transition"):
+            emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="done",
+                        actor="agent",
+                    )
+                ]
+            )
+
+        assert read_events(feature_dir) == []
+
+    def test_batch_infers_review_readiness_and_builds_evidence(self, feature_dir: Path, valid_evidence_dict: dict) -> None:
+        with patch.object(emit_module, "_saas_fan_out"):
+            events = emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="claimed",
+                        actor="agent",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="in_progress",
+                        actor="agent",
+                        workspace_context="worktree:/tmp/wp01",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="for_review",
+                        actor="agent",
+                        force=True,
+                        reason="ready for review",
+                    ),
+                ],
+                sync_dossier=False,
+            )
+
+        assert [event.to_lane for event in events] == [Lane.CLAIMED, Lane.IN_PROGRESS, Lane.FOR_REVIEW]
+
+        with patch.object(emit_module, "_saas_fan_out"):
+            done = emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="claimed",
+                        actor="agent",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="in_progress",
+                        actor="agent",
+                        workspace_context="worktree:/tmp/wp02",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="for_review",
+                        actor="agent",
+                        force=True,
+                        reason="ready for review",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="in_review",
+                        actor="reviewer",
+                        review_ref="review-1",
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="approved",
+                        actor="reviewer",
+                        review_result=ReviewResult(
+                            reviewer="reviewer",
+                            verdict="approved",
+                            reference="review-1",
+                        ),
+                    ),
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP02",
+                        to_lane="done",
+                        actor="reviewer",
+                        evidence=valid_evidence_dict,
+                    ),
+                ],
+                sync_dossier=False,
+            )
+
+        assert done[-1].evidence is not None
+        assert done[-1].to_lane == Lane.DONE
+
+    def test_batch_materialize_failure_keeps_persisted_events(self, feature_dir: Path, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            patch.object(emit_module, "_saas_fan_out"),
+            patch.object(emit_module._reducer, "materialize", side_effect=RuntimeError("boom")),
+        ):
+            events = emit_status_transition_batch(
+                [
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug="034-test-feature",
+                        wp_id="WP01",
+                        to_lane="claimed",
+                        actor="agent",
+                    )
+                ],
+                sync_dossier=False,
+            )
+
+        assert len(events) == 1
+        assert read_events(feature_dir)[0].to_lane == Lane.CLAIMED
+        assert "Materialization failed after batch" in caplog.text

--- a/tests/status/test_store.py
+++ b/tests/status/test_store.py
@@ -90,6 +90,23 @@ def test_append_events_atomic_persists_full_batch(tmp_path: Path) -> None:
     ]
 
 
+def test_append_events_atomic_empty_batch_is_noop(tmp_path: Path) -> None:
+    append_events_atomic(tmp_path, [])
+
+    assert not (tmp_path / EVENTS_FILENAME).exists()
+
+
+def test_append_events_atomic_repairs_missing_trailing_newline(tmp_path: Path) -> None:
+    first = _make_event(event_id="01AAAA0000000000000000001A", wp_id="WP01")
+    second = _make_event(event_id="01BBBB0000000000000000002B", wp_id="WP02")
+    events_path = tmp_path / EVENTS_FILENAME
+    events_path.write_text(json.dumps(first.to_dict(), sort_keys=True), encoding="utf-8")
+
+    append_events_atomic(tmp_path, [second])
+
+    assert [event.wp_id for event in read_events(tmp_path)] == ["WP01", "WP02"]
+
+
 def test_append_events_atomic_replace_failure_leaves_original(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     original = _make_event(event_id="01AAAA0000000000000000001A", wp_id="WP01")
     append_event(tmp_path, original)

--- a/tests/status/test_store.py
+++ b/tests/status/test_store.py
@@ -13,6 +13,7 @@ from specify_cli.status.store import (
     _SlugResolver,
     StoreError,
     append_event,
+    append_events_atomic,
     read_events,
     read_events_raw,
 )
@@ -69,6 +70,52 @@ def test_multiple_appends_preserve_order(tmp_path: Path) -> None:
     assert events[0].wp_id == "WP01"
     assert events[1].wp_id == "WP02"
     assert events[2].wp_id == "WP03"
+
+
+def test_append_events_atomic_persists_full_batch(tmp_path: Path) -> None:
+    e1 = _make_event(event_id="01AAAA0000000000000000001A", wp_id="WP01")
+    e2 = _make_event(
+        event_id="01BBBB0000000000000000002B",
+        wp_id="WP01",
+        from_lane=Lane.CLAIMED,
+        to_lane=Lane.IN_PROGRESS,
+    )
+
+    append_events_atomic(tmp_path, [e1, e2])
+
+    events = read_events(tmp_path)
+    assert [(event.from_lane, event.to_lane) for event in events] == [
+        (Lane.PLANNED, Lane.CLAIMED),
+        (Lane.CLAIMED, Lane.IN_PROGRESS),
+    ]
+
+
+def test_append_events_atomic_replace_failure_leaves_original(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    original = _make_event(event_id="01AAAA0000000000000000001A", wp_id="WP01")
+    append_event(tmp_path, original)
+
+    def _raise_replace(_src: Path, _dst: Path) -> None:
+        raise OSError("replace failed")
+
+    import specify_cli.status.store as status_store
+
+    monkeypatch.setattr(status_store.os, "replace", _raise_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        append_events_atomic(
+            tmp_path,
+            [
+                _make_event(
+                    event_id="01BBBB0000000000000000002B",
+                    wp_id="WP01",
+                    from_lane=Lane.CLAIMED,
+                    to_lane=Lane.IN_PROGRESS,
+                )
+            ],
+        )
+
+    events = read_events(tmp_path)
+    assert events == [original]
 
 
 def test_read_events_skips_retrospective_events(tmp_path: Path) -> None:

--- a/tests/status/test_work_package_lifecycle.py
+++ b/tests/status/test_work_package_lifecycle.py
@@ -12,6 +12,10 @@ from specify_cli.status.reducer import reduce
 from specify_cli.status.store import append_event, read_events
 from specify_cli.status.work_package_lifecycle import (
     WorkPackageClaimConflict,
+    WorkPackageStartRejected,
+    _actor_key,
+    _actors_compatible,
+    _repo_root_for_lock,
     start_implementation_status,
     start_review_status,
 )
@@ -140,6 +144,68 @@ def test_start_implementation_noops_in_progress_same_actor(tmp_path: Path) -> No
     assert len(read_events(feature_dir)) == 2
 
 
+def test_start_implementation_rejects_in_progress_different_actor(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(feature_dir, _event("01AAAA0000000000000000001A", from_lane=Lane.PLANNED, to_lane=Lane.CLAIMED))
+    append_event(
+        feature_dir,
+        _event("01BBBB0000000000000000002B", from_lane=Lane.CLAIMED, to_lane=Lane.IN_PROGRESS, actor="other-agent"),
+    )
+
+    with pytest.raises(WorkPackageClaimConflict) as exc_info:
+        start_implementation_status(
+            feature_dir=feature_dir,
+            mission_slug="099-lifecycle-test",
+            wp_id="WP01",
+            actor="claude",
+            workspace_context="worktree:/tmp/wp01",
+            execution_mode="worktree",
+            repo_root=tmp_path,
+        )
+
+    assert exc_info.value.claimed_by == "other-agent"
+
+
+def test_start_implementation_allows_forced_rework_from_review_lane(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(
+        feature_dir,
+        _event("01CCCC0000000000000000003C", from_lane=Lane.IN_PROGRESS, to_lane=Lane.FOR_REVIEW, actor="implementer"),
+    )
+
+    result = start_implementation_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="claude",
+        workspace_context="worktree:/tmp/wp01",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+        allow_rework=True,
+        rework_reason="review changes requested",
+    )
+
+    assert result.from_lane == Lane.FOR_REVIEW
+    assert result.to_lane == Lane.IN_PROGRESS
+    assert read_events(feature_dir)[-1].reason == "review changes requested"
+
+
+def test_start_implementation_rejects_unstartable_lane(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(feature_dir, _event("01DDDD0000000000000000004D", from_lane=Lane.APPROVED, to_lane=Lane.DONE))
+
+    with pytest.raises(WorkPackageStartRejected, match="cannot start implementation"):
+        start_implementation_status(
+            feature_dir=feature_dir,
+            mission_slug="099-lifecycle-test",
+            wp_id="WP01",
+            actor="claude",
+            workspace_context="worktree:/tmp/wp01",
+            execution_mode="worktree",
+            repo_root=tmp_path,
+        )
+
+
 def test_start_review_allows_reviewer_after_implementer_for_review(tmp_path: Path) -> None:
     feature_dir = _feature_dir(tmp_path)
     append_event(
@@ -161,6 +227,27 @@ def test_start_review_allows_reviewer_after_implementer_for_review(tmp_path: Pat
     assert read_events(feature_dir)[-1].to_lane == Lane.IN_REVIEW
 
 
+def test_start_review_noops_same_reviewer(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(
+        feature_dir,
+        _event("01DDDD0000000000000000004D", from_lane=Lane.FOR_REVIEW, to_lane=Lane.IN_REVIEW, actor="reviewer-a"),
+    )
+
+    result = start_review_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="reviewer-a",
+        workspace_context="review:/tmp/repo",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+    )
+
+    assert result.no_op is True
+    assert len(read_events(feature_dir)) == 1
+
+
 def test_start_review_rejects_second_reviewer(tmp_path: Path) -> None:
     feature_dir = _feature_dir(tmp_path)
     append_event(
@@ -180,6 +267,30 @@ def test_start_review_rejects_second_reviewer(tmp_path: Path) -> None:
         )
 
     assert exc_info.value.claimed_by == "reviewer-a"
+
+
+def test_start_review_rejects_non_review_lane(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+
+    with pytest.raises(WorkPackageStartRejected, match="cannot start review"):
+        start_review_status(
+            feature_dir=feature_dir,
+            mission_slug="099-lifecycle-test",
+            wp_id="WP01",
+            actor="reviewer-a",
+            workspace_context="review:/tmp/repo",
+            execution_mode="worktree",
+            repo_root=tmp_path,
+        )
+
+
+def test_lifecycle_helpers_normalize_lock_roots_and_actors(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "099-lifecycle-test"
+
+    assert _repo_root_for_lock(feature_dir, None) == tmp_path
+    assert _repo_root_for_lock(tmp_path / "loose-feature", None) == tmp_path / "loose-feature"
+    assert _actor_key(None) is None
+    assert _actors_compatible(None, "claude") is True
 
 
 def test_claimed_lane_surfaces_as_doing_in_dashboard() -> None:

--- a/tests/status/test_work_package_lifecycle.py
+++ b/tests/status/test_work_package_lifecycle.py
@@ -1,0 +1,186 @@
+"""Tests for shared work-package lifecycle start operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.dashboard.scanner import _KANBAN_COLUMN_FOR_LANE
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.reducer import reduce
+from specify_cli.status.store import append_event, read_events
+from specify_cli.status.work_package_lifecycle import (
+    WorkPackageClaimConflict,
+    start_implementation_status,
+    start_review_status,
+)
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.fixture(autouse=True)
+def _disable_status_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    import specify_cli.status.emit as status_emit
+
+    monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
+    monkeypatch.setattr(status_emit, "fire_dossier_sync", lambda *args, **kwargs: None)
+
+
+def _feature_dir(tmp_path: Path) -> Path:
+    feature_dir = tmp_path / "kitty-specs" / "099-lifecycle-test"
+    feature_dir.mkdir(parents=True)
+    return feature_dir
+
+
+def _event(
+    event_id: str,
+    *,
+    from_lane: Lane,
+    to_lane: Lane,
+    actor: str = "claude",
+    wp_id: str = "WP01",
+) -> StatusEvent:
+    return StatusEvent(
+        event_id=event_id,
+        mission_slug="099-lifecycle-test",
+        wp_id=wp_id,
+        from_lane=from_lane,
+        to_lane=to_lane,
+        at=f"2026-04-26T10:00:0{event_id[-1]}+00:00",
+        actor=actor,
+        force=False,
+        execution_mode="worktree",
+    )
+
+
+def test_start_implementation_batches_planned_to_in_progress(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+
+    result = start_implementation_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="claude",
+        workspace_context="worktree:/tmp/wp01",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+    )
+
+    assert result.from_lane == Lane.PLANNED
+    assert result.to_lane == Lane.IN_PROGRESS
+    assert result.no_op is False
+
+    events = read_events(feature_dir)
+    assert [(event.from_lane, event.to_lane) for event in events] == [
+        (Lane.PLANNED, Lane.CLAIMED),
+        (Lane.CLAIMED, Lane.IN_PROGRESS),
+    ]
+    snapshot = reduce(events)
+    assert snapshot.work_packages["WP01"]["lane"] == Lane.IN_PROGRESS
+
+
+def test_start_implementation_resumes_claimed_same_actor(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(feature_dir, _event("01AAAA0000000000000000001A", from_lane=Lane.PLANNED, to_lane=Lane.CLAIMED))
+
+    result = start_implementation_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="claude",
+        workspace_context="worktree:/tmp/wp01",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+    )
+
+    assert result.from_lane == Lane.CLAIMED
+    assert result.status_changed is True
+    assert read_events(feature_dir)[-1].to_lane == Lane.IN_PROGRESS
+
+
+def test_start_implementation_rejects_claimed_different_actor(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(
+        feature_dir,
+        _event("01AAAA0000000000000000001A", from_lane=Lane.PLANNED, to_lane=Lane.CLAIMED, actor="other-agent"),
+    )
+
+    with pytest.raises(WorkPackageClaimConflict) as exc_info:
+        start_implementation_status(
+            feature_dir=feature_dir,
+            mission_slug="099-lifecycle-test",
+            wp_id="WP01",
+            actor="claude",
+            workspace_context="worktree:/tmp/wp01",
+            execution_mode="worktree",
+            repo_root=tmp_path,
+        )
+
+    assert exc_info.value.claimed_by == "other-agent"
+    assert len(read_events(feature_dir)) == 1
+
+
+def test_start_implementation_noops_in_progress_same_actor(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(feature_dir, _event("01AAAA0000000000000000001A", from_lane=Lane.PLANNED, to_lane=Lane.CLAIMED))
+    append_event(feature_dir, _event("01BBBB0000000000000000002B", from_lane=Lane.CLAIMED, to_lane=Lane.IN_PROGRESS))
+
+    result = start_implementation_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="claude",
+        workspace_context="worktree:/tmp/wp01",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+    )
+
+    assert result.no_op is True
+    assert len(read_events(feature_dir)) == 2
+
+
+def test_start_review_allows_reviewer_after_implementer_for_review(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(
+        feature_dir,
+        _event("01CCCC0000000000000000003C", from_lane=Lane.IN_PROGRESS, to_lane=Lane.FOR_REVIEW, actor="implementer"),
+    )
+
+    result = start_review_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="reviewer",
+        workspace_context="review:/tmp/repo",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+    )
+
+    assert result.from_lane == Lane.FOR_REVIEW
+    assert read_events(feature_dir)[-1].to_lane == Lane.IN_REVIEW
+
+
+def test_start_review_rejects_second_reviewer(tmp_path: Path) -> None:
+    feature_dir = _feature_dir(tmp_path)
+    append_event(
+        feature_dir,
+        _event("01DDDD0000000000000000004D", from_lane=Lane.FOR_REVIEW, to_lane=Lane.IN_REVIEW, actor="reviewer-a"),
+    )
+
+    with pytest.raises(WorkPackageClaimConflict) as exc_info:
+        start_review_status(
+            feature_dir=feature_dir,
+            mission_slug="099-lifecycle-test",
+            wp_id="WP01",
+            actor="reviewer-b",
+            workspace_context="review:/tmp/repo",
+            execution_mode="worktree",
+            repo_root=tmp_path,
+        )
+
+    assert exc_info.value.claimed_by == "reviewer-a"
+
+
+def test_claimed_lane_surfaces_as_doing_in_dashboard() -> None:
+    assert _KANBAN_COLUMN_FOR_LANE[Lane.CLAIMED] == "doing"

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -347,7 +347,7 @@ def test_scan_feature_kanban_approved_lane(tmp_path):
 
 
 def test_scan_feature_kanban_lane_mapping(tmp_path):
-    """claimed maps to planned, in_progress maps to doing."""
+    """claimed and in_progress both map to doing."""
     feature_dir = tmp_path / "kitty-specs" / "001-demo"
     (feature_dir / "tasks").mkdir(parents=True)
     for wp_id, lane in [("WP01", "claimed"), ("WP02", "in_progress")]:
@@ -357,8 +357,8 @@ def test_scan_feature_kanban_lane_mapping(tmp_path):
         )
         _set_wp_lane(feature_dir, wp_id, lane)
     lanes = scanner.scan_feature_kanban(tmp_path, "001-demo")
-    assert len(lanes["planned"]) == 1  # claimed -> planned
-    assert len(lanes["doing"]) == 1  # in_progress -> doing
+    assert len(lanes["planned"]) == 0
+    assert len(lanes["doing"]) == 2
 
 
 @pytest.mark.fast

--- a/tests/unit/status/test_review_claim_transition.py
+++ b/tests/unit/status/test_review_claim_transition.py
@@ -88,8 +88,18 @@ class TestReviewClaimDoesNotEmitInProgress:
         )
         text = workflow_path.read_text(encoding="utf-8")
 
-        # The review-claim transition emits to_lane=Lane.IN_REVIEW. There
-        # must be no `to_lane=Lane.IN_PROGRESS` inside the review claim.
-        assert "to_lane=Lane.IN_REVIEW" in text, (
-            "workflow.review must emit Lane.IN_REVIEW for the review claim"
+        assert "start_review_status(" in text, (
+            "workflow.review must delegate the review claim to the shared review lifecycle"
+        )
+
+        lifecycle_path = (
+            repo_root
+            / "src"
+            / "specify_cli"
+            / "status"
+            / "work_package_lifecycle.py"
+        )
+        lifecycle_text = lifecycle_path.read_text(encoding="utf-8")
+        assert "to_lane=Lane.IN_REVIEW" in lifecycle_text, (
+            "shared review lifecycle must emit Lane.IN_REVIEW for the review claim"
         )


### PR DESCRIPTION
## Summary
- add atomic batch status persistence for composite WP lifecycle transitions
- route internal implement, agent action implement, and orchestrator-api through a shared idempotent start service
- recover same-actor claimed WPs, reject different actors, and avoid pre-allocation in_progress writes
- surface claimed WPs in Doing columns for CLI and dashboard

Fixes #944

## Verification
- uv run ruff check src/specify_cli/status/store.py src/specify_cli/status/emit.py src/specify_cli/status/models.py src/specify_cli/status/work_package_lifecycle.py src/specify_cli/cli/commands/implement.py src/specify_cli/cli/commands/agent/workflow.py src/specify_cli/orchestrator_api/commands.py src/specify_cli/cli/commands/agent/tasks.py src/specify_cli/dashboard/scanner.py tests/status/test_store.py tests/status/test_work_package_lifecycle.py tests/agent/test_orchestrator_commands_integration.py tests/integration/test_status_emit_on_alloc_failure.py
- uv run pytest tests/agent/test_orchestrator_commands_integration.py tests/status/test_store.py tests/status/test_work_package_lifecycle.py tests/integration/test_status_emit_on_alloc_failure.py -q --timeout=60
- uv run pytest tests/status/test_store.py tests/status/test_work_package_lifecycle.py tests/agent/test_orchestrator_commands_integration.py::TestStartImplementation tests/integration/test_status_emit_on_alloc_failure.py tests/agent/test_implement_programmatic_call.py tests/agent/test_workflow_review_lane_gate.py -q --timeout=60

Note: a wider local run including tests/status hit an existing local SaaS sync lock timeout in tests/status/test_bootstrap.py before reaching this change set; the focused regression suites above passed.