### PR TITLE
fix: harden loopback websocket URL normalization

### DIFF
--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -14,7 +14,7 @@ import random
 from contextlib import suppress
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 import websockets
 from websockets import ConnectionClosed
@@ -35,6 +35,8 @@ from specify_cli.sync.feature_flags import (
 from specify_cli.sync.project_identity import ProjectIdentity
 
 logger = logging.getLogger(__name__)
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
 
 class ConnectionStatus:
@@ -262,27 +264,36 @@ class WebSocketClient:
     @staticmethod
     def _normalize_ws_url(ws_url: str) -> str:
         """Convert provisioned HTTP(S) URLs to WS(S), rejecting insecure remote hosts."""
-        if ws_url.startswith("wss://"):
+        parsed = urlparse(ws_url)
+        scheme = parsed.scheme.lower()
+
+        if scheme == "wss":
             return ws_url
-        if ws_url.startswith("ws://"):
-            host = (urlparse(ws_url).hostname or "").lower()
-            if host not in {"127.0.0.1", "localhost", "::1"}:
+        if scheme == "ws":
+            if not WebSocketClient._is_loopback_host(parsed):
                 raise AuthenticationError(
                     "Refusing insecure WebSocket provisioning URL outside loopback."
                 )
             return ws_url
-        if ws_url.startswith("https://"):
-            return "wss://" + ws_url[len("https://") :]
-        if ws_url.startswith("http://"):
-            host = (urlparse(ws_url).hostname or "").lower()
-            if host not in {"127.0.0.1", "localhost", "::1"}:
+        if scheme == "https":
+            return WebSocketClient._replace_scheme(parsed, "wss")
+        if scheme == "http":
+            if not WebSocketClient._is_loopback_host(parsed):
                 raise AuthenticationError(
                     "Refusing insecure WebSocket provisioning URL outside loopback."
                 )
-            return "ws://" + ws_url[len("http://") :]
+            return WebSocketClient._replace_scheme(parsed, "ws")
         raise AuthenticationError(
             f"Unsupported WebSocket provisioning URL scheme: {ws_url!r}"
         )
+
+    @staticmethod
+    def _is_loopback_host(parsed: ParseResult) -> bool:
+        return (parsed.hostname or "").lower() in _LOOPBACK_HOSTS
+
+    @staticmethod
+    def _replace_scheme(parsed: ParseResult, scheme: str) -> str:
+        return parsed._replace(scheme=scheme).geturl()
 
     def get_reconnect_delay(self, attempt: int) -> float:
         """

--- a/tests/sync/test_client_integration.py
+++ b/tests/sync/test_client_integration.py
@@ -122,8 +122,10 @@ async def test_send_event_when_not_connected():
 def test_normalize_ws_url_converts_https_and_loopback_http():
     """Provisioned HTTPS URLs become WSS; loopback HTTP remains allowed for local dev."""
     assert (
-        WebSocketClient._normalize_ws_url("https://spec-kitty-dev.fly.dev/ws")
-        == "wss://spec-kitty-dev.fly.dev/ws"
+        WebSocketClient._normalize_ws_url(
+            "https://spec-kitty-dev.fly.dev/ws?project=alpha#frag"
+        )
+        == "wss://spec-kitty-dev.fly.dev/ws?project=alpha#frag"
     )
     assert (
         WebSocketClient._normalize_ws_url("http://127.0.0.1:9400/ws")


### PR DESCRIPTION
## Summary
- replace prefix-slicing websocket URL normalization with `urlparse()`-based scheme rewriting
- preserve the loopback-only exception for plaintext local provisioning while rejecting remote plaintext URLs
- extend sync client tests to cover query/fragment preservation during HTTPS->WSS normalization

## Automation findings
- GitHub vulnerability alerts are currently open for `package-lock.json` (`tmp`) and `uv.lock` (`pip 26.0.1`), but the current `main` branch already contains the apparent remediations: `package.json` overrides `tmp` to `0.2.4`, `package-lock.json` no longer contains `tmp`, and `uv.lock` already pins `pip 26.1.1`.
- GitHub code-scanning alert REST endpoints returned `404` from this environment/auth surface, so I could not enumerate open code-scanning alerts directly.
- The latest nightly `CI Quality` run on `main` failed in the `sonarcloud` job after a successful scan. SonarCloud currently reports `new_coverage=58.6%` and `new_security_hotspots_reviewed=0.0%` on `main`.
- This patch targets one actionable hotspot-adjacent path by making the insecure-scheme normalization explicit and less brittle.

## Validation
- `uv run --python 3.12 pytest tests/sync/test_client_integration.py -k normalize_ws_url`
- `uv run --python 3.12 pytest tests/sync/test_client_integration.py`
- `uv run --python 3.12 ruff check src/specify_cli/sync/client.py tests/sync/test_client_integration.py`
