### PR TITLE
fix: chip away at Sonar acceptance and review debt

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -35,6 +35,21 @@ logger = logging.getLogger(__name__)
 
 AcceptanceMode = str  # Expected values: "pr", "local", "checklist"
 
+SPEC_FILE = "spec.md"
+PLAN_FILE = "plan.md"
+TASKS_FILE = "tasks.md"
+QUICKSTART_FILE = "quickstart.md"
+DATA_MODEL_FILE = "data-model.md"
+RESEARCH_FILE = "research.md"
+PRIMARY_ARTIFACT_FILES = (
+    SPEC_FILE,
+    PLAN_FILE,
+    QUICKSTART_FILE,
+    TASKS_FILE,
+    RESEARCH_FILE,
+    DATA_MODEL_FILE,
+)
+
 
 class AcceptanceError(TaskCliError):
     """Raised when acceptance cannot complete due to outstanding issues."""
@@ -308,11 +323,11 @@ def _check_needs_clarification(files: Sequence[Path]) -> list[str]:
 
 
 def _missing_artifacts(feature_dir: Path) -> tuple[list[str], list[str]]:
-    required = [feature_dir / "spec.md", feature_dir / "plan.md", feature_dir / "tasks.md"]
+    required = [feature_dir / SPEC_FILE, feature_dir / PLAN_FILE, feature_dir / TASKS_FILE]
     optional = [
-        feature_dir / "quickstart.md",
-        feature_dir / "data-model.md",
-        feature_dir / "research.md",
+        feature_dir / QUICKSTART_FILE,
+        feature_dir / DATA_MODEL_FILE,
+        feature_dir / RESEARCH_FILE,
         feature_dir / "contracts",
     ]
     missing_required = [str(p.relative_to(feature_dir)) for p in required if not p.exists()]
@@ -347,14 +362,7 @@ def normalize_feature_encoding(repo_root: Path, feature: str) -> list[Path]:
         return []
 
     candidates: list[Path] = []
-    primary_files = [
-        feature_dir / "spec.md",
-        feature_dir / "plan.md",
-        feature_dir / "quickstart.md",
-        feature_dir / "tasks.md",
-        feature_dir / "research.md",
-        feature_dir / "data-model.md",
-    ]
+    primary_files = [feature_dir / artifact_name for artifact_name in PRIMARY_ARTIFACT_FILES]
     candidates.extend(p for p in primary_files if p.exists())
 
     for subdir in [feature_dir / "tasks", feature_dir / "research", feature_dir / "checklists"]:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import subprocess  # noqa: F401  (monkeypatched in tests)
 from pathlib import Path
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 import typer
 
@@ -40,6 +40,210 @@ from ._issue_matrix import validate_issue_matrix  # noqa: F401
 from ._lane_gate import check_wp_lanes  # noqa: F401
 from ._mode import MissionReviewMode, ModeMismatchError, resolve_mode  # noqa: F401
 from ._report import GateRecord, write_review_report  # noqa: F401
+
+
+def _fail_missing_test_extra(console: object) -> None:
+    import sys
+
+    diagnostic_code = MissionReviewDiagnostic.TEST_EXTRA_MISSING
+    diagnostic = {
+        "diagnostic_code": str(diagnostic_code),
+        "message": (
+            "pytest is not importable from the active Python interpreter. "
+            "Run `uv sync --extra test` to install the test extra, then retry."
+        ),
+        "remediation": "uv sync --extra test",
+    }
+    console.print(  # type: ignore[attr-defined]
+        f"[red]Error:[/red] {diagnostic_code}: {diagnostic['message']}"
+    )
+    sys.stdout.write(json.dumps(diagnostic) + "\n")
+    raise typer.Exit(1)
+
+
+def _resolve_repo_root(console: object) -> Path:
+    try:
+        return find_repo_root()
+    except TaskCliError as exc:
+        console.print(f"[red]Error:[/red] {exc}")  # type: ignore[attr-defined]
+        raise typer.Exit(2) from exc
+
+
+def _require_mission_handle(mission: str, console: object) -> str:
+    handle = mission.strip()
+    if not handle:
+        console.print("[red]Error:[/red] --mission is required.")  # type: ignore[attr-defined]
+        raise typer.Exit(2)
+    return handle
+
+
+def _load_meta(feature_dir: Path) -> dict[str, object]:
+    meta_path = feature_dir / "meta.json"
+    if not meta_path.exists():
+        return {}
+    try:
+        return json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _resolve_mode_or_exit(
+    *,
+    console: object,
+    cli_mode: str | None,
+    baseline_merge_commit: str | None,
+) -> tuple[MissionReviewMode, bool]:
+    try:
+        return resolve_mode(
+            cli_flag=cli_mode,
+            baseline_merge_commit=baseline_merge_commit,
+        )
+    except ModeMismatchError as exc:
+        diagnostic = {
+            "diagnostic_code": str(exc.diagnostic_code),
+            "message": exc.message,
+        }
+        console.print(f"[red]Error:[/red] {exc.diagnostic_code}")  # type: ignore[attr-defined]
+        console.print(exc.message)  # type: ignore[attr-defined]
+        import sys
+
+        sys.stdout.write(json.dumps(diagnostic) + "\n")
+        raise typer.Exit(1) from exc
+
+
+def _record_gate(
+    gates_recorded: list[GateRecord],
+    *,
+    gate_id: str,
+    name: str,
+    result: Literal["pass", "fail"],
+) -> None:
+    gates_recorded.append(
+        GateRecord(
+            id=gate_id,
+            name=name,
+            command=f"spec-kitty review (internal {gate_id.replace('_', ' ')})",
+            exit_code=1 if result == "fail" else 0,
+            result=result,
+        )
+    )
+
+
+def _run_lane_gate(
+    feature_dir: Path,
+    repo_root: Path,
+    console: object,
+    findings: list[dict[str, str]],
+    gates_recorded: list[GateRecord],
+) -> None:
+    findings_before = len(findings)
+    check_wp_lanes(feature_dir, repo_root, console, findings)  # type: ignore[arg-type]
+    result: Literal["pass", "fail"] = "fail" if len(findings) > findings_before else "pass"
+    _record_gate(gates_recorded, gate_id="gate_1", name="wp_lane_check", result=result)
+
+
+def _run_dead_code_gate(
+    *,
+    baseline_merge_commit: str | None,
+    repo_root: Path,
+    console: object,
+    findings: list[dict[str, str]],
+    mission_id: str | None,
+    mission_slug: str,
+    gates_recorded: list[GateRecord],
+) -> None:
+    findings_before = len(findings)
+    scan_dead_code(
+        baseline_merge_commit,
+        repo_root,
+        console,  # type: ignore[arg-type]
+        findings,
+        mission_id=mission_id,
+        mission_slug=mission_slug,
+    )
+    result: Literal["pass", "fail"] = "fail" if len(findings) > findings_before else "pass"
+    _record_gate(gates_recorded, gate_id="gate_2", name="dead_code_scan", result=result)
+
+
+def _run_ble001_gate(
+    repo_root: Path,
+    console: object,
+    findings: list[dict[str, str]],
+    gates_recorded: list[GateRecord],
+) -> None:
+    ble001_findings = collect_auth_storage_ble001_findings(repo_root)
+    for finding in ble001_findings:
+        findings.append(
+            {
+                "type": "ble001_suppression",
+                "file": finding.file,
+                "line": str(finding.line),
+                "content": finding.suppression,
+                "remediation": finding.remediation,
+            }
+        )
+
+    if ble001_findings:
+        console.print(  # type: ignore[attr-defined]
+            f"  [red]✗[/red]  BLE001 audit: {len(ble001_findings)} unjustified suppression(s)"
+        )
+        for finding in ble001_findings:
+            console.print(f"       {finding.file}:{finding.line}")  # type: ignore[attr-defined]
+            console.print(f"       suppression: {finding.suppression}")  # type: ignore[attr-defined]
+            console.print(f"       remediation: {finding.remediation}")  # type: ignore[attr-defined]
+        result: Literal["pass", "fail"] = "fail"
+    else:
+        console.print("  [green]✓[/green]  BLE001 audit: 0 unjustified suppressions")  # type: ignore[attr-defined]
+        result = "pass"
+
+    _record_gate(gates_recorded, gate_id="gate_3", name="ble001_audit", result=result)
+
+
+def _evaluate_issue_matrix(
+    *,
+    feature_dir: Path,
+    review_mode: MissionReviewMode,
+    console: object,
+    findings: list[dict[str, str]],
+) -> bool | Literal["not_applicable"]:
+    if review_mode is not MissionReviewMode.POST_MERGE:
+        return "not_applicable"
+
+    issue_matrix_path = feature_dir / "issue-matrix.md"
+    if not issue_matrix_path.exists():
+        console.print(  # type: ignore[attr-defined]
+            f"  [red]✗[/red]  Issue matrix: "
+            f"{MissionReviewDiagnostic.ISSUE_MATRIX_MISSING}: "
+            "issue-matrix.md not found (required in post-merge mode)"
+        )
+        findings.append(
+            {
+                "type": "issue_matrix_violation",
+                "diagnostic_code": str(MissionReviewDiagnostic.ISSUE_MATRIX_MISSING),
+                "message": "issue-matrix.md is required in post-merge mode",
+            }
+        )
+        return False
+
+    matrix_result = validate_issue_matrix(issue_matrix_path)
+    if not matrix_result.passed:
+        for diag in matrix_result.diagnostics:
+            console.print(  # type: ignore[attr-defined]
+                f"  [red]✗[/red]  Issue matrix: {diag['diagnostic_code']}: {diag['message']}"
+            )
+            findings.append(
+                {
+                    "type": "issue_matrix_violation",
+                    "diagnostic_code": diag["diagnostic_code"],
+                    "message": diag["message"],
+                }
+            )
+    else:
+        console.print(  # type: ignore[attr-defined]
+            f"  [green]✓[/green]  Issue matrix: "
+            f"{len(matrix_result.rows)} row(s) validated"
+        )
+    return True
 
 
 def review_mission(
@@ -69,240 +273,55 @@ def review_mission(
     from rich.console import Console
 
     console = Console()
-
-    # ------------------------------------------------------------------
-    # Resolve repo root
-    # ------------------------------------------------------------------
-    try:
-        repo_root = find_repo_root()
-    except TaskCliError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(2)
-
-    # ------------------------------------------------------------------
-    # Preflight: assert pytest is importable from the active venv.
-    # Fails fast with MISSION_REVIEW_TEST_EXTRA_MISSING before any gate
-    # subprocess runs, preventing PATH fallthrough to system pytest.
-    # See: src/specify_cli/cli/commands/review/ERROR_CODES.md
-    #
-    # The probe is delegated to ``assert_pytest_available()`` so the helper
-    # IS the production path — tests that exercise the helper (via real
-    # ``venv.create()`` fixtures) directly assert the live behaviour. No
-    # parallel inline implementation; no path-specific test coupling.
-    # ------------------------------------------------------------------
+    repo_root = _resolve_repo_root(console)
     try:
         assert_pytest_available(repo_root)
     except TestExtraMissing:
-        import json as _json
-        import sys as _sys
+        _fail_missing_test_extra(console)
 
-        diagnostic_code = MissionReviewDiagnostic.TEST_EXTRA_MISSING
-        diagnostic = {
-            "diagnostic_code": str(diagnostic_code),
-            "message": (
-                "pytest is not importable from the active Python interpreter. "
-                "Run `uv sync --extra test` to install the test extra, then retry."
-            ),
-            "remediation": "uv sync --extra test",
-        }
-        console.print(
-            f"[red]Error:[/red] {diagnostic_code}: {diagnostic['message']}"
-        )
-        _sys.stdout.write(_json.dumps(diagnostic) + "\n")
-        raise typer.Exit(1)
-
-    # ------------------------------------------------------------------
-    # Resolve mission handle → feature_dir
-    # ------------------------------------------------------------------
-    handle = mission.strip()
-    if not handle:
-        console.print("[red]Error:[/red] --mission is required.")
-        raise typer.Exit(2)
-
+    handle = _require_mission_handle(mission, console)
     resolved = resolve_mission_handle(handle, repo_root)
     feature_dir = resolved.feature_dir
     mission_slug = resolved.mission_slug
-
-    # ------------------------------------------------------------------
-    # Read meta.json for display fields and baseline_merge_commit
-    # ------------------------------------------------------------------
-    meta_path = feature_dir / "meta.json"
-    meta: dict[str, object] = {}
-    if meta_path.exists():
-        try:
-            meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            pass
-
+    meta = _load_meta(feature_dir)
     friendly_name: str = str(meta.get("friendly_name") or mission_slug)
     _bmc_raw = meta.get("baseline_merge_commit")
     baseline_merge_commit: str | None = str(_bmc_raw) if _bmc_raw else None
-
-    # ------------------------------------------------------------------
-    # Resolve review mode (FR-005, FR-006, FR-023)
-    # ------------------------------------------------------------------
-    try:
-        review_mode, auto_detected = resolve_mode(
-            cli_flag=mode,
-            baseline_merge_commit=baseline_merge_commit,
-        )
-    except ModeMismatchError as exc:
-        import json as _json2
-
-        diagnostic = {
-            "diagnostic_code": str(exc.diagnostic_code),
-            "message": exc.message,
-        }
-        console.print(
-            f"[red]Error:[/red] {exc.diagnostic_code}"
-        )
-        console.print(exc.message)
-        import sys as _sys2
-        _sys2.stdout.write(_json2.dumps(diagnostic) + "\n")
-        raise typer.Exit(1)
-
+    review_mode, auto_detected = _resolve_mode_or_exit(
+        console=console,
+        cli_mode=mode,
+        baseline_merge_commit=baseline_merge_commit,
+    )
     mode_label = f"{review_mode.value} ({'auto-detected' if auto_detected else 'explicit'})"
     console.print(f"\nReviewing mission: {friendly_name} ({mission_slug})")
     console.print(f"Mode: {mode_label}\n")
 
     findings: list[dict[str, str]] = []
     gates_recorded: list[GateRecord] = []
-
-    # ==================================================================
-    # Step 1 — WP lane check (Gate 1)
-    # ==================================================================
-    lane_findings_before = len(findings)
-    check_wp_lanes(feature_dir, repo_root, console, findings)
-    gate1_result: str = "fail" if len(findings) > lane_findings_before else "pass"
-    gates_recorded.append(
-        GateRecord(
-            id="gate_1",
-            name="wp_lane_check",
-            command="spec-kitty review (internal gate 1)",
-            exit_code=1 if gate1_result == "fail" else 0,
-            result=gate1_result,  # type: ignore[arg-type]
-        )
-    )
-
-    # ==================================================================
-    # Step 2 — Dead-code scan (Gate 2)
-    # ==================================================================
-    dead_code_findings_before = len(findings)
     _mission_id_raw = meta.get("mission_id")
     _mission_id: str | None = str(_mission_id_raw) if _mission_id_raw else None
-    scan_dead_code(
-        baseline_merge_commit,
-        repo_root,
-        console,
-        findings,
+    _run_lane_gate(feature_dir, repo_root, console, findings, gates_recorded)
+    _run_dead_code_gate(
+        baseline_merge_commit=baseline_merge_commit,
+        repo_root=repo_root,
+        console=console,
+        findings=findings,
         mission_id=_mission_id,
         mission_slug=mission_slug,
+        gates_recorded=gates_recorded,
     )
-    gate2_result: str = "fail" if len(findings) > dead_code_findings_before else "pass"
-    gates_recorded.append(
-        GateRecord(
-            id="gate_2",
-            name="dead_code_scan",
-            command="spec-kitty review (internal gate 2)",
-            exit_code=1 if gate2_result == "fail" else 0,
-            result=gate2_result,  # type: ignore[arg-type]
-        )
+    _run_ble001_gate(repo_root, console, findings, gates_recorded)
+    issue_matrix_present = _evaluate_issue_matrix(
+        feature_dir=feature_dir,
+        review_mode=review_mode,
+        console=console,
+        findings=findings,
     )
-
-    # ==================================================================
-    # Step 3 — BLE001 unjustified suppression audit (Gate 3)
-    # ==================================================================
-    ble001_findings = collect_auth_storage_ble001_findings(repo_root)
-    for finding in ble001_findings:
-        findings.append(
-            {
-                "type": "ble001_suppression",
-                "file": finding.file,
-                "line": str(finding.line),
-                "content": finding.suppression,
-                "remediation": finding.remediation,
-            }
-        )
-
-    if ble001_findings:
-        console.print(
-            f"  [red]✗[/red]  BLE001 audit: {len(ble001_findings)} unjustified suppression(s)"
-        )
-        for finding in ble001_findings:
-            console.print(f"       {finding.file}:{finding.line}")
-            console.print(f"       suppression: {finding.suppression}")
-            console.print(f"       remediation: {finding.remediation}")
-        gate3_result = "fail"
-    else:
-        console.print("  [green]✓[/green]  BLE001 audit: 0 unjustified suppressions")
-        gate3_result = "pass"
-
-    gates_recorded.append(
-        GateRecord(
-            id="gate_3",
-            name="ble001_audit",
-            command="spec-kitty review (internal gate 3)",
-            exit_code=1 if gate3_result == "fail" else 0,
-            result=gate3_result,  # type: ignore[arg-type]
-        )
+    mission_exception_present: bool | Literal["not_applicable"] = (
+        (feature_dir / "mission-exception.md").exists()
+        if review_mode is MissionReviewMode.POST_MERGE
+        else "not_applicable"
     )
-
-    # ==================================================================
-    # Step 3b — Issue matrix validation (post-merge gate, FR-006, FR-028-032)
-    # ==================================================================
-    issue_matrix_path = feature_dir / "issue-matrix.md"
-    issue_matrix_present: bool | Literal["not_applicable"]
-
-    if review_mode is MissionReviewMode.POST_MERGE:
-        if issue_matrix_path.exists():
-            matrix_result = validate_issue_matrix(issue_matrix_path)
-            issue_matrix_present = True
-            if not matrix_result.passed:
-                for diag in matrix_result.diagnostics:
-                    console.print(
-                        f"  [red]✗[/red]  Issue matrix: {diag['diagnostic_code']}: {diag['message']}"
-                    )
-                    findings.append(
-                        {
-                            "type": "issue_matrix_violation",
-                            "diagnostic_code": diag["diagnostic_code"],
-                            "message": diag["message"],
-                        }
-                    )
-            else:
-                console.print(
-                    f"  [green]✓[/green]  Issue matrix: "
-                    f"{len(matrix_result.rows)} row(s) validated"
-                )
-        else:
-            issue_matrix_present = False
-            console.print(
-                f"  [red]✗[/red]  Issue matrix: "
-                f"{MissionReviewDiagnostic.ISSUE_MATRIX_MISSING}: "
-                "issue-matrix.md not found (required in post-merge mode)"
-            )
-            findings.append(
-                {
-                    "type": "issue_matrix_violation",
-                    "diagnostic_code": str(MissionReviewDiagnostic.ISSUE_MATRIX_MISSING),
-                    "message": "issue-matrix.md is required in post-merge mode",
-                }
-            )
-    else:
-        issue_matrix_present = "not_applicable"
-
-    # ==================================================================
-    # Mission exception check
-    # ==================================================================
-    mission_exception_path = feature_dir / "mission-exception.md"
-    if review_mode is MissionReviewMode.POST_MERGE:
-        mission_exception_present: bool | Literal["not_applicable"] = mission_exception_path.exists()
-    else:
-        mission_exception_present = "not_applicable"
-
-    # ==================================================================
-    # Step 4 — Write report (Gate 4)
-    # ==================================================================
     write_review_report(
         feature_dir,
         repo_root,
@@ -313,15 +332,7 @@ def review_mission(
         issue_matrix_present=issue_matrix_present,
         mission_exception_present=mission_exception_present,
     )
-    gates_recorded.append(
-        GateRecord(
-            id="gate_4",
-            name="report_writer",
-            command="spec-kitty review (internal gate 4)",
-            exit_code=0,
-            result="pass",
-        )
-    )
+    _record_gate(gates_recorded, gate_id="gate_4", name="report_writer", result="pass")
 
 
 __all__ = [

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -250,6 +250,77 @@ def test_review_exits_2_when_mission_is_empty(tmp_path: Path, monkeypatch: pytes
     assert result.exit_code == 2, result.output
 
 
+def test_review_post_merge_requires_issue_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-merge mode must fail when issue-matrix.md is missing."""
+    repo_root, feature_dir = _setup_fixture(
+        tmp_path,
+        {"WP01": "done"},
+        baseline_merge_commit="0000000000000000000000000000000000000000",
+    )
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.assert_pytest_available",
+        lambda _: None,
+    )
+    _mock_resolved = _make_mock_resolved(feature_dir)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.resolve_mission_handle",
+        lambda handle, repo_root: _mock_resolved,
+    )
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "post-merge"])
+
+    assert result.exit_code == 0, result.output
+
+    report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
+    assert "verdict: pass_with_notes" in report_text
+    assert "ISSUE_MATRIX_MISSING" in result.output
+    assert "issue_matrix_present: false" in report_text
+
+
+def test_review_emits_json_diagnostic_when_pytest_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing test extra should fail before selector resolution and print JSON."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+
+    from specify_cli.cli.commands.review import TestExtraMissing
+
+    def _raise_missing(_: Path) -> None:
+        raise TestExtraMissing("MISSION_REVIEW_TEST_EXTRA_MISSING")
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.assert_pytest_available",
+        _raise_missing,
+    )
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG])
+
+    assert result.exit_code == 1, result.output
+    assert '"diagnostic_code": "MISSION_REVIEW_TEST_EXTRA_MISSING"' in result.output
+    assert "uv sync --extra test" in result.output
+
+
 # ---------------------------------------------------------------------------
 # Internal helper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- reduce Sonar duplicate-literal debt in `specify_cli.acceptance`
- split `review_mission()` into helpers to lower cognitive complexity without changing behavior
- add focused review-command coverage for post-merge issue-matrix notes and missing test-extra diagnostics

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra test pytest tests/specify_cli/cli/commands/test_review.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra test pytest tests/specify_cli/cli/commands/test_review.py tests/specify_cli/test_acceptance_regressions.py tests/cross_cutting/misc/test_acceptance_support.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra lint ruff check src/specify_cli/acceptance/__init__.py src/specify_cli/cli/commands/review/__init__.py tests/specify_cli/cli/commands/test_review.py`

## Security / Sonar notes
- GitHub code-scanning alerts: none open
- GitHub Dependabot alerts: none open
- SonarCloud `main` still fails on `new_coverage` and four low-probability localhost/loopback `S5332` hotspots currently in `TO_REVIEW`
- Those hotspot items are review-state findings on intentional local HTTP callback/dashboard flows, so they need SonarCloud UI review (or a broader product change), not just more code edits in this PR
