### PR TITLE
fix(sync): classify per-event queued/pending as in-flight, not errors (#1182)

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -245,15 +245,25 @@ def _render_top_event_types(stats: QueueStats, target_console: Console) -> None:
 
 
 def _print_sync_summary(result: object) -> None:
-    """Render the sync summary with highlighted failure details."""
+    """Render the sync summary with highlighted failure details.
+
+    The ``Pending`` segment surfaces when the server returned per-event
+    ``queued`` / ``pending`` rows (durably accepted but not yet
+    materialised). Without it the previous summary would have classified
+    those rows as ``Errors``; see issue Priivacy-ai/spec-kitty#1182.
+    """
     from specify_cli.sync.batch import format_sync_summary
 
     summary = format_sync_summary(result)
-    header = (
-        f"[green]Synced:[/green] {getattr(result, 'synced_count', 0)}  "
-        f"[dim]Duplicates:[/dim] {getattr(result, 'duplicate_count', 0)}  "
-        f"[red]Errors:[/red] {getattr(result, 'error_count', 0)}"
-    )
+    pending_count = getattr(result, "pending_count", 0)
+    header_parts = [
+        f"[green]Synced:[/green] {getattr(result, 'synced_count', 0)}",
+        f"[dim]Duplicates:[/dim] {getattr(result, 'duplicate_count', 0)}",
+    ]
+    if isinstance(pending_count, int) and not isinstance(pending_count, bool) and pending_count > 0:
+        header_parts.append(f"[yellow]Pending:[/yellow] {pending_count}")
+    header_parts.append(f"[red]Errors:[/red] {getattr(result, 'error_count', 0)}")
+    header = "  ".join(header_parts)
     for line in summary.splitlines():
         if line.startswith("  "):
             console.print(f"  [yellow]{line.strip()}[/yellow]")
@@ -278,10 +288,17 @@ def _maybe_write_sync_report(report: Path | None, result: object) -> None:
 
 
 def _sync_result_activity(result: object) -> int:
-    """Return the total number of acknowledged sync outcomes."""
+    """Return the total number of acknowledged sync outcomes.
+
+    ``pending_count`` is included so a sync that drained only
+    ``queued`` / ``pending`` rows (server-acknowledged but not yet
+    materialised; see Priivacy-ai/spec-kitty#1182) is correctly treated
+    as progress and does not trigger the "no progress" guard below.
+    """
     counts = (
         getattr(result, "synced_count", 0),
         getattr(result, "duplicate_count", 0),
+        getattr(result, "pending_count", 0),
         getattr(result, "error_count", 0),
     )
     return sum(value for value in counts if isinstance(value, int) and not isinstance(value, bool))

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -871,10 +871,10 @@ def _parse_event_results(
             result.event_results.append(BatchEventResult(event_id=event_id, status="duplicate"))
         elif status in ("queued", "pending"):
             # Server durably accepted the event but has not yet materialised
-            # it. The queue row is owned by the server now (so the local row
-            # is treated as resolved alongside synced/duplicate), but the
-            # event is NOT a terminal success and MUST NOT be classified as
-            # an error. See issue Priivacy-ai/spec-kitty#1182.
+            # it. Leave the local row untouched so a later daemon tick can
+            # observe the eventual success/duplicate response. The event is
+            # NOT a terminal success and MUST NOT be classified as an error.
+            # See issue Priivacy-ai/spec-kitty#1182.
             result.pending_count += 1
             result.pending_ids.append(event_id)
             result.event_results.append(BatchEventResult(event_id=event_id, status="pending"))

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -520,8 +520,8 @@ class BatchEventResult:
 
     Attributes:
         event_id: Unique event identifier.
-        status: One of ``"success"``, ``"duplicate"``, ``"rejected"``,
-            ``"failed_permanent"``, or ``"failed_transient"``.
+        status: One of ``"success"``, ``"duplicate"``, ``"pending"``,
+            ``"rejected"``, ``"failed_permanent"``, or ``"failed_transient"``.
 
             Queue mutation semantics (see ``OfflineQueue.process_batch_results``):
 
@@ -529,6 +529,14 @@ class BatchEventResult:
               **deleted** from the queue. Permanent failures (e.g. oversized
               events that can never be sent) are removed so the drain loop can
               continue past them without stalling.
+            * ``pending`` -- the server acknowledged the event but has not
+              yet materialised it (per-event ``status`` of ``"queued"`` or
+              ``"pending"`` inside a 200 response body). The queue row is
+              **left untouched** (same disposition as ``failed_transient``)
+              so the next daemon tick re-sends and the server's eventual
+              ``success`` / ``duplicate`` response cleans it up. The CLI
+              does **not** classify the event as a sync failure. See
+              issue Priivacy-ai/spec-kitty#1182.
             * ``rejected`` -- per-event content rejection returned by the
               server inside a 200 response body. ``retry_count`` is
               **incremented**.
@@ -544,7 +552,7 @@ class BatchEventResult:
     """
 
     event_id: str
-    status: str  # "success" | "duplicate" | "rejected" | "failed_permanent" | "failed_transient"
+    status: str  # "success" | "duplicate" | "pending" | "rejected" | "failed_permanent" | "failed_transient"
     error: str | None = None
     error_category: str | None = None
 
@@ -565,16 +573,28 @@ class BatchSyncResult:
         self.total_events: int = 0
         self.synced_count: int = 0
         self.duplicate_count: int = 0
+        # Per-event "queued"/"pending" responses from the server. The event
+        # was durably accepted but has not yet been materialised; the CLI
+        # MUST NOT classify these as sync failures. See issue
+        # Priivacy-ai/spec-kitty#1182.
+        self.pending_count: int = 0
         self.error_count: int = 0
         self.error_messages: list[str] = []
         self.synced_ids: list[str] = []
+        self.pending_ids: list[str] = []
         self.failed_ids: list[str] = []
         # NEW: per-event results for richer diagnostics
         self.event_results: list[BatchEventResult] = []
 
     @property
     def success_count(self) -> int:
-        """Events successfully processed (synced or duplicate)."""
+        """Events successfully processed (synced or duplicate).
+
+        ``pending_count`` is intentionally excluded: pending events were
+        accepted by the server but have not yet been materialised, so they
+        are durable but not yet "done". Treat ``success_count`` as the
+        terminal-success bucket and ``pending_count`` as in-flight.
+        """
         return self.synced_count + self.duplicate_count
 
     # -- Derived helpers ------------------------------------------------
@@ -751,13 +771,26 @@ def format_sync_summary(result: BatchSyncResult) -> str:
 
     Example output::
 
-        Synced: 42, Duplicates: 3, Failed: 60
+        Synced: 42, Duplicates: 3, Pending: 2, Failed: 60
           schema_mismatch: 45  -- Run `spec-kitty sync diagnose` to inspect invalid events
           auth_expired: 10  -- Run `spec-kitty auth login` to refresh credentials
           unknown: 5  -- Inspect the failure report for details: --report <file.json>
+
+    The ``Pending`` segment is included only when ``result.pending_count``
+    is non-zero (per-event ``queued`` / ``pending`` responses durably held
+    by the server pending materialisation; see issue
+    Priivacy-ai/spec-kitty#1182).
     """
     lines: list[str] = []
-    lines.append(f"Synced: {result.synced_count}, Duplicates: {result.duplicate_count}, Failed: {result.error_count}")
+    if result.pending_count:
+        lines.append(
+            f"Synced: {result.synced_count}, Duplicates: {result.duplicate_count}, "
+            f"Pending: {result.pending_count}, Failed: {result.error_count}"
+        )
+    else:
+        lines.append(
+            f"Synced: {result.synced_count}, Duplicates: {result.duplicate_count}, Failed: {result.error_count}"
+        )
 
     category_counts = result.category_counts
     if category_counts:
@@ -788,6 +821,7 @@ def generate_failure_report(result: BatchSyncResult) -> dict:
             "total_events": result.total_events,
             "synced": result.synced_count,
             "duplicates": result.duplicate_count,
+            "pending": result.pending_count,
             "failed": result.error_count,
             "categories": result.category_counts,
         },
@@ -835,8 +869,17 @@ def _parse_event_results(
             result.duplicate_count += 1
             result.synced_ids.append(event_id)
             result.event_results.append(BatchEventResult(event_id=event_id, status="duplicate"))
+        elif status in ("queued", "pending"):
+            # Server durably accepted the event but has not yet materialised
+            # it. The queue row is owned by the server now (so the local row
+            # is treated as resolved alongside synced/duplicate), but the
+            # event is NOT a terminal success and MUST NOT be classified as
+            # an error. See issue Priivacy-ai/spec-kitty#1182.
+            result.pending_count += 1
+            result.pending_ids.append(event_id)
+            result.event_results.append(BatchEventResult(event_id=event_id, status="pending"))
         else:
-            # Treat any non-success/non-duplicate status as rejected
+            # Treat any non-success/non-duplicate/non-pending status as rejected
             error_text = error_msg or "Unknown error"
             category = categorize_error(error_text)
             result.error_count += 1

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -1635,11 +1635,14 @@ class OfflineQueue:
     def process_batch_results(self, results: list[_BatchEventResultLike]) -> None:
         """Process batch sync results by status.
 
-        Four buckets (see ``BatchEventResult`` for full semantics):
+        Five buckets (see ``BatchEventResult`` for full semantics):
 
         * ``success`` / ``duplicate`` / ``failed_permanent`` -> DELETE from
           queue. ``failed_permanent`` events (e.g. oversized events) are
           removed so the drain loop can continue past them without stalling.
+        * ``pending`` -> **no mutation**. Per-event ``queued`` / ``pending``
+          rows were accepted by the server but not yet materialised, so the
+          local row stays available for the next daemon tick.
         * ``rejected`` -> UPDATE ``retry_count = retry_count + 1``. This is
           for **per-event content rejections** returned by the server inside
           a 200 response body, where the server actually evaluated that
@@ -1668,14 +1671,15 @@ class OfflineQueue:
                 synced_or_duplicate.append(r.event_id)
             elif r.status == "rejected":
                 rejected.append(r.event_id)
-            elif r.status == "failed_transient":
+            elif r.status in ("pending", "failed_transient"):
                 transient.append(r.event_id)
 
         conn = sqlite3.connect(self.db_path)
         deleted = 0
         try:
-            # Wrap both operations in a single transaction. ``failed_transient``
-            # rows are intentionally left untouched (no DELETE, no UPDATE).
+            # Wrap both operations in a single transaction. ``pending`` and
+            # ``failed_transient`` rows are intentionally left untouched (no
+            # DELETE, no UPDATE).
             if synced_or_duplicate:
                 placeholders = ",".join("?" * len(synced_or_duplicate))
                 cursor = conn.execute(

--- a/tests/sync/test_batch_error_surfacing.py
+++ b/tests/sync/test_batch_error_surfacing.py
@@ -233,6 +233,79 @@ class TestParseEventResults:
         assert result.failed_results[0].error == "Missing field X"
         assert result.failed_results[0].error_category == "schema_mismatch"
 
+    # ────────────────────────────────────────────────────────────
+    # Issue #1182: per-event queued/pending are non-error in-flight
+    # ────────────────────────────────────────────────────────────
+
+    def test_queued_status_is_pending_not_error(self):
+        """Per-event ``status=queued`` (server-accepted, not yet materialised)
+        must not become an Unknown error (Priivacy-ai/spec-kitty#1182)."""
+        result = BatchSyncResult()
+        raw = [{"event_id": "e1", "status": "queued"}]
+        _parse_event_results(raw, result)
+
+        assert result.error_count == 0
+        assert result.pending_count == 1
+        assert result.pending_ids == ["e1"]
+        assert result.synced_count == 0
+        assert result.duplicate_count == 0
+        assert len(result.event_results) == 1
+        assert result.event_results[0].status == "pending"
+        assert result.event_results[0].error is None
+
+    def test_pending_status_is_pending_not_error(self):
+        """Per-event ``status=pending`` must not become an Unknown error
+        (Priivacy-ai/spec-kitty#1182)."""
+        result = BatchSyncResult()
+        raw = [{"event_id": "e1", "status": "pending"}]
+        _parse_event_results(raw, result)
+
+        assert result.error_count == 0
+        assert result.pending_count == 1
+        assert result.pending_ids == ["e1"]
+        assert len(result.event_results) == 1
+        assert result.event_results[0].status == "pending"
+
+    def test_mixed_with_pending_does_not_inflate_errors(self):
+        """A mixed batch with success, duplicate, queued, pending, rejected
+        accounts each into its own bucket. The previous behaviour treated
+        queued/pending as Unknown errors and bumped ``error_count``."""
+        result = BatchSyncResult()
+        raw = [
+            {"event_id": "e1", "status": "success"},
+            {"event_id": "e2", "status": "duplicate"},
+            {"event_id": "e3", "status": "queued"},
+            {"event_id": "e4", "status": "pending"},
+            {"event_id": "e5", "status": "rejected", "error_message": "Invalid"},
+        ]
+        _parse_event_results(raw, result)
+
+        assert result.synced_count == 1
+        assert result.duplicate_count == 1
+        assert result.pending_count == 2
+        assert result.pending_ids == ["e3", "e4"]
+        assert result.error_count == 1
+        assert result.failed_ids == ["e5"]
+        # The previous behaviour produced category_counts={"unknown": 2}
+        # for the two pending rows; the new behaviour categorises only the
+        # genuinely rejected row.
+        assert result.category_counts == {"schema_mismatch": 1}
+
+    def test_pending_does_not_count_toward_success_count(self):
+        """``success_count`` is terminal-success only (synced + duplicate);
+        pending events are durable but not yet materialised."""
+        result = BatchSyncResult()
+        raw = [
+            {"event_id": "e1", "status": "success"},
+            {"event_id": "e2", "status": "queued"},
+            {"event_id": "e3", "status": "pending"},
+        ]
+        _parse_event_results(raw, result)
+
+        # success_count = synced + duplicate; pending is intentionally excluded
+        assert result.success_count == 1
+        assert result.pending_count == 2
+
 
 # ────────────────────────────────────────────────────────────────
 # T005: HTTP 400 details parsing
@@ -380,6 +453,35 @@ class TestFormatSyncSummary:
         assert "server_error" in CATEGORY_ACTIONS
         assert "unknown" in CATEGORY_ACTIONS
 
+    def test_pending_segment_when_nonzero(self):
+        """``Pending: N`` segment surfaces when pending_count > 0
+        (Priivacy-ai/spec-kitty#1182)."""
+        result = BatchSyncResult()
+        result.synced_count = 5
+        result.duplicate_count = 1
+        result.pending_count = 3
+        result.error_count = 0
+
+        summary = format_sync_summary(result)
+        assert "Synced: 5" in summary
+        assert "Duplicates: 1" in summary
+        assert "Pending: 3" in summary
+        assert "Failed: 0" in summary
+
+    def test_no_pending_segment_when_zero(self):
+        """``Pending`` segment is omitted when pending_count == 0
+        (preserves the historical summary shape for the common case)."""
+        result = BatchSyncResult()
+        result.synced_count = 5
+        result.duplicate_count = 1
+        result.error_count = 2
+
+        summary = format_sync_summary(result)
+        assert "Pending" not in summary
+        assert "Synced: 5" in summary
+        assert "Duplicates: 1" in summary
+        assert "Failed: 2" in summary
+
 
 # ────────────────────────────────────────────────────────────────
 # T009: Failure report generation
@@ -410,6 +512,7 @@ class TestFailureReport:
         assert report["summary"]["total_events"] == 10
         assert report["summary"]["synced"] == 7
         assert report["summary"]["duplicates"] == 1
+        assert report["summary"]["pending"] == 0
         assert report["summary"]["failed"] == 2
         assert report["summary"]["categories"] == {
             "schema_mismatch": 1,

--- a/tests/sync/test_offline_queue_counter.py
+++ b/tests/sync/test_offline_queue_counter.py
@@ -192,9 +192,9 @@ class TestRowCountCache:
     def test_counter_after_process_batch_results(
         self, temp_queue: OfflineQueue
     ) -> None:
-        for i in range(6):
+        for i in range(7):
             temp_queue.queue_event(_evt(f"b-{i}"))
-        assert temp_queue._row_count == 6
+        assert temp_queue._row_count == 7
 
         results = [
             _FakeBatchResult(status="success", event_id="b-0"),
@@ -202,15 +202,19 @@ class TestRowCountCache:
             _FakeBatchResult(status="failed_permanent", event_id="b-2"),
             _FakeBatchResult(status="rejected", event_id="b-3"),
             _FakeBatchResult(status="rejected", event_id="b-4"),
-            # Unknown status -> ignored by process_batch_results.
+            # Pending is accepted by the server but still in-flight, so it is
+            # intentionally ignored by process_batch_results.
             _FakeBatchResult(status="failed_transient", event_id="b-5"),
+            _FakeBatchResult(status="pending", event_id="b-6"),
         ]
         temp_queue.process_batch_results(results)
         # 3 rows deleted (success/duplicate/failed_permanent), 2 rejected
-        # rows bump retry_count but stay in queue, failed_transient is a
-        # no-op.
-        assert temp_queue._row_count == 3
-        assert temp_queue._size_from_disk() == 3
+        # rows bump retry_count but stay in queue, failed_transient and
+        # pending are no-ops.
+        assert temp_queue._row_count == 4
+        assert temp_queue._size_from_disk() == 4
+        stats = temp_queue.get_queue_stats()
+        assert stats.total_retried == 2
 
     def test_counter_after_drain_to_file(
         self, temp_queue: OfflineQueue, tmp_path: Path


### PR DESCRIPTION
## Summary

`spec-kitty sync now` reported queued-pending events as `Unknown`
errors and exited non-zero when the in-process final-sync hit its 5s
timeout. The events were durably queued on the SaaS side; the CLI was
misclassifying them.

Root cause: `_parse_event_results` in `src/specify_cli/sync/batch.py`
only treated `success` / `accepted` / `warning` / `duplicate` as
non-errors. Per-event `status="queued"` / `status="pending"` responses
fell into the `rejected` catch-all with `category="unknown"`.

Reproducer (direct probe, agrees with the canary's observed output):
```
queued  => errors=1, categories={'unknown': 1}
pending => errors=1, categories={'unknown': 1}
```

## What changed

- `BatchSyncResult` grows `pending_count` and `pending_ids` (defaults
  preserve existing callers).
- `_parse_event_results` routes `queued` / `pending` to the new
  pending bucket; `rejected` stays the catch-all for everything else.
- `BatchEventResult` documents the new `pending` status. Queue
  mutation policy: leave the local row untouched (same disposition as
  `failed_transient`) — the next daemon tick re-sends, the eventual
  `success` / `duplicate` cleans it up. No change to
  `OfflineQueue.process_batch_results` semantics is required.
- `format_sync_summary` and `generate_failure_report` add a `Pending`
  segment / field when non-zero. Zero-pending output unchanged.
- `_print_sync_summary` adds a `Pending: N` chip to the header when
  non-zero.
- `_sync_result_activity` counts `pending_count` toward progress, so
  the "Sync made no progress" guard does not fire when the server
  accepted everything as pending.
- Strict-exit semantics preserved: `error_count > 0` still exits 1;
  pending-only drains now exit 0.

## Test plan

- [x] `uv run pytest tests/sync/test_batch_error_surfacing.py` — 53/53 pass (6 new tests).
- [x] `uv run pytest tests/sync/test_batch_sync.py tests/sync/test_batch_retry_hygiene.py` — 46/46 pass (no regressions).
- [x] `uv run pytest tests/agent/cli/commands/test_sync.py` — 26/26 pass (no regressions in the sync command tests that mock `format_sync_summary`).
- [x] `uv run ruff check` on all three changed files — clean.
- [ ] Cut a new prerelease (rc16+) from this SHA, install via pipx, run
  the deployed-dev identity-boundary canary single-run.
  Expected: scenarios 1 and 2 no longer report `Errors: N (unknown: N)`
  on queued-pending events; sync-now exit code 0; readiness gauge
  green throughout.
- [ ] Closes `#1182` once the canary validates the change end-to-end.

## New unit tests (would fail on `main` without this fix)

- `test_queued_status_is_pending_not_error`
- `test_pending_status_is_pending_not_error`
- `test_mixed_with_pending_does_not_inflate_errors`
- `test_pending_does_not_count_toward_success_count`
- `test_pending_segment_when_nonzero`
- `test_no_pending_segment_when_zero`

These pin the contract: pending is **never** an error, **never** counts
toward `success_count` (because it's not yet materialised), but **does**
count toward sync activity (so the "no progress" guard doesn't fire).

## Companion change

This change pairs with
`Priivacy-ai/spec-kitty-end-to-end-testing#45` (fix for `#1141`).
Together they unblock Phase 4 of the auth-boundary launch gate
(scenarios 1, 2, and 4). Scenario 3 already passes on rc15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)