### PR TITLE
chore(release): prepare 3.2.0rc4

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc3
+  version: 3.2.0rc4
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.2.0rc4] - 2026-05-11
+
+3.2.0rc4 tightens the TeamSpace release candidate against the published
+`spec-kitty-events` 5.0.0 contract and includes the latest migration rehearsal
+diagnostics.
+
+### Changed
+
+- Tightened the CLI `spec-kitty-events` dependency to `>=5.0.0,<6.0.0` now
+  that the 5.0.0 TeamSpace canonical event contract is published to PyPI
+  (#978).
+- Included the TeamSpace dry-run row mapping diagnostics merged after rc3 so
+  migration rehearsals can trace source rows to synthesized TeamSpace envelopes
+  (#1014).
+
 ## [3.2.0rc3] - 2026-05-06
 
 3.2.0rc3 fixes a TeamSpace dry-run compatibility gap found during the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc3"
+version = "3.2.0rc4"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -70,9 +70,8 @@ dependencies = [
     # src/specify_cli/next/_internal_runtime/ (see WP01 of mission
     # shared-package-boundary-cutover-01KQ22DS), and absence is enforced by
     # tests/architectural/test_pyproject_shape.py.
-    # TeamSpace dry-run requires spec-kitty-events>=5.0.0 at runtime; keep
-    # this as a public bounded range until 5.0.0 is published on PyPI.
-    "spec-kitty-events>=4.0.0,<6.0.0",
+    # TeamSpace dry-run requires the canonical 5.0.0 event contract.
+    "spec-kitty-events>=5.0.0,<6.0.0",
     "spec-kitty-tracker>=0.4,<0.5",
     "websockets>=12.0",  # WebSocket client for sync protocol
     "toml>=0.10.2",  # Config file parsing

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc3"
+version = "3.2.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -2155,7 +2155,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.3.3" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.4.0" },
-    { name = "spec-kitty-events", specifier = ">=4.0.0,<6.0.0" },
+    { name = "spec-kitty-events", specifier = ">=5.0.0,<6.0.0" },
     { name = "spec-kitty-tracker", specifier = ">=0.4,<0.5" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "transitions", specifier = ">=0.9.2" },
@@ -2171,15 +2171,15 @@ requires-dist = [
 
 [[package]]
 name = "spec-kitty-events"
-version = "4.1.0"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-ulid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/25/9ecedbeceed104e382f62a74a1419b511fa57f21ca512c81763c12eb6f70/spec_kitty_events-4.1.0.tar.gz", hash = "sha256:f30fc368d880a52f009808f38df6003cdf1b3ad96d576dd0ceecfdaed1c0a915", size = 190704 }
+sdist = { url = "https://files.pythonhosted.org/packages/27/94/5255be6380fbe3f0ae942934f3af6b4ba2dca363edf15c1bbd7e0d79252e/spec_kitty_events-5.0.0.tar.gz", hash = "sha256:2970dec90efb2f0bbaf76a8abb9a03c053c78fddf5f2bcec3f930684d419091d", size = 223463 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/82/1063eef992c4b4dd5ed404bc87d769965346fa56aa1faef646557b699e4e/spec_kitty_events-4.1.0-py3-none-any.whl", hash = "sha256:3520685f5e0259d6c2fe1cc75a3a531f13ed7236a18052427b2855157842ef12", size = 299111 },
+    { url = "https://files.pythonhosted.org/packages/15/e9/adf00f4347565c653b2d8ef912e22aa64788ba020b62d026b523c1c90a2d/spec_kitty_events-5.0.0-py3-none-any.whl", hash = "sha256:c36d890e482d8f5fb710625cafc40a82393ef8eb4a54e3c27b2be708f7447786", size = 330666 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump CLI prerelease metadata to 3.2.0rc4
- tighten spec-kitty-events to >=5.0.0,<6.0.0 now that 5.0.0 is published on PyPI
- refresh uv.lock to resolve spec-kitty-events 5.0.0 and note #1014 dry-run mapping diagnostics in the changelog

## Verification
- uv sync --extra test --extra lint
- uv run pytest tests/contract/test_events_envelope_matches_resolved_version.py tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py -q
- uv run python scripts/release/check_shared_package_drift.py --check-installed --saas-pyproject ../spec-kitty-saas/pyproject.toml
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv run python -m build
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli
- uv run twine check dist/*
- uv run pytest tests/release -q

Closes #978.