### PR TITLE
Release 3.2.0rc14

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc13
+  version: 3.2.0rc14
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-27T19:12:06.441023'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc14] - 2026-05-19
+
+Ships the next 3.2 release candidate after the doctrine/charter and
+sync-boundary follow-up window:
+
+- Adds the three-layer doctrine and charter DRG work: org-pack loading across
+  every configured pack, project/org/built-in precedence diagnostics,
+  org-charter interview pre-fill, collision warnings, and the related
+  workflow/governance payload hardening.
+- Closes the org-pack and charter-scope safety follow-ups by blocking archive
+  traversal, unsafe server-provided filenames, symlink/hardlink extraction, and
+  scope roots that escape the repository.
+- Documents recovery from partially installed command namespace packages for
+  `spec-kitty-events`, including the concrete import error signature and
+  reinstall path.
+- Keeps local workflow test suites honest under the hosted sync preflight:
+  e2e workflow tests now opt out of `SPEC_KITTY_ENABLE_SAAS_SYNC` the same way
+  integration and tasks suites do, while sync/auth suites retain hosted-sync
+  coverage.
+- Restores strict mission-step-contract type checking by making ambiguous DRG
+  URN matches explicitly typed.
+- Carries review and release hygiene fixes for unsafe target-branch merge
+  guidance, retrospective workflow wording, doctrine language-bias lint, fresh
+  sync Sonar findings, and Windows/main CI health.
+
 ## [3.2.0rc13] - 2026-05-19
 
 Ships a focused sync-boundary hotfix for pipx-style CLI installs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc13"
+version = "3.2.0rc14"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc13"
+version = "3.2.0rc14"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- bump spec-kitty-cli to 3.2.0rc14 in pyproject, project metadata, and lockfile
- add 3.2.0rc14 changelog notes for the post-rc13 doctrine/charter and sync-boundary follow-ups

## Verification
- uv lock --check
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- uv run python -m pytest -v --import-mode=importlib tests/release
- rm -rf dist build && uv run python -m build
- uv run python scripts/release/check_shared_package_drift.py --check-installed
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli
- uv run twine check dist/*