### PR TITLE
Fix adaptive sync batch sizing

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -342,7 +342,7 @@ spec-kitty sync server https://spec-kitty-dev.fly.dev
 
 **Synopsis**: `spec-kitty sync now [OPTIONS]`
 
-**Description**: Trigger immediate sync of all queued events. Drains the offline queue completely, uploading events to the server in batches of 1000 until the queue is empty or all remaining events have exceeded their retry limit.
+**Description**: Trigger immediate sync of all queued events. Drains the offline queue in bounded batches, honoring server-advertised event-count and decompressed-byte limits. If the server rejects a batch as too large, the CLI retries with a smaller batch and reports single oversized events separately. Manual runs print log-readable queued, accepted, duplicate, failed, and remaining counts as the drain progresses.
 
 **Options**:
 

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -975,7 +975,7 @@ def now(
         return
 
     console.print(f"Syncing {queue_size} queued event(s)...")
-    result = service.sync_now()
+    result = service.sync_now(show_progress=True)
 
     # Print actionable summary instead of bare counts
     summary = format_sync_summary(result)

--- a/src/specify_cli/sync/background.py
+++ b/src/specify_cli/sync/background.py
@@ -280,14 +280,14 @@ class BackgroundSyncService:
     def is_running(self) -> bool:
         return self._running
 
-    def sync_now(self) -> BatchSyncResult:
+    def sync_now(self, *, show_progress: bool = False) -> BatchSyncResult:
         """Trigger an immediate sync, draining all queued events.
 
         Unlike the periodic timer (which syncs a single batch), this
         loops until the queue is empty or all remaining events have
         exceeded their retry limit.
         """
-        return self._perform_full_sync()
+        return self._perform_full_sync(show_progress=show_progress)
 
     # ── Internal ──────────────────────────────────────────────────
 
@@ -327,7 +327,7 @@ class BackgroundSyncService:
         with self._lock:
             return self._sync_once()
 
-    def _perform_full_sync(self) -> BatchSyncResult:
+    def _perform_full_sync(self, *, show_progress: bool = False) -> BatchSyncResult:
         """Drain the entire queue across multiple batches.
 
         Thread-safe: holds _lock for the full duration so background
@@ -355,7 +355,7 @@ class BackgroundSyncService:
                     auth_token=access_token,
                     server_url=self.config.get_server_url(),
                     batch_size=1000,
-                    show_progress=False,
+                    show_progress=show_progress,
                 )
                 # Treat auth failures as hard errors (#598)
                 if "auth_expired" in result.category_counts:

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -44,14 +44,13 @@ ERROR_CATEGORIES: dict[str, list[str]] = {
         "sync_batch_too_large",
         "request_too_large",
         "payload too large",
-        "413",
     ],
     "oversized_event": [
         "single event exceeds decompressed byte limit",
         "event exceeds decompressed byte limit",
         "oversized event",
     ],
-    "throttled": ["rate limit", "rate_limited", "too many requests", "429", "throttle"],
+    "throttled": ["rate limit", "rate_limited", "too many requests", "throttle"],
     "schema_mismatch": ["invalid", "schema", "field", "missing", "type"],
     "auth_expired": ["token", "expired", "unauthorized", "401"],
     "unauthenticated": ["not authenticated", "no valid access token"],
@@ -74,7 +73,7 @@ ERROR_CATEGORIES: dict[str, list[str]] = {
 CATEGORY_ACTIONS: dict[str, str] = {
     "oversized_batch": "The CLI will retry with a smaller batch; upgrade if this persists",
     "oversized_event": "Inspect or remove the oversized event from the offline queue",
-    "throttled": "Retry after the server-advertised backoff window",
+    "throttled": "Retry later; server indicated rate limiting",
     "schema_mismatch": "Run `spec-kitty sync diagnose` to inspect invalid events",
     "auth_expired": "Run `spec-kitty auth login` to refresh credentials",
     "unauthenticated": "Run `spec-kitty auth login` to authenticate",
@@ -230,19 +229,25 @@ def _select_events_for_advertised_limits(
     effective_limit = min(requested_limit, max_events) if max_events else requested_limit
     candidates = queue.drain_queue(limit=effective_limit)
     max_decompressed_bytes = _decompressed_byte_limit(advertised_limits)
+
     selected: list[dict] = []
-    payload = _build_batch_payload(selected)
+    # Track accumulated payload size incrementally (O(n)) rather than
+    # re-serializing the full list on each iteration (O(n²)).
+    # Envelope overhead: len('{"events": []}') == 14 bytes; each event after the
+    # first adds a 2-byte ", " separator.
+    accumulated = 14
 
     for event in candidates:
-        candidate_events = [*selected, event]
-        candidate_payload = _build_batch_payload(candidate_events)
-        if selected and len(candidate_payload) > max_decompressed_bytes:
+        event_bytes = len(json.dumps(event).encode("utf-8"))
+        incremental = event_bytes + (2 if selected else 0)
+        if selected and accumulated + incremental > max_decompressed_bytes:
             break
-        selected = candidate_events
-        payload = candidate_payload
-        if len(payload) > max_decompressed_bytes:
+        selected.append(event)
+        accumulated += incremental
+        if accumulated > max_decompressed_bytes:
             break
 
+    payload = _build_batch_payload(selected)
     return selected, payload
 
 
@@ -286,7 +291,7 @@ def _single_oversized_event_result(event: dict, byte_limit: int, payload_size: i
     result.total_events = 1
     event_id = event.get("event_id", "unknown")
     error = (
-        f"Single event exceeds decompressed byte limit "
+        f"single event exceeds decompressed byte limit "
         f"({payload_size} bytes > {byte_limit} bytes)"
     )
     result.error_count = 1
@@ -295,11 +300,28 @@ def _single_oversized_event_result(event: dict, byte_limit: int, payload_size: i
     result.event_results.append(
         BatchEventResult(
             event_id=event_id,
-            status="rejected",
+            # failed_permanent removes the event from the queue so the drain loop
+            # can continue past it rather than stalling indefinitely.
+            status="failed_permanent",
             error=error,
             error_category="oversized_event",
         )
     )
+    return result
+
+
+def _handle_single_oversized_event(
+    event: dict,
+    byte_limit: int,
+    payload_size: int,
+    queue: OfflineQueue,
+    *,
+    show_progress: bool,
+) -> BatchSyncResult:
+    result = _single_oversized_event_result(event, byte_limit, payload_size)
+    queue.process_batch_results(result.event_results)
+    if show_progress:
+        print(format_sync_summary(result))
     return result
 
 
@@ -375,13 +397,16 @@ class BatchEventResult:
 
     Attributes:
         event_id: Unique event identifier.
-        status: One of ``"success"``, ``"duplicate"``, ``"rejected"``.
-        error: Human-readable error message (only for rejected events).
-        error_category: Categorised reason (only for rejected events).
+        status: One of ``"success"``, ``"duplicate"``, ``"rejected"``,
+            ``"failed_permanent"``. Permanent failures (e.g. oversized events
+            that can never be sent) are removed from the queue rather than
+            having their retry count bumped.
+        error: Human-readable error message (only for failed events).
+        error_category: Categorised reason (only for failed events).
     """
 
     event_id: str
-    status: str  # "success", "duplicate", "rejected"
+    status: str  # "success", "duplicate", "rejected", "failed_permanent"
     error: str | None = None
     error_category: str | None = None
 
@@ -418,8 +443,8 @@ class BatchSyncResult:
 
     @property
     def failed_results(self) -> list[BatchEventResult]:
-        """Convenience: only rejected ``BatchEventResult`` entries."""
-        return [r for r in self.event_results if r.status == "rejected"]
+        """Convenience: only failed ``BatchEventResult`` entries (rejected or permanently failed)."""
+        return [r for r in self.event_results if r.status in ("rejected", "failed_permanent")]
 
     @property
     def category_counts(self) -> dict[str, int]:
@@ -792,20 +817,18 @@ def batch_sync(  # noqa: C901
     byte_limit = _decompressed_byte_limit(advertised_limits)
 
     if len(events) == 1 and len(payload) > byte_limit:
-        result = _single_oversized_event_result(events[0], byte_limit, len(payload))
-        queue.process_batch_results(result.event_results)
-        if show_progress:
-            print(format_sync_summary(result))
-        return result
+        return _handle_single_oversized_event(
+            events[0], byte_limit, len(payload), queue, show_progress=show_progress
+        )
 
     if show_progress:
-        remaining_after_batch = max(queue.size() - len(events), 0)
+        estimated_remaining = max(queue.size() - len(events), 0)
         print(
             "Sync batch: "
             f"events={len(events)} "
             f"decompressed_bytes={len(payload)} "
             f"limit_bytes={byte_limit} "
-            f"remaining_after_batch={remaining_after_batch}"
+            f"estimated_remaining={estimated_remaining}"
         )
 
     # Validate each event envelope against upstream contract before sending
@@ -834,15 +857,14 @@ def batch_sync(  # noqa: C901
             )
             response_body = _safe_response_json(response)
 
+            result.total_events = len(events)
             if _is_oversized_batch_response(response.status_code, response_body):
                 advertised_limits = _retry_limits_from_response(response_body, advertised_limits)
                 byte_limit = _decompressed_byte_limit(advertised_limits)
                 if len(events) == 1:
-                    result = _single_oversized_event_result(events[0], byte_limit, len(payload))
-                    queue.process_batch_results(result.event_results)
-                    if show_progress:
-                        print(format_sync_summary(result))
-                    return result
+                    return _handle_single_oversized_event(
+                        events[0], byte_limit, len(payload), queue, show_progress=show_progress
+                    )
 
                 previous_size = len(events)
                 events = _shrink_events_for_retry(events)
@@ -850,7 +872,6 @@ def batch_sync(  # noqa: C901
                 while len(events) > 1 and len(payload) > byte_limit:
                     events = _shrink_events_for_retry(events)
                     payload = _build_batch_payload(events)
-                result.total_events = len(events)
                 if show_progress:
                     print(
                         "Retrying smaller sync batch: "
@@ -1128,7 +1149,16 @@ def sync_all_queued_events(
         #      sole stderr diagnostic). Without this, sync_all_queued_events
         #      would spin forever on a shared-only session because the queue
         #      never drains.
+        #
+        # Exception: permanently-failed events (e.g. oversized_event) are
+        # removed from the queue by process_batch_results, so the drain IS
+        # making progress — continue to subsequent events rather than stopping.
         if result.success_count == 0:
+            all_permanent = bool(result.event_results) and all(
+                r.status == "failed_permanent" for r in result.event_results
+            )
+            if all_permanent:
+                continue
             if show_progress:
                 if result.error_count > 0:
                     print("Stopping: No events successfully synced in this batch")

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -39,6 +39,19 @@ from specify_cli.core.contract_gate import validate_outbound_payload
 # ---------------------------------------------------------------------------
 
 ERROR_CATEGORIES: dict[str, list[str]] = {
+    "oversized_batch": [
+        "batch payload exceeds decompressed byte limit",
+        "sync_batch_too_large",
+        "request_too_large",
+        "payload too large",
+        "413",
+    ],
+    "oversized_event": [
+        "single event exceeds decompressed byte limit",
+        "event exceeds decompressed byte limit",
+        "oversized event",
+    ],
+    "throttled": ["rate limit", "rate_limited", "too many requests", "429", "throttle"],
     "schema_mismatch": ["invalid", "schema", "field", "missing", "type"],
     "auth_expired": ["token", "expired", "unauthorized", "401"],
     "unauthenticated": ["not authenticated", "no valid access token"],
@@ -59,6 +72,9 @@ ERROR_CATEGORIES: dict[str, list[str]] = {
 }
 
 CATEGORY_ACTIONS: dict[str, str] = {
+    "oversized_batch": "The CLI will retry with a smaller batch; upgrade if this persists",
+    "oversized_event": "Inspect or remove the oversized event from the offline queue",
+    "throttled": "Retry after the server-advertised backoff window",
     "schema_mismatch": "Run `spec-kitty sync diagnose` to inspect invalid events",
     "auth_expired": "Run `spec-kitty auth login` to refresh credentials",
     "unauthenticated": "Run `spec-kitty auth login` to authenticate",
@@ -71,6 +87,7 @@ CATEGORY_ACTIONS: dict[str, str] = {
 FINAL_SYNC_MAX_ATTEMPTS = 3
 FINAL_SYNC_RETRY_BACKOFF_SECONDS = 1.0
 SYNC_INGRESS_LIMITS_TIMEOUT_SECONDS = 10
+DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH = 900_000
 
 
 def _current_team_slug() -> str | None:
@@ -196,6 +213,13 @@ def _build_batch_payload(events: list[dict]) -> bytes:
     return json.dumps({"events": events}).encode("utf-8")
 
 
+def _decompressed_byte_limit(advertised_limits: dict[str, int]) -> int:
+    return advertised_limits.get(
+        "max_decompressed_bytes_per_batch",
+        DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH,
+    )
+
+
 def _select_events_for_advertised_limits(
     queue: OfflineQueue,
     *,
@@ -204,15 +228,79 @@ def _select_events_for_advertised_limits(
 ) -> tuple[list[dict], bytes]:
     max_events = advertised_limits.get("max_events_per_batch")
     effective_limit = min(requested_limit, max_events) if max_events else requested_limit
-    events = queue.drain_queue(limit=effective_limit)
-    payload = _build_batch_payload(events)
+    candidates = queue.drain_queue(limit=effective_limit)
+    max_decompressed_bytes = _decompressed_byte_limit(advertised_limits)
+    selected: list[dict] = []
+    payload = _build_batch_payload(selected)
 
-    max_decompressed_bytes = advertised_limits.get("max_decompressed_bytes_per_batch")
-    while max_decompressed_bytes and len(events) > 1 and len(payload) > max_decompressed_bytes:
-        events = events[: max(1, len(events) // 2)]
-        payload = _build_batch_payload(events)
+    for event in candidates:
+        candidate_events = [*selected, event]
+        candidate_payload = _build_batch_payload(candidate_events)
+        if selected and len(candidate_payload) > max_decompressed_bytes:
+            break
+        selected = candidate_events
+        payload = candidate_payload
+        if len(payload) > max_decompressed_bytes:
+            break
 
-    return events, payload
+    return selected, payload
+
+
+def _is_oversized_batch_response(status_code: int, body: dict) -> bool:
+    if status_code == 413:
+        return True
+    values = [
+        body.get("error"),
+        body.get("message"),
+        body.get("detail"),
+        body.get("error_code"),
+        body.get("category"),
+    ]
+    text = " ".join(str(value) for value in values if value is not None).lower()
+    return categorize_error(text) == "oversized_batch"
+
+
+def _retry_limits_from_response(body: dict, advertised_limits: dict[str, int]) -> dict[str, int]:
+    limits = body.get("limits")
+    if not isinstance(limits, dict):
+        return advertised_limits
+    merged = dict(advertised_limits)
+    for key in (
+        "max_events_per_batch",
+        "max_decompressed_bytes_per_batch",
+        "retry_after_min_seconds",
+        "retry_after_max_seconds",
+    ):
+        value = _positive_int(limits.get(key))
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
+def _shrink_events_for_retry(events: list[dict]) -> list[dict]:
+    return events[: max(1, len(events) // 2)]
+
+
+def _single_oversized_event_result(event: dict, byte_limit: int, payload_size: int) -> BatchSyncResult:
+    result = BatchSyncResult()
+    result.total_events = 1
+    event_id = event.get("event_id", "unknown")
+    error = (
+        f"Single event exceeds decompressed byte limit "
+        f"({payload_size} bytes > {byte_limit} bytes)"
+    )
+    result.error_count = 1
+    result.failed_ids = [event_id]
+    result.error_messages.append(f"{event_id}: {error}")
+    result.event_results.append(
+        BatchEventResult(
+            event_id=event_id,
+            status="rejected",
+            error=error,
+            error_category="oversized_event",
+        )
+    )
+    return result
 
 
 def _body_mentions_missing_private_team(body: dict) -> bool:
@@ -236,7 +324,11 @@ def _http_error_category(status_code: int, body: dict | None = None) -> str:
         if _body_mentions_missing_private_team(body):
             return CATEGORY_MISSING_PRIVATE_TEAM
         return "unauthorized"
-    if status_code in {408, 429}:
+    if _is_oversized_batch_response(status_code, body):
+        return "oversized_batch"
+    if status_code == 429:
+        return "throttled"
+    if status_code == 408:
         return "retryable_transport"
     if 500 <= status_code < 600:
         return "server_error"
@@ -697,17 +789,29 @@ def batch_sync(  # noqa: C901
         advertised_limits=advertised_limits,
     )
     result.total_events = len(events)
+    byte_limit = _decompressed_byte_limit(advertised_limits)
+
+    if len(events) == 1 and len(payload) > byte_limit:
+        result = _single_oversized_event_result(events[0], byte_limit, len(payload))
+        queue.process_batch_results(result.event_results)
+        if show_progress:
+            print(format_sync_summary(result))
+        return result
 
     if show_progress:
-        print(f"Syncing {len(events)} events... (0/{len(events)})")
+        remaining_after_batch = max(queue.size() - len(events), 0)
+        print(
+            "Sync batch: "
+            f"events={len(events)} "
+            f"decompressed_bytes={len(payload)} "
+            f"limit_bytes={byte_limit} "
+            f"remaining_after_batch={remaining_after_batch}"
+        )
 
     # Validate each event envelope against upstream contract before sending
     for evt in events:
         with suppress(Exception):
             validate_outbound_payload(evt, "envelope")
-
-    # Compress payload with gzip
-    compressed = gzip.compress(payload)
 
     # POST to batch endpoint
     headers = {
@@ -720,12 +824,42 @@ def batch_sync(  # noqa: C901
     batch_url = f"{server_url.rstrip('/')}/api/v1/events/batch/"
 
     try:
-        response = requests.post(
-            batch_url,
-            data=compressed,
-            headers=headers,
-            timeout=60,
-        )
+        while True:
+            compressed = gzip.compress(payload)
+            response = requests.post(
+                batch_url,
+                data=compressed,
+                headers=headers,
+                timeout=60,
+            )
+            response_body = _safe_response_json(response)
+
+            if _is_oversized_batch_response(response.status_code, response_body):
+                advertised_limits = _retry_limits_from_response(response_body, advertised_limits)
+                byte_limit = _decompressed_byte_limit(advertised_limits)
+                if len(events) == 1:
+                    result = _single_oversized_event_result(events[0], byte_limit, len(payload))
+                    queue.process_batch_results(result.event_results)
+                    if show_progress:
+                        print(format_sync_summary(result))
+                    return result
+
+                previous_size = len(events)
+                events = _shrink_events_for_retry(events)
+                payload = _build_batch_payload(events)
+                while len(events) > 1 and len(payload) > byte_limit:
+                    events = _shrink_events_for_retry(events)
+                    payload = _build_batch_payload(events)
+                result.total_events = len(events)
+                if show_progress:
+                    print(
+                        "Retrying smaller sync batch: "
+                        f"reason=oversized_batch previous_events={previous_size} "
+                        f"next_events={len(events)} decompressed_bytes={len(payload)} "
+                        f"limit_bytes={byte_limit}"
+                    )
+                continue
+            break
 
         if response.status_code == 200:
             response_data = response.json()
@@ -757,7 +891,6 @@ def batch_sync(  # noqa: C901
             queue.process_batch_results(result.event_results)
 
         elif response.status_code == 400:
-            response_body = response.json()
             _parse_error_response(response_body, events, result)
             queue.process_batch_results(result.event_results)
             if show_progress:
@@ -766,7 +899,6 @@ def batch_sync(  # noqa: C901
         else:
             if show_progress:
                 print(f"Batch sync failed: HTTP {response.status_code}")
-            response_body = _safe_response_json(response)
             _record_all_events_failed(
                 result,
                 events,
@@ -950,11 +1082,17 @@ def sync_all_queued_events(
         return total_result
 
     batch_num = 0
+    initial_queued = queue.size()
+    if show_progress:
+        print(f"Initial queued events: {initial_queued}")
 
     while queue.size() > 0:
         batch_num += 1
         if show_progress:
-            print(f"\n--- Batch {batch_num} ---")
+            print(
+                f"\n--- Batch {batch_num} --- "
+                f"remaining={queue.size()} requested_batch_size={batch_size}"
+            )
 
         result = batch_sync(
             queue=queue,
@@ -972,6 +1110,15 @@ def sync_all_queued_events(
         total_result.failed_ids.extend(result.failed_ids)
         total_result.error_messages.extend(result.error_messages)
         total_result.event_results.extend(result.event_results)
+
+        if show_progress:
+            print(
+                "Progress: "
+                f"accepted={total_result.synced_count} "
+                f"duplicates={total_result.duplicate_count} "
+                f"failed={total_result.error_count} "
+                f"remaining={queue.size()}"
+            )
 
         # Stop if no progress made. This covers two cases:
         #   1. All events in the batch failed (error_count > 0).
@@ -991,6 +1138,7 @@ def sync_all_queued_events(
 
     if show_progress:
         print("\n=== Sync Complete ===")
+        print(f"Initial queued: {initial_queued}")
         print(format_sync_summary(total_result))
         if queue.size() > 0:
             print(f"Remaining in queue: {queue.size()} events")

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -845,7 +845,7 @@ class OfflineQueue:
             conn.close()
 
     def process_batch_results(self, results: list[_BatchEventResultLike]) -> None:
-        """Process batch sync results: remove synced/duplicate, bump retry for failures.
+        """Process batch sync results: remove synced/duplicate/permanent failures, bump retry for transient failures.
 
         Wraps all queue mutations in a single SQLite transaction for
         atomicity: either all changes apply or none do.
@@ -857,7 +857,9 @@ class OfflineQueue:
         synced_or_duplicate: list[str] = []
         rejected: list[str] = []
         for r in results:
-            if r.status in ("success", "duplicate"):
+            if r.status in ("success", "duplicate", "failed_permanent"):
+                # failed_permanent events (e.g. oversized events) are removed so
+                # the drain loop can continue past them without stalling.
                 synced_or_duplicate.append(r.event_id)
             elif r.status == "rejected":
                 rejected.append(r.event_id)

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -483,6 +483,75 @@ class TestBatchSyncSuccess:
     def test_oversized_batch_error_classifies_without_unknown(self):
         assert categorize_error("Batch payload exceeds decompressed byte limit") == "oversized_batch"
 
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_server_413_on_single_event_classifies_as_oversized_event(
+        self,
+        mock_post,
+        mock_get,
+        temp_queue,
+    ):
+        """Server-side 413 after shrinking to 1 event uses failed_permanent, not rejected."""
+        temp_queue.queue_event(
+            {
+                "event_id": "single-server-413",
+                "event_type": "WPStatusChanged",
+                "aggregate_id": "WP01",
+                "lamport_clock": 1,
+                "node_id": "test-node",
+                "payload": {"body": "x" * 50},
+            }
+        )
+
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {"limits": {"max_events_per_batch": 10, "max_decompressed_bytes_per_batch": 100_000}}
+        }
+        mock_get.return_value = health_response
+
+        rejected_413 = Mock()
+        rejected_413.status_code = 413
+        rejected_413.json.return_value = {"error": "Batch payload exceeds decompressed byte limit"}
+        mock_post.return_value = rejected_413
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            limit=10,
+            show_progress=False,
+        )
+
+        assert mock_post.call_count == 1
+        assert result.error_count == 1
+        assert result.failed_results[0].error_category == "oversized_event"
+        assert result.failed_results[0].status == "failed_permanent"
+        assert temp_queue.size() == 0
+
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_throttled_category_on_429(self, mock_post, temp_queue):
+        """HTTP 429 should classify as 'throttled', not 'retryable_transport'."""
+        temp_queue.queue_event(
+            {"event_id": "evt-429", "event_type": "WPStatusChanged", "payload": {}}
+        )
+
+        throttled = Mock()
+        throttled.status_code = 429
+        throttled.json.return_value = {"error": "Too many requests"}
+        mock_post.return_value = throttled
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="http://localhost:8000",
+            limit=10,
+            show_progress=False,
+        )
+
+        assert result.category_counts.get("throttled", 0) == 1
+        assert "retryable_transport" not in result.category_counts
+
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_auth_header(self, mock_post, populated_queue):
         """Test batch sync sends authorization header"""
@@ -835,6 +904,56 @@ class TestSyncAllQueuedEvents:
         # Should have tried once and stopped
         assert mock_post.call_count == 1
         assert result.error_count == 100
+
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_sync_all_continues_past_oversized_event(self, mock_post, mock_get, temp_queue):
+        """An oversized event at queue head must not permanently stall subsequent events."""
+        temp_queue.queue_event(
+            {
+                "event_id": "oversized-head",
+                "event_type": "WPStatusChanged",
+                "aggregate_id": "WP01",
+                "lamport_clock": 1,
+                "node_id": "test-node",
+                "payload": {"body": "x" * 500},
+            }
+        )
+        for i in range(3):
+            temp_queue.queue_event(
+                {"event_id": f"good-{i}", "event_type": "WPStatusChanged", "payload": {}}
+            )
+
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {"limits": {"max_events_per_batch": 10, "max_decompressed_bytes_per_batch": 100}}
+        }
+        mock_get.return_value = health_response
+
+        def _post_response(*args, **kwargs):
+            events = json.loads(gzip.decompress(kwargs["data"]))["events"]
+            resp = Mock()
+            resp.status_code = 200
+            resp.json.return_value = {"results": [{"event_id": e["event_id"], "status": "success"} for e in events]}
+            return resp
+
+        mock_post.side_effect = _post_response
+
+        # Use a non-localhost URL so _should_probe_advertised_limits returns True
+        # and the mocked health limits (100 bytes) take effect.
+        result = sync_all_queued_events(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            batch_size=10,
+            show_progress=False,
+        )
+
+        assert temp_queue.size() == 0
+        assert result.synced_count == 3
+        assert result.error_count == 1
+        assert result.category_counts.get("oversized_event", 0) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -17,7 +17,13 @@ from specify_cli.auth.secure_storage import SecureStorage
 from specify_cli.auth.session import StoredSession, Team
 from specify_cli.auth.token_manager import TokenManager
 from specify_cli.sync.queue import OfflineQueue
-from specify_cli.sync.batch import batch_sync, sync_all_queued_events, BatchSyncResult
+from specify_cli.sync.batch import (
+    DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH,
+    BatchSyncResult,
+    batch_sync,
+    categorize_error,
+    sync_all_queued_events,
+)
 from specify_cli.sync.feature_flags import SAAS_SYNC_ENV_VAR
 
 pytestmark = pytest.mark.fast
@@ -316,6 +322,166 @@ class TestBatchSyncSuccess:
         assert 0 < len(sent_events) < 8
         assert len(sent_payload) <= 900
         assert result.total_events == len(sent_events)
+
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_uses_fallback_decompressed_byte_limit(self, mock_post, temp_queue):
+        """When health limits are unavailable, the CLI should still avoid huge batches."""
+        for i in range(2):
+            temp_queue.queue_event(
+                {
+                    "event_id": f"fallback-large-{i}",
+                    "event_type": "WPStatusChanged",
+                    "aggregate_id": "WP01",
+                    "lamport_clock": i,
+                    "node_id": "test-node",
+                    "payload": {"body": "x" * (DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH // 2)},
+                }
+            )
+
+        post_response = Mock()
+        post_response.status_code = 200
+
+        def _post_response(*args, **kwargs):
+            sent = json.loads(gzip.decompress(kwargs["data"]))["events"]
+            post_response.json.return_value = {"results": [{"event_id": event["event_id"], "status": "success"} for event in sent]}
+            return post_response
+
+        mock_post.side_effect = _post_response
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="http://localhost:8000",
+            limit=2,
+            show_progress=False,
+        )
+
+        sent_payload = gzip.decompress(mock_post.call_args.kwargs["data"])
+        assert len(sent_payload) <= DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH
+        assert result.synced_count == 1
+        assert temp_queue.size() == 1
+
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_retries_smaller_batch_after_server_size_rejection(
+        self,
+        mock_post,
+        mock_get,
+        temp_queue,
+    ):
+        """Server decompressed-size rejections should shrink, retry, and avoid unknown errors."""
+        for i in range(4):
+            temp_queue.queue_event(
+                {
+                    "event_id": f"retry-large-{i}",
+                    "event_type": "WPStatusChanged",
+                    "aggregate_id": "WP01",
+                    "lamport_clock": i,
+                    "node_id": "test-node",
+                    "payload": {"body": "x" * 100},
+                }
+            )
+
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {
+                "limits": {
+                    "max_events_per_batch": 4,
+                    "max_decompressed_bytes_per_batch": 100_000,
+                }
+            }
+        }
+        mock_get.return_value = health_response
+
+        rejected = Mock()
+        rejected.status_code = 413
+        rejected.json.return_value = {
+            "error": "Batch payload exceeds decompressed byte limit",
+            "error_code": "sync_batch_too_large",
+            "category": "request_too_large",
+            "limits": {
+                "max_events_per_batch": 4,
+                "max_decompressed_bytes_per_batch": 900,
+            },
+        }
+
+        accepted = Mock()
+        accepted.status_code = 200
+
+        calls = {"count": 0}
+
+        def _post_response(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return rejected
+            sent = json.loads(gzip.decompress(kwargs["data"]))["events"]
+            accepted.json.return_value = {"results": [{"event_id": event["event_id"], "status": "success"} for event in sent]}
+            return accepted
+
+        mock_post.side_effect = _post_response
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            limit=4,
+            show_progress=False,
+        )
+
+        assert mock_post.call_count == 2
+        retried_payload = json.loads(gzip.decompress(mock_post.call_args.kwargs["data"]))
+        assert 0 < len(retried_payload["events"]) < 4
+        assert result.error_count == 0
+        assert result.synced_count == len(retried_payload["events"])
+
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_reports_single_oversized_event_without_posting(
+        self,
+        mock_post,
+        mock_get,
+        temp_queue,
+    ):
+        """A single event that cannot fit the advertised limit is isolated in the report."""
+        temp_queue.queue_event(
+            {
+                "event_id": "too-large-one",
+                "event_type": "WPStatusChanged",
+                "aggregate_id": "WP01",
+                "lamport_clock": 1,
+                "node_id": "test-node",
+                "payload": {"body": "x" * 500},
+            }
+        )
+
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {
+                "limits": {
+                    "max_events_per_batch": 10,
+                    "max_decompressed_bytes_per_batch": 100,
+                }
+            }
+        }
+        mock_get.return_value = health_response
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            limit=10,
+            show_progress=False,
+        )
+
+        mock_post.assert_not_called()
+        assert result.error_count == 1
+        assert result.failed_results[0].error_category == "oversized_event"
+        assert "unknown" not in result.category_counts
+
+    def test_oversized_batch_error_classifies_without_unknown(self):
+        assert categorize_error("Batch payload exceeds decompressed byte limit") == "oversized_batch"
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_auth_header(self, mock_post, populated_queue):
@@ -626,6 +792,36 @@ class TestSyncAllQueuedEvents:
         assert result.synced_count == 250
         assert temp_queue.size() == 0
         assert mock_post.call_count == 3  # 100 + 100 + 50
+
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_sync_all_progress_output_is_log_readable(self, mock_post, temp_queue, capsys):
+        """Manual drains should expose counts without relying on an interactive progress bar."""
+        for i in range(3):
+            temp_queue.queue_event({"event_id": f"evt-{i:04d}", "event_type": "Test", "payload": {}})
+
+        def mock_response_fn(*args, **kwargs):
+            events = json.loads(gzip.decompress(kwargs["data"]))["events"]
+            mock_resp = Mock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"results": [{"event_id": e["event_id"], "status": "success"} for e in events]}
+            return mock_resp
+
+        mock_post.side_effect = mock_response_fn
+
+        sync_all_queued_events(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="http://localhost:8000",
+            batch_size=2,
+            show_progress=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Initial queued events: 3" in out
+        assert "requested_batch_size=2" in out
+        assert "Sync batch: events=" in out
+        assert "Progress: accepted=" in out
+        assert "remaining=0" in out
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_sync_all_stops_on_all_errors(self, mock_post, populated_queue):


### PR DESCRIPTION
## Summary
- bound SaaS sync batches by advertised event-count and decompressed-byte limits
- add conservative fallback byte limit, shrink-and-retry after oversized batch rejection, and single oversized event reporting
- classify oversized batch/event failures without `unknown`
- surface log-readable `sync now` progress for manual drains while keeping background sync quiet
- update CLI command docs

## Verification
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/sync/test_batch_sync.py tests/sync/test_batch_error_surfacing.py tests/sync/test_background.py tests/cli/commands/test_sync_routes.py` => 105 passed
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run ruff check src/specify_cli/sync/batch.py src/specify_cli/sync/background.py src/specify_cli/cli/commands/sync.py tests/sync/test_batch_sync.py`
- SaaS contract check in sibling checkout: `uv run pytest apps/sync/tests/test_sync_limits.py apps/sync/tests/test_sync_ingress_preflight.py::SyncIngressPreflightTests::test_decompressed_gzip_limit_rejects_before_ingestion` => 5 passed
- Live dev probes: `/health/` reports SHA `e1880b3e66039297b0afe70b53b9aa7b684a36ba`; `/health/ready/` dependencies ok except drain backlog degraded; `/metrics` exposes `sync_ingress_*` counters including request-too-large

## Remaining risks
- Real beta backlog still needs to be retried after this CLI branch is installed/built.
- SaaS drain queue on deployed dev is currently degraded due backlog; do not close the SaaS epic until deployed-dev drain evidence is clean.