### PR TITLE
fix(audit): avoid legacy path literal in setup-plan docs

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -898,7 +898,7 @@ def setup_plan(
     ------------------------------------------------------------------
     This command's full call graph was audited to confirm every body
     upload / queue write goes through ``default_queue_db_path()`` and
-    that no setup-plan path opens the legacy ``~/.spec-kitty/queue.db``
+    that no setup-plan path opens the legacy home-scoped queue database
     directly. The audit covered:
 
       * ``trigger_feature_dossier_sync_if_enabled()`` (this function


### PR DESCRIPTION
## Summary
- reword the setup-plan audit note so the CLI command tree no longer contains the forbidden legacy tilde path literal in non-comment text
- keep the audit strict instead of broadening the allowlist

Fixes #1134

## Tests
- `uv run pytest tests/audit/test_no_legacy_path_literals.py::test_no_legacy_path_literals_in_cli_commands`