### PR TITLE
Prepare v3.2.0rc3 release

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc2
+  version: 3.2.0rc3
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.2.0rc3] - 2026-05-06
+
+3.2.0rc3 fixes a TeamSpace dry-run compatibility gap found during the
+historical mission-state migration rehearsal.
+
+### Fixed
+
+- Synthesized minimal repo evidence for historical done rows that only
+  preserved review evidence, allowing `doctor mission-state --teamspace-dry-run`
+  to validate those rows against the `spec-kitty-events` 5.0.0 payload contract
+  (#997).
+
 ## [3.2.0rc2] - 2026-05-05
 
 3.2.0rc2 adds the TeamSpace mission-state repair and validation surface needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc2"
+version = "3.2.0rc3"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc2"
+version = "3.2.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary\n- bump CLI metadata to 3.2.0rc3\n- add changelog entry for the TeamSpace dry-run evidence compatibility fix\n\n## Verification\n- uv run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'\n- uv run pytest tests/release -q