### PR TITLE
chore: prepare 3.2.0rc6 release

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc5
+  version: 3.2.0rc6
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.2.0rc6] - 2026-05-11
+
+3.2.0rc6 includes the post-rc5 TeamSpace migration enforcement and dry-run
+compatibility fixes needed before publishing the next TeamSpace-ready CLI
+candidate.
+
+### Changed
+
+- Surface pending TeamSpace mission-state migration during `spec-kitty upgrade`
+  and require a clean migration before hosted TeamSpace connection flows.
+- Allow the release compatibility gate to prove SaaS-supported dependency
+  versions when the candidate CLI declares a compatible range instead of an
+  exact pin.
+
+### Fixed
+
+- Render user-friendly TeamSpace migration gate failures when mission-state
+  repair raises unexpected payload or filesystem errors.
+- Preserve SaaS-disabled sync opt-in behavior while still enforcing
+  mission-state readiness for hosted sync paths.
+- Synthesize historical approval evidence during TeamSpace dry-run conversion
+  so approved/done mission-state rows can validate against the canonical event
+  contract.
+
 ## [3.2.0rc5] - 2026-05-11
 
 3.2.0rc5 closes the remaining CLI-side TeamSpace migration readiness gaps found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc5"
+version = "3.2.0rc6"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc5"
+version = "3.2.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- bump spec-kitty CLI release metadata from 3.2.0rc5 to 3.2.0rc6
- add changelog entry for the merged TeamSpace migration gate and dry-run compatibility fixes
- refresh uv.lock editable package version

## Verification
- TeamSpace final matrix from fresh workspace on merged main:
  - spec-kitty: blockers=0, dry-run valid=true, errors=0
  - spec-kitty-saas: blockers=0, dry-run valid=true, errors=0
  - spec-kitty-events: blockers=0, dry-run valid=true, errors=0
  - spec-kitty-runtime: blockers=0, dry-run valid=true, errors=0
  - spec-kitty-tracker: blockers=0, dry-run valid=true, errors=0
- `uv run python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"`
- `uv run --extra test python -m pytest tests/release -q`
- `uv run --extra test python scripts/release/check_shared_package_drift.py --saas-pyproject ../spec-kitty-saas/pyproject.toml`
- `uv run --extra test python -m build`
- `uv run --extra test python scripts/release/check_exact_install.py --package spec-kitty-cli`
- `uv run --extra test python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json`
- `uv run --with twine python -m twine check dist/*`

## Release note
After this PR lands, publish by tagging the merge commit as `v3.2.0rc6`.
