### PR TITLE
Clarify accept, merge, and retrospective workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,17 @@ Then let the runtime choose the next action until the mission is ready:
 spec-kitty next --agent claude --mission <mission-slug>
 ```
 
-Review, accept, and merge:
+Review, accept, merge, and close the loop:
 
 ```text
 /spec-kitty.review
 /spec-kitty.accept
 /spec-kitty.merge --push
 ```
+
+After merge, run `/spec-kitty-mission-review`, then capture the retrospective
+with `spec-kitty retrospect summary` and
+`spec-kitty agent retrospect synthesize --mission <mission-slug>`.
 
 For the full walkthrough, see [Your First Feature](docs/tutorials/your-first-feature.md).
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,12 @@ Review, accept, merge, and close the loop:
 /spec-kitty.merge --push
 ```
 
-After merge, run `/spec-kitty-mission-review`, then capture the retrospective
-with `spec-kitty retrospect summary` and
-`spec-kitty agent retrospect synthesize --mission <mission-slug>`.
+After merge, run `/spec-kitty-mission-review`. The mission's
+`retrospective.yaml` is authored during the runtime terminus (HiC prompt or
+autonomous facilitator), not by `merge`. Once it exists, use
+`spec-kitty retrospect summary` for the cross-mission view and
+`spec-kitty agent retrospect synthesize --mission <mission-slug>` to apply any
+staged proposals (dry-run by default — pass `--apply` to mutate).
 
 For the full walkthrough, see [Your First Feature](docs/tutorials/your-first-feature.md).
 

--- a/docs/explanation/documentation-mission.md
+++ b/docs/explanation/documentation-mission.md
@@ -749,7 +749,10 @@ Agent creates:
 ```bash
 /spec-kitty.review
 /spec-kitty.accept
+/spec-kitty.merge
 ```
+
+After merge, run `/spec-kitty-mission-review` and the retrospective workflow.
 
 **Result**: Complete documentation suite ready for deployment
 

--- a/docs/explanation/git-workflow.md
+++ b/docs/explanation/git-workflow.md
@@ -68,10 +68,14 @@ Python auto-commits the WP frontmatter change to record the lane transition. Bef
 ### 4. Merged
 
 ```bash
+spec-kitty accept --mission 042-feature
 spec-kitty merge --mission 042-feature
 ```
 
-Python merges execution branches into the target branch in dependency order. In lane mode, it first merges lane branches into the mission branch, then merges the mission branch into the target branch. For each execution worktree:
+Acceptance validates that all WPs are approved or done before merge. Python
+then merges execution branches into the target branch in dependency order. In
+lane mode, it first merges lane branches into the mission branch, then merges
+the mission branch into the target branch. For each execution worktree:
 
 1. `git merge --no-ff <workspace-branch>` (preserving merge history)
 2. `git worktree remove` (cleaning up the directory)

--- a/docs/explanation/kanban-workflow.md
+++ b/docs/explanation/kanban-workflow.md
@@ -116,8 +116,10 @@ canceled   (reachable from planned, claimed, in_progress, for_review, in_review,
 **What happens**:
 - Lane branch content is ready for merge orchestration
 - No further changes expected
-- `done` is a terminal lane (force required to leave)
-- Once ALL WPs are in `done`, run `/spec-kitty.accept` to validate the entire feature
+- `approved` unblocks dependent WPs immediately
+- `done` is recorded by merge/acceptance bookkeeping after approved work lands
+- Once all WPs are `approved` or `done`, run `/spec-kitty.accept` to validate
+  the entire mission before merge
 
 #### blocked
 
@@ -230,10 +232,8 @@ Any transition not in the 27 allowed pairs can still be performed with `--force`
    spec-kitty agent tasks move-task WP01 --to approved --approval-ref PR#42
    lane: approved
 
-7. Reviewer marks done
-   spec-kitty agent tasks move-task WP01 --to done
-   lane: done
-   (Once ALL WPs are done: /spec-kitty.accept validates entire feature)
+7. Continue until every WP is approved or done
+   (Then /spec-kitty.accept validates the mission before merge)
 ```
 
 ### Review Feedback: in_review -> planned (with feedback)
@@ -439,13 +439,10 @@ spec-kitty agent tasks move-task WP01 --to in_review --assignee reviewer
 # Approve (in_review -> approved)
 spec-kitty agent tasks move-task WP01 --to approved --approval-ref PR#42
 
-# Move WP to done after approval
-spec-kitty agent tasks move-task WP01 --to done
-
 # Request changes with feedback file (in_review -> planned)
 spec-kitty agent tasks move-task WP01 --to planned --review-feedback-file feedback.md
 
-# Once ALL WPs are done, validate entire feature
+# Once ALL WPs are approved or done, validate the mission before merge
 /spec-kitty.accept
 ```
 

--- a/docs/explanation/mission-system.md
+++ b/docs/explanation/mission-system.md
@@ -142,8 +142,8 @@ discovery --> specify --> plan --> tasks_outline --> tasks_packages --> tasks_fi
 |---|---|
 | specify --> plan | `spec.md` must exist |
 | plan --> implement | `plan.md` and `tasks.md` must exist |
-| implement --> review | All WPs must be in "done" lane |
-| review --> done | Review must be approved |
+| implement --> review | All WPs must be `approved` or `done` |
+| review --> accept | Review must be approved |
 
 **Agent context:** TDD practices, library-first architecture, tests before code.
 
@@ -307,7 +307,7 @@ Guards are conditions that must be satisfied before a mission can advance to its
 | Guard | What it checks | Example |
 |---|---|---|
 | Artifact exists | A required file is present | Can't start planning until `spec.md` exists |
-| All WPs done | Every work package reached "done" lane | Can't start review until all WPs are complete |
+| All WPs approved/done | Every work package passed review or is already landed | Can't start acceptance until all WPs are review-approved |
 | Gate passed | A named event was recorded | Can't finish until review is approved |
 | Source count | Minimum number of evidence sources | Can't synthesize until at least 3 sources documented (research) |
 

--- a/docs/explanation/runtime-loop.md
+++ b/docs/explanation/runtime-loop.md
@@ -130,7 +130,9 @@ Something is preventing the mission from advancing. The `reason` field explains 
 
 All work is done. There are no more steps to execute.
 
-**What to do:** Run `/spec-kitty.accept` for final validation, then report completion.
+**What to do:** Run `/spec-kitty.accept` for final validation. If it passes,
+run `/spec-kitty.merge`, then run `/spec-kitty-mission-review` and the
+retrospective workflow.
 
 ## The Agent Loop Pattern
 
@@ -183,7 +185,10 @@ If `--result` is omitted, the command stays in read-only query mode. Query mode 
 
 When `spec-kitty next` is called on a mission where all WPs are done but no prior runtime state exists, the runtime may create a new run starting from the beginning of the mission instead of recognizing that the mission is already complete. It will return `kind: "step"` even though there is nothing left to do.
 
-**Workaround:** Always check the `progress` field in the response. If `progress.done_wps` equals `progress.total_wps` and `total_wps` is greater than zero, treat the mission as complete regardless of the reported `kind`. Run `/spec-kitty.accept` to finalize.
+**Workaround:** Always check the `progress` field in the response. If
+approved/done WPs account for `progress.total_wps`, treat the mission as ready
+for acceptance regardless of the reported `kind`. Run `/spec-kitty.accept`;
+if it passes, merge and continue to mission-review plus retrospective.
 
 ### Some steps may return a null prompt file (#336)
 

--- a/docs/explanation/spec-driven-development.md
+++ b/docs/explanation/spec-driven-development.md
@@ -82,7 +82,8 @@ This becomes critical in parallel development where multiple AI agents implement
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
 │  /spec-kitty.review          →   Check implementation vs spec   │
-│  /spec-kitty.accept          →   Approve and merge              │
+│  /spec-kitty.accept          →   Validate readiness before merge │
+│  /spec-kitty.merge           →   Land accepted mission           │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/how-to/accept-and-merge.md
+++ b/docs/how-to/accept-and-merge.md
@@ -4,10 +4,14 @@ Use this guide to validate feature readiness and merge to the mission's target b
 
 ## Prerequisites
 
-- All WPs are in `lane: "done"`
+- All WPs are `approved` or `done`, with review feedback resolved
 - You are in a checkout where the feature can be resolved (repository root checkout or execution workspace)
 
 ## Accept the Feature
+
+Run acceptance after the implement-review loop approves every WP and before
+merge. This is a readiness nudge for humans and LLMs; merge still performs its
+own gates and remains the mission-close operation.
 
 In your agent:
 
@@ -23,7 +27,7 @@ spec-kitty accept
 
 ### What Accept Checks
 
-- All WPs are in `done`
+- All WPs are `approved` or `done`
 - Required metadata and activity logs are present
 - No unresolved `[NEEDS CLARIFICATION]` markers remain
 
@@ -50,6 +54,16 @@ spec-kitty merge --push
 By default, `spec-kitty merge` lands in the mission's recorded target branch. Use `spec-kitty merge --target <branch>` only when you intentionally need to override that destination.
 
 For detailed merge options including dry-run, strategies, and cleanup flags, see [Merge a Feature](merge-feature.md).
+
+## After Merge
+
+Run the post-merge mission review (`/spec-kitty-mission-review` in your agent),
+then run the retrospective while context is fresh:
+
+```bash
+spec-kitty retrospect summary
+spec-kitty agent retrospect synthesize --mission <slug>
+```
 
 ## Merge Strategies
 

--- a/docs/how-to/accept-and-merge.md
+++ b/docs/how-to/accept-and-merge.md
@@ -57,13 +57,24 @@ For detailed merge options including dry-run, strategies, and cleanup flags, see
 
 ## After Merge
 
-Run the post-merge mission review (`/spec-kitty-mission-review` in your agent),
-then run the retrospective while context is fresh:
+Run the post-merge mission review (`/spec-kitty-mission-review` in your agent).
+The mission's `retrospective.yaml` is captured earlier, during the runtime
+terminus — `spec-kitty next` runs the facilitator (HiC prompt in human-in-the-
+loop mode, mandatory in autonomous mode). Post-merge, while context is fresh,
+review what was captured and apply any staged proposals:
 
 ```bash
+# Cross-mission view of captured retrospectives
 spec-kitty retrospect summary
+
+# Apply staged proposals from the authored retrospective.yaml
+# (dry-run by default; pass --apply to mutate)
 spec-kitty agent retrospect synthesize --mission <slug>
 ```
+
+If `retrospective.yaml` does not exist for the mission, it was never captured —
+see [How to Use the Retrospective Learning Loop](use-retrospective-learning.md)
+for how the facilitator runs at terminus.
 
 ## Merge Strategies
 

--- a/docs/how-to/merge-feature.md
+++ b/docs/how-to/merge-feature.md
@@ -277,12 +277,14 @@ For detailed troubleshooting including conflict resolution and error recovery, s
 
 ## After Merge
 
-Run `/spec-kitty-mission-review` in your agent, then run the retrospective
-workflow before context decays:
+Run `/spec-kitty-mission-review` in your agent. The mission's
+`retrospective.yaml` is authored earlier at the runtime terminus, not by
+`merge`. Before context decays, review what was captured and apply any staged
+proposals:
 
 ```bash
-spec-kitty retrospect summary
-spec-kitty agent retrospect synthesize --mission <slug>
+spec-kitty retrospect summary                       # cross-mission view
+spec-kitty agent retrospect synthesize --mission <slug>  # dry-run; --apply to mutate
 ```
 
 ---

--- a/docs/how-to/merge-feature.md
+++ b/docs/how-to/merge-feature.md
@@ -4,7 +4,7 @@ Use this guide to merge completed work packages from a Spec Kitty mission into i
 
 ## Prerequisites
 
-- All WPs have been reviewed and marked `lane: "done"` in their prompt files
+- All WPs have been reviewed and are `approved` or `done`
 - All resolved execution worktrees have no uncommitted changes
 - You have run `/spec-kitty.accept` to validate the mission is ready
 
@@ -274,6 +274,16 @@ spec-kitty merge --abort
 This removes the merge state file and lets you start fresh.
 
 For detailed troubleshooting including conflict resolution and error recovery, see [Accept and Merge](accept-and-merge.md#troubleshooting).
+
+## After Merge
+
+Run `/spec-kitty-mission-review` in your agent, then run the retrospective
+workflow before context decays:
+
+```bash
+spec-kitty retrospect summary
+spec-kitty agent retrospect synthesize --mission <slug>
+```
 
 ---
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -24,14 +24,14 @@ Terminology note:
 
 **Commands**:
 - `init` - Initialize a new Spec Kitty project from templates
-- `accept` - Validate mission readiness before merging to main
+- `accept` - Validate an approved mission before merge
 - `config` - Display project configuration and asset resolution information
 - `dashboard` - Open or stop the Spec Kitty dashboard
 - `implement` - Create workspace for work package implementation
 - `specify` - Create a mission scaffold in kitty-specs/
 - `plan` - Scaffold plan.md for a mission
 - `tasks` - Finalize tasks metadata after task generation
-- `merge` - Merge a completed mission branch into the target branch and clean up resources
+- `merge` - Merge an accepted mission branch into the target branch and clean up resources
 - `migrate` - Migrate project .kittify/ to centralized model
 - `next` - Decide and emit the next agent action for the current mission
 - `research` - Execute Phase 0 research workflow to scaffold artifacts
@@ -163,7 +163,8 @@ spec-kitty implement WP01 --json
 
 **Synopsis**: `spec-kitty accept [OPTIONS]`
 
-**Description**: Validate mission readiness before merging to main.
+**Description**: Validate mission readiness after all WPs are approved and
+before running `spec-kitty merge`.
 
 **Options**:
 
@@ -269,7 +270,7 @@ spec-kitty merge --abort    # clear saved state and abort any in-progress git me
 - `start-review` - Move rejected WP from `for_review` back to `in_progress`
 - `transition` - Apply explicit lane transition with state-machine validation
 - `append-history` - Append activity history to a WP prompt
-- `accept-mission` - Accept a mission when all WPs are `done`
+- `accept-mission` - Accept a mission when all WPs are `approved` or `done`
 - `merge-mission` - Run preflight and land the mission into the target branch
 
 **See Also**: [Orchestrator API Reference](orchestrator-api.md)

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -170,9 +170,10 @@ Syntax format in this reference:
 **What it does**:
 - Executes `spec-kitty merge` with selected strategy and cleanup flags.
 - Optionally pushes to origin and deletes worktrees/branches.
-- After merge, run `/spec-kitty-mission-review`, then run the retrospective
-  workflow (`spec-kitty retrospect summary` and
-  `spec-kitty agent retrospect synthesize --mission <slug>`).
+- After merge, run `/spec-kitty-mission-review`, then review the retrospective
+  captured at the runtime terminus: `spec-kitty retrospect summary` and
+  `spec-kitty agent retrospect synthesize --mission <slug>` (dry-run by
+  default; add `--apply` to mutate).
 
 **Creates/updates**:
 - Merges mission branch into target branch.

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -141,7 +141,8 @@ Syntax format in this reference:
 
 **Prerequisites**:
 - Run from any checkout or branch where mission auto-detection works.
-- All WPs should be in `done` or intentionally waived.
+- All WPs should be `approved` or `done`, with review feedback resolved.
+- Run this after the implement-review loop and before `/spec-kitty.merge`.
 
 **What it does**:
 - Auto-detects mission slug and validation commands when possible.
@@ -169,6 +170,9 @@ Syntax format in this reference:
 **What it does**:
 - Executes `spec-kitty merge` with selected strategy and cleanup flags.
 - Optionally pushes to origin and deletes worktrees/branches.
+- After merge, run `/spec-kitty-mission-review`, then run the retrospective
+  workflow (`spec-kitty retrospect summary` and
+  `spec-kitty agent retrospect synthesize --mission <slug>`).
 
 **Creates/updates**:
 - Merges mission branch into target branch.

--- a/docs/reference/supported-agents.md
+++ b/docs/reference/supported-agents.md
@@ -324,8 +324,8 @@ All agents support the same 13 slash commands:
 | `/spec-kitty.tasks` | Generate work packages |
 | `/spec-kitty.implement` | Start WP implementation |
 | `/spec-kitty.review` | Review completed work |
-| `/spec-kitty.accept` | Accept feature for merge |
-| `/spec-kitty.merge` | Merge feature to main |
+| `/spec-kitty.accept` | Validate an approved mission before merge |
+| `/spec-kitty.merge` | Merge an accepted mission to its target branch |
 | `/spec-kitty.status` | Show kanban status |
 | `/spec-kitty.dashboard` | Open web dashboard |
 | `/spec-kitty.charter` | Create project principles |

--- a/docs/tutorials/claude-code-integration.md
+++ b/docs/tutorials/claude-code-integration.md
@@ -144,17 +144,22 @@ Spec Kitty enforces a specific sequence that prevents common AI coding failures:
 
 ### Phase 5: Accept BEFORE Merging
 
-**Why**: Final quality gate prevents half-baked features reaching main branch.
+**Why**: Final readiness checks catch mission-level gaps before merge.
 
 ```bash
 /spec-kitty.accept
-# Validates: All tasks done? Spec requirements met? Tests passing?
+# Validates: All WPs approved or done? Spec requirements met? Tests passing?
 
 /spec-kitty.merge --push
 # Merges to main, copies specs to kitty-specs/, cleans up worktree
 ```
 
-**Why This Matters**: Git main branch stays clean. Every feature that lands has: spec + plan + completed tasks + acceptance validation.
+After merge, run `/spec-kitty-mission-review`, then run
+`spec-kitty retrospect summary` and
+`spec-kitty agent retrospect synthesize --mission <slug>`.
+
+**Why This Matters**: Git main branch stays clean. Every feature that lands has:
+spec + plan + approved WPs + acceptance validation + post-merge learning.
 
 ---
 
@@ -471,8 +476,8 @@ spec-kitty dashboard         # Restart
 | `/spec-kitty.tasks` | After plan done | Break down → create work packages |
 | `/spec-kitty.implement` | Ready to code | Auto-pick task → implement → move lanes |
 | `/spec-kitty.review` | Code review time | Review completed work → approve or reject |
-| `/spec-kitty.accept` | Feature complete | Validate all tasks done → ready to merge |
-| `/spec-kitty.merge` | Ready to ship | Merge to mission target branch → cleanup worktree |
+| `/spec-kitty.accept` | WPs approved | Validate mission readiness → ready to merge |
+| `/spec-kitty.merge` | Accepted mission | Merge to mission target branch → cleanup worktree |
 
 ### CLI Commands (Outside Claude)
 
@@ -540,7 +545,7 @@ Encode your team's quality standards once:
 
 4. **Review before merging**
    - `/spec-kitty.accept` is your quality gate
-   - Better to catch issues before main branch
+   - Run `/spec-kitty-mission-review` and the retrospective after merge
 
 ### ❌ DON'T
 

--- a/docs/tutorials/claude-code-integration.md
+++ b/docs/tutorials/claude-code-integration.md
@@ -154,9 +154,11 @@ Spec Kitty enforces a specific sequence that prevents common AI coding failures:
 # Merges to main, copies specs to kitty-specs/, cleans up worktree
 ```
 
-After merge, run `/spec-kitty-mission-review`, then run
-`spec-kitty retrospect summary` and
-`spec-kitty agent retrospect synthesize --mission <slug>`.
+After merge, run `/spec-kitty-mission-review`, then review the retrospective
+captured at the runtime terminus: `spec-kitty retrospect summary`
+(cross-mission view) and
+`spec-kitty agent retrospect synthesize --mission <slug>` to apply staged
+proposals (dry-run by default; add `--apply` to mutate).
 
 **Why This Matters**: Git main branch stays clean. Every feature that lands has:
 spec + plan + approved WPs + acceptance validation + post-merge learning.

--- a/docs/tutorials/claude-code-workflow.md
+++ b/docs/tutorials/claude-code-workflow.md
@@ -22,7 +22,7 @@ Anthropic’s **Claude Code** pairs naturally with Spec Kitty’s guardrails. Th
 | Planning | Generate architecture briefs via Claude | `/spec-kitty.plan` |
 | Tasks | Produce work packages and prompts that Claude can execute | `/spec-kitty.tasks` |
 | Implementation | Run Claude on specific prompt files | `/spec-kitty.implement` |
-| Review & Merge | Summarize results and follow-up tasks, then land the branch | `/spec-kitty.review`, `/spec-kitty.merge` |
+| Review & Merge | Review, accept readiness, then land the branch | `/spec-kitty.review`, `/spec-kitty.accept`, `/spec-kitty.merge` |
 
 ## Setup Checklist
 
@@ -85,13 +85,16 @@ Claude will use the template metadata to understand scope, file boundaries, and 
 
 Once Claude (and any partner agents) finish the feature:
 
-1. Ensure all WPs have `lane: done` in their frontmatter and all checklists are complete.
+1. Ensure all WPs are `approved` or `done` and all review feedback is resolved.
 2. Run the guided merge:
  ```bash
+  spec-kitty accept
   spec-kitty merge --remove-worktree
   ```
    Run it from any checkout where the mission can be resolved; the CLI automatically performs the Git steps from the main checkout so execution workspaces stay in sync.
    The command documents merge steps, updates activity logs, and optionally removes the execution worktrees to keep the repository tidy.
+3. Run `/spec-kitty-mission-review`, then run `spec-kitty retrospect summary`
+   and `spec-kitty agent retrospect synthesize --mission <slug>`.
 
 ## Beyond Claude
 

--- a/docs/tutorials/claude-code-workflow.md
+++ b/docs/tutorials/claude-code-workflow.md
@@ -93,8 +93,10 @@ Once Claude (and any partner agents) finish the feature:
   ```
    Run it from any checkout where the mission can be resolved; the CLI automatically performs the Git steps from the main checkout so execution workspaces stay in sync.
    The command documents merge steps, updates activity logs, and optionally removes the execution worktrees to keep the repository tidy.
-3. Run `/spec-kitty-mission-review`, then run `spec-kitty retrospect summary`
-   and `spec-kitty agent retrospect synthesize --mission <slug>`.
+3. Run `/spec-kitty-mission-review`, then review the retrospective captured at
+   the runtime terminus: `spec-kitty retrospect summary` (cross-mission view)
+   and `spec-kitty agent retrospect synthesize --mission <slug>` (dry-run by
+   default; add `--apply` to mutate).
 
 ## Beyond Claude
 

--- a/docs/tutorials/your-first-feature.md
+++ b/docs/tutorials/your-first-feature.md
@@ -134,11 +134,12 @@ spec-kitty merge
 You should see the feature merged into the mission's target branch and the worktrees cleaned up.
 
 Before you move on, run the post-merge mission review
-(`/spec-kitty-mission-review` in your agent), then run the retrospective:
+(`/spec-kitty-mission-review` in your agent), then review the retrospective
+captured at the runtime terminus:
 
 ```bash
-spec-kitty retrospect summary
-spec-kitty agent retrospect synthesize --mission <slug>
+spec-kitty retrospect summary                       # cross-mission view
+spec-kitty agent retrospect synthesize --mission <slug>  # dry-run; --apply to mutate
 ```
 
 ## Troubleshooting

--- a/docs/tutorials/your-first-feature.md
+++ b/docs/tutorials/your-first-feature.md
@@ -133,6 +133,14 @@ spec-kitty merge
 
 You should see the feature merged into the mission's target branch and the worktrees cleaned up.
 
+Before you move on, run the post-merge mission review
+(`/spec-kitty-mission-review` in your agent), then run the retrospective:
+
+```bash
+spec-kitty retrospect summary
+spec-kitty agent retrospect synthesize --mission <slug>
+```
+
 ## Troubleshooting
 
 - **"Planning created a worktree"**: Planning stays in the repository root checkout in `3.1.x`. If you see an unexpected planning worktree, upgrade with `spec-kitty upgrade`.

--- a/src/doctrine/skills/spec-kitty-git-workflow/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-git-workflow/SKILL.md
@@ -110,6 +110,10 @@ one would create excessive git noise.
 
 ### 5. Merge Execution
 
+Run `spec-kitty accept --mission 042-mission` before merge once every WP is
+approved. Acceptance is a readiness nudge and artifact check; merge still owns
+the final mission-close transition.
+
 `spec-kitty merge --mission 042-mission` runs the full merge sequence:
 
 ```
@@ -223,6 +227,7 @@ Per-command override: `--no-auto-commit` flag on `spec-kitty implement`.
    → reviewer checks the diff
 
 4. MERGED
+   spec-kitty accept --mission 042-mission
    spec-kitty merge --mission 042-mission
    → git merge --no-ff kitty/mission-042-mission-lane-a
    → git worktree remove .worktrees/042-mission-lane-a --force

--- a/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
@@ -95,8 +95,9 @@ After review rejection (WP moves back to `planned` with `review_status: has_feed
 planned --> [workflow implement] --> in_progress --> [agent fixes] --> for_review --> [review] --> approved or planned
 ```
 
-After ALL WPs are approved: `spec-kitty merge --mission <slug>` merges
-everything and moves WPs to `done`.
+After ALL WPs are approved: run `spec-kitty accept --mission <slug>` first as
+the mission-readiness nudge. If acceptance passes, run
+`spec-kitty merge --mission <slug>` to merge everything and move WPs to `done`.
 
 **`approved` unblocks dependents immediately.** Do NOT wait for `done` before
 starting dependent WPs. The `done` lane is only reached via feature merge.
@@ -552,13 +553,14 @@ decisions between status checks.
 When each WP depends on the previous:
 
 ```
-WP01 (approved) --> WP02 (approved) --> WP03 (approved) --> merge --> all done
+WP01 (approved) --> WP02 (approved) --> WP03 (approved) --> accept --> merge --> all done
 ```
 
 1. Implement WP01, review, approve
 2. THEN implement WP02, review, approve. The implementation workspace base is inferred automatically from the approved dependency graph.
 3. THEN implement WP03, review, approve. The implementation workspace base is inferred automatically from the approved dependency graph.
-4. `spec-kitty merge --mission <slug>`
+4. `spec-kitty accept --mission <slug>`
+5. `spec-kitty merge --mission <slug>`
 
 ### Parallel Opportunities (Independent WPs)
 
@@ -621,16 +623,27 @@ spec-kitty agent tasks status --mission <slug>
 # If rejected: commit feedback, re-implement (cycle tracking)
 # If 3 rejections: arbiter mode
 
-# 6. After all WPs approved: merge
+# 6. After all WPs approved: accept, then merge
+spec-kitty accept --mission <slug>
 spec-kitty merge --mission <slug>
 ```
 
 ---
 
-## Step 6: Merge All Lanes
+## Step 6: Accept and Merge All Lanes
 
-After all WPs are approved, merge the lanes into the mission branch, then
-merge the mission branch into the mission's target branch.
+After all WPs are approved, run acceptance from the repository root checkout.
+Acceptance is a pre-merge readiness check and artifact nudge for humans and
+LLMs; it does not replace review approval and it does not close the mission.
+
+```bash
+# From the repository root checkout (NOT from a worktree)
+spec-kitty accept --mission <mission-slug>
+```
+
+If acceptance reports blockers, resolve them and rerun acceptance before
+merge. If it passes, merge the lanes into the mission branch, then merge the
+mission branch into the mission's target branch.
 
 ### Run the Merge Command
 
@@ -732,9 +745,11 @@ done
 5. **Track rejection cycles** (max 3) in commit messages
 6. **The orchestrator does not implement** -- it dispatches and monitors
 7. **`approved` unblocks dependents** -- do not wait for `done`
-8. **Never manually move WPs to `done`** -- that happens during feature merge
-9. **For Tier 3 agents**: orchestrator runs `move-task` on the agent's behalf
-10. **Parallel reviews are safe** -- each WP operates in its own worktree
+8. **Run `spec-kitty accept --mission <slug>` before merge** -- it is a
+   readiness nudge, not a replacement for WP review or merge gates
+9. **Never manually move WPs to `done`** -- that happens during feature merge
+10. **For Tier 3 agents**: orchestrator runs `move-task` on the agent's behalf
+11. **Parallel reviews are safe** -- each WP operates in its own worktree
 
 ---
 

--- a/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
@@ -36,7 +36,11 @@ do not fix anything. You document.
 - Before tagging a release that depends on this mission's changes
 - When a downstream team needs a sign-off on spec→code fidelity
 - When you suspect a WP review was too narrow and cross-WP holes exist
-- As the "accept" gate in a mission lifecycle
+
+This is not the pre-merge acceptance gate. Run `spec-kitty accept --mission
+<slug>` before merge; use this skill after merge for final spec-to-code review.
+After this mission review, remind the operator to run the retrospective while
+the work is still fresh.
 
 ---
 
@@ -762,6 +766,13 @@ specific findings that block release.]
 
 [List findings that are not blocking release but should be addressed in a
 follow-up mission.]
+
+## Retrospective Reminder
+
+Run the retrospective workflow now, before context decays:
+
+- `spec-kitty retrospect summary`
+- `spec-kitty agent retrospect synthesize --mission <slug>`
 ```
 
 ---
@@ -811,3 +822,9 @@ follow-up mission.]
    `spec-kitty-runtime-review`, which defers to the CLI-generated prompt as
    the source of truth, this skill produces original analysis. The spec and
    contracts are the source of truth.
+
+10. **Always include the retrospective reminder.** The report must end with a
+    `## Retrospective Reminder` section that tells the human or LLM operator to
+    run `spec-kitty retrospect summary` and
+    `spec-kitty agent retrospect synthesize --mission <slug>` after the
+    post-merge mission review.

--- a/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
@@ -39,8 +39,9 @@ do not fix anything. You document.
 
 This is not the pre-merge acceptance gate. Run `spec-kitty accept --mission
 <slug>` before merge; use this skill after merge for final spec-to-code review.
-After this mission review, remind the operator to run the retrospective while
-the work is still fresh.
+After this mission review, remind the operator to review the retrospective
+that was captured at terminus (`spec-kitty retrospect summary` /
+`spec-kitty agent retrospect synthesize`) while the work is still fresh.
 
 ---
 
@@ -769,10 +770,17 @@ follow-up mission.]
 
 ## Retrospective Reminder
 
-Run the retrospective workflow now, before context decays:
+The mission's `retrospective.yaml` is authored at the runtime terminus (HiC
+prompt or autonomous facilitator), not after merge. Before context decays,
+review the captured retrospective and apply any staged proposals:
 
-- `spec-kitty retrospect summary`
-- `spec-kitty agent retrospect synthesize --mission <slug>`
+- `spec-kitty retrospect summary` — cross-mission view (read-only)
+- `spec-kitty agent retrospect synthesize --mission <slug>` — apply staged
+  proposals from the authored `retrospective.yaml` (dry-run by default;
+  add `--apply` to mutate)
+
+If the record does not exist, escalate — the terminus facilitator either did
+not run or was skipped without a recorded reason.
 ```
 
 ---
@@ -824,7 +832,9 @@ Run the retrospective workflow now, before context decays:
    contracts are the source of truth.
 
 10. **Always include the retrospective reminder.** The report must end with a
-    `## Retrospective Reminder` section that tells the human or LLM operator to
-    run `spec-kitty retrospect summary` and
-    `spec-kitty agent retrospect synthesize --mission <slug>` after the
-    post-merge mission review.
+    `## Retrospective Reminder` section that tells the operator the
+    `retrospective.yaml` was authored at the runtime terminus, and that
+    `spec-kitty retrospect summary` plus
+    `spec-kitty agent retrospect synthesize --mission <slug>` review the
+    captured record and apply staged proposals (dry-run by default). If the
+    record is missing, escalate rather than proceed.

--- a/src/doctrine/skills/spec-kitty-mission-system/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-system/SKILL.md
@@ -98,8 +98,8 @@ discovery → specify → plan → tasks_outline → tasks_packages → tasks_fi
 **Guards:**
 - `specify → plan`: `spec.md` must exist
 - `plan → implement`: `plan.md` and `tasks.md` must exist
-- `implement → review`: all WPs must be done
-- `review → done`: review must be approved
+- `implement → review`: all WPs must be `approved` or `done`
+- `review → accept`: review must be approved
 
 **Agent context:** TDD practices, library-first architecture, tests before code.
 
@@ -449,7 +449,7 @@ Missions involve two orthogonal state machines:
 
 **Mission-type state** — which phase of the workflow are we in?
 ```
-discovery → specify → plan → tasks → implement → review → accept
+discovery → specify → plan → tasks → implement → review → accept → merge
 ```
 Managed by `mission-runtime.yaml` DAG and `spec-kitty next`.
 

--- a/src/doctrine/skills/spec-kitty-orchestrator-api-operator/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-orchestrator-api-operator/SKILL.md
@@ -123,7 +123,7 @@ returns `POLICY_VALIDATION_FAILED`.
 | `WP_ALREADY_CLAIMED` | Another actor owns the WP |
 | `POLICY_METADATA_REQUIRED` | Policy missing on run-affecting lane |
 | `POLICY_VALIDATION_FAILED` | Policy JSON invalid or contains secrets |
-| `MISSION_NOT_READY` | Not all WPs in done lane |
+| `MISSION_NOT_READY` | Not all WPs approved or done |
 | `PREFLIGHT_FAILED` | Worktree dirty, target diverged, or missing WPs |
 | `UNSUPPORTED_STRATEGY` | Merge strategy not in {merge, squash, rebase} |
 
@@ -276,7 +276,7 @@ This is the guard condition for the `for_review → in_progress` transition.
 spec-kitty orchestrator-api append-history \
   --mission <slug> --wp WP01 --actor "ci-bot" --note "Tests passed"
 
-# Accept mission (validates all WPs in done lane via dependency graph)
+# Accept mission (validates all WPs are approved or done via dependency graph)
 spec-kitty orchestrator-api accept-mission --mission <slug> --actor "ci-bot"
 
 # Merge mission
@@ -285,7 +285,7 @@ spec-kitty orchestrator-api merge-mission \
 ```
 
 `accept-mission` returns `MISSION_NOT_READY` if any WP from the dependency
-graph is not in `done`.
+graph is not `approved` or `done`.
 
 `merge-mission` runs **4 preflight checks** before merging:
 1. All expected WPs have worktrees

--- a/src/doctrine/skills/spec-kitty-orchestrator-api-operator/references/orchestrator-api-contract.md
+++ b/src/doctrine/skills/spec-kitty-orchestrator-api-operator/references/orchestrator-api-contract.md
@@ -332,8 +332,8 @@ spec-kitty orchestrator-api accept-mission --mission TEXT --actor TEXT
 
 **Usage notes:**
 
-- Always call `mission-state` first to verify all WPs are done
-- This is a guard-protected operation; it will reject if any WP is not done
+- Always call `mission-state` first to verify every WP is in `approved` or `done`
+- This is a guard-protected operation; it will reject if any WP is not `approved` or `done`
 
 
 ---

--- a/src/doctrine/skills/spec-kitty-orchestrator-api-operator/references/orchestrator-api-contract.md
+++ b/src/doctrine/skills/spec-kitty-orchestrator-api-operator/references/orchestrator-api-contract.md
@@ -305,7 +305,7 @@ spec-kitty orchestrator-api append-history \
 
 ## 8. accept-mission
 
-Mark a mission as accepted. All work packages must be in the `done` lane.
+Mark a mission as accepted. All work packages must be `approved` or `done`.
 
 ```bash
 spec-kitty orchestrator-api accept-mission --mission TEXT --actor TEXT
@@ -328,7 +328,7 @@ spec-kitty orchestrator-api accept-mission --mission TEXT --actor TEXT
 
 | Code | Cause |
 |------|-------|
-| `MISSION_NOT_READY` | One or more WPs are not in the `done` lane |
+| `MISSION_NOT_READY` | One or more WPs are not `approved` or `done` |
 
 **Usage notes:**
 
@@ -380,7 +380,7 @@ spec-kitty orchestrator-api merge-mission \
 |------------|----------|-------------|
 | `CONTRACT_VERSION_MISMATCH` | contract-version | Provider version too old |
 | `MISSION_NOT_FOUND` | mission-state, list-ready | Unknown mission slug |
-| `MISSION_NOT_READY` | accept-mission | Not all WPs are done |
+| `MISSION_NOT_READY` | accept-mission | Not all WPs are approved or done |
 | `POLICY_METADATA_REQUIRED` | start-implementation, start-review, transition | Missing or incomplete policy JSON |
 | `TRANSITION_REJECTED` | start-implementation, start-review, transition | Guard failure or invalid transition |
 | `WP_ALREADY_CLAIMED` | start-implementation, start-review | Another actor owns the WP |
@@ -422,7 +422,7 @@ spec-kitty orchestrator-api transition \
   --mission 017-my-mission --wp WP01 --to done --actor "reviewer-bot" \
   --force --note "Approved in PR #42"
 
-# 9. When all WPs are done, accept and merge
+# 9. When all WPs are approved or done, accept and merge
 spec-kitty orchestrator-api accept-mission --mission 017-my-mission --actor "ci-bot"
 spec-kitty orchestrator-api merge-mission --mission 017-my-mission --strategy squash --push
 ```

--- a/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
@@ -211,12 +211,17 @@ races on external side effects).
 
 ### 2i. Phase 8 — Retrospective
 
-After mission review, run the retrospective workflow every time:
+The mission's `retrospective.yaml` is captured earlier at the runtime
+terminus. After mission review, review what was captured and apply staged
+proposals every time:
 
 ```bash
-spec-kitty retrospect summary
-spec-kitty agent retrospect synthesize --mission <slug>
+spec-kitty retrospect summary                       # cross-mission view
+spec-kitty agent retrospect synthesize --mission <slug>  # dry-run; --apply to mutate
 ```
+
+If `retrospective.yaml` is missing for the mission, escalate — the terminus
+facilitator either did not run or was skipped without a recorded reason.
 
 ### 2j. Phase 9 — Post-Merge Remediation
 

--- a/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
@@ -89,16 +89,17 @@ gated on the prior phase producing a clean artifact.
 2. /spec-kitty.plan                    → plan.md + research.md + data-model.md + contracts/ + quickstart.md
 3. /spec-kitty.tasks                   → tasks.md + tasks/WPxx-*.md + finalize-tasks
 4. Implement-review loop               (dispatch sub-agents per spec-kitty-implement-review)
-5. spec-kitty merge                    → squash commit on main
+5. spec-kitty accept + merge           → readiness nudge, then squash commit on main
 6. Post-merge mark-status done         (handle invariant-check workarounds)
 7. spec-kitty-mission-review skill     → structured report with verdict
-8. Post-merge remediation branch       (address any HIGH/MEDIUM findings)
+8. Retrospective workflow              → capture learning while context is fresh
+9. Post-merge remediation branch       (address any HIGH/MEDIUM findings)
 ```
 
 Phase 0 is where user decisions are required for non-autonomous repos.
 Phases 1–3 can be delegated to a single sub-agent per repo for autonomous
 repos; keep them in the foreground when you need architectural judgment.
-Phases 4–8 run via sub-agent dispatch once the phase-3 task contract is
+Phases 4–9 run via sub-agent dispatch once the phase-3 task contract is
 finalized.
 
 ---
@@ -177,14 +178,15 @@ Use `spec-kitty-implement-review` as your loop engine. Per-WP pattern:
 4. On `rejected`, read the review cycle file, dispatch a focused
    remediation agent with the exact blocker list, then re-review.
 
-### 2f. Phase 5 — Merge
+### 2f. Phase 5 — Accept and Merge
 
-Run `spec-kitty merge --mission <slug>`. Expect potential stale-lane
-errors when many WPs touched overlapping files. The rebase pattern is:
-`cd .worktrees/<slug>-lane-<letter> && git merge kitty/mission-<slug>`,
-resolve conflicts (usually union-merge on TOML/imports/comments),
-commit, retry the outer merge. See issue #771 for planned auto-rebase
-support.
+Run `spec-kitty accept --mission <slug>` after all WPs are approved. Treat it
+as a pre-merge readiness nudge for the orchestrator and the human operator.
+If it passes, run `spec-kitty merge --mission <slug>`. Expect potential
+stale-lane errors when many WPs touched overlapping files. The rebase pattern
+is: `cd .worktrees/<slug>-lane-<letter> && git merge kitty/mission-<slug>`,
+resolve conflicts (usually union-merge on TOML/imports/comments), commit, retry
+the outer merge. See issue #771 for planned auto-rebase support.
 
 ### 2g. Phase 6 — Mark WPs Done (workaround for the invariant check)
 
@@ -207,7 +209,16 @@ review reliably catches real bugs that slipped past per-WP review
 (FR-to-test coverage gaps, dead code, API whitelist misses, TOCTOU
 races on external side effects).
 
-### 2i. Phase 8 — Post-Merge Remediation
+### 2i. Phase 8 — Retrospective
+
+After mission review, run the retrospective workflow every time:
+
+```bash
+spec-kitty retrospect summary
+spec-kitty agent retrospect synthesize --mission <slug>
+```
+
+### 2j. Phase 9 — Post-Merge Remediation
 
 If the mission review verdict is `PASS WITH NOTES` with any HIGH or
 MEDIUM findings, dispatch a remediation sub-agent to fix them on a

--- a/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
@@ -117,7 +117,7 @@ Every call to `spec-kitty next` returns exactly one decision kind:
 | `step` | Normal action available | Read `prompt_file` and execute |
 | `decision_required` | Runtime needs input | Answer with `--answer` and `--decision-id` |
 | `blocked` | Guards failing, cannot proceed | Read `reason` + `guard_failures`, resolve blockers |
-| `terminal` | Mission complete | Run `/spec-kitty.accept`, exit loop |
+| `terminal` | Mission complete | Run `/spec-kitty.accept`; if it passes, merge and continue to mission review + retrospective |
 
 ### Decision Output Fields
 
@@ -369,7 +369,7 @@ See `references/runtime-result-taxonomy.md` for the complete taxonomy.
 | `step` | Read and execute `prompt_file` (always non-empty and resolvable on disk) |
 | `decision_required` | Answer with `--answer` and `--decision-id` |
 | `blocked` | Read `reason` + `guard_failures`, resolve blockers |
-| `terminal` | Run `/spec-kitty.accept` for final validation |
+| `terminal` | Run `/spec-kitty.accept` for final validation, then merge if acceptance passes |
 
 **Always check `guard_failures`** — this field may appear on any decision kind,
 not just `blocked`.
@@ -386,7 +386,9 @@ should never observe a `kind="step"` decision with `prompt_file == null`.
 **Always check `progress` for completion.** If `progress.done_wps` equals
 `progress.total_wps` but `kind` is not `terminal`, the mission is actually
 complete (known issue #335). The runtime may not detect completion when no
-prior run state exists. Treat this as terminal and run `/spec-kitty.accept`.
+prior run state exists. Treat this as terminal and run `/spec-kitty.accept`;
+if acceptance passes, run `/spec-kitty.merge`, then run mission review and the
+retrospective workflow.
 
 ---
 
@@ -471,7 +473,11 @@ done
 
 # 3. Handle terminal state
 if [ "$KIND" = "terminal" ] || [ "$DONE" -eq "$TOTAL" ]; then
-  # Run /spec-kitty.accept
+  # Run /spec-kitty.accept.
+  # If acceptance passes, run /spec-kitty.merge.
+  # After merge, run /spec-kitty-mission-review and:
+  #   spec-kitty retrospect summary
+  #   spec-kitty agent retrospect synthesize --mission 042-mission
 fi
 ```
 

--- a/src/doctrine/skills/spec-kitty-runtime-next/references/blocked-state-recovery.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/references/blocked-state-recovery.md
@@ -86,14 +86,15 @@ The dependency graph has a cycle. This should have been caught by `finalize-task
 2. Break the cycle by removing one dependency that is not strictly required
 3. Re-run `spec-kitty agent mission finalize-tasks` to validate
 
-## Pattern 6: All WPs Done But Mission Not Complete
+## Pattern 6: All WPs Approved/Done But Mission Not Complete
 
-**Symptom:** All WPs are in `done` lane but `spec-kitty next` does not return `kind: "terminal"`.
+**Symptom:** All WPs are `approved` or `done`, but `spec-kitty next` does not
+return `kind: "terminal"`.
 
 **Diagnosis:**
 The mission state machine may require additional steps beyond WP completion (e.g., acceptance validation, merge).
 
 **Recovery:**
 1. Run `/spec-kitty.accept` to check acceptance criteria
-2. If acceptance passes: run `/spec-kitty.merge` to complete the mission
+2. If acceptance passes: run `/spec-kitty.merge` to close the mission
 3. If acceptance fails: create additional WPs to address gaps

--- a/src/doctrine/skills/spec-kitty-runtime-next/references/runtime-result-taxonomy.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/references/runtime-result-taxonomy.md
@@ -63,7 +63,9 @@ The mission has reached its final state. The agent loop should exit.
 - `reason`: Explanation of terminal state (e.g., "all work packages complete")
 - `progress`: Final WP progress summary
 
-**Agent response:** Run `/spec-kitty.accept` for final validation. Report completion to the user.
+**Agent response:** Run `/spec-kitty.accept` for final validation. If it
+passes, run `/spec-kitty.merge`, then run `/spec-kitty-mission-review` and the
+retrospective workflow.
 
 ## Progress Field
 

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -708,21 +708,21 @@ def _build_acceptance_instructions(
         else:
             instructions.extend([
                 f"Review the acceptance commit on branch `{branch}`.",
-                f"Push your branch: `git push origin {branch}`",
-                "Open a pull request referencing spec/plan/tasks artifacts.",
-                "Include acceptance summary and test evidence in the PR description.",
+                f"Run the mission merge when ready: `spec-kitty merge --mission {summary.feature}`",
+                "After merge, run /spec-kitty-mission-review and the retrospective workflow.",
             ])
     elif mode == "local":
         if is_integration_branch:
             instructions.append(f"Acceptance recorded directly on `{branch}`. No merge needed.")
         else:
             instructions.extend([
-                "Switch to your integration branch (e.g., `git checkout main`).",
-                "Synchronize it (e.g., `git pull --ff-only`).",
-                f"Merge the feature: `git merge {branch}`",
+                f"Acceptance passed. Run the mission merge: `spec-kitty merge --mission {summary.feature}`",
+                "After merge, run /spec-kitty-mission-review and the retrospective workflow.",
             ])
     else:  # checklist
-        instructions.append("All checks passed. Proceed with your manual acceptance workflow.")
+        instructions.append(
+            f"All checks passed. Recommended next step: `spec-kitty merge --mission {summary.feature}`."
+        )
 
     if summary.worktree_root != summary.primary_repo_root:
         cleanup_instructions.append(f"After merging, remove the worktree: `git worktree remove {summary.worktree_root}`")

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -902,6 +902,7 @@ def init(  # noqa: C901
     steps_lines.append("   - [cyan]/spec-kitty.review[/]    - Review prompts and move them to /tasks/done/")
     steps_lines.append("   - [cyan]/spec-kitty.accept[/]    - Run acceptance checks and verify mission complete")
     steps_lines.append("   - [cyan]/spec-kitty.merge[/]     - Merge mission into target branch and cleanup worktree")
+    steps_lines.append("   - [cyan]spec-kitty retrospect summary[/] - Review retrospective status after merge")
     step_num += 1
 
     # T003: Canonical post-#555 agent loop path

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1779,8 +1779,16 @@ def merge(
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
 
-    # -- Post-merge: Suggest mission review --
-    console.print("\n[cyan]Next:[/cyan] Run [bold]/spec-kitty-mission-review[/bold] to audit the merged mission for spec→code fidelity, drift, risks, and security.")
+    # -- Post-merge: Suggest mission review and retrospective --
+    console.print(
+        "\n[cyan]Next:[/cyan] Run [bold]/spec-kitty-mission-review[/bold] "
+        "to audit the merged mission for spec→code fidelity, drift, risks, and security."
+    )
+    console.print(
+        "[cyan]Then:[/cyan] Run [bold]spec-kitty retrospect summary[/bold] and "
+        f"[bold]spec-kitty agent retrospect synthesize --mission {resolved_feature}[/bold] "
+        "while context is fresh."
+    )
 
 
 __all__ = [

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1779,15 +1779,22 @@ def merge(
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
 
-    # -- Post-merge: Suggest mission review and retrospective --
+    # -- Post-merge: Suggest mission review and retrospective review/synthesis --
+    # The mission's retrospective.yaml is captured earlier at the runtime
+    # terminus (HiC prompt or autonomous facilitator), not by merge. The two
+    # commands below operate on an already-authored record: `summary` is a
+    # cross-mission view; `synthesize` applies any staged proposals (dry-run
+    # by default — pass `--apply` to mutate). They do not create content.
     console.print(
         "\n[cyan]Next:[/cyan] Run [bold]/spec-kitty-mission-review[/bold] "
         "to audit the merged mission for spec→code fidelity, drift, risks, and security."
     )
     console.print(
-        "[cyan]Then:[/cyan] Run [bold]spec-kitty retrospect summary[/bold] and "
-        f"[bold]spec-kitty agent retrospect synthesize --mission {resolved_feature}[/bold] "
-        "while context is fresh."
+        "[cyan]Then, while context is fresh, review the retrospective that was"
+        " captured at terminus:[/cyan]\n"
+        "  [bold]spec-kitty retrospect summary[/bold] — cross-mission view\n"
+        f"  [bold]spec-kitty agent retrospect synthesize --mission {resolved_feature}[/bold]"
+        " — apply staged proposals (dry-run; add --apply to mutate)"
     )
 
 

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -11,7 +11,7 @@ Error codes used:
   WP_NOT_FOUND                -- WP ID does not exist in the mission
   TRANSITION_REJECTED         -- transition not allowed by state machine
   WP_ALREADY_CLAIMED          -- WP claimed by a different actor
-  MISSION_NOT_READY           -- not all WPs done (for accept-mission)
+  MISSION_NOT_READY           -- not all WPs approved/done (for accept-mission)
   PREFLIGHT_FAILED            -- preflight checks failed (for merge-mission)
   CONTRACT_VERSION_MISMATCH   -- provider version is below MIN_PROVIDER_VERSION
   UNSUPPORTED_STRATEGY        -- merge strategy not implemented
@@ -957,7 +957,7 @@ def accept_mission(
     mission: str = typer.Option(..., "--mission", help=_HELP_MISSION_SLUG),
     actor: str = typer.Option(..., "--actor", help=_HELP_ACTOR),
 ) -> None:
-    """Accept a mission after all WPs are done."""
+    """Accept a mission after all WPs are approved or done."""
     cmd = "accept-mission"
 
     main_repo_root = _get_main_repo_root()
@@ -972,9 +972,14 @@ def accept_mission(
     snapshot = materialize(mission_dir)
     dep_graph = build_dependency_graph(mission_dir)
 
-    # Check all WPs (from dep_graph) are done — include WPs with no events (implicitly planned)
+    # Check all WPs (from dep_graph) are approved/done; WPs with no events are implicitly planned.
     all_wp_ids = set(dep_graph.keys()) | set(snapshot.work_packages.keys())
-    incomplete = [wp_id for wp_id in sorted(all_wp_ids) if wp_state_for(snapshot.work_packages.get(wp_id, {}).get("lane", Lane.PLANNED)).lane != Lane.DONE]
+    incomplete = [
+        wp_id
+        for wp_id in sorted(all_wp_ids)
+        if wp_state_for(snapshot.work_packages.get(wp_id, {}).get("lane", Lane.PLANNED)).lane
+        not in {Lane.APPROVED, Lane.DONE}
+    ]
     if incomplete:
         _fail(
             cmd,

--- a/src/specify_cli/shims/generator.py
+++ b/src/specify_cli/shims/generator.py
@@ -32,8 +32,8 @@ from specify_cli.shims.registry import CLI_DRIVEN_COMMANDS
 SHIM_DESCRIPTIONS: dict[str, str] = {
     "implement": "Execute a work package implementation",
     "review": "Review a work package implementation",
-    "accept": "Accept a completed mission",
-    "merge": "Merge a completed mission",
+    "accept": "Validate an approved mission before merge",
+    "merge": "Merge an accepted mission",
     "status": "Show mission and work package status",
     "dashboard": "Open the mission dashboard",
     "tasks-finalize": "Finalize a mission's work packages",

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -364,24 +364,31 @@ class TestSyncNowExitCodes:
 
     @pytest.fixture(autouse=True)
     def _stub_teamspace_gate(self, monkeypatch):
-        """Bypass the M7 ``enforce_teamspace_mission_state_ready`` gate.
+        """Bypass the M7 ``enforce_teamspace_mission_state_ready`` gate and
+        the FR-002 sync-now structural preflight.
 
-        The gate audits the local project root before any sync work, and the
-        spec-kitty checkout's own ``.kittify/`` surfaces TeamSpace blockers
-        that raise ``typer.Exit(1)`` before exit-code semantics can be
-        observed. Tests here exercise the post-gate contract, so the gate is
-        stubbed to a no-op at the call-site in ``sync.py``.
+        Both gates audit the local project root before any sync work. In the
+        spec-kitty checkout the gates surface TeamSpace / daemon-owner
+        blockers that raise ``typer.Exit(1)`` or ``typer.Exit(2)`` before the
+        sync exit-code semantics under test can be observed. Tests here
+        exercise the post-gate contract, so both gates are stubbed at the
+        call-site in ``sync.py``.
 
         Mirrors the per-test pattern introduced in commit 80f71fe14
         (``test_strict_exits_0_on_success``) and lifted here so every
         exit-code test in this class is shielded.
         """
         import specify_cli.cli.commands.sync as sync_mod
+        from specify_cli.sync.preflight import PreflightResult
 
         monkeypatch.setattr(
             sync_mod,
             "enforce_teamspace_mission_state_ready",
             lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "specify_cli.sync.preflight.run_preflight",
+            lambda **kwargs: PreflightResult(ok=True, auth_present=True),
         )
 
     def _make_service(self, queue_size: int, result: MagicMock) -> MagicMock:

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -923,6 +923,24 @@ requirement_refs:
 class TestSetupPlanCommand:
     """Tests for setup-plan command."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_git_preflight(self, monkeypatch, tmp_path):
+        """Bypass ``run_git_preflight`` for setup-plan tests.
+
+        The git preflight runs against the repo root before any setup-plan
+        logic. In CI the patched ``locate_project_root`` returns a tmp_path
+        with no git repo, so the real preflight fails and raises
+        ``typer.Exit(2)`` before the inner error paths under test can run.
+        Tests that specifically assert preflight failures patch
+        ``run_git_preflight`` themselves and override this stub.
+        """
+        from specify_cli.core.git_preflight import GitPreflightResult
+
+        monkeypatch.setattr(
+            "specify_cli.cli.commands.agent.mission.run_git_preflight",
+            lambda *args, **kwargs: GitPreflightResult(repo_root=tmp_path),
+        )
+
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.cli.commands.agent.mission._find_feature_directory")
     @patch("specify_cli.cli.commands.agent.mission._show_branch_context", return_value=(None, "main"))

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -127,6 +127,41 @@ def _emit_planned_to_done(mission_dir: Path, mission_slug: str, wp_id: str, acto
     ))
 
 
+def _emit_planned_to_approved(
+    mission_dir: Path,
+    mission_slug: str,
+    wp_id: str,
+    actor: str = "test",
+) -> None:
+    """Transition a WP to approved."""
+    from specify_cli.status.emit import emit_status_transition
+    from specify_cli.status.models import ReviewResult
+
+    emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id=wp_id, to_lane="claimed", actor=actor))
+    emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id=wp_id, to_lane="in_progress", actor=actor))
+    emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id=wp_id, to_lane="for_review", actor=actor))
+    emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id=wp_id, to_lane="in_review", actor=actor))
+    emit_status_transition(TransitionRequest(
+        feature_dir=mission_dir,
+        mission_slug=mission_slug,
+        wp_id=wp_id,
+        to_lane="approved",
+        actor=actor,
+        evidence={
+            "review": {
+                "reviewer": "reviewer-agent",
+                "verdict": "approved",
+                "reference": "review-001",
+            }
+        },
+        review_result=ReviewResult(
+            reviewer="reviewer-agent",
+            verdict="approved",
+            reference="review-001",
+        ),
+    ))
+
+
 # ── contract-version ──────────────────────────────────────────────
 
 
@@ -792,6 +827,33 @@ class TestAcceptMission:
         meta = json.loads((mission_dir / "meta.json").read_text())
         assert "accepted_at" in meta
         assert meta["accepted_by"] == "claude"
+
+    def test_all_approved_accepted(self, tmp_path):
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+
+        _emit_planned_to_approved(mission_dir, mission_slug, "WP01")
+        _emit_planned_to_approved(mission_dir, mission_slug, "WP02")
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "accept-mission",
+                    "--mission",
+                    mission_slug,
+                    "--actor",
+                    "claude",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["accepted"] is True
 
     def test_incomplete_wps_returns_error(self, tmp_path):
         repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -281,14 +281,14 @@ class TestIntegrationBranchGuard:
         )
 
     def test_feature_branch_still_gets_merge_guidance(self, tmp_path: Path) -> None:
-        """A real feature branch must still get full merge + cleanup guidance."""
+        """A real feature branch must still get spec-kitty merge + cleanup guidance."""
         summary = self._make_summary_on_branch(
             tmp_path, "kitty/mission-054-my-feature-lane-a", target_branch="main"
         )
         result = perform_acceptance(summary, mode="local", actor="tester", auto_commit=False)
 
         merged = " ".join(result.instructions + result.cleanup_instructions)
-        assert "git merge kitty/mission-054-my-feature-lane-a" in merged, (
+        assert "spec-kitty merge --mission" in merged, (
             f"Feature branch should get merge guidance. instructions={result.instructions}"
         )
         assert "git branch -d kitty/mission-054-my-feature-lane-a" in merged, (


### PR DESCRIPTION
## Summary
- Align accept/merge docs and skills around the modern lifecycle: approved WPs -> accept readiness check -> merge closes mission -> mission review -> retrospective.
- Strengthen implement-review, mission-review, runtime-next, and program orchestration reminders for accept and retrospectives.
- Update orchestrator-api accept-mission to accept approved or done WPs, matching top-level acceptance behavior, with regression coverage.

## Validation
- git diff --check
- uv run python -m compileall -q src/specify_cli/orchestrator_api/commands.py src/specify_cli/acceptance/__init__.py src/specify_cli/cli/commands/merge.py src/specify_cli/cli/commands/init.py src/specify_cli/shims/generator.py tests/agent/test_orchestrator_commands_integration.py tests/specify_cli/test_acceptance_regressions.py

## Known test blocker
- Focused pytest collection is currently blocked by the resolved spec_kitty_events 5.1.0 package lacking top-level normalize_event_id, causing import failure in src/specify_cli/status/validate.py before tests collect.