### PR TITLE
feat(audit): add read-only mission-state audit engine

### DIFF
--- a/src/specify_cli/audit/__init__.py
+++ b/src/specify_cli/audit/__init__.py
@@ -1,0 +1,15 @@
+"""Read-only mission-state audit engine for spec-kitty."""
+
+from .engine import run_audit
+from .models import AuditOptions, MissionFinding, MissionAuditResult, RepoAuditReport, Severity
+from .serializer import build_report_json
+
+__all__ = [
+    "run_audit",
+    "AuditOptions",
+    "MissionFinding",
+    "MissionAuditResult",
+    "RepoAuditReport",
+    "Severity",
+    "build_report_json",
+]

--- a/src/specify_cli/audit/classifiers/__init__.py
+++ b/src/specify_cli/audit/classifiers/__init__.py
@@ -1,0 +1,1 @@
+"""Per-artifact classifier functions for the audit engine."""

--- a/src/specify_cli/audit/classifiers/decisions_events.py
+++ b/src/specify_cli/audit/classifiers/decisions_events.py
@@ -1,0 +1,22 @@
+"""Classifier for decisions/events.jsonl mission artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import MissionFinding
+from .mission_events import _classify_jsonl_file
+
+
+def classify_decisions_events_jsonl(mission_dir: Path) -> list[MissionFinding]:
+    """Classify decisions/events.jsonl for legacy keys, forbidden keys, and corruption.
+
+    Args:
+        mission_dir: Path to the mission directory.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Returns ``[]`` when the file is absent.
+    """
+    path = mission_dir / "decisions" / "events.jsonl"
+    return _classify_jsonl_file(path, "decisions/events.jsonl", "decision_event_row")

--- a/src/specify_cli/audit/classifiers/handoff_events.py
+++ b/src/specify_cli/audit/classifiers/handoff_events.py
@@ -1,0 +1,22 @@
+"""Classifier for handoff/events.jsonl mission artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import MissionFinding
+from .mission_events import _classify_jsonl_file
+
+
+def classify_handoff_events_jsonl(mission_dir: Path) -> list[MissionFinding]:
+    """Classify handoff/events.jsonl for legacy keys, forbidden keys, and corruption.
+
+    Args:
+        mission_dir: Path to the mission directory.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Returns ``[]`` when the file is absent.
+    """
+    path = mission_dir / "handoff" / "events.jsonl"
+    return _classify_jsonl_file(path, "handoff/events.jsonl", "handoff_event_row")

--- a/src/specify_cli/audit/classifiers/meta.py
+++ b/src/specify_cli/audit/classifiers/meta.py
@@ -38,7 +38,7 @@ def classify_meta_json(mission_dir: Path) -> list[MissionFinding]:
     except json.JSONDecodeError as exc:
         return [
             MissionFinding(
-                code="CORRUPT_JSONL",
+                code="CORRUPT_JSON",
                 severity=Severity.ERROR,
                 artifact_path="meta.json",
                 detail=f"JSON decode error: {exc.msg}",

--- a/src/specify_cli/audit/classifiers/meta.py
+++ b/src/specify_cli/audit/classifiers/meta.py
@@ -1,0 +1,75 @@
+"""Classifier for meta.json mission artifacts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from ..detectors import detect_legacy_keys
+from ..models import MissionFinding, Severity
+from ..shape_registry import check_unknown_keys
+
+# ULID character set: Crockford Base32 (excludes I, L, O, U)
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+
+
+def classify_meta_json(mission_dir: Path) -> list[MissionFinding]:
+    """Classify meta.json for legacy keys, identity issues, and unknown keys.
+
+    Returns an empty list when meta.json is absent (the identity adapter
+    handles IDENTITY_MISSING for orphan missions at the repo level).
+
+    Args:
+        mission_dir: Path to the mission directory (e.g. kitty-specs/NNN-slug/).
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Never raises — all exceptions become findings.
+    """
+    path = mission_dir / "meta.json"
+    if not path.exists():
+        return []
+
+    findings: list[MissionFinding] = []
+
+    try:
+        obj: dict[str, object] = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [
+            MissionFinding(
+                code="CORRUPT_JSONL",
+                severity=Severity.ERROR,
+                artifact_path="meta.json",
+                detail=f"JSON decode error: {exc.msg}",
+            )
+        ]
+
+    # Legacy key detection (work_package_id is valid in meta, so no extra_keys)
+    findings.extend(detect_legacy_keys(obj, "meta.json"))
+
+    # Identity checks
+    mission_id = obj.get("mission_id")
+    if mission_id is None:
+        findings.append(
+            MissionFinding(
+                code="IDENTITY_MISSING",
+                severity=Severity.ERROR,
+                artifact_path="meta.json",
+                detail="missing mission_id field",
+            )
+        )
+    elif not isinstance(mission_id, str) or not _ULID_RE.match(mission_id):
+        findings.append(
+            MissionFinding(
+                code="IDENTITY_INVALID",
+                severity=Severity.ERROR,
+                artifact_path="meta.json",
+                detail=f"mission_id is not a valid ULID: {mission_id!r}",
+            )
+        )
+
+    # Unknown key detection
+    findings.extend(check_unknown_keys("meta.json", obj, "meta.json"))
+
+    return findings

--- a/src/specify_cli/audit/classifiers/mission_events.py
+++ b/src/specify_cli/audit/classifiers/mission_events.py
@@ -1,0 +1,97 @@
+"""Classifier for mission-events.jsonl mission artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..detectors import detect_forbidden_keys, detect_legacy_keys
+from ..models import MissionFinding, Severity
+from ..shape_registry import check_unknown_keys
+
+
+def _classify_jsonl_file(
+    path: Path,
+    artifact_path: str,
+    artifact_type: str,
+) -> list[MissionFinding]:
+    """Shared JSONL classifier helper.
+
+    Reads *path* line by line.  For each non-blank line:
+    - On decode error: emits ``CORRUPT_JSONL`` and continues (collects all).
+    - On valid line: runs legacy-key, forbidden-key, and unknown-key checks.
+
+    Args:
+        path: Absolute path to the JSONL file.
+        artifact_path: Relative artifact path used in findings.
+        artifact_type: Key into ``KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT``.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Never raises.
+    """
+    if not path.exists():
+        return []
+
+    findings: list[MissionFinding] = []
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [
+            MissionFinding(
+                code="CORRUPT_JSONL",
+                severity=Severity.ERROR,
+                artifact_path=artifact_path,
+                detail=f"could not read file: {exc}",
+            )
+        ]
+
+    for line_number, raw_line in enumerate(raw_text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+
+        try:
+            obj: dict[str, object] = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            findings.append(
+                MissionFinding(
+                    code="CORRUPT_JSONL",
+                    severity=Severity.ERROR,
+                    artifact_path=artifact_path,
+                    detail=f"line {line_number}: {exc.msg}",
+                )
+            )
+            continue
+
+        if not isinstance(obj, dict):
+            findings.append(
+                MissionFinding(
+                    code="CORRUPT_JSONL",
+                    severity=Severity.ERROR,
+                    artifact_path=artifact_path,
+                    detail=f"line {line_number}: expected JSON object, got {type(obj).__name__}",
+                )
+            )
+            continue
+
+        findings.extend(detect_legacy_keys(obj, artifact_path))
+        findings.extend(detect_forbidden_keys(obj, artifact_path))
+        findings.extend(check_unknown_keys(artifact_type, obj, artifact_path))
+
+    return findings
+
+
+def classify_mission_events_jsonl(mission_dir: Path) -> list[MissionFinding]:
+    """Classify mission-events.jsonl for legacy keys, forbidden keys, and corruption.
+
+    Args:
+        mission_dir: Path to the mission directory.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Returns ``[]`` when the file is absent.
+    """
+    path = mission_dir / "mission-events.jsonl"
+    return _classify_jsonl_file(path, "mission-events.jsonl", "mission_event_row")

--- a/src/specify_cli/audit/classifiers/mission_events.py
+++ b/src/specify_cli/audit/classifiers/mission_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ..detectors import detect_forbidden_keys, detect_legacy_keys
+from ..detectors import detect_legacy_keys
 from ..models import MissionFinding, Severity
 from ..shape_registry import check_unknown_keys
 
@@ -19,7 +19,7 @@ def _classify_jsonl_file(
 
     Reads *path* line by line.  For each non-blank line:
     - On decode error: emits ``CORRUPT_JSONL`` and continues (collects all).
-    - On valid line: runs legacy-key, forbidden-key, and unknown-key checks.
+    - On valid line: runs legacy-key and unknown-key checks.
 
     Args:
         path: Absolute path to the JSONL file.
@@ -77,7 +77,6 @@ def _classify_jsonl_file(
             continue
 
         findings.extend(detect_legacy_keys(obj, artifact_path))
-        findings.extend(detect_forbidden_keys(obj, artifact_path))
         findings.extend(check_unknown_keys(artifact_type, obj, artifact_path))
 
     return findings

--- a/src/specify_cli/audit/classifiers/status_events.py
+++ b/src/specify_cli/audit/classifiers/status_events.py
@@ -1,0 +1,133 @@
+"""Classifier for status.events.jsonl mission artifacts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from ..detectors import (
+    STATUS_EVENT_ONLY_LEGACY_KEYS,
+    detect_forbidden_keys,
+    detect_legacy_keys,
+)
+from ..models import MissionFinding, Severity
+from ..shape_registry import check_unknown_keys
+
+# Actor format research (from real event logs and tests):
+#
+# Modern format examples:
+#   "finalize-tasks"      — system actor (kebab word)
+#   "migration"           — system actor (single word)
+#   "claude"              — agent (single word)
+#   "human"               — actor (single word)
+#   "user"                — actor (single word, legacy)
+#   "claude:opus"         — namespaced (agent:variant)
+#   "human:rob"           — namespaced (human:name)
+#
+# Old/drift format examples:
+#   Pure integers, empty strings, or values with spaces or unusual characters.
+#
+# We accept:
+#   - Any value matching ^[a-z][a-z0-9_:-]*$ (word chars, hyphens, colons, no spaces)
+# We flag as drift:
+#   - Anything else (e.g. uppercase, spaces, empty string, numeric-only)
+_ACTOR_RE = re.compile(r"^[a-z][a-z0-9_:-]*$")
+
+
+def classify_status_events_jsonl(
+    mission_dir: Path,
+) -> tuple[list[MissionFinding], bool]:
+    """Classify status.events.jsonl for legacy keys, forbidden keys, and corruption.
+
+    Unlike other classifiers this function returns a 2-tuple so the engine can
+    pass ``skip_drift=True`` to the status_json classifier when corruption is
+    detected.
+
+    Args:
+        mission_dir: Path to the mission directory.
+
+    Returns:
+        ``(findings, has_corrupt_jsonl)`` — findings is a list of
+        :class:`~specify_cli.audit.models.MissionFinding` objects;
+        ``has_corrupt_jsonl`` is True if at least one line failed to parse.
+        Never raises — all exceptions become findings.
+    """
+    path = mission_dir / "status.events.jsonl"
+    if not path.exists():
+        return [], False
+
+    findings: list[MissionFinding] = []
+    has_corrupt_jsonl = False
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [
+            MissionFinding(
+                code="CORRUPT_JSONL",
+                severity=Severity.ERROR,
+                artifact_path="status.events.jsonl",
+                detail=f"could not read file: {exc}",
+            )
+        ], True
+
+    for line_number, raw_line in enumerate(raw_text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+
+        try:
+            obj: dict[str, object] = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            findings.append(
+                MissionFinding(
+                    code="CORRUPT_JSONL",
+                    severity=Severity.ERROR,
+                    artifact_path="status.events.jsonl",
+                    detail=f"line {line_number}: {exc.msg}",
+                )
+            )
+            has_corrupt_jsonl = True
+            continue
+
+        if not isinstance(obj, dict):
+            findings.append(
+                MissionFinding(
+                    code="CORRUPT_JSONL",
+                    severity=Severity.ERROR,
+                    artifact_path="status.events.jsonl",
+                    detail=f"line {line_number}: expected JSON object, got {type(obj).__name__}",
+                )
+            )
+            has_corrupt_jsonl = True
+            continue
+
+        # Legacy key detection — include work_package_id for event rows
+        findings.extend(
+            detect_legacy_keys(
+                obj,
+                "status.events.jsonl",
+                extra_keys=STATUS_EVENT_ONLY_LEGACY_KEYS,
+            )
+        )
+
+        # Forbidden key detection
+        findings.extend(detect_forbidden_keys(obj, "status.events.jsonl"))
+
+        # Actor drift check
+        actor = obj.get("actor")
+        if actor is not None and not (isinstance(actor, str) and _ACTOR_RE.match(actor)):
+            findings.append(
+                MissionFinding(
+                    code="ACTOR_DRIFT",
+                    severity=Severity.WARNING,
+                    artifact_path="status.events.jsonl",
+                    detail=f"actor format unexpected: {actor!r}",
+                )
+            )
+
+        # Unknown key detection
+        findings.extend(check_unknown_keys("status_event_row", obj, "status.events.jsonl"))
+
+    return findings, has_corrupt_jsonl

--- a/src/specify_cli/audit/classifiers/status_json.py
+++ b/src/specify_cli/audit/classifiers/status_json.py
@@ -44,7 +44,7 @@ def classify_status_json(
     except json.JSONDecodeError as exc:
         return [
             MissionFinding(
-                code="CORRUPT_JSONL",
+                code="CORRUPT_JSON",
                 severity=Severity.ERROR,
                 artifact_path="status.json",
                 detail=f"JSON decode error: {exc.msg}",
@@ -60,15 +60,13 @@ def classify_status_json(
     if skip_drift:
         return findings
 
-    # Read-only drift check (C-001 compliance)
+    # Read-only drift check (C-001 compliance).
     # NEVER call reducer.materialize() — it writes status.json to disk.
-    # Use reduce() + materialize_to_json() which are read-only.
+    # materialize_snapshot() keeps parity with materialize() without writing.
     try:
-        from specify_cli.status.reducer import materialize_to_json, reduce
-        from specify_cli.status.store import read_events
+        from specify_cli.status.reducer import materialize_snapshot, materialize_to_json
 
-        events = read_events(mission_dir)
-        snapshot = reduce(events)
+        snapshot = materialize_snapshot(mission_dir)
         computed_json = materialize_to_json(snapshot)
     except Exception as exc:
         findings.append(

--- a/src/specify_cli/audit/classifiers/status_json.py
+++ b/src/specify_cli/audit/classifiers/status_json.py
@@ -1,0 +1,103 @@
+"""Classifier for status.json mission artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..detectors import detect_legacy_keys
+from ..models import MissionFinding, Severity
+from ..shape_registry import check_unknown_keys
+
+
+def classify_status_json(
+    mission_dir: Path,
+    *,
+    skip_drift: bool = False,
+) -> list[MissionFinding]:
+    """Classify status.json for legacy keys, unknown keys, and snapshot drift.
+
+    The drift check is read-only: it uses ``materialize_to_json`` (which
+    produces a deterministic string without writing any file) rather than
+    ``materialize`` (which writes status.json to disk).  When
+    ``skip_drift=True`` the drift check is skipped entirely — the engine
+    passes this flag when ``status.events.jsonl`` has corruption that would
+    cause the reducer to raise.
+
+    Args:
+        mission_dir: Path to the mission directory.
+        skip_drift: If True, skip the snapshot drift check.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Never raises — all exceptions become findings.
+    """
+    path = mission_dir / "status.json"
+    if not path.exists():
+        return []
+
+    findings: list[MissionFinding] = []
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+        obj: dict[str, object] = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        return [
+            MissionFinding(
+                code="CORRUPT_JSONL",
+                severity=Severity.ERROR,
+                artifact_path="status.json",
+                detail=f"JSON decode error: {exc.msg}",
+            )
+        ]
+
+    # Legacy key detection
+    findings.extend(detect_legacy_keys(obj, "status.json"))
+
+    # Unknown key detection
+    findings.extend(check_unknown_keys("status.json", obj, "status.json"))
+
+    if skip_drift:
+        return findings
+
+    # Read-only drift check (C-001 compliance)
+    # NEVER call reducer.materialize() — it writes status.json to disk.
+    # Use reduce() + materialize_to_json() which are read-only.
+    try:
+        from specify_cli.status.reducer import materialize_to_json, reduce
+        from specify_cli.status.store import read_events
+
+        events = read_events(mission_dir)
+        snapshot = reduce(events)
+        computed_json = materialize_to_json(snapshot)
+    except Exception as exc:
+        findings.append(
+            MissionFinding(
+                code="SNAPSHOT_DRIFT",
+                severity=Severity.ERROR,
+                artifact_path="status.json",
+                detail=f"reducer raised during drift check: {exc}",
+            )
+        )
+        return findings
+
+    # Normalise both sides: parse + re-serialise with identical options
+    try:
+        persisted_normalised = (
+            json.dumps(json.loads(raw_text), sort_keys=True, indent=2) + "\n"
+        )
+    except Exception:
+        # raw_text is already parsed above, so this branch is unreachable in practice
+        persisted_normalised = raw_text
+
+    if computed_json != persisted_normalised:
+        findings.append(
+            MissionFinding(
+                code="SNAPSHOT_DRIFT",
+                severity=Severity.ERROR,
+                artifact_path="status.json",
+                detail="reducer output does not match persisted status.json",
+            )
+        )
+
+    return findings

--- a/src/specify_cli/audit/classifiers/wp_files.py
+++ b/src/specify_cli/audit/classifiers/wp_files.py
@@ -1,0 +1,105 @@
+"""Classifier for WP*.md work-package frontmatter files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specify_cli.frontmatter import FrontmatterError, FrontmatterManager
+
+from ..detectors import detect_legacy_keys
+from ..models import MissionFinding, Severity
+from ..shape_registry import check_unknown_keys
+
+# Terminal lanes that require evidence
+_TERMINAL_LANES = frozenset({"done", "approved"})
+
+# Use the canonical FrontmatterManager (same ruamel.yaml config as production)
+_fm_manager = FrontmatterManager()
+
+
+def classify_wp_files(mission_dir: Path) -> list[MissionFinding]:
+    """Classify WP*.md frontmatter for legacy keys, unknown keys, and missing evidence.
+
+    Globs ``mission_dir / "tasks" / "WP*.md"``, sorted by filename for
+    determinism.  For each file:
+    - Parses YAML frontmatter via :class:`~specify_cli.frontmatter.FrontmatterManager`.
+    - Skips files with absent or empty frontmatter (no finding — frontmatter is optional).
+    - Emits ``UNKNOWN_SHAPE`` (info) for files whose frontmatter YAML cannot be parsed.
+    - Detects legacy keys and unknown keys.
+    - Emits ``MISSING_EVIDENCE`` (warning) when a terminal lane (done/approved)
+      has no ``evidence`` field or ``evidence`` is null.
+
+    ``artifact_path`` values use forward slashes (e.g. ``"tasks/WP01.md"``).
+
+    Args:
+        mission_dir: Path to the mission directory.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Returns ``[]`` when no WP*.md files exist.  Never raises.
+    """
+    tasks_dir = mission_dir / "tasks"
+    if not tasks_dir.exists():
+        return []
+
+    wp_files = sorted(tasks_dir.glob("WP*.md"), key=lambda p: p.name)
+    if not wp_files:
+        return []
+
+    findings: list[MissionFinding] = []
+
+    for wp_path in wp_files:
+        filename = wp_path.name
+        artifact_path = f"tasks/{filename}"
+
+        try:
+            frontmatter, _ = _fm_manager.read(wp_path)
+        except FrontmatterError:
+            # Frontmatter absent or malformed YAML
+            # Check if file starts with "---" to distinguish absent vs malformed
+            try:
+                content = wp_path.read_text(encoding="utf-8-sig")
+            except OSError:
+                # File unreadable — skip
+                continue
+
+            if not content.startswith("---"):
+                # No frontmatter — skip silently (optional)
+                continue
+
+            # Has "---" but FrontmatterManager raised — malformed YAML
+            findings.append(
+                MissionFinding(
+                    code="UNKNOWN_SHAPE",
+                    severity=Severity.INFO,
+                    artifact_path=artifact_path,
+                    detail="could not parse YAML frontmatter",
+                )
+            )
+            continue
+
+        if not frontmatter:
+            # Empty frontmatter — skip silently
+            continue
+
+        # Legacy key detection (work_package_id is valid in WP frontmatter)
+        findings.extend(detect_legacy_keys(frontmatter, artifact_path))
+
+        # Unknown key detection
+        findings.extend(check_unknown_keys("wp_frontmatter", frontmatter, artifact_path))
+
+        # Missing evidence check for terminal lanes
+        lane = frontmatter.get("lane") or frontmatter.get("status")
+        if isinstance(lane, str) and lane in _TERMINAL_LANES:
+            evidence = frontmatter.get("evidence")
+            if evidence is None:
+                findings.append(
+                    MissionFinding(
+                        code="MISSING_EVIDENCE",
+                        severity=Severity.WARNING,
+                        artifact_path=artifact_path,
+                        detail=f"terminal lane {lane!r} but evidence is absent",
+                    )
+                )
+
+    return findings

--- a/src/specify_cli/audit/detectors.py
+++ b/src/specify_cli/audit/detectors.py
@@ -1,0 +1,169 @@
+"""Key-based detectors and JSONL corruption detector for the audit engine.
+
+This module provides three low-level detector functions used by classifiers
+and the audit engine:
+
+- ``detect_legacy_keys`` — finds keys in ``LEGACY_KEYS`` (and an optional
+  extra set) that indicate pre-migration artifact shapes.
+- ``detect_forbidden_keys`` — finds keys in ``FORBIDDEN_KEYS`` that must
+  never appear in canonical artifacts.
+- ``detect_corrupt_jsonl`` — reads a JSONL file and returns a finding for
+  the first line that cannot be parsed.
+
+Key constants are exposed as module-level ``frozenset`` objects so callers
+and the shape registry can import them without re-defining them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .models import MissionFinding, Severity
+
+# ---------------------------------------------------------------------------
+# Key sets (immutable)
+# ---------------------------------------------------------------------------
+
+# Keys that are legacy in ALL artifact types (meta.json, WP frontmatter, event rows).
+# Presence of any of these keys in a parsed dict indicates a pre-migration shape.
+LEGACY_KEYS: frozenset[str] = frozenset(
+    {
+        "feature_slug",
+        "feature_number",
+        "mission_key",
+        "legacy_aggregate_id",
+    }
+)
+
+# Keys that are legacy ONLY in status event rows (FR-012).
+#
+# ``work_package_id`` IS the canonical key in WP frontmatter (tasks/WP*.md),
+# so it must NOT be flagged when processing frontmatter — only in event rows.
+# Callers processing event rows must pass
+# ``extra_keys=STATUS_EVENT_ONLY_LEGACY_KEYS`` to ``detect_legacy_keys()``.
+STATUS_EVENT_ONLY_LEGACY_KEYS: frozenset[str] = frozenset(
+    {
+        "work_package_id",
+    }
+)
+
+# Keys that must never appear in canonical runtime artifacts.
+# Their presence indicates that an event row was written by a pre-migration
+# producer that used a ``type``/``name`` discriminator instead of canonical
+# ``to_lane`` / ``from_lane``.
+FORBIDDEN_KEYS: frozenset[str] = frozenset(
+    {
+        "event_type",
+        "event_name",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Detector functions
+# ---------------------------------------------------------------------------
+
+
+def detect_legacy_keys(
+    obj: dict[str, object],
+    artifact_path: str,
+    *,
+    extra_keys: frozenset[str] = frozenset(),
+) -> list[MissionFinding]:
+    """Return one ``LEGACY_KEY`` finding for each legacy key present in *obj*.
+
+    Args:
+        obj: Parsed artifact dict (e.g. ``meta.json`` contents).
+        artifact_path: Relative path to the artifact, used as ``artifact_path``
+            in findings (forward-slash, relative to mission directory).
+        extra_keys: Additional keys to treat as legacy.  Pass
+            ``STATUS_EVENT_ONLY_LEGACY_KEYS`` when processing status event rows
+            so that ``work_package_id`` is also flagged.  Omit (or pass an
+            empty ``frozenset``) for ``meta.json`` and WP frontmatter.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects,
+        one per matched key.  Empty list when none are found.
+    """
+    combined = LEGACY_KEYS | extra_keys
+    findings: list[MissionFinding] = []
+    for key in obj:
+        if key in combined:
+            findings.append(
+                MissionFinding(
+                    code="LEGACY_KEY",
+                    severity=Severity.WARNING,
+                    artifact_path=artifact_path,
+                    detail=f"legacy key: {key!r}",
+                )
+            )
+    return findings
+
+
+def detect_forbidden_keys(
+    obj: dict[str, object],
+    artifact_path: str,
+) -> list[MissionFinding]:
+    """Return one ``FORBIDDEN_KEY`` finding for each forbidden key in *obj*.
+
+    Args:
+        obj: Parsed artifact dict.
+        artifact_path: Relative path to the artifact.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Empty list when none are found.
+    """
+    findings: list[MissionFinding] = []
+    for key in obj:
+        if key in FORBIDDEN_KEYS:
+            findings.append(
+                MissionFinding(
+                    code="FORBIDDEN_KEY",
+                    severity=Severity.WARNING,
+                    artifact_path=artifact_path,
+                    detail=f"forbidden key: {key!r}",
+                )
+            )
+    return findings
+
+
+def detect_corrupt_jsonl(path: Path, artifact_path: str) -> list[MissionFinding]:
+    """Return a ``CORRUPT_JSONL`` finding for the first unparseable line.
+
+    The function stops at the **first** corrupt line to avoid producing O(n)
+    findings on a badly damaged file.  Blank lines (and lines containing only
+    whitespace) are silently skipped.  If *path* does not exist the function
+    returns an empty list.
+
+    Args:
+        path: Absolute (or resolvable) path to the ``.jsonl`` file.
+        artifact_path: Relative path used as ``artifact_path`` in findings.
+
+    Returns:
+        A list containing at most one :class:`~specify_cli.audit.models.MissionFinding`.
+        The ``detail`` field includes the 1-based line number and the
+        :class:`json.JSONDecodeError` message, but not the raw corrupt content.
+    """
+    if not path.exists():
+        return []
+
+    with path.open(encoding="utf-8") as fh:
+        for line_number, raw_line in enumerate(fh, start=1):
+            stripped = raw_line.strip()
+            if not stripped:
+                continue  # blank line — skip silently
+            try:
+                json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                return [
+                    MissionFinding(
+                        code="CORRUPT_JSONL",
+                        severity=Severity.ERROR,
+                        artifact_path=artifact_path,
+                        detail=f"line {line_number}: {exc.msg}",
+                    )
+                ]
+
+    return []

--- a/src/specify_cli/audit/engine.py
+++ b/src/specify_cli/audit/engine.py
@@ -1,0 +1,446 @@
+"""Audit engine: scan loop, classifier dispatch, repo-level findings, report assembly.
+
+This module is the integration point for the read-only mission-state audit.  It:
+
+1. Discovers mission directories under ``scan_root`` in lexicographic order.
+2. Dispatches the 7 per-artifact classifiers for each mission.
+3. Calls ``audit_repo()`` once and indexes ``IdentityState`` results by slug.
+4. Calls ``find_duplicate_prefixes()`` and ``find_ambiguous_selectors()`` for
+   repo-level findings.
+5. Sorts findings by ``(artifact_path, code)`` within each mission.
+6. Assembles ``RepoAuditReport`` with sorted missions and shape counters.
+
+Determinism contract (D4):
+- Missions processed in ``sorted(..., key=lambda p: p.name)`` order.
+- Findings sorted by ``(artifact_path, code)`` before constructing ``MissionAuditResult``.
+- ``json.dumps(sort_keys=True, indent=2)`` — enforced by ``serializer.py``.
+- No timestamps, PIDs, or wall-clock values in output.
+- ``shape_counters`` built with ``collections.Counter``, serialised with sorted keys.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from specify_cli.context.mission_resolver import (
+    AmbiguousHandleError,  # noqa: F401  (re-exported for CLI callers via engine)
+    MissionNotFoundError,  # noqa: F401
+    resolve_mission,
+)
+from specify_cli.status.identity_audit import (
+    IdentityState,
+    audit_repo,
+    find_ambiguous_selectors,
+    find_duplicate_prefixes,
+)
+
+from .classifiers.decisions_events import classify_decisions_events_jsonl
+from .classifiers.handoff_events import classify_handoff_events_jsonl
+from .classifiers.meta import classify_meta_json
+from .classifiers.mission_events import classify_mission_events_jsonl
+from .classifiers.status_events import classify_status_events_jsonl
+from .classifiers.status_json import classify_status_json
+from .classifiers.wp_files import classify_wp_files
+from .identity_adapter import (
+    identity_state_to_findings,
+)
+from .models import AuditOptions, MissionAuditResult, MissionFinding, RepoAuditReport
+
+
+# ---------------------------------------------------------------------------
+# Private: mission filter resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mission_filter(
+    handle: str | None,
+    repo_root: Path,
+    scan_root: Path,
+) -> frozenset[Path] | None:
+    """Return the set of allowed directories for ``--mission`` scoping, or None for all.
+
+    If *handle* is None, returns None — meaning all missions are scanned.
+
+    If *handle* is provided, ``resolve_mission()`` is called against *repo_root*
+    (which expects ``kitty-specs/`` to live there).  If the resolved slug
+    corresponds to an existing directory under *scan_root*, a singleton
+    ``frozenset`` is returned.  If the candidate directory is absent under
+    *scan_root* (e.g. fixture-dir mode with a missing mission), an empty
+    ``frozenset`` is returned so the scan yields an empty report.
+
+    Raises:
+        AmbiguousHandleError: The handle matches more than one mission.
+        MissionNotFoundError: The handle matches no mission.
+
+    Note: these exceptions propagate up to the CLI layer, which formats them
+    as structured errors.
+    """
+    if handle is None:
+        return None  # no filter: scan everything
+
+    resolved = resolve_mission(handle, repo_root)
+    candidate = scan_root / resolved.mission_slug
+    if candidate.is_dir():
+        return frozenset({candidate})
+    # Candidate not found under scan_root (fixture-dir mismatch).
+    return frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Private: per-mission scan loop
+# ---------------------------------------------------------------------------
+
+
+def _scan_missions(
+    scan_root: Path,
+    allowed_dirs: frozenset[Path] | None,
+    identity_index: dict[str, Any],
+) -> list[MissionAuditResult]:
+    """Walk *scan_root* and classify each mission directory.
+
+    Args:
+        scan_root: Directory to walk (usually ``repo_root / "kitty-specs"``).
+        allowed_dirs: When not None, only directories in this set are processed.
+            Pass ``frozenset()`` to produce an empty scan result.
+        identity_index: Mapping of ``{mission_slug: IdentityState}`` built from
+            ``audit_repo()``.  Used to call ``identity_state_to_findings()``
+            without re-reading ``meta.json`` for each mission.
+
+    Returns:
+        List of :class:`~specify_cli.audit.models.MissionAuditResult`, one per
+        directory, in lexicographic order of directory name.  Each result's
+        findings are sorted by ``(artifact_path, code)``.
+    """
+    if not scan_root.exists():
+        return []
+
+    try:
+        candidates = sorted(scan_root.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return []
+
+    results: list[MissionAuditResult] = []
+
+    for candidate in candidates:
+        if not candidate.is_dir():
+            continue
+
+        if allowed_dirs is not None and candidate not in allowed_dirs:
+            continue
+
+        identity_state = identity_index.get(candidate.name)
+
+        # Collect findings from all 7 classifiers in the documented order.
+        all_findings: list[MissionFinding] = []
+
+        # 1. meta.json
+        all_findings.extend(classify_meta_json(candidate))
+
+        # 2. status.events.jsonl — returns (findings, has_corrupt_jsonl)
+        findings_events, has_corrupt = classify_status_events_jsonl(candidate)
+        all_findings.extend(findings_events)
+
+        # 3. status.json — skip drift check if events are corrupt
+        all_findings.extend(classify_status_json(candidate, skip_drift=has_corrupt))
+
+        # 4. mission-events.jsonl
+        all_findings.extend(classify_mission_events_jsonl(candidate))
+
+        # 5. decisions/events.jsonl
+        all_findings.extend(classify_decisions_events_jsonl(candidate))
+
+        # 6. handoff/events.jsonl
+        all_findings.extend(classify_handoff_events_jsonl(candidate))
+
+        # 7. WP*.md frontmatter
+        all_findings.extend(classify_wp_files(candidate))
+
+        # 8. Identity-state adapter (only when identity data is available)
+        if identity_state is not None:
+            all_findings.extend(identity_state_to_findings(identity_state, candidate))
+
+        # Sort by (artifact_path, code) for determinism before constructing the result.
+        sorted_findings = sorted(all_findings, key=lambda f: (f.artifact_path, f.code))
+
+        results.append(
+            MissionAuditResult(
+                mission_slug=candidate.name,
+                mission_dir=candidate,
+                findings=sorted_findings,
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Private: repo-level finding computation (slug-attributed)
+# ---------------------------------------------------------------------------
+
+
+def _compute_repo_findings_by_slug(
+    repo_root: Path,
+    identity_states: list[IdentityState],
+    mission_results: list[MissionAuditResult],
+) -> dict[str, list[MissionFinding]]:
+    """Compute cross-mission (repo-level) findings, attributed by slug.
+
+    Calls the three repo-level identity functions and returns a dict mapping
+    each mission slug to any findings that belong to that mission.
+
+    Three sources:
+    - Duplicate 3-digit numeric prefixes (``DUPLICATE_PREFIX`` warning)
+    - Ambiguous selector handles (``AMBIGUOUS_SELECTOR`` warning)
+    - Duplicate ``mission_id`` values (``DUPLICATE_MISSION_ID`` error)
+
+    All three identity functions use *repo_root* (not ``scan_root``) because
+    they internally append ``/kitty-specs``.
+
+    The adapter functions each emit one finding *per member* of a duplicate
+    group. We attribute each finding to the correct mission by re-running the
+    adapters and tracking which state generated which finding.
+
+    Args:
+        repo_root: Repository root.
+        identity_states: All ``IdentityState`` objects from ``audit_repo()``.
+        mission_results: Per-mission results (used to build ``slug_to_dir``).
+
+    Returns:
+        Dict mapping ``{mission_slug: [MissionFinding, ...]}`` for all
+        missions that have any repo-level findings.
+    """
+    prefix_groups = find_duplicate_prefixes(repo_root)
+    selector_groups = find_ambiguous_selectors(identity_states)
+    slug_to_dir = {r.mission_slug: r.mission_dir for r in mission_results}
+
+    attributed: dict[str, list[MissionFinding]] = {}
+
+    # --- DUPLICATE_PREFIX: one finding per state in each prefix group -----------
+    for prefix, states in prefix_groups.items():
+        if len(states) < 2:
+            continue
+        all_slugs = sorted(s.slug for s in states)
+        for state in states:
+            other_slugs = ", ".join(s for s in all_slugs if s != state.slug)
+            finding = MissionFinding(
+                code="DUPLICATE_PREFIX",
+                severity=_slug_to_finding_severity("DUPLICATE_PREFIX"),
+                artifact_path="meta.json",
+                detail=f"prefix {prefix!r} shared with: {other_slugs}",
+            )
+            if state.slug in slug_to_dir:
+                attributed.setdefault(state.slug, []).append(finding)
+
+    # --- AMBIGUOUS_SELECTOR: one finding per state in each selector group -------
+    for handle, states in selector_groups.items():
+        if len(states) < 2:
+            continue
+        all_slugs = sorted(s.slug for s in states)
+        for state in states:
+            other_slugs = ", ".join(s for s in all_slugs if s != state.slug)
+            finding = MissionFinding(
+                code="AMBIGUOUS_SELECTOR",
+                severity=_slug_to_finding_severity("AMBIGUOUS_SELECTOR"),
+                artifact_path="meta.json",
+                detail=f"handle {handle!r} also matches: {other_slugs}",
+            )
+            if state.slug in slug_to_dir:
+                attributed.setdefault(state.slug, []).append(finding)
+
+    # --- DUPLICATE_MISSION_ID: one finding per mission sharing the same ID ------
+    from collections import defaultdict
+
+    by_id: dict[str, list[IdentityState]] = defaultdict(list)
+    for state in identity_states:
+        if state.mission_id is not None:
+            by_id[state.mission_id].append(state)
+
+    for mission_id, group in by_id.items():
+        if len(group) < 2:
+            continue
+        all_slugs = sorted(s.slug for s in group)
+        for state in group:
+            other_slugs = ", ".join(s for s in all_slugs if s != state.slug)
+            finding = MissionFinding(
+                code="DUPLICATE_MISSION_ID",
+                severity=_slug_to_finding_severity("DUPLICATE_MISSION_ID"),
+                artifact_path="meta.json",
+                detail=f"mission_id {mission_id!r} also used by: {other_slugs}",
+            )
+            if state.slug in slug_to_dir:
+                attributed.setdefault(state.slug, []).append(finding)
+
+    return attributed
+
+
+def _slug_to_finding_severity(code: str) -> Any:
+    """Return the severity for a repo-level finding code."""
+    from .models import Severity
+
+    _MAP = {
+        "DUPLICATE_PREFIX": Severity.WARNING,
+        "AMBIGUOUS_SELECTOR": Severity.WARNING,
+        "DUPLICATE_MISSION_ID": Severity.ERROR,
+    }
+    return _MAP.get(code, Severity.WARNING)
+
+
+def _compute_repo_findings(
+    repo_root: Path,
+    identity_states: list[IdentityState],
+    mission_results: list[MissionAuditResult],
+) -> list[MissionFinding]:
+    """Compute cross-mission (repo-level) findings as a flat list.
+
+    This thin wrapper calls ``_compute_repo_findings_by_slug`` and flattens
+    the result.  Used in the public API signature described in the WP spec.
+    """
+    by_slug = _compute_repo_findings_by_slug(repo_root, identity_states, mission_results)
+    return [f for findings in by_slug.values() for f in findings]
+
+
+def _merge_repo_findings(
+    mission_results: list[MissionAuditResult],
+    repo_findings: list[MissionFinding],
+) -> list[MissionAuditResult]:
+    """Attach repo-level findings to the appropriate per-mission result.
+
+    NOTE: This function exists to satisfy the WP spec API contract.  The
+    actual attribution is performed inside ``run_audit()`` via
+    ``_compute_repo_findings_by_slug()``, which returns slug-keyed findings.
+    When called from ``run_audit()`` the ``repo_findings`` list passed here
+    will be empty (findings are merged directly).  When called externally
+    with a non-empty list, findings are distributed using a slug-match
+    heuristic against the finding ``detail`` field.
+
+    Args:
+        mission_results: Per-mission results.
+        repo_findings: Flat list of repo-level findings to distribute.
+
+    Returns:
+        The same list of ``MissionAuditResult`` objects, modified in place.
+    """
+    # When called from run_audit(), repo_findings is always empty because
+    # attribution is already handled by _compute_repo_findings_by_slug().
+    # This function is kept for API contract compliance and external use.
+    if not repo_findings:
+        return mission_results
+
+    by_slug = {r.mission_slug: r for r in mission_results}
+    for finding in repo_findings:
+        detail = finding.detail or ""
+        matched = False
+        for slug, result in by_slug.items():
+            if slug in detail:
+                result.findings.append(finding)
+                result.findings.sort(key=lambda f: (f.artifact_path, f.code))
+                matched = True
+                break
+        if not matched:
+            for result in by_slug.values():
+                result.findings.append(finding)
+                result.findings.sort(key=lambda f: (f.artifact_path, f.code))
+
+    return mission_results
+
+
+# ---------------------------------------------------------------------------
+# Private: report assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_report(mission_results: list[MissionAuditResult]) -> RepoAuditReport:
+    """Assemble the final ``RepoAuditReport`` from per-mission results.
+
+    Args:
+        mission_results: Per-mission results, already merged with repo-level
+            findings and individually sorted.
+
+    Returns:
+        :class:`~specify_cli.audit.models.RepoAuditReport` with:
+        - ``missions`` sorted by ``mission_slug``
+        - ``shape_counters`` built via ``Counter`` (serialised with sorted keys
+          by ``RepoAuditReport.to_dict()``)
+        - ``repo_summary`` with counts and severity breakdown
+    """
+    counter: Counter[str] = Counter(
+        f.code for r in mission_results for f in r.findings
+    )
+
+    severity_counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
+    for r in mission_results:
+        for f in r.findings:
+            severity_counts[f.severity.value] += 1
+
+    repo_summary: dict[str, Any] = {
+        "total_missions": len(mission_results),
+        "missions_with_errors": sum(1 for r in mission_results if r.has_errors),
+        "missions_with_warnings": sum(1 for r in mission_results if r.has_warnings),
+        "total_findings": sum(len(r.findings) for r in mission_results),
+        "findings_by_severity": severity_counts,
+    }
+
+    return RepoAuditReport(
+        missions=sorted(mission_results, key=lambda r: r.mission_slug),
+        shape_counters=dict(counter),
+        repo_summary=repo_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_audit(options: AuditOptions) -> RepoAuditReport:
+    """Run the full mission-state audit and return a ``RepoAuditReport``.
+
+    This function is the sole public entry point for the audit engine.  It
+    is completely read-only: no files are written, no processes are spawned,
+    and no network calls are made.
+
+    Args:
+        options: Engine configuration.  ``scan_root`` defaults to
+            ``options.repo_root / "kitty-specs"`` when None.
+
+    Returns:
+        :class:`~specify_cli.audit.models.RepoAuditReport` with all findings.
+
+    Raises:
+        AmbiguousHandleError: ``options.mission_filter`` matches > 1 mission.
+        MissionNotFoundError: ``options.mission_filter`` matches 0 missions.
+    """
+    scan_root = options.scan_root or (options.repo_root / "kitty-specs")
+
+    # CRITICAL: identity functions (audit_repo, find_duplicate_prefixes) take
+    # repo_root and internally append /kitty-specs.  They must NOT receive
+    # scan_root, which would cause them to look for scan_root/kitty-specs —
+    # a path that does not exist — and silently return zero identity states.
+    identity_states = audit_repo(options.repo_root)
+    identity_index: dict[str, Any] = {s.slug: s for s in identity_states}
+
+    # Mission filter: resolve handle → allowed_dirs set (may raise on bad handle)
+    allowed_dirs = _resolve_mission_filter(
+        options.mission_filter, options.repo_root, scan_root
+    )
+
+    # Per-mission classification
+    mission_results = _scan_missions(scan_root, allowed_dirs, identity_index)
+
+    # Repo-level findings with explicit slug attribution
+    attributed = _compute_repo_findings_by_slug(
+        options.repo_root, identity_states, mission_results
+    )
+
+    # Merge attributed repo-level findings into per-mission results
+    if attributed:
+        by_slug = {r.mission_slug: r for r in mission_results}
+        for slug, findings in attributed.items():
+            if slug in by_slug:
+                by_slug[slug].findings.extend(findings)
+                by_slug[slug].findings.sort(key=lambda f: (f.artifact_path, f.code))
+
+    # Build and return the final report
+    return _build_report(mission_results)

--- a/src/specify_cli/audit/identity_adapter.py
+++ b/src/specify_cli/audit/identity_adapter.py
@@ -1,0 +1,212 @@
+"""Identity adapter: convert IdentityState objects to MissionFinding records.
+
+This module is the **only** coupling point between the audit engine and the
+existing ``specify_cli.status.identity_audit`` module.  It imports
+``IdentityState`` internally and never re-exports it — callers outside this
+module must not import ``IdentityState`` directly.
+
+Public functions
+----------------
+``identity_state_to_findings``
+    Maps a single ``IdentityState`` to zero or more ``MissionFinding`` records.
+    Only the ``orphan`` state emits a finding here; ``legacy``, ``pending``,
+    and ``assigned`` are handled by the meta-JSON classifier or emit nothing.
+
+``prefix_groups_to_findings``
+    Converts ``find_duplicate_prefixes()`` output to ``DUPLICATE_PREFIX``
+    findings.
+
+``selector_groups_to_findings``
+    Converts ``find_ambiguous_selectors()`` output to ``AMBIGUOUS_SELECTOR``
+    findings.
+
+``duplicate_ids_to_findings``
+    Detects missions that share the same ``mission_id`` value and emits
+    ``DUPLICATE_MISSION_ID`` findings.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+# Internal import — IdentityState is NOT re-exported from this module.
+from specify_cli.status.identity_audit import IdentityState
+
+from .models import MissionFinding, Severity
+
+
+# ---------------------------------------------------------------------------
+# Single-state adapter
+# ---------------------------------------------------------------------------
+
+
+def identity_state_to_findings(
+    state: IdentityState,
+    mission_dir: Path,  # noqa: ARG001  (kept for call-site symmetry)
+) -> list[MissionFinding]:
+    """Convert a single ``IdentityState`` to audit findings.
+
+    State → finding mapping:
+
+    - ``orphan``: ``meta.json`` is absent or unreadable — emits
+      ``IDENTITY_MISSING`` (error).
+    - ``legacy``: ``meta.json`` exists but has no ``mission_id``.  **No
+      finding emitted here** — ``classify_meta_json()`` (WP03) will emit
+      ``IDENTITY_MISSING`` when it processes the file contents.  Emitting
+      here too would produce a duplicate finding.
+    - ``pending``: ``mission_id`` present, ``mission_number`` null.  Valid
+      pre-merge state — no finding.
+    - ``assigned``: both ``mission_id`` and ``mission_number`` present — no
+      finding.
+
+    ``IDENTITY_INVALID`` (non-ULID ``mission_id``) is NOT this adapter's
+    responsibility.  It is detected exclusively by ``classify_meta_json()``
+    via direct regex check.
+
+    Args:
+        state: The ``IdentityState`` produced by
+            :func:`specify_cli.status.identity_audit.classify_mission`.
+        mission_dir: Absolute path to the mission directory.  Retained for
+            call-site symmetry; not used to construct findings (the finding
+            ``artifact_path`` is always ``"meta.json"``).
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
+        Empty list for ``legacy``, ``pending``, and ``assigned`` states.
+    """
+    if state.state == "orphan":
+        return [
+            MissionFinding(
+                code="IDENTITY_MISSING",
+                severity=Severity.ERROR,
+                artifact_path="meta.json",
+                detail="meta.json absent",
+            )
+        ]
+    # legacy: meta classifier handles IDENTITY_MISSING for this case
+    # pending, assigned: no finding
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Repo-level group adapters
+# ---------------------------------------------------------------------------
+
+
+def prefix_groups_to_findings(
+    groups: dict[str, list[IdentityState]],
+    slug_to_dir: dict[str, Path],  # noqa: ARG001
+) -> list[MissionFinding]:
+    """Convert ``find_duplicate_prefixes()`` output to ``DUPLICATE_PREFIX`` findings.
+
+    For each prefix that is shared by two or more missions, one finding is
+    emitted *per mission* in the group.  The ``detail`` field lists the other
+    missions sharing the same prefix (sorted, comma-separated).
+
+    Args:
+        groups: Mapping of ``{prefix: [IdentityState, ...]}`` with ≥ 2 members,
+            as returned by
+            :func:`specify_cli.status.identity_audit.find_duplicate_prefixes`.
+        slug_to_dir: Mapping of mission slug to its directory path.  Used to
+            attach findings to the right mission directory.
+
+    Returns:
+        A flat list of ``DUPLICATE_PREFIX`` findings (one per mission per
+        duplicated prefix).
+    """
+    findings: list[MissionFinding] = []
+    for prefix, states in groups.items():
+        if len(states) < 2:
+            continue
+        all_slugs = sorted(s.slug for s in states)
+        for state in states:
+            other_slugs = ", ".join(s for s in all_slugs if s != state.slug)
+            findings.append(
+                MissionFinding(
+                    code="DUPLICATE_PREFIX",
+                    severity=Severity.WARNING,
+                    artifact_path="meta.json",
+                    detail=f"prefix {prefix!r} shared with: {other_slugs}",
+                )
+            )
+    return findings
+
+
+def selector_groups_to_findings(
+    groups: dict[str, list[IdentityState]],
+    slug_to_dir: dict[str, Path],  # noqa: ARG001
+) -> list[MissionFinding]:
+    """Convert ``find_ambiguous_selectors()`` output to ``AMBIGUOUS_SELECTOR`` findings.
+
+    For each handle that resolves to two or more missions, one finding is
+    emitted *per mission* in the group.
+
+    Args:
+        groups: Mapping of ``{handle: [IdentityState, ...]}`` with ≥ 2 members,
+            as returned by
+            :func:`specify_cli.status.identity_audit.find_ambiguous_selectors`.
+        slug_to_dir: Mapping of mission slug to its directory path.
+
+    Returns:
+        A flat list of ``AMBIGUOUS_SELECTOR`` findings.
+    """
+    findings: list[MissionFinding] = []
+    for handle, states in groups.items():
+        if len(states) < 2:
+            continue
+        all_slugs = sorted(s.slug for s in states)
+        for state in states:
+            other_slugs = ", ".join(s for s in all_slugs if s != state.slug)
+            findings.append(
+                MissionFinding(
+                    code="AMBIGUOUS_SELECTOR",
+                    severity=Severity.WARNING,
+                    artifact_path="meta.json",
+                    detail=f"handle {handle!r} also matches: {other_slugs}",
+                )
+            )
+    return findings
+
+
+def duplicate_ids_to_findings(
+    states: list[IdentityState],
+    slug_to_dir: dict[str, Path],  # noqa: ARG001
+) -> list[MissionFinding]:
+    """Detect missions with identical ``mission_id`` values and emit findings.
+
+    Groups all states by ``mission_id`` (ignoring ``None``).  Any group with
+    ≥ 2 members indicates two missions with the same ULID, which is a data
+    integrity error.
+
+    Args:
+        states: All ``IdentityState`` objects for the repository (e.g. from
+            :func:`specify_cli.status.identity_audit.audit_repo`).
+        slug_to_dir: Mapping of mission slug to its directory path.
+
+    Returns:
+        A flat list of ``DUPLICATE_MISSION_ID`` findings (one per mission in
+        each group).
+    """
+    # Group by mission_id, skipping None values (orphan / legacy states).
+    by_id: dict[str, list[IdentityState]] = defaultdict(list)
+    for state in states:
+        if state.mission_id is not None:
+            by_id[state.mission_id].append(state)
+
+    findings: list[MissionFinding] = []
+    for mission_id, group in by_id.items():
+        if len(group) < 2:
+            continue
+        all_slugs = sorted(s.slug for s in group)
+        for state in group:
+            other_slugs = ", ".join(s for s in all_slugs if s != state.slug)
+            findings.append(
+                MissionFinding(
+                    code="DUPLICATE_MISSION_ID",
+                    severity=Severity.ERROR,
+                    artifact_path="meta.json",
+                    detail=f"mission_id {mission_id!r} also used by: {other_slugs}",
+                )
+            )
+    return findings

--- a/src/specify_cli/audit/models.py
+++ b/src/specify_cli/audit/models.py
@@ -1,0 +1,160 @@
+"""Data models for the read-only mission-state audit engine.
+
+This module defines the core types used throughout the audit package:
+- Severity: ordered StrEnum (error < warning < info)
+- MissionFinding: immutable finding record
+- MissionAuditResult: per-mission audit outcome
+- RepoAuditReport: full repository audit report
+- AuditOptions: engine configuration
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class Severity(StrEnum):
+    """Audit finding severity level.
+
+    Ordering: error < warning < info (lower index = higher severity).
+    Use ``__le__`` / ``__lt__`` for threshold comparisons, e.g.::
+
+        if any(f.severity <= fail_on_threshold for f in findings):
+            sys.exit(1)
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+    def __le__(self, other: Severity) -> bool:  # type: ignore[override]
+        _order = {"error": 0, "warning": 1, "info": 2}
+        return _order[self.value] <= _order[other.value]
+
+    def __lt__(self, other: Severity) -> bool:  # type: ignore[override]
+        _order = {"error": 0, "warning": 1, "info": 2}
+        return _order[self.value] < _order[other.value]
+
+
+@dataclass(frozen=True)
+class MissionFinding:
+    """A single audit finding for a mission artifact.
+
+    Invariants (enforced by callers, not runtime-checked here):
+    - ``artifact_path`` must use forward slashes, not OS-native separators.
+    - ``artifact_path`` must be relative to the mission directory, never absolute.
+    - ``detail`` must not contain any run-varying values (timestamps, PIDs,
+      memory addresses) so that deterministic serialization is possible.
+
+    Canonical finding codes are defined in ``detectors.py`` and
+    ``identity_adapter.py``; see the WP01 spec for the full table.
+    """
+
+    code: str
+    severity: Severity
+    artifact_path: str
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable dict with severity as its string value."""
+        return {
+            "artifact_path": self.artifact_path,
+            "code": self.code,
+            "detail": self.detail,
+            "severity": self.severity.value,
+        }
+
+
+@dataclass
+class MissionAuditResult:
+    """Audit outcome for a single mission directory.
+
+    The engine is responsible for sorting ``findings`` by ``(artifact_path, code)``
+    before constructing this object to guarantee deterministic serialization.
+    """
+
+    mission_slug: str
+    mission_dir: Path
+    findings: list[MissionFinding]
+
+    @property
+    def has_errors(self) -> bool:
+        """True if any finding has ERROR severity."""
+        return any(f.severity == Severity.ERROR for f in self.findings)
+
+    @property
+    def has_warnings(self) -> bool:
+        """True if any finding has WARNING severity."""
+        return any(f.severity == Severity.WARNING for f in self.findings)
+
+    @property
+    def finding_codes(self) -> set[str]:
+        """Set of all finding codes present in this result."""
+        return {f.code for f in self.findings}
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable dict.
+
+        ``mission_dir`` is serialized as a plain string because ``Path`` is
+        opaque across platforms; callers should not parse it.
+        """
+        return {
+            "finding_count": len(self.findings),
+            "findings": [f.to_dict() for f in self.findings],
+            "has_errors": self.has_errors,
+            "mission_dir": str(self.mission_dir),
+            "mission_slug": self.mission_slug,
+        }
+
+
+@dataclass
+class RepoAuditReport:
+    """Full audit report for a repository's ``kitty-specs/`` tree.
+
+    ``missions`` must be sorted lexicographically by ``mission_slug`` by the
+    engine before construction to satisfy NFR-001 (deterministic output).
+
+    ``shape_counters`` maps finding code to total count across all missions.
+    ``to_dict()`` sorts this dict by key for determinism.
+
+    ``repo_summary`` shape (produced by the engine)::
+
+        {
+            "findings_by_severity": {"error": 5, "info": 3, "warning": 10},
+            "missions_with_errors": 3,
+            "missions_with_warnings": 7,
+            "total_findings": 18,
+            "total_missions": 42,
+        }
+    """
+
+    missions: list[MissionAuditResult]
+    shape_counters: dict[str, int]
+    repo_summary: dict[str, Any]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable dict with shape_counters sorted by key."""
+        return {
+            "missions": [m.to_dict() for m in self.missions],
+            "repo_summary": self.repo_summary,
+            "shape_counters": dict(sorted(self.shape_counters.items())),
+        }
+
+
+@dataclass
+class AuditOptions:
+    """Engine configuration passed to ``run_audit()``.
+
+    ``scan_root`` defaults to ``repo_root / "kitty-specs"`` when ``None``
+    (never hardcoded here — the engine resolves the default at call time).
+    ``fail_on`` is ``None`` for "always exit 0"; set to ``Severity.ERROR``
+    to fail on errors only, ``Severity.WARNING`` for errors+warnings, etc.
+    """
+
+    repo_root: Path
+    scan_root: Path | None = None
+    mission_filter: str | None = None
+    fail_on: Severity | None = None

--- a/src/specify_cli/audit/serializer.py
+++ b/src/specify_cli/audit/serializer.py
@@ -1,0 +1,27 @@
+"""Deterministic JSON serializer for the audit engine (NFR-001).
+
+Only one public function lives here: ``build_report_json()``.  It is a thin
+wrapper around ``RepoAuditReport.to_dict()`` that enforces the formatting
+contract — ``sort_keys=True, indent=2`` — so callers never need to remember it.
+"""
+
+import json
+
+from .models import RepoAuditReport
+
+
+def build_report_json(report: RepoAuditReport) -> str:
+    """Return a deterministic JSON string for the full audit report.
+
+    Guarantees (NFR-001):
+    - ``sort_keys=True`` on all nested dicts
+    - missions sorted by mission_slug (enforced by engine before calling this)
+    - findings sorted by (artifact_path, code) (enforced by engine)
+    - shape_counters sorted by key (enforced by ``RepoAuditReport.to_dict()``)
+    - ``indent=2``
+    - No timestamps or process-state values in output
+
+    Calling this function twice on the same ``RepoAuditReport`` object must
+    produce byte-identical output.
+    """
+    return json.dumps(report.to_dict(), sort_keys=True, indent=2)

--- a/src/specify_cli/audit/shape_registry.py
+++ b/src/specify_cli/audit/shape_registry.py
@@ -1,0 +1,198 @@
+"""Shape registry: known top-level keys per artifact type.
+
+Defines ``KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT`` — a mapping from artifact type
+name to the set of top-level keys that are expected in that artifact type.
+
+``check_unknown_keys()`` uses this registry to emit ``UNKNOWN_SHAPE`` findings
+for any top-level key that is not in the known set, not a legacy key, and not
+a forbidden key (those have dedicated finding codes).
+"""
+
+from __future__ import annotations
+
+from .detectors import FORBIDDEN_KEYS, LEGACY_KEYS
+from .models import MissionFinding, Severity
+
+# ---------------------------------------------------------------------------
+# Known key sets per artifact type
+# ---------------------------------------------------------------------------
+
+KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT: dict[str, frozenset[str]] = {
+    "meta.json": frozenset(
+        {
+            "mission_id",
+            "mission_number",
+            "mission_slug",
+            "slug",
+            "friendly_name",
+            "purpose_tldr",
+            "purpose_context",
+            "mission_type",
+            "target_branch",
+            "vcs",
+            "created_at",
+            "source_description",
+        }
+    ),
+    "status.json": frozenset(
+        {
+            "mission_slug",
+            "feature_slug",  # back-compat alias
+            "mission_number",
+            "mission_type",
+            "materialized_at",
+            "event_count",
+            "last_event_id",
+            "work_packages",
+            "summary",
+            "retrospective",
+        }
+    ),
+    "status_event_row": frozenset(
+        {
+            "actor",
+            "at",
+            "event_id",
+            "evidence",
+            "execution_mode",
+            "feature_slug",
+            "force",
+            "from_lane",
+            "reason",
+            "review_ref",
+            "to_lane",
+            "wp_id",
+            "mission_id",
+            "mission_slug",
+            "policy_metadata",
+            # skip rows (legacy discriminator keys — present in some old rows):
+            "event_type",
+            "event_name",
+        }
+    ),
+    "wp_frontmatter": frozenset(
+        {
+            "work_package_id",
+            "title",
+            "dependencies",
+            "subtasks",
+            "execution_mode",
+            "owned_files",
+            "authoritative_surface",
+            "planning_base_branch",
+            "merge_target_branch",
+            "branch_strategy",
+            "agent_profile",
+            "role",
+            "agent",
+            "model",
+            "history",
+            "requirement_refs",
+            # older shapes:
+            "id",
+            "status",
+            "lane",
+            "actor",
+            "evidence",
+            "review_ref",
+            "reason",
+            "force",
+            "depends_on",
+            # newer fields (083+):
+            "tags",
+        }
+    ),
+    # mission-events.jsonl rows (MissionNextInvoked and similar mission-level events)
+    "mission_event_row": frozenset(
+        {
+            "mission",
+            "payload",
+            "timestamp",
+            "type",
+            # event_type-based rows (alternate schema)
+            "event_type",
+            "at",
+            "event_id",
+        }
+    ),
+    # decisions/events.jsonl rows (DecisionPoint* events)
+    "decision_event_row": frozenset(
+        {
+            "at",
+            "event_id",
+            "event_type",
+            "payload",
+            "timestamp",
+            "type",
+        }
+    ),
+    # handoff/events.jsonl rows (handoff lane-transition-style events)
+    "handoff_event_row": frozenset(
+        {
+            "actor",
+            "at",
+            "event_id",
+            "evidence",
+            "execution_mode",
+            "feature_slug",
+            "force",
+            "from_lane",
+            "mission_id",
+            "mission_slug",
+            "policy_metadata",
+            "reason",
+            "review_ref",
+            "to_lane",
+            "wp_id",
+        }
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Checker
+# ---------------------------------------------------------------------------
+
+
+def check_unknown_keys(
+    artifact_type: str,
+    obj: dict[str, object],
+    artifact_path: str,
+) -> list[MissionFinding]:
+    """Return ``UNKNOWN_SHAPE`` findings for unrecognised top-level keys.
+
+    A key is considered *unknown* when it is:
+    - not in ``KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT[artifact_type]``, AND
+    - not in ``LEGACY_KEYS`` (those emit ``LEGACY_KEY`` findings), AND
+    - not in ``FORBIDDEN_KEYS`` (those emit ``FORBIDDEN_KEY`` findings).
+
+    If *artifact_type* is not in ``KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT``, the
+    function returns an empty list — an unregistered artifact type is not
+    itself an error.
+
+    Args:
+        artifact_type: One of the keys in ``KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT``
+            (e.g. ``"meta.json"``, ``"status_event_row"``).
+        obj: Parsed artifact dict whose top-level keys are inspected.
+        artifact_path: Relative path to the artifact for finding records.
+
+    Returns:
+        A list of :class:`~specify_cli.audit.models.MissionFinding` objects
+        with code ``"UNKNOWN_SHAPE"`` and severity ``INFO``.
+    """
+    known = KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT.get(artifact_type)
+    if known is None:
+        return []
+
+    findings: list[MissionFinding] = []
+    for key in obj:
+        if key not in known and key not in LEGACY_KEYS and key not in FORBIDDEN_KEYS:
+            findings.append(
+                MissionFinding(
+                    code="UNKNOWN_SHAPE",
+                    severity=Severity.INFO,
+                    artifact_path=artifact_path,
+                    detail=f"unknown key: {key!r} (artifact_type={artifact_type!r})",
+                )
+            )
+    return findings

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Optional
 
 import typer
 from rich.console import Console
@@ -625,10 +625,10 @@ def sparse_checkout(
     raise typer.Exit(0 if rep.overall_success and not any_failure else 1)
 
 
-def _print_overdue_details(report: Any, console: Console) -> None:
+def _print_overdue_details(report: object, console: Console) -> None:
     console.print()
     console.print("[bold red]Overdue shims must be resolved before release:[/bold red]")
-    for e in report.entries:
+    for e in report.entries:  # type: ignore[union-attr]
         if e.status.value == "overdue":
             canonical = (
                 ", ".join(e.entry.canonical_import)
@@ -849,3 +849,140 @@ def invocation_pairing(
     )
     console.print()
     raise typer.Exit(1)
+
+
+def _print_rich_audit_report(report: object) -> None:
+    """Print a Rich table summarising audit findings per mission."""
+    from specify_cli.audit import RepoAuditReport
+
+    assert isinstance(report, RepoAuditReport)
+
+    missions_with_findings = [r for r in report.missions if r.findings]
+
+    if not missions_with_findings:
+        console.print("[green]No findings — all missions are clean.[/green]")
+        return
+
+    table = Table(box=None, padding=(0, 2), show_edge=False)
+    table.add_column("Mission", style="cyan", min_width=28)
+    table.add_column("Errors", justify="right", min_width=7)
+    table.add_column("Warnings", justify="right", min_width=9)
+    table.add_column("Info", justify="right", min_width=6)
+    table.add_column("Codes")
+
+    for result in missions_with_findings:
+        from specify_cli.audit.models import Severity
+
+        errors = sum(1 for f in result.findings if f.severity == Severity.ERROR)
+        warnings = sum(1 for f in result.findings if f.severity == Severity.WARNING)
+        infos = sum(1 for f in result.findings if f.severity == Severity.INFO)
+        codes = ", ".join(sorted({f.code for f in result.findings}))
+
+        err_str = f"[red]{errors}[/red]" if errors else str(errors)
+        warn_str = f"[yellow]{warnings}[/yellow]" if warnings else str(warnings)
+        table.add_row(result.mission_slug, err_str, warn_str, str(infos), codes)
+
+    console.print(table)
+    console.print()
+
+    summary = report.repo_summary
+    console.print(
+        f"Total missions: {summary['total_missions']} | "
+        f"With errors: {summary['missions_with_errors']} | "
+        f"With warnings: {summary['missions_with_warnings']}"
+    )
+
+
+@app.command(name="mission-state")
+def mission_state(
+    audit: Annotated[
+        bool,
+        typer.Option("--audit", help="Run mission-state audit (required to proceed)"),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit JSON report to stdout"),
+    ] = False,
+    mission: Annotated[
+        Optional[str],
+        typer.Option("--mission", help="Scope to a single mission handle"),
+    ] = None,
+    fail_on: Annotated[
+        Optional[str],
+        typer.Option("--fail-on", help="Exit 1 if any finding meets this severity (error|warning|info)"),
+    ] = None,
+    fixture_dir: Annotated[
+        Optional[Path],
+        typer.Option("--fixture-dir", help="Override scan root (for testing)"),
+    ] = None,
+) -> None:
+    """Audit mission-state shapes across kitty-specs/."""
+    from specify_cli.audit import AuditOptions, Severity, build_report_json, run_audit
+
+    if not audit:
+        typer.echo("Use --audit to run the audit. See --help for options.")
+        raise typer.Exit(0)
+
+    # Validate --fail-on
+    fail_on_severity: Optional[Severity] = None
+    if fail_on is not None:
+        try:
+            fail_on_severity = Severity(fail_on)
+        except ValueError:
+            valid = ", ".join(s.value for s in Severity)
+            typer.echo(f"Invalid --fail-on value: {fail_on!r}. Valid values: {valid}", err=True)
+            raise typer.Exit(2)
+
+    # Resolve repo root
+    try:
+        repo_root = locate_project_root()
+    except Exception as exc:
+        console.print("[red]Error:[/red] Not in a spec-kitty project")
+        raise typer.Exit(1) from exc
+
+    if repo_root is None:
+        if fixture_dir is None:
+            console.print("[red]Error:[/red] Not in a spec-kitty project")
+            raise typer.Exit(1)
+        repo_root = fixture_dir.parent
+
+    from specify_cli.context.mission_resolver import AmbiguousHandleError, MissionNotFoundError
+
+    options = AuditOptions(
+        repo_root=repo_root,
+        scan_root=fixture_dir,
+        mission_filter=mission,
+        fail_on=fail_on_severity,
+    )
+    try:
+        report = run_audit(options)
+    except MissionNotFoundError as exc:
+        if json_output:
+            import json as _json
+            sys.stdout.write(_json.dumps({"error": "MISSION_NOT_FOUND", "handle": mission}) + "\n")
+            sys.stdout.flush()
+        else:
+            typer.echo(f"Error: Mission not found: {mission!r}", err=True)
+        raise typer.Exit(1) from exc
+    except AmbiguousHandleError as exc:
+        if json_output:
+            import json as _json
+            sys.stdout.write(_json.dumps({"error": "AMBIGUOUS_HANDLE", "handle": mission}) + "\n")
+            sys.stdout.flush()
+        else:
+            typer.echo(f"Error: Ambiguous handle: {mission!r}", err=True)
+        raise typer.Exit(1) from exc
+
+    if json_output:
+        sys.stdout.write(build_report_json(report))
+        sys.stdout.flush()
+    else:
+        _print_rich_audit_report(report)
+
+    if fail_on_severity is not None:
+        if any(
+            f.severity <= fail_on_severity
+            for result in report.missions
+            for f in result.findings
+        ):
+            raise typer.Exit(1)

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Optional
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from rich.console import Console
@@ -904,15 +904,15 @@ def mission_state(
         typer.Option("--json", help="Emit JSON report to stdout"),
     ] = False,
     mission: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--mission", help="Scope to a single mission handle"),
     ] = None,
     fail_on: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--fail-on", help="Exit 1 if any finding meets this severity (error|warning|info)"),
     ] = None,
     fixture_dir: Annotated[
-        Optional[Path],
+        Path | None,
         typer.Option("--fixture-dir", help="Override scan root (for testing)"),
     ] = None,
 ) -> None:
@@ -924,14 +924,14 @@ def mission_state(
         raise typer.Exit(0)
 
     # Validate --fail-on
-    fail_on_severity: Optional[Severity] = None
+    fail_on_severity: Severity | None = None
     if fail_on is not None:
         try:
             fail_on_severity = Severity(fail_on)
         except ValueError:
             valid = ", ".join(s.value for s in Severity)
             typer.echo(f"Invalid --fail-on value: {fail_on!r}. Valid values: {valid}", err=True)
-            raise typer.Exit(2)
+            raise typer.Exit(2) from None
 
     # Resolve repo root
     try:
@@ -979,10 +979,9 @@ def mission_state(
     else:
         _print_rich_audit_report(report)
 
-    if fail_on_severity is not None:
-        if any(
-            f.severity <= fail_on_severity
-            for result in report.missions
-            for f in result.findings
-        ):
-            raise typer.Exit(1)
+    if fail_on_severity is not None and any(
+        f.severity <= fail_on_severity
+        for result in report.missions
+        for f in result.findings
+    ):
+        raise typer.Exit(1)

--- a/src/specify_cli/status/reducer.py
+++ b/src/specify_cli/status/reducer.py
@@ -248,7 +248,7 @@ def _reduce_retrospective(raw_events: list[dict[str, Any]]) -> RetrospectiveSnap
     proposals_pending = max(0, proposals_total - proposals_applied - proposals_rejected)
 
     return RetrospectiveSnapshot(
-        status=status,  # type: ignore[arg-type]
+        status=status,
         mode=mode,
         record_path=record_path,
         proposals_total=proposals_total,
@@ -276,18 +276,12 @@ def materialize_to_json(snapshot: StatusSnapshot) -> str:
     )
 
 
-def materialize(feature_dir: Path) -> StatusSnapshot:
-    """Read events, reduce to snapshot, and write status.json atomically.
+def materialize_snapshot(feature_dir: Path) -> StatusSnapshot:
+    """Read events and reduce them to the exact snapshot materialize() writes.
 
-    Skips the write when content is byte-identical to the existing file.
-    Writes to a temporary file first, then uses ``os.replace`` for an
-    atomic rename to avoid partial writes.
-
-    WP03 (additive): Also scans raw events for retrospective.* entries and
-    attaches a RetrospectiveSnapshot to the snapshot under ``retrospective``.
-    Default is None for missions with no retrospective events (backwards-compat).
-
-    Returns the materialized snapshot.
+    This helper is intentionally read-only. It keeps production materialization
+    semantics in one place so callers such as doctor/audit can compare a
+    persisted status.json without creating temp files or replacing status.json.
     """
     events = read_events(feature_dir)
     snapshot = reduce(events)
@@ -308,6 +302,23 @@ def materialize(feature_dir: Path) -> StatusSnapshot:
     if retro_snapshot.status != "absent":
         snapshot.retrospective = retro_snapshot
 
+    return snapshot
+
+
+def materialize(feature_dir: Path) -> StatusSnapshot:
+    """Read events, reduce to snapshot, and write status.json atomically.
+
+    Skips the write when content is byte-identical to the existing file.
+    Writes to a temporary file first, then uses ``os.replace`` for an
+    atomic rename to avoid partial writes.
+
+    WP03 (additive): Also scans raw events for retrospective.* entries and
+    attaches a RetrospectiveSnapshot to the snapshot under ``retrospective``.
+    Default is None for missions with no retrospective events (backwards-compat).
+
+    Returns the materialized snapshot.
+    """
+    snapshot = materialize_snapshot(feature_dir)
     json_str = materialize_to_json(snapshot)
 
     out_path = feature_dir / SNAPSHOT_FILENAME

--- a/tests/audit/fixtures/actor_drift/meta.json
+++ b/tests/audit/fixtures/actor_drift/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAM0",
+  "mission_slug": "actor-drift",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/actor_drift/status.events.jsonl
+++ b/tests/audit/fixtures/actor_drift/status.events.jsonl
@@ -1,0 +1,1 @@
+{"actor":"CLAUDE_BOT_v2","at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAM0","evidence":null,"execution_mode":"direct_repo","force":false,"from_lane":"planned","mission_slug":"actor-drift","reason":null,"review_ref":null,"to_lane":"claimed","wp_id":"WP01"}

--- a/tests/audit/fixtures/ambiguous_selector/repo/kitty-specs/001-my-feature/meta.json
+++ b/tests/audit/fixtures/ambiguous_selector/repo/kitty-specs/001-my-feature/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAT0",
+  "mission_slug": "001-my-feature",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/ambiguous_selector/repo/kitty-specs/002-my-feature/meta.json
+++ b/tests/audit/fixtures/ambiguous_selector/repo/kitty-specs/002-my-feature/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAV0",
+  "mission_slug": "002-my-feature",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/clean_modern/meta.json
+++ b/tests/audit/fixtures/clean_modern/meta.json
@@ -1,0 +1,10 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAA0",
+  "mission_slug": "clean-modern",
+  "mission_number": null,
+  "friendly_name": "Clean Modern Mission",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git",
+  "created_at": "2026-01-01T00:00:00+00:00"
+}

--- a/tests/audit/fixtures/corrupt_jsonl/meta.json
+++ b/tests/audit/fixtures/corrupt_jsonl/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAK0",
+  "mission_slug": "corrupt-jsonl",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/corrupt_jsonl/status.events.jsonl
+++ b/tests/audit/fixtures/corrupt_jsonl/status.events.jsonl
@@ -1,0 +1,2 @@
+{"actor":"claude","at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAK0","evidence":null,"execution_mode":"direct_repo","force":false,"from_lane":"planned","mission_slug":"corrupt-jsonl","reason":null,"review_ref":null,"to_lane":"claimed","wp_id":"WP01"}
+THIS IS NOT VALID JSON {{{

--- a/tests/audit/fixtures/duplicate_mission_id/repo/kitty-specs/mission-alpha/meta.json
+++ b/tests/audit/fixtures/duplicate_mission_id/repo/kitty-specs/mission-alpha/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAP0",
+  "mission_slug": "mission-alpha",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/duplicate_mission_id/repo/kitty-specs/mission-beta/meta.json
+++ b/tests/audit/fixtures/duplicate_mission_id/repo/kitty-specs/mission-beta/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAP0",
+  "mission_slug": "mission-beta",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/duplicate_prefix/repo/kitty-specs/034-mission-alpha/meta.json
+++ b/tests/audit/fixtures/duplicate_prefix/repo/kitty-specs/034-mission-alpha/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAQ0",
+  "mission_slug": "034-mission-alpha",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/duplicate_prefix/repo/kitty-specs/034-mission-beta/meta.json
+++ b/tests/audit/fixtures/duplicate_prefix/repo/kitty-specs/034-mission-beta/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAR0",
+  "mission_slug": "034-mission-beta",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/forbidden_event_name/meta.json
+++ b/tests/audit/fixtures/forbidden_event_name/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAJ0",
+  "mission_slug": "forbidden-event-name",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/forbidden_event_name/status.events.jsonl
+++ b/tests/audit/fixtures/forbidden_event_name/status.events.jsonl
@@ -1,0 +1,1 @@
+{"at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAJ0","event_name":"retrospective.started","mission_slug":"forbidden-event-name"}

--- a/tests/audit/fixtures/forbidden_event_type/meta.json
+++ b/tests/audit/fixtures/forbidden_event_type/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAH0",
+  "mission_slug": "forbidden-event-type",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/forbidden_event_type/status.events.jsonl
+++ b/tests/audit/fixtures/forbidden_event_type/status.events.jsonl
@@ -1,0 +1,1 @@
+{"at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAH0","event_type":"DecisionPointOpened","mission_slug":"forbidden-event-type","slot_key":"plan.arch.db"}

--- a/tests/audit/fixtures/identity_invalid/meta.json
+++ b/tests/audit/fixtures/identity_invalid/meta.json
@@ -1,0 +1,6 @@
+{
+  "mission_id": "NOT-A-VALID-ULID",
+  "mission_slug": "identity-invalid",
+  "mission_type": "software-dev",
+  "target_branch": "main"
+}

--- a/tests/audit/fixtures/identity_missing/meta.json
+++ b/tests/audit/fixtures/identity_missing/meta.json
@@ -1,0 +1,5 @@
+{
+  "mission_slug": "identity-missing",
+  "mission_type": "software-dev",
+  "target_branch": "main"
+}

--- a/tests/audit/fixtures/legacy_aggregate_id/meta.json
+++ b/tests/audit/fixtures/legacy_aggregate_id/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAE0",
+  "mission_slug": "legacy-aggregate-id",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/legacy_aggregate_id/status.events.jsonl
+++ b/tests/audit/fixtures/legacy_aggregate_id/status.events.jsonl
@@ -1,0 +1,1 @@
+{"actor":"claude","at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAE0","evidence":null,"execution_mode":"direct_repo","force":false,"from_lane":"planned","legacy_aggregate_id":"some-old-id","mission_slug":"legacy-agg","reason":null,"review_ref":null,"to_lane":"claimed","wp_id":"WP01"}

--- a/tests/audit/fixtures/legacy_feature_number/meta.json
+++ b/tests/audit/fixtures/legacy_feature_number/meta.json
@@ -1,0 +1,8 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAG0",
+  "mission_slug": "legacy-feature-number",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git",
+  "feature_number": 42
+}

--- a/tests/audit/fixtures/legacy_feature_slug/meta.json
+++ b/tests/audit/fixtures/legacy_feature_slug/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAC0",
+  "mission_slug": "legacy-feature-slug",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/legacy_feature_slug/status.events.jsonl
+++ b/tests/audit/fixtures/legacy_feature_slug/status.events.jsonl
@@ -1,0 +1,1 @@
+{"actor":"claude","at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAC0","evidence":null,"execution_mode":"direct_repo","feature_slug":"034-old-name","force":false,"from_lane":"planned","reason":null,"review_ref":null,"to_lane":"claimed","wp_id":"WP01"}

--- a/tests/audit/fixtures/legacy_mission_key/meta.json
+++ b/tests/audit/fixtures/legacy_mission_key/meta.json
@@ -1,0 +1,8 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAF0",
+  "mission_slug": "legacy-mission-key",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git",
+  "mission_key": "OLD-KEY-123"
+}

--- a/tests/audit/fixtures/legacy_work_package_id/meta.json
+++ b/tests/audit/fixtures/legacy_work_package_id/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAD0",
+  "mission_slug": "legacy-work-package-id",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/legacy_work_package_id/status.events.jsonl
+++ b/tests/audit/fixtures/legacy_work_package_id/status.events.jsonl
@@ -1,0 +1,1 @@
+{"actor":"claude","at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAAD0","evidence":null,"execution_mode":"direct_repo","force":false,"from_lane":"planned","mission_slug":"legacy-wp-id","reason":null,"review_ref":null,"to_lane":"claimed","work_package_id":"WP01"}

--- a/tests/audit/fixtures/missing_evidence/meta.json
+++ b/tests/audit/fixtures/missing_evidence/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAN0",
+  "mission_slug": "missing-evidence",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/missing_evidence/tasks/WP01.md
+++ b/tests/audit/fixtures/missing_evidence/tasks/WP01.md
@@ -1,0 +1,9 @@
+---
+work_package_id: "WP01"
+title: "Some Work Package"
+status: "done"
+lane: "done"
+evidence: null
+---
+
+# WP01 content here

--- a/tests/audit/fixtures/snapshot_drift/meta.json
+++ b/tests/audit/fixtures/snapshot_drift/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAALE",
+  "mission_slug": "snapshot-drift",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/snapshot_drift/status.events.jsonl
+++ b/tests/audit/fixtures/snapshot_drift/status.events.jsonl
@@ -1,0 +1,1 @@
+{"actor":"claude","at":"2026-01-01T00:00:00+00:00","event_id":"01JAAAAAAAAAAAAAAAAAAAAALE","evidence":null,"execution_mode":"direct_repo","force":false,"from_lane":"planned","mission_slug":"snapshot-drift","reason":null,"review_ref":null,"to_lane":"claimed","wp_id":"WP01"}

--- a/tests/audit/fixtures/snapshot_drift/status.json
+++ b/tests/audit/fixtures/snapshot_drift/status.json
@@ -1,0 +1,28 @@
+{
+  "event_count": 999,
+  "last_event_id": "01JAAAAAAAAAAAAAAAAAAAAALE",
+  "materialized_at": "2026-01-01T00:00:00+00:00",
+  "mission_number": "",
+  "mission_slug": "snapshot-drift",
+  "mission_type": "software-dev",
+  "summary": {
+    "approved": 0,
+    "blocked": 0,
+    "canceled": 0,
+    "claimed": 1,
+    "done": 0,
+    "for_review": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "planned": 0
+  },
+  "work_packages": {
+    "WP01": {
+      "actor": "claude",
+      "force_count": 0,
+      "lane": "claimed",
+      "last_event_id": "01JAAAAAAAAAAAAAAAAAAAAALE",
+      "last_transition_at": "2026-01-01T00:00:00+00:00"
+    }
+  }
+}

--- a/tests/audit/fixtures/unknown_shape/meta.json
+++ b/tests/audit/fixtures/unknown_shape/meta.json
@@ -1,0 +1,8 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAB0",
+  "mission_slug": "unknown-shape",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git",
+  "future_key_not_in_registry": "some value"
+}

--- a/tests/audit/fixtures/wp_frontmatter_class_a/meta.json
+++ b/tests/audit/fixtures/wp_frontmatter_class_a/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAW0",
+  "mission_slug": "wp-frontmatter-class-a",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/wp_frontmatter_class_a/tasks/WP01-some-work.md
+++ b/tests/audit/fixtures/wp_frontmatter_class_a/tasks/WP01-some-work.md
@@ -1,0 +1,16 @@
+---
+work_package_id: "WP01"
+title: "Some Work"
+dependencies: []
+subtasks: ["T001"]
+execution_mode: "code_change"
+owned_files: ["src/my/module.py"]
+authoritative_surface: "src/my/"
+planning_base_branch: "main"
+merge_target_branch: "main"
+agent_profile: "python-pedro"
+role: "implementer"
+agent: "claude"
+---
+
+# Content

--- a/tests/audit/fixtures/wp_frontmatter_class_b/meta.json
+++ b/tests/audit/fixtures/wp_frontmatter_class_b/meta.json
@@ -1,0 +1,7 @@
+{
+  "mission_id": "01JAAAAAAAAAAAAAAAAAAAAAX0",
+  "mission_slug": "wp-frontmatter-class-b",
+  "mission_type": "software-dev",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/tests/audit/fixtures/wp_frontmatter_class_b/tasks/WP01.md
+++ b/tests/audit/fixtures/wp_frontmatter_class_b/tasks/WP01.md
@@ -1,0 +1,7 @@
+---
+id: "WP01"
+status: "planned"
+old_priority_field: "high"
+---
+
+# Content

--- a/tests/audit/test_audit_architecture.py
+++ b/tests/audit/test_audit_architecture.py
@@ -1,0 +1,298 @@
+"""Tests for the 20 fixture directories in tests/audit/fixtures/.
+
+Each test asserts that the fixture triggers exactly the expected finding
+code(s) and no others from the relevant classifier(s).
+
+T024: clean_modern, unknown_shape
+T025: legacy_feature_slug, legacy_work_package_id, legacy_aggregate_id
+T026: legacy_mission_key, legacy_feature_number
+T027: forbidden_event_type, forbidden_event_name
+T028: identity_missing, identity_invalid
+T029: corrupt_jsonl, snapshot_drift
+T030: actor_drift, missing_evidence
+T031: duplicate_mission_id, duplicate_prefix, ambiguous_selector
+T032: wp_frontmatter_class_a, wp_frontmatter_class_b
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from pathlib import Path
+
+from specify_cli.audit import AuditOptions, run_audit
+from specify_cli.audit.classifiers.meta import classify_meta_json
+from specify_cli.audit.classifiers.status_events import classify_status_events_jsonl
+from specify_cli.audit.classifiers.status_json import classify_status_json
+from specify_cli.audit.classifiers.wp_files import classify_wp_files
+
+# ---------------------------------------------------------------------------
+# Fixture root
+# ---------------------------------------------------------------------------
+
+FX = Path(__file__).parent / "fixtures"
+
+
+def _codes(findings: list) -> set[str]:
+    return {f.code for f in findings}
+
+
+# ---------------------------------------------------------------------------
+# T024 — Clean and Unknown-Shape Fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_clean_modern_zero_findings() -> None:
+    """clean_modern: all classifiers return zero findings."""
+    mission_dir = FX / "clean_modern"
+    assert classify_meta_json(mission_dir) == []
+    events_findings, has_corrupt = classify_status_events_jsonl(mission_dir)
+    assert events_findings == []
+    assert not has_corrupt
+    assert classify_wp_files(mission_dir) == []
+
+
+def test_unknown_shape_meta() -> None:
+    """unknown_shape: future_key_not_in_registry triggers UNKNOWN_SHAPE on meta.json."""
+    findings = classify_meta_json(FX / "unknown_shape")
+    codes = _codes(findings)
+    assert "UNKNOWN_SHAPE" in codes
+    assert "LEGACY_KEY" not in codes
+    assert "IDENTITY_MISSING" not in codes
+
+
+# ---------------------------------------------------------------------------
+# T025 — Legacy Key Fixtures (feature_slug, work_package_id, legacy_aggregate_id)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_feature_slug() -> None:
+    """legacy_feature_slug: feature_slug in event row triggers LEGACY_KEY."""
+    findings, _ = classify_status_events_jsonl(FX / "legacy_feature_slug")
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+def test_legacy_work_package_id() -> None:
+    """legacy_work_package_id: work_package_id instead of wp_id triggers LEGACY_KEY."""
+    findings, _ = classify_status_events_jsonl(FX / "legacy_work_package_id")
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+def test_legacy_aggregate_id() -> None:
+    """legacy_aggregate_id: legacy_aggregate_id key triggers LEGACY_KEY."""
+    findings, _ = classify_status_events_jsonl(FX / "legacy_aggregate_id")
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T026 — Legacy Key Fixtures (mission_key, feature_number)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_mission_key() -> None:
+    """legacy_mission_key: mission_key in meta.json triggers LEGACY_KEY."""
+    findings = classify_meta_json(FX / "legacy_mission_key")
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+def test_legacy_feature_number() -> None:
+    """legacy_feature_number: feature_number in meta.json triggers LEGACY_KEY."""
+    findings = classify_meta_json(FX / "legacy_feature_number")
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T027 — Forbidden Key Fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_forbidden_event_type() -> None:
+    """forbidden_event_type: event_type key triggers FORBIDDEN_KEY."""
+    findings, _ = classify_status_events_jsonl(FX / "forbidden_event_type")
+    assert "FORBIDDEN_KEY" in _codes(findings)
+
+
+def test_forbidden_event_name() -> None:
+    """forbidden_event_name: event_name key triggers FORBIDDEN_KEY."""
+    findings, _ = classify_status_events_jsonl(FX / "forbidden_event_name")
+    assert "FORBIDDEN_KEY" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T028 — Identity Findings
+# ---------------------------------------------------------------------------
+
+
+def test_identity_missing() -> None:
+    """identity_missing: absent mission_id field triggers IDENTITY_MISSING."""
+    findings = classify_meta_json(FX / "identity_missing")
+    assert "IDENTITY_MISSING" in _codes(findings)
+    assert "IDENTITY_INVALID" not in _codes(findings)
+
+
+def test_identity_invalid() -> None:
+    """identity_invalid: non-ULID mission_id triggers IDENTITY_INVALID."""
+    findings = classify_meta_json(FX / "identity_invalid")
+    assert "IDENTITY_INVALID" in _codes(findings)
+    assert "IDENTITY_MISSING" not in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T029 — Corruption and Drift Fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_jsonl() -> None:
+    """corrupt_jsonl: second line of events file is invalid JSON → CORRUPT_JSONL."""
+    findings, has_corrupt = classify_status_events_jsonl(FX / "corrupt_jsonl")
+    assert has_corrupt
+    assert "CORRUPT_JSONL" in _codes(findings)
+
+
+def test_snapshot_drift() -> None:
+    """snapshot_drift: persisted status.json has wrong event_count → SNAPSHOT_DRIFT."""
+    findings = classify_status_json(FX / "snapshot_drift")
+    assert "SNAPSHOT_DRIFT" in _codes(findings)
+
+
+def test_snapshot_drift_not_on_clean(tmp_path: Path) -> None:
+    """clean_modern has no status.json → classify_status_json returns []."""
+    assert classify_status_json(FX / "clean_modern") == []
+
+
+# ---------------------------------------------------------------------------
+# T030 — Actor Drift and Missing Evidence
+# ---------------------------------------------------------------------------
+
+
+def test_actor_drift() -> None:
+    """actor_drift: 'CLAUDE_BOT_v2' actor fails ^[a-z] regex → ACTOR_DRIFT."""
+    findings, _ = classify_status_events_jsonl(FX / "actor_drift")
+    assert "ACTOR_DRIFT" in _codes(findings)
+
+
+def test_missing_evidence() -> None:
+    """missing_evidence: WP01.md has terminal lane 'done' but evidence null → MISSING_EVIDENCE."""
+    findings = classify_wp_files(FX / "missing_evidence")
+    assert "MISSING_EVIDENCE" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T031 — Multi-Mission Fixtures (Repo-Level Findings)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_mission_id() -> None:
+    """duplicate_mission_id: two missions share same ULID → DUPLICATE_MISSION_ID on both."""
+    repo_root = FX / "duplicate_mission_id" / "repo"
+    options = AuditOptions(
+        repo_root=repo_root,
+        scan_root=repo_root / "kitty-specs",
+    )
+    report = run_audit(options)
+    all_codes = {f.code for r in report.missions for f in r.findings}
+    assert "DUPLICATE_MISSION_ID" in all_codes
+
+
+def test_duplicate_prefix() -> None:
+    """duplicate_prefix: two missions share 034- prefix → DUPLICATE_PREFIX on both."""
+    repo_root = FX / "duplicate_prefix" / "repo"
+    options = AuditOptions(
+        repo_root=repo_root,
+        scan_root=repo_root / "kitty-specs",
+    )
+    report = run_audit(options)
+    all_codes = {f.code for r in report.missions for f in r.findings}
+    assert "DUPLICATE_PREFIX" in all_codes
+
+
+def test_ambiguous_selector() -> None:
+    """ambiguous_selector: '001-my-feature' and '002-my-feature' share 'my-feature' handle."""
+    repo_root = FX / "ambiguous_selector" / "repo"
+    options = AuditOptions(
+        repo_root=repo_root,
+        scan_root=repo_root / "kitty-specs",
+    )
+    report = run_audit(options)
+    all_codes = {f.code for r in report.missions for f in r.findings}
+    assert "AMBIGUOUS_SELECTOR" in all_codes
+
+
+def test_duplicate_mission_id_both_missions_flagged() -> None:
+    """Both missions in duplicate_mission_id fixture receive the finding."""
+    repo_root = FX / "duplicate_mission_id" / "repo"
+    options = AuditOptions(
+        repo_root=repo_root,
+        scan_root=repo_root / "kitty-specs",
+    )
+    report = run_audit(options)
+    flagged_slugs = {
+        r.mission_slug
+        for r in report.missions
+        if any(f.code == "DUPLICATE_MISSION_ID" for f in r.findings)
+    }
+    assert "mission-alpha" in flagged_slugs
+    assert "mission-beta" in flagged_slugs
+
+
+# ---------------------------------------------------------------------------
+# T032 — WP Frontmatter Shape Fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_wp_frontmatter_class_a_clean() -> None:
+    """wp_frontmatter_class_a: all-modern keys → zero findings from wp_files classifier."""
+    findings = classify_wp_files(FX / "wp_frontmatter_class_a")
+    assert findings == []
+
+
+def test_wp_frontmatter_class_b_unknown_shape() -> None:
+    """wp_frontmatter_class_b: old_priority_field is unknown → UNKNOWN_SHAPE."""
+    findings = classify_wp_files(FX / "wp_frontmatter_class_b")
+    assert "UNKNOWN_SHAPE" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T035 — Architectural write-guard and no-network guard
+# ---------------------------------------------------------------------------
+
+
+def _is_open_write(call: ast.Call) -> bool:
+    """Return True if this call opens a file for writing or appending."""
+    func = call.func
+    if isinstance(func, ast.Name) and func.id == "open":
+        for kw in call.keywords:
+            if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                return "w" in str(kw.value.value) or "a" in str(kw.value.value)
+        for arg in call.args[1:2]:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                return "w" in arg.value or "a" in arg.value
+    return False
+
+
+def test_no_filesystem_writes_in_audit() -> None:
+    """No write-mode file opens in src/specify_cli/audit/."""
+    audit_root = pathlib.Path("src/specify_cli/audit")
+    write_calls = []
+    for py_file in sorted(audit_root.rglob("*.py")):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_open_write(node):
+                write_calls.append(f"{py_file}:{node.lineno}")
+    assert write_calls == [], "Write-mode file opens found:\n" + "\n".join(write_calls)
+
+
+def test_no_network_imports_in_audit() -> None:
+    """No network-library imports in src/specify_cli/audit/."""
+    audit_root = pathlib.Path("src/specify_cli/audit")
+    banned = {"requests", "httpx", "urllib.request", "http.client"}
+    violations = []
+    for py_file in sorted(audit_root.rglob("*.py")):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = [alias.name for alias in getattr(node, "names", [])]
+                module = getattr(node, "module", "") or ""
+                if any(b in (module + "." + n) for b in banned for n in names):
+                    violations.append(f"{py_file}:{node.lineno}")
+    assert violations == [], "Network imports found:\n" + "\n".join(violations)

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -121,11 +121,11 @@ def test_meta_classifier_identity_invalid(tmp_path: Path) -> None:
 
 
 def test_meta_classifier_corrupt_json(tmp_path: Path) -> None:
-    """Corrupt meta.json → CORRUPT_JSONL finding."""
+    """Corrupt meta.json → CORRUPT_JSON finding."""
     (tmp_path / "meta.json").write_text("not valid json {{{", encoding="utf-8")
     findings = classify_meta_json(tmp_path)
     assert len(findings) == 1
-    assert findings[0].code == "CORRUPT_JSONL"
+    assert findings[0].code == "CORRUPT_JSON"
     assert findings[0].severity == Severity.ERROR
 
 
@@ -224,10 +224,10 @@ def test_status_json_absent_file(tmp_path: Path) -> None:
 
 
 def test_status_json_corrupt_json(tmp_path: Path) -> None:
-    """Corrupt status.json → CORRUPT_JSONL finding."""
+    """Corrupt status.json → CORRUPT_JSON finding."""
     (tmp_path / "status.json").write_text("{broken", encoding="utf-8")
     findings = classify_status_json(tmp_path)
-    assert "CORRUPT_JSONL" in _codes(findings)
+    assert "CORRUPT_JSON" in _codes(findings)
 
 
 def test_status_json_skip_drift_true(tmp_path: Path) -> None:
@@ -256,6 +256,40 @@ def test_snapshot_drift_detected(tmp_path: Path) -> None:
     drift = [f for f in findings if f.code == "SNAPSHOT_DRIFT"]
     assert len(drift) >= 1
     assert drift[0].severity == Severity.ERROR
+
+
+def test_status_json_retrospective_materialized_snapshot_is_not_drift(
+    tmp_path: Path,
+) -> None:
+    """Freshly materialized retrospective state must not produce SNAPSHOT_DRIFT."""
+    from specify_cli.status.reducer import materialize
+
+    _write_json(
+        tmp_path / "meta.json",
+        {
+            "mission_id": _VALID_ULID,
+            "mission_slug": "test-mission",
+            "mission_number": 1,
+            "mission_type": "software-dev",
+        },
+    )
+    _write_jsonl(
+        tmp_path / "status.events.jsonl",
+        [
+            _MODERN_EVENT,
+            {
+                "at": "2026-05-01T12:01:00+00:00",
+                "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGS",
+                "event_name": "retrospective.requested",
+                "payload": {"mode": "append"},
+            },
+        ],
+    )
+    materialize(tmp_path)
+
+    findings = classify_status_json(tmp_path)
+
+    assert "SNAPSHOT_DRIFT" not in _codes(findings)
 
 
 # ---------------------------------------------------------------------------
@@ -313,15 +347,11 @@ def test_decisions_events_absent_file(tmp_path: Path) -> None:
 
 
 def test_decisions_events_clean(tmp_path: Path) -> None:
-    """Clean decision event row without forbidden keys → no findings.
-
-    Note: real decisions/events.jsonl rows carry ``event_type`` which
-    is in FORBIDDEN_KEYS (a discriminator used by legacy status producers).
-    For a truly clean row we use only the known-safe keys.
-    """
+    """Clean decision event row with canonical event_type → no findings."""
     row = {
         "at": "2026-05-01T12:00:00+00:00",
         "event_id": _VALID_ULID,
+        "event_type": "DecisionPointOpened",
         "payload": {"question": "Which approach?"},
     }
     _write_jsonl(tmp_path / "decisions" / "events.jsonl", [row])

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -1,0 +1,537 @@
+"""Tests for src/specify_cli/audit/classifiers/ (T011–T018).
+
+Covers all 7 per-artifact classifiers using tmp_path fixtures.
+Total: ≥ 25 test cases.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from specify_cli.audit.classifiers.decisions_events import classify_decisions_events_jsonl
+from specify_cli.audit.classifiers.handoff_events import classify_handoff_events_jsonl
+from specify_cli.audit.classifiers.meta import classify_meta_json
+from specify_cli.audit.classifiers.mission_events import classify_mission_events_jsonl
+from specify_cli.audit.classifiers.status_events import classify_status_events_jsonl
+from specify_cli.audit.classifiers.status_json import classify_status_json
+from specify_cli.audit.classifiers.wp_files import classify_wp_files
+from specify_cli.audit.models import Severity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(r, sort_keys=True) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_corrupt_jsonl(path: Path, corrupt_line: str = "NOT JSON {{") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(corrupt_line + "\n", encoding="utf-8")
+
+
+def _codes(findings: list) -> list[str]:
+    return [f.code for f in findings]
+
+
+# Minimal valid ULID
+_VALID_ULID = "01KQHRB8GCFJAX7HM4ZY52AQGR"
+
+# Minimal modern meta.json (no legacy keys, valid identity)
+_MODERN_META: dict[str, object] = {
+    "mission_id": _VALID_ULID,
+    "mission_slug": "test-mission",
+    "mission_number": 1,
+    "friendly_name": "Test Mission",
+}
+
+# Minimal modern status event row
+_MODERN_EVENT: dict[str, object] = {
+    "actor": "finalize-tasks",
+    "at": "2026-05-01T12:00:00+00:00",
+    "event_id": _VALID_ULID,
+    "evidence": None,
+    "execution_mode": "worktree",
+    "force": False,
+    "from_lane": "planned",
+    "mission_id": _VALID_ULID,
+    "mission_slug": "test-mission",
+    "policy_metadata": None,
+    "reason": None,
+    "review_ref": None,
+    "to_lane": "planned",
+    "wp_id": "WP01",
+}
+
+
+# ---------------------------------------------------------------------------
+# T011/meta.json classifier
+# ---------------------------------------------------------------------------
+
+
+def test_meta_classifier_absent_file(tmp_path: Path) -> None:
+    """Absent meta.json → empty findings."""
+    assert classify_meta_json(tmp_path) == []
+
+
+def test_meta_classifier_clean_modern(tmp_path: Path) -> None:
+    """Clean modern meta.json → no findings."""
+    _write_json(tmp_path / "meta.json", _MODERN_META)
+    findings = classify_meta_json(tmp_path)
+    assert findings == []
+
+
+def test_meta_classifier_legacy_feature_slug(tmp_path: Path) -> None:
+    """meta.json with feature_slug → LEGACY_KEY finding."""
+    data = {**_MODERN_META, "feature_slug": "001-old-slug"}
+    _write_json(tmp_path / "meta.json", data)
+    findings = classify_meta_json(tmp_path)
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+def test_meta_classifier_identity_missing(tmp_path: Path) -> None:
+    """meta.json without mission_id → IDENTITY_MISSING finding."""
+    data = {k: v for k, v in _MODERN_META.items() if k != "mission_id"}
+    _write_json(tmp_path / "meta.json", data)
+    findings = classify_meta_json(tmp_path)
+    assert "IDENTITY_MISSING" in _codes(findings)
+    assert all(f.severity == Severity.ERROR for f in findings if f.code == "IDENTITY_MISSING")
+
+
+def test_meta_classifier_identity_invalid(tmp_path: Path) -> None:
+    """meta.json with invalid ULID → IDENTITY_INVALID finding."""
+    data = {**_MODERN_META, "mission_id": "not-a-ulid"}
+    _write_json(tmp_path / "meta.json", data)
+    findings = classify_meta_json(tmp_path)
+    assert "IDENTITY_INVALID" in _codes(findings)
+    assert all(f.severity == Severity.ERROR for f in findings if f.code == "IDENTITY_INVALID")
+
+
+def test_meta_classifier_corrupt_json(tmp_path: Path) -> None:
+    """Corrupt meta.json → CORRUPT_JSONL finding."""
+    (tmp_path / "meta.json").write_text("not valid json {{{", encoding="utf-8")
+    findings = classify_meta_json(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSONL"
+    assert findings[0].severity == Severity.ERROR
+
+
+def test_meta_classifier_unknown_key(tmp_path: Path) -> None:
+    """meta.json with unrecognised key → UNKNOWN_SHAPE finding (info)."""
+    data = {**_MODERN_META, "unrecognised_field_xyz": "value"}
+    _write_json(tmp_path / "meta.json", data)
+    findings = classify_meta_json(tmp_path)
+    assert "UNKNOWN_SHAPE" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T012/status_events.jsonl classifier
+# ---------------------------------------------------------------------------
+
+
+def test_status_events_absent_file(tmp_path: Path) -> None:
+    """Absent status.events.jsonl → ([], False)."""
+    result, flag = classify_status_events_jsonl(tmp_path)
+    assert result == []
+    assert flag is False
+
+
+def test_status_events_clean_modern(tmp_path: Path) -> None:
+    """Clean modern event row → no findings."""
+    _write_jsonl(tmp_path / "status.events.jsonl", [_MODERN_EVENT])
+    findings, flag = classify_status_events_jsonl(tmp_path)
+    assert findings == []
+    assert flag is False
+
+
+def test_status_events_corrupt_line(tmp_path: Path) -> None:
+    """Corrupt JSONL line → CORRUPT_JSONL finding and flag=True."""
+    _write_corrupt_jsonl(tmp_path / "status.events.jsonl")
+    findings, flag = classify_status_events_jsonl(tmp_path)
+    assert "CORRUPT_JSONL" in _codes(findings)
+    assert flag is True
+
+
+def test_status_events_legacy_key(tmp_path: Path) -> None:
+    """Event row with work_package_id → LEGACY_KEY finding."""
+    row = {**_MODERN_EVENT, "work_package_id": "WP01"}
+    _write_jsonl(tmp_path / "status.events.jsonl", [row])
+    findings, _ = classify_status_events_jsonl(tmp_path)
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+def test_status_events_forbidden_key(tmp_path: Path) -> None:
+    """Event row with event_type → FORBIDDEN_KEY finding."""
+    row = {**_MODERN_EVENT, "event_type": "SomeLegacyType"}
+    _write_jsonl(tmp_path / "status.events.jsonl", [row])
+    findings, _ = classify_status_events_jsonl(tmp_path)
+    assert "FORBIDDEN_KEY" in _codes(findings)
+
+
+def test_status_events_actor_drift(tmp_path: Path) -> None:
+    """Event row with bad actor format → ACTOR_DRIFT warning."""
+    row = {**_MODERN_EVENT, "actor": "UPPERCASE_ACTOR"}
+    _write_jsonl(tmp_path / "status.events.jsonl", [row])
+    findings, _ = classify_status_events_jsonl(tmp_path)
+    assert "ACTOR_DRIFT" in _codes(findings)
+    drift_findings = [f for f in findings if f.code == "ACTOR_DRIFT"]
+    assert drift_findings[0].severity == Severity.WARNING
+
+
+def test_status_events_valid_actor_formats(tmp_path: Path) -> None:
+    """Various valid actor formats should not produce ACTOR_DRIFT."""
+    for actor in ("claude", "finalize-tasks", "migration", "human", "user", "claude:opus"):
+        row = {**_MODERN_EVENT, "actor": actor}
+        (tmp_path / "status.events.jsonl").write_text(
+            json.dumps(row, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        findings, _ = classify_status_events_jsonl(tmp_path)
+        drift = [f for f in findings if f.code == "ACTOR_DRIFT"]
+        assert drift == [], f"Unexpected ACTOR_DRIFT for actor={actor!r}"
+
+
+def test_status_events_collects_all_corrupt_lines(tmp_path: Path) -> None:
+    """Multiple corrupt lines → multiple CORRUPT_JSONL findings."""
+    content = "NOT JSON\nALSO NOT JSON\n"
+    (tmp_path / "status.events.jsonl").write_text(content, encoding="utf-8")
+    findings, flag = classify_status_events_jsonl(tmp_path)
+    corrupt = [f for f in findings if f.code == "CORRUPT_JSONL"]
+    assert len(corrupt) == 2
+    assert flag is True
+
+
+# ---------------------------------------------------------------------------
+# T013/status_json classifier
+# ---------------------------------------------------------------------------
+
+
+def test_status_json_absent_file(tmp_path: Path) -> None:
+    """Absent status.json → []."""
+    assert classify_status_json(tmp_path) == []
+
+
+def test_status_json_corrupt_json(tmp_path: Path) -> None:
+    """Corrupt status.json → CORRUPT_JSONL finding."""
+    (tmp_path / "status.json").write_text("{broken", encoding="utf-8")
+    findings = classify_status_json(tmp_path)
+    assert "CORRUPT_JSONL" in _codes(findings)
+
+
+def test_status_json_skip_drift_true(tmp_path: Path) -> None:
+    """skip_drift=True → no SNAPSHOT_DRIFT even with mismatched content."""
+    # Write a status.json with content that would normally cause drift
+    (tmp_path / "status.json").write_text('{"work_packages": {}}', encoding="utf-8")
+    findings = classify_status_json(tmp_path, skip_drift=True)
+    drift = [f for f in findings if f.code == "SNAPSHOT_DRIFT"]
+    assert drift == []
+
+
+def test_snapshot_drift_detected(tmp_path: Path) -> None:
+    """Mismatched status.json vs reducer → SNAPSHOT_DRIFT finding."""
+    # Write a minimal but parsable status.json that doesn't match what
+    # the reducer would produce for an empty event log.
+    status_data = {
+        "mission_slug": "test",
+        "work_packages": {"WP01": {"lane": "planned"}},
+        "summary": {"total": 1, "by_lane": {}},
+    }
+    (tmp_path / "status.json").write_text(
+        json.dumps(status_data, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    # No status.events.jsonl → reducer produces empty snapshot
+    findings = classify_status_json(tmp_path)
+    drift = [f for f in findings if f.code == "SNAPSHOT_DRIFT"]
+    assert len(drift) >= 1
+    assert drift[0].severity == Severity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# T014/mission_events.jsonl classifier
+# ---------------------------------------------------------------------------
+
+
+def test_mission_events_absent_file(tmp_path: Path) -> None:
+    """Absent mission-events.jsonl → []."""
+    assert classify_mission_events_jsonl(tmp_path) == []
+
+
+def test_mission_events_clean(tmp_path: Path) -> None:
+    """Clean mission-events.jsonl row → no findings."""
+    row = {
+        "mission": "software-dev",
+        "payload": {"action": "discovery"},
+        "timestamp": "2026-05-01T12:00:00+00:00",
+        "type": "MissionNextInvoked",
+    }
+    _write_jsonl(tmp_path / "mission-events.jsonl", [row])
+    findings = classify_mission_events_jsonl(tmp_path)
+    assert findings == []
+
+
+def test_mission_events_corrupt(tmp_path: Path) -> None:
+    """Corrupt mission-events.jsonl → CORRUPT_JSONL finding."""
+    _write_corrupt_jsonl(tmp_path / "mission-events.jsonl")
+    findings = classify_mission_events_jsonl(tmp_path)
+    assert "CORRUPT_JSONL" in _codes(findings)
+
+
+def test_mission_events_legacy_key(tmp_path: Path) -> None:
+    """mission-events.jsonl row with legacy key → LEGACY_KEY finding."""
+    row = {
+        "mission": "software-dev",
+        "payload": {},
+        "timestamp": "2026-05-01T12:00:00+00:00",
+        "type": "SomeEvent",
+        "feature_slug": "001-legacy",
+    }
+    _write_jsonl(tmp_path / "mission-events.jsonl", [row])
+    findings = classify_mission_events_jsonl(tmp_path)
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T015/decisions/events.jsonl classifier
+# ---------------------------------------------------------------------------
+
+
+def test_decisions_events_absent_file(tmp_path: Path) -> None:
+    """Absent decisions/events.jsonl → []."""
+    assert classify_decisions_events_jsonl(tmp_path) == []
+
+
+def test_decisions_events_clean(tmp_path: Path) -> None:
+    """Clean decision event row without forbidden keys → no findings.
+
+    Note: real decisions/events.jsonl rows carry ``event_type`` which
+    is in FORBIDDEN_KEYS (a discriminator used by legacy status producers).
+    For a truly clean row we use only the known-safe keys.
+    """
+    row = {
+        "at": "2026-05-01T12:00:00+00:00",
+        "event_id": _VALID_ULID,
+        "payload": {"question": "Which approach?"},
+    }
+    _write_jsonl(tmp_path / "decisions" / "events.jsonl", [row])
+    findings = classify_decisions_events_jsonl(tmp_path)
+    assert findings == []
+
+
+def test_decisions_events_corrupt(tmp_path: Path) -> None:
+    """Corrupt decisions/events.jsonl → CORRUPT_JSONL finding."""
+    (tmp_path / "decisions").mkdir(parents=True, exist_ok=True)
+    _write_corrupt_jsonl(tmp_path / "decisions" / "events.jsonl")
+    findings = classify_decisions_events_jsonl(tmp_path)
+    assert "CORRUPT_JSONL" in _codes(findings)
+
+
+def test_decisions_events_legacy_key(tmp_path: Path) -> None:
+    """decisions/events.jsonl row with legacy key → LEGACY_KEY finding."""
+    row = {
+        "at": "2026-05-01T12:00:00+00:00",
+        "event_id": _VALID_ULID,
+        "event_type": "DecisionPointOpened",
+        "payload": {},
+        "feature_slug": "001-old",
+    }
+    _write_jsonl(tmp_path / "decisions" / "events.jsonl", [row])
+    findings = classify_decisions_events_jsonl(tmp_path)
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T016/handoff/events.jsonl classifier
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_events_absent_file(tmp_path: Path) -> None:
+    """Absent handoff/events.jsonl → []."""
+    assert classify_handoff_events_jsonl(tmp_path) == []
+
+
+def test_handoff_events_clean(tmp_path: Path) -> None:
+    """Clean handoff event row (modern keys only) → no findings.
+
+    Note: real handoff/events.jsonl rows may carry ``feature_slug`` which
+    is a LEGACY_KEY.  This test uses only modern canonical keys.
+    """
+    row = {
+        "actor": "user",
+        "at": "2026-05-01T12:00:00+00:00",
+        "event_id": _VALID_ULID,
+        "evidence": None,
+        "execution_mode": "worktree",
+        "mission_slug": "045-handoff",
+        "force": False,
+        "from_lane": "planned",
+        "policy_metadata": None,
+        "reason": None,
+        "review_ref": None,
+        "to_lane": "in_progress",
+        "wp_id": "WP01",
+    }
+    _write_jsonl(tmp_path / "handoff" / "events.jsonl", [row])
+    findings = classify_handoff_events_jsonl(tmp_path)
+    assert findings == []
+
+
+def test_handoff_events_corrupt(tmp_path: Path) -> None:
+    """Corrupt handoff/events.jsonl → CORRUPT_JSONL finding."""
+    (tmp_path / "handoff").mkdir(parents=True, exist_ok=True)
+    _write_corrupt_jsonl(tmp_path / "handoff" / "events.jsonl")
+    findings = classify_handoff_events_jsonl(tmp_path)
+    assert "CORRUPT_JSONL" in _codes(findings)
+
+
+def test_handoff_events_legacy_key(tmp_path: Path) -> None:
+    """handoff/events.jsonl row with legacy key → LEGACY_KEY finding."""
+    row = {
+        "actor": "user",
+        "at": "2026-05-01T12:00:00+00:00",
+        "event_id": _VALID_ULID,
+        "feature_slug": "045-handoff",
+        "force": False,
+        "from_lane": "planned",
+        "to_lane": "in_progress",
+        "wp_id": "WP01",
+        # legacy key:
+        "mission_key": "old-key",
+    }
+    _write_jsonl(tmp_path / "handoff" / "events.jsonl", [row])
+    findings = classify_handoff_events_jsonl(tmp_path)
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# T017/wp_files classifier
+# ---------------------------------------------------------------------------
+
+
+def test_wp_files_no_tasks_dir(tmp_path: Path) -> None:
+    """No tasks directory → []."""
+    assert classify_wp_files(tmp_path) == []
+
+
+def test_wp_files_no_wp_files(tmp_path: Path) -> None:
+    """tasks/ dir exists but no WP*.md files → []."""
+    (tmp_path / "tasks").mkdir()
+    assert classify_wp_files(tmp_path) == []
+
+
+def test_wp_files_no_frontmatter(tmp_path: Path) -> None:
+    """WP file without frontmatter → [] (no finding)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "WP01.md").write_text("# WP01\n\nSome content\n", encoding="utf-8")
+    assert classify_wp_files(tmp_path) == []
+
+
+def test_wp_files_known_frontmatter(tmp_path: Path) -> None:
+    """WP file with clean modern frontmatter → []."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    content = "---\nwork_package_id: WP01\ntitle: Test WP\ndependencies: []\n---\n\n# Body\n"
+    (tasks_dir / "WP01.md").write_text(content, encoding="utf-8")
+    findings = classify_wp_files(tmp_path)
+    assert findings == []
+
+
+def test_wp_files_terminal_lane_no_evidence(tmp_path: Path) -> None:
+    """WP file with terminal lane but no evidence → MISSING_EVIDENCE warning."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    content = "---\nwork_package_id: WP01\ntitle: Test WP\ndependencies: []\nlane: done\n---\n\n# Body\n"
+    (tasks_dir / "WP01.md").write_text(content, encoding="utf-8")
+    findings = classify_wp_files(tmp_path)
+    assert "MISSING_EVIDENCE" in _codes(findings)
+    missing = [f for f in findings if f.code == "MISSING_EVIDENCE"]
+    assert missing[0].severity == Severity.WARNING
+    assert missing[0].artifact_path == "tasks/WP01.md"
+
+
+def test_wp_files_terminal_lane_with_evidence(tmp_path: Path) -> None:
+    """WP file with terminal lane AND evidence → no MISSING_EVIDENCE."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    content = (
+        "---\n"
+        "work_package_id: WP01\n"
+        "title: Test WP\n"
+        "dependencies: []\n"
+        "lane: done\n"
+        "evidence: some evidence value\n"
+        "---\n\n# Body\n"
+    )
+    (tasks_dir / "WP01.md").write_text(content, encoding="utf-8")
+    findings = classify_wp_files(tmp_path)
+    missing = [f for f in findings if f.code == "MISSING_EVIDENCE"]
+    assert missing == []
+
+
+def test_wp_files_legacy_key_in_frontmatter(tmp_path: Path) -> None:
+    """WP file with feature_slug in frontmatter → LEGACY_KEY finding."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    content = (
+        "---\n"
+        "work_package_id: WP01\n"
+        "title: Test WP\n"
+        "dependencies: []\n"
+        "feature_slug: old-feature\n"
+        "---\n\n# Body\n"
+    )
+    (tasks_dir / "WP01.md").write_text(content, encoding="utf-8")
+    findings = classify_wp_files(tmp_path)
+    assert "LEGACY_KEY" in _codes(findings)
+
+
+def test_wp_files_approved_lane_no_evidence(tmp_path: Path) -> None:
+    """WP file with 'approved' terminal lane but no evidence → MISSING_EVIDENCE."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    content = "---\nwork_package_id: WP01\ntitle: Test WP\ndependencies: []\nlane: approved\n---\n\n# Body\n"
+    (tasks_dir / "WP01.md").write_text(content, encoding="utf-8")
+    findings = classify_wp_files(tmp_path)
+    assert "MISSING_EVIDENCE" in _codes(findings)
+
+
+def test_wp_files_artifact_path_forward_slashes(tmp_path: Path) -> None:
+    """artifact_path in findings must use forward slashes."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    content = "---\nwork_package_id: WP01\ntitle: Test WP\ndependencies: []\nlane: done\n---\n\n# Body\n"
+    (tasks_dir / "WP01.md").write_text(content, encoding="utf-8")
+    findings = classify_wp_files(tmp_path)
+    for finding in findings:
+        assert "\\" not in finding.artifact_path, f"Non-forward-slash in {finding.artifact_path!r}"
+        assert finding.artifact_path.startswith("tasks/")
+
+
+# ---------------------------------------------------------------------------
+# General: all classifiers return [] for empty mission directory
+# ---------------------------------------------------------------------------
+
+
+def test_absent_optional_files_no_findings(tmp_path: Path) -> None:
+    """Mission dir with no optional files → all classifiers return empty/false."""
+    assert classify_meta_json(tmp_path) == []
+    findings_se, flag = classify_status_events_jsonl(tmp_path)
+    assert findings_se == []
+    assert flag is False
+    assert classify_status_json(tmp_path) == []
+    assert classify_mission_events_jsonl(tmp_path) == []
+    assert classify_decisions_events_jsonl(tmp_path) == []
+    assert classify_handoff_events_jsonl(tmp_path) == []
+    assert classify_wp_files(tmp_path) == []

--- a/tests/audit/test_audit_cli.py
+++ b/tests/audit/test_audit_cli.py
@@ -1,0 +1,218 @@
+"""CLI integration tests for `spec-kitty doctor mission-state`.
+
+Uses typer.testing.CliRunner to invoke the command in-process.
+Monkeypatches locate_project_root so tests run without a real kitty project.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import specify_cli.cli.commands.doctor as doctor_mod
+from specify_cli.cli.commands.doctor import app
+
+runner = CliRunner()
+
+
+def _make_clean_mission(parent: Path, slug: str = "test-mission") -> Path:
+    """Create a minimal valid mission directory under parent."""
+    mission_dir = parent / slug
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_id": "01KQHRB8GCFJAX7HM4ZY52AQGR",
+                "mission_slug": slug,
+                "mission_type": "software-dev",
+                "target_branch": "main",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return mission_dir
+
+
+def _make_corrupt_mission(parent: Path, slug: str = "corrupt-mission") -> Path:
+    """Create a mission directory with a corrupt events file."""
+    mission_dir = parent / slug
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "meta.json").write_text(
+        json.dumps({"mission_slug": slug, "mission_type": "software-dev"}),
+        encoding="utf-8",
+    )
+    (mission_dir / "status.events.jsonl").write_text(
+        "THIS IS NOT VALID JSON {{{\n",
+        encoding="utf-8",
+    )
+    return mission_dir
+
+
+# ---------------------------------------------------------------------------
+# Test 1: --audit flag is required
+# ---------------------------------------------------------------------------
+
+
+def test_cli_requires_audit_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without --audit, command exits 0 and mentions --audit."""
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+    result = runner.invoke(app, ["mission-state"])
+    assert result.exit_code == 0
+    assert "--audit" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Test 2: --fixture-dir runs the audit
+# ---------------------------------------------------------------------------
+
+
+def test_cli_runs_audit_with_fixture_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--audit --fixture-dir scans the fixture and exits 0 for a clean mission."""
+    fixture_root = tmp_path / "fixtures"
+    _make_clean_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(app, ["mission-state", "--audit", "--fixture-dir", str(fixture_root)])
+    assert result.exit_code == 0, result.output
+    combined = (result.output or "") + (result.stderr or "")
+    assert "clean" in combined.lower() or "no findings" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: --json output shape
+# ---------------------------------------------------------------------------
+
+
+def test_cli_json_output_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--json output is valid JSON with missions, shape_counters, repo_summary keys."""
+    fixture_root = tmp_path / "fixtures"
+    _make_clean_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["mission-state", "--audit", "--json", "--fixture-dir", str(fixture_root)],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "missions" in data
+    assert "shape_counters" in data
+    assert "repo_summary" in data
+    assert data["repo_summary"]["total_missions"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4: --fail-on error exits 0 when clean
+# ---------------------------------------------------------------------------
+
+
+def test_cli_fail_on_error_exit_0_when_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--fail-on error exits 0 when the fixture has no errors."""
+    fixture_root = tmp_path / "fixtures"
+    _make_clean_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["mission-state", "--audit", "--fail-on", "error", "--fixture-dir", str(fixture_root)],
+    )
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# Test 5: --fail-on error exits 1 when errors present
+# ---------------------------------------------------------------------------
+
+
+def test_cli_fail_on_error_exit_1_when_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--fail-on error exits 1 when the fixture has a CORRUPT_JSONL (error) finding."""
+    fixture_root = tmp_path / "fixtures"
+    _make_corrupt_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["mission-state", "--audit", "--fail-on", "error", "--fixture-dir", str(fixture_root)],
+    )
+    assert result.exit_code == 1, result.output
+
+
+# ---------------------------------------------------------------------------
+# Test 6: invalid --fail-on exits 2
+# ---------------------------------------------------------------------------
+
+
+def test_cli_invalid_fail_on_exits_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unknown --fail-on value exits 2 with a helpful error message."""
+    fixture_root = tmp_path / "fixtures"
+    _make_clean_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mission-state",
+            "--audit",
+            "--fail-on",
+            "critical",
+            "--fixture-dir",
+            str(fixture_root),
+        ],
+    )
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 7: --mission scopes the audit to one mission
+# ---------------------------------------------------------------------------
+
+
+def test_cli_mission_scoping(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--mission filters the audit to a single mission slug.
+
+    Uses kitty-specs/ under repo_root since resolve_mission() needs that structure.
+    """
+    specs_dir = tmp_path / "kitty-specs"
+    _make_clean_mission(specs_dir, slug="alpha")
+    _make_clean_mission(specs_dir, slug="beta")
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["mission-state", "--audit", "--json", "--mission", "alpha"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["repo_summary"]["total_missions"] == 1
+    assert data["missions"][0]["mission_slug"] == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# Test 8: --json output is deterministic
+# ---------------------------------------------------------------------------
+
+
+def test_cli_json_determinism(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invoking --json twice on the same fixture produces byte-identical output."""
+    fixture_root = tmp_path / "fixtures"
+    _make_clean_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    args = ["mission-state", "--audit", "--json", "--fixture-dir", str(fixture_root)]
+    result1 = runner.invoke(app, args)
+    result2 = runner.invoke(app, args)
+
+    assert result1.exit_code == 0
+    assert result2.exit_code == 0
+    assert result1.output == result2.output

--- a/tests/audit/test_audit_engine.py
+++ b/tests/audit/test_audit_engine.py
@@ -1,0 +1,298 @@
+"""Tests for src/specify_cli/audit/engine.py (T023).
+
+8 test cases covering the audit engine scan loop, mission filtering,
+determinism, corrupt-JSONL resilience, repo-summary counts, performance,
+and empty-scan-root behavior.
+
+Fixture layout (for tests that need identity functions to work):
+    tmp_path/               ← repo_root
+      kitty-specs/          ← scan_root = tmp_path / "kitty-specs"
+        mission-a/
+          meta.json         ← {"mission_id": "<valid ULID>", ...}
+        mission-b/
+          meta.json
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from specify_cli.audit import AuditOptions, RepoAuditReport, run_audit
+from specify_cli.audit.serializer import build_report_json
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A set of distinct valid ULIDs (26 chars, Crockford Base32: 0-9 A-H J-N P-T V-Z)
+_ULID_A = "01KQHRB8GCFJAX7HM4ZY52AQGR"
+_ULID_B = "01KQHRB9GCFJAX7HM4ZY52AQGR"
+_ULID_C = "01KQHRB7GCFJAX7HM4ZY52AQGR"
+_ULID_D = "01KQHRC0GCFJAX7HM4ZY52AQGR"
+_ULID_E = "01KQHRC1GCFJAX7HM4ZY52AQGR"
+
+
+def _write_meta(mission_dir: Path, mission_id: str, mission_number: int | None = None) -> None:
+    """Write a minimal valid meta.json to the mission directory."""
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {
+        "mission_id": mission_id,
+        "mission_slug": mission_dir.name,
+        "friendly_name": f"Test mission {mission_dir.name}",
+    }
+    if mission_number is not None:
+        meta["mission_number"] = mission_number
+    (mission_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+
+def _make_mission(parent: Path, slug: str, mission_id: str, mission_number: int | None = None) -> Path:
+    """Create a minimal mission directory with a valid meta.json."""
+    mission_dir = parent / slug
+    _write_meta(mission_dir, mission_id, mission_number)
+    return mission_dir
+
+
+def _options(tmp_path: Path, *, mission_filter: str | None = None) -> AuditOptions:
+    """Create AuditOptions with tmp_path as repo_root and kitty-specs as scan_root."""
+    return AuditOptions(
+        repo_root=tmp_path,
+        scan_root=tmp_path / "kitty-specs",
+        mission_filter=mission_filter,
+        fail_on=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: test_scan_visits_all_missions
+# ---------------------------------------------------------------------------
+
+
+def test_scan_visits_all_missions(tmp_path: Path) -> None:
+    """Engine visits all mission directories and returns them sorted by slug."""
+    specs_dir = tmp_path / "kitty-specs"
+    _make_mission(specs_dir, "mission-a", _ULID_A)
+    _make_mission(specs_dir, "mission-b", _ULID_B)
+    _make_mission(specs_dir, "mission-c", _ULID_C)
+
+    report = run_audit(_options(tmp_path))
+
+    assert isinstance(report, RepoAuditReport)
+    slugs = [m.mission_slug for m in report.missions]
+    assert slugs == ["mission-a", "mission-b", "mission-c"]
+    assert report.repo_summary["total_missions"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 2: test_fixture_dir_substitution
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_dir_substitution(tmp_path: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """scan_root override causes the engine to scan a different directory."""
+    # Primary fixture: tmp_path/kitty-specs/fixture-mission
+    specs_dir = tmp_path / "kitty-specs"
+    _make_mission(specs_dir, "fixture-mission", _ULID_A)
+
+    # Engine with default scan_root should find fixture-mission
+    report_a = run_audit(_options(tmp_path))
+    assert any(m.mission_slug == "fixture-mission" for m in report_a.missions)
+
+    # Alternate fixture in a different tmp directory
+    alt_root = tmp_path_factory.mktemp("alt")
+    alt_specs = alt_root / "kitty-specs"
+    _make_mission(alt_specs, "alt-mission", _ULID_B)
+
+    # Override scan_root to alt_specs — should find alt-mission, NOT fixture-mission
+    alt_options = AuditOptions(
+        repo_root=alt_root,
+        scan_root=alt_specs,
+        mission_filter=None,
+        fail_on=None,
+    )
+    report_b = run_audit(alt_options)
+    slugs_b = [m.mission_slug for m in report_b.missions]
+    assert "alt-mission" in slugs_b
+    assert "fixture-mission" not in slugs_b
+
+
+# ---------------------------------------------------------------------------
+# Test 3: test_mission_filter_scoping
+# ---------------------------------------------------------------------------
+
+
+def test_mission_filter_scoping(tmp_path: Path) -> None:
+    """--mission filter restricts the scan to exactly one mission."""
+    specs_dir = tmp_path / "kitty-specs"
+    _make_mission(specs_dir, "001-alpha", _ULID_A, mission_number=1)
+    _make_mission(specs_dir, "002-beta", _ULID_B, mission_number=2)
+    _make_mission(specs_dir, "003-gamma", _ULID_C, mission_number=3)
+
+    # Filter by full slug — should return only 001-alpha
+    report = run_audit(
+        AuditOptions(
+            repo_root=tmp_path,
+            scan_root=tmp_path / "kitty-specs",
+            mission_filter="001-alpha",
+            fail_on=None,
+        )
+    )
+
+    assert len(report.missions) == 1
+    assert report.missions[0].mission_slug == "001-alpha"
+    assert report.repo_summary["total_missions"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4: test_determinism
+# ---------------------------------------------------------------------------
+
+
+def test_determinism(tmp_path: Path) -> None:
+    """Two successive run_audit() calls produce byte-identical JSON output."""
+    specs_dir = tmp_path / "kitty-specs"
+    _make_mission(specs_dir, "mission-x", _ULID_A, mission_number=1)
+    _make_mission(specs_dir, "mission-y", _ULID_B, mission_number=2)
+    _make_mission(specs_dir, "mission-z", _ULID_C, mission_number=3)
+
+    opts = _options(tmp_path)
+    report_1 = run_audit(opts)
+    report_2 = run_audit(opts)
+
+    json_1 = build_report_json(report_1)
+    json_2 = build_report_json(report_2)
+
+    assert json_1 == json_2, "Two identical run_audit() calls produced different JSON"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: test_corrupt_jsonl_does_not_crash_engine
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_jsonl_does_not_crash_engine(tmp_path: Path) -> None:
+    """Engine handles a corrupt status.events.jsonl without raising.
+
+    The corrupt line causes CORRUPT_JSONL to appear in findings.
+    SNAPSHOT_DRIFT must NOT appear because skip_drift=True was applied.
+    """
+    specs_dir = tmp_path / "kitty-specs"
+    mission_dir = specs_dir / "bad-events-mission"
+    _write_meta(mission_dir, _ULID_A)
+
+    # Write a valid status.json (minimal) so the drift check would normally run
+    (mission_dir / "status.json").write_text(
+        json.dumps({"wps": {}}) + "\n", encoding="utf-8"
+    )
+
+    # Write a corrupt status.events.jsonl
+    events_path = mission_dir / "status.events.jsonl"
+    events_path.write_text("THIS IS NOT JSON {{{\n", encoding="utf-8")
+
+    report = run_audit(_options(tmp_path))
+
+    assert len(report.missions) == 1
+    result = report.missions[0]
+    codes = {f.code for f in result.findings}
+
+    assert "CORRUPT_JSONL" in codes, f"Expected CORRUPT_JSONL in {codes}"
+    assert "SNAPSHOT_DRIFT" not in codes, f"SNAPSHOT_DRIFT should be suppressed, got {codes}"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: test_repo_summary_counts
+# ---------------------------------------------------------------------------
+
+
+def test_repo_summary_counts(tmp_path: Path) -> None:
+    """Repo summary correctly counts missions with errors/warnings."""
+    specs_dir = tmp_path / "kitty-specs"
+
+    # Clean mission: valid meta.json with mission_id + mission_number
+    _make_mission(specs_dir, "001-clean", _ULID_A, mission_number=1)
+
+    # Mission with a LEGACY_KEY warning: add feature_slug to meta.json
+    legacy_dir = specs_dir / "002-legacy"
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+    legacy_meta: dict[str, object] = {
+        "mission_id": _ULID_B,
+        "mission_slug": "002-legacy",
+        "mission_number": 2,
+        "friendly_name": "Legacy mission",
+        "feature_slug": "old-slug",  # LEGACY_KEY → WARNING
+    }
+    (legacy_dir / "meta.json").write_text(json.dumps(legacy_meta), encoding="utf-8")
+
+    report = run_audit(_options(tmp_path))
+
+    summary = report.repo_summary
+    assert summary["total_missions"] == 2
+    assert summary["missions_with_errors"] == 0
+    assert summary["missions_with_warnings"] == 1  # only 002-legacy has a warning
+    assert summary["total_findings"] >= 1
+    assert summary["findings_by_severity"]["warning"] >= 1
+    assert summary["findings_by_severity"]["error"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 7: test_performance_204_missions
+# ---------------------------------------------------------------------------
+
+
+def test_performance_204_missions(tmp_path: Path) -> None:
+    """204 minimal missions complete in under 30 seconds (NFR-003)."""
+    specs_dir = tmp_path / "kitty-specs"
+    specs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use a pool of valid ULIDs, cycling through them with a suffix to make unique
+    _BASE_ULID = "01KQHRB8GCFJAX7HM4ZY52AQ"
+    valid_suffix_chars = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+    # Generate 204 distinct valid ULIDs
+    def _make_ulid(i: int) -> str:
+        # Encode i as 2 chars from the valid Crockford Base32 alphabet
+        high = i // len(valid_suffix_chars)
+        low = i % len(valid_suffix_chars)
+        return _BASE_ULID + valid_suffix_chars[high] + valid_suffix_chars[low]
+
+    for i in range(204):
+        slug = f"mission-{i:04d}"
+        mission_dir = specs_dir / slug
+        mission_dir.mkdir()
+        meta = {
+            "mission_id": _make_ulid(i),
+            "mission_slug": slug,
+            "friendly_name": f"Mission {i}",
+            "mission_number": i,
+        }
+        (mission_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    opts = AuditOptions(repo_root=tmp_path, scan_root=specs_dir, fail_on=None)
+
+    start = time.perf_counter()
+    report = run_audit(opts)
+    elapsed = time.perf_counter() - start
+
+    assert len(report.missions) == 204, f"Expected 204 missions, got {len(report.missions)}"
+    assert elapsed < 30.0, f"204-mission audit took {elapsed:.2f}s, expected < 30s"
+
+
+# ---------------------------------------------------------------------------
+# Test 8: test_empty_scan_root
+# ---------------------------------------------------------------------------
+
+
+def test_empty_scan_root(tmp_path: Path) -> None:
+    """An empty scan_root produces an empty report with zero missions."""
+    # Create an empty kitty-specs directory
+    specs_dir = tmp_path / "kitty-specs"
+    specs_dir.mkdir(parents=True)
+
+    report = run_audit(_options(tmp_path))
+
+    assert report.missions == []
+    assert report.repo_summary["total_missions"] == 0
+    assert report.repo_summary["total_findings"] == 0

--- a/tests/audit/test_audit_models.py
+++ b/tests/audit/test_audit_models.py
@@ -1,0 +1,312 @@
+"""Tests for src/specify_cli/audit/models.py (T001–T004)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.audit.models import (
+    AuditOptions,
+    MissionAuditResult,
+    MissionFinding,
+    RepoAuditReport,
+    Severity,
+)
+
+
+# ---------------------------------------------------------------------------
+# T001: Severity StrEnum
+# ---------------------------------------------------------------------------
+
+
+class TestSeverity:
+    def test_has_exactly_three_members(self) -> None:
+        members = list(Severity)
+        assert len(members) == 3
+
+    def test_member_names(self) -> None:
+        assert Severity.ERROR
+        assert Severity.WARNING
+        assert Severity.INFO
+
+    def test_string_values(self) -> None:
+        assert Severity.ERROR == "error"
+        assert Severity.WARNING == "warning"
+        assert Severity.INFO == "info"
+
+    def test_ordering_error_lt_warning(self) -> None:
+        assert Severity.ERROR < Severity.WARNING
+
+    def test_ordering_warning_lt_info(self) -> None:
+        assert Severity.WARNING < Severity.INFO
+
+    def test_ordering_error_lt_info(self) -> None:
+        assert Severity.ERROR < Severity.INFO
+
+    def test_le_same_member(self) -> None:
+        assert Severity.ERROR <= Severity.ERROR
+        assert Severity.WARNING <= Severity.WARNING
+        assert Severity.INFO <= Severity.INFO
+
+    def test_le_across_members(self) -> None:
+        assert Severity.ERROR <= Severity.WARNING
+        assert Severity.ERROR <= Severity.INFO
+        assert Severity.WARNING <= Severity.INFO
+
+    def test_not_lt_reversed(self) -> None:
+        assert not (Severity.WARNING < Severity.ERROR)
+        assert not (Severity.INFO < Severity.ERROR)
+        assert not (Severity.INFO < Severity.WARNING)
+
+    def test_not_le_reversed(self) -> None:
+        assert not (Severity.WARNING <= Severity.ERROR)
+        assert not (Severity.INFO <= Severity.ERROR)
+        assert not (Severity.INFO <= Severity.WARNING)
+
+    def test_is_str(self) -> None:
+        assert isinstance(Severity.ERROR, str)
+
+    def test_fail_on_threshold_pattern(self) -> None:
+        """Verify the --fail-on threshold idiom works correctly."""
+        findings = [
+            MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="a.md"),
+            MissionFinding(code="CORRUPT_JSONL", severity=Severity.ERROR, artifact_path="b.jsonl"),
+        ]
+        # fail_on=ERROR: only errors trigger failure
+        assert any(f.severity <= Severity.ERROR for f in findings)
+        # fail_on=WARNING: errors and warnings trigger failure
+        assert any(f.severity <= Severity.WARNING for f in findings)
+        # fail_on=INFO: everything triggers failure
+        assert any(f.severity <= Severity.INFO for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# T002: MissionFinding frozen dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestMissionFinding:
+    def test_basic_construction(self) -> None:
+        f = MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="tasks/WP01.md")
+        assert f.code == "LEGACY_KEY"
+        assert f.severity == Severity.WARNING
+        assert f.artifact_path == "tasks/WP01.md"
+        assert f.detail is None
+
+    def test_with_detail(self) -> None:
+        f = MissionFinding(
+            code="CORRUPT_JSONL",
+            severity=Severity.ERROR,
+            artifact_path="status.events.jsonl",
+            detail="line 7 is not valid JSON",
+        )
+        assert f.detail == "line 7 is not valid JSON"
+
+    def test_frozen_immutable(self) -> None:
+        f = MissionFinding(code="X", severity=Severity.INFO, artifact_path="foo")
+        with pytest.raises((AttributeError, TypeError)):
+            f.code = "Y"  # type: ignore[misc]
+
+    def test_hashable(self) -> None:
+        f = MissionFinding(code="X", severity=Severity.INFO, artifact_path="foo")
+        assert hash(f) is not None
+        s: set[MissionFinding] = {f}
+        assert f in s
+
+    def test_to_dict_keys(self) -> None:
+        f = MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="meta.json")
+        d = f.to_dict()
+        assert set(d.keys()) == {"code", "severity", "artifact_path", "detail"}
+
+    def test_to_dict_severity_is_string(self) -> None:
+        f = MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="meta.json")
+        d = f.to_dict()
+        assert d["severity"] == "warning"
+        assert isinstance(d["severity"], str)
+
+    def test_to_dict_detail_none(self) -> None:
+        f = MissionFinding(code="X", severity=Severity.INFO, artifact_path="foo")
+        assert f.to_dict()["detail"] is None
+
+    def test_to_dict_detail_present(self) -> None:
+        f = MissionFinding(code="X", severity=Severity.INFO, artifact_path="foo", detail="some detail")
+        assert f.to_dict()["detail"] == "some detail"
+
+    def test_to_dict_values(self) -> None:
+        f = MissionFinding(
+            code="IDENTITY_MISSING",
+            severity=Severity.ERROR,
+            artifact_path="meta.json",
+            detail="mission_id field absent",
+        )
+        d = f.to_dict()
+        assert d["code"] == "IDENTITY_MISSING"
+        assert d["severity"] == "error"
+        assert d["artifact_path"] == "meta.json"
+        assert d["detail"] == "mission_id field absent"
+
+
+# ---------------------------------------------------------------------------
+# T003: MissionAuditResult dataclass
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    slug: str = "my-feature",
+    findings: list[MissionFinding] | None = None,
+) -> MissionAuditResult:
+    return MissionAuditResult(
+        mission_slug=slug,
+        mission_dir=Path("kitty-specs") / slug,
+        findings=findings or [],
+    )
+
+
+class TestMissionAuditResult:
+    def test_has_errors_false_when_empty(self) -> None:
+        r = _make_result()
+        assert r.has_errors is False
+
+    def test_has_errors_false_with_only_warnings(self) -> None:
+        r = _make_result(
+            findings=[MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="x")]
+        )
+        assert r.has_errors is False
+
+    def test_has_errors_true(self) -> None:
+        r = _make_result(
+            findings=[MissionFinding(code="CORRUPT_JSONL", severity=Severity.ERROR, artifact_path="x")]
+        )
+        assert r.has_errors is True
+
+    def test_has_warnings_false_when_empty(self) -> None:
+        r = _make_result()
+        assert r.has_warnings is False
+
+    def test_has_warnings_false_with_only_errors(self) -> None:
+        r = _make_result(
+            findings=[MissionFinding(code="CORRUPT_JSONL", severity=Severity.ERROR, artifact_path="x")]
+        )
+        assert r.has_warnings is False
+
+    def test_has_warnings_true(self) -> None:
+        r = _make_result(
+            findings=[MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="x")]
+        )
+        assert r.has_warnings is True
+
+    def test_finding_codes(self) -> None:
+        r = _make_result(
+            findings=[
+                MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="a"),
+                MissionFinding(code="CORRUPT_JSONL", severity=Severity.ERROR, artifact_path="b"),
+                MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="c"),
+            ]
+        )
+        assert r.finding_codes == {"LEGACY_KEY", "CORRUPT_JSONL"}
+
+    def test_to_dict_keys(self) -> None:
+        r = _make_result()
+        d = r.to_dict()
+        assert "mission_slug" in d
+        assert "mission_dir" in d
+        assert "findings" in d
+        assert "finding_count" in d
+        assert "has_errors" in d
+
+    def test_to_dict_mission_dir_is_string(self) -> None:
+        r = _make_result()
+        d = r.to_dict()
+        assert isinstance(d["mission_dir"], str)
+
+    def test_to_dict_finding_count(self) -> None:
+        r = _make_result(
+            findings=[
+                MissionFinding(code="X", severity=Severity.INFO, artifact_path="a"),
+                MissionFinding(code="Y", severity=Severity.INFO, artifact_path="b"),
+            ]
+        )
+        assert r.to_dict()["finding_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# T004: RepoAuditReport and AuditOptions
+# ---------------------------------------------------------------------------
+
+
+class TestRepoAuditReport:
+    def _make_report(self) -> RepoAuditReport:
+        return RepoAuditReport(
+            missions=[_make_result("alpha"), _make_result("beta")],
+            shape_counters={"CORRUPT_JSONL": 2, "LEGACY_KEY": 5, "ACTOR_DRIFT": 1},
+            repo_summary={
+                "total_missions": 2,
+                "missions_with_errors": 0,
+                "missions_with_warnings": 0,
+                "total_findings": 0,
+                "findings_by_severity": {"error": 0, "warning": 0, "info": 0},
+            },
+        )
+
+    def test_to_dict_top_level_keys(self) -> None:
+        d = self._make_report().to_dict()
+        assert set(d.keys()) == {"missions", "shape_counters", "repo_summary"}
+
+    def test_to_dict_shape_counters_sorted(self) -> None:
+        report = self._make_report()
+        d = report.to_dict()
+        keys = list(d["shape_counters"].keys())  # type: ignore[union-attr]
+        assert keys == sorted(keys)
+
+    def test_to_dict_shape_counters_values(self) -> None:
+        report = self._make_report()
+        d = report.to_dict()
+        sc = d["shape_counters"]
+        assert sc == {"ACTOR_DRIFT": 1, "CORRUPT_JSONL": 2, "LEGACY_KEY": 5}  # type: ignore[comparison-overlap]
+
+    def test_empty_missions(self) -> None:
+        report = RepoAuditReport(
+            missions=[],
+            shape_counters={},
+            repo_summary={},
+        )
+        d = report.to_dict()
+        assert d["missions"] == []
+        assert d["shape_counters"] == {}
+
+    def test_missions_serialized(self) -> None:
+        report = self._make_report()
+        d = report.to_dict()
+        assert isinstance(d["missions"], list)
+        assert len(d["missions"]) == 2  # type: ignore[arg-type]
+
+
+class TestAuditOptions:
+    def test_required_repo_root(self) -> None:
+        opts = AuditOptions(repo_root=Path("/repo"))
+        assert opts.repo_root == Path("/repo")
+
+    def test_defaults(self) -> None:
+        opts = AuditOptions(repo_root=Path("/repo"))
+        assert opts.scan_root is None
+        assert opts.mission_filter is None
+        assert opts.fail_on is None
+
+    def test_with_all_fields(self) -> None:
+        opts = AuditOptions(
+            repo_root=Path("/repo"),
+            scan_root=Path("/repo/kitty-specs"),
+            mission_filter="my-feature",
+            fail_on=Severity.ERROR,
+        )
+        assert opts.scan_root == Path("/repo/kitty-specs")
+        assert opts.mission_filter == "my-feature"
+        assert opts.fail_on == Severity.ERROR
+
+    def test_fail_on_warning_threshold(self) -> None:
+        opts = AuditOptions(repo_root=Path("/repo"), fail_on=Severity.WARNING)
+        assert opts.fail_on == Severity.WARNING
+        assert opts.fail_on <= Severity.WARNING
+        # error is also <= warning (more severe)
+        assert opts.fail_on >= Severity.ERROR  # type: ignore[operator]

--- a/tests/audit/test_audit_serializer.py
+++ b/tests/audit/test_audit_serializer.py
@@ -1,0 +1,176 @@
+"""Tests for src/specify_cli/audit/serializer.py (T005).
+
+The determinism test (NFR-001) is the most important test here: calling
+``build_report_json()`` twice on the same object must produce byte-identical
+output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from specify_cli.audit.models import (
+    MissionAuditResult,
+    MissionFinding,
+    RepoAuditReport,
+    Severity,
+)
+from specify_cli.audit.serializer import build_report_json
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _finding(code: str, severity: Severity, artifact_path: str, detail: str | None = None) -> MissionFinding:
+    return MissionFinding(code=code, severity=severity, artifact_path=artifact_path, detail=detail)
+
+
+def _result(slug: str, findings: list[MissionFinding]) -> MissionAuditResult:
+    return MissionAuditResult(
+        mission_slug=slug,
+        mission_dir=Path("kitty-specs") / slug,
+        findings=findings,
+    )
+
+
+def _rich_report() -> RepoAuditReport:
+    """Build a report with >=3 missions covering all 3 severity levels."""
+    alpha_findings = [
+        _finding("CORRUPT_JSONL", Severity.ERROR, "status.events.jsonl", "line 3 malformed"),
+        _finding("LEGACY_KEY", Severity.WARNING, "meta.json"),
+        _finding("UNKNOWN_SHAPE", Severity.INFO, "tasks/WP01.md"),
+    ]
+    beta_findings = [
+        _finding("IDENTITY_MISSING", Severity.ERROR, "meta.json"),
+        _finding("ACTOR_DRIFT", Severity.WARNING, "status.events.jsonl", "actor mismatch"),
+    ]
+    gamma_findings = [
+        _finding("DUPLICATE_PREFIX", Severity.WARNING, "meta.json"),
+        _finding("UNKNOWN_SHAPE", Severity.INFO, "spec.md"),
+    ]
+    return RepoAuditReport(
+        missions=[
+            _result("alpha-mission", alpha_findings),
+            _result("beta-mission", beta_findings),
+            _result("gamma-mission", gamma_findings),
+        ],
+        shape_counters={
+            "CORRUPT_JSONL": 1,
+            "LEGACY_KEY": 1,
+            "UNKNOWN_SHAPE": 2,
+            "IDENTITY_MISSING": 1,
+            "ACTOR_DRIFT": 1,
+            "DUPLICATE_PREFIX": 1,
+        },
+        repo_summary={
+            "total_missions": 3,
+            "missions_with_errors": 2,
+            "missions_with_warnings": 3,
+            "total_findings": 7,
+            "findings_by_severity": {"error": 2, "warning": 4, "info": 1},
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# NFR-001: Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_byte_identical_on_same_object(self) -> None:
+        """Calling build_report_json() twice on the same object is byte-identical."""
+        report = _rich_report()
+        first = build_report_json(report)
+        second = build_report_json(report)
+        assert first == second, "build_report_json() must produce identical output on repeated calls"
+
+    def test_byte_identical_on_equal_objects(self) -> None:
+        """Two independently constructed equal reports serialize identically."""
+        report_a = _rich_report()
+        report_b = _rich_report()
+        assert build_report_json(report_a) == build_report_json(report_b)
+
+    def test_valid_json(self) -> None:
+        result = build_report_json(_rich_report())
+        # Must not raise
+        parsed = json.loads(result)
+        assert isinstance(parsed, dict)
+
+    def test_top_level_keys_present(self) -> None:
+        result = build_report_json(_rich_report())
+        parsed = json.loads(result)
+        assert "missions" in parsed
+        assert "shape_counters" in parsed
+        assert "repo_summary" in parsed
+
+    def test_uses_indent_2(self) -> None:
+        """Output must be pretty-printed with indent=2."""
+        result = build_report_json(_rich_report())
+        # A pretty-printed JSON has lines starting with "  " (two spaces)
+        lines = result.splitlines()
+        indented = [ln for ln in lines if ln.startswith("  ")]
+        assert len(indented) > 0, "Expected indented output"
+
+    def test_keys_sorted(self) -> None:
+        """sort_keys=True means dict keys appear in lexicographic order."""
+        result = build_report_json(_rich_report())
+        parsed = json.loads(result)
+        # shape_counters must be in sorted order
+        sc_keys = list(parsed["shape_counters"].keys())
+        assert sc_keys == sorted(sc_keys)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyReport:
+    def test_zero_missions(self) -> None:
+        report = RepoAuditReport(
+            missions=[],
+            shape_counters={},
+            repo_summary={
+                "total_missions": 0,
+                "missions_with_errors": 0,
+                "missions_with_warnings": 0,
+                "total_findings": 0,
+                "findings_by_severity": {"error": 0, "warning": 0, "info": 0},
+            },
+        )
+        result = build_report_json(report)
+        parsed = json.loads(result)
+        assert parsed["missions"] == []
+        assert parsed["shape_counters"] == {}
+        assert "repo_summary" in parsed
+
+    def test_empty_report_is_deterministic(self) -> None:
+        report = RepoAuditReport(missions=[], shape_counters={}, repo_summary={})
+        assert build_report_json(report) == build_report_json(report)
+
+
+class TestSingleMission:
+    def test_single_finding_round_trips(self) -> None:
+        report = RepoAuditReport(
+            missions=[
+                _result(
+                    "solo-mission",
+                    [_finding("LEGACY_KEY", Severity.WARNING, "meta.json", "found 'lane' key")],
+                )
+            ],
+            shape_counters={"LEGACY_KEY": 1},
+            repo_summary={"total_missions": 1},
+        )
+        result = build_report_json(report)
+        parsed = json.loads(result)
+        mission = parsed["missions"][0]
+        assert mission["mission_slug"] == "solo-mission"
+        finding = mission["findings"][0]
+        assert finding["code"] == "LEGACY_KEY"
+        assert finding["severity"] == "warning"
+        assert finding["artifact_path"] == "meta.json"
+        assert finding["detail"] == "found 'lane' key"

--- a/tests/audit/test_detectors.py
+++ b/tests/audit/test_detectors.py
@@ -1,0 +1,217 @@
+"""Tests for src/specify_cli/audit/detectors.py (T010).
+
+12 test cases covering:
+- detect_legacy_keys (T001-T004)
+- detect_forbidden_keys (T005-T006)
+- detect_corrupt_jsonl (T007-T010)
+- check_unknown_keys from shape_registry (T011-T012, included here for convenience)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from specify_cli.audit.detectors import (
+    FORBIDDEN_KEYS,
+    LEGACY_KEYS,
+    STATUS_EVENT_ONLY_LEGACY_KEYS,
+    detect_corrupt_jsonl,
+    detect_forbidden_keys,
+    detect_legacy_keys,
+)
+from specify_cli.audit.models import Severity
+from specify_cli.audit.shape_registry import check_unknown_keys
+
+
+# ---------------------------------------------------------------------------
+# detect_legacy_keys
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLegacyKeys:
+    def test_detect_legacy_keys_feature_slug(self) -> None:
+        """A dict with 'feature_slug' produces one LEGACY_KEY finding."""
+        findings = detect_legacy_keys({"feature_slug": "x"}, "meta.json")
+        assert len(findings) == 1
+        assert findings[0].code == "LEGACY_KEY"
+        assert findings[0].severity == Severity.WARNING
+        assert findings[0].artifact_path == "meta.json"
+        assert "feature_slug" in (findings[0].detail or "")
+
+    def test_detect_legacy_keys_multiple(self) -> None:
+        """A dict with 3 legacy keys produces 3 findings."""
+        obj = {
+            "feature_slug": "a",
+            "feature_number": 1,
+            "mission_key": "k",
+            "irrelevant": "v",
+        }
+        findings = detect_legacy_keys(obj, "meta.json")
+        assert len(findings) == 3
+        codes = {f.code for f in findings}
+        assert codes == {"LEGACY_KEY"}
+
+    def test_detect_legacy_keys_no_match(self) -> None:
+        """A clean dict returns no findings."""
+        findings = detect_legacy_keys({"mission_id": "abc", "friendly_name": "Foo"}, "meta.json")
+        assert findings == []
+
+    def test_detect_legacy_keys_extra_keys_event_rows(self) -> None:
+        """work_package_id is flagged when extra_keys=STATUS_EVENT_ONLY_LEGACY_KEYS."""
+        findings = detect_legacy_keys(
+            {"work_package_id": "WP01"},
+            "status.events.jsonl",
+            extra_keys=STATUS_EVENT_ONLY_LEGACY_KEYS,
+        )
+        assert len(findings) == 1
+        assert findings[0].code == "LEGACY_KEY"
+        assert "work_package_id" in (findings[0].detail or "")
+
+    def test_detect_legacy_keys_work_package_id_not_flagged_without_extra(self) -> None:
+        """work_package_id is NOT flagged without extra_keys (correct for WP frontmatter)."""
+        findings = detect_legacy_keys({"work_package_id": "WP01"}, "tasks/WP01.md")
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# detect_forbidden_keys
+# ---------------------------------------------------------------------------
+
+
+class TestDetectForbiddenKeys:
+    def test_detect_forbidden_keys_event_type(self) -> None:
+        """'event_type' produces a FORBIDDEN_KEY finding."""
+        findings = detect_forbidden_keys({"event_type": "Foo"}, "status.events.jsonl")
+        assert len(findings) == 1
+        assert findings[0].code == "FORBIDDEN_KEY"
+        assert findings[0].severity == Severity.WARNING
+        assert "event_type" in (findings[0].detail or "")
+
+    def test_detect_forbidden_keys_event_name(self) -> None:
+        """'event_name' produces a FORBIDDEN_KEY finding."""
+        findings = detect_forbidden_keys({"event_name": "bar"}, "status.events.jsonl")
+        assert len(findings) == 1
+        assert findings[0].code == "FORBIDDEN_KEY"
+        assert "event_name" in (findings[0].detail or "")
+
+    def test_detect_forbidden_keys_clean_dict(self) -> None:
+        """A dict with no forbidden keys returns no findings."""
+        findings = detect_forbidden_keys({"actor": "claude", "to_lane": "claimed"}, "status.events.jsonl")
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# detect_corrupt_jsonl
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCorruptJsonl:
+    def test_detect_corrupt_jsonl_valid_file(self, tmp_path: Path) -> None:
+        """A file with all valid JSONL lines returns no findings."""
+        f = tmp_path / "events.jsonl"
+        f.write_text(
+            json.dumps({"actor": "claude", "to_lane": "claimed"}) + "\n"
+            + json.dumps({"actor": "human", "to_lane": "approved"}) + "\n",
+            encoding="utf-8",
+        )
+        findings = detect_corrupt_jsonl(f, "status.events.jsonl")
+        assert findings == []
+
+    def test_detect_corrupt_jsonl_corrupt_line(self, tmp_path: Path) -> None:
+        """One bad line produces exactly one CORRUPT_JSONL finding with correct line number."""
+        f = tmp_path / "events.jsonl"
+        f.write_text(
+            json.dumps({"actor": "claude"}) + "\n"
+            "not valid json\n"
+            + json.dumps({"actor": "human"}) + "\n",
+            encoding="utf-8",
+        )
+        findings = detect_corrupt_jsonl(f, "status.events.jsonl")
+        assert len(findings) == 1
+        assert findings[0].code == "CORRUPT_JSONL"
+        assert findings[0].severity == Severity.ERROR
+        # Line 2 is the corrupt line
+        assert "line 2" in (findings[0].detail or "")
+
+    def test_detect_corrupt_jsonl_stops_at_first_corrupt(self, tmp_path: Path) -> None:
+        """Two corrupt lines: only the first is reported (stop-at-first semantics)."""
+        f = tmp_path / "events.jsonl"
+        f.write_text(
+            "bad json line\n"
+            "also bad\n",
+            encoding="utf-8",
+        )
+        findings = detect_corrupt_jsonl(f, "status.events.jsonl")
+        # Must return exactly ONE finding regardless of how many bad lines exist.
+        assert len(findings) == 1
+        assert "line 1" in (findings[0].detail or "")
+
+    def test_detect_corrupt_jsonl_blank_lines_ignored(self, tmp_path: Path) -> None:
+        """Blank / whitespace-only lines are skipped silently."""
+        f = tmp_path / "events.jsonl"
+        f.write_text(
+            "\n"
+            "   \n"
+            + json.dumps({"ok": True}) + "\n"
+            "\n",
+            encoding="utf-8",
+        )
+        findings = detect_corrupt_jsonl(f, "status.events.jsonl")
+        assert findings == []
+
+    def test_detect_corrupt_jsonl_nonexistent_file(self, tmp_path: Path) -> None:
+        """A missing file returns an empty list (not an exception)."""
+        missing = tmp_path / "does_not_exist.jsonl"
+        findings = detect_corrupt_jsonl(missing, "status.events.jsonl")
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# check_unknown_keys (from shape_registry)
+# T011–T012
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUnknownKeys:
+    def test_check_unknown_keys_known_key(self) -> None:
+        """A key that is in the known set produces no findings."""
+        findings = check_unknown_keys("meta.json", {"mission_id": "abc"}, "meta.json")
+        assert findings == []
+
+    def test_check_unknown_keys_unknown_key(self) -> None:
+        """An unrecognised key that is not legacy or forbidden produces an UNKNOWN_SHAPE finding."""
+        findings = check_unknown_keys(
+            "meta.json",
+            {"totally_new_field": "value"},
+            "meta.json",
+        )
+        assert len(findings) == 1
+        assert findings[0].code == "UNKNOWN_SHAPE"
+        assert findings[0].severity == Severity.INFO
+        assert "totally_new_field" in (findings[0].detail or "")
+
+    def test_check_unknown_keys_legacy_key_not_unknown(self) -> None:
+        """A legacy key present in the dict does NOT produce an UNKNOWN_SHAPE finding.
+
+        The legacy key is covered by detect_legacy_keys(); check_unknown_keys()
+        should not double-report it as UNKNOWN_SHAPE.
+        """
+        # Pick any legacy key
+        legacy_key = next(iter(LEGACY_KEYS))
+        findings = check_unknown_keys("meta.json", {legacy_key: "x"}, "meta.json")
+        # Must not contain UNKNOWN_SHAPE for this key
+        unknown_findings = [f for f in findings if f.code == "UNKNOWN_SHAPE"]
+        assert unknown_findings == []
+
+    def test_check_unknown_keys_forbidden_key_not_unknown(self) -> None:
+        """A forbidden key present does NOT produce an UNKNOWN_SHAPE finding either."""
+        forbidden_key = next(iter(FORBIDDEN_KEYS))
+        findings = check_unknown_keys("meta.json", {forbidden_key: "x"}, "meta.json")
+        unknown_findings = [f for f in findings if f.code == "UNKNOWN_SHAPE"]
+        assert unknown_findings == []
+
+    def test_check_unknown_keys_unregistered_artifact_type(self) -> None:
+        """An artifact type not in the registry returns empty (not an error)."""
+        findings = check_unknown_keys("some_new_artifact", {"anything": "x"}, "some_file")
+        assert findings == []

--- a/tests/audit/test_identity_adapter.py
+++ b/tests/audit/test_identity_adapter.py
@@ -1,0 +1,303 @@
+"""Tests for src/specify_cli/audit/identity_adapter.py (T009).
+
+Uses real IdentityState objects constructed via classify_mission() with
+tmp_path fixtures — no mocking of IdentityState.
+
+Test index:
+1. test_orphan_state_emits_identity_missing
+2. test_legacy_state_emits_no_findings
+3. test_pending_state_emits_no_findings
+4. test_assigned_state_emits_no_findings
+5. test_duplicate_prefix_two_missions
+6. test_duplicate_mission_id_two_missions
+7. test_ambiguous_selector_emits_warning
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from specify_cli.audit.identity_adapter import (
+    duplicate_ids_to_findings,
+    identity_state_to_findings,
+    prefix_groups_to_findings,
+    selector_groups_to_findings,
+)
+from specify_cli.audit.models import Severity
+from specify_cli.status.identity_audit import (
+    classify_mission,
+    find_ambiguous_selectors,
+    find_duplicate_prefixes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to create mission fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_mission_dir(
+    parent: Path,
+    slug: str,
+    *,
+    mission_id: str | None = None,
+    mission_number: int | None = None,
+) -> Path:
+    """Create a minimal mission directory with an optional meta.json."""
+    mission_dir = parent / slug
+    mission_dir.mkdir(parents=True, exist_ok=True)
+
+    if mission_id is not None or mission_number is not None:
+        meta: dict[str, object] = {}
+        if mission_id is not None:
+            meta["mission_id"] = mission_id
+        if mission_number is not None:
+            meta["mission_number"] = mission_number
+        (mission_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    return mission_dir
+
+
+def _make_kitty_specs(parent: Path) -> Path:
+    """Create a kitty-specs directory under parent and return it."""
+    specs = parent / "kitty-specs"
+    specs.mkdir(parents=True, exist_ok=True)
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# T1: orphan (meta.json absent) → IDENTITY_MISSING
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityStateToFindings:
+    def test_orphan_state_emits_identity_missing(self, tmp_path: Path) -> None:
+        """Orphan state (no meta.json) → IDENTITY_MISSING finding."""
+        mission_dir = tmp_path / "orphan-mission"
+        mission_dir.mkdir()
+        # Deliberately do NOT create meta.json
+
+        state = classify_mission(mission_dir)
+        assert state.state == "orphan"
+
+        findings = identity_state_to_findings(state, mission_dir)
+        assert len(findings) == 1
+        assert findings[0].code == "IDENTITY_MISSING"
+        assert findings[0].severity == Severity.ERROR
+        assert findings[0].artifact_path == "meta.json"
+        assert findings[0].detail == "meta.json absent"
+
+    def test_legacy_state_emits_no_findings(self, tmp_path: Path) -> None:
+        """Legacy state (meta.json exists, mission_number set, mission_id absent) → [].
+
+        The meta classifier (WP03) handles IDENTITY_MISSING for this case.
+        The adapter must NOT duplicate the finding.
+        """
+        mission_dir = _make_mission_dir(
+            tmp_path,
+            "042-legacy-mission",
+            mission_number=42,
+            # mission_id intentionally absent
+        )
+
+        state = classify_mission(mission_dir)
+        assert state.state == "legacy"
+
+        findings = identity_state_to_findings(state, mission_dir)
+        assert findings == []
+
+    def test_pending_state_emits_no_findings(self, tmp_path: Path) -> None:
+        """Pending state (mission_id present, mission_number null) → no finding."""
+        mission_dir = _make_mission_dir(
+            tmp_path,
+            "pending-feature-01ABCDEFGH",
+            mission_id="01ABCDEFGHJKMNPQRSTVWXYZ01",
+            # mission_number intentionally absent (null = pre-merge)
+        )
+
+        state = classify_mission(mission_dir)
+        assert state.state == "pending"
+
+        findings = identity_state_to_findings(state, mission_dir)
+        assert findings == []
+
+    def test_assigned_state_emits_no_findings(self, tmp_path: Path) -> None:
+        """Assigned state (both mission_id and mission_number present) → no finding."""
+        mission_dir = _make_mission_dir(
+            tmp_path,
+            "083-assigned-mission",
+            mission_id="01ABCDEFGHJKMNPQRSTVWXYZ01",
+            mission_number=83,
+        )
+
+        state = classify_mission(mission_dir)
+        assert state.state == "assigned"
+
+        findings = identity_state_to_findings(state, mission_dir)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# T5: duplicate_prefix_two_missions → DUPLICATE_PREFIX
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixGroupsToFindings:
+    def test_duplicate_prefix_two_missions(self, tmp_path: Path) -> None:
+        """Two missions with the same NNN- prefix each get a DUPLICATE_PREFIX finding
+        listing the other.
+        """
+        specs = _make_kitty_specs(tmp_path)
+
+        # Both share the "042" prefix
+        dir_a = _make_mission_dir(specs, "042-alpha", mission_number=1)
+        dir_b = _make_mission_dir(specs, "042-beta", mission_number=2)
+
+        groups = find_duplicate_prefixes(tmp_path)
+        assert "042" in groups
+
+        slug_to_dir = {"042-alpha": dir_a, "042-beta": dir_b}
+        findings = prefix_groups_to_findings(groups, slug_to_dir)
+
+        assert len(findings) == 2
+        codes = {f.code for f in findings}
+        assert codes == {"DUPLICATE_PREFIX"}
+        severities = {f.severity for f in findings}
+        assert severities == {Severity.WARNING}
+
+        # Each finding mentions the other slug
+        alpha_finding = next(f for f in findings if "042-beta" in (f.detail or ""))
+        beta_finding = next(f for f in findings if "042-alpha" in (f.detail or ""))
+        assert alpha_finding is not None
+        assert beta_finding is not None
+
+    def test_no_duplicates_returns_empty(self, tmp_path: Path) -> None:
+        """No duplicate prefixes → empty findings list."""
+        specs = _make_kitty_specs(tmp_path)
+        _make_mission_dir(specs, "001-unique", mission_number=1)
+        _make_mission_dir(specs, "002-also-unique", mission_number=2)
+
+        groups = find_duplicate_prefixes(tmp_path)
+        findings = prefix_groups_to_findings(groups, {})
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# T6: duplicate_mission_id_two_missions → DUPLICATE_MISSION_ID
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateIdsToFindings:
+    def test_duplicate_mission_id_two_missions(self, tmp_path: Path) -> None:
+        """Two missions sharing the same mission_id each get a DUPLICATE_MISSION_ID
+        finding listing the other.
+        """
+        shared_id = "01ABCDEFGHJKMNPQRSTVWXYZ01"
+
+        dir_a = _make_mission_dir(
+            tmp_path, "001-first", mission_id=shared_id, mission_number=1
+        )
+        dir_b = _make_mission_dir(
+            tmp_path, "002-second", mission_id=shared_id, mission_number=2
+        )
+
+        from specify_cli.status.identity_audit import classify_mission as cm
+
+        state_a = cm(dir_a)
+        state_b = cm(dir_b)
+
+        slug_to_dir = {"001-first": dir_a, "002-second": dir_b}
+        findings = duplicate_ids_to_findings([state_a, state_b], slug_to_dir)
+
+        assert len(findings) == 2
+        codes = {f.code for f in findings}
+        assert codes == {"DUPLICATE_MISSION_ID"}
+        severities = {f.severity for f in findings}
+        assert severities == {Severity.ERROR}
+
+        # Each finding names the other mission
+        first_finding = next(f for f in findings if "002-second" in (f.detail or ""))
+        second_finding = next(f for f in findings if "001-first" in (f.detail or ""))
+        assert first_finding is not None
+        assert second_finding is not None
+
+    def test_unique_mission_ids_returns_empty(self, tmp_path: Path) -> None:
+        """Missions with distinct mission_ids → empty findings."""
+        dir_a = _make_mission_dir(
+            tmp_path, "001-a", mission_id="01AAAAAAAAAAAAAAAAAAAAAAAAA1", mission_number=1
+        )
+        dir_b = _make_mission_dir(
+            tmp_path, "002-b", mission_id="01BBBBBBBBBBBBBBBBBBBBBBBBB1", mission_number=2
+        )
+
+        from specify_cli.status.identity_audit import classify_mission as cm
+
+        findings = duplicate_ids_to_findings(
+            [cm(dir_a), cm(dir_b)],
+            {"001-a": dir_a, "002-b": dir_b},
+        )
+        assert findings == []
+
+    def test_none_mission_ids_not_grouped(self, tmp_path: Path) -> None:
+        """Missions without mission_id (None) are not grouped as duplicates."""
+        dir_a = _make_mission_dir(tmp_path, "001-no-id", mission_number=1)
+        dir_b = _make_mission_dir(tmp_path, "002-also-no-id", mission_number=2)
+
+        from specify_cli.status.identity_audit import classify_mission as cm
+
+        state_a = cm(dir_a)
+        state_b = cm(dir_b)
+        assert state_a.mission_id is None
+        assert state_b.mission_id is None
+
+        findings = duplicate_ids_to_findings([state_a, state_b], {})
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# T7: ambiguous_selector_emits_warning → AMBIGUOUS_SELECTOR
+# ---------------------------------------------------------------------------
+
+
+class TestSelectorGroupsToFindings:
+    def test_ambiguous_selector_emits_warning(self, tmp_path: Path) -> None:
+        """Two missions that share a selector handle both get an AMBIGUOUS_SELECTOR
+        warning.
+        """
+        specs = _make_kitty_specs(tmp_path)
+
+        # "042-foo" and "042-bar" share the numeric handle "042"
+        dir_a = _make_mission_dir(specs, "042-foo", mission_number=42)
+        dir_b = _make_mission_dir(specs, "042-bar", mission_number=43)
+
+        from specify_cli.status.identity_audit import audit_repo
+
+        states = audit_repo(tmp_path)
+        groups = find_ambiguous_selectors(states)
+
+        # The "042" numeric handle should be ambiguous
+        assert any(len(v) >= 2 for v in groups.values()), (
+            "Expected at least one ambiguous handle; groups were: " + repr(groups)
+        )
+
+        slug_to_dir = {"042-foo": dir_a, "042-bar": dir_b}
+        findings = selector_groups_to_findings(groups, slug_to_dir)
+
+        ambiguous = [f for f in findings if f.code == "AMBIGUOUS_SELECTOR"]
+        assert len(ambiguous) >= 2  # at least one finding per mission
+        severities = {f.severity for f in ambiguous}
+        assert severities == {Severity.WARNING}
+
+    def test_unambiguous_selectors_returns_empty(self, tmp_path: Path) -> None:
+        """Missions with distinct selectors → empty findings."""
+        specs = _make_kitty_specs(tmp_path)
+        _make_mission_dir(specs, "001-alpha", mission_number=1)
+        _make_mission_dir(specs, "002-beta", mission_number=2)
+
+        from specify_cli.status.identity_audit import audit_repo
+
+        states = audit_repo(tmp_path)
+        groups = find_ambiguous_selectors(states)
+        findings = selector_groups_to_findings(groups, {})
+        assert findings == []


### PR DESCRIPTION
## Summary

- Adds `specify_cli.audit` package: a fully read-only mission-state audit engine that scans `kitty-specs/` and produces structured findings
- 7 per-artifact classifiers: `meta.json`, `status.events.jsonl`, `status.json`, `mission-events.jsonl`, `decisions/events.jsonl`, `handoff/events.jsonl`, `tasks/WP*.md` frontmatter
- Detection surface: `LEGACY_KEY`, `FORBIDDEN_KEY`, `CORRUPT_JSONL`, `SNAPSHOT_DRIFT`, `ACTOR_DRIFT`, `MISSING_EVIDENCE`, `IDENTITY_MISSING`, `IDENTITY_INVALID`, `UNKNOWN_SHAPE`, `DUPLICATE_PREFIX`, `AMBIGUOUS_SELECTOR`, `DUPLICATE_MISSION_ID`
- `run_audit(AuditOptions) -> RepoAuditReport` public API with deterministic JSON output
- `spec-kitty doctor mission-state --audit [--json] [--mission <handle>] [--fail-on <severity>] [--fixture-dir <path>]` CLI subcommand
- 20-fixture test suite (one per finding code class), 164 tests total

Post-review fixes also included:
- Handle `MissionNotFoundError`/`AmbiguousHandleError` in CLI with structured JSON error output
- Fix inverted slug-match logic in `_merge_repo_findings`

## Test plan

- [ ] `pytest tests/audit/ -q` — 164 tests pass
- [ ] `mypy --strict src/specify_cli/audit/` — clean
- [ ] `ruff check src/specify_cli/audit/` — clean
- [ ] `spec-kitty doctor mission-state --audit --json` runs against this repo
- [ ] `spec-kitty doctor mission-state --audit --fail-on error` exits 0 when no errors
- [ ] `spec-kitty doctor mission-state --audit --mission <bad-handle>` exits 1 with JSON error

🤖 Generated with [Claude Code](https://claude.com/claude-code)