### PR TITLE
Fix TeamSpace dry-run for historical approval evidence

### DIFF
--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -535,16 +535,13 @@ def _status_event_to_teamspace_envelope(
     repo_slug: str | None,
 ) -> dict[str, Any]:
     evidence = status_event.evidence.to_dict() if status_event.evidence else None
-    if evidence is not None and not evidence.get("repos"):
-        # Older done rows only recorded review evidence; the 5.0.0 TeamSpace
-        # contract requires at least one repo evidence entry.
-        evidence["repos"] = [
-            {
-                "repo": repo_slug or project_slug,
-                "branch": "historical-mission-state-repair",
-                "commit": "historical-mission-state-repair",
-            }
-        ]
+    if str(status_event.to_lane) in {"approved", "done"}:
+        evidence = _historical_teamspace_evidence(
+            status_event,
+            evidence=evidence,
+            project_slug=project_slug,
+            repo_slug=repo_slug,
+        )
 
     payload = {
         "mission_slug": status_event.mission_slug,
@@ -577,6 +574,40 @@ def _status_event_to_teamspace_envelope(
         ),
         "schema_version": CANONICAL_ENVELOPE_SCHEMA_VERSION,
     }
+
+
+def _historical_teamspace_evidence(
+    status_event: StatusEvent,
+    *,
+    evidence: dict[str, Any] | None,
+    project_slug: str,
+    repo_slug: str | None,
+) -> dict[str, Any]:
+    """Return deterministic evidence for historical approval/done rows.
+
+    Older local status rows may have no evidence at all, or may have review
+    evidence without repo evidence. The TeamSpace 5.0.0 event contract requires
+    evidence for both approved and done transitions, including at least one repo
+    entry, so dry-run/import synthesis fills only the missing historical facts.
+    """
+    resolved = dict(evidence or {})
+    if not resolved.get("review"):
+        resolved["review"] = {
+            "reviewer": status_event.actor or "historical-mission-state-repair",
+            "verdict": "approved",
+            "reference": status_event.review_ref
+            or f"historical-mission-state-repair:{status_event.mission_slug}:{status_event.wp_id}:{status_event.event_id}",
+        }
+    if not resolved.get("repos"):
+        resolved["repos"] = [
+            {
+                "repo": repo_slug or project_slug,
+                "branch": "historical-mission-state-repair",
+                "commit": "historical-mission-state-repair",
+            }
+        ]
+    resolved.setdefault("verification", [])
+    return resolved
 
 
 def _scan_raw_status_rows(repo_root: Path, mission_dir: Path) -> list[dict[str, object]]:

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -394,6 +394,74 @@ def test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows(tm
     assert len(dry_run.row_mappings) == 1
 
 
+def test_teamspace_dry_run_synthesizes_missing_historical_approval_evidence(tmp_path: Path) -> None:
+    if not _has_events_5():
+        pytest.skip("TeamSpace dry-run validation requires spec-kitty-events >= 5.0.0")
+
+    repo = tmp_path
+    mission = repo / "kitty-specs" / "001-historical-approval"
+    mission.mkdir(parents=True)
+    mission_id = "01KQHRB8GCFJAX7HM4ZY52AQGR"
+    _write_json(
+        mission / "meta.json",
+        {
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "friendly_name": "Historical Approval",
+            "mission_id": mission_id,
+            "mission_number": 1,
+            "mission_slug": "001-historical-approval",
+            "mission_type": "software-dev",
+            "slug": "001-historical-approval",
+            "target_branch": "main",
+        },
+    )
+    rows = [
+        {
+            "actor": "codex",
+            "at": "2026-01-01T00:00:00+00:00",
+            "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGS",
+            "execution_mode": "worktree",
+            "force": False,
+            "from_lane": "for_review",
+            "mission_id": mission_id,
+            "mission_slug": "001-historical-approval",
+            "policy_metadata": None,
+            "reason": None,
+            "review_ref": None,
+            "evidence": None,
+            "to_lane": "approved",
+            "wp_id": "WP01",
+        },
+        {
+            "actor": "codex",
+            "at": "2026-01-01T00:00:01+00:00",
+            "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGT",
+            "execution_mode": "worktree",
+            "force": False,
+            "from_lane": "approved",
+            "mission_id": mission_id,
+            "mission_slug": "001-historical-approval",
+            "policy_metadata": None,
+            "reason": None,
+            "review_ref": "review://historical",
+            "evidence": None,
+            "to_lane": "done",
+            "wp_id": "WP01",
+        },
+    ]
+    (mission / "status.events.jsonl").write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    dry_run = teamspace_dry_run(repo, mission="001-historical-approval")
+
+    assert dry_run.valid
+    assert dry_run.envelope_count == 2
+    assert dry_run.errors == ()
+    assert len(dry_run.row_mappings) == 2
+
+
 def test_repo_slug_preserves_https_remote_colon(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class _Result:
         def __init__(self, stdout: str) -> None:


### PR DESCRIPTION
## Summary
- synthesize deterministic TeamSpace evidence for historical approved/done rows when local status rows have no evidence object
- preserve existing review evidence and continue filling missing repo evidence for historical rows
- add a regression test covering missing historical approval and done evidence

## Validation
Before fix, dry-run errors were all `PAYLOAD_INVALID` due `to_lane in {approved, done} requires evidence`:
- spec-kitty: valid=false, 110 errors
- spec-kitty-saas: valid=false, 41 errors
- spec-kitty-events: valid=false, 5 errors
- spec-kitty-runtime: valid=true, 0 errors

After fix in fresh monorepo-prep workspace:
- spec-kitty: valid=true, 4295 envelopes, 0 errors
- spec-kitty-saas: valid=true, 1865 envelopes, 0 errors
- spec-kitty-events: valid=true, 337 envelopes, 0 errors
- spec-kitty-runtime: valid=true, 93 envelopes, 0 errors

## Test commands
- `ruff check src/specify_cli/migration/mission_state.py tests/migration/test_mission_state_repair.py`
- `pytest -q tests/migration/test_mission_state_repair.py::test_teamspace_dry_run_synthesizes_missing_historical_approval_evidence tests/migration/test_mission_state_repair.py::test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows`
- `pytest -q tests/migration/test_mission_state_repair.py tests/migration/test_teamspace_migration_rehearsal.py tests/audit/test_audit_cli.py`

Related to #920.