### PR TITLE
fix(next): preflight task requirement mappings before finalization

### DIFF
--- a/src/specify_cli/missions/software-dev/command-templates/tasks-finalize.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks-finalize.md
@@ -26,27 +26,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission finalize-tasks --json
+spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -57,7 +76,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -66,7 +85,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/src/specify_cli/missions/software-dev/command-templates/tasks.md
+++ b/src/specify_cli/missions/software-dev/command-templates/tasks.md
@@ -219,15 +219,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/src/specify_cli/next/runtime_bridge.py
+++ b/src/specify_cli/next/runtime_bridge.py
@@ -375,6 +375,8 @@ def _check_cli_guards(step_id: str, feature_dir: Path) -> list[str]:  # noqa: C9
         tasks_dir = feature_dir / "tasks"
         if not tasks_dir.is_dir() or not list(tasks_dir.glob(TASKS_GLOB)):
             failures.append(MISSING_TASK_FILES_MESSAGE)
+        else:
+            failures.extend(_check_requirement_mapping_ready(feature_dir))
 
     elif step_id == "tasks_finalize":
         tasks_dir = feature_dir / "tasks"
@@ -398,6 +400,88 @@ def _check_cli_guards(step_id: str, feature_dir: Path) -> list[str]:  # noqa: C9
         failures.append("Not all work packages are approved or done")
 
     return failures
+
+
+def _check_requirement_mapping_ready(feature_dir: Path) -> list[str]:
+    """Validate requirement coverage before issuing the finalize-tasks prompt.
+
+    This intentionally mirrors ``agent mission finalize-tasks`` requirement
+    source precedence: WP frontmatter is primary, and ``tasks.md`` is only a
+    legacy fallback when no ``wps.yaml`` manifest is present.
+    """
+    spec_md = feature_dir / SPEC_ARTIFACT
+    if not spec_md.exists():
+        return []
+
+    tasks_dir = feature_dir / "tasks"
+    if not tasks_dir.is_dir():
+        return []
+
+    try:
+        from specify_cli.core.wps_manifest import load_wps_manifest
+        from specify_cli.requirement_mapping import (
+            parse_requirement_ids_from_spec_md,
+            read_all_wp_requirement_refs,
+        )
+
+        spec_ids = parse_requirement_ids_from_spec_md(spec_md.read_text(encoding="utf-8"))
+        all_spec_requirement_ids = set(spec_ids["all"])
+        functional_requirement_ids = set(spec_ids["functional"])
+
+        wps_manifest = load_wps_manifest(feature_dir)
+        wp_requirement_refs = read_all_wp_requirement_refs(tasks_dir)
+
+        if wps_manifest is None:
+            tasks_md = feature_dir / TASKS_ARTIFACT
+            if tasks_md.exists():
+                from specify_cli.cli.commands.agent.mission import _parse_requirement_refs_from_tasks_md
+
+                tasks_md_refs = _parse_requirement_refs_from_tasks_md(tasks_md.read_text(encoding="utf-8"))
+                for wp_id, refs in tasks_md_refs.items():
+                    if refs and not wp_requirement_refs.get(wp_id):
+                        wp_requirement_refs[wp_id] = refs
+    except Exception as exc:
+        return [f"Requirement mapping preflight failed: {exc}"]
+
+    wp_ids = sorted(wp_file.stem.split("-", 1)[0] for wp_file in tasks_dir.glob(TASKS_GLOB))
+    missing_requirement_refs_wps: list[str] = []
+    unknown_requirement_refs: dict[str, list[str]] = {}
+    mapped_requirement_ids: set[str] = set()
+
+    for wp_id in wp_ids:
+        refs = wp_requirement_refs.get(wp_id, [])
+        if not refs:
+            missing_requirement_refs_wps.append(wp_id)
+            continue
+
+        unknown_refs = sorted(ref for ref in refs if ref not in all_spec_requirement_ids)
+        if unknown_refs:
+            unknown_requirement_refs[wp_id] = unknown_refs
+        else:
+            mapped_requirement_ids.update(refs)
+
+    unmapped_functional_requirements = sorted(functional_requirement_ids - mapped_requirement_ids)
+    if not (missing_requirement_refs_wps or unknown_requirement_refs or unmapped_functional_requirements):
+        return []
+
+    details: list[str] = []
+    if missing_requirement_refs_wps:
+        details.append(f"missing refs for WPs: {', '.join(missing_requirement_refs_wps)}")
+    if unknown_requirement_refs:
+        unknown_parts = [
+            f"{wp_id}: {', '.join(refs)}"
+            for wp_id, refs in sorted(unknown_requirement_refs.items())
+        ]
+        details.append(f"unknown refs: {'; '.join(unknown_parts)}")
+    if unmapped_functional_requirements:
+        details.append(f"unmapped FRs: {', '.join(unmapped_functional_requirements)}")
+
+    return [
+        "Requirement mapping incomplete before finalize-tasks: "
+        + "; ".join(details)
+        + ". Run `spec-kitty agent tasks map-requirements --batch ... --mission "
+        + f"{feature_dir.name} --json` or update WP requirement_refs before finalizing."
+    ]
 
 
 def _has_raw_dependencies_field(wp_file: Path) -> bool:
@@ -817,12 +901,15 @@ def _check_composed_action_guard(  # noqa: C901
         elif legacy_step_id == "tasks_packages":
             # After tasks_packages: tasks.md AND >=1 WP file. Dependencies
             # are not yet expected — finalize-tasks adds them in the next
-            # substep.
+            # substep. Requirement mapping must already be complete so the
+            # next surfaced prompt does not blindly run finalize-tasks.
             if not (feature_dir / TASKS_ARTIFACT).exists():
                 failures.append(MISSING_ARTIFACT_MESSAGE.format(name=TASKS_ARTIFACT))
             tasks_dir = feature_dir / "tasks"
             if not tasks_dir.is_dir() or not list(tasks_dir.glob("WP*.md")):
                 failures.append("Required: at least one tasks/WP*.md file")
+            else:
+                failures.extend(_check_requirement_mapping_ready(feature_dir))
         else:
             # legacy_step_id == "tasks_finalize" OR composition-only
             # (legacy_step_id is None): demand the full terminal state.
@@ -834,6 +921,7 @@ def _check_composed_action_guard(  # noqa: C901
             if not tasks_dir.is_dir() or not list(tasks_dir.glob("WP*.md")):
                 failures.append("Required: at least one tasks/WP*.md file")
             else:
+                failures.extend(_check_requirement_mapping_ready(feature_dir))
                 for wp_file in sorted(tasks_dir.glob("WP*.md")):
                     if not _has_raw_dependencies_field(wp_file):
                         failures.append(

--- a/tests/next/test_next_command_integration.py
+++ b/tests/next/test_next_command_integration.py
@@ -907,7 +907,14 @@ class TestAtomicTaskTransitions:
         feature_dir = repo_root / "kitty-specs" / "042-test-feature"
 
         # Create artifacts for earlier steps
-        (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
         (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
         (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
 
@@ -915,7 +922,8 @@ class TestAtomicTaskTransitions:
         tasks_dir = feature_dir / "tasks"
         tasks_dir.mkdir(exist_ok=True)
         (tasks_dir / "WP01.md").write_text(
-            "---\nwork_package_id: WP01\nlane: done\ndependencies: []\ntitle: WP01\n---\n# WP01\n",
+            "---\nwork_package_id: WP01\nlane: done\ndependencies: []\n"
+            "requirement_refs: [FR-001]\ntitle: WP01\n---\n# WP01\n",
             encoding="utf-8",
         )
         # Seed event log so runtime bridge reads WP01 as done

--- a/tests/next/test_retrospective_terminus_wiring.py
+++ b/tests/next/test_retrospective_terminus_wiring.py
@@ -266,13 +266,21 @@ def _scaffold_opt_in_project(tmp_path: Path) -> tuple[Path, Path]:
     )
 
     # CLI guard artifacts
-    (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+    (feature_dir / "spec.md").write_text(
+        "# Spec\n\n"
+        "## Functional Requirements\n\n"
+        "| ID | Requirement | Acceptance Criteria | Status |\n"
+        "| --- | --- | --- | --- |\n"
+        "| FR-001 | First | Covered by WP01. | proposed |\n",
+        encoding="utf-8",
+    )
     (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
     (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir()
     (tasks_dir / "WP01.md").write_text(
-        "---\nwork_package_id: WP01\nlane: done\ndependencies: []\ntitle: WP01\n---\n# WP01\n",
+        "---\nwork_package_id: WP01\nlane: done\ndependencies: []\n"
+        "requirement_refs: [FR-001]\ntitle: WP01\n---\n# WP01\n",
         encoding="utf-8",
     )
     _seed_wp_lane(feature_dir, "WP01", "done")

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -664,14 +664,22 @@ class TestFullLoop:
         feature_dir = repo_root / "kitty-specs" / "042-test-feature"
 
         # Create required artifacts so CLI guards pass
-        (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
         (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
         (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
         # Create WP files with explicit dependencies for tasks_finalize guard
         tasks_dir = feature_dir / "tasks"
         tasks_dir.mkdir(exist_ok=True)
         (tasks_dir / "WP01.md").write_text(
-            "---\nwork_package_id: WP01\nlane: done\ndependencies: []\ntitle: WP01\n---\n# WP01\n",
+            "---\nwork_package_id: WP01\nlane: done\ndependencies: []\n"
+            "requirement_refs: [FR-001]\ntitle: WP01\n---\n# WP01\n",
             encoding="utf-8",
         )
         # Seed event log so runtime bridge reads WP01 as done

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -848,6 +848,129 @@ class TestAtomicTaskSteps:
         assert len(failures) == 0
 
     @pytest.mark.git_repo
+    def test_tasks_packages_guard_blocks_unmapped_functional_requirements(self, tmp_path: Path) -> None:
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n"
+            "| FR-002 | Second | Must be mapped before finalization. | proposed |\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\n"
+            "work_package_id: WP01\n"
+            "title: WP01\n"
+            "requirement_refs:\n"
+            "  - FR-001\n"
+            "---\n"
+            "# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert len(failures) == 1
+        assert "Requirement mapping incomplete" in failures[0]
+        assert "unmapped FRs: FR-002" in failures[0]
+        assert "map-requirements" in failures[0]
+
+    @pytest.mark.git_repo
+    def test_composed_tasks_packages_guard_blocks_unmapped_functional_requirements(self, tmp_path: Path) -> None:
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n"
+            "| FR-002 | Second | Must be mapped before finalization. | proposed |\n",
+            encoding="utf-8",
+        )
+        (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\nrequirement_refs: [FR-001]\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_composed_action_guard
+
+        failures = _check_composed_action_guard(
+            "tasks",
+            feature_dir,
+            legacy_step_id="tasks_packages",
+        )
+        assert len(failures) == 1
+        assert "Requirement mapping incomplete" in failures[0]
+        assert "unmapped FRs: FR-002" in failures[0]
+
+    @pytest.mark.git_repo
+    def test_tasks_packages_guard_passes_when_functional_requirements_are_mapped(self, tmp_path: Path) -> None:
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n"
+            "| FR-002 | Second | Covered by WP02. | proposed |\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\nrequirement_refs: [FR-001]\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+        (tasks_dir / "WP02.md").write_text(
+            "---\nwork_package_id: WP02\ntitle: WP02\nrequirement_refs: [FR-002]\n---\n# WP02\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert failures == []
+
+    @pytest.mark.git_repo
+    def test_tasks_packages_guard_uses_legacy_tasks_md_refs_without_wps_yaml(self, tmp_path: Path) -> None:
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
+        (feature_dir / "tasks.md").write_text(
+            "## Work Package WP01\n\n**Requirement Refs**: FR-001\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert failures == []
+
+    @pytest.mark.git_repo
     def test_tasks_finalize_guard_blocks_without_raw_dependencies(self, tmp_path: Path) -> None:
         """WP files exist but no explicit dependencies: in raw frontmatter."""
         repo_root = _scaffold_project(tmp_path)

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -979,6 +979,106 @@ class TestAtomicTaskSteps:
         assert failures == []
 
     @pytest.mark.git_repo
+    def test_tasks_packages_guard_blocks_missing_requirement_refs(self, tmp_path: Path) -> None:
+        """WP has no requirement_refs at all → missing-refs branch."""
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert len(failures) == 1
+        assert "missing refs for WPs: WP01" in failures[0]
+        assert "map-requirements" in failures[0]
+
+    @pytest.mark.git_repo
+    def test_tasks_packages_guard_blocks_unknown_requirement_refs(self, tmp_path: Path) -> None:
+        """WP references an FR that doesn't exist in spec.md → unknown-refs branch."""
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\nrequirement_refs: [FR-999]\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert len(failures) == 1
+        assert "unknown refs: WP01: FR-999" in failures[0]
+
+    @pytest.mark.git_repo
+    def test_requirement_mapping_preflight_noop_when_no_tasks_dir(self, tmp_path: Path) -> None:
+        """Helper returns [] when tasks/ does not exist even if spec.md does."""
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_requirement_mapping_ready
+
+        assert _check_requirement_mapping_ready(feature_dir) == []
+
+    @pytest.mark.git_repo
+    def test_requirement_mapping_preflight_wraps_unexpected_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unexpected exceptions during preflight surface as a guard failure, not a crash."""
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\nrequirement_refs: [FR-001]\n---\n",
+            encoding="utf-8",
+        )
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("simulated preflight crash")
+
+        from specify_cli import requirement_mapping as rm
+
+        monkeypatch.setattr(rm, "parse_requirement_ids_from_spec_md", _boom)
+
+        from specify_cli.next.runtime_bridge import _check_requirement_mapping_ready
+
+        failures = _check_requirement_mapping_ready(feature_dir)
+        assert len(failures) == 1
+        assert "Requirement mapping preflight failed" in failures[0]
+        assert "simulated preflight crash" in failures[0]
+
+    @pytest.mark.git_repo
     def test_tasks_finalize_guard_blocks_without_raw_dependencies(self, tmp_path: Path) -> None:
         """WP files exist but no explicit dependencies: in raw frontmatter."""
         repo_root = _scaffold_project(tmp_path)

--- a/tests/specify_cli/next/test_runtime_bridge_composition.py
+++ b/tests/specify_cli/next/test_runtime_bridge_composition.py
@@ -67,17 +67,30 @@ def _local_only_sync_emitter(monkeypatch: pytest.MonkeyPatch) -> None:
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_SPEC_MD = (
+    "# Spec\n\n"
+    "## Functional Requirements\n\n"
+    "| ID | Requirement | Acceptance Criteria | Status |\n"
+    "| --- | --- | --- | --- |\n"
+    "| FR-001 | First | Covered by WP01. | proposed |\n"
+)
+
+
 def _write_wp_file(
     tasks_dir: Path,
     wp_id: str,
     *,
     with_dependencies: bool = True,
+    requirement_refs: list[str] | None = ("FR-001",),
 ) -> Path:
     """Write a minimal WP*.md file with optional 'dependencies:' frontmatter."""
     wp_file = tasks_dir / f"{wp_id}-test.md"
     deps_line = "dependencies: []\n" if with_dependencies else ""
+    refs_line = ""
+    if requirement_refs:
+        refs_line = f"requirement_refs: [{', '.join(requirement_refs)}]\n"
     wp_file.write_text(
-        f"---\nwork_package_id: {wp_id}\ntitle: Test\n{deps_line}---\nbody\n",
+        f"---\nwork_package_id: {wp_id}\ntitle: Test\n{deps_line}{refs_line}---\nbody\n",
         encoding="utf-8",
     )
     return wp_file
@@ -96,7 +109,7 @@ def feature_dir_with_full_tasks(tmp_path: Path) -> Path:
     """Feature dir with spec.md, plan.md, tasks.md, and one valid WP*.md."""
     fd = tmp_path / "kitty-specs" / "test-feature"
     fd.mkdir(parents=True)
-    (fd / "spec.md").write_text("# spec", encoding="utf-8")
+    (fd / "spec.md").write_text(_DEFAULT_SPEC_MD, encoding="utf-8")
     (fd / "plan.md").write_text("# plan", encoding="utf-8")
     (fd / "tasks.md").write_text("# tasks", encoding="utf-8")
     tasks = fd / "tasks"
@@ -886,7 +899,7 @@ def composed_software_dev_project(tmp_path: Path):
     repo_root, feature_dir, mission_slug = _scaffold_software_dev_project(tmp_path)
     # Lay down the artifacts every composed action's guard wants present so a
     # success path actually reaches the advancement helper.
-    (feature_dir / "spec.md").write_text("# spec", encoding="utf-8")
+    (feature_dir / "spec.md").write_text(_DEFAULT_SPEC_MD, encoding="utf-8")
     (feature_dir / "plan.md").write_text("# plan", encoding="utf-8")
     (feature_dir / "tasks.md").write_text("# tasks", encoding="utf-8")
     tasks = feature_dir / "tasks"

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-finalize.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-finalize.prompt.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks.prompt.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-finalize.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-finalize.toml
@@ -27,27 +27,46 @@ them, update WP<!-- glossary:glossary:wp --> frontmatter, and commit all task ar
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -58,7 +77,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -67,7 +86,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks.toml
@@ -206,15 +206,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-finalize.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-finalize.toml
@@ -27,27 +27,46 @@ them, update WP<!-- glossary:glossary:wp --> frontmatter, and commit all task ar
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -58,7 +77,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -67,7 +86,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks.toml
@@ -206,15 +206,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-finalize.md
@@ -28,27 +28,46 @@ $ARGUMENTS
 
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --json
+spec-kitty agent mission<!-- glossary:glossary:mission --> finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -59,7 +78,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -68,7 +87,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks.md
@@ -207,15 +207,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
@@ -26,27 +26,46 @@ The content of the user's message that invoked this skill (everything after the 
 You **MUST** consider this user input before proceeding (if not empty).
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission finalize-tasks --json
+spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -57,7 +76,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -66,7 +85,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
@@ -204,15 +204,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
@@ -26,27 +26,46 @@ The content of the user's message that invoked this skill (everything after the 
 You **MUST** consider this user input before proceeding (if not empty).
 ## Steps
 
-### 1. Run Finalization Command
+### 1. Run Validate-Only Preflight
 
-**CRITICAL**: Run this command from repo root:
+**CRITICAL**: Run this preflight command from repo root before any mutating
+finalization:
 
 ```bash
-spec-kitty agent mission finalize-tasks --json
+spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
 ```
 
 This command will:
 
 - Parse dependencies from tasks.md
 - Parse `Requirement Refs` from tasks.md
-- Update WP frontmatter with `dependencies` and `requirement_refs` fields
+- Preview WP frontmatter updates without writing files
 - Validate dependencies (check for cycles, invalid references)
 - Validate requirement mapping:
   - Every WP has at least one requirement reference
   - Referenced requirement IDs exist in spec.md
   - Every FR-### in spec.md is mapped to at least one WP
-- Commit all tasks to target branch
 
-### 2. Check Output
+If the JSON output contains `"error": "Requirement mapping validation failed"`,
+do **not** run finalization. Report the blocking fields
+(`missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+`unmapped_functional_requirements`), then fix mappings with
+`spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
+updating WP `requirement_refs`.
+
+### 2. Run Finalization Command
+
+Only after validate-only exits successfully, run the mutating finalization
+command from repo root:
+
+```bash
+spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
+```
+
+This command will update WP frontmatter, compute lanes, and commit all tasks to
+the target branch.
+
+### 3. Check Output
 
 The JSON output includes:
 
@@ -57,7 +76,7 @@ The JSON output includes:
 - `"requirement_refs_parsed"` — requirement reference mapping found
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
 
-### 3. Verify
+### 4. Verify
 
 **IMPORTANT — DO NOT COMMIT AGAIN AFTER THIS COMMAND**:
 
@@ -66,7 +85,7 @@ The JSON output includes:
 - Other dirty files shown by `git status` (templates, config) are UNRELATED
 - Verify using the `commit_hash` from JSON output, not by running `git add/commit` again
 
-### 4. Report
+### 5. Report
 
 Provide a concise outcome summary:
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
@@ -204,15 +204,29 @@ Prompts do not rediscover feature context. Commands do.
    - Run `spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json` to check ownership before committing.
 
 8. **Finalize tasks with dependency parsing and commit**:
-   After generating all WP prompt files, run the finalization command to:
+   After generating all WP prompt files, run validate-only first to prove the
+   finalization requirements are met:
    - Parse dependencies from tasks.md
-   - Update WP frontmatter with dependencies field
+   - Preview WP frontmatter updates without writing files
    - Validate dependencies (check for cycles, invalid references)
-   - Commit all tasks to target branch
+   - Validate requirement coverage before any commit
 
-   **CRITICAL**: Run this command from repo root:
+   **CRITICAL**: Run this preflight command from repo root:
    ```bash
-   spec-kitty agent mission finalize-tasks --json --mission <mission-slug>
+   spec-kitty agent mission finalize-tasks --validate-only --mission <mission-slug> --json
+   ```
+
+   If the JSON output contains `"error": "Requirement mapping validation failed"`,
+   do **not** run the mutating finalization command. Report
+   `missing_requirement_refs_wps`, `unknown_requirement_refs`, and
+   `unmapped_functional_requirements`, then fix mappings with
+   `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or
+   by updating WP `requirement_refs`.
+
+   Only after validate-only exits successfully, run the mutating command from
+   repo root:
+   ```bash
+   spec-kitty agent mission finalize-tasks --mission <mission-slug> --json
    ```
 
    This step is MANDATORY. Without it:

--- a/tests/specify_cli/test_command_template_cleanliness.py
+++ b/tests/specify_cli/test_command_template_cleanliness.py
@@ -353,6 +353,24 @@ def test_tasks_template_finalize_tasks_has_mission() -> None:
     )
 
 
+def test_tasks_template_finalization_is_preflight_first() -> None:
+    """tasks.md must instruct agents to validate before mutating finalization."""
+    content = _template_content("tasks")
+    validate_index = content.index("finalize-tasks --validate-only --mission")
+    mutate_index = content.index("finalize-tasks --mission <mission-slug> --json")
+    assert validate_index < mutate_index
+    assert "do **not** run the mutating finalization command" in content
+
+
+def test_tasks_finalize_template_is_preflight_first() -> None:
+    """tasks-finalize.md must not hand agents the mutating command first."""
+    content = _template_content("tasks-finalize")
+    validate_index = content.index("finalize-tasks --validate-only --mission")
+    mutate_index = content.index("finalize-tasks --mission <mission-slug> --json")
+    assert validate_index < mutate_index
+    assert "do **not** run finalization" in content
+
+
 def test_tasks_template_map_requirements_has_mission() -> None:
     """tasks.md map-requirements examples must include --mission (T030)."""
     content = _template_content("tasks")


### PR DESCRIPTION
## Summary
- make tasks-finalize and tasks prompts run `finalize-tasks --validate-only --mission <slug> --json` before the mutating finalization command
- add a `next`/runtime bridge guard that blocks task finalization when WP requirement refs are missing, unknown, or leave functional requirements unmapped
- update command renderer and twelve-agent task-family baselines for the prompt changes

## Tests
- `uv run pytest tests/next/test_runtime_bridge_unit.py::TestAtomicTaskSteps tests/specify_cli/test_command_template_cleanliness.py::test_tasks_template_finalize_tasks_has_mission tests/specify_cli/test_command_template_cleanliness.py::test_tasks_template_finalization_is_preflight_first tests/specify_cli/test_command_template_cleanliness.py::test_tasks_finalize_template_is_preflight_first -q`
- `uv run pytest tests/specify_cli/skills/test_command_renderer.py -q`
- `uv run pytest tests/specify_cli/regression/test_twelve_agent_parity.py::test_command_output_unchanged -k tasks -q`
- `uv run ruff check src/specify_cli/next/runtime_bridge.py tests/next/test_runtime_bridge_unit.py tests/specify_cli/test_command_template_cleanliness.py`
- `git diff --check`

## Note
A full `tests/specify_cli/regression/test_twelve_agent_parity.py` run also reports pre-existing non-task baseline drift for `plan`, `review`, and `specify`; this PR updates only the task-family baselines affected by these prompt edits.
