### PR TITLE
Document spec-kitty-events namespace-package recovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,40 @@ pytest
 
 This is the most common test issue and is easy to fix. The test isolation system will detect mismatches automatically.
 
+### Troubleshooting Shared Package Import Issues
+
+If pytest fails during collection with an error like:
+
+```text
+ImportError: cannot import name 'normalize_event_id' from 'spec_kitty_events' (unknown location)
+```
+
+check whether Python is resolving `spec_kitty_events` as a namespace package:
+
+```bash
+python - <<'PY'
+import spec_kitty_events
+
+print(repr(getattr(spec_kitty_events, "__file__", None)))
+print(spec_kitty_events.__path__)
+PY
+```
+
+Healthy output points at `spec_kitty_events/__init__.py`. Broken output shows
+`None _NamespacePath(...)`, which means the local install is corrupted. Rebuild
+the project environment with:
+
+```bash
+uv sync --reinstall-package spec-kitty-events
+```
+
+If the broken package lives in a global or Homebrew Python environment, remove
+the stale `spec_kitty_events/` directory and matching `.dist-info/` metadata
+from that interpreter's `site-packages`, then reinstall
+`spec-kitty-events`. See
+[Diagnose Installation Problems](docs/how-to/diagnose-installation.md#9-shared-package-imports-resolve-as-a-namespace-package)
+for the full recovery procedure.
+
 ### How Test Isolation Works
 
 The test infrastructure guarantees that tests always use source code:
@@ -338,10 +372,12 @@ git push origin vX.Y.Z
 ```
 
 #### Version already exists on PyPI
+
 - You attempted to release a version that's already published
 - Bump to the next version number and retry
 
 #### Changelog validation fails
+
 - Ensure CHANGELOG.md has a section matching the version in pyproject.toml
 - Check the date format is `YYYY-MM-DD`
 - Verify the version number is monotonically increasing

--- a/docs/how-to/diagnose-installation.md
+++ b/docs/how-to/diagnose-installation.md
@@ -47,7 +47,7 @@ spec-kitty verify-setup --diagnostics
 
 ## Common failure patterns
 
-Below are the eight most frequent failure states, each with its symptoms,
+Below are the nine most frequent failure states, each with its symptoms,
 root cause, and recovery steps.
 
 ### 1. Missing skill root
@@ -237,6 +237,80 @@ spec-kitty agent action implement WP01 --agent <name>
 ```
 
 ---
+
+### 9. Shared package imports resolve as a namespace package
+
+**Symptoms:**
+
+- `pytest` fails during collection before any tests run.
+- The traceback contains an error like:
+
+  ```text
+  ImportError: cannot import name 'normalize_event_id' from 'spec_kitty_events' (unknown location)
+  ```
+
+- The affected package reports `__file__` as `None`:
+
+  ```bash
+  python -c 'import spec_kitty_events as e; print(repr(getattr(e, "__file__", None))); print(e.__path__)'
+  ```
+
+  Broken output looks like:
+
+  ```text
+  None _NamespacePath([.../site-packages/spec_kitty_events])
+  ```
+
+**Cause:**  Python is resolving `spec_kitty_events` as a PEP 420 implicit
+namespace package instead of a normal package. This usually means an earlier
+install was partially removed: submodule files remain on disk, but
+`spec_kitty_events/__init__.py` or the matching `.dist-info/` metadata is
+missing, stale, or mismatched. In that state, top-level re-exports such as
+`normalize_event_id` are unavailable even when the installed wheel normally
+provides them.
+
+**Recovery:**
+
+For a project virtual environment managed by `uv`, reinstall the dependency:
+
+```bash
+uv sync --reinstall-package spec-kitty-events
+```
+
+For the affected Python interpreter, remove the stale package directory and
+metadata before reinstalling:
+
+```bash
+python -m pip uninstall -y spec-kitty-events
+
+python - <<'PY'
+from pathlib import Path
+import site
+
+for root in map(Path, site.getsitepackages()):
+    for path in root.glob("spec_kitty_events*"):
+        print(path)
+PY
+```
+
+Inspect the printed paths. They should be under the affected interpreter's
+`site-packages`. Then remove the stale package directory and metadata:
+
+```bash
+rm -rf /path/to/site-packages/spec_kitty_events \
+       /path/to/site-packages/spec_kitty_events-*.dist-info
+python -m pip install --force-reinstall spec-kitty-events==5.1.0
+```
+
+Re-run the diagnostic check. Healthy output includes a real `__init__.py` path:
+
+```text
+'.../site-packages/spec_kitty_events/__init__.py' [...]
+```
+
+Do not work around this by changing Spec Kitty imports to
+`spec_kitty_events.models`. The CLI intentionally consumes the public top-level
+`spec_kitty_events` surface, and the consumer contract tests pin that surface.
 
 ## Safety warning: --remove-orphaned and shared directories
 

--- a/src/doctrine/skills/spec-kitty-setup-doctor/references/common-failure-signatures.md
+++ b/src/doctrine/skills/spec-kitty-setup-doctor/references/common-failure-signatures.md
@@ -173,3 +173,65 @@ git worktree prune
 # Re-create the worktree if needed
 spec-kitty implement WP01
 ```
+
+---
+
+## 9. Shared Package Import Resolves As Namespace Package
+
+**Symptom:** Pytest collection or CLI startup fails with:
+
+```text
+ImportError: cannot import name 'normalize_event_id' from 'spec_kitty_events' (unknown location)
+```
+
+Diagnostic command:
+
+```bash
+python - <<'PY'
+import spec_kitty_events
+
+print(repr(getattr(spec_kitty_events, "__file__", None)))
+print(spec_kitty_events.__path__)
+PY
+```
+
+Broken output shows `None _NamespacePath(...)`. Healthy output points at
+`spec_kitty_events/__init__.py`.
+
+**Cause:** The local Python environment contains a partially removed or
+mismatched `spec-kitty-events` install. Python treats the leftover
+`spec_kitty_events/` directory as a PEP 420 namespace package, so top-level
+re-exports from `__init__.py` are unavailable.
+
+**Recovery:**
+
+For the project venv:
+
+```bash
+uv sync --reinstall-package spec-kitty-events
+```
+
+For a global or Homebrew Python interpreter, remove stale package files before
+reinstalling:
+
+```bash
+python -m pip uninstall -y spec-kitty-events
+python - <<'PY'
+from pathlib import Path
+import site
+
+for root in map(Path, site.getsitepackages()):
+    for path in root.glob("spec_kitty_events*"):
+        print(path)
+PY
+```
+
+After inspecting the printed `site-packages` paths, delete the stale
+`spec_kitty_events/` directory and `spec_kitty_events-*.dist-info`, then run:
+
+```bash
+python -m pip install --force-reinstall spec-kitty-events==5.1.0
+```
+
+Do not bypass this by importing private submodules from Spec Kitty code. The
+CLI intentionally consumes the public top-level `spec_kitty_events` contract.

--- a/src/doctrine/skills/spec-kitty-setup-doctor/references/common-failure-signatures.md
+++ b/src/doctrine/skills/spec-kitty-setup-doctor/references/common-failure-signatures.md
@@ -178,7 +178,7 @@ spec-kitty implement WP01
 
 ## 9. Shared Package Import Resolves As Namespace Package
 
-**Symptom:** Pytest collection or CLI startup fails with:
+**Symptom:** Test collection or CLI startup fails with:
 
 ```text
 ImportError: cannot import name 'normalize_event_id' from 'spec_kitty_events' (unknown location)


### PR DESCRIPTION
## Summary
- document the `spec_kitty_events` namespace-package corruption signature in installation troubleshooting docs
- add contributor guidance for pytest collection failures caused by corrupted shared-package installs
- add the same failure signature to the setup-doctor skill reference so agents diagnose it correctly

Closes #1137

## Validation
- `uv run python - <<'PY' ...` confirmed `spec_kitty_events.__file__` points to `__init__.py` and `normalize_event_id` is exported in a clean venv
- `uv run pytest tests/contract/spec_kitty_events_consumer/test_consumer_contract.py::test_normalize_event_id_signature tests/agent/test_orchestrator_commands_integration.py::TestAcceptMission -q`
- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint-cli2.jsonc CONTRIBUTING.md docs/how-to/diagnose-installation.md src/doctrine/skills/spec-kitty-setup-doctor/references/common-failure-signatures.md`
- `git diff --check`