### PR TITLE
Fix TeamSpace dry-run validation for historical done evidence

### DIFF
--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -370,6 +370,18 @@ def _status_event_to_teamspace_envelope(
     project_slug: str,
     repo_slug: str | None,
 ) -> dict[str, Any]:
+    evidence = status_event.evidence.to_dict() if status_event.evidence else None
+    if evidence is not None and not evidence.get("repos"):
+        # Older done rows only recorded review evidence; the 5.0.0 TeamSpace
+        # contract requires at least one repo evidence entry.
+        evidence["repos"] = [
+            {
+                "repo": repo_slug or project_slug,
+                "branch": "historical-mission-state-repair",
+                "commit": "historical-mission-state-repair",
+            }
+        ]
+
     payload = {
         "mission_slug": status_event.mission_slug,
         "wp_id": status_event.wp_id,
@@ -380,7 +392,7 @@ def _status_event_to_teamspace_envelope(
         "reason": status_event.reason,
         "execution_mode": status_event.execution_mode,
         "review_ref": status_event.review_ref,
-        "evidence": status_event.evidence.to_dict() if status_event.evidence else None,
+        "evidence": evidence,
     }
     return {
         "event_id": status_event.event_id,

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -261,3 +261,61 @@ def test_teamspace_dry_run_fails_when_status_rows_still_contain_legacy_keys(tmp_
             "path": "$.nested.feature_slug",
         },
     )
+
+
+def test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows(tmp_path: Path) -> None:
+    if not _has_events_5():
+        pytest.skip("TeamSpace dry-run validation requires spec-kitty-events >= 5.0.0")
+
+    repo = tmp_path
+    mission = repo / "kitty-specs" / "001-historical-done"
+    mission.mkdir(parents=True)
+    mission_id = "01KQHRB8GCFJAX7HM4ZY52AQGR"
+    _write_json(
+        mission / "meta.json",
+        {
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "friendly_name": "Historical Done",
+            "mission_id": mission_id,
+            "mission_number": 1,
+            "mission_slug": "001-historical-done",
+            "mission_type": "software-dev",
+            "slug": "001-historical-done",
+            "target_branch": "main",
+        },
+    )
+    (mission / "status.events.jsonl").write_text(
+        json.dumps(
+            {
+                "actor": "codex",
+                "at": "2026-01-01T00:00:00+00:00",
+                "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGS",
+                "execution_mode": "worktree",
+                "force": False,
+                "from_lane": "approved",
+                "mission_id": mission_id,
+                "mission_slug": "001-historical-done",
+                "policy_metadata": None,
+                "reason": None,
+                "review_ref": "review://historical",
+                "evidence": {
+                    "review": {
+                        "reviewer": "historical-reviewer",
+                        "verdict": "approved",
+                        "reference": "review://historical",
+                    }
+                },
+                "to_lane": "done",
+                "wp_id": "WP01",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    dry_run = teamspace_dry_run(repo, mission="001-historical-done")
+
+    assert dry_run.valid
+    assert dry_run.envelope_count == 1
+    assert dry_run.errors == ()


### PR DESCRIPTION
## Summary\n- synthesize minimal repo evidence for historical done rows that only preserved review evidence\n- keep TeamSpace dry-run validation compatible with spec-kitty-events 5.0.0\n\n## Verification\n- uv run pytest tests/migration/test_mission_state_repair.py -q\n- PYTHONPATH=/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/spec-kitty-20260506-082728-FPXorD/spec-kitty-events/src uv run pytest tests/migration/test_mission_state_repair.py -q\n- uv run ruff check src/specify_cli/migration/mission_state.py tests/migration/test_mission_state_repair.py