### PR TITLE
Tighten sync batch byte safety margin

### DIFF
--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -87,6 +87,7 @@ FINAL_SYNC_MAX_ATTEMPTS = 3
 FINAL_SYNC_RETRY_BACKOFF_SECONDS = 1.0
 SYNC_INGRESS_LIMITS_TIMEOUT_SECONDS = 10
 DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH = 900_000
+DECOMPRESSED_BYTES_SAFETY_FACTOR = 0.90
 
 
 def _current_team_slug() -> str | None:
@@ -213,10 +214,11 @@ def _build_batch_payload(events: list[dict]) -> bytes:
 
 
 def _decompressed_byte_limit(advertised_limits: dict[str, int]) -> int:
-    return advertised_limits.get(
+    advertised_limit = advertised_limits.get(
         "max_decompressed_bytes_per_batch",
         DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH,
     )
+    return max(1, int(advertised_limit * DECOMPRESSED_BYTES_SAFETY_FACTOR))
 
 
 def _select_events_for_advertised_limits(

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -320,7 +320,7 @@ class TestBatchSyncSuccess:
         sent_payload = gzip.decompress(mock_post.call_args.kwargs["data"])
         sent_events = json.loads(sent_payload)["events"]
         assert 0 < len(sent_events) < 8
-        assert len(sent_payload) <= 900
+        assert len(sent_payload) <= int(900 * 0.90)
         assert result.total_events == len(sent_events)
 
     @patch("specify_cli.sync.batch.requests.post")


### PR DESCRIPTION
## Summary
- Treat advertised SaaS decompressed byte limits as an upper bound with a 90% client-side safety margin.
- Keep adaptive batch splitting below the effective byte cap before posting to SaaS.
- Update the byte-limit unit assertion to verify the conservative cap.

## Verification
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/sync/test_batch_sync.py tests/sync/test_batch_error_surfacing.py tests/sync/test_background.py tests/cli/commands/test_sync_routes.py -q
- Deployed-dev E2E was run from the sibling spec-kitty-end-to-end-testing checkout against https://spec-kitty-dev.fly.dev with real CLI auth/sync; final run passed: 1 test in 318.63s. Evidence captured 1200 accepted Event rows and 1200 BatchIntakeItem rows for actor one, 3/3 for actor two, and zero cross-private-team leakage.

## Notes
- This is a follow-up because #1006 was merged while the live deployed-dev E2E was still running; this branch carries only the safety-margin delta on top of current main.