### PR TITLE
fix(status): drop actor from MissionCreated payload + add conformance guard (#1190)

### DIFF
--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -191,22 +191,47 @@ def _repo_root_for_lifecycle_log(log_path: Path | None) -> Path | None:
 
 
 def _validate_lifecycle_payload(event_type: str, payload: Mapping[str, Any]) -> None:
-    """Validate lifecycle payloads against the shared package when available."""
-    from spec_kitty_events import project_lifecycle
+    """Validate lifecycle payloads against the canonical events contract.
 
-    payload_models = {
-        PROJECT_INITIALIZED: project_lifecycle.ProjectInitializedPayload,
-        SPECIFY_STARTED: project_lifecycle.SpecifyStartedPayload,
-        SPECIFY_COMPLETED: project_lifecycle.SpecifyCompletedPayload,
-        PLAN_STARTED: project_lifecycle.PlanStartedPayload,
-        PLAN_COMPLETED: project_lifecycle.PlanCompletedPayload,
-        TASKS_STARTED: project_lifecycle.TasksStartedPayload,
-        TASKS_COMPLETED: project_lifecycle.TasksCompletedPayload,
-        WP_CREATED: project_lifecycle.WPCreatedPayload,
-    }
-    model = payload_models.get(event_type)
-    if model is not None:
-        model.model_validate(dict(payload))
+    Delegates to ``spec_kitty_events.conformance.validate_event`` so every
+    event type the events package recognises (lifecycle, status, dossier,
+    build, …) is checked under the same canonical rules. The previous
+    selective dispatch via a hand-maintained ``project_lifecycle`` dict
+    silently passed through event types missing from the dict, which let
+    ``MissionCreated.payload.actor`` and similar extra-property drift
+    land in the offline queue and only surface at the SaaS jsonschema
+    boundary. See issue Priivacy-ai/spec-kitty#1190.
+
+    Scope: only ``extra_forbidden`` violations are fatal here. Missing
+    required-field violations are intentionally tolerated because the
+    deployed SaaS currently accepts payloads with absent required fields
+    (e.g. ``MissionCreated`` without ``mission_type`` / ``wp_count``).
+    Tightening the local guard past what the SaaS enforces would block
+    emits that successfully sync. When the SaaS ratchets to strict
+    required-field enforcement, this can be widened in the same place.
+
+    Unknown event types (e.g. ``BuildRegistered`` until the events
+    package ships a schema for it) pass through quietly so unrecognised
+    types don't become sudden hard failures.
+    """
+    from spec_kitty_events.conformance import validate_event
+    from spec_kitty_events.conformance.validators import _EVENT_TYPE_TO_MODEL
+
+    if event_type not in _EVENT_TYPE_TO_MODEL:
+        return
+
+    result = validate_event(dict(payload), event_type, strict=False)
+    extra_violations = [
+        v for v in result.model_violations if v.violation_type == "extra_forbidden"
+    ]
+    if extra_violations:
+        details = "; ".join(
+            f"{v.field}={v.input_value!r}" for v in extra_violations
+        )
+        raise ValueError(
+            f"Lifecycle payload for {event_type!r} contains unexpected fields "
+            f"that the SaaS schema will reject: {details}"
+        )
 
 
 def _build_saas_lifecycle_event(
@@ -435,11 +460,21 @@ def emit_mission_created_local(
     ``status.events.jsonl`` is created on first call.
     """
     log_path = mission_event_log_path(feature_dir)
+    # NOTE: the ``actor`` parameter is intentionally NOT placed in the
+    # MissionCreated payload. The canonical events 5.1.0 schema for
+    # ``mission_created_payload`` declares ``additionalProperties: false``
+    # and does not list ``actor`` — the SaaS jsonschema validator
+    # otherwise rejects batches with
+    # ``Additional properties are not allowed ('actor' was unexpected)``.
+    # See issue Priivacy-ai/spec-kitty#1190. The parameter is retained on
+    # the function signature for caller compatibility and is logically
+    # captured by the surrounding StatusEvent envelope; future cleanup
+    # may remove it entirely once all call sites are audited.
+    del actor  # mark "deliberately unused in payload" for readers
     payload: dict[str, Any] = {
         "mission_slug": mission_slug,
         "mission_number": mission_number,
         "target_branch": target_branch,
-        "actor": actor,
         "created_at": created_at or _now_iso(),
     }
     if mission_id is not None:

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -134,6 +134,36 @@ def test_mission_created_dedupe_on_mission_slug(feature_dir: Path) -> None:
     assert len(entries) == 1
 
 
+def test_mission_created_payload_does_not_contain_actor(feature_dir: Path) -> None:
+    """``actor`` is forbidden by the canonical MissionCreated payload
+    schema. The SaaS jsonschema validator rejects any batch that includes
+    it; we must not put it in the payload locally either. See issue
+    Priivacy-ai/spec-kitty#1190."""
+    envelope = emit_mission_created_local(
+        feature_dir,
+        mission_slug="demo-mission",
+        mission_id="01J6XW9KQT7M0YB3N4R5CQZ2EX",
+        mission_number=None,
+        target_branch="main",
+        actor="spec-kitty mission create",
+        friendly_name="Demo Mission",
+        purpose_tldr="Demo TLDR",
+        purpose_context="Demo context paragraph.",
+    )
+    assert envelope is not None
+    payload = envelope["payload"]
+    assert "actor" not in payload, (
+        f"MissionCreated payload must not contain 'actor'; got {payload!r}. "
+        "See Priivacy-ai/spec-kitty#1190."
+    )
+    # Other expected keys are still present so the canonical contract
+    # isn't degraded by the drift removal.
+    assert payload["mission_slug"] == "demo-mission"
+    assert payload["mission_id"] == "01J6XW9KQT7M0YB3N4R5CQZ2EX"
+    assert payload["target_branch"] == "main"
+    assert payload["friendly_name"] == "Demo Mission"
+
+
 # ---------------------------------------------------------------------------
 # Artifact phases (Specify / Plan / Tasks)
 # ---------------------------------------------------------------------------
@@ -670,3 +700,57 @@ def test_lifecycle_saas_outbox_suppresses_queue_failures(
         actor="test",
         artifact_path="kitty-specs/demo-mission/spec.md",
     )
+
+
+# ---------------------------------------------------------------------------
+# Canonical-conformance guard (issue Priivacy-ai/spec-kitty#1190)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_lifecycle_payload_rejects_unexpected_extra_fields() -> None:
+    """The canonical-conformance guard catches extra-property drift at
+    emit time. This is the regression guard for issue
+    Priivacy-ai/spec-kitty#1190 — the exact shape that previously
+    sailed through the local validator and only failed at the SaaS
+    jsonschema boundary."""
+    bad_payload = {
+        "mission_slug": "demo",
+        "mission_number": None,
+        "target_branch": "main",
+        "mission_id": "01J6XW9KQT7M0YB3N4R5CQZ2EX",
+        "actor": "spec-kitty mission create",  # extra — schema forbids it
+        "created_at": "2026-05-20T00:00:00+00:00",
+        "friendly_name": "Demo",
+        "purpose_tldr": "tldr",
+        "purpose_context": "context",
+    }
+    with pytest.raises(ValueError, match="actor"):
+        lifecycle._validate_lifecycle_payload("MissionCreated", bad_payload)
+
+
+def test_validate_lifecycle_payload_passes_when_payload_matches_schema() -> None:
+    """A cleaned MissionCreated payload (no unexpected extras) passes
+    the conformance guard. Missing required fields like ``mission_type``
+    and ``wp_count`` are intentionally tolerated (matches actual SaaS
+    enforcement at the time of this fix); see the docstring on
+    ``_validate_lifecycle_payload``."""
+    good_payload = {
+        "mission_slug": "demo",
+        "mission_number": None,
+        "target_branch": "main",
+        "mission_id": "01J6XW9KQT7M0YB3N4R5CQZ2EX",
+        "created_at": "2026-05-20T00:00:00+00:00",
+        "friendly_name": "Demo",
+        "purpose_tldr": "tldr",
+        "purpose_context": "context",
+    }
+    # Should not raise.
+    lifecycle._validate_lifecycle_payload("MissionCreated", good_payload)
+
+
+def test_validate_lifecycle_payload_falls_through_for_unknown_event_types() -> None:
+    """Unknown event types (i.e. not yet known to the installed events
+    package) must pass through quietly so adding a new event type
+    upstream doesn't become a sudden hard failure for installed CLIs."""
+    # Should not raise even for a completely-made-up event_type.
+    lifecycle._validate_lifecycle_payload("NotARealEventType", {"foo": "bar"})

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc15"
+version = "3.2.0rc17"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Drops the unexpected ``actor`` key from the ``MissionCreated`` payload
built by ``emit_mission_created_local``, and refactors
``_validate_lifecycle_payload`` to use the canonical
``spec_kitty_events.conformance.validate_event`` so future
extra-property drift is caught locally before queueing.

This is the surgical fix + guard recommended in #1190 (the third drift
in the auth-boundary launch-gate chain; see "Background" below).

## Surgical fix

`src/specify_cli/status/lifecycle_events.py:emit_mission_created_local`
previously wrote ``actor`` directly into the MissionCreated payload:

```python
payload = {
    "mission_slug": mission_slug,
    "mission_number": mission_number,
    "target_branch": target_branch,
    "actor": actor,                       # ← schema forbids it
    "created_at": created_at or _now_iso(),
}
```

The events 5.1.0 `mission_created_payload.schema.json` declares
``additionalProperties: false`` with no ``actor`` property, and the
SaaS jsonschema validator rejects every batch containing such an event
with `Additional properties are not allowed ('actor' was unexpected)`.
The SaaS validates atomically, so one bad MissionCreated poisons the
whole batch and the same error is attributed to every event in the
failure report.

A direct queue audit on the rc17 canary failure confirmed
``MissionCreated`` was the ONLY rejected event type with an extra-
property drift; every other payload (``WPCreated``,
``WPStatusChanged``, ``TasksCompleted``,
``MissionDossierArtifactIndexed``, ``MissionDossierSnapshotComputed``)
matched its canonical schema cleanly.

The ``actor`` parameter is retained on the function signature for
caller compatibility but explicitly marked unused with an explanatory
comment.

## Guard

``_validate_lifecycle_payload`` previously dispatched on a hand-
maintained dict of ``project_lifecycle.*Payload`` classes. There was
no ``MISSION_CREATED → MissionCreatedPayload`` entry, and
``MissionCreatedPayload`` actually lives in
``spec_kitty_events.lifecycle``. So the validation was a no-op for
``MissionCreated`` (and several other event types) and the drift
sailed through.

Replaced with a delegation to
``spec_kitty_events.conformance.validate_event(payload, event_type,
strict=False)``. That canonical validator already maps every events-
package event type to its pydantic model and JSON schema and gives
us full coverage automatically as new event types are added in future
events releases.

**Validation scope is currently extra-property drift only**: the
guard fires on ``violation_type == "extra_forbidden"`` and tolerates
``violation_type == "missing"`` (required-field) violations. This
matches actual deployed-dev SaaS behavior at the time of the fix —
the SaaS currently accepts payloads with absent required fields
(e.g. ``MissionCreated`` without ``mission_type`` / ``wp_count``).
Tightening the local guard past what the SaaS enforces would block
emits that successfully sync. When the SaaS ratchets to strict
required-field enforcement, this can be widened in the same place.

Unknown event types (e.g. ``BuildRegistered`` until the events
package ships a schema for it) pass through quietly so unrecognised
types don't become sudden hard failures.

## Regression tests

`tests/status/test_lifecycle_events.py` gains four tests:

- `test_mission_created_payload_does_not_contain_actor` — pins the
  cleaned payload shape against future regressions.
- `test_validate_lifecycle_payload_rejects_unexpected_extra_fields` —
  pins that the guard catches the exact drift from #1190 (would have
  fired on the pre-fix code).
- `test_validate_lifecycle_payload_passes_when_payload_matches_schema` —
  pins that valid cleaned payloads pass without raising.
- `test_validate_lifecycle_payload_falls_through_for_unknown_event_types` —
  pins graceful fallback for event types the events package doesn't
  recognise yet.

## Test plan

- [x] `uv run pytest tests/status/test_lifecycle_events.py` — 33 / 33 pass (29 pre-existing + 4 new).
- [x] `uv run pytest tests/status/ tests/specify_cli/core/test_mission_creation_specify_started.py` — 630 / 630 pass.
- [x] `uv run ruff check` clean on changed files.
- [ ] Cut rc18 from the merge SHA, re-run the deployed-dev identity-boundary canary single-run, expect 4/4 PASS for the first time in this gate.

## Verification gate

Without the surgical fix and with the guard enabled, the existing
``test_mission_created_local_appended_before_any_saas_fan_out`` would
fail because the validator would catch ``actor`` in the payload. With
both parts in place, the cleaned payload passes both layers and the
new regression test pins it.

## Background — the four prior masks

- `#1142` (audit predicate gap) — fixed in rc15.
- `#1182` (parser misclassification of `queued`/`pending`) — fixed in
  rc16 (#1187).
- `#1141` (canary command shape) — fixed in
  `spec-kitty-end-to-end-testing#45`.
- `#1188` (`WPStatusChanged` envelope duplication) — fixed in rc17
  (#1189).
- `#1190` (this PR) — `MissionCreated.payload.actor`. The previous
  four fixes were necessary but not sufficient; with them all out of
  the way, the underlying payload drift is the only thing the
  deployed-dev canary trips on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)