### PR TITLE
fix(security): remediate urllib3 alert and harden dashboard CDN script

### DIFF
--- a/src/specify_cli/dashboard/templates/index.html
+++ b/src/specify_cli/dashboard/templates/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Spec Kitty Dashboard</title>
     <link rel="icon" type="image/png" href="/static/spec-kitty.png">
-    <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js" integrity="sha384-zbcZAIxlvJtNE3Dp5nxLXdXtXyxwOdnILY1TDPVmKFhl4r4nSUG1r8bcFXGVa4Te" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="/static/dashboard/dashboard.css">
     <script>
         window.__INITIAL_MISSION__ = null;

--- a/uv.lock
+++ b/uv.lock
@@ -2429,11 +2429,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade `urllib3` in `uv.lock` from `2.6.3` to `2.7.0` to clear the open GitHub dependency alerts
- add Subresource Integrity and `crossorigin` to the dashboard's external `marked` CDN script
- investigate current SonarCloud `main` failures and separate actionable code fixes from review-only hotspots

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv lock --check`
- local `pip-audit` reproduction was attempted twice, but the repo venv was created without `pip`, so GitHub CI remains the authoritative audit for this change

## SonarCloud notes
- previous night's scheduled `CI Quality` run on `main`: https://github.com/Priivacy-ai/spec-kitty/actions/runs/25716032519
- quality gate failure was `new_coverage=56.5%` and `new_security_hotspots_reviewed=0.0%`
- open SonarCloud hotspots are dominated by loopback/local-only `http` usage that likely need review or architectural change rather than a safe suppression in this PR