### PR TITLE
fix: reduce sync Sonar findings

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -51,6 +51,44 @@ _STATUS_LAST_SYNC_LABEL = "Last Sync"
 _UNAUTHENTICATED_SYNC_NOW_MESSAGE = (
     "not authenticated: no valid access token. Run `spec-kitty auth login`."
 )
+_WARNING_HEADER_STYLE = "bold yellow"
+_ABSENT_VALUE = "<absent>"
+_UNSET_VALUE = "<unset>"
+_ZERO_STATUS = "[green]0[/green]"
+_BOUNDARY_LABEL_PACKAGE_VERSION = "  Package version"
+_BOUNDARY_LABEL_EXECUTABLE_PATH = "  Executable path"
+_BOUNDARY_LABEL_SOURCE_PATH = "  Source path"
+_BOUNDARY_LABEL_SERVER_URL = "  Server URL"
+_BOUNDARY_LABEL_TEAM_USER = "  Team/User"
+_BOUNDARY_LABEL_QUEUE_DB_PATH = "  Queue DB path"
+_MISMATCHED_FIELDS_LABEL = "Mismatched fields"
+
+
+def _string_or(value: object | None, fallback: str) -> str:
+    """Return *fallback* when *value* is falsey, otherwise coerce to ``str``."""
+    return str(value) if value else fallback
+
+
+def _add_boundary_identity_rows(
+    table: Table,
+    rows: list[tuple[str, object | None]],
+    *,
+    fallback: str,
+) -> None:
+    """Render a flat sequence of key/value rows into the boundary table."""
+    for label, value in rows:
+        table.add_row(label, _string_or(value, fallback))
+
+
+def _add_boundary_identity_row(
+    table: Table,
+    label: str,
+    value: object | None,
+    *,
+    fallback: str,
+) -> None:
+    """Render a single key/value row into the boundary table."""
+    table.add_row(label, _string_or(value, fallback))
 
 
 def _sync_result_looks_unauthenticated(queue_size: int, result: object) -> bool:
@@ -806,7 +844,7 @@ def _display_conflicts(conflicts: list[ConflictInfo]) -> None:
     console.print(f"\n[yellow]Conflicts ({len(conflicts)} files):[/yellow]")
 
     # Create a table for better formatting
-    table = Table(show_header=True, header_style="bold yellow", show_lines=False)
+    table = Table(show_header=True, header_style=_WARNING_HEADER_STYLE, show_lines=False)
     table.add_column("File", style="cyan")
     table.add_column("Type", style="dim")
     table.add_column("Lines", style="dim")
@@ -1846,7 +1884,8 @@ def status(  # noqa: C901
             )
         finally:
             _conn.close()
-    except Exception:  # noqa: BLE001 — read-only diagnostic, never raise
+    # Read-only diagnostic: never let status rendering fail on queue inspection.
+    except Exception:  # noqa: BLE001
         body_queue_count = 0
 
     # Legacy body-upload count (read-only).
@@ -1867,52 +1906,78 @@ def status(  # noqa: C901
 
     # FR-005: Foreground identity (full field set per contract).
     boundary_table.add_row("Foreground:", "")
-    boundary_table.add_row("  Package version", str(fg.package_version or "-"))
-    boundary_table.add_row("  Executable path", str(fg.executable_path or "-"))
-    boundary_table.add_row("  Source path", str(fg.source_path or "-"))
-    boundary_table.add_row(
-        "  Server URL", fg.server_url if fg.server_url else "<unset>"
+    _add_boundary_identity_row(
+        boundary_table,
+        _BOUNDARY_LABEL_PACKAGE_VERSION,
+        fg.package_version,
+        fallback="-",
     )
-    boundary_table.add_row(
-        "  Team/User", fg.team_or_user if fg.team_or_user else "<unset>"
+    _add_boundary_identity_row(
+        boundary_table,
+        _BOUNDARY_LABEL_EXECUTABLE_PATH,
+        fg.executable_path,
+        fallback="-",
     )
-    boundary_table.add_row("  Queue DB path", str(fg.queue_db_path or "-"))
+    _add_boundary_identity_row(
+        boundary_table,
+        _BOUNDARY_LABEL_SOURCE_PATH,
+        fg.source_path,
+        fallback="-",
+    )
+    _add_boundary_identity_row(
+        boundary_table,
+        _BOUNDARY_LABEL_SERVER_URL,
+        fg.server_url,
+        fallback=_UNSET_VALUE,
+    )
+    _add_boundary_identity_row(
+        boundary_table,
+        _BOUNDARY_LABEL_TEAM_USER,
+        fg.team_or_user,
+        fallback=_UNSET_VALUE,
+    )
+    _add_boundary_identity_row(
+        boundary_table,
+        _BOUNDARY_LABEL_QUEUE_DB_PATH,
+        fg.queue_db_path,
+        fallback="-",
+    )
 
     # FR-005: Daemon owner record.
     boundary_table.add_row("Daemon owner record:", "")
     boundary_table.add_row("  Status", daemon_status_label)
     if daemon_record is None:
-        boundary_table.add_row("  PID", "<absent>")
-        boundary_table.add_row("  Port", "<absent>")
-        boundary_table.add_row("  Package version", "<absent>")
-        boundary_table.add_row("  Executable path", "<absent>")
-        boundary_table.add_row("  Source path", "<absent>")
-        boundary_table.add_row("  Server URL", "<absent>")
-        boundary_table.add_row("  Team/User", "<absent>")
-        boundary_table.add_row("  Queue DB path", "<absent>")
+        _add_boundary_identity_rows(
+            boundary_table,
+            [
+                ("  PID", None),
+                ("  Port", None),
+                (_BOUNDARY_LABEL_PACKAGE_VERSION, None),
+                (_BOUNDARY_LABEL_EXECUTABLE_PATH, None),
+                (_BOUNDARY_LABEL_SOURCE_PATH, None),
+                (_BOUNDARY_LABEL_SERVER_URL, None),
+                (_BOUNDARY_LABEL_TEAM_USER, None),
+                (_BOUNDARY_LABEL_QUEUE_DB_PATH, None),
+            ],
+            fallback=_ABSENT_VALUE,
+        )
     else:
-        boundary_table.add_row("  PID", str(daemon_record.pid))
-        boundary_table.add_row("  Port", str(daemon_record.port))
-        boundary_table.add_row(
-            "  Package version", daemon_record.package_version or "<absent>"
-        )
-        boundary_table.add_row(
-            "  Executable path", daemon_record.executable_path or "<absent>"
-        )
-        boundary_table.add_row(
-            "  Source path", daemon_record.source_checkout_path or "<absent>"
-        )
-        boundary_table.add_row(
-            "  Server URL", daemon_record.server_url or "<absent>"
-        )
         # Render daemon team_or_user as "principal[/team]" to match the
         # canonical contract field.
         daemon_team_or_user = _render_daemon_team_or_user(daemon_record)
-        boundary_table.add_row(
-            "  Team/User", daemon_team_or_user if daemon_team_or_user else "<absent>"
-        )
-        boundary_table.add_row(
-            "  Queue DB path", daemon_record.queue_db_path or "<absent>"
+        _add_boundary_identity_rows(
+            boundary_table,
+            [
+                ("  PID", daemon_record.pid),
+                ("  Port", daemon_record.port),
+                (_BOUNDARY_LABEL_PACKAGE_VERSION, daemon_record.package_version),
+                (_BOUNDARY_LABEL_EXECUTABLE_PATH, daemon_record.executable_path),
+                (_BOUNDARY_LABEL_SOURCE_PATH, daemon_record.source_checkout_path),
+                (_BOUNDARY_LABEL_SERVER_URL, daemon_record.server_url),
+                (_BOUNDARY_LABEL_TEAM_USER, daemon_team_or_user),
+                (_BOUNDARY_LABEL_QUEUE_DB_PATH, daemon_record.queue_db_path),
+            ],
+            fallback=_ABSENT_VALUE,
         )
 
     # FR-005: Active queue.
@@ -1943,13 +2008,13 @@ def status(  # noqa: C901
     n_mismatches = len(failure_set.mismatches)
     boundary_table.add_row(
         "Mismatches",
-        f"[red]{n_mismatches}[/red]" if n_mismatches else "[green]0[/green]",
+        f"[red]{n_mismatches}[/red]" if n_mismatches else _ZERO_STATUS,
     )
     boundary_table.add_row(
         "Orphan records",
         f"[yellow]{orphan_record_count}[/yellow]"
         if orphan_record_count
-        else "[green]0[/green]",
+        else _ZERO_STATUS,
     )
 
     # Preserve backward-compatible legacy-event/body summary line so
@@ -1967,21 +2032,21 @@ def status(  # noqa: C901
     if failure_set.mismatches:
         mismatch_field_names = [m.field for m in failure_set.mismatches]
         boundary_table.add_row(
-            "Mismatched fields",
+            _MISMATCHED_FIELDS_LABEL,
             f"[red]{', '.join(mismatch_field_names)}[/red]",
         )
     elif daemon_mismatched:
         boundary_table.add_row(
-            "Mismatched fields",
+            _MISMATCHED_FIELDS_LABEL,
             f"[red]{', '.join(daemon_mismatched)}[/red]",
         )
     else:
-        boundary_table.add_row("Mismatched fields", "[green]none[/green]")
+        boundary_table.add_row(_MISMATCHED_FIELDS_LABEL, "[green]none[/green]")
     boundary_table.add_row(
         "Orphan daemon records",
         f"[yellow]{orphan_record_count}[/yellow]"
         if orphan_record_count
-        else "[green]0[/green]",
+        else _ZERO_STATUS,
     )
 
     # When the canonical mismatch list is non-empty, render the detail

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -606,7 +606,8 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
     def _cleanup_owner_record() -> None:
         try:
             remove_owner_record()
-        except Exception:  # noqa: BLE001 — best-effort, never block exit
+        # Best-effort cleanup: never block daemon exit on owner-record removal.
+        except Exception:  # noqa: BLE001
             logger.debug("Owner record cleanup raised; continuing")
 
     atexit.register(_cleanup_owner_record)

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -36,7 +36,7 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from rich.console import Console
 from rich.table import Table
@@ -199,20 +199,7 @@ class PreflightResult:
         )
 
         if self.mismatches:
-            table = Table(title=None, show_lines=False)
-            table.add_column("Field", style="bold")
-            table.add_column("Foreground")
-            table.add_column("Daemon")
-            # Sort by canonical order so the table is stable.
-            by_field: dict[MismatchField, OwnerMismatch] = {
-                m.field: m for m in self.mismatches
-            }
-            for fname in _CANONICAL_FIELD_ORDER:
-                m = by_field.get(fname)
-                if m is None:
-                    continue
-                table.add_row(m.field, m.foreground_value, m.daemon_value)
-            console.print(table)
+            console.print(_build_mismatch_table(self.mismatches))
 
         # Remediation bullets — compressed for the NFR-004 25-line budget
         # at 80 columns. Most daemon-field mismatches share a single
@@ -230,47 +217,13 @@ class PreflightResult:
         # ``daemon_server_url`` and ``daemon_team_or_user`` keep their own
         # bullets because their remediations differ from the simple
         # restart-daemon path (they involve auth).
-        remediation_lines: list[str] = []
-
-        mismatch_fields = {m.field for m in self.mismatches}
-        restart_class: tuple[MismatchField, ...] = (
-            "daemon_package_version",
-            "daemon_executable_path",
-            "daemon_source_path",
-            "daemon_queue_db_path",
+        remediation_lines = _build_remediation_lines(
+            self.mismatches,
+            orphan_count=n_orphan,
+            legacy_rows=k_legacy,
+            auth_required=self.auth_required,
+            auth_present=self.auth_present,
         )
-        if any(f in mismatch_fields for f in restart_class):
-            remediation_lines.append(
-                "  • Run `spec-kitty doctor restart-daemon` to restart the "
-                "daemon at the foreground version/source."
-            )
-        if "daemon_server_url" in mismatch_fields:
-            remediation_lines.append(
-                "  • Reauthenticate (`spec-kitty auth login`) or restart "
-                "the daemon against the matching server."
-            )
-        if "daemon_team_or_user" in mismatch_fields:
-            remediation_lines.append(
-                "  • Switch team/user (`spec-kitty auth switch ...`) or "
-                "restart the daemon."
-            )
-
-        if self.orphan_records:
-            remediation_lines.append(
-                f"  • Run `spec-kitty doctor orphan-daemons` to clean up "
-                f"{n_orphan} orphan daemon record(s)."
-            )
-        if k_legacy > 0:
-            remediation_lines.append(
-                f"  • Run `spec-kitty sync now` to flush {k_legacy} legacy "
-                f"rows for the current scope after the boundary is coherent."
-            )
-        if self.auth_required and not self.auth_present:
-            remediation_lines.append(
-                "  • Run `spec-kitty auth login` — SaaS sync enabled but "
-                "no authenticated identity is available."
-            )
-
         if remediation_lines:
             console.print("Remediation:")
             for line in remediation_lines:
@@ -314,6 +267,75 @@ def _orphan_record_to_dict(record: DaemonOwnerRecord) -> dict[str, Any]:
     if "token" in data:
         data["token"] = "<redacted>"
     return data
+
+
+def _build_mismatch_table(mismatches: tuple[OwnerMismatch, ...]) -> Table:
+    """Build a stable mismatch table ordered by canonical field sequence."""
+    table = Table(title=None, show_lines=False)
+    table.add_column("Field", style="bold")
+    table.add_column("Foreground")
+    table.add_column("Daemon")
+    by_field: dict[MismatchField, OwnerMismatch] = {m.field: m for m in mismatches}
+    for field_name in _CANONICAL_FIELD_ORDER:
+        mismatch = by_field.get(field_name)
+        if mismatch is None:
+            continue
+        table.add_row(
+            mismatch.field,
+            mismatch.foreground_value,
+            mismatch.daemon_value,
+        )
+    return table
+
+
+def _build_remediation_lines(
+    mismatches: tuple[OwnerMismatch, ...],
+    *,
+    orphan_count: int,
+    legacy_rows: int,
+    auth_required: bool,
+    auth_present: bool,
+) -> list[str]:
+    """Return the compressed remediation bullets for a preflight failure."""
+    remediation_lines: list[str] = []
+    mismatch_fields = {m.field for m in mismatches}
+    restart_class: tuple[MismatchField, ...] = (
+        "daemon_package_version",
+        "daemon_executable_path",
+        "daemon_source_path",
+        "daemon_queue_db_path",
+    )
+    if any(field_name in mismatch_fields for field_name in restart_class):
+        remediation_lines.append(
+            "  • Run `spec-kitty doctor restart-daemon` to restart the "
+            "daemon at the foreground version/source."
+        )
+    if "daemon_server_url" in mismatch_fields:
+        remediation_lines.append(
+            "  • Reauthenticate (`spec-kitty auth login`) or restart "
+            "the daemon against the matching server."
+        )
+    if "daemon_team_or_user" in mismatch_fields:
+        remediation_lines.append(
+            "  • Switch team/user (`spec-kitty auth switch ...`) or "
+            "restart the daemon."
+        )
+    if orphan_count:
+        remediation_lines.append(
+            f"  • Run `spec-kitty doctor orphan-daemons` to clean up "
+            f"{orphan_count} orphan daemon record(s)."
+        )
+    if legacy_rows > 0:
+        remediation_lines.append(
+            f"  • Run `spec-kitty sync now` to flush {legacy_rows} legacy "
+            f"rows for the current scope after the boundary is coherent."
+        )
+    if auth_required and not auth_present:
+        remediation_lines.append(
+            "  • Run `spec-kitty auth login` — SaaS sync enabled but "
+            "no authenticated identity is available."
+        )
+    return remediation_lines
 
 
 # ---------------------------------------------------------------------------
@@ -609,23 +631,12 @@ def _count_legacy_rows_for_scope(
         detect_legacy_rows_for_scope,
     )
 
-    # Build the scope string from the foreground identity. The legacy DB
-    # has no per-scope partitioning today, so the scope is informational;
-    # the helper still respects its API contract.
-    if foreground.server_url and foreground.team_or_user:
-        # The foreground.team_or_user is "principal[/team]" — recover the
-        # individual parts when present.
-        if "/" in foreground.team_or_user:
-            principal, team = foreground.team_or_user.split("/", 1)
-        else:
-            principal, team = foreground.team_or_user, "no-team"
-        scope = build_queue_scope(foreground.server_url, principal, team)
-    else:
-        scope = ""
+    scope = _build_legacy_scope(foreground, build_queue_scope)
 
     try:
         counts = detect_legacy_rows_for_scope(scope)
-    except Exception:  # noqa: BLE001 — defensive: never block preflight on a query error
+    # Defensive: never block preflight on a legacy-row query error.
+    except Exception:  # noqa: BLE001
         return (0, 0)
 
     # Preferred path: the structured ``LegacyRowCounts`` exposes the
@@ -650,6 +661,21 @@ def _count_legacy_rows_for_scope(
             # All other migration tables (sync_events, etc.) are event-class.
             event_rows += count
     return event_rows, body_rows
+
+
+def _build_legacy_scope(
+    foreground: ForegroundIdentity,
+    build_queue_scope: Callable[[str, str, str], str],
+) -> str:
+    """Build the scope string used for legacy-queue inspection."""
+    if not foreground.server_url or not foreground.team_or_user:
+        return ""
+
+    if "/" in foreground.team_or_user:
+        principal, team = foreground.team_or_user.split("/", 1)
+    else:
+        principal, team = foreground.team_or_user, "no-team"
+    return build_queue_scope(foreground.server_url, principal, team)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- reduce fresh sync-related Sonar findings by deduplicating repeated status literals and extracting boundary rendering helpers
- split sync preflight mismatch/remediation rendering and legacy scope building into smaller helpers
- fix malformed `noqa: BLE001` comments Sonar flagged in sync status and daemon cleanup paths

## Investigation
- GitHub Dependabot alerts: none open
- GitHub code scanning alerts: none open
- SonarCloud `main` quality gate currently fails on `new_coverage=57.7` and `new_security_hotspots_reviewed=0.0`
- The previous nightly CI run on 2026-05-18 also had an unrelated `fast-tests-agent` failure in `tests/agent/test_init_command.py::test_init_rejects_removed_agent_strategy_option`

## Validation
- `python -m py_compile src/specify_cli/cli/commands/sync.py src/specify_cli/sync/preflight.py src/specify_cli/sync/daemon.py`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run --extra test python -m pytest tests/agent/cli/commands/test_sync.py -k "display_changes_integrated or display_conflicts" tests/sync/test_sync_boundary_preflight.py tests/sync/test_sync_status_boundary_check.py -q`
- Broader local `tests/agent/cli/commands/test_sync.py` exit-code cases still fail in this environment with exit code 2 before the patched helpers are exercised; left unchanged in this PR
