### PR TITLE
fix(intake): show full brief hash and race-safe clearing

### DIFF
--- a/src/specify_cli/cli/commands/intake.py
+++ b/src/specify_cli/cli/commands/intake.py
@@ -188,7 +188,7 @@ def intake(
             console.print(
                 f"[bold]Source:[/bold] {source.get('source_file', '')} "
                 f"  [bold]Ingested:[/bold] {source.get('ingested_at', '')} "
-                f"  [bold]Hash:[/bold] {source.get('brief_hash', '')[:16]}..."
+                f"  [bold]Hash:[/bold] {source.get('brief_hash', '')}"
             )
         if brief is not None:
             console.print(brief)

--- a/src/specify_cli/mission_brief.py
+++ b/src/specify_cli/mission_brief.py
@@ -229,5 +229,4 @@ def clear_mission_brief(repo_root: Path) -> None:
     """Remove both brief artefacts if they exist (idempotent)."""
     for filename in (MISSION_BRIEF_FILENAME, BRIEF_SOURCE_FILENAME):
         path = repo_root / ".kittify" / filename
-        if path.exists():
-            path.unlink()
+        path.unlink(missing_ok=True)

--- a/tests/cli/commands/test_intake.py
+++ b/tests/cli/commands/test_intake.py
@@ -116,6 +116,27 @@ def test_intake_show_prints_brief(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert "Source:" in result.output or PLAN_CONTENT in result.output
 
 
+def test_intake_show_prints_full_brief_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--show prints the full stored SHA-256 hash for integrity checks."""
+    monkeypatch.chdir(tmp_path)
+    plan_file = tmp_path / "PLAN.md"
+    plan_file.write_text(PLAN_CONTENT)
+
+    runner.invoke(app, ["intake", str(plan_file)], catch_exceptions=False)
+
+    source_text = (tmp_path / ".kittify" / BRIEF_SOURCE_FILENAME).read_text(encoding="utf-8")
+    full_hash = next(
+        line.split(": ", 1)[1].strip()
+        for line in source_text.splitlines()
+        if line.startswith("brief_hash: ")
+    )
+    result = runner.invoke(app, ["intake", "--show"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert full_hash in result.output
+    assert f"{full_hash[:16]}..." not in result.output
+
+
 def test_intake_show_no_brief_exits_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """--show exits 1 when no brief has been written."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- print the full stored brief SHA-256 in `spec-kitty intake --show`
- make `clear_mission_brief` use `unlink(missing_ok=True)` for idempotent concurrent cleanup
- add regression coverage for full hash display

Fixes #728
Fixes #729

## Tests
- `uv run pytest tests/cli/test_mission_brief.py::test_clear_is_idempotent tests/cli/test_mission_brief.py::test_clear_removes_both_files tests/cli/commands/test_intake.py::test_intake_show_prints_full_brief_hash tests/cli/commands/test_intake.py::test_intake_show_prints_brief`