### PR TITLE
fix: accept SaaS-supported versions within CLI dependency ranges

### DIFF
--- a/scripts/release/check_candidate_consumer_compat.py
+++ b/scripts/release/check_candidate_consumer_compat.py
@@ -7,8 +7,8 @@ import argparse
 import email
 import json
 import zipfile
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable, List
 
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
@@ -56,7 +56,7 @@ def read_wheel_metadata(wheel_path: Path) -> email.message.Message:
     return email.message_from_string(payload)
 
 
-def load_contract(path: Path) -> Dict[str, object]:
+def load_contract(path: Path) -> dict[str, object]:
     if not path.exists():
         raise SystemExit(f"Consumer contract not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -84,13 +84,71 @@ def exact_pin(requirement: Requirement) -> str | None:
     return spec.version
 
 
-def extract_requirements(requires_dist: Iterable[str]) -> Dict[str, Requirement]:
-    requirements: Dict[str, Requirement] = {}
+def exact_versions(specifier: SpecifierSet) -> list[Version]:
+    versions: list[Version] = []
+    for spec in specifier:
+        if spec.operator == "==" and not spec.version.endswith(".*"):
+            versions.append(Version(spec.version))
+    return versions
+
+
+def extract_requirements(requires_dist: Iterable[str]) -> dict[str, Requirement]:
+    requirements: dict[str, Requirement] = {}
     for raw in requires_dist:
         req = parse_requirement(raw)
         if req.name.startswith("spec-kitty-"):
             requirements[req.name] = req
     return requirements
+
+
+def validate_package_requirement(
+    package: str,
+    supported_range: str,
+    requirement: Requirement | None,
+) -> tuple[str | None, str | None]:
+    if supported_range == "vendored":
+        return f"{package}: vendored by consumer, skipped", None
+
+    if requirement is None:
+        return None, f"Candidate wheel is missing required dependency metadata for {package}"
+
+    if requirement.url or not str(requirement.specifier):
+        return (
+            None,
+            f"{package}: candidate must carry dependency version metadata, found {requirement}",
+        )
+
+    specifier = SpecifierSet(supported_range)
+    consumer_exact_versions = exact_versions(specifier)
+    if consumer_exact_versions:
+        unsupported = [
+            version
+            for version in consumer_exact_versions
+            if not requirement.specifier.contains(version, prereleases=True)
+        ]
+        if unsupported:
+            versions = ", ".join(str(version) for version in unsupported)
+            return (
+                None,
+                f"{package}: SaaS supports {versions}, but candidate metadata {requirement} does not allow it",
+            )
+        versions = ", ".join(str(version) for version in consumer_exact_versions)
+        return f"{package}: candidate allows SaaS-supported {versions}", None
+
+    pinned = exact_pin(requirement)
+    if pinned is None:
+        return (
+            None,
+            f"{package}: consumer range {supported_range} is not exact and candidate metadata {requirement} is not exact; compatibility cannot be proven",
+        )
+
+    if Version(pinned) not in specifier:
+        return (
+            None,
+            f"{package}: pinned version {pinned} is outside consumer-supported range {supported_range}",
+        )
+
+    return f"{package}: {pinned} satisfies {supported_range}", None
 
 
 def main() -> int:
@@ -110,11 +168,11 @@ def main() -> int:
     if not isinstance(families, list):
         raise SystemExit("Consumer contract missing contract_families list")
 
-    summary: List[str] = [
+    summary: list[str] = [
         f"candidate: {metadata.get('Name', args.package)}=={metadata.get('Version', 'unknown')}",
         f"consumer: {contract.get('consumer', 'unknown')}",
     ]
-    issues: List[str] = []
+    issues: list[str] = []
 
     for entry in families:
         if not isinstance(entry, dict):
@@ -124,30 +182,15 @@ def main() -> int:
         if not isinstance(package, str) or not isinstance(supported_range, str):
             raise SystemExit("Contract family entries must include package and supported_range")
 
-        requirement = requirements.get(package)
-        if supported_range == "vendored":
-            summary.append(f"{package}: vendored by consumer, skipped")
-            continue
-
-        if requirement is None:
-            issues.append(f"Candidate wheel is missing required dependency metadata for {package}")
-            continue
-
-        pinned = exact_pin(requirement)
-        if pinned is None:
-            issues.append(
-                f"{package}: candidate must carry an exact == pin, found {requirement}"
-            )
-            continue
-
-        specifier = SpecifierSet(supported_range)
-        if Version(pinned) not in specifier:
-            issues.append(
-                f"{package}: pinned version {pinned} is outside consumer-supported range {supported_range}"
-            )
-            continue
-
-        summary.append(f"{package}: {pinned} satisfies {supported_range}")
+        summary_line, issue = validate_package_requirement(
+            package,
+            supported_range,
+            requirements.get(package),
+        )
+        if summary_line is not None:
+            summary.append(summary_line)
+        if issue is not None:
+            issues.append(issue)
 
     print("Candidate Consumer Compatibility Summary")
     print("----------------------------------------")

--- a/tests/release/test_check_candidate_consumer_compat.py
+++ b/tests/release/test_check_candidate_consumer_compat.py
@@ -32,12 +32,17 @@ def write_wheel(dist_dir: Path, *, version: str, requirements: list[str]) -> Pat
     return wheel_path
 
 
-def write_contract(path: Path) -> None:
+def write_contract(
+    path: Path,
+    *,
+    events_range: str = ">=3.2.0,<4.0",
+    tracker_range: str = ">=0.4.0,<0.5",
+) -> None:
     payload = {
         "consumer": "spec-kitty-saas",
         "contract_families": [
-            {"package": "spec-kitty-events", "supported_range": ">=3.2.0,<4.0"},
-            {"package": "spec-kitty-tracker", "supported_range": ">=0.4.0,<0.5"},
+            {"package": "spec-kitty-events", "supported_range": events_range},
+            {"package": "spec-kitty-tracker", "supported_range": tracker_range},
             {"package": "spec-kitty-runtime", "supported_range": "vendored"},
         ],
     }
@@ -109,3 +114,104 @@ def test_candidate_consumer_compat_fails_for_out_of_range_pin(tmp_path: Path) ->
 
     assert result.returncode == 1
     assert "outside consumer-supported range" in result.stdout
+
+
+def test_candidate_consumer_compat_passes_when_candidate_range_contains_saas_pin(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contract = tmp_path / "consumer-compatibility.json"
+    write_contract(contract, events_range="==5.0.0", tracker_range="==0.4.3")
+    write_wheel(
+        dist_dir,
+        version="3.2.0rc5",
+        requirements=[
+            "spec-kitty-events>=5.0.0,<6.0.0",
+            "spec-kitty-runtime==0.4.4",
+            "spec-kitty-tracker>=0.4,<0.5",
+        ],
+    )
+
+    result = run_check(
+        tmp_path,
+        "--dist-dir",
+        str(dist_dir),
+        "--package",
+        "spec-kitty-cli",
+        "--consumer-contract",
+        str(contract),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "spec-kitty-events: candidate allows SaaS-supported 5.0.0" in result.stdout
+    assert "spec-kitty-tracker: candidate allows SaaS-supported 0.4.3" in result.stdout
+
+
+def test_candidate_consumer_compat_fails_when_candidate_range_excludes_saas_pin(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contract = tmp_path / "consumer-compatibility.json"
+    write_contract(contract, events_range="==5.0.0", tracker_range="==0.4.3")
+    write_wheel(
+        dist_dir,
+        version="3.2.0rc5",
+        requirements=[
+            "spec-kitty-events>=4.0.0,<5.0.0",
+            "spec-kitty-runtime==0.4.4",
+            "spec-kitty-tracker>=0.5,<0.6",
+        ],
+    )
+
+    result = run_check(
+        tmp_path,
+        "--dist-dir",
+        str(dist_dir),
+        "--package",
+        "spec-kitty-cli",
+        "--consumer-contract",
+        str(contract),
+    )
+
+    assert result.returncode == 1
+    assert (
+        "spec-kitty-events: SaaS supports 5.0.0, but candidate metadata "
+        "spec-kitty-events<5.0.0,>=4.0.0 does not allow it"
+    ) in result.stdout
+    assert (
+        "spec-kitty-tracker: SaaS supports 0.4.3, but candidate metadata "
+        "spec-kitty-tracker<0.6,>=0.5 does not allow it"
+    ) in result.stdout
+
+
+def test_candidate_consumer_compat_fails_when_both_sides_use_broad_ranges(
+    tmp_path: Path,
+) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contract = tmp_path / "consumer-compatibility.json"
+    write_contract(contract, events_range=">=5.0.0,<6.0.0", tracker_range="==0.4.3")
+    write_wheel(
+        dist_dir,
+        version="3.2.0rc5",
+        requirements=[
+            "spec-kitty-events>=5.0.0,<6.0.0",
+            "spec-kitty-runtime==0.4.4",
+            "spec-kitty-tracker>=0.4,<0.5",
+        ],
+    )
+
+    result = run_check(
+        tmp_path,
+        "--dist-dir",
+        str(dist_dir),
+        "--package",
+        "spec-kitty-cli",
+        "--consumer-contract",
+        str(contract),
+    )
+
+    assert result.returncode == 1
+    assert "compatibility cannot be proven" in result.stdout


### PR DESCRIPTION
## Summary
- update the SaaS consumer compatibility release gate to accept candidate CLI dependency ranges that include SaaS-supported exact versions
- keep conservative behavior for broad consumer ranges by requiring an exact candidate pin when no exact SaaS-supported version is declared
- add regression coverage for range-containing-SaaS-pin, range-excluding-SaaS-pin, exact-pin, broad-range ambiguity, and vendored runtime behavior

## Verification
- uv run pytest tests/release/test_check_candidate_consumer_compat.py -q
- uv run ruff check scripts/release/check_candidate_consumer_compat.py tests/release/test_check_candidate_consumer_compat.py
- uv run --extra test python -m build
- uv run --extra test python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json
- uv run --extra test python scripts/release/check_exact_install.py --package spec-kitty-cli
- uv run --extra test pytest tests/release -q
- uv run --extra test python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv run --extra test python scripts/release/check_shared_package_drift.py --saas-pyproject ../spec-kitty-saas/pyproject.toml