### PR TITLE
chore(release): prepare 3.2.0rc18

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc17
+  version: 3.2.0rc18
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc18] - 2026-05-20
+
+Ships the final observed Phase 4 launch-gate payload drift fix after the
+rc17 `WPStatusChanged` envelope cleanup.
+
+- Closes `#1190` via `#1191`: `emit_mission_created_local` no longer writes
+  `actor` into the `MissionCreated` payload. The canonical
+  `spec-kitty-events` 5.1.0 schema declares `additionalProperties: false` for
+  `mission_created_payload` and does not allow `actor`, so deployed SaaS batch
+  ingest rejected every batch containing one of these events.
+- Refactors `_validate_lifecycle_payload` to delegate to
+  `spec_kitty_events.conformance.validate_event`, replacing the previous
+  hand-maintained lifecycle payload map that missed `MissionCreated` and other
+  known event types. The local guard now catches extra-property drift before
+  queue fan-out while still tolerating currently accepted missing-field
+  violations.
+- Adds regression coverage for the cleaned `MissionCreated` payload, the
+  conformance guard's extra-field rejection, valid-payload pass-through, and
+  graceful fallback for event types not recognised by the installed events
+  package.
+
 ## [3.2.0rc17] - 2026-05-20
 
 Ships the third Phase 4 launch-gate fix: the actual SaaS-side schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc17"
+version = "3.2.0rc18"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc17"
+version = "3.2.0rc18"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Prepare the next 3.2.0 release candidate after #1191.

- bump spec-kitty-cli metadata from 3.2.0rc17 to 3.2.0rc18
- add CHANGELOG notes for the MissionCreated payload actor removal and conformance guard
- keep uv.lock and .kittify metadata in sync

## Local verification

- python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv lock --check
- uv run pytest tests/release/test_validate_metadata_yaml_sync.py tests/release/test_check_shared_package_drift.py tests/release/test_dogfood_command_set.py -q
- python -m build
- uv run python scripts/release/check_shared_package_drift.py --check-installed
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli
- uv run python -m twine check dist/*