### PR TITLE
Fix partial command install self-healing

### DIFF
--- a/src/specify_cli/runtime/agent_commands.py
+++ b/src/specify_cli/runtime/agent_commands.py
@@ -18,6 +18,7 @@ for the design rationale.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 from pathlib import Path
@@ -30,6 +31,8 @@ logger = logging.getLogger(__name__)
 _VERSION_FILENAME = "agent-commands.lock"
 _LOCK_FILENAME = ".agent-commands.lock"
 _MISSION_NAME = "software-dev"
+_VERSION_MARKER_PREFIX = "<!-- spec-kitty-command-version:"
+_VERSION_MARKER_HEAD_LINES = 20
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +116,77 @@ def _compute_output_filename(command: str, agent_key: str) -> str:
     if ext:
         return f"spec-kitty.{stem}.{ext}"
     return f"spec-kitty.{stem}"
+
+
+def _expected_command_filenames(agent_key: str, templates_dir: Path) -> set[str]:
+    """Return the complete managed command filename set for *agent_key*.
+
+    The prompt-driven half is only valid when its backing template is present.
+    Missing templates therefore make the health check fail instead of allowing a
+    partial command install to be stamped as current.
+    """
+    from specify_cli.shims.registry import CLI_DRIVEN_COMMANDS, PROMPT_DRIVEN_COMMANDS
+
+    template_commands = {
+        template_path.stem
+        for template_path in templates_dir.glob("*.md")
+        if template_path.is_file()
+    }
+    if not template_commands >= PROMPT_DRIVEN_COMMANDS:
+        return set()
+
+    return {
+        _compute_output_filename(command, agent_key)
+        for command in sorted(PROMPT_DRIVEN_COMMANDS | CLI_DRIVEN_COMMANDS)
+    }
+
+
+def _file_has_current_version_marker(path: Path, cli_version: str) -> bool:
+    """Return True when *path* has this CLI version's managed marker."""
+    expected = f"{_VERSION_MARKER_PREFIX} {cli_version} -->"
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+    return any(
+        line.strip() == expected
+        for line in content.splitlines()[:_VERSION_MARKER_HEAD_LINES]
+    )
+
+
+def _agent_commands_healthy(agent_key: str, templates_dir: Path, cli_version: str) -> bool:
+    """Return True when one agent's global command directory is complete."""
+    expected = _expected_command_filenames(agent_key, templates_dir)
+    if not expected:
+        return False
+
+    output_dir = get_global_command_dir(agent_key)
+    if not output_dir.is_dir():
+        return False
+
+    existing = {
+        path.name
+        for path in output_dir.iterdir()
+        if path.is_file() and path.name.startswith("spec-kitty.")
+    }
+    if existing != expected:
+        return False
+
+    return all(
+        _file_has_current_version_marker(output_dir / filename, cli_version)
+        for filename in expected
+    )
+
+
+def _all_global_agent_commands_healthy(templates_dir: Path, cli_version: str) -> bool:
+    """Return True when every command-layer agent has a complete command set."""
+    from specify_cli.core.config import AGENT_COMMAND_CONFIG
+
+    return all(
+        _agent_commands_healthy(agent_key, templates_dir, cli_version)
+        for agent_key in AGENT_COMMAND_CONFIG
+    )
 
 
 def _sync_agent_commands(agent_key: str, templates_dir: Path, script_type: str) -> None:
@@ -229,7 +303,11 @@ def ensure_global_agent_commands() -> None:
 
     version_file = cache_dir / _VERSION_FILENAME
     cli_version = _get_cli_version()
-    if version_file.exists() and version_file.read_text().strip() == cli_version:
+    if (
+        version_file.exists()
+        and version_file.read_text().strip() == cli_version
+        and _all_global_agent_commands_healthy(templates_dir, cli_version)
+    ):
         return
 
     lock_path = cache_dir / _LOCK_FILENAME
@@ -237,7 +315,11 @@ def ensure_global_agent_commands() -> None:
     try:
         _lock_exclusive(lock_fd)
         # Re-check after acquiring lock (another process may have finished).
-        if version_file.exists() and version_file.read_text().strip() == cli_version:
+        if (
+            version_file.exists()
+            and version_file.read_text().strip() == cli_version
+            and _all_global_agent_commands_healthy(templates_dir, cli_version)
+        ):
             return
 
         from specify_cli.core.config import AGENT_COMMAND_CONFIG
@@ -253,8 +335,12 @@ def ensure_global_agent_commands() -> None:
                     exc_info=True,
                 )
 
-        # Write version last — an incomplete run leaves no version file,
-        # so the next invocation will retry the full sync.
-        version_file.write_text(cli_version)
+        # Write version last, and only after validating the complete managed
+        # command surface.  A partial install must not poison the fast path.
+        if _all_global_agent_commands_healthy(templates_dir, cli_version):
+            version_file.write_text(cli_version)
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                version_file.unlink()
     finally:
         lock_fd.close()

--- a/src/specify_cli/skills/command_installer.py
+++ b/src/specify_cli/skills/command_installer.py
@@ -298,19 +298,21 @@ def install(repo_root: Path, agent_key: str) -> InstallReport:
         existing = manifest.find(rel_path)
 
         if existing is not None:
-            # Drift check: on-disk hash must match the manifest record.
+            # Drift check: if the file exists, its hash must match the
+            # manifest record. A missing managed file is a repairable gap.
+            file_exists = abs_path.exists()
             on_disk_hash = (
                 manifest_store.fingerprint_file(abs_path)
-                if abs_path.exists()
+                if file_exists
                 else None
             )
-            if on_disk_hash != existing.content_hash:
+            if file_exists and on_disk_hash != existing.content_hash:
                 raise InstallerError("unexpected_collision", path=rel_path)
 
             # Compute the hash we *would* write.
             would_write_hash = manifest_store.fingerprint(skill_md_bytes)
 
-            if existing.content_hash == would_write_hash:
+            if file_exists and existing.content_hash == would_write_hash:
                 # Same bytes — either already claimed by this agent or shared.
                 if agent_key in existing.agents:
                     report.already_installed.append(rel_path)

--- a/tests/specify_cli/runtime/test_agent_commands_routing.py
+++ b/tests/specify_cli/runtime/test_agent_commands_routing.py
@@ -25,7 +25,11 @@ from unittest.mock import patch
 import pytest
 
 from specify_cli.core.config import AGENT_COMMAND_CONFIG
-from specify_cli.runtime.agent_commands import _sync_agent_commands, get_global_command_dir
+from specify_cli.runtime.agent_commands import (
+    _sync_agent_commands,
+    ensure_global_agent_commands,
+    get_global_command_dir,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -123,3 +127,88 @@ def test_opencode_global_commands_respect_custom_config_dir(tmp_path: Path, monk
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
 
     assert get_global_command_dir("opencode") == tmp_path / "custom-opencode" / "commands"
+
+
+def test_current_version_lock_does_not_mask_partial_global_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A current lock file is not proof that every command file exists."""
+    home = tmp_path / "home"
+    kittify_home = tmp_path / "kittify"
+    claude_commands = home / ".claude" / "commands"
+    claude_commands.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(kittify_home))
+    monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    from specify_cli.runtime.agent_commands import _get_cli_version
+
+    cli_version = _get_cli_version()
+    cache_dir = kittify_home / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "agent-commands.lock").write_text(cli_version, encoding="utf-8")
+
+    for command in (
+        "accept",
+        "dashboard",
+        "implement",
+        "merge",
+        "review",
+        "status",
+        "tasks-finalize",
+    ):
+        (claude_commands / f"spec-kitty.{command}.md").write_text(
+            "---\n"
+            f"description: {command}\n"
+            "---\n"
+            f"<!-- spec-kitty-command-version: {cli_version} -->\n",
+            encoding="utf-8",
+        )
+
+    ensure_global_agent_commands()
+
+    actual = sorted(path.name for path in claude_commands.glob("spec-kitty.*.md"))
+    assert actual == [
+        "spec-kitty.accept.md",
+        "spec-kitty.analyze.md",
+        "spec-kitty.charter.md",
+        "spec-kitty.dashboard.md",
+        "spec-kitty.implement.md",
+        "spec-kitty.merge.md",
+        "spec-kitty.plan.md",
+        "spec-kitty.research.md",
+        "spec-kitty.review.md",
+        "spec-kitty.specify.md",
+        "spec-kitty.status.md",
+        "spec-kitty.tasks-finalize.md",
+        "spec-kitty.tasks-outline.md",
+        "spec-kitty.tasks-packages.md",
+        "spec-kitty.tasks.md",
+    ]
+    assert (cache_dir / "agent-commands.lock").read_text(encoding="utf-8") == cli_version
+
+
+def test_partial_global_command_sync_does_not_write_current_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If templates are incomplete, retry on the next CLI invocation."""
+    home = tmp_path / "home"
+    kittify_home = tmp_path / "kittify"
+    templates_dir = tmp_path / "templates" / "software-dev" / "command-templates"
+    templates_dir.mkdir(parents=True)
+    (templates_dir / "specify.md").write_text(
+        "---\ndescription: Specify\n---\n\n# Specify\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(kittify_home))
+    monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(tmp_path / "templates"))
+    monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    ensure_global_agent_commands()
+
+    assert not (kittify_home / "cache" / "agent-commands.lock").exists()

--- a/tests/specify_cli/skills/test_command_installer.py
+++ b/tests/specify_cli/skills/test_command_installer.py
@@ -228,6 +228,19 @@ class TestIdempotentInstall:
                 f"File mtime changed (unexpected write) for {cmd!r}"
             )
 
+    def test_second_call_repairs_missing_manifest_entry_file(self, repo: Path) -> None:
+        install(repo, "vibe")
+        skill_path = _skill_path(repo, "tasks")
+        rel_path = ".agents/skills/spec-kitty.tasks/SKILL.md"
+        skill_path.unlink()
+
+        report = install(repo, "vibe")
+
+        assert skill_path.exists()
+        assert rel_path in report.added
+        assert rel_path not in report.already_installed
+        assert verify(repo).gaps == []
+
 
 # ---------------------------------------------------------------------------
 # Reused-shared (two agents, one set of files)


### PR DESCRIPTION
## Summary
- validate the full global command-file surface before trusting `agent-commands.lock`
- repair missing or stale global command files on the next CLI startup instead of fast-exiting on a version-only lock
- make command-skill installs repair missing managed `SKILL.md` files while still failing closed on edited-file drift

## Why
A user can end up with `~/.kittify/cache/agent-commands.lock` stamped for the current CLI version while `~/.claude/commands/` only contains the seven CLI-driven shim commands. In that state, `spec-kitty init` and `agent config status` treat the command root as OK even though prompt-driven commands like `/spec-kitty.specify`, `/spec-kitty.plan`, and `/spec-kitty.tasks` are missing.

This changes the lock from "version was seen" to "all managed command files for every command-layer agent are present and current".

## Verification
- `uv run ruff check src/specify_cli/runtime/agent_commands.py src/specify_cli/skills/command_installer.py tests/specify_cli/runtime/test_agent_commands_routing.py tests/specify_cli/skills/test_command_installer.py`
- `uv run pytest tests/specify_cli/runtime/test_agent_commands_routing.py tests/specify_cli/skills/test_command_installer.py -q`

## Local Recovery
For affected users before this ships:

```bash
rm -f ~/.kittify/cache/agent-commands.lock
SPEC_KITTY_NO_UPGRADE_CHECK=1 spec-kitty agent config status
```

Note: `spec-kitty --version` exits early and does not run the bootstrap path.
