### PR TITLE
Fix Windows readonly skill reinstall

### DIFF
--- a/src/specify_cli/skills/installer.py
+++ b/src/specify_cli/skills/installer.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import shutil
+import stat
+from collections.abc import Callable
+from contextlib import suppress
 from datetime import datetime, timezone, UTC
 from pathlib import Path
 
@@ -25,6 +28,31 @@ from specify_cli.skills.registry import CanonicalSkill, SkillRegistry
 
 DELIVERY_COPY = "copy"
 DELIVERY_SYMLINK = "symlink"
+
+
+def _make_path_writable(path: str | Path) -> None:
+    """Clear Windows ReadOnly before deleting managed files."""
+    path = Path(path)
+    with suppress(OSError):
+        path.chmod(path.stat().st_mode | stat.S_IWRITE)
+
+
+def _force_writable_and_retry(function: Callable[[str], object], path: str, _exc_info: object) -> None:
+    """shutil.rmtree onerror handler: clear readonly and retry the failed operation."""
+    _make_path_writable(path)
+    function(path)
+
+
+def _safe_unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except PermissionError:
+        _make_path_writable(path)
+        path.unlink()
+
+
+def _safe_rmtree(path: Path) -> None:
+    shutil.rmtree(path, onerror=_force_writable_and_retry)
 
 
 def _make_tree_read_only(root: Path) -> None:
@@ -50,12 +78,12 @@ def _normalize_skill_md(skill: CanonicalSkill, dest_dir: Path) -> None:
 def _sync_global_skill(skill: CanonicalSkill, target_root: Path) -> Path:
     """Install one canonical skill into the user-global root."""
     target_root.mkdir(parents=True, exist_ok=True)
-    dest_dir = target_root / skill.name
+    dest_dir: Path = target_root / str(skill.name)
     if dest_dir.exists() or dest_dir.is_symlink():
         if dest_dir.is_symlink() or dest_dir.is_file():
-            dest_dir.unlink()
+            _safe_unlink(dest_dir)
         else:
-            shutil.rmtree(dest_dir)
+            _safe_rmtree(dest_dir)
     shutil.copytree(skill.skill_dir, dest_dir)
     _normalize_skill_md(skill, dest_dir)
     _make_tree_read_only(dest_dir)
@@ -77,6 +105,7 @@ def _archive_existing_path(dest: Path, project_path: Path, backup_root: Path | N
     backup_root = _ensure_backup_root(project_path, backup_root)
     backup_path = backup_root / dest.relative_to(project_path)
     backup_path.parent.mkdir(parents=True, exist_ok=True)
+    _make_path_writable(dest)
     shutil.move(str(dest), str(backup_path))
     return backup_root
 
@@ -100,11 +129,11 @@ def _project_skill_file(
                 return DELIVERY_SYMLINK, backup_root
         except OSError:
             pass
-        dest.unlink()
+        _safe_unlink(dest)
     elif dest.exists():
         try:
             if dest.is_file() and compute_content_hash(dest) == compute_content_hash(source_file):
-                dest.unlink()
+                _safe_unlink(dest)
             else:
                 backup_root = _ensure_backup_root(project_path, backup_root)
                 if archived_paths is not None:

--- a/tests/specify_cli/skills/test_installer.py
+++ b/tests/specify_cli/skills/test_installer.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import shutil
+import stat
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -157,6 +160,82 @@ class TestInstallSharedRootAgent:
         content = installed.read_text(encoding="utf-8")
         assert content.startswith("---\n")
         assert "name: plain-skill\n" in content
+
+    def test_reinstall_clears_windows_readonly_global_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from specify_cli.skills import installer
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+        skills_root = tmp_path / "skills_src"
+        project = tmp_path / "project"
+        project.mkdir()
+
+        skill = _make_skill(skills_root, "my-skill")
+        install_skills_for_agent(project, "claude", [skill])
+
+        real_rmtree = shutil.rmtree
+
+        def windows_like_rmtree(
+            path: str | Path,
+            ignore_errors: bool = False,
+            onerror: Callable[[Callable[[str], object], str, object], object] | None = None,
+            **kwargs: object,
+        ) -> None:
+            readonly_files = [
+                file_path
+                for file_path in Path(path).rglob("*")
+                if file_path.is_file() and not file_path.stat().st_mode & stat.S_IWRITE
+            ]
+            if readonly_files and onerror is None:
+                raise PermissionError(readonly_files[0])
+            for readonly_file in readonly_files:
+                assert onerror is not None
+
+                def remove_after_chmod(path_str: str) -> None:
+                    target = Path(path_str)
+                    if not target.stat().st_mode & stat.S_IWRITE:
+                        raise PermissionError(path_str)
+                    target.unlink()
+
+                onerror(remove_after_chmod, str(readonly_file), PermissionError(str(readonly_file)))
+            real_rmtree(path, ignore_errors=ignore_errors, onerror=onerror, **kwargs)
+
+        monkeypatch.setattr(installer.shutil, "rmtree", windows_like_rmtree)
+
+        install_skills_for_agent(project, "claude", [skill])
+
+        installed = project / ".claude" / "skills" / "my-skill" / "SKILL.md"
+        assert installed.exists()
+
+    def test_reinstall_clears_windows_readonly_copied_projection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+        skills_root = tmp_path / "skills_src"
+        project = tmp_path / "project"
+        project.mkdir()
+
+        def raise_symlink_unavailable(self: Path, target: str | Path, target_is_directory: bool = False) -> None:
+            raise OSError("symlinks unavailable")
+
+        real_unlink = Path.unlink
+
+        def windows_like_unlink(self: Path, missing_ok: bool = False) -> None:
+            if self.exists() and self.is_file() and not self.stat().st_mode & stat.S_IWRITE:
+                raise PermissionError(self)
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "symlink_to", raise_symlink_unavailable)
+        monkeypatch.setattr(Path, "unlink", windows_like_unlink)
+
+        skill = _make_skill(skills_root, "my-skill")
+        install_skills_for_agent(project, "claude", [skill])
+        install_skills_for_agent(project, "claude", [skill])
+
+        installed = project / ".claude" / "skills" / "my-skill" / "SKILL.md"
+        assert installed.is_file()
+        assert not installed.is_symlink()
 
 
 class TestInstallWrapperOnlyAgentSkipped:


### PR DESCRIPTION
## Summary
- clear the Windows ReadOnly attribute before unlinking managed skill files
- install global skill trees with an rmtree retry handler that makes readonly files writable before retrying
- add regression coverage for global skill reinstall and copied project projection reinstall paths

Thanks @vdgsx for the detailed bug report and suggested root cause. Your reproduction notes made this straightforward to pin down.

Fixes #999

## Verification
- uv run pytest tests/specify_cli/skills/test_installer.py
- uv run pytest tests/specify_cli/skills/test_e2e.py tests/specify_cli/skills/test_verifier.py
- uv run pytest tests/specify_cli/skills -q
- uv run ruff check src tests
- uv run mypy --strict src/specify_cli/skills/installer.py --disable-error-code unused-ignore