### PR TITLE
fix: remediate urllib3 alert and charter sonar findings

### DIFF
--- a/src/charter/evidence/code_reader.py
+++ b/src/charter/evidence/code_reader.py
@@ -205,9 +205,9 @@ class CodeReadingCollector:
                 indicator_files.add(filename)
 
                 # Count TS vs JS files for disambiguation
-                if filename.endswith(".ts") or filename.endswith(".tsx"):
+                if filename.endswith((".ts", ".tsx")):
                     ts_files += 1
-                elif filename.endswith(".js") or filename.endswith(".jsx") or filename.endswith(".mjs"):
+                elif filename.endswith((".js", ".jsx", ".mjs")):
                     js_files += 1
 
                 # Bucket into source vs test

--- a/src/charter/interview.py
+++ b/src/charter/interview.py
@@ -76,7 +76,7 @@ def validate_local_support_declarations(
             )
             continue
         # Reject paths that look like directories (trailing slash)
-        if path.endswith("/") or path.endswith("\\"):
+        if path.endswith(("/", "\\")):
             errors.append(
                 f"local_supporting_files path '{path}' looks like a directory; "
                 "explicit file paths only."

--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -183,7 +183,7 @@ def sync(
         )
 
     except Exception as e:
-        logger.error(f"Sync failed: {e}")
+        logger.exception("Sync failed: %s", e)
         return SyncResult(
             synced=False,
             stale_before=False,

--- a/uv.lock
+++ b/uv.lock
@@ -2429,11 +2429,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade locked `urllib3` from `2.6.3` to `2.7.0` to address the open GitHub security alerts on `uv.lock`
- replace the charter sync failure log with `logger.exception(...)` so tracebacks are preserved and Sonar no longer flags the pattern
- collapse small chained `endswith()` checks in charter code into tuple-based calls to clear low-risk Sonar findings

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run --python 3.12 pytest tests/charter/test_compiler.py -k 'validate_'`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run --python 3.12 pytest tests/charter/test_integration.py -k 'post_save_hook'`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run --python 3.12 pytest tests/charter/evidence/test_code_reader.py`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run --python 3.12 ruff check src/charter/sync.py src/charter/interview.py src/charter/evidence/code_reader.py`

## Notes
- SonarCloud on `main` is still failing on project-level gate conditions (`new_coverage=56.5`, `new_security_hotspots_reviewed=0.0`) that predate this PR. This PR addresses actionable code/dependency findings surfaced in the nightly scan and GitHub security alerts; it does not suppress any Sonar rule.