### PR TITLE
fix: clear nightly sonar and neutrality regressions

### DIFF
--- a/src/charter/neutrality/language_scoped_allowlist.yaml
+++ b/src/charter/neutrality/language_scoped_allowlist.yaml
@@ -69,3 +69,8 @@ paths:
     owner: "charter team"
     reason: "Maven review-checks toolguide; Maven/Java tool names (pytest reference is cross-check example) are the subject matter."
     added_in: "3.2.4"
+  - path: "src/doctrine/tactics/shipped/secure-regex-catastrophic-backtracking.tactic.yaml"
+    scope: python
+    owner: "charter team"
+    reason: "Secure regex remediation tactic intentionally discusses Python test tooling and timing guards."
+    added_in: "3.3.3"

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -63,6 +63,10 @@ app = typer.Typer(name="mission", help="Mission lifecycle commands for AI agents
 
 console = Console()
 
+TASKS_MD_FILENAME = "tasks.md"
+SETUP_PLAN_COMMAND_NAME = "spec-kitty agent mission setup-plan"
+FINALIZE_TASKS_COMMAND_NAME = "spec-kitty agent mission finalize-tasks"
+
 
 def _extract_wp_ids_from_task_files(wp_files: list[Path]) -> list[str]:
     """Return canonical WP IDs discovered from task filenames."""
@@ -84,7 +88,7 @@ def _collect_finalize_artifacts(
     candidates: list[Path] = [
         feature_dir / "status.events.jsonl",
         feature_dir / "status.json",
-        feature_dir / "tasks.md",
+        feature_dir / TASKS_MD_FILENAME,
         feature_dir / ".kittify" / "dossiers" / mission_slug / "snapshot-latest.json",
     ]
     candidates.extend(sorted(path for path in tasks_dir.iterdir() if path.is_file()))
@@ -901,7 +905,7 @@ def setup_plan(
         _enforce_git_preflight(
             repo_root,
             json_output=json_output,
-            command_name="spec-kitty agent mission setup-plan",
+            command_name=SETUP_PLAN_COMMAND_NAME,
         )
 
         # Determine feature directory using centralized detection.
@@ -942,7 +946,7 @@ def setup_plan(
                 "spec_file": str(spec_file.resolve()),
                 "remediation": [
                     f"Restore the missing spec file at {spec_file.resolve()}",
-                    "Or select another mission explicitly: spec-kitty agent mission setup-plan --mission <mission-slug> --json",
+                    f"Or select another mission explicitly: {SETUP_PLAN_COMMAND_NAME} --mission <mission-slug> --json",
                 ],
             }
             if json_output:
@@ -1030,14 +1034,14 @@ def setup_plan(
                 feature_dir,
                 event_type=SPECIFY_COMPLETED,
                 mission_slug=mission_slug,
-                actor="spec-kitty agent mission setup-plan",
+                actor=SETUP_PLAN_COMMAND_NAME,
                 artifact_path=str(spec_file.relative_to(repo_root)),
             )
             emit_artifact_phase(
                 feature_dir,
                 event_type=PLAN_STARTED,
                 mission_slug=mission_slug,
-                actor="spec-kitty agent mission setup-plan",
+                actor=SETUP_PLAN_COMMAND_NAME,
             )
         except Exception as _phase_exc:  # noqa: BLE001
             logger.debug("Lifecycle phase emission skipped: %s", _phase_exc)
@@ -1060,7 +1064,7 @@ def setup_plan(
                     feature_dir,
                     event_type=PLAN_COMPLETED,
                     mission_slug=mission_slug,
-                    actor="spec-kitty agent mission setup-plan",
+                    actor=SETUP_PLAN_COMMAND_NAME,
                     artifact_path=str(plan_file.relative_to(repo_root)),
                 )
             except Exception as _plan_exc:  # noqa: BLE001
@@ -1592,7 +1596,7 @@ def finalize_tasks(
         # Parse dependencies and requirement refs using 2-tier priority:
         # 1. WP frontmatter (primary — map-requirements writes here directly)
         # 2. tasks.md text parsing (backward compat for pre-API projects)
-        tasks_md = feature_dir / "tasks.md"
+        tasks_md = feature_dir / TASKS_MD_FILENAME
         wp_dependencies: dict[str, list[str]] = {}
         wp_requirement_refs: dict[str, list[str]] = {}
 
@@ -1990,7 +1994,7 @@ def finalize_tasks(
                     feature_dir,
                     event_type=TASKS_STARTED,
                     mission_slug=mission_slug,
-                    actor="spec-kitty agent mission finalize-tasks",
+                    actor=FINALIZE_TASKS_COMMAND_NAME,
                     wp_count=len(work_packages),
                 )
             except Exception as _tasks_started_exc:  # noqa: BLE001
@@ -2105,10 +2109,10 @@ def finalize_tasks(
                     wp_title=_wp_title,
                     wp_path=_wp_path,
                     depends_on=_depends_on,
-                    actor="spec-kitty agent mission finalize-tasks",
+                    actor=FINALIZE_TASKS_COMMAND_NAME,
                 )
 
-            _tasks_artifact = feature_dir / "tasks.md"
+            _tasks_artifact = feature_dir / TASKS_MD_FILENAME
             _tasks_artifact_rel: str | None = None
             if _tasks_artifact.exists():
                 try:
@@ -2119,8 +2123,8 @@ def finalize_tasks(
                 feature_dir,
                 event_type=TASKS_COMPLETED,
                 mission_slug=mission_slug,
-                actor="spec-kitty agent mission finalize-tasks",
-                artifact_path=_tasks_artifact_rel or "tasks.md",
+                actor=FINALIZE_TASKS_COMMAND_NAME,
+                artifact_path=_tasks_artifact_rel or TASKS_MD_FILENAME,
                 wp_count=len(work_packages),
             )
         except Exception as _local_wp_exc:  # noqa: BLE001

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -112,6 +112,99 @@ _DRAIN_BLOCKED_HELP = {
 }
 
 
+def _build_queue_summary_lines(stats: QueueStats) -> list[str]:
+    """Build the queue-health summary lines shown in the panel."""
+    summary_lines: list[str] = []
+    pct = (stats.total_queued / stats.max_queue_size * 100) if stats.max_queue_size > 0 else 0
+    depth_color = "red" if pct >= 100 else ("yellow" if pct >= 80 else "green")
+    summary_lines.append(
+        f"[bold]Queue Depth:[/bold] [{depth_color}]{stats.total_queued:,} / {stats.max_queue_size:,}[/{depth_color}] "
+        f"({pct:.0f}%)"
+    )
+    summary_lines.append(f"[bold]Retried:[/bold]    {stats.total_retried:,}")
+    if stats.oldest_event_age is not None:
+        age_str = humanize_timedelta(stats.oldest_event_age)
+        summary_lines.append(f"[bold]Oldest Event:[/bold] {age_str} ago")
+
+    if stats.drain_blocked_counts:
+        ready = stats.drain_blocked_counts.get("ready", 0)
+        blocked = stats.total_queued - ready
+        ready_color = "green" if blocked == 0 else "yellow"
+        summary_lines.append(
+            f"[bold]Drain Ready:[/bold] [{ready_color}]{ready:,} ready[/{ready_color}]"
+            f" / [yellow]{blocked:,} blocked[/yellow]"
+        )
+    return summary_lines
+
+
+def _render_drain_blockers(stats: QueueStats, target_console: Console) -> None:
+    """Render the drain-blocker breakdown when blocked items exist."""
+    blocked_only = {k: v for k, v in stats.drain_blocked_counts.items() if k != "ready" and v > 0}
+    if not blocked_only:
+        return
+
+    block_table = Table(
+        title="Drain Blockers",
+        show_header=True,
+        header_style="bold",
+        show_lines=False,
+        expand=False,
+    )
+    block_table.add_column("Reason", style="yellow")
+    block_table.add_column("Count", justify="right")
+    block_table.add_column("Remediation", style="dim")
+    for reason, count in sorted(blocked_only.items(), key=lambda kv: -kv[1]):
+        block_table.add_row(
+            reason,
+            str(count),
+            _DRAIN_BLOCKED_HELP.get(reason, ""),
+        )
+    target_console.print(block_table)
+
+
+def _render_retry_distribution(stats: QueueStats, target_console: Console) -> None:
+    """Render retry buckets when queue retry stats are present."""
+    if not stats.retry_distribution:
+        return
+
+    retry_table = Table(
+        title="Retry Distribution",
+        show_header=True,
+        header_style="bold",
+        show_lines=False,
+        expand=False,
+    )
+    retry_table.add_column("Bucket", style="dim")
+    retry_table.add_column("Count", justify="right")
+
+    for bucket in ("0 retries", "1-3 retries", "4+ retries"):
+        if bucket in stats.retry_distribution:
+            retry_table.add_row(bucket, str(stats.retry_distribution[bucket]))
+
+    target_console.print(retry_table)
+
+
+def _render_top_event_types(stats: QueueStats, target_console: Console) -> None:
+    """Render the top event types table when data is available."""
+    if not stats.top_event_types:
+        return
+
+    type_table = Table(
+        title="Top Event Types",
+        show_header=True,
+        header_style="bold",
+        show_lines=False,
+        expand=False,
+    )
+    type_table.add_column("Event Type", style="cyan")
+    type_table.add_column("Count", justify="right")
+
+    for event_type, count in stats.top_event_types:
+        type_table.add_row(event_type, str(count))
+
+    target_console.print(type_table)
+
+
 def format_queue_health(stats: QueueStats, target_console: Console) -> None:
     """Render queue health metrics as Rich panels/tables.
 
@@ -125,30 +218,7 @@ def format_queue_health(stats: QueueStats, target_console: Console) -> None:
         stats: Aggregate queue statistics from OfflineQueue.get_queue_stats()
         target_console: Rich Console to print to (allows testing with captured output)
     """
-    # --- Summary panel ---
-    summary_lines: list[str] = []
-    pct = (stats.total_queued / stats.max_queue_size * 100) if stats.max_queue_size > 0 else 0
-    depth_color = "red" if pct >= 100 else ("yellow" if pct >= 80 else "green")
-    summary_lines.append(
-        f"[bold]Queue Depth:[/bold] [{depth_color}]{stats.total_queued:,} / {stats.max_queue_size:,}[/{depth_color}] "
-        f"({pct:.0f}%)"
-    )
-    summary_lines.append(f"[bold]Retried:[/bold]    {stats.total_retried:,}")
-    if stats.oldest_event_age is not None:
-        age_str = humanize_timedelta(stats.oldest_event_age)
-        summary_lines.append(f"[bold]Oldest Event:[/bold] {age_str} ago")
-
-    # Highlight drain readiness right next to the depth so operators see
-    # ready-vs-blocked at a glance (issue #1075).
-    if stats.drain_blocked_counts:
-        ready = stats.drain_blocked_counts.get("ready", 0)
-        blocked = stats.total_queued - ready
-        ready_color = "green" if blocked == 0 else "yellow"
-        summary_lines.append(
-            f"[bold]Drain Ready:[/bold] [{ready_color}]{ready:,} ready[/{ready_color}]"
-            f" / [yellow]{blocked:,} blocked[/yellow]"
-        )
-
+    summary_lines = _build_queue_summary_lines(stats)
     target_console.print(
         Panel(
             "\n".join(summary_lines),
@@ -158,63 +228,9 @@ def format_queue_health(stats: QueueStats, target_console: Console) -> None:
         )
     )
 
-    # --- Drain blocker breakdown ---
-    blocked_only = {k: v for k, v in stats.drain_blocked_counts.items() if k != "ready" and v > 0}
-    if blocked_only:
-        block_table = Table(
-            title="Drain Blockers",
-            show_header=True,
-            header_style="bold",
-            show_lines=False,
-            expand=False,
-        )
-        block_table.add_column("Reason", style="yellow")
-        block_table.add_column("Count", justify="right")
-        block_table.add_column("Remediation", style="dim")
-        for reason, count in sorted(blocked_only.items(), key=lambda kv: -kv[1]):
-            block_table.add_row(
-                reason,
-                str(count),
-                _DRAIN_BLOCKED_HELP.get(reason, ""),
-            )
-        target_console.print(block_table)
-
-    # --- Retry distribution ---
-    if stats.retry_distribution:
-        retry_table = Table(
-            title="Retry Distribution",
-            show_header=True,
-            header_style="bold",
-            show_lines=False,
-            expand=False,
-        )
-        retry_table.add_column("Bucket", style="dim")
-        retry_table.add_column("Count", justify="right")
-
-        # Ensure deterministic bucket order
-        bucket_order = ["0 retries", "1-3 retries", "4+ retries"]
-        for bucket in bucket_order:
-            if bucket in stats.retry_distribution:
-                retry_table.add_row(bucket, str(stats.retry_distribution[bucket]))
-
-        target_console.print(retry_table)
-
-    # --- Top event types ---
-    if stats.top_event_types:
-        type_table = Table(
-            title="Top Event Types",
-            show_header=True,
-            header_style="bold",
-            show_lines=False,
-            expand=False,
-        )
-        type_table.add_column("Event Type", style="cyan")
-        type_table.add_column("Count", justify="right")
-
-        for event_type, count in stats.top_event_types:
-            type_table.add_row(event_type, str(count))
-
-        target_console.print(type_table)
+    _render_drain_blockers(stats, target_console)
+    _render_retry_distribution(stats, target_console)
+    _render_top_event_types(stats, target_console)
 
 
 # Create a Typer app for sync subcommands


### PR DESCRIPTION
## Summary
- add the missing neutrality allowlist entry for the shipped secure-regex tactic so nightly charter lint passes on `main`
- extract queue health rendering helpers to reduce `format_queue_health()` complexity below the Sonar threshold without changing output
- centralize repeated `setup-plan`, `finalize-tasks`, and `tasks.md` literals in `agent/mission.py` to clear new Sonar duplication findings

## Validation
- `python3 -m pytest tests/charter/test_neutrality_lint.py -q`
- `python3 -m pytest tests/cli/commands/test_sync_status_drain_blockers.py tests/sync/test_offline_queue.py tests/sync/test_sync_doctor.py -q`
- `python3 -m pytest tests/tasks/test_planning_workflow_integration.py tests/e2e/test_cli_smoke.py -q -k 'setup_plan or finalize_tasks or planning_workflow'`
- `python3 -m ruff check src/specify_cli/cli/commands/sync.py src/specify_cli/cli/commands/agent/mission.py tests/charter/test_neutrality_lint.py tests/cli/commands/test_sync_status_drain_blockers.py tests/sync/test_offline_queue.py tests/sync/test_sync_doctor.py tests/tasks/test_planning_workflow_integration.py tests/e2e/test_cli_smoke.py`
- `python3 -m py_compile src/specify_cli/cli/commands/sync.py src/specify_cli/cli/commands/agent/mission.py`

## Notes
- The allowlist addition is intentional rather than a suppression shortcut: `src/doctrine/tactics/shipped/secure-regex-catastrophic-backtracking.tactic.yaml` is a language-scoped remediation tactic whose subject matter explicitly includes Python test tooling (`pytest`, `pytest-timeout`) as part of the guidance.
- GitHub Dependabot alerts: none open.
- GitHub code-scanning alerts: none open.
- SonarCloud quality gate on `main` still reports `new_security_hotspots_reviewed=0%` globally, but I did not find a separate code change in this nightly surface that would fix that metric from the repository side.
