### PR TITLE
Release 3.2.0rc8

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc7
+  version: 3.2.0rc8
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.2.0rc8] - 2026-05-14
+
+3.2.0rc8 rolls up the post-rc7 TeamSpace launch fixes and compatibility
+cleanup needed before the final 3.2.0 cut. It includes defensive sync batching
+for real edge-proxy limits, the Mission Dossier event-envelope migration for
+`spec-kitty-events>=5.0.0`, and the small compatibility/quality fixes that
+landed after rc7.
+
+### Changed
+
+- Reduced the CLI's default sync batch decompressed byte budget to 256 KiB and
+  added a 512 KiB hard ceiling for over-generous server-advertised limits, so
+  large TeamSpace queue drains split into safe requests instead of relying on
+  HTTP 413 retry shrinkage.
+- Migrated all four Mission Dossier event emitters to the namespaced envelope
+  required by `spec-kitty-events>=5.0.0`, including `namespace`,
+  `artifact_id`/`expected_identity`, content refs, and schema-compatible
+  diagnostics.
+- Preserved legacy queued Mission Dossier events by migrating flat queued
+  payloads on drain when namespace data is available, and kept queue coalescing
+  scoped correctly across both legacy and namespaced payload shapes.
+
+### Fixed
+
+- Restored agent profile list compatibility after the rc7 candidate.
+- Reduced SonarCloud noise in path helper and charter synthesizer code without
+  changing runtime behavior.
+- Fixed the deployed-dev TeamSpace sync canary failure where a 1200-event
+  backlog could cascade into 1000 HTTP 413 failures.
+- Fixed SaaS ingestion rejection of CLI-emitted Mission Dossier artifact events
+  caused by the old flat payload shape being rejected with
+  `Additional properties are not allowed`.
+
 ## [3.2.0rc7] - 2026-05-12
 
 3.2.0rc7 lands the `review-merge-gate-hardening-3-2-x-01KRC57C` mission

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc7"
+version = "3.2.0rc8"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc7"
+version = "3.2.0rc8"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- bump spec-kitty-cli release metadata to 3.2.0rc8
- add populated 3.2.0rc8 changelog notes for the post-rc7 TeamSpace launch fixes

## Validation
- python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'\n- python scripts/release/validate_release.py --mode tag --tag v3.2.0rc8 --tag-pattern 'v*.*.*'\n- uv run pytest tests/release -q\n- uv run --with build python -m build\n- uv run --with twine twine check dist/*