### PR TITLE
fix: reduce Sonar auth recovery debt

### DIFF
--- a/src/specify_cli/cli/commands/_auth_recovery.py
+++ b/src/specify_cli/cli/commands/_auth_recovery.py
@@ -63,7 +63,7 @@ class RecoveryOutcome(StrEnum):
 
 
 def detect_logged_out_with_connected_teamspace(
-    repo_root: Path | None = None,  # noqa: ARG001 - reserved for future use
+    repo_root: Path | None = None,
 ) -> str | None:
     """Return a teamspace handle if logged-out on a connected repo, else None.
 
@@ -99,7 +99,7 @@ def detect_logged_out_with_connected_teamspace(
     try:
         from specify_cli.sync.routing import resolve_checkout_sync_routing  # lazy
 
-        routing = resolve_checkout_sync_routing()
+        routing = resolve_checkout_sync_routing(start=repo_root)
     except Exception:  # pragma: no cover - defensive
         routing = None
 
@@ -126,6 +126,29 @@ def detect_logged_out_with_connected_teamspace(
                     return name.strip()
 
     return None
+
+
+def _run_login_recovery(console: Console) -> RecoveryOutcome:
+    """Run the deferred login flow and map failures to ``SKIPPED``."""
+    try:
+        from specify_cli.cli.commands._auth_login import login_impl  # lazy
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Login flow is unavailable:[/red] {exc}")
+        return RecoveryOutcome.SKIPPED
+
+    try:
+        from specify_cli.auth.errors import AuthenticationError  # lazy
+    except Exception:  # pragma: no cover - defensive
+        authentication_error = Exception
+    else:
+        authentication_error = AuthenticationError
+
+    try:
+        asyncio.run(login_impl(headless=False, force=False))
+    except authentication_error as exc:
+        console.print(f"[red]Login failed:[/red] {exc}")
+        return RecoveryOutcome.SKIPPED
+    return RecoveryOutcome.LOGGED_IN
 
 
 def is_interactive() -> bool:
@@ -217,23 +240,7 @@ def offer_login_recovery(
     console.print(choice or "")
 
     if choice == "l":
-        try:
-            from specify_cli.cli.commands._auth_login import login_impl  # lazy
-        except Exception as exc:  # pragma: no cover - defensive
-            console.print(f"[red]Login flow is unavailable:[/red] {exc}")
-            return RecoveryOutcome.SKIPPED
-
-        try:
-            from specify_cli.auth.errors import AuthenticationError  # lazy
-        except Exception:  # pragma: no cover - defensive
-            AuthenticationError = Exception  # type: ignore[assignment, misc]  # fallback when auth module is unavailable
-
-        try:
-            asyncio.run(login_impl(headless=False, force=False))
-        except AuthenticationError as exc:
-            console.print(f"[red]Login failed:[/red] {exc}")
-            return RecoveryOutcome.SKIPPED
-        return RecoveryOutcome.LOGGED_IN
+        return _run_login_recovery(console)
 
     if choice == "q":
         return RecoveryOutcome.QUIT

--- a/tests/cli/commands/test_auth_recovery.py
+++ b/tests/cli/commands/test_auth_recovery.py
@@ -52,7 +52,7 @@ class TestDetector:
         routing = SimpleNamespace(repo_slug="acme-eng", project_slug="acme")
         monkeypatch.setattr(
             "specify_cli.sync.routing.resolve_checkout_sync_routing",
-            lambda: routing,
+            lambda start=None: routing,
         )
         assert detect_logged_out_with_connected_teamspace() == "acme-eng"
 
@@ -63,9 +63,27 @@ class TestDetector:
         routing = SimpleNamespace(repo_slug=None, project_slug="acme")
         monkeypatch.setattr(
             "specify_cli.sync.routing.resolve_checkout_sync_routing",
-            lambda: routing,
+            lambda start=None: routing,
         )
         assert detect_logged_out_with_connected_teamspace() == "acme"
+
+    def test_repo_root_is_forwarded_to_routing_resolution(self, monkeypatch, tmp_path):
+        tm = MagicMock()
+        tm.is_authenticated = False
+        monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: tm)
+        seen: list[object] = []
+
+        def fake_resolve_checkout_sync_routing(*, start=None):
+            seen.append(start)
+            return SimpleNamespace(repo_slug="acme-eng", project_slug=None)
+
+        monkeypatch.setattr(
+            "specify_cli.sync.routing.resolve_checkout_sync_routing",
+            fake_resolve_checkout_sync_routing,
+        )
+
+        assert detect_logged_out_with_connected_teamspace(tmp_path) == "acme-eng"
+        assert seen == [tmp_path]
 
     def test_falls_back_to_stored_private_team_name(self, monkeypatch):
         team = SimpleNamespace(name="Engineering", is_private_teamspace=True)

--- a/tests/cli/commands/test_auth_recovery.py
+++ b/tests/cli/commands/test_auth_recovery.py
@@ -85,6 +85,24 @@ class TestDetector:
         assert detect_logged_out_with_connected_teamspace(tmp_path) == "acme-eng"
         assert seen == [tmp_path]
 
+    def test_default_path_still_resolves_with_none_start(self, monkeypatch):
+        tm = MagicMock()
+        tm.is_authenticated = False
+        monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: tm)
+        seen: list[object] = []
+
+        def fake_resolve_checkout_sync_routing(*, start=None):
+            seen.append(start)
+            return SimpleNamespace(repo_slug="acme-eng", project_slug=None)
+
+        monkeypatch.setattr(
+            "specify_cli.sync.routing.resolve_checkout_sync_routing",
+            fake_resolve_checkout_sync_routing,
+        )
+
+        assert detect_logged_out_with_connected_teamspace() == "acme-eng"
+        assert seen == [None]
+
     def test_falls_back_to_stored_private_team_name(self, monkeypatch):
         team = SimpleNamespace(name="Engineering", is_private_teamspace=True)
         session = SimpleNamespace(teams=[team])
@@ -94,7 +112,7 @@ class TestDetector:
         monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: tm)
         monkeypatch.setattr(
             "specify_cli.sync.routing.resolve_checkout_sync_routing",
-            lambda: None,
+            lambda start=None: None,
         )
         assert detect_logged_out_with_connected_teamspace() == "Engineering"
 
@@ -105,7 +123,7 @@ class TestDetector:
         monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: tm)
         monkeypatch.setattr(
             "specify_cli.sync.routing.resolve_checkout_sync_routing",
-            lambda: None,
+            lambda start=None: None,
         )
         assert detect_logged_out_with_connected_teamspace() is None
 
@@ -117,7 +135,7 @@ class TestDetector:
         routing = SimpleNamespace(repo_slug="   ", project_slug="")
         monkeypatch.setattr(
             "specify_cli.sync.routing.resolve_checkout_sync_routing",
-            lambda: routing,
+            lambda start=None: routing,
         )
         assert detect_logged_out_with_connected_teamspace() is None
 


### PR DESCRIPTION
## Summary

- wire `detect_logged_out_with_connected_teamspace()` through its existing `repo_root` parameter so routing resolution can inspect an explicit checkout root
- extract the interactive login branch into a helper to reduce Sonar cognitive-complexity/naming issues in `_auth_recovery.py`
- add focused regression tests proving both the existing default path remains `start=None` and the explicit-root path forwards the provided checkout root

## Findings reviewed

- GitHub Dependabot alerts: none open on 2026-05-18
- GitHub code-scanning alerts: none open on 2026-05-18
- Latest scheduled `CI Quality` run on `main` (run 26017488511, 2026-05-18) failed its quality gate on `new_coverage=60.3` and `new_security_hotspots_reviewed=0.0`
- The same scheduled run also had a `fast-tests-agent` failure in `tests/agent/test_init_command.py::test_init_rejects_removed_agent_strategy_option`, but that did not reproduce locally at the same `main` SHA under the repo's pinned `uv` environment
- SonarCloud security issues on `main`: no open vulnerabilities; four open hotspot reviews remain, all `http` localhost/internal-use findings that are review-process debt rather than clean code fixes in this PR

## Verification

- `./.venv/bin/python -m pytest tests/cli/commands/test_auth_recovery.py -q`
- `./.venv/bin/python -m pytest tests/sync/test_sync_logged_out_recovery.py tests/agent/cli/commands/test_sync.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-20260518-090120/.uv-cache uv run --extra lint ruff check src/specify_cli/cli/commands/_auth_recovery.py tests/cli/commands/test_auth_recovery.py`
