### PR TITLE
fix: reduce fresh SonarCloud issues in sync and mission flows

### DIFF
--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -403,7 +403,7 @@ def _is_inside_git_work_tree(target: Path) -> bool:
             capture_output=True,
             text=True,
         )
-    except (FileNotFoundError, OSError):
+    except OSError:
         return False
     return result.returncode == 0 and result.stdout.strip() == "true"
 

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -205,6 +205,60 @@ def _render_top_event_types(stats: QueueStats, target_console: Console) -> None:
     target_console.print(type_table)
 
 
+def _print_sync_summary(result: object) -> None:
+    """Render the sync summary with highlighted failure details."""
+    from specify_cli.sync.batch import format_sync_summary
+
+    summary = format_sync_summary(result)
+    header = (
+        f"[green]Synced:[/green] {getattr(result, 'synced_count', 0)}  "
+        f"[dim]Duplicates:[/dim] {getattr(result, 'duplicate_count', 0)}  "
+        f"[red]Errors:[/red] {getattr(result, 'error_count', 0)}"
+    )
+    for line in summary.splitlines():
+        if line.startswith("  "):
+            console.print(f"  [yellow]{line.strip()}[/yellow]")
+            continue
+        console.print(header)
+
+
+def _maybe_write_sync_report(report: Path | None, result: object) -> None:
+    """Persist the per-event failure report when requested."""
+    if report is None:
+        return
+
+    failed_results = getattr(result, "failed_results", ())
+    if failed_results:
+        from specify_cli.sync.batch import write_failure_report
+
+        write_failure_report(report, result)
+        console.print(f"\n[cyan]Failure report written to {report}[/cyan]")
+        return
+
+    console.print("\n[dim]No failures to report.[/dim]")
+
+
+def _sync_result_activity(result: object) -> int:
+    """Return the total number of acknowledged sync outcomes."""
+    counts = (
+        getattr(result, "synced_count", 0),
+        getattr(result, "duplicate_count", 0),
+        getattr(result, "error_count", 0),
+    )
+    return sum(value for value in counts if isinstance(value, int) and not isinstance(value, bool))
+
+
+def _enforce_sync_now_exit(strict: bool, queue_size: int, result: object) -> None:
+    """Apply the strict exit contract for ``spec-kitty sync now``."""
+    error_count = getattr(result, "error_count", 0)
+    if strict and isinstance(error_count, int) and error_count > 0:
+        raise typer.Exit(1)
+
+    if strict and queue_size > 0 and _sync_result_activity(result) == 0:
+        console.print("[red]Error:[/red] Sync made no progress; not authenticated or sync is blocked.")
+        raise typer.Exit(1)
+
+
 def format_queue_health(stats: QueueStats, target_console: Console) -> None:
     """Render queue health metrics as Rich panels/tables.
 
@@ -1102,7 +1156,6 @@ def now(
         spec-kitty sync now --no-strict
     """
     from specify_cli.sync.background import get_sync_service
-    from specify_cli.sync.batch import format_sync_summary, write_failure_report
 
     if not is_saas_sync_enabled():
         console.print(f"[yellow]{saas_sync_disabled_message()}[/yellow]")
@@ -1146,36 +1199,9 @@ def now(
             raise typer.Exit(1)
         return
 
-    # Print actionable summary instead of bare counts
-    summary = format_sync_summary(result)
-    for line in summary.split("\n"):
-        if line.startswith("  "):
-            console.print(f"  [yellow]{line.strip()}[/yellow]")
-        else:
-            console.print(
-                f"[green]Synced:[/green] {result.synced_count}  "
-                f"[dim]Duplicates:[/dim] {result.duplicate_count}  "
-                f"[red]Errors:[/red] {result.error_count}"
-            )
-
-    # Write failure report if requested and there are failures
-    if report and result.failed_results:
-        write_failure_report(report, result)
-        console.print(f"\n[cyan]Failure report written to {report}[/cyan]")
-    elif report and not result.failed_results:
-        console.print("\n[dim]No failures to report.[/dim]")
-
-    # Strict exit: fail on sync errors surfaced by the service result.
-    if strict and result.error_count > 0:
-        raise typer.Exit(1)
-
-    # Preserve the strict contract for queue-backed syncs that report no
-    # progress at all. A non-empty queue combined with an all-zero result is
-    # treated as an unauthenticated/no-progress failure instead of silently
-    # succeeding.
-    if strict and queue_size > 0 and (result.synced_count + result.duplicate_count + result.error_count) == 0:
-        console.print("[red]Error:[/red] Sync made no progress; not authenticated or sync is blocked.")
-        raise typer.Exit(1)
+    _print_sync_summary(result)
+    _maybe_write_sync_report(report, result)
+    _enforce_sync_now_exit(strict, queue_size, result)
 
 
 @app.command()

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -453,6 +453,25 @@ def read_lifecycle_events(log_path: Path) -> list[dict[str, Any]]:
     return _read_lifecycle_lines(log_path)
 
 
+def _iter_status_event_objects(text: str) -> Iterable[dict[str, Any]]:
+    """Yield reducer-style status events from raw mission log text."""
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "event_type" not in obj:
+            yield obj
+
+
+def _is_bootstrap_status_event(obj: Mapping[str, Any]) -> bool:
+    """Return True when the reducer event is the forced bootstrap planned event."""
+    return bool(obj.get("force")) and obj.get("to_lane") == "planned" and obj.get("from_lane") in (None, "planned")
+
+
 def has_non_bootstrap_status_history(feature_dir: Path) -> bool:
     """Return True when the mission status log contains a non-bootstrap event.
 
@@ -471,32 +490,11 @@ def has_non_bootstrap_status_history(feature_dir: Path) -> bool:
         text = log_path.read_text(encoding="utf-8")
     except OSError:
         return False
-    for raw in text.splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        # WPStatusChanged events from the status reducer carry
-        # ``wp_id`` + ``from_lane`` + ``to_lane`` and do NOT carry a
-        # top-level ``event_type`` field (that field is reserved for
-        # lifecycle events; the status reducer keys its events by
-        # the absence of the field — see status.store).
-        if not isinstance(obj, dict):
-            continue
-        if "event_type" in obj:
-            # Lifecycle and other event-typed entries prove that the stream
-            # exists, but they do not prove a WP advanced beyond bootstrap
-            # planned state. The merge guard needs real status transitions.
-            continue
+    for obj in _iter_status_event_objects(text):
         to_lane = obj.get("to_lane")
-        from_lane = obj.get("from_lane")
-        force = bool(obj.get("force"))
         if to_lane != "planned":
             return True
-        if force and to_lane == "planned" and from_lane in (None, "planned"):
+        if _is_bootstrap_status_event(obj):
             # Bootstrap planned event — skip.
             continue
         # Non-bootstrap planned event (e.g. legitimate planned -> planned

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -177,7 +177,7 @@ def _should_probe_advertised_limits(server_url: str) -> bool:
     host = (parsed.hostname or "").lower()
     if host in {"localhost", "127.0.0.1", "::1"}:
         return False
-    if host.endswith(".example") or host.endswith(".example.com"):
+    if host.endswith((".example", ".example.com")):
         return False
     return parsed.scheme in {"https", "http"} and bool(host)
 
@@ -1368,14 +1368,7 @@ def sync_all_queued_events(
             show_progress=show_progress,
         )
 
-        total_result.total_events += result.total_events
-        total_result.synced_count += result.synced_count
-        total_result.duplicate_count += result.duplicate_count
-        total_result.error_count += result.error_count
-        total_result.synced_ids.extend(result.synced_ids)
-        total_result.failed_ids.extend(result.failed_ids)
-        total_result.error_messages.extend(result.error_messages)
-        total_result.event_results.extend(result.event_results)
+        _merge_batch_sync_result(total_result, result)
 
         if show_progress:
             print(
@@ -1398,17 +1391,7 @@ def sync_all_queued_events(
         # Exception: permanently-failed events (e.g. oversized_event) are
         # removed from the queue by process_batch_results, so the drain IS
         # making progress — continue to subsequent events rather than stopping.
-        if result.success_count == 0:
-            all_permanent = bool(result.event_results) and all(
-                r.status == "failed_permanent" for r in result.event_results
-            )
-            if all_permanent:
-                continue
-            if show_progress:
-                if result.error_count > 0:
-                    print("Stopping: No events successfully synced in this batch")
-                else:
-                    print("Stopping: Batch skipped (no Private Teamspace; see structured stderr diagnostic)")
+        if _should_stop_sync_loop(result, show_progress):
             break
 
     if show_progress:
@@ -1419,3 +1402,34 @@ def sync_all_queued_events(
             print(f"Remaining in queue: {queue.size()} events")
 
     return total_result
+
+
+def _merge_batch_sync_result(total_result: BatchSyncResult, batch_result: BatchSyncResult) -> None:
+    """Accumulate a single batch result into the running total."""
+    total_result.total_events += batch_result.total_events
+    total_result.synced_count += batch_result.synced_count
+    total_result.duplicate_count += batch_result.duplicate_count
+    total_result.error_count += batch_result.error_count
+    total_result.synced_ids.extend(batch_result.synced_ids)
+    total_result.failed_ids.extend(batch_result.failed_ids)
+    total_result.error_messages.extend(batch_result.error_messages)
+    total_result.event_results.extend(batch_result.event_results)
+
+
+def _should_stop_sync_loop(result: BatchSyncResult, show_progress: bool) -> bool:
+    """Return True when the replay loop should stop after this batch."""
+    if result.success_count > 0:
+        return False
+
+    all_permanent = bool(result.event_results) and all(
+        event_result.status == "failed_permanent" for event_result in result.event_results
+    )
+    if all_permanent:
+        return False
+
+    if show_progress:
+        if result.error_count > 0:
+            print("Stopping: No events successfully synced in this batch")
+        else:
+            print("Stopping: Batch skipped (no Private Teamspace; see structured stderr diagnostic)")
+    return True

--- a/src/specify_cli/sync/orphan_sweep.py
+++ b/src/specify_cli/sync/orphan_sweep.py
@@ -21,7 +21,6 @@ import json
 import socket
 import subprocess
 import time
-import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
@@ -114,9 +113,7 @@ def _probe_health(port: int) -> dict[str, Any] | None:
             if response.status != 200:
                 return None
             payload = response.read()
-    except (urllib.error.URLError, OSError, TimeoutError):
-        return None
-    except Exception:
+    except OSError:
         return None
 
     try:


### PR DESCRIPTION
## Summary
- reduce the fresh SonarCloud issues reported from the overnight `main` analysis in sync and mission command paths
- replace repeated command/path literals in mission flows with shared constants
- extract small helpers to lower cognitive complexity in sync status, queue replay, and lifecycle guard paths

## Investigation
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud `main` quality gate from the 2026-05-17 scheduled `CI Quality` run is failing on `new_coverage` and `new_security_hotspots_reviewed`
- Fresh actionable code issues from that analysis were in `mission.py`, `sync.py`, `lifecycle_events.py`, `batch.py`, `init.py`, and `orphan_sweep.py`

## Validation
- `python -m pytest tests/cli/commands/test_sync_status_drain_blockers.py tests/agent/cli/commands/test_sync.py tests/status/test_lifecycle_events.py tests/sync/test_batch_sync.py -q`
- `python -m pytest tests/agent/test_agent_feature.py -q`
- `python -m ruff check src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/sync.py src/specify_cli/status/lifecycle_events.py src/specify_cli/sync/batch.py src/specify_cli/cli/commands/init.py src/specify_cli/sync/orphan_sweep.py`

## Notes
- `tests/sync/test_orphan_sweep.py` failed locally before exercising the touched code because the test daemon never started listening on ports 9425/9426 in this environment.
