### PR TITLE
Release 3.2.0rc13

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc12
+  version: 3.2.0rc13
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc13] - 2026-05-19
+
+Ships a focused sync-boundary hotfix for pipx-style CLI installs:
+
+- Fixes `#1120`: daemon owner records now canonicalize
+  `executable_path` at the `DaemonOwnerRecord` boundary, and foreground
+  sync identity uses the same canonicalization helper. Pipx-installed CLIs
+  whose `sys.executable` flows through a symlink no longer report a spurious
+  `daemon_executable_path` mismatch during `sync status --check` or
+  sync-producing command preflight.
+- Adds adversarial coverage for owner-record dataclass canonicalization,
+  resolve-failure fallback behavior, and the asymmetric one-sided resolve
+  failure class that could reintroduce false split-brain detection.
+
 ## [3.2.0rc12] - 2026-05-18
 
 Ships the MVP CLI sync-boundary preflight surface required by the Teamspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc12"
+version = "3.2.0rc13"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc12"
+version = "3.2.0rc13"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- bump spec-kitty-cli to 3.2.0rc13
- add changelog entry for the pipx/symlink daemon executable sync-boundary hotfix from #1120
- keep uv.lock aligned with the new project version

## Validation
- `pipx run uv==0.11.15 lock --check`
- `pipx run uv==0.11.15 run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'`
- `pipx run uv==0.11.15 run python scripts/release/check_shared_package_drift.py --saas-pyproject ../spec-kitty-saas/pyproject.toml`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pipx run uv==0.11.15 run python -m pytest tests/sync/test_daemon_owner_record.py tests/sync/test_sync_boundary_preflight.py tests/sync/test_sync_action_gate.py tests/sync/test_sync_status_boundary_check.py -q`
- `pipx run uv==0.11.15 run python -m pytest tests/release -q`
- `pipx run uv==0.11.15 run python -m build`
- `pipx run uv==0.11.15 run python scripts/release/check_exact_install.py --package spec-kitty-cli`
- `pipx run uv==0.11.15 run python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json`
- `pipx run uv==0.11.15 run --with twine twine check dist/*`
