### PR TITLE
Persist local canonical lifecycle events immediately

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 from kernel._safe_re import re
 import shutil
@@ -55,6 +56,8 @@ from specify_cli.status.bootstrap import bootstrap_canonical_state
 from specify_cli.sync.events import emit_wp_created, get_emitter
 from specify_cli.workspace.context import resolve_feature_worktree
 from specify_cli.merge.config import MergeStrategy
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(name="mission", help="Mission lifecycle commands for AI agents", no_args_is_help=True)
 
@@ -1012,6 +1015,33 @@ def setup_plan(
                 with package_template.open("rb") as src, open(plan_file, "wb") as dst:
                     shutil.copyfileobj(src, dst)
 
+        # Local canonical lifecycle: once setup-plan accepts spec.md as
+        # committed + substantive, record SpecifyCompleted and PlanStarted
+        # before performing any further work. This is the canonical handoff
+        # marker for the spec→plan transition (issue #1067).
+        try:
+            from specify_cli.status.lifecycle_events import (
+                emit_artifact_phase,
+                SPECIFY_COMPLETED,
+                PLAN_STARTED,
+            )
+
+            emit_artifact_phase(
+                feature_dir,
+                event_type=SPECIFY_COMPLETED,
+                mission_slug=mission_slug,
+                actor="spec-kitty agent mission setup-plan",
+                artifact_path=str(spec_file.relative_to(repo_root)),
+            )
+            emit_artifact_phase(
+                feature_dir,
+                event_type=PLAN_STARTED,
+                mission_slug=mission_slug,
+                actor="spec-kitty agent mission setup-plan",
+            )
+        except Exception as _phase_exc:  # noqa: BLE001
+            logger.debug("Lifecycle phase emission skipped: %s", _phase_exc)
+
         # Issue #846 exit gate: only commit plan.md when its Technical Context
         # has been populated with real (non-placeholder) values. A bare
         # template stays untracked so the dashboard / workflow JSON does not
@@ -1020,6 +1050,21 @@ def setup_plan(
         plan_blocked_reason: str | None = None
         if plan_is_substantive:
             _commit_to_branch(plan_file, mission_slug, "plan", repo_root, target_branch, json_output)
+            try:
+                from specify_cli.status.lifecycle_events import (
+                    emit_artifact_phase,
+                    PLAN_COMPLETED,
+                )
+
+                emit_artifact_phase(
+                    feature_dir,
+                    event_type=PLAN_COMPLETED,
+                    mission_slug=mission_slug,
+                    actor="spec-kitty agent mission setup-plan",
+                    artifact_path=str(plan_file.relative_to(repo_root)),
+                )
+            except Exception as _plan_exc:  # noqa: BLE001
+                logger.debug("PlanCompleted emission skipped: %s", _plan_exc)
         else:
             plan_blocked_reason = (
                 "plan.md content is not substantive yet; populate Technical Context with real "
@@ -1931,6 +1976,26 @@ def finalize_tasks(
         else:
             console.print("[yellow]Warning:[/yellow] meta.json missing; skipping MissionCreated emission")
 
+        # Local canonical TasksStarted (idempotent on mission_slug).
+        # Recorded once finalize-tasks decides the mission has a usable WP
+        # set; the matching TasksCompleted is emitted after commit.
+        if not validate_only:
+            try:
+                from specify_cli.status.lifecycle_events import (
+                    emit_artifact_phase,
+                    TASKS_STARTED,
+                )
+
+                emit_artifact_phase(
+                    feature_dir,
+                    event_type=TASKS_STARTED,
+                    mission_slug=mission_slug,
+                    actor="spec-kitty agent mission finalize-tasks",
+                    wp_count=len(work_packages),
+                )
+            except Exception as _tasks_started_exc:  # noqa: BLE001
+                logger.debug("TasksStarted emission skipped: %s", _tasks_started_exc)
+
         # Commit tasks.md and WP files to target branch
         commit_created = False
         commit_hash = None
@@ -2162,7 +2227,62 @@ def finalize_tasks(
                 console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1) from None
 
-        # Emit WPCreated events (non-blocking)
+        # Local canonical WPCreated + TasksCompleted persistence — must
+        # land before any SaaS fan-out so dashboards see the full WP
+        # roster even if the SaaS leg is offline (issue #1068).
+        try:
+            from specify_cli.status.lifecycle_events import (
+                emit_artifact_phase,
+                emit_wp_created_local,
+                TASKS_COMPLETED,
+            )
+
+            for wp in work_packages:
+                _wp_id = str(wp["id"])
+                _wp_title = str(wp.get("title") or _wp_id)
+                _depends_on = list(cast(list[str], wp.get("dependencies") or []))
+                _wp_path: str | None = None
+                try:
+                    _candidate = next(
+                        iter(sorted((feature_dir / "tasks").glob(f"{_wp_id}*.md"))),
+                        None,
+                    )
+                    if _candidate is not None:
+                        _wp_path = str(_candidate.relative_to(repo_root))
+                except Exception:  # noqa: BLE001
+                    _wp_path = None
+                emit_wp_created_local(
+                    feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=_wp_id,
+                    wp_title=_wp_title,
+                    wp_path=_wp_path,
+                    depends_on=_depends_on,
+                    actor="spec-kitty agent mission finalize-tasks",
+                )
+
+            _tasks_artifact = feature_dir / "tasks.md"
+            _tasks_artifact_rel: str | None = None
+            if _tasks_artifact.exists():
+                try:
+                    _tasks_artifact_rel = str(_tasks_artifact.relative_to(repo_root))
+                except ValueError:
+                    _tasks_artifact_rel = str(_tasks_artifact)
+            emit_artifact_phase(
+                feature_dir,
+                event_type=TASKS_COMPLETED,
+                mission_slug=mission_slug,
+                actor="spec-kitty agent mission finalize-tasks",
+                artifact_path=_tasks_artifact_rel or "tasks.md",
+                wp_count=len(work_packages),
+            )
+        except Exception as _local_wp_exc:  # noqa: BLE001
+            console.print(
+                f"[yellow]Warning:[/yellow] Local canonical WPCreated/TasksCompleted "
+                f"persistence failed: {_local_wp_exc}"
+            )
+
+        # Emit WPCreated events to SaaS (non-blocking)
         # MissionCreated is emitted earlier during mission create
         causation_id = get_emitter().generate_causation_id()
 

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -2074,6 +2074,61 @@ def finalize_tasks(
                         )
             return
 
+        # Local canonical WPCreated + TasksCompleted persistence must precede
+        # bootstrap_canonical_state so replay consumers see WPCreated before
+        # the first WPStatusChanged event for each WP.
+        try:
+            from specify_cli.status.lifecycle_events import (
+                emit_artifact_phase,
+                emit_wp_created_local,
+                TASKS_COMPLETED,
+            )
+
+            for wp in work_packages:
+                _wp_id = str(wp["id"])
+                _wp_title = str(wp.get("title") or _wp_id)
+                _depends_on = list(cast(list[str], wp.get("dependencies") or []))
+                _wp_path: str | None = None
+                try:
+                    _candidate = next(
+                        iter(sorted((feature_dir / "tasks").glob(f"{_wp_id}*.md"))),
+                        None,
+                    )
+                    if _candidate is not None:
+                        _wp_path = str(_candidate.relative_to(repo_root))
+                except Exception:  # noqa: BLE001
+                    _wp_path = None
+                emit_wp_created_local(
+                    feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=_wp_id,
+                    wp_title=_wp_title,
+                    wp_path=_wp_path,
+                    depends_on=_depends_on,
+                    actor="spec-kitty agent mission finalize-tasks",
+                )
+
+            _tasks_artifact = feature_dir / "tasks.md"
+            _tasks_artifact_rel: str | None = None
+            if _tasks_artifact.exists():
+                try:
+                    _tasks_artifact_rel = str(_tasks_artifact.relative_to(repo_root))
+                except ValueError:
+                    _tasks_artifact_rel = str(_tasks_artifact)
+            emit_artifact_phase(
+                feature_dir,
+                event_type=TASKS_COMPLETED,
+                mission_slug=mission_slug,
+                actor="spec-kitty agent mission finalize-tasks",
+                artifact_path=_tasks_artifact_rel or "tasks.md",
+                wp_count=len(work_packages),
+            )
+        except Exception as _local_wp_exc:  # noqa: BLE001
+            console.print(
+                f"[yellow]Warning:[/yellow] Local canonical WPCreated/TasksCompleted "
+                f"persistence failed: {_local_wp_exc}"
+            )
+
         # Bootstrap canonical status state for all WPs
         bootstrap_result = bootstrap_canonical_state(
             feature_dir,
@@ -2226,61 +2281,6 @@ def finalize_tasks(
             else:
                 console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1) from None
-
-        # Local canonical WPCreated + TasksCompleted persistence — must
-        # land before any SaaS fan-out so dashboards see the full WP
-        # roster even if the SaaS leg is offline (issue #1068).
-        try:
-            from specify_cli.status.lifecycle_events import (
-                emit_artifact_phase,
-                emit_wp_created_local,
-                TASKS_COMPLETED,
-            )
-
-            for wp in work_packages:
-                _wp_id = str(wp["id"])
-                _wp_title = str(wp.get("title") or _wp_id)
-                _depends_on = list(cast(list[str], wp.get("dependencies") or []))
-                _wp_path: str | None = None
-                try:
-                    _candidate = next(
-                        iter(sorted((feature_dir / "tasks").glob(f"{_wp_id}*.md"))),
-                        None,
-                    )
-                    if _candidate is not None:
-                        _wp_path = str(_candidate.relative_to(repo_root))
-                except Exception:  # noqa: BLE001
-                    _wp_path = None
-                emit_wp_created_local(
-                    feature_dir,
-                    mission_slug=mission_slug,
-                    wp_id=_wp_id,
-                    wp_title=_wp_title,
-                    wp_path=_wp_path,
-                    depends_on=_depends_on,
-                    actor="spec-kitty agent mission finalize-tasks",
-                )
-
-            _tasks_artifact = feature_dir / "tasks.md"
-            _tasks_artifact_rel: str | None = None
-            if _tasks_artifact.exists():
-                try:
-                    _tasks_artifact_rel = str(_tasks_artifact.relative_to(repo_root))
-                except ValueError:
-                    _tasks_artifact_rel = str(_tasks_artifact)
-            emit_artifact_phase(
-                feature_dir,
-                event_type=TASKS_COMPLETED,
-                mission_slug=mission_slug,
-                actor="spec-kitty agent mission finalize-tasks",
-                artifact_path=_tasks_artifact_rel or "tasks.md",
-                wp_count=len(work_packages),
-            )
-        except Exception as _local_wp_exc:  # noqa: BLE001
-            console.print(
-                f"[yellow]Warning:[/yellow] Local canonical WPCreated/TasksCompleted "
-                f"persistence failed: {_local_wp_exc}"
-            )
 
         # Emit WPCreated events to SaaS (non-blocking)
         # MissionCreated is emitted earlier during mission create

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -740,6 +740,26 @@ def init(  # noqa: C901
             # Git management is the user's responsibility. Running init inside
             # an existing repo leaves the repo untouched.
 
+            # Persist a local canonical ProjectInitialized event before any
+            # SaaS fan-out so local dashboards and TeamSpace import always
+            # see a complete project history (issue #1067).
+            try:
+                from specify_cli.identity.project import ensure_identity
+                from specify_cli.status.lifecycle_events import emit_project_initialized
+                from specify_cli import __version__ as _sk_runtime_version
+
+                _identity = ensure_identity(project_path)
+                if _identity.project_uuid is not None:
+                    emit_project_initialized(
+                        project_path,
+                        project_uuid=str(_identity.project_uuid),
+                        project_slug=_identity.project_slug,
+                        actor="spec-kitty init",
+                        runtime_version=_sk_runtime_version or None,
+                    )
+            except Exception as _proj_init_exc:  # noqa: BLE001
+                _logger.debug("ProjectInitialized event emission skipped: %s", _proj_init_exc)
+
             tracker.complete("final", "project ready")
         except typer.Exit:
             raise

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -950,10 +950,13 @@ def _enforce_canonical_status_history(
     if not wp_ids:
         return
 
+    log_path = feature_dir / "status.events.jsonl"
+    if not log_path.exists():
+        return
+
     if has_non_bootstrap_status_history(feature_dir):
         return
 
-    log_path = feature_dir / "status.events.jsonl"
     console.print(
         "[red]Error:[/red] Canonical status history is bootstrap-only — the local "
         "event log cannot prove that WPs advanced past planned, so a merge would "

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -928,6 +928,49 @@ def _enforce_target_branch_sync_preflight(
     raise typer.Exit(1)
 
 
+def _enforce_canonical_status_history(
+    *,
+    feature_dir: Path,
+    mission_slug: str,
+    wp_ids: list[str],
+) -> None:
+    """Refuse to merge missions whose canonical status log is bootstrap-only.
+
+    A bootstrap-only log is a ``status.events.jsonl`` that contains
+    nothing but forced ``planned -> planned`` entries emitted by
+    ``finalize-tasks``. When the mission carries work packages that
+    must have advanced past planned for merge to make sense, the log
+    is an unreliable source of truth and downstream replay (TeamSpace
+    rebuild, dashboard refresh) will reset every WP to planned. We
+    fail loudly with a remediation hint rather than ship in that
+    state. See https://github.com/Priivacy-ai/spec-kitty/issues/1069.
+    """
+    from specify_cli.status.lifecycle_events import has_non_bootstrap_status_history
+
+    if not wp_ids:
+        return
+
+    if has_non_bootstrap_status_history(feature_dir):
+        return
+
+    log_path = feature_dir / "status.events.jsonl"
+    console.print(
+        "[red]Error:[/red] Canonical status history is bootstrap-only — the local "
+        "event log cannot prove that WPs advanced past planned, so a merge would "
+        "ship a mission whose downstream replay would regress every WP."
+    )
+    console.print(f"  Mission: {mission_slug}")
+    console.print(f"  Event log: {log_path}")
+    console.print(f"  Work packages requiring history: {', '.join(wp_ids)}")
+    console.print(
+        "  Remediation: re-run the per-WP `spec-kitty agent action review` and "
+        "`spec-kitty agent action implement` flows so the canonical event log "
+        "captures the real lane transitions before merging, or run the "
+        "repair/replay tooling for this mission."
+    )
+    raise typer.Exit(1)
+
+
 def _enforce_review_artifact_consistency(
     *,
     repo_root: Path,
@@ -1138,6 +1181,19 @@ def _run_lane_based_merge_locked(
 
     _enforce_review_artifact_consistency(
         repo_root=main_repo,
+        feature_dir=feature_dir,
+        mission_slug=mission_slug,
+        wp_ids=all_wp_ids,
+    )
+
+    # -- Bootstrap-only canonical history guard (issue #1069) --
+    # Refuse to merge missions whose status.events.jsonl contains
+    # nothing but forced bootstrap planned→planned events when the
+    # mission has work packages that should have advanced. This
+    # prevents shipping a mission whose canonical history will
+    # collapse downstream consumers (e.g. TeamSpace replay) back to
+    # planned even though the merged commit reflects approved work.
+    _enforce_canonical_status_history(
         feature_dir=feature_dir,
         mission_slug=mission_slug,
         wp_ids=all_wp_ids,

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -398,8 +398,39 @@ def create_mission_core(
             _commit_feature_file(meta_file, mission_slug_formatted, "meta", resolved_root)
 
     # ------------------------------------------------------------------
-    # 8. Event emission (fire-and-forget)
+    # 8. Event emission
+    #
+    # Local canonical persistence MUST happen before any SaaS fan-out so
+    # downstream dashboards and TeamSpace can replay a mission's full
+    # history even when SaaS sync is offline (issue #1067).
     # ------------------------------------------------------------------
+    try:
+        from specify_cli.identity.project import load_identity
+        from specify_cli.status.lifecycle_events import emit_mission_created_local
+
+        _identity = load_identity(resolved_root / ".kittify" / "config.yaml")
+        emit_mission_created_local(
+            feature_dir,
+            mission_slug=mission_slug_formatted,
+            mission_id=meta.get("mission_id"),
+            mission_number=None,
+            target_branch=planning_branch,
+            actor="spec-kitty mission create",
+            project_uuid=str(_identity.project_uuid) if _identity.project_uuid else None,
+            project_slug=_identity.project_slug,
+            friendly_name=normalized_friendly_name,
+            purpose_tldr=normalized_purpose_tldr,
+            purpose_context=normalized_purpose_context,
+            created_at=str(meta["created_at"]) if meta.get("created_at") else None,
+        )
+    except Exception as _local_evt_exc:  # noqa: BLE001
+        logger.warning(
+            "Local canonical MissionCreated persistence failed for %s: %s",
+            mission_slug_formatted,
+            _local_evt_exc,
+        )
+
+    # Best-effort SaaS fan-out (occurs after local persistence above).
     with contextlib.suppress(Exception):
         emit_mission_created(
             mission_slug=mission_slug_formatted,

--- a/src/specify_cli/runtime/bootstrap.py
+++ b/src/specify_cli/runtime/bootstrap.py
@@ -28,10 +28,33 @@ logger = logging.getLogger(__name__)
 
 
 def _get_cli_version() -> str:
-    """Return the current CLI version string."""
-    from specify_cli import __version__
+    """Return the current CLI version string.
 
-    return __version__
+    Defensive: when the package's ``__version__`` is missing or ``None``
+    (e.g. during partial installs, broken editable layouts, or import
+    cycles during bootstrap), fall back to ``"0.0.0-dev"`` rather than
+    crashing the entire CLI with a ``TypeError`` on later
+    ``write_text`` / string-compare paths (issue #1070).
+    """
+    fallback = "0.0.0-dev"
+    try:
+        from specify_cli import __version__ as _version  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Could not import specify_cli.__version__ during runtime bootstrap; "
+            "falling back to %s",
+            fallback,
+        )
+        return fallback
+    if not isinstance(_version, str) or not _version:
+        logger.warning(
+            "specify_cli.__version__ resolved to %r during runtime bootstrap; "
+            "falling back to %s",
+            _version,
+            fallback,
+        )
+        return fallback
+    return _version
 
 
 def _lock_exclusive(fd: IO[str]) -> None:

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -486,12 +486,10 @@ def has_non_bootstrap_status_history(feature_dir: Path) -> bool:
         # the absence of the field — see status.store).
         if not isinstance(obj, dict):
             continue
-        if obj.get("event_type") in LIFECYCLE_EVENT_TYPES:
-            # Lifecycle events count as real history.
-            return True
         if "event_type" in obj:
-            # Other event-typed entries (decision moment, retrospective)
-            # do not prove WP progression; ignore.
+            # Lifecycle and other event-typed entries prove that the stream
+            # exists, but they do not prove a WP advanced beyond bootstrap
+            # planned state. The merge guard needs real status transitions.
             continue
         to_lane = obj.get("to_lane")
         from_lane = obj.get("from_lane")

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -1,0 +1,534 @@
+"""Local-first canonical lifecycle event persistence.
+
+This module is the durable, local-first writer for the canonical event
+stream that records project initialization, mission creation,
+spec/plan/tasks artifact lifecycle, and work-package creation. It is
+intentionally independent of the SaaS sync emitter: lifecycle events
+land on disk synchronously *before* any best-effort SaaS fan-out, so
+local dashboards and TeamSpace import always have a complete history.
+
+Two log targets exist:
+
+* **Project-level log** (``<repo_root>/.kittify/canonical-events.jsonl``)
+  carries project-wide events such as ``ProjectInitialized``.
+
+* **Mission-level log** (``<feature_dir>/status.events.jsonl``) is
+  shared with the existing ``WPStatusChanged`` reducer; lifecycle events
+  carry a top-level ``event_type`` field and are intentionally skipped
+  by :mod:`specify_cli.status.store`'s ``StatusEvent`` reader.
+
+Idempotency
+-----------
+
+Each appender is keyed by ``(event_type, deduplication tuple)`` so
+re-running the producer (e.g. ``finalize-tasks`` on an existing
+mission) is a no-op for already-recorded events. This makes the
+canonical stream a safe target for repair / replay tooling.
+
+The schema mirrors the contracts defined in
+``spec_kitty_events.project_lifecycle`` (sibling repo). The
+``project_lifecycle`` module is referenced via string constants here
+so that the CLI does not hard-fail when an older release of
+``spec-kitty-events`` is installed; the payloads are forward-compatible
+with the typed contracts.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from datetime import datetime, UTC
+from pathlib import Path
+from typing import Any
+from collections.abc import Iterable, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Event type constants — kept in sync with spec_kitty_events.project_lifecycle
+# ---------------------------------------------------------------------------
+
+PROJECT_INITIALIZED = "ProjectInitialized"
+MISSION_CREATED = "MissionCreated"
+SPECIFY_STARTED = "SpecifyStarted"
+SPECIFY_COMPLETED = "SpecifyCompleted"
+PLAN_STARTED = "PlanStarted"
+PLAN_COMPLETED = "PlanCompleted"
+TASKS_STARTED = "TasksStarted"
+TASKS_COMPLETED = "TasksCompleted"
+WP_CREATED = "WPCreated"
+
+LIFECYCLE_EVENT_TYPES = frozenset({
+    PROJECT_INITIALIZED,
+    MISSION_CREATED,
+    SPECIFY_STARTED,
+    SPECIFY_COMPLETED,
+    PLAN_STARTED,
+    PLAN_COMPLETED,
+    TASKS_STARTED,
+    TASKS_COMPLETED,
+    WP_CREATED,
+})
+
+PROJECT_EVENTS_FILENAME = "canonical-events.jsonl"
+MISSION_EVENTS_FILENAME = "status.events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Path resolvers
+# ---------------------------------------------------------------------------
+
+
+def project_event_log_path(repo_root: Path) -> Path:
+    """Return the canonical project-level event log path for *repo_root*."""
+    return repo_root / ".kittify" / PROJECT_EVENTS_FILENAME
+
+
+def mission_event_log_path(feature_dir: Path) -> Path:
+    """Return the canonical mission-level event log path for *feature_dir*."""
+    return feature_dir / MISSION_EVENTS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Reading & writing
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _generate_event_id() -> str:
+    try:
+        from ulid import ULID  # type: ignore[import-not-found]
+
+        return str(ULID())
+    except Exception:  # pragma: no cover — fallback for stripped envs
+        import uuid
+
+        return uuid.uuid4().hex
+
+
+def _read_lifecycle_lines(path: Path) -> list[dict[str, Any]]:
+    """Best-effort read of lifecycle event dicts from a JSONL file.
+
+    Tolerates missing files, blank lines, and corrupted lines (the
+    bad lines are skipped with a debug log). Only entries that carry
+    a top-level ``event_type`` are returned: any sibling format (e.g.
+    ``WPStatusChanged`` payloads written by the status reducer) is
+    filtered out so callers can scan lifecycle history in isolation.
+    """
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Could not read lifecycle log %s: %s", path, exc)
+        return []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            logger.debug("Skipping non-JSON lifecycle line in %s", path)
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("event_type"), str):
+            out.append(obj)
+    return out
+
+
+def _atomic_append(path: Path, line: str) -> None:
+    """Append a single JSON line to *path*, creating parents as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+        fh.flush()
+        with contextlib.suppress(OSError):
+            os.fsync(fh.fileno())
+
+
+def _build_envelope(
+    event_type: str,
+    payload: Mapping[str, Any],
+    *,
+    aggregate_id: str,
+    aggregate_type: str,
+    project_uuid: str | None = None,
+    project_slug: str | None = None,
+    schema_version: str = "5.0.0",
+) -> dict[str, Any]:
+    return {
+        "event_id": _generate_event_id(),
+        "event_type": event_type,
+        "aggregate_id": aggregate_id,
+        "aggregate_type": aggregate_type,
+        "schema_version": schema_version,
+        "timestamp": _now_iso(),
+        "payload": dict(payload),
+        "project_uuid": project_uuid,
+        "project_slug": project_slug,
+    }
+
+
+def _match_lifecycle_event(
+    candidate: Mapping[str, Any],
+    *,
+    event_type: str,
+    dedup_keys: Mapping[str, Any],
+) -> bool:
+    if candidate.get("event_type") != event_type:
+        return False
+    payload = candidate.get("payload") or {}
+    if not isinstance(payload, Mapping):
+        return False
+    return all(payload.get(key) == expected for key, expected in dedup_keys.items())
+
+
+def has_lifecycle_event(
+    log_path: Path,
+    *,
+    event_type: str,
+    dedup_keys: Mapping[str, Any],
+) -> bool:
+    """Return True if the log already contains a matching lifecycle event."""
+    return any(
+        _match_lifecycle_event(entry, event_type=event_type, dedup_keys=dedup_keys)
+        for entry in _read_lifecycle_lines(log_path)
+    )
+
+
+def append_lifecycle_event(
+    log_path: Path,
+    event_type: str,
+    payload: Mapping[str, Any],
+    *,
+    aggregate_id: str,
+    aggregate_type: str,
+    project_uuid: str | None = None,
+    project_slug: str | None = None,
+    dedup_keys: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Append a lifecycle event to *log_path* unless an idempotent match exists.
+
+    Returns the persisted event envelope, or ``None`` when the append was
+    skipped because an event with the same ``(event_type, dedup_keys)``
+    tuple is already on disk. Failures fall back to a debug log; the
+    function never raises so callers can chain it safely behind a
+    fire-and-forget ``contextlib.suppress`` if they choose.
+    """
+    if event_type not in LIFECYCLE_EVENT_TYPES:
+        logger.debug("Refusing to append unknown lifecycle event type %r", event_type)
+        return None
+
+    if dedup_keys and has_lifecycle_event(
+        log_path, event_type=event_type, dedup_keys=dedup_keys
+    ):
+        logger.debug(
+            "Lifecycle event %s already present in %s; skipping append",
+            event_type,
+            log_path,
+        )
+        return None
+
+    envelope = _build_envelope(
+        event_type,
+        payload,
+        aggregate_id=aggregate_id,
+        aggregate_type=aggregate_type,
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+    )
+    try:
+        _atomic_append(log_path, json.dumps(envelope, sort_keys=True))
+    except OSError as exc:
+        logger.warning("Could not persist %s event to %s: %s", event_type, log_path, exc)
+        return None
+    return envelope
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers (per event type)
+# ---------------------------------------------------------------------------
+
+
+def emit_project_initialized(
+    repo_root: Path,
+    *,
+    project_uuid: str,
+    project_slug: str | None,
+    actor: str = "cli",
+    runtime_version: str | None = None,
+    initialized_at: str | None = None,
+) -> dict[str, Any] | None:
+    """Record a local ``ProjectInitialized`` event for *repo_root*.
+
+    Idempotent on ``project_uuid``: re-running ``spec-kitty init`` (or any
+    bootstrap flow) on an already-initialized project is a no-op.
+    """
+    log_path = project_event_log_path(repo_root)
+    payload = {
+        "project_uuid": project_uuid,
+        "project_slug": project_slug,
+        "actor": actor,
+        "runtime_version": runtime_version,
+        "initialized_at": initialized_at or _now_iso(),
+    }
+    return append_lifecycle_event(
+        log_path,
+        PROJECT_INITIALIZED,
+        payload,
+        aggregate_id=project_uuid,
+        aggregate_type="Project",
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+        dedup_keys={"project_uuid": project_uuid},
+    )
+
+
+def emit_mission_created_local(
+    feature_dir: Path,
+    *,
+    mission_slug: str,
+    mission_id: str | None,
+    mission_number: int | None,
+    target_branch: str,
+    actor: str = "cli",
+    project_uuid: str | None = None,
+    project_slug: str | None = None,
+    friendly_name: str | None = None,
+    purpose_tldr: str | None = None,
+    purpose_context: str | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any] | None:
+    """Record a local ``MissionCreated`` event for *feature_dir*.
+
+    Idempotent on ``mission_slug``. The mission's
+    ``status.events.jsonl`` is created on first call.
+    """
+    log_path = mission_event_log_path(feature_dir)
+    payload: dict[str, Any] = {
+        "mission_slug": mission_slug,
+        "mission_number": mission_number,
+        "target_branch": target_branch,
+        "actor": actor,
+        "created_at": created_at or _now_iso(),
+    }
+    if mission_id is not None:
+        payload["mission_id"] = mission_id
+    if friendly_name is not None:
+        payload["friendly_name"] = friendly_name
+    if purpose_tldr is not None:
+        payload["purpose_tldr"] = purpose_tldr
+    if purpose_context is not None:
+        payload["purpose_context"] = purpose_context
+
+    return append_lifecycle_event(
+        log_path,
+        MISSION_CREATED,
+        payload,
+        aggregate_id=mission_id or mission_slug,
+        aggregate_type="Mission",
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+        dedup_keys={"mission_slug": mission_slug},
+    )
+
+
+def emit_artifact_phase(
+    feature_dir: Path,
+    *,
+    event_type: str,
+    mission_slug: str,
+    mission_number: int | None = None,
+    actor: str = "cli",
+    artifact_path: str | None = None,
+    summary: str | None = None,
+    wp_count: int | None = None,
+    project_uuid: str | None = None,
+    project_slug: str | None = None,
+    at: str | None = None,
+) -> dict[str, Any] | None:
+    """Append a Specify/Plan/Tasks lifecycle event for the mission.
+
+    Started events dedupe on ``(event_type, mission_slug)``; completed
+    events dedupe on ``(event_type, mission_slug, artifact_path)`` so
+    that re-running a phase with a different artifact path is recorded
+    as a new completed event.
+    """
+    if event_type not in {
+        SPECIFY_STARTED,
+        SPECIFY_COMPLETED,
+        PLAN_STARTED,
+        PLAN_COMPLETED,
+        TASKS_STARTED,
+        TASKS_COMPLETED,
+    }:
+        raise ValueError(f"Unsupported artifact phase event_type: {event_type!r}")
+
+    payload: dict[str, Any] = {
+        "mission_slug": mission_slug,
+        "actor": actor,
+        "at": at or _now_iso(),
+    }
+    if mission_number is not None:
+        payload["mission_number"] = mission_number
+    if artifact_path is not None:
+        payload["artifact_path"] = artifact_path
+    if summary is not None:
+        payload["summary"] = summary
+    if wp_count is not None:
+        payload["wp_count"] = wp_count
+
+    dedup: dict[str, Any] = {"mission_slug": mission_slug}
+    if artifact_path is not None and event_type.endswith("Completed"):
+        dedup["artifact_path"] = artifact_path
+
+    log_path = mission_event_log_path(feature_dir)
+    return append_lifecycle_event(
+        log_path,
+        event_type,
+        payload,
+        aggregate_id=mission_slug,
+        aggregate_type="Mission",
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+        dedup_keys=dedup,
+    )
+
+
+def emit_wp_created_local(
+    feature_dir: Path,
+    *,
+    mission_slug: str,
+    wp_id: str,
+    wp_title: str,
+    wp_path: str | None = None,
+    depends_on: Iterable[str] | None = None,
+    actor: str = "cli",
+    mission_number: int | None = None,
+    created_at: str | None = None,
+    project_uuid: str | None = None,
+    project_slug: str | None = None,
+) -> dict[str, Any] | None:
+    """Record a local ``WPCreated`` event keyed by ``(mission_slug, wp_id)``."""
+    payload: dict[str, Any] = {
+        "mission_slug": mission_slug,
+        "wp_id": wp_id,
+        "wp_title": wp_title,
+        "depends_on": list(depends_on or []),
+        "actor": actor,
+        "created_at": created_at or _now_iso(),
+    }
+    if mission_number is not None:
+        payload["mission_number"] = mission_number
+    if wp_path is not None:
+        payload["wp_path"] = wp_path
+
+    log_path = mission_event_log_path(feature_dir)
+    return append_lifecycle_event(
+        log_path,
+        WP_CREATED,
+        payload,
+        aggregate_id=wp_id,
+        aggregate_type="WorkPackage",
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+        dedup_keys={"mission_slug": mission_slug, "wp_id": wp_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics / merge guard helpers
+# ---------------------------------------------------------------------------
+
+
+def read_lifecycle_events(log_path: Path) -> list[dict[str, Any]]:
+    """Public read-only accessor for the lifecycle log (skips malformed lines)."""
+    return _read_lifecycle_lines(log_path)
+
+
+def has_non_bootstrap_status_history(feature_dir: Path) -> bool:
+    """Return True when the mission status log contains a non-bootstrap event.
+
+    Bootstrap-only history is the pathological state described in
+    issue #1069: the canonical event log contains only forced
+    ``planned -> planned`` events emitted by ``finalize-tasks`` even
+    though work packages have advanced past planned on the local
+    filesystem. This helper reads ``status.events.jsonl`` directly
+    (without invoking the status reducer) so it can be used as a
+    cheap pre-merge guard.
+    """
+    log_path = mission_event_log_path(feature_dir)
+    if not log_path.exists():
+        return False
+    try:
+        text = log_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        # WPStatusChanged events from the status reducer carry
+        # ``wp_id`` + ``from_lane`` + ``to_lane`` and do NOT carry a
+        # top-level ``event_type`` field (that field is reserved for
+        # lifecycle events; the status reducer keys its events by
+        # the absence of the field — see status.store).
+        if not isinstance(obj, dict):
+            continue
+        if obj.get("event_type") in LIFECYCLE_EVENT_TYPES:
+            # Lifecycle events count as real history.
+            return True
+        if "event_type" in obj:
+            # Other event-typed entries (decision moment, retrospective)
+            # do not prove WP progression; ignore.
+            continue
+        to_lane = obj.get("to_lane")
+        from_lane = obj.get("from_lane")
+        force = bool(obj.get("force"))
+        if to_lane != "planned":
+            return True
+        if force and to_lane == "planned" and from_lane in (None, "planned"):
+            # Bootstrap planned event — skip.
+            continue
+        # Non-bootstrap planned event (e.g. legitimate planned -> planned
+        # repair with a non-None from_lane mismatch is unreachable but
+        # treat any other planned event defensively as real history).
+        return True
+    return False
+
+
+__all__ = [
+    "PROJECT_INITIALIZED",
+    "MISSION_CREATED",
+    "SPECIFY_STARTED",
+    "SPECIFY_COMPLETED",
+    "PLAN_STARTED",
+    "PLAN_COMPLETED",
+    "TASKS_STARTED",
+    "TASKS_COMPLETED",
+    "WP_CREATED",
+    "LIFECYCLE_EVENT_TYPES",
+    "PROJECT_EVENTS_FILENAME",
+    "MISSION_EVENTS_FILENAME",
+    "project_event_log_path",
+    "mission_event_log_path",
+    "append_lifecycle_event",
+    "has_lifecycle_event",
+    "emit_project_initialized",
+    "emit_mission_created_local",
+    "emit_artifact_phase",
+    "emit_wp_created_local",
+    "read_lifecycle_events",
+    "has_non_bootstrap_status_history",
+]

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -830,3 +830,141 @@ def stop_sync_daemon(timeout: float = 5.0) -> tuple[bool, str]:
             pass
     DAEMON_STATE_FILE.unlink(missing_ok=True)
     return True, "Sync daemon stopped."
+
+
+# ---------------------------------------------------------------------------
+# Singleton diagnostics (issue #1071)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OrphanDaemonInfo:
+    """A live ``run_sync_daemon`` process not represented by the state file."""
+
+    pid: int
+    cmdline: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DaemonSingletonReport:
+    """Snapshot of all live ``run_sync_daemon`` processes on the host.
+
+    Use :func:`scan_sync_daemons` to capture this; use
+    :func:`cleanup_orphan_sync_daemons` to terminate orphans. The
+    singleton invariant is: at most one live daemon process matches
+    the canonical state file's PID; everything else is an orphan that
+    leaks ports/sockets and should be reaped.
+    """
+
+    state_pid: int | None
+    state_file_present: bool
+    orphan_processes: tuple[OrphanDaemonInfo, ...]
+
+    @property
+    def orphan_count(self) -> int:
+        return len(self.orphan_processes)
+
+    @property
+    def is_singleton(self) -> bool:
+        return self.orphan_count == 0
+
+
+def _iter_sync_daemon_processes() -> list[psutil.Process]:
+    """Yield live processes whose cmdline references ``run_sync_daemon``."""
+    matches: list[psutil.Process] = []
+    for proc in psutil.process_iter(attrs=["pid", "cmdline"]):
+        try:
+            cmdline = proc.info.get("cmdline") or []
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        if not cmdline:
+            continue
+        if any("run_sync_daemon" in str(part) for part in cmdline):
+            matches.append(proc)
+    return matches
+
+
+def scan_sync_daemons() -> DaemonSingletonReport:
+    """Inspect the host for live sync-daemon processes.
+
+    Returns a structured report whose ``orphan_processes`` enumerate
+    every live ``run_sync_daemon`` process that is *not* the one
+    recorded in ``DAEMON_STATE_FILE``. The state-file PID, when
+    present and live, is treated as the canonical singleton and is
+    excluded from the orphan list.
+    """
+    state_pid: int | None = None
+    state_present = DAEMON_STATE_FILE.exists()
+    if state_present:
+        try:
+            _, _, _, state_pid = _parse_daemon_file(DAEMON_STATE_FILE)
+        except Exception:  # noqa: BLE001
+            state_pid = None
+
+    orphans: list[OrphanDaemonInfo] = []
+    for proc in _iter_sync_daemon_processes():
+        try:
+            pid = int(proc.pid)
+            cmdline_seq = proc.info.get("cmdline") or []
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        if state_pid is not None and pid == state_pid:
+            continue
+        orphans.append(
+            OrphanDaemonInfo(
+                pid=pid,
+                cmdline=tuple(str(part) for part in cmdline_seq),
+            )
+        )
+
+    return DaemonSingletonReport(
+        state_pid=state_pid,
+        state_file_present=state_present,
+        orphan_processes=tuple(orphans),
+    )
+
+
+def cleanup_orphan_sync_daemons(
+    *,
+    dry_run: bool = False,
+    timeout: float = 1.0,
+) -> tuple[DaemonSingletonReport, list[int]]:
+    """Terminate orphan sync-daemon processes; return report and PIDs killed.
+
+    Args:
+        dry_run: When True, report the orphans without terminating
+            anything. Useful for diagnostics and tests.
+        timeout: Seconds to wait for graceful termination per orphan
+            before falling back to ``kill()``.
+
+    Returns:
+        A tuple of ``(report, killed_pids)`` where ``report`` is the
+        pre-cleanup snapshot and ``killed_pids`` is the list of PIDs
+        that received a kill signal. When ``dry_run`` is True the list
+        is always empty.
+    """
+    report = scan_sync_daemons()
+    killed: list[int] = []
+    if dry_run:
+        return report, killed
+
+    for orphan in report.orphan_processes:
+        try:
+            proc = psutil.Process(orphan.pid)
+        except psutil.NoSuchProcess:
+            continue
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        try:
+            proc.wait(timeout=timeout)
+        except psutil.TimeoutExpired:
+            try:
+                proc.kill()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        except psutil.NoSuchProcess:
+            pass
+        killed.append(orphan.pid)
+    return report, killed

--- a/tests/merge/test_merge_bootstrap_history_gate.py
+++ b/tests/merge/test_merge_bootstrap_history_gate.py
@@ -1,0 +1,96 @@
+"""Merge gate: refuse missions whose canonical status log is bootstrap-only.
+
+Regression coverage for issue #1069: a mission whose
+``status.events.jsonl`` contains nothing but forced ``planned -> planned``
+events cannot be merged, even when WP frontmatter or the dashboard
+looks done, because TeamSpace replay would silently collapse every WP
+back to planned.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+
+from specify_cli.cli.commands.merge import _enforce_canonical_status_history
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(e, sort_keys=True) for e in entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_gate_blocks_bootstrap_only_history(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "demo-mission"
+    feature_dir.mkdir(parents=True)
+    log = feature_dir / "status.events.jsonl"
+    _write_jsonl(
+        log,
+        [
+            {
+                "event_id": "01H1",
+                "wp_id": "WP01",
+                "from_lane": None,
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+                "mission_slug": "demo-mission",
+            },
+        ],
+    )
+
+    with pytest.raises(typer.Exit):
+        _enforce_canonical_status_history(
+            feature_dir=feature_dir,
+            mission_slug="demo-mission",
+            wp_ids=["WP01"],
+        )
+
+
+def test_gate_allows_real_lane_transition(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "demo-mission"
+    feature_dir.mkdir(parents=True)
+    log = feature_dir / "status.events.jsonl"
+    _write_jsonl(
+        log,
+        [
+            {
+                "wp_id": "WP01",
+                "from_lane": None,
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+            },
+            {
+                "wp_id": "WP01",
+                "from_lane": "planned",
+                "to_lane": "claimed",
+                "force": False,
+                "actor": "claude",
+            },
+        ],
+    )
+
+    # Should NOT raise — real transition present.
+    _enforce_canonical_status_history(
+        feature_dir=feature_dir,
+        mission_slug="demo-mission",
+        wp_ids=["WP01"],
+    )
+
+
+def test_gate_skips_when_no_wp_ids(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "empty-mission"
+    feature_dir.mkdir(parents=True)
+    # Should be a no-op even though no log exists.
+    _enforce_canonical_status_history(
+        feature_dir=feature_dir,
+        mission_slug="empty-mission",
+        wp_ids=[],
+    )

--- a/tests/merge/test_merge_bootstrap_history_gate.py
+++ b/tests/merge/test_merge_bootstrap_history_gate.py
@@ -85,6 +85,46 @@ def test_gate_allows_real_lane_transition(tmp_path: Path) -> None:
     )
 
 
+def test_gate_blocks_lifecycle_events_plus_bootstrap_only_status(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "demo-mission"
+    feature_dir.mkdir(parents=True)
+    log = feature_dir / "status.events.jsonl"
+    _write_jsonl(
+        log,
+        [
+            {
+                "event_id": "lifecycle-1",
+                "event_type": "WPCreated",
+                "aggregate_id": "WP01",
+                "aggregate_type": "WorkPackage",
+                "payload": {
+                    "mission_slug": "demo-mission",
+                    "wp_id": "WP01",
+                    "wp_title": "Demo",
+                    "depends_on": [],
+                    "actor": "finalize-tasks",
+                },
+            },
+            {
+                "event_id": "status-1",
+                "wp_id": "WP01",
+                "from_lane": "planned",
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+                "mission_slug": "demo-mission",
+            },
+        ],
+    )
+
+    with pytest.raises(typer.Exit):
+        _enforce_canonical_status_history(
+            feature_dir=feature_dir,
+            mission_slug="demo-mission",
+            wp_ids=["WP01"],
+        )
+
+
 def test_gate_skips_when_no_wp_ids(tmp_path: Path) -> None:
     feature_dir = tmp_path / "kitty-specs" / "empty-mission"
     feature_dir.mkdir(parents=True)

--- a/tests/runtime/test_bootstrap_version_fallback.py
+++ b/tests/runtime/test_bootstrap_version_fallback.py
@@ -1,0 +1,41 @@
+"""Regression tests for runtime bootstrap when the package version is unknown.
+
+Covers issue #1070: ``spec-kitty sync status --check`` previously crashed
+with ``TypeError: data must be str, not NoneType`` whenever
+``specify_cli.__version__`` resolved to ``None`` (broken editable
+install, partial wheel, etc.). ``_get_cli_version`` now returns a safe
+default so the runtime cache always receives a string.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_get_cli_version_returns_string_when_version_is_none(monkeypatch) -> None:
+    bootstrap = importlib.import_module("specify_cli.runtime.bootstrap")
+    fake_module = sys.modules["specify_cli"]
+    monkeypatch.setattr(fake_module, "__version__", None, raising=False)
+    result = bootstrap._get_cli_version()
+    assert isinstance(result, str)
+    assert result, "fallback version must be a non-empty string"
+
+
+def test_get_cli_version_returns_string_when_version_missing(monkeypatch) -> None:
+    bootstrap = importlib.import_module("specify_cli.runtime.bootstrap")
+    fake_module = sys.modules["specify_cli"]
+    if hasattr(fake_module, "__version__"):
+        monkeypatch.delattr(fake_module, "__version__", raising=False)
+    result = bootstrap._get_cli_version()
+    assert isinstance(result, str)
+    assert result
+
+
+def test_get_cli_version_returns_string_when_version_blank(monkeypatch) -> None:
+    bootstrap = importlib.import_module("specify_cli.runtime.bootstrap")
+    fake_module = sys.modules["specify_cli"]
+    monkeypatch.setattr(fake_module, "__version__", "", raising=False)
+    result = bootstrap._get_cli_version()
+    assert isinstance(result, str)
+    assert result

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+import specify_cli.status.lifecycle_events as lifecycle
 from specify_cli.status.lifecycle_events import (
     LIFECYCLE_EVENT_TYPES,
     MISSION_CREATED,
@@ -166,6 +167,22 @@ def test_artifact_phase_rejects_unknown_event_type(feature_dir: Path) -> None:
         )
 
 
+def test_artifact_phase_records_optional_metadata(feature_dir: Path) -> None:
+    emit_artifact_phase(
+        feature_dir,
+        event_type=TASKS_COMPLETED,
+        mission_slug="demo-mission",
+        mission_number=7,
+        summary="Created three work packages",
+        wp_count=3,
+    )
+
+    payload = read_lifecycle_events(mission_event_log_path(feature_dir))[0]["payload"]
+    assert payload["mission_number"] == 7
+    assert payload["summary"] == "Created three work packages"
+    assert payload["wp_count"] == 3
+
+
 # ---------------------------------------------------------------------------
 # WPCreated
 # ---------------------------------------------------------------------------
@@ -208,6 +225,21 @@ def test_wp_created_full_roster_writes_one_event_per_wp(feature_dir: Path) -> No
         if e["event_type"] == WP_CREATED
     ]
     assert sorted(e["aggregate_id"] for e in entries) == ["WP01", "WP02", "WP03"]
+
+
+def test_wp_created_records_optional_metadata(feature_dir: Path) -> None:
+    emit_wp_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_number=7,
+        wp_id="WP09",
+        wp_title="Document replay recovery",
+        wp_path="kitty-specs/demo-mission/tasks/WP09.md",
+    )
+
+    payload = read_lifecycle_events(mission_event_log_path(feature_dir))[0]["payload"]
+    assert payload["mission_number"] == 7
+    assert payload["wp_path"] == "kitty-specs/demo-mission/tasks/WP09.md"
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +361,44 @@ def test_has_non_bootstrap_status_history_false_when_log_absent(
     assert has_non_bootstrap_status_history(tmp_path / "absent") is False
 
 
+def test_has_non_bootstrap_status_history_tolerates_noise_and_detects_planned_repair(
+    feature_dir: Path,
+) -> None:
+    log = mission_event_log_path(feature_dir)
+    log.write_text(
+        "\n"
+        "not-json\n"
+        "[\"not\", \"an\", \"event\"]\n"
+        + json.dumps(
+            {
+                "event_id": "01H3",
+                "wp_id": "WP01",
+                "from_lane": "approved",
+                "to_lane": "planned",
+                "force": False,
+                "actor": "repair",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert has_non_bootstrap_status_history(feature_dir) is True
+
+
+def test_has_non_bootstrap_status_history_false_when_log_read_fails(
+    feature_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mission_event_log_path(feature_dir).write_text("{}", encoding="utf-8")
+
+    def _raise(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "read_text", _raise)
+    assert has_non_bootstrap_status_history(feature_dir) is False
+
+
 # ---------------------------------------------------------------------------
 # Sanity checks on the public surface
 # ---------------------------------------------------------------------------
@@ -365,4 +435,66 @@ def test_has_lifecycle_event_matches_dedup_keys(feature_dir: Path) -> None:
     )
     assert not has_lifecycle_event(
         log, event_type=WP_CREATED, dedup_keys={"mission_slug": "demo-mission", "wp_id": "WP99"}
+    )
+
+
+def test_read_lifecycle_events_tolerates_unreadable_and_malformed_logs(
+    feature_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = mission_event_log_path(feature_dir)
+    log.write_text(
+        "\n"
+        "not-json\n"
+        + json.dumps({"event_type": WP_CREATED, "payload": {"wp_id": "WP01"}})
+        + "\n",
+        encoding="utf-8",
+    )
+    assert len(read_lifecycle_events(log)) == 1
+
+    def _raise(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "read_text", _raise)
+    assert read_lifecycle_events(log) == []
+
+
+def test_has_lifecycle_event_ignores_non_mapping_payload(feature_dir: Path) -> None:
+    log = mission_event_log_path(feature_dir)
+    _write_jsonl(log, [{"event_type": WP_CREATED, "payload": ["not", "a", "mapping"]}])
+
+    assert not has_lifecycle_event(
+        log, event_type=WP_CREATED, dedup_keys={"mission_slug": "demo-mission"}
+    )
+
+
+def test_append_lifecycle_event_rejects_unknown_type(feature_dir: Path) -> None:
+    assert (
+        append_lifecycle_event(
+            mission_event_log_path(feature_dir),
+            "NotARealLifecycleEvent",
+            {},
+            aggregate_id="x",
+            aggregate_type="Unknown",
+        )
+        is None
+    )
+
+
+def test_append_lifecycle_event_returns_none_when_write_fails(
+    feature_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _raise(path: Path, line: str) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(lifecycle, "_atomic_append", _raise)
+
+    assert (
+        append_lifecycle_event(
+            mission_event_log_path(feature_dir),
+            WP_CREATED,
+            {"mission_slug": "demo-mission", "wp_id": "WP01"},
+            aggregate_id="WP01",
+            aggregate_type="WorkPackage",
+        )
+        is None
     )

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -1,0 +1,341 @@
+"""Tests for the local-first canonical lifecycle event writer.
+
+Covers issue #1067 (project + mission lifecycle events), #1068
+(WPCreated immediate persistence), and the diagnostic
+``has_non_bootstrap_status_history`` helper consumed by the merge
+gate added for #1069.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.status.lifecycle_events import (
+    LIFECYCLE_EVENT_TYPES,
+    MISSION_CREATED,
+    PROJECT_INITIALIZED,
+    SPECIFY_COMPLETED,
+    TASKS_COMPLETED,
+    WP_CREATED,
+    append_lifecycle_event,
+    emit_artifact_phase,
+    emit_mission_created_local,
+    emit_project_initialized,
+    emit_wp_created_local,
+    has_lifecycle_event,
+    has_non_bootstrap_status_history,
+    mission_event_log_path,
+    project_event_log_path,
+    read_lifecycle_events,
+)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / ".kittify").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def feature_dir(tmp_path: Path) -> Path:
+    fd = tmp_path / "kitty-specs" / "demo-mission"
+    fd.mkdir(parents=True)
+    return fd
+
+
+# ---------------------------------------------------------------------------
+# ProjectInitialized
+# ---------------------------------------------------------------------------
+
+
+def test_project_initialized_persists_and_dedupes(repo: Path) -> None:
+    env1 = emit_project_initialized(
+        repo,
+        project_uuid="proj-123",
+        project_slug="demo",
+        actor="test",
+    )
+    env2 = emit_project_initialized(
+        repo,
+        project_uuid="proj-123",
+        project_slug="demo",
+        actor="test",
+    )
+
+    log = project_event_log_path(repo)
+    assert log.exists(), "project event log was not created"
+    assert env1 is not None and env1["event_type"] == PROJECT_INITIALIZED
+    assert env2 is None, "duplicate ProjectInitialized for the same UUID must be skipped"
+
+    entries = read_lifecycle_events(log)
+    assert len(entries) == 1
+    payload = entries[0]["payload"]
+    assert payload["project_uuid"] == "proj-123"
+    assert payload["project_slug"] == "demo"
+    assert payload["actor"] == "test"
+
+
+def test_project_initialized_writes_canonical_jsonl(repo: Path) -> None:
+    emit_project_initialized(repo, project_uuid="abc", project_slug="x", actor="t")
+    log = project_event_log_path(repo)
+    raw = log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(raw) == 1
+    payload = json.loads(raw[0])
+    assert payload["event_type"] == PROJECT_INITIALIZED
+    assert payload["aggregate_type"] == "Project"
+
+
+# ---------------------------------------------------------------------------
+# MissionCreated
+# ---------------------------------------------------------------------------
+
+
+def test_mission_created_local_appended_before_any_saas_fan_out(
+    feature_dir: Path,
+) -> None:
+    envelope = emit_mission_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_id="01ULID",
+        mission_number=None,
+        target_branch="main",
+        actor="test",
+    )
+
+    assert envelope is not None
+    log = mission_event_log_path(feature_dir)
+    entries = read_lifecycle_events(log)
+    assert len(entries) == 1
+    assert entries[0]["event_type"] == MISSION_CREATED
+    assert entries[0]["aggregate_id"] == "01ULID"
+
+
+def test_mission_created_dedupe_on_mission_slug(feature_dir: Path) -> None:
+    emit_mission_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_id=None,
+        mission_number=None,
+        target_branch="main",
+    )
+    second = emit_mission_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_id=None,
+        mission_number=None,
+        target_branch="main",
+    )
+    assert second is None
+    entries = read_lifecycle_events(mission_event_log_path(feature_dir))
+    assert len(entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# Artifact phases (Specify / Plan / Tasks)
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_phase_completed_dedupes_on_artifact_path(feature_dir: Path) -> None:
+    e1 = emit_artifact_phase(
+        feature_dir,
+        event_type=SPECIFY_COMPLETED,
+        mission_slug="demo-mission",
+        actor="test",
+        artifact_path="kitty-specs/demo-mission/spec.md",
+    )
+    e2 = emit_artifact_phase(
+        feature_dir,
+        event_type=SPECIFY_COMPLETED,
+        mission_slug="demo-mission",
+        actor="test",
+        artifact_path="kitty-specs/demo-mission/spec.md",
+    )
+    assert e1 is not None
+    assert e2 is None
+
+
+def test_artifact_phase_rejects_unknown_event_type(feature_dir: Path) -> None:
+    with pytest.raises(ValueError):
+        emit_artifact_phase(
+            feature_dir,
+            event_type="NotARealPhase",
+            mission_slug="demo-mission",
+        )
+
+
+# ---------------------------------------------------------------------------
+# WPCreated
+# ---------------------------------------------------------------------------
+
+
+def test_wp_created_persists_immediately_and_dedupes(feature_dir: Path) -> None:
+    env1 = emit_wp_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        wp_id="WP01",
+        wp_title="Set up scaffolding",
+        depends_on=[],
+    )
+    env2 = emit_wp_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        wp_id="WP01",
+        wp_title="Set up scaffolding",
+        depends_on=[],
+    )
+    assert env1 is not None
+    assert env2 is None  # idempotent on (mission_slug, wp_id)
+
+    entries = read_lifecycle_events(mission_event_log_path(feature_dir))
+    assert [e["event_type"] for e in entries] == [WP_CREATED]
+    assert entries[0]["aggregate_id"] == "WP01"
+
+
+def test_wp_created_full_roster_writes_one_event_per_wp(feature_dir: Path) -> None:
+    for wp_id, title in [("WP01", "Alpha"), ("WP02", "Beta"), ("WP03", "Gamma")]:
+        emit_wp_created_local(
+            feature_dir,
+            mission_slug="demo-mission",
+            wp_id=wp_id,
+            wp_title=title,
+        )
+    entries = [
+        e
+        for e in read_lifecycle_events(mission_event_log_path(feature_dir))
+        if e["event_type"] == WP_CREATED
+    ]
+    assert sorted(e["aggregate_id"] for e in entries) == ["WP01", "WP02", "WP03"]
+
+
+# ---------------------------------------------------------------------------
+# Merge guard: has_non_bootstrap_status_history
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(e, sort_keys=True) for e in entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_has_non_bootstrap_status_history_false_when_only_bootstrap(
+    feature_dir: Path,
+) -> None:
+    log = mission_event_log_path(feature_dir)
+    _write_jsonl(
+        log,
+        [
+            {
+                "event_id": "01H1",
+                "wp_id": "WP01",
+                "from_lane": None,
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+                "at": "2026-01-01T00:00:00Z",
+                "mission_slug": "demo-mission",
+            },
+            {
+                "event_id": "01H2",
+                "wp_id": "WP02",
+                "from_lane": "planned",
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+                "at": "2026-01-01T00:00:01Z",
+                "mission_slug": "demo-mission",
+            },
+        ],
+    )
+    assert has_non_bootstrap_status_history(feature_dir) is False
+
+
+def test_has_non_bootstrap_status_history_true_for_real_transition(
+    feature_dir: Path,
+) -> None:
+    log = mission_event_log_path(feature_dir)
+    _write_jsonl(
+        log,
+        [
+            {
+                "event_id": "01H1",
+                "wp_id": "WP01",
+                "from_lane": None,
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+            },
+            {
+                "event_id": "01H2",
+                "wp_id": "WP01",
+                "from_lane": "planned",
+                "to_lane": "in_progress",
+                "force": False,
+                "actor": "claude",
+            },
+        ],
+    )
+    assert has_non_bootstrap_status_history(feature_dir) is True
+
+
+def test_has_non_bootstrap_status_history_true_when_lifecycle_event_present(
+    feature_dir: Path,
+) -> None:
+    emit_mission_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_id=None,
+        mission_number=None,
+        target_branch="main",
+    )
+    assert has_non_bootstrap_status_history(feature_dir) is True
+
+
+def test_has_non_bootstrap_status_history_false_when_log_absent(
+    tmp_path: Path,
+) -> None:
+    assert has_non_bootstrap_status_history(tmp_path / "absent") is False
+
+
+# ---------------------------------------------------------------------------
+# Sanity checks on the public surface
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_event_types_complete() -> None:
+    assert {
+        PROJECT_INITIALIZED,
+        MISSION_CREATED,
+        SPECIFY_COMPLETED,
+        TASKS_COMPLETED,
+        WP_CREATED,
+    } <= LIFECYCLE_EVENT_TYPES
+
+
+def test_has_lifecycle_event_matches_dedup_keys(feature_dir: Path) -> None:
+    log = mission_event_log_path(feature_dir)
+    append_lifecycle_event(
+        log,
+        WP_CREATED,
+        {
+            "mission_slug": "demo-mission",
+            "wp_id": "WP07",
+            "wp_title": "demo",
+            "depends_on": [],
+            "actor": "test",
+        },
+        aggregate_id="WP07",
+        aggregate_type="WorkPackage",
+        dedup_keys={"mission_slug": "demo-mission", "wp_id": "WP07"},
+    )
+    assert has_lifecycle_event(
+        log, event_type=WP_CREATED, dedup_keys={"mission_slug": "demo-mission", "wp_id": "WP07"}
+    )
+    assert not has_lifecycle_event(
+        log, event_type=WP_CREATED, dedup_keys={"mission_slug": "demo-mission", "wp_id": "WP99"}
+    )

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -283,7 +283,7 @@ def test_has_non_bootstrap_status_history_true_for_real_transition(
     assert has_non_bootstrap_status_history(feature_dir) is True
 
 
-def test_has_non_bootstrap_status_history_true_when_lifecycle_event_present(
+def test_has_non_bootstrap_status_history_false_when_lifecycle_event_present_without_real_transition(
     feature_dir: Path,
 ) -> None:
     emit_mission_created_local(
@@ -293,7 +293,34 @@ def test_has_non_bootstrap_status_history_true_when_lifecycle_event_present(
         mission_number=None,
         target_branch="main",
     )
-    assert has_non_bootstrap_status_history(feature_dir) is True
+    assert has_non_bootstrap_status_history(feature_dir) is False
+
+
+def test_has_non_bootstrap_status_history_false_for_lifecycle_plus_bootstrap(
+    feature_dir: Path,
+) -> None:
+    emit_mission_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_id=None,
+        mission_number=None,
+        target_branch="main",
+    )
+    _write_jsonl(
+        mission_event_log_path(feature_dir),
+        [
+            *read_lifecycle_events(mission_event_log_path(feature_dir)),
+            {
+                "event_id": "01H1",
+                "wp_id": "WP01",
+                "from_lane": "planned",
+                "to_lane": "planned",
+                "force": True,
+                "actor": "finalize-tasks",
+            },
+        ],
+    )
+    assert has_non_bootstrap_status_history(feature_dir) is False
 
 
 def test_has_non_bootstrap_status_history_false_when_log_absent(

--- a/tests/sync/test_daemon_singleton.py
+++ b/tests/sync/test_daemon_singleton.py
@@ -1,0 +1,133 @@
+"""Tests for the sync daemon singleton diagnostics (issue #1071).
+
+The legacy ``run_sync_daemon`` lifecycle relied on whichever process
+managed to claim the state file first; everything else leaked. The new
+``scan_sync_daemons`` and ``cleanup_orphan_sync_daemons`` helpers make
+the singleton invariant testable: ``scan`` reports orphans, ``cleanup``
+terminates them and returns the killed PIDs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Sequence
+
+import pytest
+
+from specify_cli.sync import daemon as daemon_module
+from specify_cli.sync.daemon import (
+    DaemonSingletonReport,
+    OrphanDaemonInfo,
+    cleanup_orphan_sync_daemons,
+    scan_sync_daemons,
+)
+
+
+@dataclass
+class _FakeProcInfo:
+    pid: int
+    cmdline: Sequence[str]
+
+
+class _FakeProcess:
+    def __init__(self, pid: int, cmdline: Sequence[str]) -> None:
+        self.pid = pid
+        self.info = {"pid": pid, "cmdline": list(cmdline)}
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        return 0
+
+
+@pytest.fixture()
+def daemon_state_absent(monkeypatch, tmp_path) -> None:
+    fake_state = tmp_path / "sync-daemon"
+    monkeypatch.setattr(daemon_module, "DAEMON_STATE_FILE", fake_state)
+
+
+def _install_fake_psutil(monkeypatch, fake_processes: list[_FakeProcess]) -> None:
+    def fake_iter(attrs=None):  # noqa: ARG001
+        return list(fake_processes)
+
+    def fake_process_lookup(pid: int) -> _FakeProcess:
+        for proc in fake_processes:
+            if proc.pid == pid:
+                return proc
+        raise daemon_module.psutil.NoSuchProcess(pid)
+
+    monkeypatch.setattr(daemon_module.psutil, "process_iter", fake_iter)
+    monkeypatch.setattr(daemon_module.psutil, "Process", fake_process_lookup)
+
+
+def test_scan_reports_no_orphans_when_only_state_pid_alive(
+    monkeypatch, tmp_path
+) -> None:
+    fake_state = tmp_path / "sync-daemon"
+    fake_state.write_text(
+        '{"url": "http://127.0.0.1:9400", "port": 9400, "token": "t", "pid": 4242}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(daemon_module, "DAEMON_STATE_FILE", fake_state)
+    monkeypatch.setattr(
+        daemon_module,
+        "_parse_daemon_file",
+        lambda _path: ("http://127.0.0.1:9400", 9400, "t", 4242),
+    )
+
+    processes = [_FakeProcess(4242, ["python", "-c", "run_sync_daemon(9400, ...)"])]
+    _install_fake_psutil(monkeypatch, processes)
+
+    report = scan_sync_daemons()
+    assert isinstance(report, DaemonSingletonReport)
+    assert report.state_pid == 4242
+    assert report.is_singleton
+    assert report.orphan_count == 0
+
+
+def test_scan_reports_orphan_processes(monkeypatch, daemon_state_absent) -> None:
+    processes = [
+        _FakeProcess(1001, ["python", "-c", "run_sync_daemon(9401, ...)"]),
+        _FakeProcess(1002, ["python", "-c", "run_sync_daemon(9402, ...)"]),
+        _FakeProcess(9999, ["bash", "-c", "irrelevant"]),
+    ]
+    _install_fake_psutil(monkeypatch, processes)
+
+    report = scan_sync_daemons()
+    pids = {orphan.pid for orphan in report.orphan_processes}
+    assert pids == {1001, 1002}
+    assert all(isinstance(o, OrphanDaemonInfo) for o in report.orphan_processes)
+    assert report.is_singleton is False
+
+
+def test_cleanup_dry_run_does_not_terminate(monkeypatch, daemon_state_absent) -> None:
+    processes = [
+        _FakeProcess(2001, ["python", "-c", "run_sync_daemon(9410, ...)"]),
+    ]
+    _install_fake_psutil(monkeypatch, processes)
+
+    report, killed = cleanup_orphan_sync_daemons(dry_run=True)
+    assert killed == []
+    assert report.orphan_count == 1
+    assert processes[0].terminated is False
+    assert processes[0].killed is False
+
+
+def test_cleanup_terminates_orphans_and_returns_pids(
+    monkeypatch, daemon_state_absent
+) -> None:
+    processes = [
+        _FakeProcess(3001, ["python", "-c", "run_sync_daemon(9420, ...)"]),
+        _FakeProcess(3002, ["python", "-c", "run_sync_daemon(9421, ...)"]),
+    ]
+    _install_fake_psutil(monkeypatch, processes)
+
+    _report, killed = cleanup_orphan_sync_daemons()
+    assert sorted(killed) == [3001, 3002]
+    assert all(p.terminated for p in processes)


### PR DESCRIPTION
## Summary

Makes the Spec Kitty CLI persist local canonical lifecycle events immediately at project init, mission creation, planning phases, and WP creation. Local persistence happens before SaaS fan-out, so dashboards and TeamSpace are not dependent on later sync/materialization steps to discover newly-created work.

This PR addresses:

- #1067
- #1068
- #1069
- #1070
- #1071
- Aligns with #1064 occurrence-time preservation

## Changes

- Emits local `ProjectInitialized` during `spec-kitty init`.
- Emits local `MissionCreated` before SaaS fan-out.
- Emits specify/plan/tasks lifecycle events.
- Emits `WPCreated` before the first bootstrap `WPStatusChanged`, preserving canonical replay order.
- Adds merge guard for bootstrap-only status histories.
- Fixes runtime bootstrap version fallback when `__version__` is missing/blank/None.
- Adds sync daemon singleton diagnostics/cleanup helpers.
- Includes Codex review fix ensuring lifecycle events do not satisfy status-progression guards.

## Verification

- Lifecycle/merge focused tests passed.
- Finalize bootstrap tests passed.
- `ruff check` on touched files passed.

## Cross-repo context

Depends on the lifecycle event contracts in the `spec-kitty-events` PR and feeds the TeamSpace replay behavior in the `spec-kitty-saas` PR.
