### PR TITLE
Fix release health checks for rc11

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -85,6 +85,25 @@ jobs:
             exit 0
           fi
 
+          # Release commits are allowed only when the pushed commit is already
+          # tagged with the matching release tag. This keeps release publication
+          # explicit while preventing untagged version/changelog commits from
+          # bypassing the normal PR or mission merge paths.
+          if [[ "$COMMIT_MSG" =~ ^Release\ spec-kitty\ ([0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?)$ ]]; then
+            RELEASE_VERSION="${BASH_REMATCH[1]}"
+            RELEASE_TAG="v${RELEASE_VERSION}"
+            git fetch --force --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" || true
+
+            if git tag --points-at HEAD | grep -Fxq "$RELEASE_TAG"; then
+              echo "✅ Commit is a tagged spec-kitty release commit (${RELEASE_TAG})"
+              exit 0
+            fi
+
+            echo "::error::Release commit message found, but HEAD is not tagged with ${RELEASE_TAG}."
+            echo "::error::Release commits must be pushed with their matching annotated tag."
+            exit 1
+          fi
+
           # If we get here, this appears to be a direct push
           echo "::error::❌ Direct push to main branch detected!"
           echo "::error::"
@@ -101,7 +120,7 @@ jobs:
           echo "::error::   - Enable 'Require pull request reviews before merging'"
           echo "::error::   - Enable 'Require status checks to pass before merging'"
           echo "::error::"
-          echo "::error::📖 See: docs/releases/readiness-checklist.md for the complete workflow"
+          echo "::error::📖 See: RELEASE_CHECKLIST.md for the complete workflow"
 
           # Add to job summary
           {
@@ -141,7 +160,7 @@ jobs:
             echo ""
             echo "## Reference"
             echo ""
-            echo "📖 [Release Readiness Checklist](https://github.com/${{ github.repository }}/blob/main/docs/releases/readiness-checklist.md)"
+            echo "📖 [Release Checklist](https://github.com/${{ github.repository }}/blob/main/RELEASE_CHECKLIST.md)"
           } >> $GITHUB_STEP_SUMMARY
 
           exit 1

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -206,6 +206,8 @@ jobs:
             echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
             echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
             echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This report covers release-readiness checks for this workflow only. Do not summarize a release as green until the required branch checks on the same commit are also green." >> $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.metadata_changes.outputs.release_metadata }}" != "true" ]]; then
             echo "✅ **Release workflow checks passed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -216,6 +218,8 @@ jobs:
             echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
             echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
             echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This report covers release-workflow checks only. Do not summarize a release as green until the required branch checks on the same commit are also green." >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ **Readiness checks failed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -57,6 +57,9 @@ Use this checklist for releases from `main`.
     --saas-pyproject ../spec-kitty-saas/pyproject.toml \
     --runtime-pyproject /path/to/spec-kitty-runtime/pyproject.toml
   ```
+- [ ] If a SaaS consumer pin lands after the CLI candidate commit, rerun the
+  shared-package drift workflow or the local drift command against the updated
+  SaaS `main` before recording branch-health evidence.
 - [ ] Verify the built wheel installs cleanly with plain `pip`:
   ```bash
   python scripts/release/check_exact_install.py --package spec-kitty-cli
@@ -120,7 +123,12 @@ gh pr create --base main --title "Release X.Y.Z" --fill
 ### 4. Wait for CI and Review
 
 - [ ] `Release Readiness Check` passes.
-- [ ] `CI Quality` passes or has explicitly accepted non-blocking failures.
+- [ ] `CI Quality` passes or has explicitly accepted non-blocking failures with
+  issue links.
+- [ ] `Check Shared Package Drift` passes against the current SaaS consumer
+  pins.
+- [ ] `Protect Main Branch` is expected to pass for the eventual merge or
+  tagged release commit path.
 - [ ] Maintainer approval is recorded.
 - [ ] Any release-note or install-doc feedback is resolved.
 
@@ -167,6 +175,15 @@ package first, verify it is installable from PyPI, and only then tag the CLI.
   - publishes to PyPI
   - creates the GitHub release
 - [ ] If this is a prerelease, confirm GitHub marks the release as `Pre-release`.
+- [ ] Verify the publishing workflow result separately from branch health.
+  A successful PyPI/GitHub release proves publication only; it does not prove
+  that `main` is green.
+- [ ] Verify all required checks on the released commit are green, or record
+  every failing check with an issue link before using the release as launch-gate
+  evidence:
+  ```bash
+  gh run list --commit "$(git rev-parse HEAD)" --limit 20
+  ```
 - [ ] Verify the GitHub release payload:
   ```bash
   gh release view vX.Y.Z

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -108,6 +108,9 @@ Release workflow sequence:
 
 ```bash
 # 1) prepare version + changelog
+git checkout main
+git pull origin main
+git checkout -b release/3.1.0a0
 vim pyproject.toml   # version = "3.1.0a0" for prerelease, "3.1.0" for stable
 vim CHANGELOG.md     # add ## [3.1.0a0] - YYYY-MM-DD (or final ## [3.1.0])
 
@@ -126,15 +129,31 @@ twine check dist/*
 # 3) clean build artifacts
 rm -rf dist/ build/
 
-# 4a) prerelease publish from main
+# 4) commit, push, and merge the release metadata through a PR
+git add pyproject.toml CHANGELOG.md
+git commit -m "chore(release): prepare 3.1.0a0"
+git push origin release/3.1.0a0
+gh pr create --base main --title "Release 3.1.0a0" --fill
+
+# 5a) prerelease publish from updated main
+git checkout main
+git pull origin main
 git tag v3.1.0a0 -m "Release 3.1.0a0"
 git push origin v3.1.0a0
 
-# 4b) stable publish from main
+# 5b) stable publish from updated main
 #     Edit pyproject.toml to "3.1.0" and rename the changelog heading to [3.1.0]
 git tag v3.1.0 -m "Release 3.1.0"
 git push origin v3.1.0
 ```
+
+Treat publish success and branch health as separate evidence. The tag-time
+publish workflow proves PyPI/GitHub release publication; release summaries
+should only call `main` green after the required branch checks on the same
+commit have also passed. If SaaS consumes a shared-package bump after the CLI
+candidate commit, rerun the shared-package drift workflow or the local drift
+command against the updated SaaS `main` before recording release-health
+evidence.
 
 ## Troubleshooting
 

--- a/tests/cross_cutting/test_gitignore_manager_unit.py
+++ b/tests/cross_cutting/test_gitignore_manager_unit.py
@@ -117,15 +117,10 @@ class TestGitignoreManager:
         assert ".claude/" in content
 
     def test_protect_all_agents_includes_all_agents(self, manager):
-        """Test that all 13 agent directories are protected."""
+        """Test that all registered agent directories are protected."""
         manager.protect_all_agents()
 
-        expected_dirs = [
-            ".claude/", ".codex/", ".opencode/", ".windsurf/",
-            ".gemini/", ".cursor/", ".qwen/", ".kilocode/",
-            ".augment/", ".roo/", ".amazonq/", ".agent/",
-            ".github/copilot/"
-        ]
+        expected_dirs = [agent.directory for agent in AGENT_DIRECTORIES]
 
         content = manager.gitignore_path.read_text()
         for dir_name in expected_dirs:
@@ -351,9 +346,8 @@ class TestGitignoreManager:
 
         # Modifying one shouldn't affect the other
         dirs1.append(AgentDirectory("test", ".test/", False, "Test"))
-        # Count rose from 13 → 14 when PR #626 added Kiro.
-        assert len(dirs1) == 16  # 15 original + 1 test agent
-        assert len(dirs2) == 15  # Original unchanged
+        assert len(dirs1) == len(AGENT_DIRECTORIES) + 1
+        assert len(dirs2) == len(AGENT_DIRECTORIES)
 
     def test_all_agent_directories_have_trailing_slash(self):
         """Test that all agent directories end with trailing slash."""


### PR DESCRIPTION
## Summary

Fixes #1109.

- Removes stale hard-coded supported-agent totals from the gitignore manager unit tests.
- Adds an explicit Protect Main release-commit path that only accepts `Release spec-kitty X.Y.Z...` commits when `HEAD` has the matching `vX.Y.Z...` tag.
- Updates release-readiness summaries and release docs so publish success is recorded separately from full `main` branch health, including rerunning shared-package drift against updated SaaS `main` when SaaS consumer pins land after the CLI candidate.

## Verification

- `uv run --extra test python -m pytest tests/cross_cutting/test_gitignore_manager_unit.py -q`
- `uv run --extra test python -m pytest tests/release/test_check_shared_package_drift.py -q`
- `uv run python scripts/release/check_shared_package_drift.py --saas-pyproject ../spec-kitty-saas/pyproject.toml`
- `uv run --extra lint ruff check tests/cross_cutting/test_gitignore_manager_unit.py`
- `python - <<'PY' ... yaml.safe_load(...) ... PY` for touched workflows
- `git diff --check`

`actionlint` is not installed in the local workspace; GitHub Actions will validate workflow semantics.
