### PR TITLE
fix: chip away at Sonar findings and restore fast agent CI

### DIFF
--- a/src/specify_cli/auth/flows/refresh.py
+++ b/src/specify_cli/auth/flows/refresh.py
@@ -105,22 +105,7 @@ class TokenRefreshFlow:
                 raise RefreshReplayError(retry_after=int(body.get("retry_after", 0)))
             # Non-replay 409 (unexpected) — fall through to generic TokenRefreshError below
 
-        if response.status_code in {400, 401}:
-            try:
-                body = response.json()
-            except ValueError:
-                body = {}
-            error = body.get("error", "")
-            if error == "invalid_grant":
-                raise RefreshTokenExpiredError(
-                    "Refresh token is invalid or expired. "
-                    "Run `spec-kitty auth login` again."
-                )
-            if error == "session_invalid":
-                raise SessionInvalidError(
-                    "Session has been invalidated server-side. "
-                    "Run `spec-kitty auth login` again."
-                )
+        self._raise_known_auth_error(response)
 
         raise TokenRefreshError(
             f"Token refresh failed: HTTP {response.status_code} - "
@@ -211,6 +196,26 @@ class TokenRefreshFlow:
         # we never produce a session with an indeterminate refresh expiry
         # when we previously had one.
         return session.refresh_token_expires_at
+
+    @staticmethod
+    def _raise_known_auth_error(response: Any) -> None:
+        if response.status_code not in {400, 401}:
+            return
+        try:
+            body = response.json()
+        except ValueError:
+            body = {}
+        error = body.get("error", "")
+        if error == "invalid_grant":
+            raise RefreshTokenExpiredError(
+                "Refresh token is invalid or expired. "
+                "Run `spec-kitty auth login` again."
+            )
+        if error == "session_invalid":
+            raise SessionInvalidError(
+                "Session has been invalidated server-side. "
+                "Run `spec-kitty auth login` again."
+            )
 
 
 def _parse_iso_utc(value: str) -> datetime:

--- a/src/specify_cli/cli/commands/_auth_recovery.py
+++ b/src/specify_cli/cli/commands/_auth_recovery.py
@@ -63,7 +63,6 @@ class RecoveryOutcome(StrEnum):
 
 
 def detect_logged_out_with_connected_teamspace(
-    repo_root: Path | None = None,  # noqa: ARG001 - reserved for future use
 ) -> str | None:
     """Return a teamspace handle if logged-out on a connected repo, else None.
 
@@ -224,13 +223,13 @@ def offer_login_recovery(
             return RecoveryOutcome.SKIPPED
 
         try:
-            from specify_cli.auth.errors import AuthenticationError  # lazy
+            from specify_cli.auth.errors import AuthenticationError as authentication_error_cls  # lazy
         except Exception:  # pragma: no cover - defensive
-            AuthenticationError = Exception  # type: ignore[assignment, misc]  # fallback when auth module is unavailable
+            authentication_error_cls = Exception
 
         try:
             asyncio.run(login_impl(headless=False, force=False))
-        except AuthenticationError as exc:
+        except authentication_error_cls as exc:
             console.print(f"[red]Login failed:[/red] {exc}")
             return RecoveryOutcome.SKIPPED
         return RecoveryOutcome.LOGGED_IN

--- a/src/specify_cli/dashboard/handlers/features.py
+++ b/src/specify_cli/dashboard/handlers/features.py
@@ -30,6 +30,54 @@ __all__ = ["FeatureHandler"]
 
 
 logger = logging.getLogger(__name__)
+_PROJECT_DIR_NOT_CONFIGURED = "dashboard project_dir is not configured"
+
+
+def _require_project_path(project_dir: str | None) -> Path:
+    if project_dir is None:
+        raise RuntimeError(_PROJECT_DIR_NOT_CONFIGURED)
+    return Path(project_dir).resolve()
+
+
+def _resolve_active_mission_context(project_path: Path) -> tuple[dict[str, object] | None, MissionContext]:
+    active_feature = resolve_active_feature(project_path)
+    mission_context: MissionContext = {
+        "name": "No active feature",
+        "domain": "unknown",
+        "version": "",
+        "slug": "",
+        "description": "",
+        "path": "",
+    }
+    if not active_feature:
+        return None, mission_context
+
+    feature_mission_type = active_feature.get("meta", {}).get("mission", "software-dev")
+    try:
+        kittify_dir = project_path / ".kittify"
+        mission = get_mission_by_name(feature_mission_type, kittify_dir)
+    except MissionError:
+        mission_context = {
+            "name": f"Unknown ({feature_mission_type})",
+            "domain": "unknown",
+            "version": "",
+            "slug": feature_mission_type,
+            "description": "",
+            "path": "",
+            "feature": active_feature.get("name", ""),
+        }
+        return active_feature, mission_context
+
+    mission_context = {
+        "name": mission.name,
+        "domain": mission.config.domain,
+        "version": mission.config.version,
+        "slug": mission.path.name,
+        "description": mission.config.description or "",
+        "path": format_path_for_display(str(mission.path)),
+        "feature": active_feature.get("name", ""),
+    }
+    return active_feature, mission_context
 
 
 class FeatureHandler(DashboardHandler):
@@ -38,9 +86,7 @@ class FeatureHandler(DashboardHandler):
     def handle_features_list(self) -> None:
         """Return summary data for all features."""
         try:
-            if self.project_dir is None:
-                raise RuntimeError("dashboard project_dir is not configured")
-            project_path = Path(self.project_dir).resolve()
+            project_path = _require_project_path(self.project_dir)
             features = scan_all_features(project_path)
 
             # Add legacy format indicator to each feature
@@ -48,43 +94,7 @@ class FeatureHandler(DashboardHandler):
                 feature_dir = project_path / feature["path"]
                 feature["is_legacy"] = is_legacy_format(feature_dir)
 
-            # Derive active mission from the same active-feature resolver used by CLI status.
-            mission_context: MissionContext = {
-                "name": "No active feature",
-                "domain": "unknown",
-                "version": "",
-                "slug": "",
-                "description": "",
-                "path": "",
-            }
-
-            active_feature = resolve_active_feature(project_path)
-
-            if active_feature:
-                feature_mission_type = active_feature.get("meta", {}).get("mission", "software-dev")
-                try:
-                    kittify_dir = project_path / ".kittify"
-                    mission = get_mission_by_name(feature_mission_type, kittify_dir)
-                    mission_context = {
-                        "name": mission.name,
-                        "domain": mission.config.domain,
-                        "version": mission.config.version,
-                        "slug": mission.path.name,
-                        "description": mission.config.description or "",
-                        "path": format_path_for_display(str(mission.path)),
-                        "feature": active_feature.get("name", ""),
-                    }
-                except MissionError:
-                    # Fallback: show feature name with unknown mission
-                    mission_context = {
-                        "name": f"Unknown ({feature_mission_type})",
-                        "domain": "unknown",
-                        "version": "",
-                        "slug": feature_mission_type,
-                        "description": "",
-                        "path": "",
-                        "feature": active_feature.get("name", ""),
-                    }
+            active_feature, mission_context = _resolve_active_mission_context(project_path)
 
             worktrees_root_path = project_path / ".worktrees"
             try:
@@ -129,9 +139,7 @@ class FeatureHandler(DashboardHandler):
         parts = path.split("/")
         if len(parts) >= 4:
             feature_id = parts[3]
-            if self.project_dir is None:
-                raise RuntimeError("dashboard project_dir is not configured")
-            project_path = Path(self.project_dir).resolve()
+            project_path = _require_project_path(self.project_dir)
             kanban_data = scan_feature_kanban(project_path, feature_id)
 
             # Check if feature uses legacy format
@@ -177,9 +185,7 @@ class FeatureHandler(DashboardHandler):
             return
 
         feature_id = parts[3]
-        if self.project_dir is None:
-            raise RuntimeError("dashboard project_dir is not configured")
-        project_path = Path(self.project_dir)
+        project_path = _require_project_path(self.project_dir)
         feature_dir = resolve_feature_dir(project_path, feature_id)
 
         if len(parts) == 4:

--- a/src/specify_cli/dossier/events.py
+++ b/src/specify_cli/dossier/events.py
@@ -244,7 +244,7 @@ def _coerce_namespace(
     try:
         return LocalNamespaceTuple(**merged)
     except (TypeError, ValueError) as exc:
-        logger.error("Cannot build LocalNamespaceTuple from %r: %s", namespace, exc)
+        logger.exception("Cannot build LocalNamespaceTuple from %r: %s", namespace, exc)
         return None
 
 
@@ -505,7 +505,7 @@ def emit_snapshot_computed(
     snapshot_id: str,
     namespace: LocalNamespaceTuple | dict[str, Any] | None = None,
     *,
-    mission_type: str | None = None,  # noqa: ARG001 — pulled from namespace
+    mission_type: str | None = None,
     computed_at: str | None = None,
     anomaly_count: int | None = None,
     context_diagnostics: dict[str, str] | None = None,
@@ -519,6 +519,12 @@ def emit_snapshot_computed(
     if ns is None:
         _missing_namespace_log("MissionDossierSnapshotComputed")
         return None
+    if mission_type and mission_type != ns.mission_type:
+        logger.warning(
+            "Snapshot mission_type %r did not match namespace mission_type %r; using namespace value",
+            mission_type,
+            ns.mission_type,
+        )
 
     try:
         diagnostics = _snapshot_legacy_diagnostics(

--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -129,7 +129,7 @@ class WebSocketClient:
         except TokenRefreshError as exc:
             self.connected = False
             self.status = ConnectionStatus.OFFLINE
-            logger.error("Token refresh failed: %s", exc)
+            logger.exception("Token refresh failed: %s", exc)
             raise
         except Exception as exc:
             self.connected = False

--- a/tests/agent/test_init_command.py
+++ b/tests/agent/test_init_command.py
@@ -237,4 +237,5 @@ def test_init_rejects_removed_agent_strategy_option(cli_app, monkeypatch: pytest
     )
     assert result.exit_code == 2
     plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-    assert re.search(r"No such option:\s+-{1,2}agent-strategy", plain_output)
+    assert "No such option" in plain_output
+    assert "--agent-strategy" in plain_output


### PR DESCRIPTION
## Summary
- reduce a small set of actionable SonarCloud issues in covered auth, dashboard, sync, and dossier paths
- keep the auth-recovery/dashboard refactors behavior-preserving while removing duplicated literals and low-signal complexity
- make the removed `--agent-strategy` init assertion more robust so the fast agent CI lane passes again

## Investigation
- Open GitHub code-scanning alerts: none
- Open GitHub Dependabot alerts: none
- Latest scheduled `ci-quality` on `main` (2026-05-18, run 26017488511): failed on `fast-tests-agent` and SonarCloud quality gate
- Previous scheduled nightly on `main` (2026-05-17, run 25982897663): failed on SonarCloud quality gate
- SonarCloud `main` gate currently fails on `new_coverage` and unreviewed loopback/localhost HTTPS hotspots; the hotspots are still review-state items in the Sonar UI rather than code-only fixes

## Validation
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/test_dashboard/test_api_handler.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/cli/commands/test_auth_recovery.py tests/dossier/test_events.py tests/auth/test_refresh_flow.py tests/sync/test_strict_json_stdout.py tests/agent/test_init_command.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/agent -m 'fast and not windows_ci' -q --tb=short --cov=src/specify_cli/agent_utils --cov-fail-under=10 --cov-report=xml:out/reports/coverage/coverage-fast-agent.xml`

## Notes
- No Sonar suppressions were added.
- The remaining Sonar quality gate failure on `main` still includes `new_coverage` and `new_security_hotspots_reviewed`; the hotspot portion requires Sonar UI review state changes in addition to code fixes.
