### PR TITLE
feat: report TeamSpace dry-run row mappings

### DIFF
--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -177,6 +177,34 @@ class RepairReport:
 
 
 @dataclass(frozen=True)
+class TeamspaceDryRunRowMapping:
+    """Mapping from one local status row to its synthesized TeamSpace event."""
+
+    mission_slug: str
+    artifact_path: str
+    line_number: int | None
+    source_event_id: str
+    synthesized_event_id: str
+    synthesized_event_type: str
+    aggregate_id: str
+    row_sha256: str | None
+    envelope_sha256: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "mission_slug": self.mission_slug,
+            "artifact_path": self.artifact_path,
+            "line_number": self.line_number,
+            "source_event_id": self.source_event_id,
+            "synthesized_event_id": self.synthesized_event_id,
+            "synthesized_event_type": self.synthesized_event_type,
+            "aggregate_id": self.aggregate_id,
+            "row_sha256": self.row_sha256,
+            "envelope_sha256": self.envelope_sha256,
+        }
+
+
+@dataclass(frozen=True)
 class TeamspaceDryRunReport:
     """Validation report for canonical envelopes synthesized from local state."""
 
@@ -185,6 +213,8 @@ class TeamspaceDryRunReport:
     envelope_count: int
     valid: bool
     errors: tuple[dict[str, object], ...]
+    row_mappings: tuple[TeamspaceDryRunRowMapping, ...] = ()
+    context_warnings: tuple[dict[str, object], ...] = ()
     side_logs: tuple[dict[str, object], ...] = ()
 
     def to_dict(self) -> dict[str, object]:
@@ -194,6 +224,8 @@ class TeamspaceDryRunReport:
             "envelope_count": self.envelope_count,
             "valid": self.valid,
             "errors": list(self.errors),
+            "row_mappings": [mapping.to_dict() for mapping in self.row_mappings],
+            "context_warnings": list(self.context_warnings),
             "side_logs": list(self.side_logs),
         }
 
@@ -281,6 +313,8 @@ def teamspace_dry_run(
     count = 0
     project_slug = repo_root.resolve().name
     repo_slug = _repo_slug(repo_root.resolve())
+    row_mappings: list[TeamspaceDryRunRowMapping] = []
+    context_warnings = _teamspace_context_warnings(repo_root.resolve(), project_uuid)
 
     from specify_cli.status.store import read_events
 
@@ -290,6 +324,7 @@ def teamspace_dry_run(
         errors.extend(raw_status_errors)
         if raw_status_errors:
             continue
+        row_locations = _status_row_locations(mission_dir)
         try:
             events = read_events(mission_dir)
         except Exception as exc:
@@ -309,6 +344,26 @@ def teamspace_dry_run(
                 lamport_clock=index,
                 project_slug=project_slug,
                 repo_slug=repo_slug,
+            )
+            row_location = row_locations.get(status_event.event_id)
+            row_mappings.append(
+                TeamspaceDryRunRowMapping(
+                    mission_slug=status_event.mission_slug,
+                    artifact_path=_repo_relpath(repo_root.resolve(), mission_dir / EVENTS_FILENAME),
+                    line_number=row_location.line_number if row_location is not None else None,
+                    source_event_id=status_event.event_id,
+                    synthesized_event_id=envelope["event_id"],
+                    synthesized_event_type=envelope["event_type"],
+                    aggregate_id=envelope["aggregate_id"],
+                    row_sha256=(
+                        hashlib.sha256(row_location.text.encode("utf-8")).hexdigest()
+                        if row_location is not None
+                        else None
+                    ),
+                    envelope_sha256=hashlib.sha256(
+                        json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                    ).hexdigest(),
+                )
             )
             try:
                 event_cls.model_validate(envelope)
@@ -346,8 +401,57 @@ def teamspace_dry_run(
         envelope_count=count,
         valid=not errors,
         errors=tuple(errors),
+        row_mappings=tuple(row_mappings),
+        context_warnings=tuple(context_warnings),
         side_logs=tuple(side_logs),
     )
+
+
+def _teamspace_context_warnings(repo_root: Path, project_uuid: uuid.UUID) -> list[dict[str, object]]:
+    warnings: list[dict[str, object]] = []
+    try:
+        from specify_cli.identity.project import load_identity
+
+        identity = load_identity(repo_root / ".kittify" / "config.yaml")
+    except Exception:
+        identity = None
+
+    if identity is None or identity.project_uuid is None:
+        warnings.append(
+            {
+                "code": "TEAMSPACE_PROJECT_CONTEXT_MISSING",
+                "message": (
+                    "No persisted project.uuid was found; dry-run used a deterministic "
+                    "offline project_uuid for schema validation only."
+                ),
+                "dry_run_project_uuid": str(project_uuid),
+            }
+        )
+
+    warnings.append(
+        {
+            "code": "TEAMSPACE_TEAM_CONTEXT_NOT_VALIDATED",
+            "message": "Team/private TeamSpace membership is not checked by offline dry-run.",
+        }
+    )
+    return warnings
+
+
+def _status_row_locations(mission_dir: Path) -> dict[str, _RawJsonlRow]:
+    status_path = mission_dir / EVENTS_FILENAME
+    if not status_path.exists():
+        return {}
+    try:
+        rows = _read_jsonl_rows(status_path)
+    except Exception:
+        return {}
+
+    locations: dict[str, _RawJsonlRow] = {}
+    for row in rows:
+        event_id = _event_id(row.data)
+        if event_id is not None:
+            locations.setdefault(event_id, row)
+    return locations
 
 
 def _load_events_contract() -> tuple[type[Any], Any, str]:
@@ -1116,6 +1220,7 @@ __all__ = [
     "MissionStateDryRunError",
     "MissionStateRepairError",
     "RepairReport",
+    "TeamspaceDryRunRowMapping",
     "TeamspaceDryRunReport",
     "deterministic_ulid",
     "repair_repo",

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -145,6 +145,24 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
     assert dry_run.events_package_version == "5.0.0"
     assert dry_run.envelope_count == 1
     assert dry_run.errors == ()
+    assert len(dry_run.row_mappings) == 1
+    mapping = dry_run.row_mappings[0].to_dict()
+    assert mapping["mission_slug"] == "042-historical-shape"
+    assert mapping["artifact_path"] == "kitty-specs/042-historical-shape/status.events.jsonl"
+    assert mapping["line_number"] == 1
+    assert mapping["source_event_id"] == "01KQHRB8GCFJAX7HM4ZY52AQGR"
+    assert mapping["synthesized_event_id"] == "01KQHRB8GCFJAX7HM4ZY52AQGR"
+    assert mapping["synthesized_event_type"] == "WPStatusChanged"
+    assert mapping["aggregate_id"] == "WP01"
+    assert isinstance(mapping["row_sha256"], str)
+    assert isinstance(mapping["envelope_sha256"], str)
+    assert {
+        warning["code"]
+        for warning in dry_run.context_warnings
+    } == {
+        "TEAMSPACE_PROJECT_CONTEXT_MISSING",
+        "TEAMSPACE_TEAM_CONTEXT_NOT_VALIDATED",
+    }
     assert dry_run.side_logs == (
         {
             "artifact_path": "kitty-specs/042-historical-shape/mission-events.jsonl",
@@ -320,6 +338,7 @@ def test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows(tm
     assert dry_run.valid
     assert dry_run.envelope_count == 1
     assert dry_run.errors == ()
+    assert len(dry_run.row_mappings) == 1
 
 
 def test_repo_slug_preserves_https_remote_colon(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds deterministic `row_mappings` to `spec-kitty doctor mission-state --teamspace-dry-run --json` so operators can see exactly which local `status.events.jsonl` rows synthesize into TeamSpace envelopes.
- Adds `context_warnings` for offline dry-run context: missing persisted `project.uuid` is reported separately from local schema validity, and team/private TeamSpace membership is explicitly marked as not validated offline.
- Covers the new report shape in mission-state repair tests.

## Why Now

This closes the remaining reporting gap for the TeamSpace historical mission-state dry-run path in #927 and supports the broader launch-readiness epic #920, E2E rehearsal #932, and CI launch gate #934.

## Effect on Existing Projects

Runtime / compatibility: JSON output gains additive fields only. Existing dry-run validity semantics are unchanged.

Upgrade / migration: none.

Operator / reviewer impact: dry-run artifacts now contain stable source row hashes and synthesized envelope hashes for audit/rehearsal evidence.

## Validation

- [x] `uv run ruff check src/specify_cli/migration/mission_state.py tests/migration/test_mission_state_repair.py`
- [x] `uv run pytest tests/migration/test_mission_state_repair.py -q`

## Tickets / Contracts

| Ticket | Relationship |
|--------|--------------|
| #920 | Supports epic |
| #927 | Addresses dry-run row reporting/context separation |
| #932 | Provides deterministic rehearsal evidence |
| #934 | Keeps offline readiness gate deterministic |
