### PR TITLE
fix: address Sonar cleanups and idna vulnerability

### DIFF
--- a/src/charter/_drg_helpers.py
+++ b/src/charter/_drg_helpers.py
@@ -32,7 +32,7 @@ from doctrine.drg.models import DRGGraph
 from doctrine.drg.validator import assert_valid
 
 
-def _resolve_org_root(repo_root: Path) -> Path | None:  # noqa: ARG001
+def _resolve_org_root(_repo_root: Path) -> Path | None:
     """Return the configured org doctrine snapshot path, or ``None`` if absent.
 
     The charter-layer implementation is intentionally inert — it always returns

--- a/src/charter/neutrality/language_scoped_allowlist.yaml
+++ b/src/charter/neutrality/language_scoped_allowlist.yaml
@@ -34,6 +34,11 @@ paths:
     owner: "charter team"
     reason: "Spec Kitty itself is a Python package; setup-doctor skill necessarily references Python tooling."
     added_in: "3.2.0"
+  - path: "src/doctrine/skills/spec-kitty-setup-doctor/references/common-failure-signatures.md"
+    scope: python
+    owner: "charter team"
+    reason: "Setup-doctor failure-signature catalog intentionally documents Python interpreter and pip recovery commands."
+    added_in: "3.3.3"
   - path: "src/charter/corpus/python.corpus.yaml"
     scope: python
     owner: "charter team"

--- a/src/doctrine/agent_profiles/repository.py
+++ b/src/doctrine/agent_profiles/repository.py
@@ -28,6 +28,7 @@ from .validation import reject_agent_profile_inline_refs
 
 _MAX_LOW_WORKLOAD = 2
 _MAX_MEDIUM_WORKLOAD = 4
+_AGENT_PROFILE_GLOB = "*.agent.yaml"
 
 
 def _filter_candidates_by_role(candidates: list[AgentProfile], required_role: str | None) -> list[AgentProfile]:
@@ -234,7 +235,7 @@ class AgentProfileRepository:
         shipped_profiles: dict[str, AgentProfile] = {}
 
         if self._shipped_dir.exists():
-            for yaml_file in self._shipped_dir.rglob("*.agent.yaml"):
+            for yaml_file in self._shipped_dir.rglob(_AGENT_PROFILE_GLOB):
                 try:
                     data = yaml.load(yaml_file)
                     if data is None:
@@ -264,7 +265,7 @@ class AgentProfileRepository:
 
         # Load and merge project profiles
         if self._project_dir and self._project_dir.exists():
-            for yaml_file in self._project_dir.glob("*.agent.yaml"):
+            for yaml_file in self._project_dir.glob(_AGENT_PROFILE_GLOB):
                 try:
                     data = yaml.load(yaml_file)
                     if data is None:
@@ -329,7 +330,7 @@ class AgentProfileRepository:
         """
         if not org_dir.exists():
             return
-        for yaml_file in org_dir.glob("*.agent.yaml"):
+        for yaml_file in org_dir.glob(_AGENT_PROFILE_GLOB):
             try:
                 data = yaml.load(yaml_file)
                 if data is None:

--- a/src/specify_cli/next/_internal_runtime/planner.py
+++ b/src/specify_cli/next/_internal_runtime/planner.py
@@ -48,7 +48,6 @@ from specify_cli.next._internal_runtime.schema import (
     StepContextBundle,
 )
 from specify_cli.next._internal_runtime.workflow_registry import (
-    UnknownWorkflowError,
     get_workflow,
     list_available_workflows,
 )
@@ -138,13 +137,7 @@ def resolve_next_workflow_action(
     ValueError
         When ``current_action`` is not present in the workflow's action graph.
     """
-    try:
-        workflow: WorkflowSequence = _resolve_workflow_for_mission(mission_dir)
-    except UnknownWorkflowError:
-        # FR-015: propagate immediately; do not fall back.
-        # list_available_workflows is imported so callers can inspect the
-        # available set programmatically if they catch UnknownWorkflowError.
-        raise
+    workflow: WorkflowSequence = _resolve_workflow_for_mission(mission_dir)
     by_name: dict[str, ActionStep] = {a.action_name: a for a in workflow.actions}
     action: ActionStep | None = by_name.get(current_action)
     if action is None:

--- a/src/specify_cli/next/runtime_bridge.py
+++ b/src/specify_cli/next/runtime_bridge.py
@@ -194,9 +194,12 @@ def _resolve_mission_id_for_terminus(feature_dir: Path) -> str:
     return feature_dir.name
 
 
+_RESOLUTION_ERROR = "<resolution_error>"
+
+
 def _build_retrospective_facilitator_callback(
     mission_slug: str,
-    repo_root: Path,  # noqa: ARG001
+    repo_root: Path,
     provenance_kind: str = "runtime_post_completion",
 ) -> Any:
     """Build the facilitator callback that wires WP01/02/03 surfaces into the terminus.
@@ -216,6 +219,7 @@ def _build_retrospective_facilitator_callback(
 
     WP04 — T018/T019/T020/T021
     """
+    del repo_root
     # Late imports to keep the module-level import graph clean and to allow
     # the terminus to remain the single import point for heavy optional deps.
     from specify_cli.retrospective.policy import (
@@ -362,9 +366,9 @@ def _build_retrospective_facilitator_callback(
 def _resolution_error_source_map() -> dict[str, str]:
     """Return a minimal policy source map for malformed policy failures."""
     return {
-        "enabled": "<resolution_error>",
-        "timing": "<resolution_error>",
-        "failure_policy": "<resolution_error>",
+        "enabled": _RESOLUTION_ERROR,
+        "timing": _RESOLUTION_ERROR,
+        "failure_policy": _RESOLUTION_ERROR,
     }
 
 

--- a/src/specify_cli/retrospective/schema.py
+++ b/src/specify_cli/retrospective/schema.py
@@ -455,9 +455,9 @@ class RetrospectiveRecord(BaseModel):
 # Validation patterns (matching JSON Schema patterns)
 # ---------------------------------------------------------------------------
 
-_FINDING_ID_RE = re.compile(r"^[a-z]-[0-9]{3,}$")
-_PROPOSAL_ID_RE = re.compile(r"^p-[0-9]{3,}$")
-_EVIDENCE_ID_RE = re.compile(r"^e-[0-9]{3,}$")
+_FINDING_ID_RE = re.compile(r"^[a-z]-\d{3,}$")
+_PROPOSAL_ID_RE = re.compile(r"^p-\d{3,}$")
+_EVIDENCE_ID_RE = re.compile(r"^e-\d{3,}$")
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/sync/__init__.py
+++ b/src/specify_cli/sync/__init__.py
@@ -22,31 +22,31 @@ must fetch bearer tokens via
 deletion).
 """
 
-from .clock import LamportClock, generate_node_id
-from .diagnose import emit_diagnostic
-from .events import (
-    get_emitter,
-    reset_emitter,
-    emit_wp_status_changed,
-    emit_wp_created,
-    emit_wp_assigned,
-    emit_mission_created,
-    emit_mission_closed,
-    emit_history_added,
-    emit_error_logged,
-    emit_dependency_resolved,
-    emit_token_usage_recorded,
-    emit_diff_summary_recorded,
-)
-from .queue import OfflineQueue
-from .feature_flags import (
-    SAAS_SYNC_ENV_VAR,
-    is_saas_sync_enabled,
-    saas_sync_disabled_message,
-)
-
-# Lazy-loaded names (require 'requests' or 'websockets' at runtime)
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    # Keep package init cheap. Importing a sync submodule such as
+    # ``runtime_event_emitter`` still initializes this package first, so
+    # every common export must stay lazy to avoid pulling in auth/queue/
+    # daemon machinery on unrelated startup paths like ``spec-kitty next``.
+    "LamportClock": (".clock", "LamportClock"),
+    "generate_node_id": (".clock", "generate_node_id"),
+    "emit_diagnostic": (".diagnose", "emit_diagnostic"),
+    "get_emitter": (".events", "get_emitter"),
+    "reset_emitter": (".events", "reset_emitter"),
+    "emit_wp_status_changed": (".events", "emit_wp_status_changed"),
+    "emit_wp_created": (".events", "emit_wp_created"),
+    "emit_wp_assigned": (".events", "emit_wp_assigned"),
+    "emit_mission_created": (".events", "emit_mission_created"),
+    "emit_mission_closed": (".events", "emit_mission_closed"),
+    "emit_history_added": (".events", "emit_history_added"),
+    "emit_error_logged": (".events", "emit_error_logged"),
+    "emit_dependency_resolved": (".events", "emit_dependency_resolved"),
+    "emit_token_usage_recorded": (".events", "emit_token_usage_recorded"),
+    "emit_diff_summary_recorded": (".events", "emit_diff_summary_recorded"),
+    "OfflineQueue": (".queue", "OfflineQueue"),
+    "SAAS_SYNC_ENV_VAR": (".feature_flags", "SAAS_SYNC_ENV_VAR"),
+    "is_saas_sync_enabled": (".feature_flags", "is_saas_sync_enabled"),
+    "saas_sync_disabled_message": (".feature_flags", "saas_sync_disabled_message"),
+    # Lazy-loaded names that require heavier optional/runtime dependencies.
     "BatchEventResult": (".batch", "BatchEventResult"),
     "BatchSyncResult": (".batch", "BatchSyncResult"),
     "batch_sync": (".batch", "batch_sync"),

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -512,9 +512,10 @@ def collect_foreground_identity(repo_root: Path) -> ForegroundIdentity:
     # strings as None for robustness against credential-file edge cases.
     has_auth = bool(auth_principal) and bool(server_url_raw)
     server_url: str | None = str(server_url_raw) if has_auth else None
-    team_or_user = (
+    principal_display = (
         f"{auth_principal}/{auth_team}" if auth_team else str(auth_principal)
-    ) if has_auth else None
+    )
+    team_or_user = principal_display if has_auth else None
 
     executable_path = Path(_canonical_executable_path(sys.executable))
     source_path = _resolve_source_path()

--- a/tests/charter/test_neutrality_lint.py
+++ b/tests/charter/test_neutrality_lint.py
@@ -239,6 +239,30 @@ def test_fault_injection_respects_allowlist(tmp_path: Path) -> None:
     assert result.passed
 
 
+def test_setup_doctor_failure_signatures_are_allowlisted(tmp_path: Path) -> None:
+    """The setup-doctor failure catalog may mention Python recovery commands."""
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "src" / "doctrine" / "skills" / "spec-kitty-setup-doctor" / "references" / "common-failure-signatures.md"
+    project_allowlist = repo_root / "src" / "charter" / "neutrality" / "language_scoped_allowlist.yaml"
+
+    empty_allowlist = tmp_path / "allow.yaml"
+    empty_allowlist.write_text("schema_version: '1'\npaths: []\n", encoding="utf-8")
+
+    unallowlisted = run_neutrality_lint(
+        repo_root=repo_root,
+        scan_roots=[target],
+        allowlist_path=empty_allowlist,
+    )
+    assert {hit.match for hit in unallowlisted.hits} >= {"python -m", "pip install"}
+
+    allowlisted = run_neutrality_lint(
+        repo_root=repo_root,
+        scan_roots=[target],
+        allowlist_path=project_allowlist,
+    )
+    assert allowlisted.passed, f"Expected allowlist to suppress setup-doctor recovery commands; got hits={allowlisted.hits}"
+
+
 def test_stale_allowlist_entry_is_reported(tmp_path: Path) -> None:
     """An allowlist entry that resolves to zero files must be flagged as stale."""
     (tmp_path / "src" / "doctrine").mkdir(parents=True)

--- a/uv.lock
+++ b/uv.lock
@@ -655,11 +655,11 @@ socks = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-20T02:52:57.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-20T02:52:55.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump the locked `idna` dependency from `3.13` to `3.15` to address Dependabot alert GHSA-65pc-fj4g-8rjx / CVE-2026-45409
- apply low-risk Sonar cleanup fixes in touched Python modules without broad behavior changes
- validate with targeted and adjacent runtime/sync test suites plus `ruff` and `uv lock --check`

## Sonar / security notes
- The latest scheduled `main` SonarCloud run failed its quality gate on `new_coverage` and `new_security_hotspots_reviewed`.
- The open security hotspots shown by SonarCloud are longstanding `http://localhost` / loopback findings; they are not actionable code changes in this patch and still require review state changes in SonarCloud UI to satisfy the hotspot-review gate.
- I intentionally did not take on the broader historical cognitive-complexity backlog in this automation patch.

## Validation
- `uv run pytest tests/specify_cli/compat/test_planner.py tests/next/test_runtime_bridge_unit.py tests/retrospective/test_schema_roundtrip.py tests/status/test_preflight.py tests/doctrine/agent_profiles/test_scoring.py`
- `uv run pytest tests/specify_cli/next/test_runtime_bridge.py tests/sync/test_sync_boundary_preflight.py tests/specify_cli/cli/commands/test_sync_status_check_paths.py`
- `uv run ruff check src/charter/_drg_helpers.py src/doctrine/agent_profiles/repository.py src/specify_cli/next/_internal_runtime/planner.py src/specify_cli/next/runtime_bridge.py src/specify_cli/retrospective/schema.py src/specify_cli/sync/preflight.py`
- `uv lock --check`
