### PR TITLE
Fix new SonarCloud findings from main

### DIFF
--- a/src/specify_cli/post_merge/stale_assertions.py
+++ b/src/specify_cli/post_merge/stale_assertions.py
@@ -301,23 +301,42 @@ def _constants_in_subtree(node: ast.AST) -> set[str]:
 def _assertion_negatively_checks_literal_absence(assertion: ast.AST, literal: str) -> bool:
     """Return True for assertions that intentionally require a removed literal to be absent."""
     if isinstance(assertion, ast.Assert):
-        for node in ast.walk(assertion.test):
-            if not isinstance(node, ast.Compare):
-                continue
-            for op, comparator in zip(node.ops, node.comparators, strict=False):
-                if not isinstance(op, ast.NotIn):
-                    continue
-                if _node_contains_literal(node.left, literal) or _node_contains_literal(
-                    comparator, literal
-                ):
-                    return True
+        return _assert_test_checks_literal_absence(assertion.test, literal)
 
     if isinstance(assertion, ast.Call):
-        func = assertion.func
-        if isinstance(func, ast.Attribute) and func.attr == "assertNotIn":
-            return any(_node_contains_literal(arg, literal) for arg in assertion.args)
+        return _assert_call_checks_literal_absence(assertion, literal)
 
     return False
+
+
+def _assert_test_checks_literal_absence(test: ast.AST, literal: str) -> bool:
+    """Return True when an ``assert`` test checks that *literal* is absent."""
+    for node in ast.walk(test):
+        if not isinstance(node, ast.Compare):
+            continue
+        if _compare_checks_literal_absence(node, literal):
+            return True
+    return False
+
+
+def _compare_checks_literal_absence(node: ast.Compare, literal: str) -> bool:
+    """Return True when a comparison uses ``not in`` with *literal*."""
+    for op, comparator in zip(node.ops, node.comparators, strict=False):
+        if not isinstance(op, ast.NotIn):
+            continue
+        if _node_contains_literal(node.left, literal) or _node_contains_literal(
+            comparator, literal
+        ):
+            return True
+    return False
+
+
+def _assert_call_checks_literal_absence(assertion: ast.Call, literal: str) -> bool:
+    """Return True when an ``assertNotIn`` call checks that *literal* is absent."""
+    func = assertion.func
+    if not isinstance(func, ast.Attribute) or func.attr != "assertNotIn":
+        return False
+    return any(_node_contains_literal(arg, literal) for arg in assertion.args)
 
 
 def _node_contains_literal(node: ast.AST, literal: str) -> bool:

--- a/src/specify_cli/skills/verifier.py
+++ b/src/specify_cli/skills/verifier.py
@@ -24,6 +24,8 @@ from specify_cli.template import get_local_repo_root
 
 logger = logging.getLogger(__name__)
 
+SKILL_MANIFEST_FILENAME = "SKILL.md"
+
 
 @dataclass
 class VerifyResult:
@@ -133,7 +135,7 @@ def repair_skills(
                 if global_root is None:
                     raise OSError(f"No global skill root configured for agent {entry.agent_key}")
                 global_source = global_root / entry.skill_name / entry.source_file
-                if not global_source.exists() or entry.source_file == "SKILL.md":
+                if not global_source.exists() or entry.source_file == SKILL_MANIFEST_FILENAME:
                     _sync_skill_to_global_root(skill, global_root)
                 if dest.exists() or dest.is_symlink():
                     if dest.is_symlink() or dest.is_file():
@@ -241,7 +243,7 @@ def _sync_skill_to_global_root(skill: Any, global_root: Path) -> None:
         else:
             shutil.rmtree(dest_dir)
     shutil.copytree(skill.skill_dir, dest_dir)
-    skill_md = dest_dir / "SKILL.md"
+    skill_md = dest_dir / SKILL_MANIFEST_FILENAME
     if skill_md.is_file():
         content = skill_md.read_text(encoding="utf-8")
         normalized = ensure_skill_frontmatter(content, skill.name)
@@ -259,7 +261,7 @@ def _project_managed_path(project_path: Path, installed_path: str) -> Path:
 
 def _copy_skill_file(source: Path, dest: Path, skill_name: str, source_file: str) -> None:
     """Copy a managed skill file, normalizing SKILL.md frontmatter if needed."""
-    if source_file == "SKILL.md":
+    if source_file == SKILL_MANIFEST_FILENAME:
         content = source.read_text(encoding="utf-8")
         dest.write_text(ensure_skill_frontmatter(content, skill_name), encoding="utf-8")
         return
@@ -268,7 +270,7 @@ def _copy_skill_file(source: Path, dest: Path, skill_name: str, source_file: str
 
 def _expected_content_hash(source: Path, skill_name: str, source_file: str) -> str:
     """Return the hash that install/repair should produce for a source file."""
-    if source_file != "SKILL.md":
+    if source_file != SKILL_MANIFEST_FILENAME:
         return compute_content_hash(source)
     content = source.read_text(encoding="utf-8")
     normalized = ensure_skill_frontmatter(content, skill_name).encode("utf-8")


### PR DESCRIPTION
## Summary
- reduce the new cognitive-complexity SonarCloud finding in `src/specify_cli/post_merge/stale_assertions.py` by splitting literal-absence detection into helpers
- replace repeated `"SKILL.md"` literals in `src/specify_cli/skills/verifier.py` with a single constant
- validate the touched paths with targeted pytest coverage

## Validation
- `python3 -m py_compile src/specify_cli/post_merge/stale_assertions.py src/specify_cli/skills/verifier.py`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run --python 3.12 --extra test pytest tests/post_merge/test_stale_assertions.py::TestChangedStringLiteralFlaggedLowConfidence::test_removed_literal_negative_membership_assertion_not_flagged tests/post_merge/test_stale_assertions.py::TestChangedStringLiteralFlaggedLowConfidence::test_removed_literal_assert_not_in_call_not_flagged tests/post_merge/test_stale_assertions.py::TestScanTestFile tests/specify_cli/skills/test_verifier.py`

## Investigated But Not Fixed
- Open Dependabot alert [#2](https://github.com/Priivacy-ai/spec-kitty/security/dependabot/2) tracks transitive `pip` `CVE-2026-3219` via `pip-audit` in `uv.lock`. GitHub currently reports no patched version (`first_patched_version: null`), so there is no safe code-side upgrade to apply in this PR.
