### PR TITLE
fix: restore merge dry-run preview and bump pip lock

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1522,30 +1522,6 @@ def merge(
                 console.print(f"[red]Error:[/red] {error_msg}")
             raise typer.Exit(1) from exc
 
-        _enforce_target_branch_sync_preflight(
-            get_main_repo_root(repo_root),
-            target_branch=resolved_target_branch,
-            mission_slug=resolved_feature,
-            mission_branch=lanes_manifest.mission_branch,
-            json_output=json_output,
-        )
-
-        branch_ok, branch_blocker = _check_mission_branch(
-            resolved_feature,
-            get_main_repo_root(repo_root),
-        )
-        if not branch_ok:
-            assert branch_blocker is not None
-            if json_output:
-                print(json.dumps(branch_blocker))
-            else:
-                console.print(
-                    "[red]Cannot proceed: mission branch missing.[/red]\n"
-                    f"Expected branch: {branch_blocker['expected_branch']}\n"
-                    f"Remediation: {branch_blocker['remediation']}"
-                )
-            raise typer.Exit(1)
-
         # WP10/T053: dry-run preview of merge-time mission_number assignment.
         feature_dir_for_preview = (
             get_main_repo_root(repo_root) / "kitty-specs" / resolved_feature

--- a/uv.lock
+++ b/uv.lock
@@ -1290,11 +1290,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747 }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723 },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- allow `spec-kitty merge --dry-run` preview JSON to load `lanes.json` without requiring merge-time mission-branch or target-sync preflights
- update `uv.lock` from `pip 26.0.1` to `pip 26.1.1` to address Dependabot alert GHSA-jp4c-xjxw-mgf9
- keep real merge execution preflights unchanged outside dry-run preview mode

## Validation
- `uv lock --check`
- `uv run --python /opt/homebrew/bin/python3.12 --extra test python -m pytest tests/agent/test_commands.py::test_merge_dry_run_outputs_lane_payload tests/agent/test_commands.py::test_merge_json_dry_run_honors_keep_flags tests/lanes/test_merge_policy.py::test_merge_dry_run_loads_lane_manifest -q`
- `HOME=/tmp/spec-kitty-20260507-090717/.codex-home XDG_CACHE_HOME=/tmp/spec-kitty-20260507-090717/.xdg-cache XDG_STATE_HOME=/tmp/spec-kitty-20260507-090717/.local-state SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --python /opt/homebrew/bin/python3.12 --extra test python -m pytest tests/agent -m 'fast and not windows_ci' -q --tb=short --cov=src/specify_cli/agent_utils --cov-fail-under=10 --cov-report=xml:out/reports/coverage/coverage-fast-agent.xml`
- `uv run --python /opt/homebrew/bin/python3.12 --extra test python -m pytest tests/lanes/ -m 'not windows_ci and (git_repo or integration)' -q --tb=short --cov=src/specify_cli/lanes --cov-report=xml:out/reports/coverage/coverage-integration-lanes.xml`

## Notes
- SonarCloud `main` quality gate is still failing on `new_coverage=58.5` and `new_security_hotspots_reviewed=0.0`; this PR addresses the actionable code/lock issues surfaced alongside that nightly run.