### PR TITLE
docs: prefer pipx for CLI installation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ gh run watch <run_id>
 
 # 5. Verify:
 gh release view vX.Y.Z
-pip install --upgrade spec-kitty-cli && spec-kitty --version
+pipx install --force spec-kitty-cli==X.Y.Z && spec-kitty --version
 ```
 
 Full docs: [CONTRIBUTING.md](CONTRIBUTING.md#release-process)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ unset GITHUB_TOKEN && gh run watch <run-id>
 
 # 5. Verify
 unset GITHUB_TOKEN && gh release view vX.Y.Z
-pip install spec-kitty-cli==X.Y.Z
+pipx install --force spec-kitty-cli==X.Y.Z
 ```
 
 ### Full Release (Minor/Major)
@@ -257,7 +257,7 @@ For larger releases with multiple changes:
 8. **Verify the release**
    ```bash
    unset GITHUB_TOKEN && gh release view vX.Y.Z
-   pip install spec-kitty-cli==X.Y.Z
+   pipx install --force spec-kitty-cli==X.Y.Z
    ```
 
 9. **Clean up**
@@ -298,7 +298,7 @@ Before tagging a release, ensure:
 - **Use annotated tags** — always use `git tag -a`, not `git tag`
 - **Monitor the release workflow** — watch for failures and be ready to fix issues
 - **PyPI is immutable** — once published, a version cannot be changed (only yanked)
-- **PyPI CDN caching** — `pip install --upgrade` may not find the new version immediately; use `pip install spec-kitty-cli==X.Y.Z` instead
+- **PyPI CDN caching** — `pipx upgrade` may not find the new version immediately; use `pipx install --force spec-kitty-cli==X.Y.Z` instead
 
 ### Troubleshooting Releases
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,19 @@ It is probably overkill for one-off edits, tiny scripts, or teams that do not us
 Install the CLI:
 
 ```bash
-pip install spec-kitty-cli
-# or
+pipx install spec-kitty-cli
+```
+
+`pipx` is the preferred installer for the CLI because it keeps Spec Kitty in its
+own virtual environment and avoids the `externally-managed-environment` errors
+common on modern Linux distributions.
+
+Other supported install methods:
+
+```bash
 uv tool install spec-kitty-cli
+# or, inside an activated virtual environment
+python -m pip install spec-kitty-cli
 ```
 
 Create or initialize a project:

--- a/docs/explanation/ai-agent-architecture.md
+++ b/docs/explanation/ai-agent-architecture.md
@@ -121,7 +121,8 @@ Each command template contains:
 
 ### Keeping Templates in Sync
 
-When you upgrade Spec Kitty (`pip install --upgrade spec-kitty-cli`), migrations update all agent directories:
+When you upgrade Spec Kitty (`pipx upgrade spec-kitty-cli`, or the equivalent
+command for your installer), migrations update all agent directories:
 
 ```python
 # Example migration updating all 12 agents

--- a/docs/how-to/2-1-main-cutover-checklist.md
+++ b/docs/how-to/2-1-main-cutover-checklist.md
@@ -88,7 +88,8 @@ Do these steps in GitHub settings/UI during the freeze window.
 
 - [ ] Verify GitHub release `v2.1.0` exists.
 - [ ] Verify PyPI shows `2.1.0` as the latest version.
-- [ ] Verify `pip install spec-kitty-cli` installs `2.1.0`.
+- [ ] Verify `pipx install spec-kitty-cli` installs `2.1.0`; optionally verify
+      `python -m pip install spec-kitty-cli` inside a virtual environment.
 - [ ] Smoke-test `spec-kitty --version` and `spec-kitty init` from the PyPI install.
 - [ ] Verify upgrade behavior on a representative existing project.
 

--- a/docs/how-to/install-and-upgrade.md
+++ b/docs/how-to/install-and-upgrade.md
@@ -15,6 +15,38 @@ Spec Kitty never silently upgrades itself and never touches projects you are not
 
 ---
 
+## Install the CLI
+
+For new installations, prefer `pipx`:
+
+```bash
+pipx install spec-kitty-cli
+pipx ensurepath
+spec-kitty --version
+```
+
+`pipx` keeps the CLI in its own virtual environment while exposing the
+`spec-kitty` command on your PATH. This avoids the PEP 668
+`externally-managed-environment` failure that direct `pip install` commands can
+hit on Ubuntu 24.04, Debian 12, Fedora, and other distro-managed Python
+installations.
+
+Other supported install methods:
+
+```bash
+uv tool install spec-kitty-cli
+```
+
+```bash
+# Inside an activated virtual environment or managed CI Python image
+python -m pip install spec-kitty-cli
+```
+
+Use `pip` when you are intentionally managing the Python environment yourself.
+Do not use `--break-system-packages` as a normal Spec Kitty install path.
+
+---
+
 ## Upgrade the CLI
 
 Run from anywhere:
@@ -27,7 +59,7 @@ Spec Kitty detects your install method and prints the right command:
 
 | Install method | Upgrade command |
 |---|---|
-| pipx | `pipx upgrade spec-kitty-cli` |
+| pipx (preferred) | `pipx upgrade spec-kitty-cli` |
 | pip (user) | `pip install --upgrade --user spec-kitty-cli` |
 | pip (venv/system) | `pip install --upgrade spec-kitty-cli` |
 | Homebrew | `brew upgrade spec-kitty` |

--- a/docs/how-to/install-spec-kitty.md
+++ b/docs/how-to/install-spec-kitty.md
@@ -8,9 +8,10 @@
 
 - **Linux/macOS** (or Windows; PowerShell scripts now supported without WSL)
 - AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
-- [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
+- [pipx](https://pipx.pypa.io/stable/installation/) for the recommended CLI install path
+- Optional: [uv](https://docs.astral.sh/uv/) if your team standardizes on uv-managed tools
 
 ## Installation
 
@@ -18,9 +19,28 @@
 
 #### From PyPI (Recommended - Stable Releases)
 
-**Using pip:**
+**Using pipx (preferred):**
 ```bash
-pip install spec-kitty-cli
+pipx install spec-kitty-cli
+```
+
+`pipx` installs Spec Kitty as an application in an isolated virtual environment
+and places the `spec-kitty` command on your PATH. This is the safest default on
+modern Python installations because many Linux distributions now block direct
+system-wide `pip install` commands with PEP 668
+`externally-managed-environment` errors.
+
+If this is your first `pipx` install, make sure its binary directory is on your
+PATH:
+
+```bash
+pipx ensurepath
+```
+
+Then open a new shell and verify:
+
+```bash
+spec-kitty --version
 ```
 
 **Using uv:**
@@ -28,11 +48,23 @@ pip install spec-kitty-cli
 uv tool install spec-kitty-cli
 ```
 
+**Using pip in an activated virtual environment or managed CI Python image:**
+```bash
+python -m pip install spec-kitty-cli
+```
+
+Use `pip` when you are already inside a project-specific virtual environment,
+CI image, or other Python environment you intentionally manage. Avoid direct
+system-wide `pip install spec-kitty-cli` on distro-managed Python installs.
+
 #### From GitHub (Latest Development)
 
-**Using pip:**
+Use the GitHub install path when you need the latest unreleased code from
+`main`.
+
+**Using pipx (preferred):**
 ```bash
-pip install git+https://github.com/Priivacy-ai/spec-kitty.git
+pipx install git+https://github.com/Priivacy-ai/spec-kitty.git
 ```
 
 **Using uv:**
@@ -40,11 +72,16 @@ pip install git+https://github.com/Priivacy-ai/spec-kitty.git
 uv tool install spec-kitty-cli --from git+https://github.com/Priivacy-ai/spec-kitty.git
 ```
 
+**Using pip in an activated virtual environment or managed CI Python image:**
+```bash
+python -m pip install git+https://github.com/Priivacy-ai/spec-kitty.git
+```
+
 ### Initialize a New Project
 
 After installation, initialize a new project:
 
-**If installed globally:**
+**If installed with pipx, uv, or an active virtual environment:**
 ```bash
 spec-kitty init <PROJECT_NAME>
 ```
@@ -123,6 +160,25 @@ After initialization, you should see the following commands available in your AI
 Run `spec-kitty dashboard --open` if you want the live dashboard immediately after setup.
 
 ## Troubleshooting
+
+### `pip install` fails with `externally-managed-environment`
+
+On Ubuntu 24.04, Debian 12, Fedora, and other modern distributions, Python may
+refuse direct system-wide `pip install spec-kitty-cli` commands because the OS
+owns the system Python environment. Install the CLI with `pipx` instead:
+
+```bash
+pipx install spec-kitty-cli
+pipx ensurepath
+```
+
+If you must use `pip`, create and activate a virtual environment first:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install spec-kitty-cli
+```
 
 ### Git Credential Manager on Linux
 

--- a/docs/how-to/manage-agents.md
+++ b/docs/how-to/manage-agents.md
@@ -518,7 +518,11 @@ spec-kitty agent config add claude codex opencode
 
 **Cause**: spec-kitty is not installed or not in PATH.
 
-**Solution**: Ensure spec-kitty is installed via `pip install spec-kitty-cli` and your shell's PATH includes Python package binaries.
+**Solution**: Install Spec Kitty with `pipx install spec-kitty-cli`, then run
+`pipx ensurepath` and open a new shell. If your team uses `uv`, `uv tool
+install spec-kitty-cli` is also supported. Use `python -m pip install
+spec-kitty-cli` only inside an activated virtual environment or another Python
+environment you intentionally manage.
 
 **Not a configuration issue**: This is an installation problem. See [Installation Guide](install-spec-kitty.md).
 

--- a/docs/how-to/upgrade-to-0-12-0.md
+++ b/docs/how-to/upgrade-to-0-12-0.md
@@ -43,7 +43,9 @@ This updates `config.yaml` AND deletes directories consistently.
 ### Step 2: Upgrade spec-kitty
 
 ```bash
-pip install --upgrade spec-kitty-cli
+pipx upgrade spec-kitty-cli
+# or, inside an activated virtual environment:
+python -m pip install --upgrade spec-kitty-cli
 ```
 
 ### Step 3: Verify Configuration

--- a/docs/migration/shared-package-boundary-cutover.md
+++ b/docs/migration/shared-package-boundary-cutover.md
@@ -14,7 +14,10 @@ external PyPI dependencies, but the vendored events copy at
 
 Concretely, after this release:
 
-- `pip install spec-kitty-cli` is the only install step.
+- `spec-kitty-cli` is the only package you need to install. Prefer
+  `pipx install spec-kitty-cli` for the CLI; `python -m pip install
+  spec-kitty-cli` remains supported inside a virtual environment or another
+  intentionally managed Python environment.
 - `spec-kitty-events` and `spec-kitty-tracker` are pulled in transitively
   with compatibility ranges (`>=4.0.0,<5.0.0` and `>=0.4,<0.5`,
   respectively); exact versions live in `uv.lock`.
@@ -23,10 +26,11 @@ Concretely, after this release:
 ## Action required
 
 For most operators: nothing. Re-run
-`pip install --upgrade spec-kitty-cli` (or
-`uv tool upgrade spec-kitty-cli`) and the new release works without
-`spec-kitty-runtime`. The retired package may remain installed in your
-environment from a previous release; it is harmless and unused.
+`pipx upgrade spec-kitty-cli` (or the equivalent upgrade command for your
+installer, such as `uv tool upgrade spec-kitty-cli` or `python -m pip install
+--upgrade spec-kitty-cli` inside a virtual environment) and the new release
+works without `spec-kitty-runtime`. The retired package may remain installed in
+your environment from a previous release; it is harmless and unused.
 
 ## Optional cleanup
 

--- a/docs/tutorials/claude-code-integration.md
+++ b/docs/tutorials/claude-code-integration.md
@@ -17,7 +17,7 @@ Spec Kitty provides structured slash commands that keep Claude Code focused on r
 
 ```bash
 # 1. Install both tools
-pip install spec-kitty-cli
+pipx install spec-kitty-cli
 
 # 2. Initialize your project
 spec-kitty init myproject --ai claude
@@ -434,7 +434,7 @@ claude
 **Cause**: Installed v0.10.0-0.10.8 which had bundling bug
 **Fix**:
 ```bash
-pip install --upgrade spec-kitty-cli  # Get v0.10.9+
+pipx upgrade spec-kitty-cli  # Get v0.10.9+
 cd myproject
 spec-kitty upgrade  # Auto-repairs templates
 ```

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -9,14 +9,26 @@ In this tutorial, you'll install Spec Kitty and create your first feature specif
 
 ## Step 1: Install Spec Kitty
 
-Choose one install method:
+Install the CLI with `pipx`:
 
 ```bash
-pip install spec-kitty-cli
+pipx install spec-kitty-cli
 ```
+
+`pipx` is preferred for command-line tools because it creates an isolated
+virtual environment for Spec Kitty and avoids the
+`externally-managed-environment` errors that modern Linux distributions can
+raise for direct `pip install` commands.
+
+Other supported install methods:
 
 ```bash
 uv tool install spec-kitty-cli
+```
+
+```bash
+# Inside an activated virtual environment
+python -m pip install spec-kitty-cli
 ```
 
 Verify the CLI is available:
@@ -89,7 +101,8 @@ ls .worktrees
 
 ## Troubleshooting
 
-- **`spec-kitty: command not found`**: Reopen your shell or reinstall via `pipx` or `uv`. Then rerun `spec-kitty --version`.
+- **`spec-kitty: command not found`**: Reopen your shell, run `pipx ensurepath` if you installed with `pipx`, or reinstall via `pipx` or `uv`. Then rerun `spec-kitty --version`.
+- **`pip install` fails with `externally-managed-environment`**: Use `pipx install spec-kitty-cli`, or create and activate a virtual environment before using `python -m pip install spec-kitty-cli`.
 - **No `/spec-kitty.specify` command available**: Re-run `spec-kitty init . --ai <your-agent>` from the project root, then verify the setup with `spec-kitty verify-setup --diagnostics`.
 - **`WAITING_FOR_DISCOVERY_INPUT`**: The command is paused for your answers; provide the requested details and continue.
 

--- a/examples/solo-developer-workflow.md
+++ b/examples/solo-developer-workflow.md
@@ -13,7 +13,7 @@ Quick iteration for individual developers using Spec Kitty with a single AI agen
 ### 0. Install & Initialize (One-time)
 ```bash
 # Install CLI
-pip install spec-kitty-cli
+pipx install spec-kitty-cli
 
 # Initialize project
 spec-kitty init my-saas-app --ai claude

--- a/src/doctrine/skills/spec-kitty-setup-doctor/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-setup-doctor/SKILL.md
@@ -63,7 +63,8 @@ spec-kitty verify-setup
 If `spec-kitty` is not installed:
 
 ```bash
-pip install spec-kitty-cli
+pipx install spec-kitty-cli
+pipx ensurepath
 spec-kitty --version
 ```
 

--- a/src/specify_cli/core/version_checker.py
+++ b/src/specify_cli/core/version_checker.py
@@ -215,7 +215,11 @@ Your project is NEWER than your CLI.
 This project was created or upgraded with a newer version
 of spec-kitty-cli. Please upgrade your CLI:
 
-  pip install --upgrade spec-kitty-cli
+  pipx upgrade spec-kitty-cli
+
+Or use the upgrade command for your install method, such as
+`uv tool upgrade spec-kitty-cli` or `python -m pip install --upgrade
+spec-kitty-cli` inside an activated virtual environment.
 
 After upgrading, run:
 

--- a/src/specify_cli/migration/schema_version.py
+++ b/src/specify_cli/migration/schema_version.py
@@ -179,7 +179,8 @@ def check_compatibility(
             message=(
                 f"Project schema version {project_version} is newer than this CLI "
                 f"supports ({cli_version}). "
-                "Upgrade your CLI: `pip install --upgrade spec-kitty-cli`"
+                "Upgrade your CLI: `pipx upgrade spec-kitty-cli` or use the "
+                "upgrade command for your installer."
             ),
             exit_code=1,
         )

--- a/src/specify_cli/template/asset_generator.py
+++ b/src/specify_cli/template/asset_generator.py
@@ -247,8 +247,8 @@ def _raise_template_discovery_error(commands_dir: Path) -> None:  # noqa: ARG001
         + (f" = {remote_repo}" if remote_repo else " (not configured)")
         + "\n\n"
         "To fix this, try one of these approaches:\n\n"
-        "1. Reinstall from PyPI (recommended for end users):\n"
-        "   pip install --upgrade spec-kitty-cli\n\n"
+        "1. Reinstall from PyPI with pipx (recommended for end users):\n"
+        "   pipx install --force spec-kitty-cli\n\n"
         "2. Use --template-root flag (for development):\n"
         "   spec-kitty init . --template-root=/path/to/spec-kitty\n\n"
         "3. Set environment variable (for development):\n"


### PR DESCRIPTION
## Summary
- Prefer pipx across README, DocFX install docs, tutorials, examples, and setup-doctor guidance
- Keep pip documented for activated virtual environments and managed CI Python images
- Update generic CLI recovery messages to avoid recommending bare system pip by default

Fixes #1012

## Verification
- uv run --extra test python -m pytest -q tests/specify_cli/compat/test_upgrade_hint.py tests/specify_cli/cli/commands/test_upgrade_command.py tests/docs/test_architecture_docs_consistency.py tests/docs/test_versioned_docs_integrity.py
- git diff --check