### PR TITLE
Fix e2e cross-cutting CI shard

### DIFF
--- a/src/specify_cli/mission_step_contracts/executor.py
+++ b/src/specify_cli/mission_step_contracts/executor.py
@@ -290,8 +290,8 @@ class StepContractExecutor:
             if directive_node is not None and directive_node.kind == node_kind:
                 return directive_urn
 
-        matches = [
-            node.urn
+        matches: list[str] = [
+            str(node.urn)
             for node in graph.nodes
             if node.kind == node_kind and node.urn.split(":", 1)[1] == candidate
         ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,6 +22,19 @@ from specify_cli.migration.schema_version import MAX_SUPPORTED_SCHEMA, SCHEMA_CA
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+@pytest.fixture(autouse=True)
+def _disable_saas_sync_for_e2e_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable hosted sync preflight for local workflow e2e tests.
+
+    The root conftest enables SPEC_KITTY_ENABLE_SAAS_SYNC=1 so hosted
+    sync/auth coverage stays live in the suites that intentionally exercise
+    it. The tests in this tree drive local CLI workflows in temporary
+    projects without hosted credentials, so the preflight would otherwise
+    fail before the behavior under test runs.
+    """
+    monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # Source-checkout pollution-guard helpers (T002)
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_charter_epic_golden_path.py
+++ b/tests/e2e/test_charter_epic_golden_path.py
@@ -463,10 +463,9 @@ def _run_charter_flow(project: Path, run_cli: RunCli) -> None:
       project using the default adapter, without hand-seeding
       `.kittify/doctrine/`.
 
-    All subcommands run with `SPEC_KITTY_ENABLE_SAAS_SYNC=1` because the
-    `run_cli` fixture inherits the test environment which sets
-    `SPEC_KITTY_TEST_MODE=1`; SaaS-touching paths are still exercised
-    end-to-end where applicable (see C-003).
+    All subcommands run with `SPEC_KITTY_TEST_MODE=1`; hosted sync/auth
+    behavior is covered in the dedicated SaaS and sync suites. This golden
+    path stays focused on local CLI workflow composition.
     """
     # FR-004 Step 1: charter interview (the "setup" phase — non-interactive
     # via --profile minimal --defaults). No public `charter setup`


### PR DESCRIPTION
## Summary
- disable hosted sync preflight for local e2e workflow tests, matching existing integration/tasks-suite opt-outs
- keep charter golden-path docs aligned with the local workflow scope
- tighten mission step contract URN matching to satisfy strict mypy

## Verification
- uv run python -m pytest -q tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_setup_plan tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_full_workflow_sequence tests/e2e/test_charter_epic_golden_path.py::test_charter_epic_golden_path tests/cross_cutting/test_mypy_strict_mission_step_contracts.py::test_mission_step_contracts_executor_is_mypy_strict_clean
- uv run python -m pytest -v tests/e2e/ tests/cross_cutting/ -m "not distribution and not windows_ci" --cov=src/specify_cli --cov=src/charter --cov=src/doctrine --cov-report=xml:out/reports/coverage/coverage-e2e.xml --junitxml=out/reports/xunit-reports/xunit-result-e2e-local.xml