### PR TITLE
fix(ci): quote protect-main commit metadata

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -37,6 +37,9 @@ jobs:
           fetch-depth: 2
 
       - name: Verify commit came from PR
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          HEAD_COMMITTER_NAME: ${{ github.event.head_commit.committer.name }}
         run: |
           # Skip check for repository initialization (first commit)
           if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
@@ -45,8 +48,8 @@ jobs:
           fi
 
           # Get commit message and metadata
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          COMMITTER="${{ github.event.head_commit.committer.name }}"
+          COMMIT_MSG="$HEAD_COMMIT_MESSAGE"
+          COMMITTER="$HEAD_COMMITTER_NAME"
 
           echo "Commit message: $COMMIT_MSG"
           echo "Committer: $COMMITTER"


### PR DESCRIPTION
## Summary

Fixes the post-merge Protect Main Branch workflow failure triggered by squash-merge commit bodies containing backticks.

The workflow was interpolating the full commit message directly into Bash source:

- backticks in the commit body were evaluated as command substitutions
- the compliance check failed before it could evaluate the PR-reference pattern

This moves the head commit message and committer name into step env vars, then reads those vars from Bash.

## Verification

- `git diff --check`
- Parsed `.github/workflows/protect-main.yml` with `yaml.safe_load(...)`
