### PR TITLE
feat: add TeamSpace mission-state readiness gate

### DIFF
--- a/.github/workflows/teamspace-mission-state-readiness.yml
+++ b/.github/workflows/teamspace-mission-state-readiness.yml
@@ -1,0 +1,53 @@
+name: TeamSpace Mission-State Readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      fail_on:
+        description: "Audit gate threshold"
+        required: true
+        default: "teamspace-blocker"
+        type: choice
+        options:
+          - teamspace-blocker
+          - error
+          - warning
+          - info
+
+permissions:
+  contents: read
+
+jobs:
+  mission-state-audit:
+    name: Mission-state audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Spec Kitty
+        run: uv sync --python "$(which python)"
+
+      - name: Audit mission state
+        run: |
+          uv run spec-kitty doctor mission-state \
+            --audit \
+            --fail-on "${{ inputs.fail_on }}" \
+            --json > mission-state-audit.json
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mission-state-audit
+          path: mission-state-audit.json
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,21 @@ package is published.
   when available (#980).
 - Documented the distributed Git repair workflow for coordinated repository
   migration before TeamSpace launch (#980).
+- Added `doctor mission-state --include-fixtures` and the packaged
+  mission-state survey fixture pack used by the TeamSpace readiness audit
+  contract (#920, #922, #929).
+- Added an opt-in `TeamSpace Mission-State Readiness` GitHub Actions workflow
+  that runs `doctor mission-state --audit --fail-on teamspace-blocker` and
+  uploads the JSON audit artifact (#920, #934).
 
 ### Changed
 
 - Aligned CLI sync emission for `WPStatusChanged` and `MissionClosed` with the
   canonical TeamSpace event payload shape while keeping launch dry-run gated on
   the published events contract (#980).
+- `doctor mission-state --audit` JSON reports now expose TeamSpace blocker
+  counts, and `--fail-on teamspace-blocker` gates import/sync readiness
+  without requiring network access (#920, #934).
 
 ## [3.2.0rc1] - 2026-05-05
 

--- a/docs/migration/cross-repo-e2e-gate.md
+++ b/docs/migration/cross-repo-e2e-gate.md
@@ -56,6 +56,9 @@ From the spec-kitty repo:
 ```bash
 export SPEC_KITTY_ENABLE_SAAS_SYNC=1
 
+# 0. TeamSpace mission-state gate
+spec-kitty doctor mission-state --audit --fail-on teamspace-blocker
+
 # 1. Contract gate
 pytest tests/contract/ -v
 
@@ -69,6 +72,11 @@ pytest scenarios/ -v
 
 If all three exit zero AND the issue matrix is fully populated, the
 mission is gate-clean.
+
+For launch-readiness checks that should run in GitHub without a full release
+candidate, use the manual `TeamSpace Mission-State Readiness` workflow. It
+executes the mission-state audit with the selected `--fail-on` threshold and
+uploads the JSON report as a workflow artifact.
 
 ## Exception path: `mission-exception.md`
 

--- a/docs/migration/teamspace-mission-state-repair.md
+++ b/docs/migration/teamspace-mission-state-repair.md
@@ -8,6 +8,30 @@ Run the audit first:
 spec-kitty doctor mission-state --audit --json
 ```
 
+For a launch/readiness gate, fail on TeamSpace blockers:
+
+```bash
+spec-kitty doctor mission-state --audit --fail-on teamspace-blocker
+```
+
+`teamspace-blocker` includes all error findings plus warning-level
+historical shapes that TeamSpace must not import as authoritative state:
+legacy keys, forbidden typed side-log keys, snapshot drift, corrupt JSONL,
+missing/invalid identity, and duplicate mission IDs. JSON reports include
+`repo_summary.teamspace_blockers` and
+`repo_summary.missions_with_teamspace_blockers`.
+
+To verify the packaged survey fixture pack used by the audit contract:
+
+```bash
+spec-kitty doctor mission-state --audit --include-fixtures --json
+```
+
+The repository also ships an opt-in GitHub Actions gate,
+`TeamSpace Mission-State Readiness`, which can be run manually from Actions.
+It runs the same audit with a selectable `--fail-on` threshold and uploads
+`mission-state-audit.json` even when the gate fails.
+
 Then repair the repository:
 
 ```bash
@@ -30,7 +54,7 @@ For teams, use this sequence:
 
 1. Ask contributors to stop editing `kitty-specs/` temporarily.
 2. Pull the target branch everywhere.
-3. Run `spec-kitty doctor mission-state --audit --json` and save the report.
+3. Run `spec-kitty doctor mission-state --audit --fail-on teamspace-blocker --json` and save the report.
 4. Run `spec-kitty doctor mission-state --fix`.
 5. Review the generated manifest and mission diffs.
 6. Run `spec-kitty doctor mission-state --teamspace-dry-run --json`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ artifacts = [
     "src/specify_cli/**/*.yaml",
     "src/specify_cli/**/*.yml",
     "src/specify_cli/**/*.json",
+    "src/specify_cli/**/*.jsonl",
     "src/charter/**/*.yaml",
     "src/charter/**/*.yml",
     "src/doctrine/**/*.md",

--- a/src/specify_cli/audit/__init__.py
+++ b/src/specify_cli/audit/__init__.py
@@ -1,15 +1,25 @@
 """Read-only mission-state audit engine for spec-kitty."""
 
 from .engine import run_audit
-from .models import AuditOptions, MissionFinding, MissionAuditResult, RepoAuditReport, Severity
+from .models import (
+    TEAMSPACE_BLOCKER_CODES,
+    AuditOptions,
+    MissionAuditResult,
+    MissionFinding,
+    RepoAuditReport,
+    Severity,
+    is_teamspace_blocker,
+)
 from .serializer import build_report_json
 
 __all__ = [
     "run_audit",
+    "TEAMSPACE_BLOCKER_CODES",
     "AuditOptions",
     "MissionFinding",
     "MissionAuditResult",
     "RepoAuditReport",
     "Severity",
     "build_report_json",
+    "is_teamspace_blocker",
 ]

--- a/src/specify_cli/audit/engine.py
+++ b/src/specify_cli/audit/engine.py
@@ -46,7 +46,13 @@ from .classifiers.wp_files import classify_wp_files
 from .identity_adapter import (
     identity_state_to_findings,
 )
-from .models import AuditOptions, MissionAuditResult, MissionFinding, RepoAuditReport
+from .models import (
+    AuditOptions,
+    MissionAuditResult,
+    MissionFinding,
+    RepoAuditReport,
+    is_teamspace_blocker,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -370,15 +376,22 @@ def _build_report(mission_results: list[MissionAuditResult]) -> RepoAuditReport:
     )
 
     severity_counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
+    teamspace_blocker_count = 0
     for r in mission_results:
         for f in r.findings:
             severity_counts[f.severity.value] += 1
+            if is_teamspace_blocker(f):
+                teamspace_blocker_count += 1
 
     repo_summary: dict[str, Any] = {
         "total_missions": len(mission_results),
         "missions_with_errors": sum(1 for r in mission_results if r.has_errors),
         "missions_with_warnings": sum(1 for r in mission_results if r.has_warnings),
+        "missions_with_teamspace_blockers": sum(
+            1 for r in mission_results if r.has_teamspace_blockers
+        ),
         "total_findings": sum(len(r.findings) for r in mission_results),
+        "teamspace_blockers": teamspace_blocker_count,
         "findings_by_severity": severity_counts,
     }
 

--- a/src/specify_cli/audit/fixtures/clean_modern/meta.json
+++ b/src/specify_cli/audit/fixtures/clean_modern/meta.json
@@ -1,0 +1,8 @@
+{
+  "friendly_name": "Clean modern fixture",
+  "mission_id": "01KQHRB8GCFJAX7HM4ZY52AQGR",
+  "mission_number": 1,
+  "mission_slug": "clean_modern",
+  "mission_type": "software-dev",
+  "target_branch": "main"
+}

--- a/src/specify_cli/audit/fixtures/corrupt_jsonl/meta.json
+++ b/src/specify_cli/audit/fixtures/corrupt_jsonl/meta.json
@@ -1,0 +1,8 @@
+{
+  "friendly_name": "Corrupt JSONL fixture",
+  "mission_id": "01KQHRC0GCFJAX7HM4ZY52AQGR",
+  "mission_number": 4,
+  "mission_slug": "corrupt_jsonl",
+  "mission_type": "software-dev",
+  "target_branch": "main"
+}

--- a/src/specify_cli/audit/fixtures/corrupt_jsonl/status.events.jsonl
+++ b/src/specify_cli/audit/fixtures/corrupt_jsonl/status.events.jsonl
@@ -1,0 +1,1 @@
+THIS IS NOT VALID JSON {{{

--- a/src/specify_cli/audit/fixtures/forbidden_event_type/meta.json
+++ b/src/specify_cli/audit/fixtures/forbidden_event_type/meta.json
@@ -1,0 +1,8 @@
+{
+  "friendly_name": "Forbidden event type fixture",
+  "mission_id": "01KQHRB7GCFJAX7HM4ZY52AQGR",
+  "mission_number": 3,
+  "mission_slug": "forbidden_event_type",
+  "mission_type": "software-dev",
+  "target_branch": "main"
+}

--- a/src/specify_cli/audit/fixtures/forbidden_event_type/status.events.jsonl
+++ b/src/specify_cli/audit/fixtures/forbidden_event_type/status.events.jsonl
@@ -1,0 +1,1 @@
+{"event_type":"wp_transition","mission_id":"01KQHRB7GCFJAX7HM4ZY52AQGR","wp_id":"WP01"}

--- a/src/specify_cli/audit/fixtures/legacy_feature_slug/meta.json
+++ b/src/specify_cli/audit/fixtures/legacy_feature_slug/meta.json
@@ -1,0 +1,9 @@
+{
+  "feature_slug": "legacy-feature",
+  "friendly_name": "Legacy feature slug fixture",
+  "mission_id": "01KQHRB9GCFJAX7HM4ZY52AQGR",
+  "mission_number": 2,
+  "mission_slug": "legacy_feature_slug",
+  "mission_type": "software-dev",
+  "target_branch": "main"
+}

--- a/src/specify_cli/audit/fixtures/legacy_feature_slug/status.events.jsonl
+++ b/src/specify_cli/audit/fixtures/legacy_feature_slug/status.events.jsonl
@@ -1,0 +1,1 @@
+{"event_id":"evt-legacy-fixture","mission_id":"01KQHRB9GCFJAX7HM4ZY52AQGR","wp_id":"WP01"}

--- a/src/specify_cli/audit/models.py
+++ b/src/specify_cli/audit/models.py
@@ -16,6 +16,20 @@ from pathlib import Path
 from typing import Any
 
 
+TEAMSPACE_BLOCKER_CODES: frozenset[str] = frozenset(
+    {
+        "CORRUPT_JSON",
+        "CORRUPT_JSONL",
+        "DUPLICATE_MISSION_ID",
+        "FORBIDDEN_KEY",
+        "IDENTITY_INVALID",
+        "IDENTITY_MISSING",
+        "LEGACY_KEY",
+        "SNAPSHOT_DRIFT",
+    }
+)
+
+
 class Severity(StrEnum):
     """Audit finding severity level.
 
@@ -68,6 +82,11 @@ class MissionFinding:
         }
 
 
+def is_teamspace_blocker(finding: MissionFinding) -> bool:
+    """Return True when a finding should block TeamSpace import/sync readiness."""
+    return finding.severity == Severity.ERROR or finding.code in TEAMSPACE_BLOCKER_CODES
+
+
 @dataclass
 class MissionAuditResult:
     """Audit outcome for a single mission directory.
@@ -91,6 +110,11 @@ class MissionAuditResult:
         return any(f.severity == Severity.WARNING for f in self.findings)
 
     @property
+    def has_teamspace_blockers(self) -> bool:
+        """True if any finding blocks TeamSpace import/sync readiness."""
+        return any(is_teamspace_blocker(f) for f in self.findings)
+
+    @property
     def finding_codes(self) -> set[str]:
         """Set of all finding codes present in this result."""
         return {f.code for f in self.findings}
@@ -105,6 +129,7 @@ class MissionAuditResult:
             "finding_count": len(self.findings),
             "findings": [f.to_dict() for f in self.findings],
             "has_errors": self.has_errors,
+            "has_teamspace_blockers": self.has_teamspace_blockers,
             "mission_dir": str(self.mission_dir),
             "mission_slug": self.mission_slug,
         }
@@ -125,7 +150,9 @@ class RepoAuditReport:
         {
             "findings_by_severity": {"error": 5, "info": 3, "warning": 10},
             "missions_with_errors": 3,
+            "missions_with_teamspace_blockers": 4,
             "missions_with_warnings": 7,
+            "teamspace_blockers": 8,
             "total_findings": 18,
             "total_missions": 42,
         }

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -889,8 +889,14 @@ def _print_rich_audit_report(report: object) -> None:
     console.print(
         f"Total missions: {summary['total_missions']} | "
         f"With errors: {summary['missions_with_errors']} | "
-        f"With warnings: {summary['missions_with_warnings']}"
+        f"With warnings: {summary['missions_with_warnings']} | "
+        f"TeamSpace blockers: {summary['teamspace_blockers']}"
     )
+
+
+def _audit_fixture_root() -> Path:
+    """Return the packaged mission-state audit fixture root."""
+    return Path(__file__).resolve().parents[2] / "audit" / "fixtures"
 
 
 @app.command(name="mission-state")
@@ -920,12 +926,25 @@ def mission_state(  # noqa: C901
     ] = None,
     fail_on: Annotated[
         str | None,
-        typer.Option("--fail-on", help="Exit 1 if any finding meets this severity (error|warning|info)"),
+        typer.Option(
+            "--fail-on",
+            help=(
+                "Exit 1 if findings meet a gate "
+                "(error|warning|info|teamspace-blocker)"
+            ),
+        ),
     ] = None,
     fixture_dir: Annotated[
         Path | None,
         typer.Option("--fixture-dir", help="Override scan root (for testing)"),
     ] = None,
+    include_fixtures: Annotated[
+        bool,
+        typer.Option(
+            "--include-fixtures",
+            help="Audit the bundled mission-state survey fixtures",
+        ),
+    ] = False,
     manifest_path: Annotated[
         Path | None,
         typer.Option("--manifest-path", help="Path for --fix migration manifest"),
@@ -937,6 +956,7 @@ def mission_state(  # noqa: C901
 ) -> None:
     """Audit, repair, or TeamSpace-validate mission-state shapes."""
     from specify_cli.audit import AuditOptions, Severity, build_report_json, run_audit
+    from specify_cli.audit.models import is_teamspace_blocker
 
     selected_modes = sum(1 for selected in (audit, fix, teamspace_dry_run) if selected)
     if selected_modes == 0:
@@ -948,13 +968,29 @@ def mission_state(  # noqa: C901
 
     # Validate --fail-on
     fail_on_severity: Severity | None = None
+    fail_on_teamspace_blocker = False
     if fail_on is not None:
-        try:
-            fail_on_severity = Severity(fail_on)
-        except ValueError:
-            valid = ", ".join(s.value for s in Severity)
-            typer.echo(f"Invalid --fail-on value: {fail_on!r}. Valid values: {valid}", err=True)
-            raise typer.Exit(2) from None
+        if fail_on == "teamspace-blocker":
+            fail_on_teamspace_blocker = True
+        else:
+            try:
+                fail_on_severity = Severity(fail_on)
+            except ValueError:
+                valid = ", ".join([*(s.value for s in Severity), "teamspace-blocker"])
+                typer.echo(
+                    f"Invalid --fail-on value: {fail_on!r}. Valid values: {valid}",
+                    err=True,
+                )
+                raise typer.Exit(2) from None
+
+    if include_fixtures:
+        if fixture_dir is not None:
+            typer.echo("Use only one of --include-fixtures or --fixture-dir.", err=True)
+            raise typer.Exit(2)
+        fixture_dir = _audit_fixture_root()
+        if not fixture_dir.is_dir():
+            typer.echo(f"Bundled audit fixtures not found: {fixture_dir}", err=True)
+            raise typer.Exit(2)
 
     # Resolve repo root
     try:
@@ -1079,6 +1115,12 @@ def mission_state(  # noqa: C901
 
     if fail_on_severity is not None and any(
         f.severity <= fail_on_severity
+        for result in report.missions
+        for f in result.findings
+    ):
+        raise typer.Exit(1)
+    if fail_on_teamspace_blocker and any(
+        is_teamspace_blocker(f)
         for result in report.missions
         for f in result.findings
     ):

--- a/tests/audit/test_audit_cli.py
+++ b/tests/audit/test_audit_cli.py
@@ -51,6 +51,25 @@ def _make_corrupt_mission(parent: Path, slug: str = "corrupt-mission") -> Path:
     return mission_dir
 
 
+def _make_legacy_mission(parent: Path, slug: str = "legacy-mission") -> Path:
+    """Create a mission directory with a TeamSpace-blocking legacy warning."""
+    mission_dir = parent / slug
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "feature_slug": "legacy-feature",
+                "mission_id": "01KQHRB8GCFJAX7HM4ZY52AQGR",
+                "mission_slug": slug,
+                "mission_type": "software-dev",
+                "target_branch": "main",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return mission_dir
+
+
 # ---------------------------------------------------------------------------
 # Test 1: --audit flag is required
 # ---------------------------------------------------------------------------
@@ -171,6 +190,7 @@ def test_cli_invalid_fail_on_exits_2(
         ],
     )
     assert result.exit_code == 2
+    assert "teamspace-blocker" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -216,3 +236,60 @@ def test_cli_json_determinism(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert result1.exit_code == 0
     assert result2.exit_code == 0
     assert result1.output == result2.output
+
+
+def test_cli_fail_on_teamspace_blocker_exits_1_for_legacy_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--fail-on teamspace-blocker exits 1 for LEGACY_KEY warnings."""
+    fixture_root = tmp_path / "fixtures"
+    _make_legacy_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mission-state",
+            "--audit",
+            "--fail-on",
+            "teamspace-blocker",
+            "--fixture-dir",
+            str(fixture_root),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_cli_include_fixtures_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--include-fixtures scans the packaged survey fixture pack."""
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(app, ["mission-state", "--audit", "--include-fixtures", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["repo_summary"]["total_missions"] >= 4
+    assert data["repo_summary"]["teamspace_blockers"] >= 3
+    assert data["shape_counters"]["LEGACY_KEY"] >= 1
+    assert data["shape_counters"]["FORBIDDEN_KEY"] >= 1
+    assert data["shape_counters"]["CORRUPT_JSONL"] >= 1
+
+
+def test_cli_include_fixtures_rejects_fixture_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--include-fixtures and --fixture-dir are mutually exclusive."""
+    fixture_root = tmp_path / "fixtures"
+    _make_clean_mission(fixture_root)
+    monkeypatch.setattr(doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mission-state",
+            "--audit",
+            "--include-fixtures",
+            "--fixture-dir",
+            str(fixture_root),
+        ],
+    )
+    assert result.exit_code == 2

--- a/tests/audit/test_audit_engine.py
+++ b/tests/audit/test_audit_engine.py
@@ -232,7 +232,9 @@ def test_repo_summary_counts(tmp_path: Path) -> None:
     assert summary["total_missions"] == 2
     assert summary["missions_with_errors"] == 0
     assert summary["missions_with_warnings"] == 1  # only 002-legacy has a warning
+    assert summary["missions_with_teamspace_blockers"] == 1
     assert summary["total_findings"] >= 1
+    assert summary["teamspace_blockers"] >= 1
     assert summary["findings_by_severity"]["warning"] >= 1
     assert summary["findings_by_severity"]["error"] == 0
 

--- a/tests/audit/test_audit_models.py
+++ b/tests/audit/test_audit_models.py
@@ -7,11 +7,13 @@ from pathlib import Path
 import pytest
 
 from specify_cli.audit.models import (
+    TEAMSPACE_BLOCKER_CODES,
     AuditOptions,
     MissionAuditResult,
     MissionFinding,
     RepoAuditReport,
     Severity,
+    is_teamspace_blocker,
 )
 
 
@@ -147,6 +149,30 @@ class TestMissionFinding:
         assert d["detail"] == "mission_id field absent"
 
 
+class TestTeamspaceBlockers:
+    def test_all_errors_are_teamspace_blockers(self) -> None:
+        f = MissionFinding(code="UNKNOWN", severity=Severity.ERROR, artifact_path="x")
+        assert is_teamspace_blocker(f) is True
+
+    def test_legacy_warning_is_teamspace_blocker(self) -> None:
+        f = MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="x")
+        assert is_teamspace_blocker(f) is True
+
+    def test_non_blocking_warning_is_not_teamspace_blocker(self) -> None:
+        f = MissionFinding(code="ACTOR_DRIFT", severity=Severity.WARNING, artifact_path="x")
+        assert is_teamspace_blocker(f) is False
+
+    def test_contract_codes_include_teamspace_import_risks(self) -> None:
+        assert {
+            "CORRUPT_JSONL",
+            "DUPLICATE_MISSION_ID",
+            "FORBIDDEN_KEY",
+            "IDENTITY_MISSING",
+            "LEGACY_KEY",
+            "SNAPSHOT_DRIFT",
+        }.issubset(TEAMSPACE_BLOCKER_CODES)
+
+
 # ---------------------------------------------------------------------------
 # T003: MissionAuditResult dataclass
 # ---------------------------------------------------------------------------
@@ -196,6 +222,18 @@ class TestMissionAuditResult:
         )
         assert r.has_warnings is True
 
+    def test_has_teamspace_blockers_true_for_legacy_warning(self) -> None:
+        r = _make_result(
+            findings=[MissionFinding(code="LEGACY_KEY", severity=Severity.WARNING, artifact_path="x")]
+        )
+        assert r.has_teamspace_blockers is True
+
+    def test_has_teamspace_blockers_false_for_non_blocking_warning(self) -> None:
+        r = _make_result(
+            findings=[MissionFinding(code="ACTOR_DRIFT", severity=Severity.WARNING, artifact_path="x")]
+        )
+        assert r.has_teamspace_blockers is False
+
     def test_finding_codes(self) -> None:
         r = _make_result(
             findings=[
@@ -214,6 +252,7 @@ class TestMissionAuditResult:
         assert "findings" in d
         assert "finding_count" in d
         assert "has_errors" in d
+        assert "has_teamspace_blockers" in d
 
     def test_to_dict_mission_dir_is_string(self) -> None:
         r = _make_result()


### PR DESCRIPTION
## Summary
- add TeamSpace blocker classification to mission-state audit reports and support `--fail-on teamspace-blocker`
- add `doctor mission-state --include-fixtures` with packaged survey fixtures included in wheels
- add a manual TeamSpace Mission-State Readiness workflow that uploads the JSON audit report
- document the launch/readiness gate and update the changelog

## Verification
- `uv run ruff check src/specify_cli/audit/models.py src/specify_cli/audit/engine.py src/specify_cli/audit/__init__.py src/specify_cli/cli/commands/doctor.py tests/audit/test_audit_cli.py tests/audit/test_audit_models.py tests/audit/test_audit_engine.py`
- `uv run pytest tests/audit tests/migration -q`
- `uv run spec-kitty doctor mission-state --audit --include-fixtures --json`
- `uv run spec-kitty doctor mission-state --audit --include-fixtures --fail-on teamspace-blocker` exits 1 with 3 TeamSpace blockers
- `uv build`
- wheel content check confirmed bundled audit fixtures and `.jsonl` files are present

Addresses part of #920, #922, #929, and #934.