### PR TITLE
fix: harden URL-list conflict classifier hotspot

### DIFF
--- a/src/specify_cli/merge/conflict_classifier.py
+++ b/src/specify_cli/merge/conflict_classifier.py
@@ -423,7 +423,9 @@ def _is_urls_list_eligible(file_path: Path, hunk_text: str) -> bool:
             continue
 
         name, sep, value = stripped.partition("=")
-        if not sep:
+        if sep:
+            name = name.split(":", 1)[0]
+        else:
             name, sep, value = stripped.partition(":")
         if not sep:
             continue

--- a/src/specify_cli/merge/conflict_classifier.py
+++ b/src/specify_cli/merge/conflict_classifier.py
@@ -417,11 +417,26 @@ def _is_urls_list_eligible(file_path: Path, hunk_text: str) -> bool:
     """Eligibility predicate for the URL-list-union rule."""
     if file_path.name == "urls.py":
         return True
-    return bool(re.search(
-        r"^\s*(?:_?URLS?|URL_PATTERNS)\s*[:=]?\s*[A-Za-z\[]",
-        hunk_text,
-        re.MULTILINE,
-    ))
+    for raw in hunk_text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        name, sep, value = stripped.partition("=")
+        if not sep:
+            name, sep, value = stripped.partition(":")
+        if not sep:
+            continue
+
+        candidate = name.strip()
+        if candidate not in {"URLS", "_URLS", "URL", "_URL", "URL_PATTERNS"}:
+            continue
+
+        value = value.lstrip()
+        if value and (value[0].isalpha() or value[0] == "["):
+            return True
+
+    return False
 
 
 def _find_url_entry_conflict(

--- a/tests/merge/test_conflict_classifier.py
+++ b/tests/merge/test_conflict_classifier.py
@@ -25,6 +25,7 @@ from specify_cli.merge.conflict_classifier import (
     ConflictClassification,
     Manual,
     _extract_module,
+    _is_urls_list_eligible,
     _parse_dep_lines,
     _parse_import_lines,
     _parse_url_entries,
@@ -215,6 +216,12 @@ class TestUrlsListUnion:
             _hunk('    "x",\n', '    "y",\n'),
         )
         assert cls is None
+
+    def test_accepts_non_urls_py_url_constant_without_regex_backtracking(self) -> None:
+        assert _is_urls_list_eligible(
+            Path("src/config.py"),
+            'URL_PATTERNS = [\n<<<<<<< HEAD\n    "alpha/",\n=======\n    "beta/",\n>>>>>>> mission\n',
+        )
 
     def test_returns_none_for_malformed_conflict_region(self) -> None:
         cls = r_urls_list_union(Path("app/urls.py"), "<<<<<<< HEAD\n")

--- a/tests/merge/test_conflict_classifier.py
+++ b/tests/merge/test_conflict_classifier.py
@@ -223,6 +223,12 @@ class TestUrlsListUnion:
             'URL_PATTERNS = [\n<<<<<<< HEAD\n    "alpha/",\n=======\n    "beta/",\n>>>>>>> mission\n',
         )
 
+    def test_accepts_type_annotated_non_urls_py_url_constant(self) -> None:
+        assert _is_urls_list_eligible(
+            Path("src/config.py"),
+            'URL_PATTERNS: list[URLPattern] = [\n<<<<<<< HEAD\n    "alpha/",\n=======\n    "beta/",\n>>>>>>> mission\n',
+        )
+
     def test_returns_none_for_malformed_conflict_region(self) -> None:
         cls = r_urls_list_union(Path("app/urls.py"), "<<<<<<< HEAD\n")
         assert cls is None


### PR DESCRIPTION
## Summary
- replace the URL-list eligibility regex with bounded line parsing to avoid regex backtracking risk
- add focused regression coverage for non-`urls.py` URL constant detection
- keep the localhost-only Sonar hotspots unchanged because they are loopback transport endpoints, not remote plaintext flows

## Validation
- `python3 -m pytest tests/merge/test_conflict_classifier.py -q`
- `python3 -m pytest tests/merge -q`
- `python3 -m ruff check src/specify_cli/merge/conflict_classifier.py tests/merge/test_conflict_classifier.py`
- `python3 -m py_compile src/specify_cli/merge/conflict_classifier.py`
