### PR TITLE
Clarify unsafe target branch merge guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,14 @@ Different agents use different argument placeholders:
 
 `main` has a **Protect Main Branch** CI workflow that fails on any direct push. This is intentional branch-protection policy enforcement, not a code bug.
 
-- `spec-kitty merge` pushes directly to `main` by design. The "Protect Main Branch" failure this causes is **expected and known** — do not attempt to fix it.
+- `spec-kitty merge` may push directly to `main` by design when the local target branch is clean and intentionally ready to publish. The "Protect Main Branch" failure this causes is **expected and known** — do not attempt to fix it as a code-health failure.
+- If `spec-kitty merge` blocks because local `main` is ahead of or diverged from `origin/main`, do **not** advise `git push origin main` just to satisfy the preflight. First inspect both commit history and changed paths:
+  ```bash
+  git log --oneline --left-right --cherry-pick main...origin/main
+  git diff --name-only origin/main...main
+  ```
+- If the ahead commits include Spec Kitty orchestration history, agent state commits, worktree bookkeeping, unrelated missions, or any other change outside the deliverable, use the focused PR branch path from the merge preflight instead of pushing `main`.
+- Only recommend pushing `main` after verifying every ahead commit belongs on `main` now and the human explicitly wants direct-main delivery.
 - The only CI result relevant to code health is **CI Quality**. If that passes, the commit is clean.
 - Do not create extra PRs, force-push, or revert commits to address the Protect Main Branch failure.
 

--- a/docs/how-to/troubleshoot-merge.md
+++ b/docs/how-to/troubleshoot-merge.md
@@ -232,21 +232,36 @@ Pre-flight failed. Fix these issues before merging:
 spec-kitty agent action implement WP03
 ```
 
-### Target Branch Behind Origin
+### Target Branch Not Synchronized With Origin
 
 ```
-Pre-flight failed. Fix these issues before merging:
-  1. main is 3 commit(s) behind origin. Run: git checkout main && git pull
+Error: Target branch is not synchronized with its tracking branch.
+  diagnostic_code: TARGET_BRANCH_NOT_SYNCHRONIZED
+  branch_or_work_package: main
+  violated_invariant: local_target_branch_must_match_tracking_branch
 ```
 
-**Fix**: Update your local main branch:
+`spec-kitty merge` stops before mutating merge state when the target branch is ahead of, behind, or diverged from its tracking branch.
+
+First inspect the branch state:
 
 ```bash
-git checkout main
-git pull
+git fetch origin main
+git log --oneline --left-right --cherry-pick main...origin/main
+git diff --name-only origin/main...main
 ```
 
-Then retry the merge from any checkout where the mission resolves correctly.
+If local `main` is **ahead** or **diverged**, do not push it just to satisfy the preflight. Ahead commits may include Spec Kitty orchestration history, agent state commits, worktree bookkeeping, unrelated missions, or other local-only work. Use the focused PR path from the diagnostic unless you verified every ahead commit belongs on `main` now:
+
+```bash
+git switch -c kitty/pr/<mission-slug>-to-main kitty/mission-<mission-slug>
+git push -u origin kitty/pr/<mission-slug>-to-main
+gh pr create --base main --head kitty/pr/<mission-slug>-to-main
+```
+
+Only direct-push `main` after reviewing both commits and changed paths, and only when the human explicitly wants those commits published.
+
+If local `main` is only **behind**, update it from the tracking branch after reviewing remote-only commits, then retry the merge from any checkout where the mission resolves correctly.
 
 ### Branch Does Not Exist
 
@@ -276,7 +291,8 @@ spec-kitty implement WP02
 | `Target repository at <path> has uncommitted changes.` | Repository root checkout has uncommitted work | Commit or stash in the repository root checkout |
 | `Missing worktree for WP##. Expected at <path>. Run: spec-kitty agent action implement WP##` | The resolved execution workspace for that WP does not exist yet | Run `spec-kitty agent action implement WP##` |
 | `Branch <branch> does not exist` | Git branch was deleted manually | Recreate worktree with `spec-kitty implement WP##` |
-| `<branch> is N commit(s) behind origin. Run: git checkout <branch> && git pull` | Target branch diverged from origin | Run the suggested git checkout and pull commands |
+| `TARGET_BRANCH_NOT_SYNCHRONIZED` | Target branch is ahead of, behind, or diverged from its tracking branch | Inspect commits and paths; use the focused PR path for ahead/diverged local target branches unless every ahead commit is intentionally ready for `main` |
+| `<branch> is N commit(s) behind origin. Run: git checkout <branch> && git pull` | Legacy target branch staleness diagnostic | Review remote-only commits, then update the local target branch |
 | `Warning: Could not fast-forward <branch>.` | Fast-forward failed, conflicts likely | Resolve conflicts manually |
 | `Merge failed. Resolve conflicts and try again.` | Git merge conflict occurred in a multi-workspace mission | Resolve conflicts, then `spec-kitty merge --resume` |
 | `Merge failed. You may need to resolve conflicts.` | Git merge conflict occurred (legacy merge) | Resolve conflicts, then re-run merge |

--- a/src/specify_cli/merge/preflight.py
+++ b/src/specify_cli/merge/preflight.py
@@ -215,7 +215,35 @@ def target_branch_sync_remediation(
             "Inspect differences: "
             f"git log --oneline --left-right --cherry-pick {status.target_branch}...{tracking_branch}"
         ),
+        (
+            "Inspect changed paths: "
+            f"git diff --name-only {tracking_branch}...{status.target_branch}"
+        ),
     ]
+
+    if status.state in {"ahead", "diverged"}:
+        lines.extend(
+            [
+                (
+                    "Recommended: use the focused PR path unless you verified every ahead "
+                    f"commit belongs on '{status.target_branch}' now."
+                ),
+                (
+                    f"Do not run 'git push origin {status.target_branch}' just to satisfy "
+                    "this preflight; local target commits may include orchestration history "
+                    "or unrelated missions."
+                ),
+                (
+                    f"Only direct-push '{status.target_branch}' after reviewing the ahead "
+                    "commits and changed paths."
+                ),
+            ]
+        )
+    elif status.state == "behind":
+        lines.append(
+            f"Recommended: update local '{status.target_branch}' from '{tracking_branch}' "
+            "after reviewing remote-only commits; do not push the local target branch."
+        )
 
     if mission_slug:
         focused_branch = focused_pr_branch_name(mission_slug, status.target_branch)

--- a/tests/merge/test_target_branch_preflight.py
+++ b/tests/merge/test_target_branch_preflight.py
@@ -201,6 +201,10 @@ def test_merge_preflight_blocks_unsafe_target_with_non_destructive_guidance(
     )
     assert any("git fetch origin main" in line for line in remediation)
     assert any("git log --oneline --left-right" in line for line in remediation)
+    assert any("git diff --name-only origin/main...main" in line for line in remediation)
+    assert any("Recommended: use the focused PR path" in line for line in remediation)
+    assert any("Do not run 'git push origin main'" in line for line in remediation)
+    assert any("Only direct-push 'main' after reviewing" in line for line in remediation)
     assert any("git switch -c kitty/pr/release-320-workflow-reliability-01KQKV85-to-main" in line for line in remediation)
     assert all("reset" not in line.lower() or "do not use" in line.lower() for line in remediation)
     assert focused_pr_branch_name("release-320-workflow-reliability-01KQKV85", "main") in "\n".join(remediation)
@@ -240,6 +244,28 @@ def test_merge_preflight_fetches_before_detecting_remote_main_behind(
     refreshed_status = inspect_target_branch_sync(repo, "main")
     assert refreshed_status.state == "behind"
     assert refreshed_status.behind_count == 1
+
+
+def test_target_branch_preflight_behind_guidance_does_not_recommend_push(
+    synced_repo: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    repo, origin = synced_repo
+    updater = _configured_clone(origin, tmp_path / "updater")
+    _commit(updater, "remote.txt", "remote only\n", "remote ahead")
+    _run(["git", "push", "origin", "main"], cwd=updater)
+    _run(["git", "fetch", "origin", "main"], cwd=repo)
+
+    status = inspect_target_branch_sync(repo, "main")
+    remediation = target_branch_sync_remediation(
+        status,
+        mission_slug="release-320-workflow-reliability-01KQKV85",
+        mission_branch="kitty/mission-release-320-workflow-reliability-01KQKV85",
+    )
+
+    assert status.state == "behind"
+    assert any("Recommended: update local 'main' from 'origin/main'" in line for line in remediation)
+    assert not any("git push origin main" in line for line in remediation)
 
 
 def test_refresh_target_branch_tracking_ref_allows_repo_without_origin(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Make target-branch sync remediation recommend the focused PR path when local target is ahead/diverged
- Warn agents not to push `main` just to satisfy the preflight without inspecting commits and changed paths
- Update agent-facing and troubleshooting docs with the branch-contamination decision rule
- Add regression assertions for safer ahead/diverged guidance and behind-only guidance

## Verification
- `uv run python -m py_compile src/specify_cli/merge/preflight.py`
- `uv run ruff check src/specify_cli/merge/preflight.py tests/merge/test_target_branch_preflight.py`
- `git diff --check`

## Note
- `uv run pytest tests/merge/test_target_branch_preflight.py -q` is currently blocked during collection in this fresh clone by `ImportError: cannot import name normalize_event_id from spec_kitty_events` before these tests execute.