### PR TITLE
fix: restore agent profile list compatibility

### DIFF
--- a/src/specify_cli/cli/commands/agent/__init__.py
+++ b/src/specify_cli/cli/commands/agent/__init__.py
@@ -4,6 +4,7 @@ import typer
 from typing_extensions import Annotated
 
 from . import config, mission, tasks, context, release, workflow, status, tests
+from specify_cli.cli.commands import profiles_cmd
 from specify_cli.cli.commands.agent_retrospect import app as retrospect_app
 from specify_cli.cli.commands.decision import decision_app
 
@@ -25,6 +26,12 @@ app.add_typer(status.app, name="status")
 app.add_typer(tests.app, name="tests")
 app.add_typer(decision_app, name="decision")
 app.add_typer(retrospect_app, name="retrospect", help="Retrospective synthesis commands")
+app.add_typer(
+    profiles_cmd.app,
+    name="profile",
+    help="Compatibility alias for listing agent profiles",
+    hidden=True,
+)
 
 
 @app.command(name="check-prerequisites", hidden=True)

--- a/src/specify_cli/cli/commands/profiles_cmd.py
+++ b/src/specify_cli/cli/commands/profiles_cmd.py
@@ -57,6 +57,7 @@ def list_profiles(
         descriptors.append(
             {
                 "profile_id": p.profile_id,
+                "identifier": p.profile_id,
                 "name": p.name,  # AgentProfile.name (not friendly_name — that field does not exist)
                 "role": str(p.role),
                 "action_domains": sorted({*canonical_verbs, *collab_verbs, *domain_kws}),

--- a/tests/specify_cli/invocation/cli/test_profiles.py
+++ b/tests/specify_cli/invocation/cli/test_profiles.py
@@ -54,6 +54,8 @@ class TestProfilesListJsonOutput:
         assert len(profiles) >= 1
         for p in profiles:
             assert "profile_id" in p
+            assert "identifier" in p
+            assert p["identifier"] == p["profile_id"]
             assert "name" in p
             assert "role" in p
             assert "action_domains" in p
@@ -122,3 +124,15 @@ class TestProfilesHelp:
         result = runner.invoke(cli_app, ["profiles", "--help"])
         assert result.exit_code == 0
         assert "profiles" in result.output.lower()
+
+
+class TestAgentProfileCompatibilityAlias:
+    def test_agent_profile_list_json_routes_to_profiles_list(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        with patch("specify_cli.cli.commands.profiles_cmd.find_repo_root", return_value=project):
+            result = runner.invoke(cli_app, ["agent", "profile", "list", "--json"])
+        assert result.exit_code == 0, result.output
+        profiles = json.loads(result.output)
+        profile_ids = [p["profile_id"] for p in profiles]
+        assert "implementer-fixture" in profile_ids
+        assert all(p["identifier"] == p["profile_id"] for p in profiles)


### PR DESCRIPTION
## Summary
- restore `spec-kitty agent profile list` as a hidden compatibility alias for the canonical `spec-kitty profiles list` command
- include `identifier` as a JSON alias for `profile_id` so existing agent scripts do not crash while canonical consumers keep using `profile_id`
- add regression coverage for the compatibility path

## Verification
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/invocation/cli/test_profiles.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run spec-kitty agent profile list --json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['profile_id'], d[0]['identifier'])"`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run spec-kitty profiles list --json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['profile_id'], d[0]['identifier'])"`