### PR TITLE
Align release merge guidance with protect-main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ sync-boundary follow-up window:
 - Carries review and release hygiene fixes for unsafe target-branch merge
   guidance, retrospective workflow wording, doctrine language-bias lint, fresh
   sync Sonar findings, and Windows/main CI health.
+- Aligns the release checklist with the main-branch protection workflow:
+  release PRs should be squash-merged so the resulting commit retains the PR
+  marker that `Protect Main Branch` recognizes.
 
 ## [3.2.0rc13] - 2026-05-19
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -134,10 +134,14 @@ gh pr create --base main --title "Release X.Y.Z" --fill
 
 ### 5. Merge the Release PR
 
-- [ ] Use a linear-history merge strategy that matches branch protection (`rebase` if available).
+- [ ] Use a merge strategy that leaves a PR marker in the main-branch commit
+      message so the `Protect Main Branch` workflow can verify provenance.
+      Today that means squash-merge for release PRs; do not use `--rebase`
+      unless the protection workflow has been updated to recognize rebased PR
+      commits.
 
 ```bash
-gh pr merge --rebase --delete-branch
+gh pr merge --squash --delete-branch
 ```
 
 ### 6. Tag the Release from `main`


### PR DESCRIPTION
## Summary
- update release checklist to use squash merge for release PRs so Protect Main Branch sees the PR marker
- add the release-hygiene note to the 3.2.0rc14 changelog before tagging

## Verification
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- npx --yes markdownlint-cli2@0.18.1 --config .markdownlint-cli2.jsonc RELEASE_CHECKLIST.md CHANGELOG.md