### PR TITLE
Add Pi and Letta agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd my-project
 spec-kitty verify-setup
 ```
 
-Replace `claude` with your agent key when needed. Common choices include `codex`, `cursor`, `gemini`, `copilot`, `opencode`, `qwen`, `windsurf`, `kiro`, and `vibe`.
+Replace `claude` with your agent key when needed. Common choices include `codex`, `cursor`, `gemini`, `copilot`, `opencode`, `qwen`, `windsurf`, `kiro`, `vibe`, `pi`, and `letta`.
 
 Open your AI coding agent in the project and run the core workflow:
 

--- a/docs/host-surface-parity.md
+++ b/docs/host-surface-parity.md
@@ -7,7 +7,7 @@ This is Spec Kitty's authoritative record of how each supported host surface tea
 **Schema and parity rubric**: see [kitty-specs/phase-4-closeout-host-surfaces-and-trail-01KPWA5X/contracts/host-surface-inventory.md](../kitty-specs/phase-4-closeout-host-surfaces-and-trail-01KPWA5X/contracts/host-surface-inventory.md).
 
 **Canonical skill packs referenced by `guidance_style=pointer` rows**:
-- [`.agents/skills/spec-kitty.advise/SKILL.md`](../.agents/skills/spec-kitty.advise/SKILL.md) — Codex CLI, Vibe.
+- [`.agents/skills/spec-kitty.advise/SKILL.md`](../.agents/skills/spec-kitty.advise/SKILL.md) — Codex CLI, Vibe, Pi, Letta Code.
 - [`src/doctrine/skills/spec-kitty-runtime-next/SKILL.md`](../src/doctrine/skills/spec-kitty-runtime-next/SKILL.md) — Claude Code.
 
 ---
@@ -29,3 +29,5 @@ This is Spec Kitty's authoritative record of how each supported host surface tea
 | agent | .agent/workflows/ | slash_command | yes | yes | yes | pointer | at_parity | Pointer at `.agent/workflows/spec-kitty-standalone.md` redirects to canonical `.agents/skills/spec-kitty.advise/SKILL.md`. Shipped by WP04 (T018). |
 | codex | .agents/skills/ | agent_skill | yes | yes | yes | inline | at_parity | Priority slice 3.2.0a5 shipped `.agents/skills/spec-kitty.advise/SKILL.md` with all three parity sections: "Discover profiles", "Get governance context (advise/ask/do)", "Governance context injection", and "Close the record". Codex CLI reads the `.agents/skills/` tree directly. Manifest at `.kittify/command-skills-manifest.json` records the installed package (agents: [codex]). |
 | vibe | .agents/skills/ | agent_skill | yes | yes | yes | inline | partial | The canonical skill pack at `.agents/skills/spec-kitty.advise/SKILL.md` is at parity (same content as codex). However, `.vibe/config.toml` is absent from this project — Vibe cannot load the skill pack without a `skill_paths` entry pointing at `.agents/skills/`. WP04 owned_files did not include `.vibe/config.toml`; the config.toml was not shipped. Remaining gap: add `.vibe/config.toml` with `skill_paths = [".agents/skills"]` to wire up Vibe's access to the existing skill pack. |
+| pi | .agents/skills/ | agent_skill | yes | yes | yes | inline | at_parity | Pi discovers project `.agents/skills/` directly, so the canonical Spec Kitty command-skill packages provide the same governance guidance used by Codex. Manifest at `.kittify/command-skills-manifest.json` records installed packages with agents including `pi`. |
+| letta | .agents/skills/ | agent_skill | yes | yes | yes | inline | at_parity | Letta Code prefers project `.agents/skills/`, so the canonical Spec Kitty command-skill packages provide the same governance guidance used by Codex. Manifest at `.kittify/command-skills-manifest.json` records installed packages with agents including `letta`. |

--- a/docs/how-to/manage-agents.md
+++ b/docs/how-to/manage-agents.md
@@ -4,11 +4,11 @@ Learn how to add, remove, and manage AI agents in your spec-kitty project after 
 
 ## Overview
 
-Spec-kitty supports 12 AI agents, including Claude Code, GitHub Codex, Google Gemini, Cursor, Qwen Code, OpenCode, Windsurf, GitHub Copilot, Kilocode, Augment Code, Roo Cline, and Amazon Q. Each agent provides slash commands for feature specification, planning, task generation, implementation, and review workflows.
+Spec-kitty supports slash-command agents such as Claude Code, Gemini CLI, Cursor, Qwen Code, OpenCode, Windsurf, GitHub Copilot, Kilo Code, Auggie CLI, Roo Code, Kiro CLI, legacy Amazon Q, and Google Antigravity. It also supports command-skill agents such as Codex CLI, Mistral Vibe, Pi, and Letta Code.
 
 This guide applies after you've run `spec-kitty init` and want to change which agents are active in your project. For initial setup, see the [Getting Started](../tutorials/getting-started.md) guide.
 
-Agent configuration is managed through `.kittify/config.yaml` and the `spec-kitty agent config` command family. The config file acts as the single source of truth for which agents are active in the project. Slash-command agents use user-global command roots such as `~/.opencode/command/`; Codex and Vibe use project-local command skills under `.agents/skills/`.
+Agent configuration is managed through `.kittify/config.yaml` and the `spec-kitty agent config` command family. The config file acts as the single source of truth for which agents are active in the project. Slash-command agents use user-global command roots such as `~/.opencode/command/`; Codex, Vibe, Pi, and Letta use project-local command skills under `.agents/skills/`.
 
 This guide shows you how to add agents to enable multi-agent workflows, remove agents you don't use, list configured agents, check sync status, and synchronize your filesystem with the config file.
 
@@ -47,7 +47,7 @@ Before using agent config commands, ensure:
 
 `.kittify/config.yaml` is the single source of truth for agent configuration. All agent management commands read from and write to this file, and the filesystem is automatically synchronized to match it.
 
-This means the config records active agents, while the command surface depends on the agent class. For slash-command agents such as Claude, Gemini, OpenCode, and Kiro, commands are installed globally at CLI startup. When you add one of these agents using `spec-kitty agent config add`, the command updates the config and points at the global command root. For Codex and Vibe, Spec Kitty writes project-local command skills under `.agents/skills/`.
+This means the config records active agents, while the command surface depends on the agent class. For slash-command agents such as Claude, Gemini, OpenCode, and Kiro, commands are installed globally at CLI startup. When you add one of these agents using `spec-kitty agent config add`, the command updates the config and points at the global command root. For Codex, Vibe, Pi, and Letta, Spec Kitty writes project-local command skills under `.agents/skills/`.
 
 Do not manually edit agent directories or config.yaml directly - use the `spec-kitty agent config` commands instead. This ensures consistency and prevents sync issues.
 
@@ -68,7 +68,7 @@ The `available` field contains a list of active agent keys. Each key corresponds
 - `codex` → `.agents/skills/spec-kitty.<command>/` (project-local Agent Skills)
 - `opencode` → `~/.opencode/command/` (global)
 
-When you run `spec-kitty agent config add` or `remove`, this list is automatically updated. Global slash-command files are refreshed by normal CLI startup; Codex and Vibe command skills are managed inside the project.
+When you run `spec-kitty agent config add` or `remove`, this list is automatically updated. Global slash-command files are refreshed by normal CLI startup; Codex, Vibe, Pi, and Letta command skills are managed inside the project.
 
 Managed command surfaces are created and refreshed by CLI commands. You should never need to manually create or delete them.
 
@@ -143,7 +143,7 @@ spec-kitty agent config add codex gemini cursor
 
 When you add an agent, spec-kitty:
 1. Registers slash-command agents against their global command root
-2. Installs project-local command skills for Codex and Vibe
+2. Installs project-local command skills for Codex, Vibe, Pi, and Letta
 3. Adds the agent key to `.kittify/config.yaml` under `agents.available`
 4. Displays success message for each agent added
 
@@ -170,7 +170,8 @@ Error: Invalid agent keys: cluade
 
 Valid agent keys:
   claude, codex, gemini, cursor, qwen, opencode,
-  windsurf, kilocode, roo, copilot, auggie, q
+  windsurf, kilocode, roo, copilot, auggie, q, kiro,
+  antigravity, vibe, pi, letta
 ```
 
 **Already configured**: If an agent is already configured, it's skipped with a message:
@@ -538,7 +539,8 @@ environment you intentionally manage.
 # Error message shows:
 # Valid agent keys:
 #   claude, codex, gemini, cursor, qwen, opencode,
-#   windsurf, kilocode, roo, copilot, auggie, q
+#   windsurf, kilocode, roo, copilot, auggie, q, kiro,
+#   antigravity, vibe, pi, letta
 
 # Fix typo and retry
 spec-kitty agent config add claude  # Not "cluade"
@@ -565,7 +567,7 @@ For more information on agent management and related topics:
 
 ### Supported Agents
 
-- [Supported AI Agents](../reference/supported-agents.md) - Complete list of the 13 slash-command agents with capabilities, installation requirements, and usage notes
+- [Supported AI Agents](../reference/supported-agents.md) - Complete list of slash-command agents with capabilities, installation requirements, and usage notes
 
 ### Configuration
 

--- a/docs/how-to/non-interactive-init.md
+++ b/docs/how-to/non-interactive-init.md
@@ -284,7 +284,7 @@ spec-kitty init proj --ai CODEX
 spec-kitty init proj --ai codex
 ```
 
-Valid keys are lowercase: `codex`, `claude`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `auggie`, `roo`, `copilot`, `q`
+Valid keys are lowercase: `codex`, `claude`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `auggie`, `roo`, `copilot`, `q`, `kiro`, `vibe`, `pi`, `letta`
 
 ## Complete Reference
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -18,7 +18,7 @@ Reference docs are:
 - [Environment Variables](environment-variables.md) - All environment variables
 - [File Structure](file-structure.md) - Directory layout and file purposes
 - [Missions](missions.md) - Mission types and configuration
-- [Supported Agents](supported-agents.md) - The 13 slash-command agents supported by the CLI
+- [Supported Agents](supported-agents.md) - Slash-command agents supported by the CLI
 
 ## See Also
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -619,7 +619,7 @@ Manage project AI agent configuration (add, remove, list agents).
 spec-kitty agent config [OPTIONS] COMMAND [ARGS]...
 ```
 
-**Description**: The `config` subcommand provides tools for managing which AI agents are active in your project. Agent configuration is stored in `.kittify/config.yaml`; slash-command agents use user-global command roots, while Codex and Vibe use project-local command skills under `.agents/skills/`.
+**Description**: The `config` subcommand provides tools for managing which AI agents are active in your project. Agent configuration is stored in `.kittify/config.yaml`; slash-command agents use user-global command roots, while Codex, Vibe, Pi, and Letta use project-local command skills under `.agents/skills/`.
 
 **Subcommands**:
 
@@ -692,11 +692,11 @@ spec-kitty agent config add <agent1> [agent2] [agent3] ...
 
 **Description**:
 
-Adds specified agents to your project by registering slash-command agents against their global command roots, installing Codex/Vibe command skills where applicable, and updating `.kittify/config.yaml`.
+Adds specified agents to your project by registering slash-command agents against their global command roots, installing command skills where applicable, and updating `.kittify/config.yaml`.
 
 **Arguments**:
 
-- `<agents>`: Space-separated list of agent keys to add. Valid keys: `claude`, `codex`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `roo`, `copilot`, `auggie`, `q`.
+- `<agents>`: Space-separated list of agent keys to add. Valid keys: `claude`, `codex`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `roo`, `copilot`, `auggie`, `q`, `kiro`, `vibe`, `pi`, `letta`.
 
 **Options**: None
 
@@ -709,7 +709,7 @@ Adds specified agents to your project by registering slash-command agents agains
 **Side Effects**:
 
 - Uses the global command root for slash-command agents (e.g., `~/.claude/commands/`)
-- Creates project-local command skills for Codex and Vibe
+- Creates project-local command skills for Codex, Vibe, Pi, and Letta
 - Adds agent key to `.kittify/config.yaml` under `agents.available`
 
 **Examples**:
@@ -742,7 +742,8 @@ Error: Invalid agent keys: cluade
 
 Valid agent keys:
   claude, codex, gemini, cursor, qwen, opencode,
-  windsurf, kilocode, roo, copilot, auggie, q
+  windsurf, kilocode, roo, copilot, auggie, q, kiro,
+  antigravity, vibe, pi, letta
 ```
 
 #### spec-kitty agent config remove

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -270,7 +270,7 @@ VCS Backend: git
 
 ## Agent Configuration
 
-Spec Kitty supports AI agents across different platforms. Agent configuration is stored in `.kittify/config.yaml` and can be managed via CLI commands. Slash-command agents use user-global command roots; Codex and Vibe use project-local command skills under `.agents/skills/`.
+Spec Kitty supports AI agents across different platforms. Agent configuration is stored in `.kittify/config.yaml` and can be managed via CLI commands. Slash-command agents use user-global command roots; Codex, Vibe, Pi, and Letta Code use project-local command skills under `.agents/skills/`.
 
 ### Supported Agents
 
@@ -284,6 +284,8 @@ Spec Kitty supports AI agents across different platforms. Agent configuration is
 | `opencode` | `~/.opencode/command/` | OpenCode |
 | `windsurf` | `~/.windsurf/workflows/` | Windsurf |
 | `codex` | `.agents/skills/spec-kitty.<command>/` | Codex CLI |
+| `pi` | `.agents/skills/spec-kitty.<command>/` | Pi |
+| `letta` | `.agents/skills/spec-kitty.<command>/` | Letta Code |
 | `kilocode` | `~/.kilocode/workflows/` | Kilocode |
 | `auggie` | `~/.augment/commands/` | Augment Code |
 | `roo` | `~/.roo/commands/` | Roo Cline |
@@ -311,7 +313,7 @@ Starting in spec-kitty 0.12.0, agent configuration follows a config-driven model
 **Key principles**:
 - Active agents are derived from `config.yaml`
 - Slash-command files are installed globally at CLI startup
-- Codex and Vibe command skills are project-local under `.agents/skills/`
+- Codex, Vibe, Pi, and Letta command skills are project-local under `.agents/skills/`
 - Migrations respect `config.yaml` - only process configured agents
 - Use `spec-kitty agent config` commands to manage agents (not manual editing)
 
@@ -360,7 +362,7 @@ spec-kitty agent config add claude codex
 
 This command:
 1. Registers slash-command agents against their global command roots
-2. Installs project-local command skills for Codex and Vibe
+2. Installs project-local command skills for Codex, Vibe, Pi, and Letta
 3. Updates `config.yaml` to include new agents
 
 #### Remove Agents

--- a/docs/reference/supported-agents.md
+++ b/docs/reference/supported-agents.md
@@ -2,7 +2,7 @@
 
 Spec Kitty currently exposes **13 slash-command agent surfaces**. This page documents the agents that get user-global command directories such as `~/.claude/commands/` or `~/.opencode/command/`.
 
-Related assistant integrations such as Codex CLI and Vibe use shared skill roots rather than slash-command directories, so they are intentionally out of scope for this specific table.
+Related assistant integrations such as Codex CLI, Vibe, Pi, and Letta Code use shared skill roots rather than slash-command directories, so they are intentionally out of scope for this specific table.
 
 ---
 
@@ -289,14 +289,14 @@ spec-kitty init my-project --ai kiro
 You can initialize a project with multiple agents:
 
 ```bash
-# Initialize with Claude and Codex
-spec-kitty init my-project --ai claude,codex
+# Initialize with Claude and Pi
+spec-kitty init my-project --ai claude,pi
 
 # Initialize with all agents
-spec-kitty init my-project --ai claude,copilot,gemini,cursor,qwen,opencode,windsurf,codex,kilocode,augment,roo,q
+spec-kitty init my-project --ai claude,copilot,gemini,cursor,qwen,opencode,windsurf,codex,kilocode,auggie,roo,q,kiro,antigravity,vibe,pi,letta
 ```
 
-This registers all specified agents, allowing team members to use their preferred tool. Slash-command files are installed in user-global agent roots at CLI startup.
+This registers all specified agents, allowing team members to use their preferred tool. Slash-command files are installed in user-global agent roots at CLI startup; Codex, Vibe, Pi, and Letta command skills are installed project-locally under `.agents/skills/`.
 
 ---
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -120,7 +120,7 @@ Continue with [Your First Feature](your-first-feature.md) for the complete workf
 
 - [CLI Commands](../reference/cli-commands.md) - Full command reference
 - [Slash Commands](../reference/slash-commands.md) - AI agent slash commands
-- [Supported Agents](../reference/supported-agents.md) - The 13 slash-command agents supported by the CLI
+- [Supported Agents](../reference/supported-agents.md) - Slash-command agents supported by the CLI
 
 ### Learn More
 

--- a/src/doctrine/skills/spec-kitty-setup-doctor/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-setup-doctor/SKILL.md
@@ -51,7 +51,7 @@ Check that skill roots, wrapper roots, manifest, and generated artifacts are pre
 - Wrapper root (slash-command directory) exists for the active agent
 - The relevant manifest exists and is valid JSON:
   `.kittify/skills-manifest.json` for legacy canonical skills and/or
-  `.kittify/command-skills-manifest.json` for Codex/Vibe command skills
+  `.kittify/command-skills-manifest.json` for command-skill agents
 - Skill files listed in the manifest are present on disk
 
 **Commands:**

--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -36,7 +36,7 @@ KEY_TO_AGENT_DIR = {
     for agent_dir, subdir in CompleteLaneMigration.AGENT_DIRS
     if agent_dir in AGENT_DIR_TO_KEY
 }
-SKILL_ONLY_AGENTS = {"codex", "vibe"}
+SKILL_ONLY_AGENTS = {"codex", "vibe", "pi", "letta"}
 GLOBAL_COMMAND_AGENTS = frozenset(AGENT_COMMAND_CONFIG)
 VALID_AGENTS = set(AGENT_DIR_TO_KEY.values()) | SKILL_ONLY_AGENTS
 
@@ -123,7 +123,7 @@ def _load_config_or_exit(repo_root: Path) -> AgentConfig:
 
 
 def _register_skill_agent(repo_root: Path, config: AgentConfig, agent_key: str) -> tuple[bool, str | None]:
-    """Install command skills for Codex/Vibe and update config."""
+    """Install command skills for skill-only agents and update config."""
     from specify_cli.skills import command_installer  # noqa: PLC0415
     from specify_cli.skills.vibe_config import ensure_project_skill_path  # noqa: PLC0415
 
@@ -308,7 +308,7 @@ def add_agents(
     config = _load_config_or_exit(repo_root)
 
     # Validate agent keys — command-layer agents come from AGENT_DIR_TO_KEY;
-    # skill-only agents (codex, vibe) have their own installer path.
+    # skill-only agents have their own installer path.
     invalid = [a for a in agents if a not in VALID_AGENTS]
     if invalid:
         console.print(f"[red]Error:[/red] Invalid agent keys: {', '.join(invalid)}")
@@ -385,7 +385,7 @@ def remove_agents(
     config = _load_config_or_exit(repo_root)
 
     # Validate agent keys — command-layer agents come from AGENT_DIR_TO_KEY;
-    # skill-only agents (codex, vibe) have their own installer path.
+    # skill-only agents have their own installer path.
     invalid = [a for a in agents if a not in VALID_AGENTS]
     if invalid:
         console.print(f"[red]Error:[/red] Invalid agent keys: {', '.join(invalid)}")
@@ -397,7 +397,7 @@ def remove_agents(
     errors = []
 
     for agent_key in agents:
-        if agent_key in ("codex", "vibe"):
+        if agent_key in SKILL_ONLY_AGENTS:
             from specify_cli.skills import command_installer
             try:
                 report = command_installer.remove(repo_root, agent_key)

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -685,9 +685,10 @@ def init(  # noqa: C901
                     if agent_skill_class == SKILL_CLASS_WRAPPER:
                         # WRAPPER agents have no installable root.
                         tracker.complete(f"{agent_key}-skills", "skipped (wrapper)")
-                    elif agent_key in ("codex", "vibe"):
-                        # Codex and Vibe receive Spec Kitty's slash commands as
-                        # Agent Skills packages rendered into .agents/skills/.
+                    elif agent_key in ("codex", "vibe", "pi", "letta"):
+                        # Command-skill agents receive Spec Kitty's slash
+                        # commands as Agent Skills packages rendered into
+                        # .agents/skills/.
                         from specify_cli.skills import command_installer  # noqa: PLC0415
                         from specify_cli.skills.vibe_config import ensure_project_skill_path  # noqa: PLC0415
 
@@ -773,6 +774,8 @@ def init(  # noqa: C901
         "roo": ".roo/",
         "q": ".amazonq/",
         "kiro": ".kiro/",
+        "pi": ".pi/",
+        "letta": ".letta/",
     }
 
     notice_entries = []
@@ -866,6 +869,42 @@ def init(  # noqa: C901
         )
         _console.print()
         _console.print(vibe_panel)
+
+    if "pi" in selected_agents:
+        pi_steps_lines = [
+            "1. Install Pi if you haven't already:",
+            "     [cyan]curl -fsSL https://pi.dev/install.sh | sh[/cyan]",
+            "2. Launch Pi in this project:",
+            "     [cyan]pi[/cyan]",
+            "3. Invoke your first Spec Kitty command skill:",
+            "     [cyan]/skill:spec-kitty.specify <describe what you want to build>[/cyan]",
+        ]
+        pi_panel = Panel(
+            "\n".join(pi_steps_lines),
+            title="Next Steps for Pi",
+            border_style="cyan",
+            padding=(1, 2),
+        )
+        _console.print()
+        _console.print(pi_panel)
+
+    if "letta" in selected_agents:
+        letta_steps_lines = [
+            "1. Install Letta Code if you haven't already:",
+            "     [cyan]npm install -g @letta-ai/letta-code[/cyan]",
+            "2. Launch Letta Code in this project:",
+            "     [cyan]letta[/cyan]",
+            "3. Ask Letta Code to use the Spec Kitty specify skill:",
+            "     [cyan]Use spec-kitty.specify to specify <describe what you want to build>[/cyan]",
+        ]
+        letta_panel = Panel(
+            "\n".join(letta_steps_lines),
+            title="Next Steps for Letta Code",
+            border_style="cyan",
+            padding=(1, 2),
+        )
+        _console.print()
+        _console.print(letta_panel)
 
     enhancement_lines = [
         "Optional commands that you can use for your specs [bright_black](improve quality & confidence)[/bright_black]",

--- a/src/specify_cli/cli/commands/init_help.py
+++ b/src/specify_cli/cli/commands/init_help.py
@@ -28,7 +28,7 @@ What Gets Created:
 Specifying AI Assistants (--ai flag):
 Use comma-separated agent keys (no spaces). Valid keys include:
 codex, claude, gemini, cursor, qwen, opencode, windsurf, kilocode,
-auggie, roo, copilot, q, kiro.
+auggie, roo, copilot, q, kiro, pi, letta.
 
 Template Discovery (Development Mode):
 Set SPEC_KITTY_TEMPLATE_ROOT to override bundled templates for local development.

--- a/src/specify_cli/cli/commands/verify.py
+++ b/src/specify_cli/cli/commands/verify.py
@@ -51,6 +51,8 @@ TOOL_LABELS = [
     ("opencode", "opencode"),
     ("codex", "Codex CLI"),
     ("vibe", "Mistral Vibe"),
+    ("pi", "Pi"),
+    ("letta", "Letta Code"),
     ("auggie", "Auggie CLI"),
     ("q", "Amazon Q Developer CLI (legacy)"),
     ("kiro-cli", "Kiro CLI"),

--- a/src/specify_cli/core/config.py
+++ b/src/specify_cli/core/config.py
@@ -18,6 +18,8 @@ AI_CHOICES = {
     "kiro": "Kiro CLI (formerly Amazon Q Developer CLI)",
     "antigravity": "Google Antigravity",
     "vibe": "Mistral Vibe",
+    "pi": "Pi",
+    "letta": "Letta Code",
 }
 
 MISSION_CHOICES = {
@@ -37,6 +39,8 @@ AGENT_TOOL_REQUIREMENTS: dict[str, tuple[str, str]] = {
     "q": ("q", "https://aws.amazon.com/developer/learning/q-developer-cli/"),
     "vibe": ("vibe", "https://github.com/mistralai/mistral-vibe"),
     "kiro": ("kiro-cli", "https://kiro.dev/docs/cli/"),
+    "pi": ("pi", "https://pi.dev/docs/latest"),
+    "letta": ("letta", "https://docs.letta.com/letta-code/cli/"),
 }
 
 SCRIPT_TYPE_CHOICES = {"sh": "POSIX Shell (bash/zsh)", "ps": "PowerShell"}
@@ -77,6 +81,8 @@ AGENT_SKILL_CONFIG: dict[str, dict[str, str | list[str] | None]] = {
     "windsurf":     {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/", ".windsurf/skills/"]},
     "codex":        {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/"]},
     "vibe":         {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/"]},
+    "pi":           {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/", ".pi/skills/"]},
+    "letta":        {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/"]},
     "kilocode":     {"class": SKILL_CLASS_NATIVE,  "skill_roots": [".kilocode/skills/"]},
     "auggie":       {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/", ".augment/skills/"]},
     "roo":          {"class": SKILL_CLASS_SHARED,  "skill_roots": [".agents/skills/", ".roo/skills/"]},

--- a/src/specify_cli/gitignore_manager.py
+++ b/src/specify_cli/gitignore_manager.py
@@ -58,6 +58,8 @@ AGENT_DIRECTORIES = [
     AgentDirectory("claude", ".claude/", False, "Claude Code CLI"),
     AgentDirectory("codex", ".codex/", False, "Codex (contains auth.json)"),
     AgentDirectory("vibe", ".vibe/", False, "Mistral Vibe (runtime state, config, session logs)"),
+    AgentDirectory("pi", ".pi/", False, "Pi (runtime state, auth, session logs)"),
+    AgentDirectory("letta", ".letta/", False, "Letta Code (runtime state, auth, memory)"),
     AgentDirectory("opencode", ".opencode/", False, "opencode CLI"),
     AgentDirectory("windsurf", ".windsurf/", False, "Windsurf"),
     AgentDirectory("gemini", ".gemini/", False, "Google Gemini"),

--- a/src/specify_cli/runtime/agent_commands.py
+++ b/src/specify_cli/runtime/agent_commands.py
@@ -124,7 +124,8 @@ def _sync_agent_commands(agent_key: str, templates_dir: Path, script_type: str) 
     * Stale ``spec-kitty.*`` files no longer in the canonical set are removed.
     * All written files are set read-only (``chmod mode & ~0o222``).
 
-    ``codex`` and ``vibe`` are not handled here. Their command installation
+    Command-skill agents such as ``codex``, ``vibe``, ``pi``, and ``letta`` are
+    not handled here. Their command installation
     is driven by ``init`` and ``spec-kitty agent config add`` through
     :mod:`specify_cli.skills.command_installer`, which writes project-local
     skill packages under ``.agents/skills/``.

--- a/src/specify_cli/skills/command_installer.py
+++ b/src/specify_cli/skills/command_installer.py
@@ -1,7 +1,8 @@
-"""Command-Skill Installer for Codex and Vibe.
+"""Command-Skill Installer for shared-root command-skill agents.
 
-This module owns all mutations under ``.agents/skills/`` for the Codex and Vibe
-agents.  It wraps :mod:`specify_cli.skills.manifest_store` (WP01) and
+This module owns all mutations under ``.agents/skills/`` for agents that consume
+Spec Kitty slash commands as Agent Skills.  It wraps
+:mod:`specify_cli.skills.manifest_store` (WP01) and
 :mod:`specify_cli.skills.command_renderer` (WP02) to provide three public
 operations:
 
@@ -39,7 +40,7 @@ from specify_cli.skills import command_renderer
 # Constants
 # ---------------------------------------------------------------------------
 
-SUPPORTED_AGENTS: tuple[str, ...] = ("codex", "vibe")
+SUPPORTED_AGENTS: tuple[str, ...] = ("codex", "vibe", "pi", "letta")
 
 #: The canonical command templates that exist in the current codebase.
 #: Matches the files under
@@ -255,7 +256,7 @@ def install(repo_root: Path, agent_key: str) -> InstallReport:
         Absolute path to the project root (the directory that contains
         ``.kittify/`` and ``.agents/``).
     agent_key:
-        One of :data:`SUPPORTED_AGENTS` (``"codex"`` or ``"vibe"``).
+        One of :data:`SUPPORTED_AGENTS`.
 
     Returns
     -------
@@ -367,7 +368,7 @@ def remove(repo_root: Path, agent_key: str) -> RemoveReport:
     repo_root:
         Absolute path to the project root.
     agent_key:
-        The agent to remove (``"codex"`` or ``"vibe"``).
+        The supported command-skill agent to remove.
 
     Returns
     -------

--- a/src/specify_cli/skills/command_renderer.py
+++ b/src/specify_cli/skills/command_renderer.py
@@ -1,8 +1,9 @@
-"""Command-Skill Renderer for Codex and Vibe.
+"""Command-Skill Renderer for shared-root command-skill agents.
 
 Turns a ``command-templates/<command>.md`` source file into a
 :class:`RenderedSkill` (YAML frontmatter + markdown body) that can be written
-as a ``SKILL.md`` file for OpenAI Codex or Mistral Vibe.
+as a ``SKILL.md`` file for command-skill agents such as Codex, Vibe, Pi,
+and Letta Code.
 
 Three invariants are enforced by this module:
 
@@ -14,7 +15,7 @@ Three invariants are enforced by this module:
    contains the literal token ``$ARGUMENTS``.  Any occurrence that survives the
    User-Input block rewrite raises :class:`SkillRenderError`.
 
-3. **Single body for both agents** — Codex and Vibe receive identical skill
+3. **Single body for every agent** — supported agents receive identical skill
    bodies.  The only per-agent variation permitted is in frontmatter, and even
    that is currently identical for the initial release.
 """
@@ -25,7 +26,7 @@ import hashlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from specify_cli.skills._user_input_block import rewrite as _rewrite_user_input
 
@@ -33,7 +34,7 @@ from specify_cli.skills._user_input_block import rewrite as _rewrite_user_input
 # Constants
 # ---------------------------------------------------------------------------
 
-SUPPORTED_AGENTS: tuple[str, ...] = ("codex", "vibe")
+SUPPORTED_AGENTS: tuple[str, ...] = ("codex", "vibe", "pi", "letta")
 
 # Matches the YAML frontmatter block at the very start of a template file
 # (delimited by ``---`` lines).  Handles both ``---\nkey: value\n---`` and
@@ -103,7 +104,7 @@ class RenderedSkill:
     source_hash:
         SHA-256 hex digest of the raw source template bytes at render time.
     agent_key:
-        The agent this rendering was produced for (``"codex"`` or ``"vibe"``).
+        The agent this rendering was produced for.
     spec_kitty_version:
         The CLI version string passed to :func:`render`.
     """
@@ -113,7 +114,7 @@ class RenderedSkill:
     body: str
     source_template: Path
     source_hash: str
-    agent_key: Literal["codex", "vibe"]
+    agent_key: str
     spec_kitty_version: str
 
     def to_skill_md(self) -> str:
@@ -396,7 +397,7 @@ def render(
     template_path:
         Absolute path to a ``command-templates/<command>.md`` source file.
     agent_key:
-        Must be one of :data:`SUPPORTED_AGENTS` (``"codex"`` or ``"vibe"``).
+        Must be one of :data:`SUPPORTED_AGENTS`.
     spec_kitty_version:
         The current CLI version string, stored on the returned record for
         auditability.

--- a/src/specify_cli/skills/data/skills-manifest.schema.json
+++ b/src/specify_cli/skills/data/skills-manifest.schema.json
@@ -40,7 +40,7 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "enum": ["codex", "vibe"]
+            "enum": ["codex", "vibe", "pi", "letta"]
           },
           "description": "Sorted list of agent keys that installed this entry. The file is physically deleted when the list becomes empty. New shared-root agents added in later missions may extend this enum."
         },

--- a/tests/agent/test_agent_config_migration.py
+++ b/tests/agent/test_agent_config_migration.py
@@ -77,8 +77,8 @@ class TestGetAgentDirsForProject:
         agent_dirs = get_agent_dirs_for_project(tmp_path)
 
         # Should return all 13 slash-command agents (fallback).
-        # Count is 13 post PR #626 (Kiro registration); codex+vibe use AGENT_SKILL_CONFIG
-        # and are not listed in AGENT_DIRS.
+        # Count is 13 post PR #626 (Kiro registration); command-skill agents
+        # use AGENT_SKILL_CONFIG and are not listed in AGENT_DIRS.
         assert len(agent_dirs) == 13
         assert (".claude", "commands") in agent_dirs
         assert (".opencode", "command") in agent_dirs
@@ -229,7 +229,7 @@ class TestAgentDirMapping:
     def test_agent_dir_to_key_complete(self):
         """Verify all agents have key mappings."""
         # All 13 slash-command agents should be mapped
-        # (codex and vibe use AGENT_SKILL_CONFIG, not AGENT_DIR_TO_KEY).
+        # (command-skill agents use AGENT_SKILL_CONFIG, not AGENT_DIR_TO_KEY).
         assert len(AGENT_DIR_TO_KEY) == 13
 
         # Verify special mappings

--- a/tests/specify_cli/cli/commands/test_agent_config_pi_letta.py
+++ b/tests/specify_cli/cli/commands/test_agent_config_pi_letta.py
@@ -1,0 +1,54 @@
+"""Integration tests for agent config add/remove pi and letta."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.agent.config import app
+from specify_cli.core.agent_config import AgentConfig, load_agent_config, save_agent_config
+from specify_cli.skills import command_installer, manifest_store
+
+pytestmark = [pytest.mark.integration, pytest.mark.non_sandbox]
+runner = CliRunner()
+
+
+def _write_config(tmp_path: Path, agents: list[str]) -> None:
+    (tmp_path / ".kittify").mkdir(parents=True, exist_ok=True)
+    save_agent_config(tmp_path, AgentConfig(available=agents))
+
+
+@pytest.mark.parametrize("agent_key", ["pi", "letta"])
+def test_add_pi_letta_updates_config_and_installs_skills(
+    tmp_path: Path, agent_key: str
+) -> None:
+    _write_config(tmp_path, [])
+
+    with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+        result = runner.invoke(app, ["add", agent_key])
+
+    assert result.exit_code == 0, result.output
+    config = load_agent_config(tmp_path)
+    assert agent_key in config.available
+
+    manifest = manifest_store.load(tmp_path)
+    assert len(manifest.entries) == len(command_installer.CANONICAL_COMMANDS)
+    for entry in manifest.entries:
+        assert entry.agents == (agent_key,)
+
+
+@pytest.mark.parametrize("agent_key", ["pi", "letta"])
+def test_remove_pi_letta_removes_skill_claims(tmp_path: Path, agent_key: str) -> None:
+    _write_config(tmp_path, [agent_key])
+    command_installer.install(tmp_path, agent_key)
+
+    with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+        result = runner.invoke(app, ["remove", agent_key])
+
+    assert result.exit_code == 0, result.output
+    config = load_agent_config(tmp_path)
+    assert agent_key not in config.available
+    assert manifest_store.load(tmp_path).entries == []

--- a/tests/specify_cli/cli/commands/test_init_pi_letta.py
+++ b/tests/specify_cli/cli/commands/test_init_pi_letta.py
@@ -1,0 +1,91 @@
+"""Integration tests for spec-kitty init --ai pi/letta."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+from typer import Typer
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import init as init_module
+from specify_cli.cli.commands.init import register_init_command
+from specify_cli.core.agent_config import load_agent_config
+from specify_cli.skills.command_installer import CANONICAL_COMMANDS
+
+pytestmark = pytest.mark.integration
+
+
+def _make_app() -> tuple[Typer, io.StringIO]:
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    app = Typer()
+
+    register_init_command(
+        app,
+        console=console,
+        show_banner=lambda: None,
+        activate_mission=lambda proj, mtype, mdisplay, _con: mdisplay,
+        ensure_executable_scripts=lambda path, tracker=None: None,
+    )
+    return app, buf
+
+
+def _run(app: Typer, args: list[str]) -> object:
+    return CliRunner().invoke(app, args, catch_exceptions=True)
+
+
+def _fake_copy_package(project_path: Path) -> Path:
+    kittify = project_path / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    return kittify / "templates" / "command-templates"
+
+
+@pytest.mark.parametrize(
+    ("agent_key", "agent_dir", "install_snippet", "usage_snippet"),
+    [
+        ("pi", ".pi/", "https://pi.dev/install.sh", "/skill:spec-kitty.specify"),
+        ("letta", ".letta/", "@letta-ai/letta-code", "Use spec-kitty.specify"),
+    ],
+)
+def test_init_pi_letta_installs_command_skills_and_prints_next_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    agent_key: str,
+    agent_dir: str,
+    install_snippet: str,
+    usage_snippet: str,
+) -> None:
+    app, output = _make_app()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(init_module, "get_local_repo_root", lambda override_path=None: None)
+    monkeypatch.setattr(init_module, "copy_specify_base_from_package", _fake_copy_package)
+
+    result = _run(app, ["init", f"{agent_key}-proj", "--ai", agent_key, "--non-interactive"])
+
+    assert result.exit_code == 0, result.output
+    project_path = tmp_path / f"{agent_key}-proj"
+    assert agent_key in load_agent_config(project_path).available
+
+    skills_root = project_path / ".agents" / "skills"
+    for command in CANONICAL_COMMANDS:
+        assert (skills_root / f"spec-kitty.{command}" / "SKILL.md").is_file()
+
+    manifest = json.loads(
+        (project_path / ".kittify" / "command-skills-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert len(manifest["entries"]) == len(CANONICAL_COMMANDS)
+    for entry in manifest["entries"]:
+        assert entry["agents"] == [agent_key]
+
+    gitignore_lines = (project_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert agent_dir in gitignore_lines
+
+    rendered = output.getvalue()
+    assert install_snippet in rendered
+    assert usage_snippet in rendered

--- a/tests/specify_cli/core/test_config_registry.py
+++ b/tests/specify_cli/core/test_config_registry.py
@@ -1,10 +1,11 @@
 """Registry invariant tests for WP04 (T022).
 
 Asserts that after the WP04 edits:
-- ``vibe`` is present in AI_CHOICES, AGENT_TOOL_REQUIREMENTS, AGENT_SKILL_CONFIG.
+- ``vibe``, ``pi``, and ``letta`` are present in AI_CHOICES,
+  AGENT_TOOL_REQUIREMENTS, AGENT_SKILL_CONFIG.
 - ``codex`` is NOT in AGENT_COMMAND_CONFIG.
-- ``vibe`` is NOT in AGENT_COMMAND_CONFIG.
-- Both codex and vibe have class SKILL_CLASS_SHARED with .agents/skills/ as root.
+- ``vibe``, ``pi``, and ``letta`` are NOT in AGENT_COMMAND_CONFIG.
+- Command-skill agents have class SKILL_CLASS_SHARED with .agents/skills/ as root.
 - The twelve non-migrated command-layer agents are still present in AGENT_COMMAND_CONFIG.
 """
 
@@ -29,6 +30,11 @@ def test_vibe_in_ai_choices() -> None:
     assert AI_CHOICES["vibe"] == "Mistral Vibe"
 
 
+def test_pi_and_letta_in_ai_choices() -> None:
+    assert AI_CHOICES["pi"] == "Pi"
+    assert AI_CHOICES["letta"] == "Letta Code"
+
+
 # ---------------------------------------------------------------------------
 # AGENT_TOOL_REQUIREMENTS
 # ---------------------------------------------------------------------------
@@ -37,6 +43,11 @@ def test_vibe_in_ai_choices() -> None:
 def test_vibe_tool_requirement() -> None:
     assert "vibe" in AGENT_TOOL_REQUIREMENTS
     assert AGENT_TOOL_REQUIREMENTS["vibe"][0] == "vibe"
+
+
+def test_pi_and_letta_tool_requirements() -> None:
+    assert AGENT_TOOL_REQUIREMENTS["pi"][0] == "pi"
+    assert AGENT_TOOL_REQUIREMENTS["letta"][0] == "letta"
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +61,11 @@ def test_codex_not_in_command_config() -> None:
 
 def test_vibe_not_in_command_config() -> None:
     assert "vibe" not in AGENT_COMMAND_CONFIG
+
+
+def test_pi_and_letta_not_in_command_config() -> None:
+    assert "pi" not in AGENT_COMMAND_CONFIG
+    assert "letta" not in AGENT_COMMAND_CONFIG
 
 
 def test_twelve_agents_still_in_command_config() -> None:
@@ -77,8 +93,8 @@ def test_twelve_agents_still_in_command_config() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_codex_and_vibe_are_shared_skill_roots() -> None:
-    for key in ("codex", "vibe"):
+def test_command_skill_agents_are_shared_skill_roots() -> None:
+    for key in ("codex", "vibe", "pi", "letta"):
         assert key in AGENT_SKILL_CONFIG, f"{key!r} missing from AGENT_SKILL_CONFIG"
         entry = AGENT_SKILL_CONFIG[key]
         assert entry["class"] == SKILL_CLASS_SHARED, (

--- a/tests/specify_cli/docs/test_host_surface_inventory.py
+++ b/tests/specify_cli/docs/test_host_surface_inventory.py
@@ -13,11 +13,11 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 PARITY_DOC = REPO_ROOT / "docs/host-surface-parity.md"
 
 # Pulled from src/specify_cli/upgrade/migrations/m_0_9_1_complete_lane_migration.py::AGENT_DIRS
-# plus the 2 Agent Skills surfaces (codex, vibe).
+# plus Agent Skills surfaces.
 EXPECTED_SURFACES = frozenset({
     "claude", "copilot", "gemini", "cursor", "qwen",
     "opencode", "windsurf", "kilocode", "auggie", "roo",
-    "q", "kiro", "agent", "codex", "vibe",
+    "q", "kiro", "agent", "codex", "vibe", "pi", "letta",
 })
 
 VALID_PARITY_STATUS = {"at_parity", "partial", "missing"}

--- a/tests/specify_cli/regression/__init__.py
+++ b/tests/specify_cli/regression/__init__.py
@@ -8,9 +8,9 @@ The twelve non-migrated agents are the keys of ``AGENT_COMMAND_CONFIG``:
 claude, gemini, copilot, cursor, qwen, opencode, windsurf, kilocode,
 auggie, roo, q, antigravity.
 
-Codex and Vibe are excluded because mission 083 deliberately migrated
-them from the command-file pipeline to the Agent Skills pipeline
-(``.agents/skills/``).  Their snapshots live under
+Command-skill agents such as Codex, Vibe, Pi, and Letta are excluded
+because they use the Agent Skills pipeline (``.agents/skills/``) instead
+of per-agent command files.  Representative renderer snapshots live under
 ``tests/specify_cli/skills/__snapshots__/``.
 
 Baseline capture

--- a/tests/specify_cli/regression/test_twelve_agent_parity.py
+++ b/tests/specify_cli/regression/test_twelve_agent_parity.py
@@ -5,7 +5,7 @@ committed baseline under ``_twelve_agent_baseline/`` for every agent in
 ``AGENT_COMMAND_CONFIG`` (the twelve agents whose command-delivery mechanism
 was not changed by mission 083-agent-skills-codex-vibe).
 
-Codex and Vibe are intentionally excluded — they were migrated to the Agent
+Codex, Vibe, Pi, and Letta are intentionally excluded — they use the Agent
 Skills pipeline (``tests/specify_cli/skills/__snapshots__/`` covers them).
 
 Baseline note
@@ -51,7 +51,7 @@ TEMPLATES_DIR = (
 BASELINE_DIR = Path(__file__).parent / "_twelve_agent_baseline"
 
 # Agents covered by this regression suite — all keys in AGENT_COMMAND_CONFIG.
-# Codex and Vibe are absent: they use the Agent Skills pipeline.
+# Command-skill agents are absent: they use the Agent Skills pipeline.
 NON_MIGRATED_AGENTS: tuple[str, ...] = tuple(AGENT_COMMAND_CONFIG.keys())
 
 # Canonical command templates to test (one .md source file per command).
@@ -152,11 +152,11 @@ def test_command_output_unchanged(agent: str, command: str) -> None:
 
 
 def test_non_migrated_agents_count() -> None:
-    """Exactly 13 agents are in AGENT_COMMAND_CONFIG (codex and vibe are migrated to skills).
+    """Exactly 13 agents are in AGENT_COMMAND_CONFIG.
 
     Count rose from 12 to 13 when PR #626 registered Kiro as a first-class slash-command
-    agent alongside the 12 existing non-migrated agents. Codex and Vibe remain absent
-    (they use the Agent Skills pipeline — see AGENT_SKILL_CONFIG).
+    agent alongside the 12 existing non-migrated agents. Command-skill agents remain
+    absent (they use the Agent Skills pipeline — see AGENT_SKILL_CONFIG).
     """
     assert len(NON_MIGRATED_AGENTS) == 13, (
         f"Expected 13 non-migrated agents, got {len(NON_MIGRATED_AGENTS)}: "
@@ -179,6 +179,12 @@ def test_vibe_not_in_agent_command_config() -> None:
         "vibe was found in AGENT_COMMAND_CONFIG. "
         "Vibe uses the Agent Skills pipeline, not the command-file pipeline."
     )
+
+
+def test_pi_and_letta_not_in_agent_command_config() -> None:
+    """pi and letta must NOT be in AGENT_COMMAND_CONFIG."""
+    assert "pi" not in AGENT_COMMAND_CONFIG
+    assert "letta" not in AGENT_COMMAND_CONFIG
 
 
 @pytest.mark.parametrize("agent", NON_MIGRATED_AGENTS)
@@ -215,7 +221,7 @@ def test_agent_outputs_contain_arg_placeholder(agent: str) -> None:
 
     Verifies that $ARGUMENTS or {{args}} is present in at least one rendered
     command for the agent (the skill-renderer transformation must NOT have
-    been applied to these agents — that transformation is codex/vibe only).
+    been applied to these agents — that transformation is command-skill only).
     """
     config = AGENT_COMMAND_CONFIG[agent]
     expected_placeholder = config["arg_format"]

--- a/tests/specify_cli/runtime/test_agent_commands_routing.py
+++ b/tests/specify_cli/runtime/test_agent_commands_routing.py
@@ -3,15 +3,15 @@
 Post-mission-review correction: `_sync_agent_commands` is the global command-
 layer sync path (writes to ``~/.claude/commands/``, ``~/.gemini/commands/``,
 etc.). It is called in a loop over ``AGENT_COMMAND_CONFIG``, which no longer
-contains ``codex`` or ``vibe``. Command-skill installation for codex/vibe is
+contains command-skill agents. Command-skill installation for those agents is
 therefore driven from ``init`` and ``agent config add``, NOT from this
 function. These tests verify that:
 
-- ``_sync_agent_commands`` does not try to handle codex/vibe (it is the
+- ``_sync_agent_commands`` does not try to handle command-skill agents (it is the
   wrong call site for them).
 - ``claude`` (and by extension every other command-layer agent) still
   reaches the legacy render-commands path here.
-- ``codex`` and ``vibe`` are absent from ``AGENT_COMMAND_CONFIG`` so the
+- command-skill agents are absent from ``AGENT_COMMAND_CONFIG`` so the
   caller loop never sees them.
 """
 
@@ -33,14 +33,14 @@ from specify_cli.runtime.agent_commands import _sync_agent_commands, get_global_
 # ---------------------------------------------------------------------------
 
 
-def test_codex_and_vibe_absent_from_command_config() -> None:
+def test_command_skill_agents_absent_from_command_config() -> None:
     """The loop in ``ensure_runtime`` iterates ``AGENT_COMMAND_CONFIG``.
 
-    Codex and Vibe must not appear there or the legacy command-file renderer
+    Command-skill agents must not appear there or the legacy command-file renderer
     would write their files into ``~/.claude/commands/``-style directories.
     """
-    assert "codex" not in AGENT_COMMAND_CONFIG
-    assert "vibe" not in AGENT_COMMAND_CONFIG
+    for agent_key in ("codex", "vibe", "pi", "letta"):
+        assert agent_key not in AGENT_COMMAND_CONFIG
 
 
 def test_sync_does_not_invoke_skill_installer(tmp_path: Path) -> None:

--- a/tests/specify_cli/skills/test_command_installer.py
+++ b/tests/specify_cli/skills/test_command_installer.py
@@ -122,6 +122,18 @@ class TestHappyPathInstall:
                 f"Entry {entry.path!r} has unexpected agents {entry.agents!r}"
             )
 
+    @pytest.mark.parametrize("agent_key", ["pi", "letta"])
+    def test_new_command_skill_agents_install_manifest_entries(
+        self, repo: Path, agent_key: str
+    ) -> None:
+        report = install(repo, agent_key)
+
+        assert len(report.added) == len(CANONICAL_COMMANDS)
+        manifest = manifest_store.load(repo)
+        assert len(manifest.entries) == len(CANONICAL_COMMANDS)
+        for entry in manifest.entries:
+            assert entry.agents == (agent_key,)
+
     def test_manifest_entries_have_correct_paths(self, repo: Path) -> None:
         install(repo, "vibe")
 
@@ -624,9 +636,8 @@ class TestVerifyOrphans:
 
 
 class TestConstants:
-    def test_supported_agents_contains_codex_and_vibe(self) -> None:
-        assert "codex" in SUPPORTED_AGENTS
-        assert "vibe" in SUPPORTED_AGENTS
+    def test_supported_agents_contains_command_skill_agents(self) -> None:
+        assert set(SUPPORTED_AGENTS) == {"codex", "vibe", "pi", "letta"}
 
     def test_canonical_commands_count(self) -> None:
         # Was 12 before 3.2.0a5; checklist retired (FR-003 / FR-004 / #815).

--- a/tests/specify_cli/skills/test_command_renderer.py
+++ b/tests/specify_cli/skills/test_command_renderer.py
@@ -1,6 +1,6 @@
 """Tests for the command-skill renderer (WP02 — T011).
 
-Snapshot tests cover all canonical command templates × 2 agents (codex, vibe).
+Snapshot tests cover all canonical command templates × representative agents.
 Snapshots are committed under ``tests/specify_cli/skills/__snapshots__/<agent>/``.
 
 Regenerating snapshots
@@ -51,6 +51,7 @@ SNAPSHOTS_DIR = Path(__file__).parent / "__snapshots__"
 
 # Fixed version string used for all snapshot renders so the output is stable.
 _TEST_VERSION = "3.0.0"
+SNAPSHOT_AGENTS: tuple[str, ...] = ("codex", "vibe")
 
 # Whether to update snapshots instead of asserting against them.
 _UPDATE = os.environ.get("PYTEST_UPDATE_SNAPSHOTS", "0") not in ("", "0", "false", "False")
@@ -98,9 +99,9 @@ def _render_and_compare(template_path: Path, agent_key: str) -> None:
 
 
 @pytest.mark.parametrize("template_path", _all_templates(), ids=lambda p: p.stem)
-@pytest.mark.parametrize("agent_key", SUPPORTED_AGENTS)
+@pytest.mark.parametrize("agent_key", SNAPSHOT_AGENTS)
 def test_snapshot(template_path: Path, agent_key: str) -> None:
-    """All canonical templates × 2 agents must match their committed snapshots."""
+    """Representative agent renders must match their committed snapshots."""
     _render_and_compare(template_path, agent_key)
 
 

--- a/tests/specify_cli/skills/test_manifest_store.py
+++ b/tests/specify_cli/skills/test_manifest_store.py
@@ -294,7 +294,7 @@ def test_schema_validation_missing_content_hash(tmp_path: Path) -> None:
 
 
 def test_schema_validation_invalid_agent_enum(tmp_path: Path) -> None:
-    """An agent key not in {codex, vibe} fails validation."""
+    """An unsupported agent key fails validation."""
     _write_raw(
         tmp_path,
         {


### PR DESCRIPTION
## Summary

Adds first-class Spec Kitty support for Pi and Letta Code as command-skill agents.

- registers `pi` and `letta` in agent choices, setup verification, skill config, and init help
- installs Spec Kitty command skills for Pi/Letta under `.agents/skills/`
- supports `spec-kitty init --ai pi|letta` and `spec-kitty agent config add/remove pi|letta`
- adds `.pi/` and `.letta/` gitignore/security-notice coverage
- updates docs and host-surface parity matrix
- adds regression coverage for init, agent config, renderer/installer, registry, and docs inventory

## Verification

- `uv run pytest tests/specify_cli/core/test_config_registry.py tests/specify_cli/cli/commands/test_init_pi_letta.py tests/specify_cli/cli/commands/test_agent_config_pi_letta.py tests/specify_cli/skills/test_command_installer.py tests/specify_cli/skills/test_command_renderer.py tests/specify_cli/docs/test_host_surface_inventory.py`
  - 154 passed, 1 existing deprecation warning
- Earlier broader targeted run:
  - 228 passed, 1 existing deprecation warning
- `uv run ruff check ...`
  - passed

## Notes

The companion `spec-kitty-orchestrator` Pi/Letta invoker support was pushed directly to `Priivacy-ai/spec-kitty-orchestrator@main` in commit `9fcf6e1`.
