### PR TITLE
fix: restore sync and merge regression paths

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1530,6 +1530,22 @@ def merge(
             json_output=json_output,
         )
 
+        branch_ok, branch_blocker = _check_mission_branch(
+            resolved_feature,
+            get_main_repo_root(repo_root),
+        )
+        if not branch_ok:
+            assert branch_blocker is not None
+            if json_output:
+                print(json.dumps(branch_blocker))
+            else:
+                console.print(
+                    "[red]Cannot proceed: mission branch missing.[/red]\n"
+                    f"Expected branch: {branch_blocker['expected_branch']}\n"
+                    f"Remediation: {branch_blocker['remediation']}"
+                )
+            raise typer.Exit(1)
+
         # WP10/T053: dry-run preview of merge-time mission_number assignment.
         feature_dir_for_preview = (
             get_main_repo_root(repo_root) / "kitty-specs" / resolved_feature

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1530,22 +1530,6 @@ def merge(
             json_output=json_output,
         )
 
-        branch_ok, branch_blocker = _check_mission_branch(
-            resolved_feature,
-            get_main_repo_root(repo_root),
-        )
-        if not branch_ok:
-            assert branch_blocker is not None
-            if json_output:
-                print(json.dumps(branch_blocker))
-            else:
-                console.print(
-                    "[red]Cannot proceed: mission branch missing.[/red]\n"
-                    f"Expected branch: {branch_blocker['expected_branch']}\n"
-                    f"Remediation: {branch_blocker['remediation']}"
-                )
-            raise typer.Exit(1)
-
         # WP10/T053: dry-run preview of merge-time mission_number assignment.
         feature_dir_for_preview = (
             get_main_repo_root(repo_root) / "kitty-specs" / resolved_feature

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1000,6 +1000,14 @@ def now(
     if strict and result.error_count > 0:
         raise typer.Exit(1)
 
+    # Preserve the strict contract for queue-backed syncs that report no
+    # progress at all. A non-empty queue combined with an all-zero result is
+    # treated as an unauthenticated/no-progress failure instead of silently
+    # succeeding.
+    if strict and queue_size > 0 and (result.synced_count + result.duplicate_count + result.error_count) == 0:
+        console.print("[red]Error:[/red] Sync made no progress; not authenticated or sync is blocked.")
+        raise typer.Exit(1)
+
 
 @app.command()
 def status(


### PR DESCRIPTION
## Summary
- restore `spec-kitty sync now --strict` failure semantics when a non-empty queue reports zero progress
- allow `spec-kitty merge --json --dry-run` to emit its lane payload without requiring a pre-created mission branch
- cover the exact `fast-tests-agent` regressions that broke the 2026-05-06 scheduled `main` CI run

## Validation
- `pytest tests/agent/cli/commands/test_sync.py::TestSyncNowExitCodes::test_strict_exits_1_on_auth_missing tests/agent/test_commands.py::test_merge_dry_run_outputs_lane_payload tests/agent/test_commands.py::test_merge_json_dry_run_honors_keep_flags -q`
- `python -m pytest tests/agent -m "fast and not windows_ci" -q --tb=short --cov=src/specify_cli/agent_utils --cov-fail-under=10 --cov-report=xml:out/reports/coverage/coverage-fast-agent.xml`

## Notes
- GitHub code scanning is currently clean.
- Dependabot alert `GHSA-58qw-9mgm-455v` remains blocked upstream because GitHub still reports no patched version for transitive `pip` in `uv.lock`.
- SonarCloud still shows `new_security_hotspots_reviewed=0.0` on `main`; those are Sonar review-state items rather than code defects changed in this PR.