### PR TITLE
Release 3.2.0rc10 (#1038 launch-gate roll-up)

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc9
+  version: 3.2.0rc10
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.2.0rc9] - Unreleased
+## [3.2.0rc10] - 2026-05-17
+
+Rolls forward `3.2.0rc9` (never tagged) and adds the Teamspace MVP
+canonical-lifecycle / sync-daemon launch-gate followups:
+
+- **#1067 follow-up.** `core/mission_creation.py:create_mission_core`
+  now emits the canonical `SpecifyStarted` event immediately after
+  `MissionCreated`, referencing the freshly scaffolded `spec.md`
+  artifact path. Previously the constant was defined but never emitted,
+  so the canonical lifecycle stream skipped straight from
+  `MissionCreated` to `SpecifyCompleted` at setup-plan time — leaving
+  TeamSpace replay and the local dashboard blind to in-progress
+  specifying. Regression coverage in
+  `tests/specify_cli/core/test_mission_creation_specify_started.py`.
+- **#1071 follow-up.** `sync status --check` and `sync doctor` now
+  surface the daemon PID/port and any orphan `run_sync_daemon`
+  processes (via the existing `scan_sync_daemons` helper), so operators
+  see cross-checkout daemon divergence without grepping `ps`.
+  `_kill_and_cleanup` now waits for the killed PID to actually exit
+  before clearing `DAEMON_STATE_FILE` — closing the AC bullet that
+  required version-mismatch replacement not leave older daemons live.
+  Module docstring updated to be honest about state-file-scoped
+  singleton semantics. Regression coverage in
+  `tests/cli/commands/test_sync_status_singleton_diagnostics.py` and
+  `tests/sync/test_daemon_replace_on_version_mismatch.py`.
+
+Everything previously slated for rc9 (below) is included in rc10.
+
+## [3.2.0rc9] (rolled into rc10)
 
 The `quality-devex-hardening-3-2-01KRJGKH` mission closes six epic-#822
 tickets and lands the doctrine tactics, canonical-terminology glossary,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc9"
+version = "3.2.0rc10"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc9"
+version = "3.2.0rc10"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Bumps version to `3.2.0rc10` and rolls the never-tagged `3.2.0rc9` content forward together with the two Teamspace MVP launch-gate followups that just merged:

- `#1085` → emits canonical `SpecifyStarted` from `core/mission_creation.py:create_mission_core` (#1067 follow-up).
- `#1084` → surfaces daemon PID/port + orphan `run_sync_daemon` processes in `sync status --check` / `sync doctor`, plus kill-and-wait verification in `_kill_and_cleanup` (#1071 follow-up).

Once this lands on main, tagging the merge SHA as `v3.2.0rc10` triggers the publish workflow against the PyPI trusted-publisher OIDC environment (no token needed from operators).

Refs `#1038`. Stays open after publish so the launch-gate evidence can be attached.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: `git tag v3.2.0rc10 <merge-sha>` + `git push origin v3.2.0rc10`.
- [ ] Watch the release workflow publish `spec-kitty-cli==3.2.0rc10` to PyPI.
- [ ] Verify `pipx install spec-kitty-cli==3.2.0rc10` reports the published version on a clean shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)