### PR TITLE
Close mission-state migration readiness gaps

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc4
+  version: 3.2.0rc5
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc3
+  version: 3.2.0rc4
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.2.0rc4] - 2026-05-10
+
+3.2.0rc4 closes the remaining CLI-side migration readiness gaps found while
+rechecking the TeamSpace mission-state migration parent issue.
+
+### Changed
+
+- Require `spec-kitty-events>=5.0.0` now that the 5.0.0 contract package is
+  published, and lock the release candidate against the PyPI package.
+- Document the deterministic historical mission-state repair contract and the
+  safe release sequencing used before any repository-wide repair is required.
+
+### Fixed
+
+- Block TeamSpace dry-run/import envelope synthesis when audit findings still
+  contain TeamSpace blockers, so legacy mission-state rows cannot bypass the
+  readiness audit.
+- Reject historical mission-state sync batches with legacy status fields before
+  network submission, preserving the local queue and returning remediation.
+
 ## [3.2.0rc3] - 2026-05-06
 
 3.2.0rc3 fixes a TeamSpace dry-run compatibility gap found during the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Removed
+
+## [3.2.0rc5] - 2026-05-11
+
+3.2.0rc5 closes the remaining CLI-side TeamSpace migration readiness gaps found
+while rechecking the historical mission-state migration parent issue.
+
+### Changed
+
 - Documented the deterministic historical mission-state repair contract and
   safe release sequencing used before any repository-wide repair is required.
 
@@ -23,8 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   readiness audit.
 - Reject historical mission-state sync batches with legacy status fields before
   network submission, preserving the local queue and returning remediation.
-
-### Removed
 
 ## [3.2.0rc4] - 2026-05-11
 

--- a/architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md
+++ b/architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md
@@ -1,0 +1,67 @@
+# ADR 1 (2026-05-10): Deterministic Historical Mission-State Repair Identity
+
+**Date:** 2026-05-10
+**Status:** Accepted
+**Deciders:** spec-kitty core team
+**Technical Story:** Priivacy-ai/spec-kitty#920, Priivacy-ai/spec-kitty#923
+**Tags:** mission-state, migration, identity, distributed-git, teamspace
+
+## Context
+
+Historical `kitty-specs/` directories may predate `mission_id`. TeamSpace import
+requires stable mission identity, but public migration must be safe in
+distributed Git: two clones of the same historical repository must produce the
+same repaired artifacts without consulting a server, a clock, or randomness.
+
+New missions still use creation-time ULIDs as decided in
+`2026-04-09-1-mission-identity-uses-ulid-not-sequential-prefix.md`. This ADR
+only governs deterministic repair for historical missions that lack a valid
+`mission_id`.
+
+## Decision
+
+Historical repair derives missing `mission_id` values deterministically from
+repository-local mission material:
+
+1. Existing valid `mission_id` values are authoritative and are never changed.
+2. Missing or invalid IDs are replaced by `deterministic_ulid(seed)`, where the
+   seed is JSON serialized with sorted keys from:
+   - canonical mission slug,
+   - `slug`,
+   - `friendly_name`,
+   - `created_at`,
+   - `target_branch`,
+   - `mission_type`,
+   - first status-event `event_id`, when present,
+   - first status-event `at`, when present.
+3. When historical material is sparse, repair still uses deterministic defaults
+   already written by the canonicalizer, including the mission directory name
+   and the Unix epoch fallback for missing `created_at`.
+4. The generated identifier must be ULID-compatible in shape: 26 Crockford
+   Base32 characters accepted by the current `ULID_PATTERN`.
+5. Timestamp bits are not interpreted as wall-clock time for repaired IDs. The
+   full 128-bit value is derived from SHA-256 seed material, so the encoded
+   prefix is deterministic hash material, not a chronological claim.
+6. Fork behavior is content-based: two clones with byte-identical historical
+   mission material produce the same repaired ID; forks that change seed
+   material before repair can produce different repaired IDs. Once a valid
+   `mission_id` exists, later forks preserve it unchanged.
+
+## Consequences
+
+- Repair is reproducible across clones and CI runners.
+- Repair does not need hosted TeamSpace, tracker, auth, or sync configuration.
+- Sparse historical missions remain repairable, but the manifest and audit
+  output show what was defaulted.
+- Operators must coordinate the repair commit before TeamSpace import so forked
+  branches inherit the same persisted `mission_id`.
+
+## Confirmation
+
+This ADR is implemented when tests prove:
+
+- two cloned historical fixtures produce byte-identical repair diffs;
+- running repair twice yields no second diff;
+- existing valid IDs are preserved;
+- divergent pre-repair seed material produces different deterministic IDs;
+- TeamSpace dry-run refuses audit-blocking historical shapes before import.

--- a/docs/migration/teamspace-mission-state-920-closeout.md
+++ b/docs/migration/teamspace-mission-state-920-closeout.md
@@ -1,0 +1,70 @@
+# TeamSpace Mission-State #920 Closeout Evidence
+
+Generated from clean workspace
+`spec-kitty-20260510-191702-gGiW54`.
+
+## Current conclusion
+
+Do not close `Priivacy-ai/spec-kitty#920` yet.
+
+The CLI repair/import-readiness implementation is now covered, and this branch
+closes the remaining spec-kitty implementation/documentation gaps found in
+`#923`, `#925`, `#931`, `#935`, and `#978`. The parent epic still has real
+operational and cross-repo work outside this branch:
+
+- `Priivacy-ai/spec-kitty#979` is open: the actual coordinated repair commits
+  have not been run across active repositories.
+- Active repository audits still report TeamSpace blockers:
+  - `spec-kitty`: 140 missions, 86 missions with TeamSpace blockers, 2455
+    total blockers.
+  - `spec-kitty-saas`: 48 missions, 33 missions with TeamSpace blockers, 1773
+    total blockers.
+  - `spec-kitty-events`: 18 missions, 15 missions with TeamSpace blockers, 499
+    total blockers.
+- `Priivacy-ai/spec-kitty-runtime#17` is still open.
+- `Priivacy-ai/spec-kitty-saas#143`, `#144`, `#145`, and `#146` are still open.
+
+## Evidence by issue
+
+| Issue | Status | Evidence |
+|---|---:|---|
+| spec-kitty `#921` audit engine | implemented | `tests/audit -q` passed: 174 tests. |
+| spec-kitty `#922` CLI audit command | implemented | `tests/audit/test_audit_cli.py` covered `--audit`, `--json`, `--mission`, `--fail-on`, and `--include-fixtures`. |
+| spec-kitty `#923` identity ADR | implemented on this branch | ADR added at `architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md`; fork-seed behavior covered in `test_deterministic_repair_ids_follow_fork_seed_material`. |
+| spec-kitty `#924` local canonicalizer | implemented | `tests/migration/test_mission_state_repair.py` covers canonicalization, idempotency, deterministic IDs, event preservation, quarantine, and manifest evidence. |
+| spec-kitty `#925` distributed Git safety | implemented on this branch | Added tests for held common-dir lock and dirty relevant paths in a linked worktree. No commit mode exists, so path-whitelisted staging is not applicable. |
+| spec-kitty `#926` deterministic public migration | implemented | Two-clone rehearsal verifies byte-identical diffs and deterministic dry-run output. |
+| spec-kitty `#927` TeamSpace dry-run | closed | Dry-run validates against `spec-kitty-events` 5.0.0 and reports row mappings/side logs. |
+| spec-kitty `#928` side logs | implemented | Dry-run reports decision/runtime/mission side logs with skipped disposition; audit/dry-run prevent them being reduced as status transitions. |
+| spec-kitty `#929` fixture pack | implemented | Packaged and test fixtures are exercised by `tests/audit`. |
+| spec-kitty `#930` manifest | implemented | `RepairReport` records schema version, run id, repo head, targets, file checksums, row transformations, quarantine counts, and validation results. |
+| spec-kitty `#931` sync/import guardrail | implemented on this branch | `teamspace_dry_run` now blocks on audit blockers before envelope synthesis; batch sync rejects historical mission-state fields before network POST. |
+| spec-kitty `#932` rehearsal | closed | `tests/migration/test_teamspace_migration_rehearsal.py` passes with `spec-kitty-events` 5.0.0. |
+| spec-kitty `#933` operator runbook | implemented | `docs/migration/teamspace-mission-state-repair.md`. |
+| spec-kitty `#934` CI readiness gate | closed | `.github/workflows/teamspace-mission-state-readiness.yml`. |
+| spec-kitty `#935` release sequencing | implemented on this branch | Release sequencing section added to the runbook. |
+| spec-kitty `#978` events dependency | implemented on this branch | `pyproject.toml` now requires `spec-kitty-events>=5.0.0,<6.0.0`; `uv.lock` resolves 5.0.0 from PyPI. |
+| spec-kitty `#979` actual repair commit | open | Not done. Audits above prove the active repositories still need coordinated repair commits. |
+| spec-kitty-events `#18`, `#19`, `#20` | closed | GitHub state is closed; local dependency now resolves `spec-kitty-events` 5.0.0. |
+| spec-kitty-tracker `#13` | closed | Existing issue comments record focused tracker verification: canonical TeamSpace/no-rollout tests passed. |
+| spec-kitty-saas `#149` | closed | GitHub state is closed. |
+| spec-kitty-saas `#143`-`#146` | open | Still open in GitHub and listed by the parent epic. |
+| spec-kitty-runtime `#17` | open | Still open in GitHub and listed by the parent epic. |
+
+## Verification run
+
+Commands run in the clean checkout:
+
+```bash
+uv run ruff check architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md docs/migration/teamspace-mission-state-repair.md pyproject.toml src/specify_cli/migration/mission_state.py src/specify_cli/sync/batch.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/contract/test_events_envelope_matches_resolved_version.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py::TestHistoricalMissionStateGuard tests/release/test_check_shared_package_drift.py tests/architectural/test_pyproject_shape.py -q
+uv run pytest tests/audit -q
+uv lock --check
+```
+
+Results:
+
+- Ruff passed.
+- Targeted migration/contract/sync/release/architecture suite: 26 passed.
+- Audit suite: 174 passed.
+- `uv lock --check` passed.

--- a/docs/migration/teamspace-mission-state-920-closeout.md
+++ b/docs/migration/teamspace-mission-state-920-closeout.md
@@ -43,7 +43,7 @@ operational and cross-repo work outside this branch:
 | spec-kitty `#933` operator runbook | implemented | `docs/migration/teamspace-mission-state-repair.md`. |
 | spec-kitty `#934` CI readiness gate | closed | `.github/workflows/teamspace-mission-state-readiness.yml`. |
 | spec-kitty `#935` release sequencing | implemented on this branch | Release sequencing section added to the runbook. |
-| spec-kitty `#978` events dependency | implemented on this branch | `pyproject.toml` now requires `spec-kitty-events>=5.0.0,<6.0.0`; `uv.lock` resolves 5.0.0 from PyPI; release metadata advanced to `3.2.0rc4`. |
+| spec-kitty `#978` events dependency | implemented on this branch | `pyproject.toml` now requires `spec-kitty-events>=5.0.0,<6.0.0`; `uv.lock` resolves 5.0.0 from PyPI; release metadata advanced to `3.2.0rc5`. |
 | spec-kitty `#979` actual repair commit | open | Not done. Audits above prove the active repositories still need coordinated repair commits. |
 | spec-kitty-events `#18`, `#19`, `#20` | closed | GitHub state is closed; local dependency now resolves `spec-kitty-events` 5.0.0. |
 | spec-kitty-tracker `#13` | closed | Existing issue comments record focused tracker verification: canonical TeamSpace/no-rollout tests passed. |
@@ -65,8 +65,8 @@ uv lock --check
 
 Results:
 
-- Release metadata validation passed for `3.2.0rc4` against latest tag
-  `v3.2.0rc3`.
+- Release metadata validation passed for `3.2.0rc5` against latest tag
+  `v3.2.0rc4`.
 - Ruff passed.
 - Targeted migration/contract/sync/release/architecture suite: 33 passed, 5
   skipped.

--- a/docs/migration/teamspace-mission-state-920-closeout.md
+++ b/docs/migration/teamspace-mission-state-920-closeout.md
@@ -43,7 +43,7 @@ operational and cross-repo work outside this branch:
 | spec-kitty `#933` operator runbook | implemented | `docs/migration/teamspace-mission-state-repair.md`. |
 | spec-kitty `#934` CI readiness gate | closed | `.github/workflows/teamspace-mission-state-readiness.yml`. |
 | spec-kitty `#935` release sequencing | implemented on this branch | Release sequencing section added to the runbook. |
-| spec-kitty `#978` events dependency | implemented on this branch | `pyproject.toml` now requires `spec-kitty-events>=5.0.0,<6.0.0`; `uv.lock` resolves 5.0.0 from PyPI. |
+| spec-kitty `#978` events dependency | implemented on this branch | `pyproject.toml` now requires `spec-kitty-events>=5.0.0,<6.0.0`; `uv.lock` resolves 5.0.0 from PyPI; release metadata advanced to `3.2.0rc4`. |
 | spec-kitty `#979` actual repair commit | open | Not done. Audits above prove the active repositories still need coordinated repair commits. |
 | spec-kitty-events `#18`, `#19`, `#20` | closed | GitHub state is closed; local dependency now resolves `spec-kitty-events` 5.0.0. |
 | spec-kitty-tracker `#13` | closed | Existing issue comments record focused tracker verification: canonical TeamSpace/no-rollout tests passed. |
@@ -56,15 +56,19 @@ operational and cross-repo work outside this branch:
 Commands run in the clean checkout:
 
 ```bash
-uv run ruff check architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md docs/migration/teamspace-mission-state-repair.md pyproject.toml src/specify_cli/migration/mission_state.py src/specify_cli/sync/batch.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py
-SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/contract/test_events_envelope_matches_resolved_version.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py::TestHistoricalMissionStateGuard tests/release/test_check_shared_package_drift.py tests/architectural/test_pyproject_shape.py -q
+python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
+uv run ruff check architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md docs/migration/teamspace-mission-state-repair.md docs/migration/teamspace-mission-state-920-closeout.md src/specify_cli/migration/mission_state.py src/specify_cli/sync/batch.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py tests/release/test_dogfood_command_set.py tests/release/test_validate_metadata_yaml_sync.py
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/contract/test_events_envelope_matches_resolved_version.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py::TestHistoricalMissionStateGuard tests/release/test_check_shared_package_drift.py tests/architectural/test_pyproject_shape.py tests/release/test_dogfood_command_set.py tests/release/test_validate_metadata_yaml_sync.py -q
 uv run pytest tests/audit -q
 uv lock --check
 ```
 
 Results:
 
+- Release metadata validation passed for `3.2.0rc4` against latest tag
+  `v3.2.0rc3`.
 - Ruff passed.
-- Targeted migration/contract/sync/release/architecture suite: 26 passed.
+- Targeted migration/contract/sync/release/architecture suite: 33 passed, 5
+  skipped.
 - Audit suite: 174 passed.
 - `uv lock --check` passed.

--- a/docs/migration/teamspace-mission-state-repair.md
+++ b/docs/migration/teamspace-mission-state-repair.md
@@ -100,3 +100,26 @@ make local-db-down
 Those SaaS tests validate canonical historical preflight, import
 deduplication, no persistence for rejected raw rows, and canonical mission
 identity behavior when the CLI supplies a mission ID.
+
+## Release Sequencing
+
+Use this rollout order for public TeamSpace launch:
+
+1. Phase 0: finalize the event contracts, identity ADR, and repair manifest
+   shape. Do not enable public import while contracts are still moving.
+2. Phase 1: ship the read-only audit and run it internally with
+   `--fail-on teamspace-blocker`.
+3. Phase 2: ship deterministic local `--fix`, rehearse it across cloned
+   historical repositories, and review generated manifests.
+4. Phase 3: ship `--teamspace-dry-run` and validate against SaaS dev without
+   uploading raw historical rows.
+5. Phase 4: enable the explicit TeamSpace import/sync path only after audit
+   and dry-run pass. Keep the GitHub readiness gate opt-in for repositories
+   that want CI enforcement.
+6. Phase 5: publish public launch documentation after the internal repair
+   window and dry-run evidence are complete.
+
+No public user should be forced through an untested repo-wide rewrite. Local
+CLI workflows continue to tolerate legacy missions where safe; TeamSpace
+import remains an explicit operator step after audit, repair, manifest review,
+and dry-run pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc4"
+version = "3.2.0rc5"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,9 @@ dependencies = [
     # src/specify_cli/next/_internal_runtime/ (see WP01 of mission
     # shared-package-boundary-cutover-01KQ22DS), and absence is enforced by
     # tests/architectural/test_pyproject_shape.py.
-    # TeamSpace dry-run requires spec-kitty-events>=5.0.0 at runtime; keep
-    # this as a public bounded range until 5.0.0 is published on PyPI.
-    "spec-kitty-events>=4.0.0,<6.0.0",
+    # TeamSpace dry-run and historical mission-state import readiness require
+    # the canonical 5.x event contract.
+    "spec-kitty-events>=5.0.0,<6.0.0",
     "spec-kitty-tracker>=0.4,<0.5",
     "websockets>=12.0",  # WebSocket client for sync protocol
     "toml>=0.10.2",  # Config file parsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc3"
+version = "3.2.0rc4"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -304,6 +304,20 @@ def teamspace_dry_run(
     """Synthesize TeamSpace envelopes from local status logs and validate them."""
     event_cls, validate_event, package_version = _load_events_contract()
     mission_dirs = _select_mission_dirs(repo_root.resolve(), scan_root=scan_root, mission=mission)
+    audit_errors = _teamspace_audit_blockers(repo_root.resolve(), scan_root=scan_root, mission_dirs=mission_dirs)
+    if audit_errors:
+        return TeamspaceDryRunReport(
+            schema_version=CANONICAL_ENVELOPE_SCHEMA_VERSION,
+            events_package_version=package_version,
+            envelope_count=0,
+            valid=False,
+            errors=tuple(audit_errors),
+            side_logs=tuple(
+                side_log
+                for mission_dir in mission_dirs
+                for side_log in _classify_side_logs(repo_root.resolve(), mission_dir)
+            ),
+        )
     project_uuid = uuid.uuid5(
         uuid.NAMESPACE_URL,
         "spec-kitty:teamspace-dry-run:" + "|".join(path.name for path in mission_dirs),
@@ -404,6 +418,50 @@ def teamspace_dry_run(
         row_mappings=tuple(row_mappings),
         context_warnings=tuple(context_warnings),
         side_logs=tuple(side_logs),
+    )
+
+
+def _teamspace_audit_blockers(
+    repo_root: Path,
+    *,
+    scan_root: Path | None,
+    mission_dirs: Sequence[Path],
+) -> list[dict[str, object]]:
+    """Return audit findings that must block TeamSpace historical import."""
+    from specify_cli.audit import AuditOptions, run_audit
+    from specify_cli.audit.models import is_teamspace_blocker
+
+    report = run_audit(AuditOptions(repo_root=repo_root, scan_root=scan_root))
+    selected_slugs = {path.name for path in mission_dirs}
+    errors: list[dict[str, object]] = []
+    for result in report.missions:
+        if result.mission_slug not in selected_slugs:
+            continue
+        for finding in result.findings:
+            if not is_teamspace_blocker(finding):
+                continue
+            errors.append(
+                {
+                    "mission_slug": result.mission_slug,
+                    "artifact_path": finding.artifact_path,
+                    "error": "MISSION_STATE_AUDIT_BLOCKER",
+                    "finding_code": finding.code,
+                    "severity": finding.severity.value,
+                    "message": finding.detail or finding.code,
+                    "remediation": (
+                        "Run `spec-kitty doctor mission-state --audit --fail-on "
+                        "teamspace-blocker`, then `--fix`, then "
+                        "`--teamspace-dry-run` before TeamSpace import/sync."
+                    ),
+                }
+            )
+    return sorted(
+        errors,
+        key=lambda item: (
+            str(item["mission_slug"]),
+            str(item["artifact_path"]),
+            str(item["finding_code"]),
+        ),
     )
 
 

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -88,6 +88,15 @@ FINAL_SYNC_RETRY_BACKOFF_SECONDS = 1.0
 SYNC_INGRESS_LIMITS_TIMEOUT_SECONDS = 10
 DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH = 900_000
 DECOMPRESSED_BYTES_SAFETY_FACTOR = 0.90
+HISTORICAL_MISSION_STATE_FORBIDDEN_KEYS = frozenset(
+    {
+        "feature_slug",
+        "feature_number",
+        "mission_key",
+        "legacy_aggregate_id",
+        "work_package_id",
+    }
+)
 
 
 def _current_team_slug() -> str | None:
@@ -211,6 +220,57 @@ def _fetch_advertised_sync_ingress_limits(
 
 def _build_batch_payload(events: list[dict]) -> bytes:
     return json.dumps({"events": events}).encode("utf-8")
+
+
+def _find_historical_mission_state_keys(value: object, *, prefix: str = "$") -> list[tuple[str, str]]:
+    findings: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{prefix}.{key}"
+            if key in HISTORICAL_MISSION_STATE_FORBIDDEN_KEYS:
+                findings.append((child_path, str(key)))
+            findings.extend(_find_historical_mission_state_keys(child, prefix=child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            findings.extend(_find_historical_mission_state_keys(child, prefix=f"{prefix}[{index}]"))
+    return findings
+
+
+def _historical_mission_state_rejection(events: list[dict]) -> BatchSyncResult | None:
+    violations: list[tuple[dict, str, str]] = []
+    for event in events:
+        for path, key in _find_historical_mission_state_keys(event):
+            violations.append((event, path, key))
+
+    if not violations:
+        return None
+
+    by_event: dict[str, list[tuple[str, str]]] = {}
+    for event, path, key in violations:
+        event_id = str(event.get("event_id", "unknown"))
+        by_event.setdefault(event_id, []).append((path, key))
+
+    result = BatchSyncResult()
+    result.total_events = len(events)
+    result.error_count = len(by_event)
+    result.failed_ids = sorted(by_event)
+    message = (
+        "Historical mission-state rows cannot be sent directly to TeamSpace. "
+        "Run `spec-kitty doctor mission-state --audit --fail-on teamspace-blocker`, "
+        "then `--fix`, then `--teamspace-dry-run` before sync/import."
+    )
+    result.error_messages.append(message)
+    for event_id, event_violations in sorted(by_event.items()):
+        details = ", ".join(f"{path} ({key})" for path, key in sorted(event_violations))
+        result.event_results.append(
+            BatchEventResult(
+                event_id=event_id,
+                status="rejected",
+                error=f"{message} Forbidden historical field(s): {details}",
+                error_category="historical_mission_state",
+            )
+        )
+    return result
 
 
 def _decompressed_byte_limit(advertised_limits: dict[str, int]) -> int:
@@ -863,6 +923,12 @@ def batch_sync(  # noqa: C901
     )
     result.total_events = len(events)
     byte_limit = _decompressed_byte_limit(advertised_limits)
+
+    historical_rejection = _historical_mission_state_rejection(events)
+    if historical_rejection is not None:
+        if show_progress:
+            print(historical_rejection.error_messages[0])
+        return historical_rejection
 
     if len(events) == 1 and len(payload) > byte_limit:
         return _handle_single_oversized_event(

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any, cast
 
@@ -32,6 +33,14 @@ def _write_json(path: Path, data: dict[str, object]) -> None:
 def _read_json(path: Path) -> dict[str, object]:
     data = json.loads(path.read_text(encoding="utf-8"))
     return cast(dict[str, object], data)
+
+
+def _init_git_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "repair-test@spec-kitty.test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "repair test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "baseline"], cwd=repo, check=True)
 
 
 def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) -> None:
@@ -223,6 +232,50 @@ def test_repair_is_idempotent_after_first_canonicalization(tmp_path: Path) -> No
     assert second.missions[0].row_transformations == []
 
 
+def test_deterministic_repair_ids_follow_fork_seed_material(tmp_path: Path) -> None:
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    mission_a = repo_a / "kitty-specs" / "001-historical"
+    mission_b = repo_b / "kitty-specs" / "001-historical"
+    mission_a.mkdir(parents=True)
+    mission_b.mkdir(parents=True)
+    for mission, event_id in (
+        (mission_a, "01KQHRB8GCFJAX7HM4ZY52AQGR"),
+        (mission_b, "01KQHRB8GCFJAX7HM4ZY52AQGS"),
+    ):
+        _write_json(
+            mission / "meta.json",
+            {
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "feature_number": "001",
+                "feature_slug": "001-historical",
+                "friendly_name": "Historical",
+                "mission": "software-dev",
+                "target_branch": "main",
+            },
+        )
+        (mission / "status.events.jsonl").write_text(
+            json.dumps(
+                {
+                    "actor": "codex",
+                    "at": "2026-01-01T00:00:00+00:00",
+                    "event_id": event_id,
+                    "from_lane": "planned",
+                    "to_lane": "claimed",
+                    "work_package_id": "WP01",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    repair_repo(repo_a)
+    repair_repo(repo_b)
+
+    assert _read_json(mission_a / "meta.json")["mission_id"] != _read_json(mission_b / "meta.json")["mission_id"]
+
+
 def test_teamspace_dry_run_fails_when_status_rows_still_contain_legacy_keys(tmp_path: Path) -> None:
     if not _has_events_5():
         pytest.skip("TeamSpace dry-run validation requires spec-kitty-events >= 5.0.0")
@@ -355,3 +408,61 @@ def test_repo_slug_preserves_https_remote_colon(monkeypatch: pytest.MonkeyPatch,
     monkeypatch.setattr("specify_cli.migration.mission_state._git", fake_git)
 
     assert _repo_slug(tmp_path) == "Priivacy-ai/spec-kitty"
+
+
+def test_repair_refuses_when_common_git_lock_is_held(tmp_path: Path) -> None:
+    repo = tmp_path
+    mission = repo / "kitty-specs" / "001-modern"
+    mission.mkdir(parents=True)
+    _write_json(
+        mission / "meta.json",
+        {
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "friendly_name": "Modern",
+            "mission_id": "01KQHRB8GCFJAX7HM4ZY52AQGR",
+            "mission_number": 1,
+            "mission_slug": "001-modern",
+            "mission_type": "software-dev",
+            "slug": "001-modern",
+            "target_branch": "main",
+        },
+    )
+    _init_git_repo(repo)
+    lock = repo / ".git" / "spec-kitty-mission-state.lock"
+    lock.write_text("held", encoding="ascii")
+
+    with pytest.raises(Exception, match="Another mission-state repair appears to be running"):
+        repair_repo(repo)
+
+
+def test_repair_checks_dirty_relevant_paths_in_linked_worktrees(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mission = repo / "kitty-specs" / "001-modern"
+    mission.mkdir(parents=True)
+    _write_json(
+        mission / "meta.json",
+        {
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "friendly_name": "Modern",
+            "mission_id": "01KQHRB8GCFJAX7HM4ZY52AQGR",
+            "mission_number": 1,
+            "mission_slug": "001-modern",
+            "mission_type": "software-dev",
+            "slug": "001-modern",
+            "target_branch": "main",
+        },
+    )
+    _init_git_repo(repo)
+    linked = tmp_path / "linked"
+    subprocess.run(["git", "worktree", "add", "-q", "-b", "linked-branch", str(linked)], cwd=repo, check=True)
+    (linked / "kitty-specs" / "001-modern" / "meta.json").write_text(
+        json.dumps({"mission_slug": "dirty"}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Exception, match="dirty relevant paths"):
+        repair_repo(repo)
+
+    report = repair_repo(repo, allow_dirty=True)
+    assert report.missions[0].status == "unchanged"

--- a/tests/migration/test_teamspace_migration_rehearsal.py
+++ b/tests/migration/test_teamspace_migration_rehearsal.py
@@ -174,9 +174,11 @@ def test_teamspace_mission_state_rehearsal_is_deterministic_across_clones(tmp_pa
 
     raw_dry_run = teamspace_dry_run(clone_a)
     assert not raw_dry_run.valid
-    assert {error["error"] for error in raw_dry_run.errors} >= {
-        "FORBIDDEN_LEGACY_KEY",
-        "STATUS_ROW_NOT_REPAIRED",
+    assert {error["error"] for error in raw_dry_run.errors} == {
+        "MISSION_STATE_AUDIT_BLOCKER",
+    }
+    assert {"FORBIDDEN_KEY", "LEGACY_KEY"} <= {
+        error["finding_code"] for error in raw_dry_run.errors
     }
     first_raw_row = _jsonl_rows(clone_a / "kitty-specs/042-historical-shape/status.events.jsonl")[0]
     with pytest.raises(ValidationError):

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -165,6 +165,51 @@ class TestSaasFeatureFlag:
         mock_post.assert_not_called()
 
 
+class TestHistoricalMissionStateGuard:
+    """TeamSpace import guard for historical mission-state rows."""
+
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_rejects_legacy_status_row_before_network(
+        self,
+        mock_post,
+        temp_queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv(SAAS_SYNC_ENV_VAR, "1")
+        temp_queue.queue_event(
+            {
+                "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGR",
+                "event_type": "WPStatusChanged",
+                "aggregate_id": "WP01",
+                "aggregate_type": "WorkPackage",
+                "schema_version": "3.0.0",
+                "build_id": "test-build",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "node_id": "test-node",
+                "lamport_clock": 1,
+                "payload": {
+                    "feature_slug": "001-legacy",
+                    "work_package_id": "WP01",
+                },
+            }
+        )
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="test-token",
+            server_url="http://localhost:8000",
+            show_progress=False,
+        )
+
+        mock_post.assert_not_called()
+        assert result.total_events == 1
+        assert result.error_count == 1
+        assert result.failed_ids == ["01KQHRB8GCFJAX7HM4ZY52AQGR"]
+        assert result.event_results[0].error_category == "historical_mission_state"
+        assert "doctor mission-state --audit" in result.error_messages[0]
+        assert temp_queue.size() == 1
+
+
 class TestBatchSyncSuccess:
     """Test successful batch sync operations"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc4"
+version = "3.2.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc3"
+version = "3.2.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2155,7 +2155,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.3.3" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.4.0" },
-    { name = "spec-kitty-events", specifier = ">=4.0.0,<6.0.0" },
+    { name = "spec-kitty-events", specifier = ">=5.0.0,<6.0.0" },
     { name = "spec-kitty-tracker", specifier = ">=0.4,<0.5" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "transitions", specifier = ">=0.9.2" },
@@ -2171,15 +2171,15 @@ requires-dist = [
 
 [[package]]
 name = "spec-kitty-events"
-version = "4.1.0"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-ulid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/25/9ecedbeceed104e382f62a74a1419b511fa57f21ca512c81763c12eb6f70/spec_kitty_events-4.1.0.tar.gz", hash = "sha256:f30fc368d880a52f009808f38df6003cdf1b3ad96d576dd0ceecfdaed1c0a915", size = 190704 }
+sdist = { url = "https://files.pythonhosted.org/packages/27/94/5255be6380fbe3f0ae942934f3af6b4ba2dca363edf15c1bbd7e0d79252e/spec_kitty_events-5.0.0.tar.gz", hash = "sha256:2970dec90efb2f0bbaf76a8abb9a03c053c78fddf5f2bcec3f930684d419091d", size = 223463 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/82/1063eef992c4b4dd5ed404bc87d769965346fa56aa1faef646557b699e4e/spec_kitty_events-4.1.0-py3-none-any.whl", hash = "sha256:3520685f5e0259d6c2fe1cc75a3a531f13ed7236a18052427b2855157842ef12", size = 299111 },
+    { url = "https://files.pythonhosted.org/packages/15/e9/adf00f4347565c653b2d8ef912e22aa64788ba020b62d026b523c1c90a2d/spec_kitty_events-5.0.0-py3-none-any.whl", hash = "sha256:c36d890e482d8f5fb710625cafc40a82393ef8eb4a54e3c27b2be708f7447786", size = 330666 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- tighten `spec-kitty-events` to the published `>=5.0.0,<6.0.0` range and refresh `uv.lock`
- advance release metadata to `3.2.0rc5` with a changelog entry so the readiness gate is meaningful after the current `v3.2.0rc4` tag
- add the historical mission-state identity ADR, release sequencing docs, and a #920 closeout evidence document
- fail TeamSpace dry-run on audit blockers before envelope synthesis and reject legacy-shaped queued events before batch-sync POST
- add tests for deterministic fork seed behavior, common-dir repair lock refusal, linked-worktree dirty-path refusal, and live sync/import legacy-shape rejection

## Verification

- `python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'`\n- `uv run ruff check architecture/2.x/adr/2026-05-10-1-deterministic-historical-mission-state-repair.md docs/migration/teamspace-mission-state-repair.md docs/migration/teamspace-mission-state-920-closeout.md src/specify_cli/migration/mission_state.py src/specify_cli/sync/batch.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py`\n- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/contract/test_events_envelope_matches_resolved_version.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/sync/test_batch_sync.py::TestHistoricalMissionStateGuard tests/release/test_check_shared_package_drift.py tests/architectural/test_pyproject_shape.py tests/release/test_validate_metadata_yaml_sync.py -q`\n- `uv lock --check`\n\n## Issue handling\n\nCloses #923.\nCloses #925.\nCloses #931.\nCloses #935.\nCloses #978.\n\nDoes not close #920: the closeout doc shows #979, spec-kitty-runtime #17, and spec-kitty-saas #143/#144/#145/#146 still open, and clean-checkout audits show active repos still have TeamSpace blockers.