### PR TITLE
fix(sync): clamp batch-sync byte budget to defensive ceiling (#1045)

### DIFF
--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -86,8 +86,20 @@ CATEGORY_ACTIONS: dict[str, str] = {
 FINAL_SYNC_MAX_ATTEMPTS = 3
 FINAL_SYNC_RETRY_BACKOFF_SECONDS = 1.0
 SYNC_INGRESS_LIMITS_TIMEOUT_SECONDS = 10
-DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH = 900_000
+# Default per-request decompressed byte budget. Kept well below the 1 MiB
+# server cap (`apps.sync.limits.SYNC_INGRESS_MAX_DECOMPRESSED_BYTES`) so the
+# first POST attempt comfortably fits common edge/proxy limits and large
+# queues degrade gracefully into more, smaller requests rather than relying on
+# the HTTP 413 retry-with-shrink fallback (see issue
+# https://github.com/Priivacy-ai/spec-kitty/issues/1045).
+DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH = 262_144
 DECOMPRESSED_BYTES_SAFETY_FACTOR = 0.90
+# Hard ceiling applied to *any* per-request byte budget regardless of what the
+# server advertises via `/api/v1/sync/health/`. The advertised cap is honored
+# as an upper bound, but the CLI never sends requests larger than this ceiling
+# so that real-world edge proxies, intermediate gateways, and decompression
+# safety margins are respected.
+MAX_DECOMPRESSED_BYTES_PER_BATCH_CEILING = 524_288
 HISTORICAL_MISSION_STATE_FORBIDDEN_KEYS = frozenset(
     {
         "feature_slug",
@@ -278,7 +290,12 @@ def _decompressed_byte_limit(advertised_limits: dict[str, int]) -> int:
         "max_decompressed_bytes_per_batch",
         DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH,
     )
-    return max(1, int(advertised_limit * DECOMPRESSED_BYTES_SAFETY_FACTOR))
+    # Apply the safety margin, then clamp to the CLI's per-request ceiling so
+    # an over-generous server advertisement cannot push us into edge-proxy
+    # 413 territory. See issue
+    # https://github.com/Priivacy-ai/spec-kitty/issues/1045.
+    after_safety = int(advertised_limit * DECOMPRESSED_BYTES_SAFETY_FACTOR)
+    return max(1, min(after_safety, MAX_DECOMPRESSED_BYTES_PER_BATCH_CEILING))
 
 
 def _select_events_for_advertised_limits(

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -19,6 +19,7 @@ from specify_cli.auth.token_manager import TokenManager
 from specify_cli.sync.queue import OfflineQueue
 from specify_cli.sync.batch import (
     DEFAULT_MAX_DECOMPRESSED_BYTES_PER_BATCH,
+    MAX_DECOMPRESSED_BYTES_PER_BATCH_CEILING,
     BatchSyncResult,
     batch_sync,
     categorize_error,
@@ -367,6 +368,80 @@ class TestBatchSyncSuccess:
         assert 0 < len(sent_events) < 8
         assert len(sent_payload) <= int(900 * 0.90)
         assert result.total_events == len(sent_events)
+
+    @patch("specify_cli.sync.batch.requests.get")
+    @patch("specify_cli.sync.batch.requests.post")
+    def test_batch_sync_caps_advertised_limit_to_cli_ceiling(
+        self,
+        mock_post,
+        mock_get,
+        temp_queue,
+    ):
+        """An over-generous advertised cap must be clamped by the CLI ceiling.
+
+        Issue https://github.com/Priivacy-ai/spec-kitty/issues/1045: even when
+        the server advertises a 1 MiB decompressed budget, real edge proxies
+        and middlebox limits make sending requests that large unreliable. The
+        CLI must clamp to ``MAX_DECOMPRESSED_BYTES_PER_BATCH_CEILING`` so
+        successive POSTs stay safely small.
+        """
+        for i in range(64):
+            temp_queue.queue_event(
+                {
+                    "event_id": f"ceiling-evt-{i:04d}",
+                    "event_type": "WPStatusChanged",
+                    "aggregate_id": "WP01",
+                    "lamport_clock": i,
+                    "node_id": "test-node",
+                    "payload": {"body": "x" * 16_000},
+                }
+            )
+
+        health_response = Mock()
+        health_response.status_code = 200
+        health_response.json.return_value = {
+            "sync_ingress": {
+                "limits": {
+                    "max_events_per_batch": 1000,
+                    # 1 MiB advertised cap. Without clamping the CLI would
+                    # send roughly 943 KB per request and overshoot real edge
+                    # proxy limits.
+                    "max_decompressed_bytes_per_batch": 1_048_576,
+                }
+            }
+        }
+        mock_get.return_value = health_response
+
+        post_response = Mock()
+        post_response.status_code = 200
+
+        def _post_response(*args, **kwargs):
+            sent = json.loads(gzip.decompress(kwargs["data"]))["events"]
+            post_response.json.return_value = {
+                "results": [
+                    {"event_id": event["event_id"], "status": "success"}
+                    for event in sent
+                ]
+            }
+            return post_response
+
+        mock_post.side_effect = _post_response
+
+        result = batch_sync(
+            queue=temp_queue,
+            auth_token="token",
+            server_url="https://spec-kitty-dev.fly.dev",
+            limit=1000,
+            show_progress=False,
+        )
+
+        sent_payload = gzip.decompress(mock_post.call_args.kwargs["data"])
+        assert len(sent_payload) <= MAX_DECOMPRESSED_BYTES_PER_BATCH_CEILING
+        # At ~16 KB per event, no single batch can carry all 64 events under
+        # the ceiling, so the queue must retain leftovers for a subsequent
+        # batch round-trip.
+        assert result.total_events < 64
+        assert temp_queue.size() > 0
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_uses_fallback_decompressed_byte_limit(self, mock_post, temp_queue):


### PR DESCRIPTION
## Summary

- Lower the CLI default decompressed byte budget from 900 KB to 256 KiB and add a hard 512 KiB ceiling so the first POST always fits comfortably under real edge-proxy limits and large queues degrade into more, smaller requests instead of triggering the HTTP 413 retry-with-shrink fallback.
- New unit test in `tests/sync/test_batch_sync.py` pins the ceiling behavior even when the server advertises a 1 MiB cap.
- Verified end-to-end: `tests/test_teamspace_sync_deployed_dev_e2e.py::test_deployed_dev_sync_now_handles_large_backlog_progress_and_private_actor_isolation` now passes against the promoted SaaS digest `d44bb6e7cafbaf757887cb1d150691c5f70d300c` on `https://spec-kitty-dev.fly.dev` (106 s).

Fixes #1045. Server-side companion: `Priivacy-ai/spec-kitty-saas#186`. Cross-ref: `Priivacy-ai/spec-kitty-end-to-end-testing#37`.

## Test plan

- [x] `uv run pytest tests/sync/test_batch_sync.py -q` — 38/38 passing.
- [x] Deployed-dev TeamSpace launch canary against the promoted digest — passing (was failing with 1000× HTTP 413).
- [ ] CI: full backend test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)