### PR TITLE
Gate TeamSpace connect on mission-state migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -971,3 +971,21 @@ Architectural enforcement of these invariants lives in `tests/architectural/test
 ADR: [`architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md`](architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md). Migration runbook: [`docs/migration/shared-package-boundary-cutover.md`](docs/migration/shared-package-boundary-cutover.md).
 
 <!-- MANUAL ADDITIONS END -->
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore

--- a/scripts/release/check_candidate_consumer_compat.py
+++ b/scripts/release/check_candidate_consumer_compat.py
@@ -7,8 +7,8 @@ import argparse
 import email
 import json
 import zipfile
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable, List
 
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
@@ -56,7 +56,7 @@ def read_wheel_metadata(wheel_path: Path) -> email.message.Message:
     return email.message_from_string(payload)
 
 
-def load_contract(path: Path) -> Dict[str, object]:
+def load_contract(path: Path) -> dict[str, object]:
     if not path.exists():
         raise SystemExit(f"Consumer contract not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -84,13 +84,71 @@ def exact_pin(requirement: Requirement) -> str | None:
     return spec.version
 
 
-def extract_requirements(requires_dist: Iterable[str]) -> Dict[str, Requirement]:
-    requirements: Dict[str, Requirement] = {}
+def exact_versions(specifier: SpecifierSet) -> list[Version]:
+    versions: list[Version] = []
+    for spec in specifier:
+        if spec.operator == "==" and not spec.version.endswith(".*"):
+            versions.append(Version(spec.version))
+    return versions
+
+
+def extract_requirements(requires_dist: Iterable[str]) -> dict[str, Requirement]:
+    requirements: dict[str, Requirement] = {}
     for raw in requires_dist:
         req = parse_requirement(raw)
         if req.name.startswith("spec-kitty-"):
             requirements[req.name] = req
     return requirements
+
+
+def validate_package_requirement(
+    package: str,
+    supported_range: str,
+    requirement: Requirement | None,
+) -> tuple[str | None, str | None]:
+    if supported_range == "vendored":
+        return f"{package}: vendored by consumer, skipped", None
+
+    if requirement is None:
+        return None, f"Candidate wheel is missing required dependency metadata for {package}"
+
+    if requirement.url or not str(requirement.specifier):
+        return (
+            None,
+            f"{package}: candidate must carry dependency version metadata, found {requirement}",
+        )
+
+    specifier = SpecifierSet(supported_range)
+    consumer_exact_versions = exact_versions(specifier)
+    if consumer_exact_versions:
+        unsupported = [
+            version
+            for version in consumer_exact_versions
+            if not requirement.specifier.contains(version, prereleases=True)
+        ]
+        if unsupported:
+            versions = ", ".join(str(version) for version in unsupported)
+            return (
+                None,
+                f"{package}: SaaS supports {versions}, but candidate metadata {requirement} does not allow it",
+            )
+        versions = ", ".join(str(version) for version in consumer_exact_versions)
+        return f"{package}: candidate allows SaaS-supported {versions}", None
+
+    pinned = exact_pin(requirement)
+    if pinned is None:
+        return (
+            None,
+            f"{package}: consumer range {supported_range} is not exact and candidate metadata {requirement} is not exact; compatibility cannot be proven",
+        )
+
+    if Version(pinned) not in specifier:
+        return (
+            None,
+            f"{package}: pinned version {pinned} is outside consumer-supported range {supported_range}",
+        )
+
+    return f"{package}: {pinned} satisfies {supported_range}", None
 
 
 def main() -> int:
@@ -110,11 +168,11 @@ def main() -> int:
     if not isinstance(families, list):
         raise SystemExit("Consumer contract missing contract_families list")
 
-    summary: List[str] = [
+    summary: list[str] = [
         f"candidate: {metadata.get('Name', args.package)}=={metadata.get('Version', 'unknown')}",
         f"consumer: {contract.get('consumer', 'unknown')}",
     ]
-    issues: List[str] = []
+    issues: list[str] = []
 
     for entry in families:
         if not isinstance(entry, dict):
@@ -124,30 +182,15 @@ def main() -> int:
         if not isinstance(package, str) or not isinstance(supported_range, str):
             raise SystemExit("Contract family entries must include package and supported_range")
 
-        requirement = requirements.get(package)
-        if supported_range == "vendored":
-            summary.append(f"{package}: vendored by consumer, skipped")
-            continue
-
-        if requirement is None:
-            issues.append(f"Candidate wheel is missing required dependency metadata for {package}")
-            continue
-
-        pinned = exact_pin(requirement)
-        if pinned is None:
-            issues.append(
-                f"{package}: candidate must carry an exact == pin, found {requirement}"
-            )
-            continue
-
-        specifier = SpecifierSet(supported_range)
-        if Version(pinned) not in specifier:
-            issues.append(
-                f"{package}: pinned version {pinned} is outside consumer-supported range {supported_range}"
-            )
-            continue
-
-        summary.append(f"{package}: {pinned} satisfies {supported_range}")
+        summary_line, issue = validate_package_requirement(
+            package,
+            supported_range,
+            requirements.get(package),
+        )
+        if summary_line is not None:
+            summary.append(summary_line)
+        if issue is not None:
+            issues.append(issue)
 
     print("Candidate Consumer Compatibility Summary")
     print("----------------------------------------")

--- a/src/specify_cli/cli/commands/_auth_login.py
+++ b/src/specify_cli/cli/commands/_auth_login.py
@@ -31,6 +31,9 @@ from specify_cli.auth import (
     get_token_manager,
 )
 from specify_cli.auth.config import get_saas_base_url
+from specify_cli.cli.commands._teamspace_mission_state_gate import (
+    enforce_teamspace_mission_state_ready,
+)
 
 if TYPE_CHECKING:
     from specify_cli.auth.session import StorageBackend, StoredSession
@@ -49,6 +52,11 @@ async def login_impl(*, headless: bool, force: bool) -> None:
         force: When True, re-authenticates even if a session is already
             present. Defaults to False.
     """
+    enforce_teamspace_mission_state_ready(
+        console=console,
+        command_name="spec-kitty auth login",
+    )
+
     try:
         saas_url = get_saas_base_url()
     except ConfigurationError as exc:

--- a/src/specify_cli/cli/commands/_teamspace_mission_state_gate.py
+++ b/src/specify_cli/cli/commands/_teamspace_mission_state_gate.py
@@ -1,0 +1,208 @@
+"""TeamSpace mission-state migration prompt and connection gate helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+
+@dataclass(frozen=True)
+class TeamspaceMissionStateReadiness:
+    """Readiness summary for TeamSpace historical mission-state import."""
+
+    repo_root: Path
+    total_missions: int = 0
+    blocker_count: int = 0
+    missions_with_blockers: int = 0
+    blocker_codes: tuple[str, ...] = ()
+    audit_error: str | None = None
+
+    @property
+    def migration_pending(self) -> bool:
+        return self.blocker_count > 0
+
+    @property
+    def blocked(self) -> bool:
+        return self.migration_pending or self.audit_error is not None
+
+
+def check_teamspace_mission_state_readiness(repo_root: Path) -> TeamspaceMissionStateReadiness:
+    """Return mission-state readiness for TeamSpace connect/import paths."""
+    repo_root = repo_root.resolve()
+    if not (repo_root / "kitty-specs").is_dir():
+        return TeamspaceMissionStateReadiness(repo_root=repo_root)
+
+    try:
+        from specify_cli.audit import AuditOptions, run_audit
+        from specify_cli.audit.models import is_teamspace_blocker
+
+        report = run_audit(AuditOptions(repo_root=repo_root))
+    except Exception as exc:  # noqa: BLE001 - connection paths fail closed on unknown readiness
+        return TeamspaceMissionStateReadiness(
+            repo_root=repo_root,
+            audit_error=str(exc),
+        )
+
+    blocker_codes: set[str] = set()
+    blocker_count = 0
+    missions_with_blockers = 0
+    for mission in report.missions:
+        mission_has_blocker = False
+        for finding in mission.findings:
+            if not is_teamspace_blocker(finding):
+                continue
+            blocker_count += 1
+            blocker_codes.add(finding.code)
+            mission_has_blocker = True
+        if mission_has_blocker:
+            missions_with_blockers += 1
+
+    return TeamspaceMissionStateReadiness(
+        repo_root=repo_root,
+        total_missions=int(report.repo_summary.get("total_missions", len(report.missions))),
+        blocker_count=blocker_count,
+        missions_with_blockers=missions_with_blockers,
+        blocker_codes=tuple(sorted(blocker_codes)),
+    )
+
+
+def _guidance_lines(readiness: TeamspaceMissionStateReadiness) -> list[str]:
+    if readiness.audit_error:
+        return [
+            "Spec Kitty could not verify local mission-state readiness.",
+            f"Audit error: {readiness.audit_error}",
+            "",
+            "Run the audit before connecting to TeamSpace:",
+            "  spec-kitty doctor mission-state --audit --fail-on teamspace-blocker",
+        ]
+
+    codes = ", ".join(readiness.blocker_codes) if readiness.blocker_codes else "unknown"
+    return [
+        "TeamSpace mission-state migration is required before connecting.",
+        (
+            f"Found {readiness.blocker_count} TeamSpace blocker(s) "
+            f"across {readiness.missions_with_blockers} mission(s)."
+        ),
+        f"Finding codes: {codes}",
+        "",
+        "Recommended sequence:",
+        "  spec-kitty doctor mission-state --audit --fail-on teamspace-blocker",
+        "  spec-kitty doctor mission-state --fix",
+        "  spec-kitty doctor mission-state --teamspace-dry-run",
+    ]
+
+
+def _print_notice(
+    readiness: TeamspaceMissionStateReadiness,
+    *,
+    console: Console,
+    title: str,
+    border_style: str,
+) -> None:
+    console.print(
+        Panel(
+            "\n".join(_guidance_lines(readiness)),
+            title=title,
+            border_style=border_style,
+            expand=False,
+        )
+    )
+
+
+def enforce_teamspace_mission_state_ready(*, console: Console, command_name: str) -> None:
+    """Block TeamSpace connect/sync commands until local mission-state is ready."""
+    try:
+        from specify_cli.core.paths import locate_project_root
+
+        repo_root = locate_project_root()
+    except Exception:  # noqa: BLE001 - outside a project is not a project migration problem
+        repo_root = None
+
+    if repo_root is None:
+        return
+
+    readiness = check_teamspace_mission_state_readiness(repo_root)
+    if not readiness.blocked:
+        return
+
+    _print_notice(
+        readiness,
+        console=console,
+        title="TeamSpace Migration Required",
+        border_style="red",
+    )
+    console.print(f"[red]Blocked:[/red] `{command_name}` will not connect until this migration is complete.")
+    raise typer.Exit(1)
+
+
+def offer_teamspace_mission_state_migration(
+    project_path: Path,
+    *,
+    console: Console,
+    dry_run: bool,
+    assume_yes: bool,
+) -> tuple[bool, bool]:
+    """Surface and optionally run the TeamSpace mission-state migration.
+
+    Returns ``(migration_was_pending, repair_ran)``.
+    """
+    readiness = check_teamspace_mission_state_readiness(project_path)
+    if not readiness.blocked:
+        return False, False
+
+    _print_notice(
+        readiness,
+        console=console,
+        title="TeamSpace Mission-State Migration",
+        border_style="yellow",
+    )
+
+    if readiness.audit_error:
+        return True, False
+
+    if dry_run:
+        console.print("[dim]Dry run: mission-state repair was not run.[/dim]")
+        return True, False
+
+    should_run = assume_yes or typer.confirm(
+        "Run `spec-kitty doctor mission-state --fix` now?",
+        default=True,
+    )
+    if not should_run:
+        console.print("[yellow]Skipped TeamSpace mission-state repair.[/yellow]")
+        return True, False
+
+    from specify_cli.migration.mission_state import MissionStateRepairError, repair_repo
+
+    try:
+        report = repair_repo(project_path)
+    except MissionStateRepairError as exc:
+        console.print(f"[red]Mission-state repair failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    summary = report.to_dict()["summary"]
+    assert isinstance(summary, dict)
+    console.print(
+        "[green]Mission-state repair complete[/green] "
+        f"(updated={summary['missions_updated']}, "
+        f"unchanged={summary['missions_unchanged']}, "
+        f"errors={summary['missions_error']})."
+    )
+    console.print(f"Manifest: {report.manifest_path}")
+
+    post_repair = check_teamspace_mission_state_readiness(project_path)
+    if post_repair.blocked:
+        _print_notice(
+            post_repair,
+            console=console,
+            title="TeamSpace Migration Still Blocked",
+            border_style="red",
+        )
+        raise typer.Exit(1)
+
+    console.print("[green]TeamSpace mission-state blockers cleared.[/green]")
+    return True, True

--- a/src/specify_cli/cli/commands/_teamspace_mission_state_gate.py
+++ b/src/specify_cli/cli/commands/_teamspace_mission_state_gate.py
@@ -183,9 +183,13 @@ def offer_teamspace_mission_state_migration(
     except MissionStateRepairError as exc:
         console.print(f"[red]Mission-state repair failed:[/red] {exc}")
         raise typer.Exit(1) from exc
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Mission-state repair encountered an unexpected error:[/red] {exc}")
+        raise typer.Exit(1) from exc
 
     summary = report.to_dict()["summary"]
-    assert isinstance(summary, dict)
+    if not isinstance(summary, dict):
+        raise MissionStateRepairError(f"Unexpected repair report summary type: {type(summary)!r}")
     console.print(
         "[green]Mission-state repair complete[/green] "
         f"(updated={summary['missions_updated']}, "

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -19,6 +19,9 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from specify_cli.cli.commands._teamspace_mission_state_gate import (
+    enforce_teamspace_mission_state_ready,
+)
 from specify_cli.core.vcs import (
     ChangeInfo,
     ConflictInfo,
@@ -275,6 +278,11 @@ def routes() -> None:
         console.print()
         return
 
+    enforce_teamspace_mission_state_ready(
+        console=console,
+        command_name="spec-kitty sync routes",
+    )
+
     try:
         shares = list_repository_shares_sync(source_project_uuid=routing.project_uuid)
     except RepositorySharingClientError as exc:
@@ -320,6 +328,11 @@ def share(
     if not is_saas_sync_enabled():
         console.print(f"[red]{saas_sync_disabled_message()}[/red]")
         raise typer.Exit(1)
+
+    enforce_teamspace_mission_state_ready(
+        console=console,
+        command_name="spec-kitty sync share",
+    )
 
     routing = _require_active_checkout()
     _require_authenticated_session()
@@ -388,6 +401,11 @@ def unshare(
     if not is_saas_sync_enabled():
         console.print(f"[red]{saas_sync_disabled_message()}[/red]")
         raise typer.Exit(1)
+
+    enforce_teamspace_mission_state_ready(
+        console=console,
+        command_name="spec-kitty sync unshare",
+    )
 
     routing = _require_active_checkout()
     _require_authenticated_session()
@@ -508,6 +526,11 @@ def opt_in(
 ) -> None:
     """Enable SaaS sync for this checkout."""
     from specify_cli.sync.routing import enable_checkout_sync
+
+    enforce_teamspace_mission_state_ready(
+        console=console,
+        command_name="spec-kitty sync opt-in",
+    )
 
     routing = _require_active_checkout()
     refreshed = enable_checkout_sync(
@@ -992,6 +1015,11 @@ def now(
         console.print(f"[yellow]{saas_sync_disabled_message()}[/yellow]")
         console.print(f"[dim]Set {SAAS_SYNC_ENV_VAR}=1 to enable upload.[/dim]")
         return
+
+    enforce_teamspace_mission_state_ready(
+        console=console,
+        command_name="spec-kitty sync now",
+    )
 
     service = get_sync_service()
     queue_size = service.queue.size()

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -527,6 +527,10 @@ def opt_in(
     """Enable SaaS sync for this checkout."""
     from specify_cli.sync.routing import enable_checkout_sync
 
+    if not is_saas_sync_enabled():
+        console.print(f"[dim]{saas_sync_disabled_message()}[/dim]")
+        return
+
     enforce_teamspace_mission_state_ready(
         console=console,
         command_name="spec-kitty sync opt-in",

--- a/src/specify_cli/cli/commands/tracker.py
+++ b/src/specify_cli/cli/commands/tracker.py
@@ -17,6 +17,9 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from specify_cli.cli.commands._teamspace_mission_state_gate import (
+    enforce_teamspace_mission_state_ready,
+)
 from specify_cli.tracker.config import (
     LOCAL_PROVIDERS,
     REMOVED_PROVIDERS,
@@ -125,6 +128,11 @@ def _check_readiness(
             repo_root = require_repo_root()
         except Exception:
             repo_root = Path.cwd()
+
+    enforce_teamspace_mission_state_ready(
+        console=Console(),
+        command_name="spec-kitty tracker",
+    )
 
     feature_slug = _resolve_active_feature_slug(repo_root)
     result = evaluate_readiness(

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -49,6 +49,9 @@ from rich.panel import Panel
 from rich.table import Table
 
 from specify_cli.cli.helpers import console, show_banner
+from specify_cli.cli.commands._teamspace_mission_state_gate import (
+    offer_teamspace_mission_state_migration,
+)
 from specify_cli.git.commit_helpers import safe_commit
 
 
@@ -394,7 +397,7 @@ def upgrade(  # noqa: C901
         raise typer.Exit(2)
 
     # T034 — --yes aliases --force (both remain functional)
-    confirm = yes or force
+    confirm = (yes is True) or (force is True)
 
     # T035 — --cli mode: project-agnostic CLI guidance
     if cli:
@@ -525,6 +528,14 @@ def upgrade(  # noqa: C901
             metadata.last_upgraded_at = datetime.now()
             metadata.save(kittify_dir)
 
+        if not json_output:
+            offer_teamspace_mission_state_migration(
+                project_path,
+                console=console,
+                dry_run=dry_run,
+                assume_yes=confirm,
+            )
+
         if not dry_run:
             auto_committed, auto_commit_paths, auto_commit_warning = _auto_commit_upgrade_changes(
                 project_path=project_path,
@@ -607,6 +618,13 @@ def upgrade(  # noqa: C901
     auto_commit_paths_list: list[str] = []
     auto_commit_warning: str | None = None
     manual_review_paths = _collect_manual_review_paths(result.migration_results)
+    if result.success and not json_output:
+        offer_teamspace_mission_state_migration(
+            project_path,
+            console=console,
+            dry_run=dry_run,
+            assume_yes=confirm,
+        )
     if result.success and not dry_run:
         if manual_review_paths:
             auto_commit_warning = "Skipped auto-commit because the upgrade preserved customized files that require manual review."

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -528,20 +528,20 @@ def upgrade(  # noqa: C901
             metadata.last_upgraded_at = datetime.now()
             metadata.save(kittify_dir)
 
-        if not json_output:
-            offer_teamspace_mission_state_migration(
-                project_path,
-                console=console,
-                dry_run=dry_run,
-                assume_yes=confirm,
-            )
-
         if not dry_run:
             auto_committed, auto_commit_paths, auto_commit_warning = _auto_commit_upgrade_changes(
                 project_path=project_path,
                 from_version=current_version,
                 to_version=target_version,
                 baseline_paths=baseline_changed_paths,
+            )
+
+        if not json_output:
+            offer_teamspace_mission_state_migration(
+                project_path,
+                console=console,
+                dry_run=dry_run,
+                assume_yes=confirm,
             )
 
         if json_output:
@@ -618,13 +618,6 @@ def upgrade(  # noqa: C901
     auto_commit_paths_list: list[str] = []
     auto_commit_warning: str | None = None
     manual_review_paths = _collect_manual_review_paths(result.migration_results)
-    if result.success and not json_output:
-        offer_teamspace_mission_state_migration(
-            project_path,
-            console=console,
-            dry_run=dry_run,
-            assume_yes=confirm,
-        )
     if result.success and not dry_run:
         if manual_review_paths:
             auto_commit_warning = "Skipped auto-commit because the upgrade preserved customized files that require manual review."
@@ -638,6 +631,14 @@ def upgrade(  # noqa: C901
             )
             if auto_commit_warning:
                 result.warnings.append(auto_commit_warning)
+
+    if result.success and not json_output:
+        offer_teamspace_mission_state_migration(
+            project_path,
+            console=console,
+            dry_run=dry_run,
+            assume_yes=confirm,
+        )
 
     if json_output:
         # Build detailed migrations array

--- a/tests/cli/commands/test_auth_login.py
+++ b/tests/cli/commands/test_auth_login.py
@@ -24,6 +24,7 @@ import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from specify_cli.auth import reset_token_manager
@@ -43,6 +44,10 @@ def _reset_tm(monkeypatch):
     missing-config path delete the env var explicitly.
     """
     monkeypatch.setenv("SPEC_KITTY_SAAS_URL", "https://saas.test")
+    monkeypatch.setattr(
+        "specify_cli.cli.commands._auth_login.enforce_teamspace_mission_state_ready",
+        lambda **_kwargs: None,
+    )
     reset_token_manager()
     yield
     reset_token_manager()
@@ -103,6 +108,18 @@ class TestAuthLoginHelp:
 
 
 class TestAuthLoginDispatch:
+    def test_blocks_login_when_teamspace_mission_state_migration_pending(self):
+        with patch(
+            "specify_cli.cli.commands._auth_login.enforce_teamspace_mission_state_ready",
+            side_effect=typer.Exit(1),
+        ) as mock_gate, patch(
+            "specify_cli.cli.commands._auth_login.get_saas_base_url"
+        ) as mock_config:
+            result = runner.invoke(app, ["login"])
+
+        assert result.exit_code == 1
+        mock_gate.assert_called_once()
+        mock_config.assert_not_called()
 
     def test_default_dispatches_to_browser_flow(self):
         async def _noop(*args, **kwargs):

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, UTC
 from unittest.mock import Mock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from specify_cli.auth.session import StoredSession, Team
@@ -15,6 +16,15 @@ from specify_cli.sync.batch import BatchEventResult, BatchSyncResult
 
 runner = CliRunner()
 pytestmark = pytest.mark.fast
+
+
+@pytest.fixture(autouse=True)
+def _disable_teamspace_mission_state_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sync_module,
+        "enforce_teamspace_mission_state_ready",
+        lambda **_kwargs: None,
+    )
 
 
 def _session() -> StoredSession:
@@ -129,6 +139,27 @@ def test_share_command_retries_after_materializing_private_source(monkeypatch: p
     mock_materialize.assert_called_once_with()
     assert "Share request recorded" in result.stdout
     assert "Waiting for a team admin" in result.stdout
+
+
+def test_share_command_blocks_when_teamspace_mission_state_migration_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_share = Mock()
+    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
+    monkeypatch.setattr(
+        sync_module,
+        "enforce_teamspace_mission_state_ready",
+        Mock(side_effect=typer.Exit(1)),
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.sharing_client.request_repository_share_sync",
+        request_share,
+    )
+
+    result = runner.invoke(sync_module.app, ["share", "product-team"])
+
+    assert result.exit_code == 1
+    request_share.assert_not_called()
 
 
 def test_opt_out_command_reports_purged_counts(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/release/test_check_candidate_consumer_compat.py
+++ b/tests/release/test_check_candidate_consumer_compat.py
@@ -32,12 +32,17 @@ def write_wheel(dist_dir: Path, *, version: str, requirements: list[str]) -> Pat
     return wheel_path
 
 
-def write_contract(path: Path) -> None:
+def write_contract(
+    path: Path,
+    *,
+    events_range: str = ">=3.2.0,<4.0",
+    tracker_range: str = ">=0.4.0,<0.5",
+) -> None:
     payload = {
         "consumer": "spec-kitty-saas",
         "contract_families": [
-            {"package": "spec-kitty-events", "supported_range": ">=3.2.0,<4.0"},
-            {"package": "spec-kitty-tracker", "supported_range": ">=0.4.0,<0.5"},
+            {"package": "spec-kitty-events", "supported_range": events_range},
+            {"package": "spec-kitty-tracker", "supported_range": tracker_range},
             {"package": "spec-kitty-runtime", "supported_range": "vendored"},
         ],
     }
@@ -109,3 +114,104 @@ def test_candidate_consumer_compat_fails_for_out_of_range_pin(tmp_path: Path) ->
 
     assert result.returncode == 1
     assert "outside consumer-supported range" in result.stdout
+
+
+def test_candidate_consumer_compat_passes_when_candidate_range_contains_saas_pin(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contract = tmp_path / "consumer-compatibility.json"
+    write_contract(contract, events_range="==5.0.0", tracker_range="==0.4.3")
+    write_wheel(
+        dist_dir,
+        version="3.2.0rc5",
+        requirements=[
+            "spec-kitty-events>=5.0.0,<6.0.0",
+            "spec-kitty-runtime==0.4.4",
+            "spec-kitty-tracker>=0.4,<0.5",
+        ],
+    )
+
+    result = run_check(
+        tmp_path,
+        "--dist-dir",
+        str(dist_dir),
+        "--package",
+        "spec-kitty-cli",
+        "--consumer-contract",
+        str(contract),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "spec-kitty-events: candidate allows SaaS-supported 5.0.0" in result.stdout
+    assert "spec-kitty-tracker: candidate allows SaaS-supported 0.4.3" in result.stdout
+
+
+def test_candidate_consumer_compat_fails_when_candidate_range_excludes_saas_pin(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contract = tmp_path / "consumer-compatibility.json"
+    write_contract(contract, events_range="==5.0.0", tracker_range="==0.4.3")
+    write_wheel(
+        dist_dir,
+        version="3.2.0rc5",
+        requirements=[
+            "spec-kitty-events>=4.0.0,<5.0.0",
+            "spec-kitty-runtime==0.4.4",
+            "spec-kitty-tracker>=0.5,<0.6",
+        ],
+    )
+
+    result = run_check(
+        tmp_path,
+        "--dist-dir",
+        str(dist_dir),
+        "--package",
+        "spec-kitty-cli",
+        "--consumer-contract",
+        str(contract),
+    )
+
+    assert result.returncode == 1
+    assert (
+        "spec-kitty-events: SaaS supports 5.0.0, but candidate metadata "
+        "spec-kitty-events<5.0.0,>=4.0.0 does not allow it"
+    ) in result.stdout
+    assert (
+        "spec-kitty-tracker: SaaS supports 0.4.3, but candidate metadata "
+        "spec-kitty-tracker<0.6,>=0.5 does not allow it"
+    ) in result.stdout
+
+
+def test_candidate_consumer_compat_fails_when_both_sides_use_broad_ranges(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contract = tmp_path / "consumer-compatibility.json"
+    write_contract(contract, events_range=">=5.0.0,<6.0.0", tracker_range="==0.4.3")
+    write_wheel(
+        dist_dir,
+        version="3.2.0rc5",
+        requirements=[
+            "spec-kitty-events>=5.0.0,<6.0.0",
+            "spec-kitty-runtime==0.4.4",
+            "spec-kitty-tracker>=0.4,<0.5",
+        ],
+    )
+
+    result = run_check(
+        tmp_path,
+        "--dist-dir",
+        str(dist_dir),
+        "--package",
+        "spec-kitty-cli",
+        "--consumer-contract",
+        str(contract),
+    )
+
+    assert result.returncode == 1
+    assert "compatibility cannot be proven" in result.stdout

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -484,6 +484,46 @@ def test_upgrade_no_migrations_json_includes_auto_commit_fields(
     assert data["warnings"] == []
 
 
+def test_upgrade_no_migrations_surfaces_teamspace_mission_state_prompt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A normal upgrade run checks TeamSpace mission-state readiness even when up to date."""
+    project_path = _setup_upgrade_project(tmp_path)
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+    monkeypatch.setattr(upgrade_cmd, "show_banner", lambda: None)
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_offer(project_path: Path, **kwargs):
+        kwargs["project_path"] = project_path
+        calls.append(kwargs)
+        return True, False
+
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "offer_teamspace_mission_state_migration",
+        _fake_offer,
+    )
+
+    upgrade_cmd.upgrade(
+        dry_run=False,
+        force=True,
+        target="1.0.0a1",
+        json_output=False,
+        verbose=False,
+        no_worktrees=True,
+        cli=False,
+        project=False,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["project_path"] == project_path
+    assert calls[0]["dry_run"] is False
+    assert calls[0]["assume_yes"] is True
+
+
 def test_upgrade_dry_run_skips_auto_commit(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add a reusable TeamSpace mission-state readiness gate backed by the existing audit/fix APIs
- surface pending mission-state migration from `spec-kitty upgrade` and offer/run repair in interactive upgrade flows
- hard-block auth login, SaaS sync/share commands, and hosted tracker readiness until TeamSpace blockers are cleared
- add focused tests for upgrade surfacing and connect-path blocking

## Verification
- `ruff check src/specify_cli/cli/commands/_teamspace_mission_state_gate.py src/specify_cli/cli/commands/upgrade.py src/specify_cli/cli/commands/_auth_login.py src/specify_cli/cli/commands/sync.py src/specify_cli/cli/commands/tracker.py tests/upgrade/test_upgrade_auto_commit_unit.py tests/cli/commands/test_auth_login.py tests/cli/commands/test_sync_routes.py`
- `pytest -q tests/upgrade/test_upgrade_auto_commit_unit.py tests/cli/commands/test_auth_login.py tests/cli/commands/test_sync_routes.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest -q tests/agent/cli/commands/test_tracker.py tests/agent/cli/commands/test_tracker_discover.py tests/agent/cli/commands/test_tracker_status.py tests/sync/tracker/test_saas_service.py`
- `pytest -q tests/audit/test_audit_cli.py tests/migration/test_mission_state_repair.py`

Related to #920.