### PR TITLE
fix(doctrine): allow pack-relative guide_path in Toolguide (#1157)

### DIFF
--- a/src/doctrine/schemas/toolguide.schema.yaml
+++ b/src/doctrine/schemas/toolguide.schema.yaml
@@ -26,7 +26,7 @@ properties:
     minLength: 1
   guide_path:
     type: string
-    pattern: ^src/doctrine/.+\.md$
+    pattern: ^[^/].*\.md$
   summary:
     type: string
     minLength: 1

--- a/src/doctrine/toolguides/models.py
+++ b/src/doctrine/toolguides/models.py
@@ -12,7 +12,7 @@ class Toolguide(BaseModel):
     schema_version: str = Field(pattern=r"^1\.0$")
     tool: str
     title: str
-    guide_path: str = Field(pattern=r"^src/doctrine/.+\.md$")
+    guide_path: str = Field(pattern=r"^[^/].*\.md$")
     summary: str
     commands: list[str] = Field(default_factory=list)
     applies_to_languages: list[str] = Field(default_factory=list)

--- a/tests/doctrine/fixtures/toolguide/invalid/bad-guide-path.yaml
+++ b/tests/doctrine/fixtures/toolguide/invalid/bad-guide-path.yaml
@@ -2,5 +2,5 @@ schema_version: "1.0"
 id: powershell-syntax
 tool: powershell
 title: PowerShell Syntax Guide
-guide_path: docs/POWERSHELL_SYNTAX.md
+guide_path: /absolute/POWERSHELL_SYNTAX.md
 summary: PowerShell-specific syntax and parameter conventions.

--- a/tests/doctrine/toolguides/test_models.py
+++ b/tests/doctrine/toolguides/test_models.py
@@ -25,8 +25,26 @@ class TestToolguide:
         with pytest.raises(ValidationError):
             toolguide.title = "changed"  # type: ignore[misc]
 
+    def test_pack_relative_guide_path_accepted(self, sample_toolguide_data: dict) -> None:
+        """Pack-relative paths like toolguides/my-tool.md must be accepted (issue #1157)."""
+        sample_toolguide_data["guide_path"] = "toolguides/my-tool.md"
+        toolguide = Toolguide.model_validate(sample_toolguide_data)
+        assert toolguide.guide_path == "toolguides/my-tool.md"
+
+    def test_nested_pack_relative_guide_path_accepted(self, sample_toolguide_data: dict) -> None:
+        """Nested pack-relative paths must be accepted (issue #1157)."""
+        sample_toolguide_data["guide_path"] = "docs/guides/my-tool.md"
+        toolguide = Toolguide.model_validate(sample_toolguide_data)
+        assert toolguide.guide_path == "docs/guides/my-tool.md"
+
+    def test_absolute_guide_path_rejected(self, sample_toolguide_data: dict) -> None:
+        """Absolute paths must be rejected — they can never be pack-relative."""
+        sample_toolguide_data["guide_path"] = "/absolute/path.md"
+        with pytest.raises(ValidationError):
+            Toolguide.model_validate(sample_toolguide_data)
+
     def test_invalid_guide_path_pattern_raises(self, sample_toolguide_data: dict) -> None:
-        sample_toolguide_data["guide_path"] = "docs/guide.md"
+        sample_toolguide_data["guide_path"] = "/absolute/guide.md"
         with pytest.raises(ValidationError):
             Toolguide.model_validate(sample_toolguide_data)
 

--- a/tests/doctrine/toolguides/test_validation.py
+++ b/tests/doctrine/toolguides/test_validation.py
@@ -20,8 +20,14 @@ class TestValidateToolguide:
         errors = validate_toolguide(data)
         assert len(errors) > 0
 
+    def test_pack_relative_guide_path_is_valid(self, sample_toolguide_data: dict) -> None:
+        """Pack-relative guide_path must pass JSON schema validation (issue #1157)."""
+        sample_toolguide_data["guide_path"] = "toolguides/my-tool.md"
+        errors = validate_toolguide(sample_toolguide_data)
+        assert errors == []
+
     def test_invalid_guide_path_pattern(self, sample_toolguide_data: dict) -> None:
-        sample_toolguide_data["guide_path"] = "docs/guide.md"
+        sample_toolguide_data["guide_path"] = "/absolute/guide.md"
         errors = validate_toolguide(sample_toolguide_data)
         assert any("guide_path" in e for e in errors)
 


### PR DESCRIPTION
## Summary

- Relaxes the `guide_path` validation pattern from `^src/doctrine/.+\.md$` to `^[^/].*\.md$` in both the Pydantic model (`src/doctrine/toolguides/models.py`) and the JSON schema (`src/doctrine/schemas/toolguide.schema.yaml`)
- Pack-relative paths like `toolguides/my-tool.md` are now accepted; absolute paths (starting with `/`) remain rejected
- Updates the stale `bad-guide-path.yaml` fixture and two existing "invalid path" tests that used `docs/guide.md` (now valid) to use `/absolute/guide.md` instead

Fixes #1157.

## Test plan

- [x] `test_pack_relative_guide_path_accepted` — `toolguides/my-tool.md` accepted by Pydantic model
- [x] `test_nested_pack_relative_guide_path_accepted` — `docs/guides/my-tool.md` accepted
- [x] `test_absolute_guide_path_rejected` — `/absolute/path.md` still rejected
- [x] `test_pack_relative_guide_path_is_valid` — pack-relative path passes JSON schema validation
- [x] Full doctrine test suite: 23/23 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)