### PR TITLE
fix(sync): normalize daemon executable symlinks

### DIFF
--- a/src/specify_cli/sync/owner.py
+++ b/src/specify_cli/sync/owner.py
@@ -32,6 +32,7 @@ Design notes
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 import tempfile
@@ -46,6 +47,30 @@ from specify_cli.sync.daemon import (
     _is_process_alive,
     _sync_root,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _canonical_executable_path(value: object) -> str:
+    """Return the canonical (symlink-resolved) form of an executable path.
+
+    Resolution failures (deleted target, permission denied, runaway symlink
+    loop) fall back to the raw string. Logging at DEBUG so operators can
+    correlate a spurious mismatch with the underlying resolve failure.
+
+    This is the single source of truth for executable-path normalization on
+    both write paths (foreground identity, daemon record build) and the read
+    path (deserialization in :func:`read_owner_record`). Compare sites SHOULD
+    NOT re-resolve — by construction, every ``DaemonOwnerRecord.executable_path``
+    in memory has already passed through this helper.
+    """
+    raw = str(value)
+    try:
+        return str(Path(raw).resolve())
+    except (OSError, RuntimeError) as exc:
+        logger.debug("executable path resolve failed: %r (%s)", raw, exc)
+        return raw
+
 
 # ---------------------------------------------------------------------------
 # Data class
@@ -66,7 +91,13 @@ class DaemonOwnerRecord:
     - ``port``: TCP port the daemon listens on (127.0.0.1).
     - ``token``: control-plane bearer token (NEVER serialised to clients).
     - ``package_version``: ``importlib.metadata`` version of ``spec-kitty-cli``.
-    - ``executable_path``: resolved ``sys.executable`` of the daemon process.
+    - ``executable_path``: canonical (symlink-resolved) ``sys.executable`` of
+      the daemon process. The invariant is established by
+      :func:`_canonical_executable_path` on every write boundary (foreground
+      identity, daemon record build) and on the read boundary
+      (:func:`read_owner_record`). Compare sites MUST NOT re-resolve.
+      Case is not normalized — case-insensitive filesystems (APFS/NTFS) may
+      still produce a mismatch if daemon and foreground disagree on casing.
     - ``source_checkout_path``: repo root of the installed package (the same
       algorithm is used on the foreground side so the strings compare cleanly).
     - ``server_url``: SaaS server URL configured for this scope.
@@ -90,6 +121,16 @@ class DaemonOwnerRecord:
     auth_scope: str | None
     queue_db_path: str
     started_at: str
+
+    def __post_init__(self) -> None:
+        # Enforce the canonical-executable-path invariant at the dataclass
+        # boundary so callers cannot bypass normalization by constructing a
+        # record directly (e.g. test fixtures). ``frozen=True`` requires
+        # ``object.__setattr__`` for the rewrite; fall back to the raw value
+        # on resolve failure (logged inside the helper).
+        canonical = _canonical_executable_path(self.executable_path)
+        if canonical != self.executable_path:
+            object.__setattr__(self, "executable_path", canonical)
 
     def as_dict(self) -> dict[str, Any]:
         """Return the record as a plain dict (token NOT redacted).
@@ -190,6 +231,7 @@ def read_owner_record() -> DaemonOwnerRecord | None:
             port=int(data["port"]),
             token=str(data["token"]),
             package_version=str(data["package_version"]),
+            # ``executable_path`` is canonicalized in ``DaemonOwnerRecord.__post_init__``.
             executable_path=str(data["executable_path"]),
             source_checkout_path=str(data["source_checkout_path"]),
             server_url=str(data["server_url"]),
@@ -294,7 +336,7 @@ def compute_foreground_identity() -> dict[str, Any]:
 
     return {
         "package_version": _get_package_version(),
-        "executable_path": str(Path(sys.executable).resolve()),
+        "executable_path": _canonical_executable_path(sys.executable),
         "source_checkout_path": _resolve_source_checkout_path(),
         "server_url": _read_server_url_for_scope(),
         "auth_principal": auth_principal,
@@ -334,12 +376,6 @@ def mismatched_fields(
     for field in MISMATCH_FIELDS:
         daemon_value = getattr(daemon_record, field)
         fg_value = foreground_identity.get(field)
-        if field == "executable_path":
-            try:
-                daemon_value = str(Path(str(daemon_value)).resolve())
-                fg_value = str(Path(str(fg_value)).resolve())
-            except (OSError, RuntimeError):
-                pass
         if daemon_value != fg_value:
             out.append(field)
     return out

--- a/src/specify_cli/sync/owner.py
+++ b/src/specify_cli/sync/owner.py
@@ -66,7 +66,7 @@ class DaemonOwnerRecord:
     - ``port``: TCP port the daemon listens on (127.0.0.1).
     - ``token``: control-plane bearer token (NEVER serialised to clients).
     - ``package_version``: ``importlib.metadata`` version of ``spec-kitty-cli``.
-    - ``executable_path``: ``sys.executable`` of the daemon process.
+    - ``executable_path``: resolved ``sys.executable`` of the daemon process.
     - ``source_checkout_path``: repo root of the installed package (the same
       algorithm is used on the foreground side so the strings compare cleanly).
     - ``server_url``: SaaS server URL configured for this scope.
@@ -294,7 +294,7 @@ def compute_foreground_identity() -> dict[str, Any]:
 
     return {
         "package_version": _get_package_version(),
-        "executable_path": sys.executable,
+        "executable_path": str(Path(sys.executable).resolve()),
         "source_checkout_path": _resolve_source_checkout_path(),
         "server_url": _read_server_url_for_scope(),
         "auth_principal": auth_principal,
@@ -334,6 +334,12 @@ def mismatched_fields(
     for field in MISMATCH_FIELDS:
         daemon_value = getattr(daemon_record, field)
         fg_value = foreground_identity.get(field)
+        if field == "executable_path":
+            try:
+                daemon_value = str(Path(str(daemon_value)).resolve())
+                fg_value = str(Path(str(fg_value)).resolve())
+            except (OSError, RuntimeError):
+                pass
         if daemon_value != fg_value:
             out.append(field)
     return out

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -43,6 +43,7 @@ from rich.table import Table
 
 from specify_cli.sync.owner import (
     DaemonOwnerRecord,
+    _canonical_executable_path,
     is_orphan,
     list_orphan_records,
     owner_record_path,
@@ -495,7 +496,7 @@ def collect_foreground_identity(repo_root: Path) -> ForegroundIdentity:
     else:
         team_or_user = None
 
-    executable_path = Path(sys.executable).resolve()
+    executable_path = Path(_canonical_executable_path(sys.executable))
     source_path = _resolve_source_path()
     queue_db_path = _resolve_queue_db_path_readonly()
 
@@ -547,15 +548,13 @@ def _build_mismatches(
     daemon_team_or_user = _daemon_team_or_user(record)
 
     # (canonical_field, foreground_value, daemon_value)
-    daemon_executable_path: Path = Path(record.executable_path)
-    try:
-        daemon_executable_path = daemon_executable_path.resolve()
-    except (OSError, RuntimeError):
-        pass
-
+    # ``record.executable_path`` is already canonicalized at read time by
+    # :func:`specify_cli.sync.owner._canonical_executable_path`; no defensive
+    # resolve here (asymmetric resolution would re-introduce the bug this
+    # canonicalization closes).
     comparisons: list[tuple[MismatchField, object, object]] = [
         ("daemon_package_version", foreground.package_version, record.package_version),
-        ("daemon_executable_path", foreground.executable_path, daemon_executable_path),
+        ("daemon_executable_path", foreground.executable_path, Path(record.executable_path)),
         ("daemon_source_path", foreground.source_path, Path(record.source_checkout_path)),
         ("daemon_server_url", foreground.server_url, record.server_url or None),
         ("daemon_team_or_user", foreground.team_or_user, daemon_team_or_user),

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -547,9 +547,15 @@ def _build_mismatches(
     daemon_team_or_user = _daemon_team_or_user(record)
 
     # (canonical_field, foreground_value, daemon_value)
+    daemon_executable_path: Path = Path(record.executable_path)
+    try:
+        daemon_executable_path = daemon_executable_path.resolve()
+    except (OSError, RuntimeError):
+        pass
+
     comparisons: list[tuple[MismatchField, object, object]] = [
         ("daemon_package_version", foreground.package_version, record.package_version),
-        ("daemon_executable_path", foreground.executable_path, Path(record.executable_path)),
+        ("daemon_executable_path", foreground.executable_path, daemon_executable_path),
         ("daemon_source_path", foreground.source_path, Path(record.source_checkout_path)),
         ("daemon_server_url", foreground.server_url, record.server_url or None),
         ("daemon_team_or_user", foreground.team_or_user, daemon_team_or_user),

--- a/tests/sync/test_daemon_owner_record.py
+++ b/tests/sync/test_daemon_owner_record.py
@@ -240,6 +240,25 @@ def test_mismatched_fields_returns_empty_when_aligned(_scoped_home: Path) -> Non
     assert mismatched_fields(record, fg) == []
 
 
+def test_mismatched_fields_normalizes_executable_symlink(
+    _scoped_home: Path, tmp_path: Path
+) -> None:
+    """pipx-style executable symlinks should not create split-brain mismatches."""
+    from specify_cli.sync.owner import mismatched_fields
+
+    symlink = tmp_path / Path(sys.executable).name
+    try:
+        symlink.symlink_to(Path(sys.executable))
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    record = _build_record(executable_path=str(symlink))
+    fg = _fg_from_record(record)
+    fg["executable_path"] = str(Path(sys.executable).resolve())
+
+    assert mismatched_fields(record, fg) == []
+
+
 @pytest.mark.parametrize(
     "field, mutated_value",
     [

--- a/tests/sync/test_daemon_owner_record.py
+++ b/tests/sync/test_daemon_owner_record.py
@@ -259,6 +259,80 @@ def test_mismatched_fields_normalizes_executable_symlink(
     assert mismatched_fields(record, fg) == []
 
 
+def test_dataclass_canonicalizes_executable_path(
+    _scoped_home: Path, tmp_path: Path
+) -> None:
+    """Constructing a record with a symlink path stores the resolved target.
+
+    This locks in the dataclass-level invariant so future callers cannot
+    silently bypass normalization by constructing records directly.
+    """
+    symlink = tmp_path / Path(sys.executable).name
+    try:
+        symlink.symlink_to(Path(sys.executable))
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    record = _build_record(executable_path=str(symlink))
+    assert record.executable_path == str(Path(sys.executable).resolve())
+
+
+def test_canonical_executable_path_falls_back_to_raw_when_resolve_fails(
+    _scoped_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If :meth:`Path.resolve` raises, the raw string survives unchanged.
+
+    Exercises the ``except (OSError, RuntimeError)`` branch of
+    ``_canonical_executable_path`` — without this test the fallback is
+    untested and a regression could silently swallow the bug fix.
+    """
+    from specify_cli.sync import owner as owner_module
+
+    raw_path = "/no/such/python-that-will-not-resolve"
+
+    real_resolve = Path.resolve
+
+    def _exploding_resolve(self: Path, *args: Any, **kwargs: Any) -> Path:
+        if str(self) == raw_path:
+            raise OSError("simulated resolve failure")
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _exploding_resolve)
+
+    assert owner_module._canonical_executable_path(raw_path) == raw_path
+
+
+def test_mismatched_fields_when_one_side_fails_to_resolve(
+    _scoped_home: Path, tmp_path: Path
+) -> None:
+    """Resolution failure on one side must NOT produce a half-mutated compare.
+
+    Regression test for the earlier non-atomic try/except where a successful
+    resolve on the daemon side combined with a failed resolve on the foreground
+    side produced a spurious mismatch. With dataclass-level canonicalization,
+    both sides are pre-normalized at write time, so this scenario reduces to a
+    plain string compare and the helper cannot be tricked into a half-state.
+    """
+    from specify_cli.sync.owner import mismatched_fields
+
+    symlink = tmp_path / Path(sys.executable).name
+    try:
+        symlink.symlink_to(Path(sys.executable))
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    record = _build_record(executable_path=str(symlink))
+    fg = _fg_from_record(record)
+    # Foreground stores a path that no longer exists on disk; the canonical
+    # helper still resolves it lexically (or falls back to raw) without
+    # contaminating the daemon-side value the way the old try/except could.
+    bogus = "/nonexistent/path/that/cannot/be/resolved/python"
+    fg["executable_path"] = bogus
+
+    mismatches = mismatched_fields(record, fg)
+    assert mismatches == ["executable_path"]
+
+
 @pytest.mark.parametrize(
     "field, mutated_value",
     [

--- a/tests/sync/test_sync_boundary_preflight.py
+++ b/tests/sync/test_sync_boundary_preflight.py
@@ -399,6 +399,26 @@ def test_run_preflight_refuses_on_per_field_mismatch(
     )
 
 
+def test_run_preflight_accepts_daemon_executable_symlink(
+    tmp_path: Path, patched_legacy_counts
+) -> None:
+    """Regression: pipx-installed CLIs may record symlinked ``sys.executable``."""
+    patched_legacy_counts({})
+    symlink = tmp_path / Path(sys.executable).name
+    try:
+        symlink.symlink_to(Path(sys.executable))
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    _write_record(executable_path=str(symlink))
+    foreground = _make_foreground(executable_path=Path(sys.executable).resolve())
+
+    result = run_preflight(repo_root=tmp_path, foreground=foreground, require_auth=True)
+
+    assert result.ok is True
+    assert [m.field for m in result.mismatches] == []
+
+
 def test_canonical_mismatch_field_names_are_exact() -> None:
     """The :class:`MismatchField` Literal carries exactly six canonical names."""
     import typing


### PR DESCRIPTION
## Summary

Fixes a spurious sync-boundary refusal for pipx-style installs where the foreground preflight resolves `sys.executable` through symlinks but the daemon owner record stores the unresolved executable path.

Changes:
- Store resolved `sys.executable` in the daemon owner foreground identity.
- Resolve both sides of `executable_path` comparison in the low-level owner mismatch helper.
- Resolve the daemon owner executable before the structured sync preflight builds `daemon_executable_path` mismatches.
- Add regression coverage for a symlinked daemon executable in both owner comparison and preflight paths.

Context: follow-up under the daemon-owner coherence surface tracked by #1088.

## Verification

```bash
SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python -m pytest \
  tests/sync/test_daemon_owner_record.py \
  tests/sync/test_sync_boundary_preflight.py \
  tests/sync/test_offline_replay.py::TestOfflineWorkflowEndToEnd::test_intermittent_connectivity -q
```

Result: `55 passed, 1 warning`.

Also ran the broader sync package:

```bash
SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python -m pytest tests/sync
```

Result: `1666 passed, 8 skipped, 2 failed`. The focused intermittent-connectivity failure passed when rerun alone. The remaining `test_doctor_healthy` failure was environmental on this machine: `sync doctor` detected 4 live orphan `run_sync_daemon` processes already present on the host.
