### PR TITLE
Consume SaaS advertised sync ingress limits

### DIFF
--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, UTC
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 
@@ -61,9 +62,7 @@ CATEGORY_ACTIONS: dict[str, str] = {
     "schema_mismatch": "Run `spec-kitty sync diagnose` to inspect invalid events",
     "auth_expired": "Run `spec-kitty auth login` to refresh credentials",
     "unauthenticated": "Run `spec-kitty auth login` to authenticate",
-    CATEGORY_MISSING_PRIVATE_TEAM: (
-        "Private Teamspace access is required for direct ingress"
-    ),
+    CATEGORY_MISSING_PRIVATE_TEAM: ("Private Teamspace access is required for direct ingress"),
     "retryable_transport": "Retry later or check network connectivity",
     "server_error": "Retry later or check server status",
     "unknown": "Inspect the failure report for details: --report <file.json>",
@@ -71,6 +70,7 @@ CATEGORY_ACTIONS: dict[str, str] = {
 
 FINAL_SYNC_MAX_ATTEMPTS = 3
 FINAL_SYNC_RETRY_BACKOFF_SECONDS = 1.0
+SYNC_INGRESS_LIMITS_TIMEOUT_SECONDS = 10
 
 
 def _current_team_slug() -> str | None:
@@ -90,9 +90,7 @@ def _current_team_slug() -> str | None:
     except Exception as exc:  # noqa: BLE001 — explicit "log and skip" boundary
         import logging
 
-        logging.getLogger(__name__).warning(
-            "_current_team_slug: ingress resolver raised: %s", exc
-        )
+        logging.getLogger(__name__).warning("_current_team_slug: ingress resolver raised: %s", exc)
         return None
 
 
@@ -120,6 +118,103 @@ def _safe_response_json(response: object) -> dict:
     return body if isinstance(body, dict) else {}
 
 
+def _positive_int(value: object) -> int | None:
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _should_probe_advertised_limits(server_url: str) -> bool:
+    """Return True when the base URL looks like a real SaaS endpoint.
+
+    Unit tests and local development commonly pass localhost or reserved
+    ``.example`` hosts with ``requests.post`` mocked. Avoiding the health probe
+    there preserves the existing no-network test contract while still enabling
+    live SaaS clients to honor server-advertised ingress limits.
+    """
+    parsed = urlparse(server_url)
+    host = (parsed.hostname or "").lower()
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return False
+    if host.endswith(".example") or host.endswith(".example.com"):
+        return False
+    return parsed.scheme in {"https", "http"} and bool(host)
+
+
+def _extract_sync_ingress_limits(response_body: dict) -> dict[str, int]:
+    sync_ingress = response_body.get("sync_ingress")
+    if not isinstance(sync_ingress, dict):
+        return {}
+    limits = sync_ingress.get("limits")
+    if not isinstance(limits, dict):
+        return {}
+
+    extracted: dict[str, int] = {}
+    for key in (
+        "max_events_per_batch",
+        "max_decompressed_bytes_per_batch",
+        "retry_after_min_seconds",
+        "retry_after_max_seconds",
+    ):
+        value = _positive_int(limits.get(key))
+        if value is not None:
+            extracted[key] = value
+    return extracted
+
+
+def _fetch_advertised_sync_ingress_limits(
+    *,
+    server_url: str,
+    auth_token: str,
+    team_slug: str,
+) -> dict[str, int]:
+    """Fetch server-advertised sync ingress limits, failing open on errors."""
+    if not _should_probe_advertised_limits(server_url):
+        return {}
+
+    health_url = f"{server_url.rstrip('/')}/api/v1/sync/health/"
+    headers = {
+        "Authorization": f"Bearer {auth_token}",
+        "X-Team-Slug": team_slug,
+    }
+    try:
+        response = requests.get(
+            health_url,
+            headers=headers,
+            timeout=SYNC_INGRESS_LIMITS_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException:
+        return {}
+    if response.status_code != 200:
+        return {}
+    return _extract_sync_ingress_limits(_safe_response_json(response))
+
+
+def _build_batch_payload(events: list[dict]) -> bytes:
+    return json.dumps({"events": events}).encode("utf-8")
+
+
+def _select_events_for_advertised_limits(
+    queue: OfflineQueue,
+    *,
+    requested_limit: int,
+    advertised_limits: dict[str, int],
+) -> tuple[list[dict], bytes]:
+    max_events = advertised_limits.get("max_events_per_batch")
+    effective_limit = min(requested_limit, max_events) if max_events else requested_limit
+    events = queue.drain_queue(limit=effective_limit)
+    payload = _build_batch_payload(events)
+
+    max_decompressed_bytes = advertised_limits.get("max_decompressed_bytes_per_batch")
+    while max_decompressed_bytes and len(events) > 1 and len(payload) > max_decompressed_bytes:
+        events = events[: max(1, len(events) // 2)]
+        payload = _build_batch_payload(events)
+
+    return events, payload
+
+
 def _body_mentions_missing_private_team(body: dict) -> bool:
     values = [
         body.get("category"),
@@ -129,11 +224,7 @@ def _body_mentions_missing_private_team(body: dict) -> bool:
         body.get("detail"),
     ]
     text = " ".join(str(value) for value in values if value is not None).lower()
-    return (
-        CATEGORY_MISSING_PRIVATE_TEAM in text
-        or "private teamspace" in text
-        or ("private team" in text and "direct ingress" in text)
-    )
+    return CATEGORY_MISSING_PRIVATE_TEAM in text or "private teamspace" in text or ("private team" in text and "direct ingress" in text)
 
 
 def _http_error_category(status_code: int, body: dict | None = None) -> str:
@@ -275,9 +366,7 @@ def run_final_sync_with_retries(
         last_error = None
         if not _should_retry_final_sync_result(result):
             if _is_failed_final_sync_result(result):
-                _emit_final_sync_failure_diagnostic(
-                    _final_sync_result_error_text(result)
-                )
+                _emit_final_sync_failure_diagnostic(_final_sync_result_error_text(result))
             return result
         if attempt < FINAL_SYNC_MAX_ATTEMPTS:
             sleeper(FINAL_SYNC_RETRY_BACKOFF_SECONDS)
@@ -328,9 +417,7 @@ def _emit_final_sync_failure_diagnostic(error_text: str) -> None:
     code: SyncDiagnosticCode = classify_sync_error(error_text)
     emit_sync_diagnostic(
         code,
-        "Final sync failed after local command success. "
-        "Queued events remain durable and will be retried. "
-        f"Detail: {error_text}",
+        f"Final sync failed after local command success. Queued events remain durable and will be retried. Detail: {error_text}",
     )
 
 
@@ -569,32 +656,11 @@ def batch_sync(  # noqa: C901
             print(message)
         return result
 
-    events = queue.drain_queue(limit=limit)
-    result.total_events = len(events)
-
-    if not events:
+    if queue.size() == 0:
         if show_progress:
             print("No events to sync")
         return result
 
-    if show_progress:
-        print(f"Syncing {len(events)} events... (0/{len(events)})")
-
-    # Validate each event envelope against upstream contract before sending
-    for evt in events:
-        with suppress(Exception):
-            validate_outbound_payload(evt, "envelope")
-
-    # Compress payload with gzip
-    payload = json.dumps({"events": events}).encode("utf-8")
-    compressed = gzip.compress(payload)
-
-    # POST to batch endpoint
-    headers = {
-        "Authorization": f"Bearer {auth_token}",
-        "Content-Encoding": "gzip",
-        "Content-Type": "application/json",
-    }
     team_slug = _current_team_slug()
     if team_slug is None:
         # FR-002/FR-004/FR-005/FR-007/NFR-002 (private-teamspace-ingress-safeguards):
@@ -610,6 +676,8 @@ def batch_sync(  # noqa: C901
         # of spinning indefinitely on a queue that will never drain (Scenario
         # 6 in spec.md). The message is operator-facing diagnostic only; it
         # is NOT printed to stdout because callers route it through stderr/log.
+        events = queue.drain_queue(limit=limit)
+        result.total_events = len(events)
         _record_all_events_failed(
             result,
             events,
@@ -617,6 +685,36 @@ def batch_sync(  # noqa: C901
             category=CATEGORY_MISSING_PRIVATE_TEAM,
         )
         return result
+
+    advertised_limits = _fetch_advertised_sync_ingress_limits(
+        server_url=server_url,
+        auth_token=auth_token,
+        team_slug=team_slug,
+    )
+    events, payload = _select_events_for_advertised_limits(
+        queue,
+        requested_limit=limit,
+        advertised_limits=advertised_limits,
+    )
+    result.total_events = len(events)
+
+    if show_progress:
+        print(f"Syncing {len(events)} events... (0/{len(events)})")
+
+    # Validate each event envelope against upstream contract before sending
+    for evt in events:
+        with suppress(Exception):
+            validate_outbound_payload(evt, "envelope")
+
+    # Compress payload with gzip
+    compressed = gzip.compress(payload)
+
+    # POST to batch endpoint
+    headers = {
+        "Authorization": f"Bearer {auth_token}",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json",
+    }
     headers["X-Team-Slug"] = team_slug
 
     batch_url = f"{server_url.rstrip('/')}/api/v1/events/batch/"
@@ -888,10 +986,7 @@ def sync_all_queued_events(
                 if result.error_count > 0:
                     print("Stopping: No events successfully synced in this batch")
                 else:
-                    print(
-                        "Stopping: Batch skipped (no Private Teamspace; "
-                        "see structured stderr diagnostic)"
-                    )
+                    print("Stopping: Batch skipped (no Private Teamspace; see structured stderr diagnostic)")
             break
 
     if show_progress:

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -131,9 +131,7 @@ class TestBatchSyncEmptyQueue:
 
     def test_batch_sync_empty_queue(self, temp_queue):
         """Test batch_sync with no events returns early"""
-        result = batch_sync(
-            queue=temp_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=temp_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.total_events == 0
         assert result.synced_count == 0
@@ -170,14 +168,10 @@ class TestBatchSyncSuccess:
         # Mock successful response
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(100)]
-        }
+        mock_response.json.return_value = {"results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(100)]}
         mock_post.return_value = mock_response
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.total_events == 100
         assert result.synced_count == 100
@@ -190,16 +184,10 @@ class TestBatchSyncSuccess:
         # Mock response with some duplicates
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "results": [
-                {"event_id": f"evt-{i:04d}", "status": "success" if i % 2 == 0 else "duplicate"} for i in range(100)
-            ]
-        }
+        mock_response.json.return_value = {"results": [{"event_id": f"evt-{i:04d}", "status": "success" if i % 2 == 0 else "duplicate"} for i in range(100)]}
         mock_post.return_value = mock_response
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.synced_count == 50  # Even indices
         assert result.duplicate_count == 50  # Odd indices
@@ -211,14 +199,10 @@ class TestBatchSyncSuccess:
         """Test batch sync sends gzip compressed data"""
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(100)]
-        }
+        mock_response.json.return_value = {"results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(100)]}
         mock_post.return_value = mock_response
 
-        batch_sync(
-            queue=populated_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False
-        )
+        batch_sync(queue=populated_queue, auth_token="test-token", server_url="http://localhost:8000", show_progress=False)
 
         # Verify request was made with gzip headers
         call_args = mock_post.call_args
@@ -233,6 +217,106 @@ class TestBatchSyncSuccess:
         assert "events" in payload
         assert len(payload["events"]) == 100
 
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_consumes_advertised_max_events_per_batch(
+        self,
+        mock_post,
+        mock_get,
+        populated_queue,
+    ):
+        """Live SaaS limits should cap the number of events sent per request."""
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {
+                "contract_version": "sync-ingress-limits.v1",
+                "limits": {
+                    "max_events_per_batch": 25,
+                    "max_decompressed_bytes_per_batch": 1_000_000,
+                    "retry_after_min_seconds": 5,
+                    "retry_after_max_seconds": 60,
+                },
+            }
+        }
+        mock_get.return_value = health_response
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.json.return_value = {"results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(25)]}
+        mock_post.return_value = post_response
+
+        result = batch_sync(
+            queue=populated_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            limit=1000,
+            show_progress=False,
+        )
+
+        assert result.total_events == 25
+        call_args = mock_post.call_args
+        payload = json.loads(gzip.decompress(call_args.kwargs["data"]))
+        assert len(payload["events"]) == 25
+        assert mock_get.call_args.args[0] == "https://spec-kitty-dev.fly.dev/api/v1/sync/health/"
+
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_shrinks_batch_to_advertised_decompressed_bytes(
+        self,
+        mock_post,
+        mock_get,
+        temp_queue,
+    ):
+        """The CLI should split oversized batches before sending to SaaS."""
+        for i in range(8):
+            temp_queue.queue_event(
+                {
+                    "event_id": f"large-evt-{i:04d}",
+                    "event_type": "WPStatusChanged",
+                    "aggregate_id": "WP01",
+                    "lamport_clock": i,
+                    "node_id": "test-node",
+                    "payload": {"body": "x" * 200},
+                }
+            )
+
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {
+                "limits": {
+                    "max_events_per_batch": 8,
+                    "max_decompressed_bytes_per_batch": 900,
+                }
+            }
+        }
+        mock_get.return_value = health_response
+
+        post_response = Mock()
+        post_response.status_code = 200
+
+        def _post_response(*args, **kwargs):
+            sent = json.loads(gzip.decompress(kwargs["data"]))["events"]
+            post_response.json.return_value = {"results": [{"event_id": event["event_id"], "status": "success"} for event in sent]}
+            return post_response
+
+        mock_post.side_effect = _post_response
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            limit=8,
+            show_progress=False,
+        )
+
+        sent_payload = gzip.decompress(mock_post.call_args.kwargs["data"])
+        sent_events = json.loads(sent_payload)["events"]
+        assert 0 < len(sent_events) < 8
+        assert len(sent_payload) <= 900
+        assert result.total_events == len(sent_events)
+
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_auth_header(self, mock_post, populated_queue):
         """Test batch sync sends authorization header"""
@@ -241,9 +325,7 @@ class TestBatchSyncSuccess:
         mock_response.json.return_value = {"results": []}
         mock_post.return_value = mock_response
 
-        batch_sync(
-            queue=populated_queue, auth_token="my-secret-token", server_url="http://localhost:8000", show_progress=False
-        )
+        batch_sync(queue=populated_queue, auth_token="my-secret-token", server_url="http://localhost:8000", show_progress=False)
 
         call_args = mock_post.call_args
         headers = call_args.kwargs["headers"]
@@ -362,9 +444,7 @@ class TestBatchSyncErrors:
 
         initial_size = populated_queue.size()
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="invalid-token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="invalid-token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.error_count == 100
         assert "Authentication failed" in result.error_messages
@@ -378,9 +458,7 @@ class TestBatchSyncErrors:
         mock_response.json.return_value = {"error": "Max 1000 events per batch"}
         mock_post.return_value = mock_response
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.error_count == 100
         assert "Max 1000 events per batch" in result.error_messages
@@ -392,9 +470,7 @@ class TestBatchSyncErrors:
         mock_response.status_code = 500
         mock_post.return_value = mock_response
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.error_count == 100
         assert "HTTP 500" in result.error_messages[0]
@@ -406,9 +482,7 @@ class TestBatchSyncErrors:
 
         mock_post.side_effect = requests.exceptions.Timeout()
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.error_count == 100
         assert "Request timeout" in result.error_messages
@@ -420,9 +494,7 @@ class TestBatchSyncErrors:
 
         mock_post.side_effect = requests.exceptions.ConnectionError("Network unreachable")
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.error_count == 100
         assert "Connection error" in result.error_messages[0]
@@ -433,16 +505,11 @@ class TestBatchSyncErrors:
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "results": [
-                {"event_id": f"evt-{i:04d}", "status": "success" if i < 90 else "error", "error_message": "DB error"}
-                for i in range(100)
-            ]
+            "results": [{"event_id": f"evt-{i:04d}", "status": "success" if i < 90 else "error", "error_message": "DB error"} for i in range(100)]
         }
         mock_post.return_value = mock_response
 
-        result = batch_sync(
-            queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = batch_sync(queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False)
 
         assert result.synced_count == 90
         assert result.error_count == 10
@@ -464,14 +531,10 @@ class TestBatchSyncLimit:
 
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(50)]
-        }
+        mock_response.json.return_value = {"results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(50)]}
         mock_post.return_value = mock_response
 
-        result = batch_sync(
-            queue=temp_queue, auth_token="token", server_url="http://localhost:8000", limit=50, show_progress=False
-        )
+        result = batch_sync(queue=temp_queue, auth_token="token", server_url="http://localhost:8000", limit=50, show_progress=False)
 
         assert result.total_events == 50
         assert temp_queue.size() == 150  # 150 events remain
@@ -503,9 +566,7 @@ class TestBatchSync1000Events:
         # Mock successful response for all queued events
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(event_count)]
-        }
+        mock_response.json.return_value = {"results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(event_count)]}
         mock_post.return_value = mock_response
 
         result = batch_sync(
@@ -548,9 +609,7 @@ class TestSyncAllQueuedEvents:
 
             mock_resp = Mock()
             mock_resp.status_code = 200
-            mock_resp.json.return_value = {
-                "results": [{"event_id": e["event_id"], "status": "success"} for e in events]
-            }
+            mock_resp.json.return_value = {"results": [{"event_id": e["event_id"], "status": "success"} for e in events]}
             return mock_resp
 
         mock_post.side_effect = mock_response_fn
@@ -575,9 +634,7 @@ class TestSyncAllQueuedEvents:
         mock_response.status_code = 500
         mock_post.return_value = mock_response
 
-        result = sync_all_queued_events(
-            queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False
-        )
+        result = sync_all_queued_events(queue=populated_queue, auth_token="token", server_url="http://localhost:8000", show_progress=False)
 
         # Should have tried once and stopped
         assert mock_post.call_count == 1
@@ -697,12 +754,7 @@ def flush_some_events(token_manager: TokenManager, monkeypatch: pytest.MonkeyPat
         with patch("specify_cli.sync.batch.requests.post") as mock_post:
             response = Mock()
             response.status_code = 200
-            response.json.return_value = {
-                "results": [
-                    {"event_id": f"wp04-evt-{i:04d}", "status": "success"}
-                    for i in range(3)
-                ]
-            }
+            response.json.return_value = {"results": [{"event_id": f"wp04-evt-{i:04d}", "status": "success"} for i in range(3)]}
             mock_post.return_value = response
             batch_sync(
                 queue=queue,
@@ -772,10 +824,7 @@ def test_batch_skips_ingress_when_rehydrate_yields_no_private(
         mock_post = flush_some_events(token_manager_with_shared_only_session, monkeypatch)
 
     assert mock_post.call_count == 0
-    assert any(
-        "direct_ingress_missing_private_team" in record.getMessage()
-        for record in caplog.records
-    )
+    assert any("direct_ingress_missing_private_team" in record.getMessage() for record in caplog.records)
 
 
 @respx.mock
@@ -814,9 +863,7 @@ def test_batch_healthy_session_no_rehydrate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Scenario 1 regression: session with private team => no /api/v1/me call; batch goes through."""
-    me_route = respx.get(f"{_INGRESS_SAAS_BASE_URL}/api/v1/me").mock(
-        return_value=httpx.Response(200, json={})
-    )
+    me_route = respx.get(f"{_INGRESS_SAAS_BASE_URL}/api/v1/me").mock(return_value=httpx.Response(200, json={}))
 
     mock_post = flush_some_events(token_manager_with_private_session, monkeypatch)
 
@@ -903,6 +950,4 @@ def test_sync_all_queued_events_terminates_on_no_private_team(
         # The skip-path sentinel surfaces on the result for operator-visible
         # diagnostics (also goes to stderr via the helper's structured
         # logger.warning, but operators reading the result get a hint too).
-        assert any(
-            "Private Teamspace" in m for m in result.error_messages
-        ), f"expected skip-sentinel in error_messages, got {result.error_messages!r}"
+        assert any("Private Teamspace" in m for m in result.error_messages), f"expected skip-sentinel in error_messages, got {result.error_messages!r}"


### PR DESCRIPTION
## Summary
- fetch authenticated `/api/v1/sync/health/` before live SaaS batch uploads
- cap CLI batch event count using advertised `max_events_per_batch`
- shrink oversized payloads to fit advertised decompressed-byte limits when possible
- keep localhost and reserved example hosts on the existing no-network test path

## Verification
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/sync/test_batch_sync.py -q`
- `uv run ruff check src/specify_cli/sync/batch.py tests/sync/test_batch_sync.py`