### PR TITLE
fix: restore sync diagnostics and sonar follow-ups

### DIFF
--- a/src/specify_cli/cli/commands/_auth_doctor.py
+++ b/src/specify_cli/cli/commands/_auth_doctor.py
@@ -584,8 +584,10 @@ def assemble_report(*, stuck_threshold_s: float = 60.0) -> DoctorReport:
     )
 
 
-def render_report(report: DoctorReport, console: Console, *, show_server_hint: bool = True) -> None:  # noqa: C901, PLR0912 — the 7-section layout is intentionally linear and section-by-section so reviewers can map each block to the contract; splitting it adds indirection without clarity.
+def render_report(report: DoctorReport, console: Console, *, show_server_hint: bool = True) -> None:  # noqa: C901, PLR0912
     """Render a :class:`DoctorReport` as the 7-section Rich layout."""
+    # The 7-section layout intentionally stays linear so reviewers can map each
+    # block to the contract without bouncing through helper indirection.
     # Section 1 — Identity.
     console.print("[bold]Identity[/bold]")
     if report.session is None:

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import re
-import subprocess
 import time
 from pathlib import Path
 
@@ -545,13 +544,13 @@ def _bake_mission_number_into_mission_branch(
 
 def _has_branch_ref(repo_root: Path, ref_name: str) -> bool:
     """Return True when a local branch/ref resolves to a commit."""
-    probe = subprocess.run(
+    retcode, _stdout, _stderr = run_command(
         ["git", "rev-parse", "--verify", f"{ref_name}^{{commit}}"],
-        cwd=str(repo_root),
-        capture_output=True,
-        text=True,
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
     )
-    return probe.returncode == 0
+    return retcode == 0
 
 
 def _check_mission_branch(
@@ -568,17 +567,13 @@ def _check_mission_branch(
     if _has_branch_ref(repo_root, expected_branch):
         return True, None
 
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=str(repo_root),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        base_sha = result.stdout.strip()[:12]
-    except subprocess.CalledProcessError:
-        base_sha = "<base-commit>"
+    retcode, stdout, _stderr = run_command(
+        ["git", "rev-parse", "HEAD"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    base_sha = stdout.strip()[:12] if retcode == 0 else "<base-commit>"
 
     blocker_payload: MissionBranchBlocker = {
         "ready": False,

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -39,6 +39,32 @@ console = Console()
 _STATUS_ACCESS_TOKEN_LABEL = "Access token"  # noqa: S105
 _STATUS_REFRESH_TOKEN_LABEL = "Refresh token"  # noqa: S105
 _STATUS_LAST_SYNC_LABEL = "Last Sync"
+_UNAUTHENTICATED_SYNC_NOW_MESSAGE = (
+    "not authenticated: no valid access token. Run `spec-kitty auth login`."
+)
+
+
+def _sync_result_looks_unauthenticated(queue_size: int, result: object) -> bool:
+    """Detect the legacy auth-missing result shape from ``sync_now``."""
+    if queue_size <= 0:
+        return False
+
+    def _int_attr(name: str) -> int:
+        value = getattr(result, name, 0)
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    total_events = _int_attr("total_events")
+    synced_count = _int_attr("synced_count")
+    duplicate_count = _int_attr("duplicate_count")
+    error_count = _int_attr("error_count")
+    failed_results = getattr(result, "failed_results", ())
+    return (
+        total_events == 0
+        and synced_count == 0
+        and duplicate_count == 0
+        and error_count == 0
+        and len(failed_results) == 0
+    )
 
 
 def humanize_timedelta(td: timedelta) -> str:
@@ -976,6 +1002,12 @@ def now(
 
     console.print(f"Syncing {queue_size} queued event(s)...")
     result = service.sync_now()
+
+    if _sync_result_looks_unauthenticated(queue_size, result):
+        console.print(f"[yellow]{_UNAUTHENTICATED_SYNC_NOW_MESSAGE}[/yellow]")
+        if strict:
+            raise typer.Exit(1)
+        return
 
     # Print actionable summary instead of bare counts
     summary = format_sync_summary(result)

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -18,6 +18,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 from packaging.version import Version
 
@@ -66,6 +67,7 @@ _UUID_HYPHEN_RE = re.compile(
     re.IGNORECASE,
 )
 _UUID_BARE_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
+_REMOTE_URL_SCHEMES = frozenset({"http", "https"})
 
 
 class MissionStateRepairError(RuntimeError):
@@ -1010,13 +1012,18 @@ def _resolve_repo_relative(repo_root: Path, path: Path) -> Path:
     return repo_root / path
 
 
+def _is_remote_url(slug: str) -> bool:
+    """Return True when *slug* is an HTTP(S) remote URL."""
+    return urlsplit(slug).scheme in _REMOTE_URL_SCHEMES
+
+
 def _repo_slug(repo_root: Path) -> str | None:
     result = _git(repo_root, "config", "--get", "remote.origin.url", check=False)
     remote = result.stdout.strip()
     if not remote:
         return repo_root.name
     slug = remote.removesuffix(".git").rstrip("/")
-    if ":" in slug and not slug.startswith(("http://", "https://")):
+    if ":" in slug and not _is_remote_url(slug):
         slug = slug.rsplit(":", 1)[1]
     elif "/" in slug:
         parts = slug.split("/")

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -355,25 +355,71 @@ def run_final_sync_with_retries(
             result = sync_operation()
         except Exception as exc:  # noqa: BLE001 - final sync is best effort
             last_error = exc
-            if attempt < FINAL_SYNC_MAX_ATTEMPTS:
-                sleeper(FINAL_SYNC_RETRY_BACKOFF_SECONDS)
+            maybe_result = _handle_final_sync_exception(exc, attempt, sleeper)
+            if maybe_result is None:
                 continue
-            error_text = str(exc)
-            _emit_final_sync_failure_diagnostic(error_text)
-            return _result_from_final_sync_exception(exc)
+            return maybe_result
 
         last_result = result
         last_error = None
-        if not _should_retry_final_sync_result(result):
-            if _is_failed_final_sync_result(result):
-                _emit_final_sync_failure_diagnostic(_final_sync_result_error_text(result))
-            return result
-        if attempt < FINAL_SYNC_MAX_ATTEMPTS:
-            sleeper(FINAL_SYNC_RETRY_BACKOFF_SECONDS)
+        maybe_result = _handle_final_sync_result(result, attempt, sleeper)
+        if maybe_result is not None:
+            return maybe_result
 
+    return _finalize_exhausted_final_sync(last_result, last_error)
+
+
+def _has_final_sync_retry_remaining(attempt: int) -> bool:
+    """Return True when another final-sync retry attempt is available."""
+    return attempt < FINAL_SYNC_MAX_ATTEMPTS
+
+
+def _sleep_before_final_sync_retry(
+    attempt: int,
+    sleeper: Callable[[float], None],
+) -> bool:
+    """Sleep for a retry when attempts remain and report whether we retried."""
+    if not _has_final_sync_retry_remaining(attempt):
+        return False
+    sleeper(FINAL_SYNC_RETRY_BACKOFF_SECONDS)
+    return True
+
+
+def _handle_final_sync_exception(
+    exc: BaseException,
+    attempt: int,
+    sleeper: Callable[[float], None],
+) -> BatchSyncResult | None:
+    """Retry or finalize an exception raised during final sync."""
+    if _sleep_before_final_sync_retry(attempt, sleeper):
+        return None
+    _emit_final_sync_failure_diagnostic(str(exc))
+    return _result_from_final_sync_exception(exc)
+
+
+def _handle_final_sync_result(
+    result: BatchSyncResult,
+    attempt: int,
+    sleeper: Callable[[float], None],
+) -> BatchSyncResult | None:
+    """Retry or finalize a completed final-sync result."""
+    if not _should_retry_final_sync_result(result):
+        if _is_failed_final_sync_result(result):
+            _emit_final_sync_failure_diagnostic(_final_sync_result_error_text(result))
+        return result
+    if _sleep_before_final_sync_retry(attempt, sleeper):
+        return None
+    _emit_final_sync_failure_diagnostic(_final_sync_result_error_text(result))
+    return result
+
+
+def _finalize_exhausted_final_sync(
+    last_result: BatchSyncResult | None,
+    last_error: BaseException | None,
+) -> BatchSyncResult:
+    """Return the best available exhausted final-sync outcome."""
     if last_result is not None:
-        error_text = _final_sync_result_error_text(last_result)
-        _emit_final_sync_failure_diagnostic(error_text)
+        _emit_final_sync_failure_diagnostic(_final_sync_result_error_text(last_result))
         return last_result
     if last_error is not None:
         _emit_final_sync_failure_diagnostic(str(last_error))

--- a/tests/merge/test_merge_preflight_mission_branch.py
+++ b/tests/merge/test_merge_preflight_mission_branch.py
@@ -106,8 +106,10 @@ class TestCheckMissionBranch:
         with patch(
             "specify_cli.cli.commands.merge._has_branch_ref",
             return_value=False,
-        ), patch("specify_cli.cli.commands.merge.subprocess.run") as mock_run:
-            mock_run.return_value.stdout = "abc1234def5678\n"
+        ), patch(
+            "specify_cli.cli.commands.merge.run_command",
+            return_value=(0, "abc1234def5678\n", ""),
+        ):
             exists, blocker = _check_mission_branch("my-mission-01KQ", tmp_path)
 
         assert exists is False
@@ -121,49 +123,41 @@ class TestCheckMissionBranch:
 class TestMergeDryRunMissingBranch:
     """Integration tests for merge --dry-run with missing mission branch."""
 
-    def test_dry_run_json_missing_branch(
+    def test_dry_run_json_missing_branch_still_previews(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """merge --dry-run --json reports ready:false with structured blocker."""
+        """merge --dry-run --json does not require a local mission branch."""
         _prepare_dry_run(monkeypatch, tmp_path, branch_ok=False)
-        monkeypatch.setattr(
-            merge_mod,
-            "needs_number_assignment",
-            Mock(side_effect=AssertionError("lane preview should not run")),
-        )
+        monkeypatch.setattr(merge_mod, "needs_number_assignment", lambda _feature_dir: False)
 
-        with pytest.raises(typer.Exit) as exc_info:
-            _invoke_merge_dry_run(json_output=True)
+        _invoke_merge_dry_run(json_output=True)
 
-        assert exc_info.value.exit_code == 1
         payload = json.loads(capsys.readouterr().out)
-        assert payload == _blocker()
+        assert payload["mission_slug"] == MISSION_SLUG
+        assert payload["mission_branch"] == f"kitty/mission-{MISSION_SLUG}"
+        assert payload["target_branch"] == "main"
+        assert payload["would_assign_mission_number"] is None
 
-    def test_dry_run_human_missing_branch(
+    def test_dry_run_human_missing_branch_still_previews(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """merge --dry-run (no --json) shows remediation in human text."""
+        """merge --dry-run (no --json) still emits the preview payload."""
         _prepare_dry_run(monkeypatch, tmp_path, branch_ok=False)
-        monkeypatch.setattr(
-            merge_mod,
-            "needs_number_assignment",
-            Mock(side_effect=AssertionError("lane preview should not run")),
-        )
+        monkeypatch.setattr(merge_mod, "needs_number_assignment", lambda _feature_dir: False)
 
-        with pytest.raises(typer.Exit) as exc_info:
-            _invoke_merge_dry_run(json_output=False)
+        _invoke_merge_dry_run(json_output=False)
 
-        assert exc_info.value.exit_code == 1
-        output = _compact_output(capsys.readouterr().out)
-        assert "Cannot proceed: mission branch missing." in output
-        assert f"Expected branch: kitty/mission-{MISSION_SLUG}" in output
-        assert f"Remediation: git branch kitty/mission-{MISSION_SLUG} abc1234def56" in output
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["mission_slug"] == MISSION_SLUG
+        assert payload["mission_branch"] == f"kitty/mission-{MISSION_SLUG}"
+        assert payload["target_branch"] == "main"
+        assert payload["would_assign_mission_number"] is None
 
     def test_real_merge_blocked_missing_branch(
         self,

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 
 from specify_cli.migration.mission_state import (
     MissionStateDryRunError,
+    _repo_slug,
     deterministic_ulid,
     repair_repo,
     teamspace_dry_run,
@@ -319,3 +320,19 @@ def test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows(tm
     assert dry_run.valid
     assert dry_run.envelope_count == 1
     assert dry_run.errors == ()
+
+
+def test_repo_slug_preserves_https_remote_colon(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Result:
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+
+    def fake_git(repo_root: Path, *args: str, check: bool = False) -> _Result:
+        assert repo_root == tmp_path
+        assert args == ("config", "--get", "remote.origin.url")
+        assert check is False
+        return _Result("https://github.com/Priivacy-ai/spec-kitty.git\n")
+
+    monkeypatch.setattr("specify_cli.migration.mission_state._git", fake_git)
+
+    assert _repo_slug(tmp_path) == "Priivacy-ai/spec-kitty"


### PR DESCRIPTION
## Summary
- restore strict `sync now` handling for legacy all-zero sync results when the queue is non-empty
- route merge mission-branch checks through the shared `run_command` helper and update dry-run tests for preview-only behavior
- refactor final-sync retry handling without changing diagnostic semantics
- clean up auth doctor and mission-state Sonar follow-ups, including HTTPS remote slug parsing coverage

## Validation
- `uv lock --check`
- `uv run --python /opt/homebrew/bin/python3.12 --extra lint ruff check src/specify_cli/cli/commands/_auth_doctor.py src/specify_cli/cli/commands/merge.py src/specify_cli/cli/commands/sync.py src/specify_cli/sync/batch.py src/specify_cli/migration/mission_state.py tests/migration/test_mission_state_repair.py tests/merge/test_merge_preflight_mission_branch.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --python /opt/homebrew/bin/python3.12 --extra test python -m pytest tests/sync/test_final_sync_diagnostics.py tests/migration/test_mission_state_repair.py tests/agent/cli/commands/test_sync.py::TestSyncNowExitCodes::test_strict_exits_1_on_auth_missing tests/agent/test_commands.py::test_merge_dry_run_outputs_lane_payload tests/agent/test_commands.py::test_merge_json_dry_run_honors_keep_flags tests/merge/test_merge_preflight_mission_branch.py -q`

## Repair notes
- Rebuilt the PR branch on top of `main` after #1004 merged.
- Replaced the duplicated merge-commit history with one conventional commit so CI commit hygiene can pass.