### PR TITLE
fix(sync): drop envelope_fields duplication in WPStatusChanged (#1188)

### DIFF
--- a/src/specify_cli/core/upstream_contract.json
+++ b/src/specify_cli/core/upstream_contract.json
@@ -5,7 +5,7 @@
   "_schema_version": "3.0.0",
   "envelope": {
     "required_fields": ["schema_version", "build_id", "aggregate_type", "event_type"],
-    "forbidden_fields": ["feature_slug", "feature_number"],
+    "forbidden_fields": ["feature_slug", "feature_number", "from_lane", "to_lane", "actor", "force", "reason", "review_ref", "execution_mode", "evidence"],
     "aggregate_type": {
       "allowed": ["Build", "Mission", "WorkPackage", "MissionDossier"],
       "forbidden": ["Feature"]

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -817,6 +817,12 @@ class EventEmitter:
             "execution_mode": execution_mode or "direct_repo",
             "evidence": evidence_payload,
         }
+        # Do NOT pass envelope_fields=...; the canonical envelope keys are
+        # already nested inside ``payload``. Duplicating them at the top
+        # level violates the SaaS schema with
+        # ``Additional properties are not allowed ('actor' was unexpected)``
+        # and rejects every WPStatusChanged batch with HTTP 400. See issue
+        # Priivacy-ai/spec-kitty#1188.
         return self._emit(
             event_type="WPStatusChanged",
             aggregate_id=wp_id,
@@ -824,16 +830,6 @@ class EventEmitter:
             payload=payload,
             causation_id=causation_id,
             occurred_at=occurred_at,
-            envelope_fields={
-                "from_lane": from_lane,
-                "to_lane": to_lane,
-                "actor": actor,
-                "force": force,
-                "reason": reason,
-                "review_ref": review_ref,
-                "execution_mode": execution_mode,
-                "evidence": evidence_payload,
-            },
         )
 
     def emit_wp_created(

--- a/tests/sync/test_events.py
+++ b/tests/sync/test_events.py
@@ -252,7 +252,11 @@ class TestWPStatusChanged:
     """Test emit_wp_status_changed (SC-001, SC-002, SC-003)."""
 
     def test_basic_emission(self, emitter: EventEmitter, temp_queue):
-        """WPStatusChanged event has correct structure."""
+        """WPStatusChanged event has correct structure.
+
+        Payload-only fields must NOT be duplicated at the envelope level —
+        the SaaS schema rejects extras (issue Priivacy-ai/spec-kitty#1188).
+        """
         event = emitter.emit_wp_status_changed(
             wp_id="WP01",
             from_lane="planned",
@@ -262,12 +266,26 @@ class TestWPStatusChanged:
         assert event["event_type"] == "WPStatusChanged"
         assert event["aggregate_id"] == "WP01"
         assert event["aggregate_type"] == "WorkPackage"
-        assert event["from_lane"] == "planned"
-        assert event["to_lane"] == "in_progress"
-        assert event["actor"] == "user"
+        # Canonical placement is inside payload (issue #1188).
         assert event["payload"]["wp_id"] == "WP01"
         assert event["payload"]["from_lane"] == "planned"
         assert event["payload"]["to_lane"] == "in_progress"
+        assert event["payload"]["actor"] == "user"
+        # The envelope MUST NOT carry duplicates of payload-only fields.
+        for forbidden in (
+            "from_lane",
+            "to_lane",
+            "actor",
+            "force",
+            "reason",
+            "review_ref",
+            "execution_mode",
+            "evidence",
+        ):
+            assert forbidden not in event, (
+                f"WPStatusChanged envelope must not contain {forbidden!r}; "
+                "see Priivacy-ai/spec-kitty#1188"
+            )
 
     def test_actor_default(self, emitter: EventEmitter, temp_queue):
         """actor defaults to 'user'."""
@@ -333,7 +351,14 @@ class TestWPStatusChanged:
         assert event["payload"]["evidence"]["repos"] == [
             {"repo": "test-org/test-repo", "branch": "test-branch", "commit": "a" * 40}
         ]
-        assert event["evidence"] == event["payload"]["evidence"]
+        # Evidence (and the other payload-only keys) MUST live in payload
+        # only; a top-level copy violates the SaaS schema (issue
+        # Priivacy-ai/spec-kitty#1188).
+        assert "evidence" not in event
+        assert "force" not in event
+        assert "reason" not in event
+        assert "review_ref" not in event
+        assert "execution_mode" not in event
         assert "repos" not in evidence
 
     def test_queued_in_offline_queue(self, emitter: EventEmitter, temp_queue):


### PR DESCRIPTION
## Summary

`emit_wp_status_changed` was duplicating payload keys at the envelope
level via `envelope_fields=`. The SaaS schema rejects extras, so every
`WPStatusChanged`-containing batch returned HTTP 400 with
`Additional properties are not allowed ('actor' was unexpected)`. This
blocked Phase 4 of the auth-boundary launch gate.

## Root cause

`src/specify_cli/sync/emitter.py:763-837` — `emit_wp_status_changed`
constructed `payload` with all the fields (correct) and then **also**
passed `envelope_fields={"from_lane": ..., "to_lane": ..., "actor":
..., ...}` to `_emit`. `_emit` at line 1542-1543 ran
`event.update(envelope_fields)`, planting those keys at the envelope
level alongside `event_id` / `event_type` / etc.

Introduced 2026-04-14 in commit `533e47d2`. Masked on previous RCs by
other batch failures (#1142) and by the parser mis-classification
fixed in #1187.

## Fix

1. **Drop `envelope_fields=` from `emit_wp_status_changed`** —
   `payload` already carries the fields. No other emitter
   (`emit_wp_created`, `emit_wp_assigned`, lifecycle emitters) passes
   `envelope_fields`, and they all batch successfully.
2. **Extend `upstream_contract.json` envelope.forbidden_fields** to
   include the payload-only keys. The existing contract test
   `test_no_forbidden_fields_in_envelope` iterates this list, so the
   regression guard is automatic.
3. **Update unit tests** that previously asserted the top-level
   duplicates — flip them to assert the keys are **absent** at the
   envelope.

## Why the local gate missed it

`validate_outbound_payload` consults `upstream_contract.json`'s
`forbidden_fields = ["feature_slug", "feature_number"]`. It said
nothing about `actor` / `from_lane` / etc., so the duplicated event
sailed past the local gate. The SaaS-side jsonschema is stricter.

## Test plan

- [x] `uv run pytest tests/sync/test_events.py tests/contract/test_event_envelope.py` — 107/107 pass.
- [x] Broader sweep `tests/sync/ tests/contract/ tests/architectural/`: 2135 passed, 25 failed — **all 25 failures are pre-existing on main** (missing `spec-kitty-events 5.1.0` snapshot file, dead-module / marker-convention / status-sync-boundary architectural lints). None caused by this PR.
- [x] `uv run ruff check` clean on changed files.
- [x] Local consumer audit: `grep -rn 'event\[.from_lane.\]\|event\.get(.from_lane.)' src/` finds only `status.events.jsonl` readers (retrospective / changelog / validate / migration). Those operate on local StatusEvent JSONL rows, which have a flat shape independent of the SaaS envelope. Safe.
- [ ] Cut rc17 from the merge SHA, re-run the deployed-dev identity-boundary canary single-run, expect 4/4 PASS.

## Verification gate

Without this fix and with the contract change applied,
`test_no_forbidden_fields_in_envelope` fails on `WPStatusChanged`. With
this fix it passes. The test ↔ contract pair pins the regression.

## Companion / dependency context

- Closes Priivacy-ai/spec-kitty#1188.
- Builds on #1187 (parser fix for `queued`/`pending`) and
  `spec-kitty-end-to-end-testing#45` (canary command shape). Both stay
  landed; the failure mode here was upstream of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)