### PR TITLE
test(sync): isolate doctor daemon health

### DIFF
--- a/tests/sync/test_sync_doctor.py
+++ b/tests/sync/test_sync_doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, UTC
 from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -74,6 +75,8 @@ class TestFormatQueueHealthCapacity:
 class TestDoctorCommand:
     """Smoke tests for the doctor subcommand output."""
 
+    @patch("specify_cli.sync.owner.list_orphan_records", return_value=[])
+    @patch("specify_cli.sync.daemon.scan_sync_daemons")
     @patch("specify_cli.sync.diagnose.diagnose_body_queue")
     @patch("specify_cli.sync.body_queue.OfflineBodyUploadQueue")
     @patch("specify_cli.sync.queue.OfflineQueue")
@@ -88,9 +91,15 @@ class TestDoctorCommand:
         mock_queue_cls,
         mock_body_queue_cls,
         mock_body_diag,
+        mock_scan_daemons,
+        _mock_orphan_records,
         capsys,
     ):
         """Doctor reports no issues when queue is empty, auth is valid, server reachable."""
+        mock_scan_daemons.return_value = SimpleNamespace(
+            orphan_count=0,
+            orphan_processes=[],
+        )
         mock_queue = MagicMock()
         mock_queue.get_queue_stats.return_value = QueueStats(total_queued=0)
         mock_queue.db_path = "/tmp/test.db"
@@ -130,6 +139,8 @@ class TestDoctorCommand:
         captured = capsys.readouterr()
         assert "No issues detected" in captured.out
 
+    @patch("specify_cli.sync.owner.list_orphan_records", return_value=[])
+    @patch("specify_cli.sync.daemon.scan_sync_daemons")
     @patch("specify_cli.sync.diagnose.diagnose_body_queue")
     @patch("specify_cli.sync.body_queue.OfflineBodyUploadQueue")
     @patch("specify_cli.sync.queue.OfflineQueue")
@@ -144,9 +155,15 @@ class TestDoctorCommand:
         mock_queue_cls,
         mock_body_queue_cls,
         mock_body_diag,
+        mock_scan_daemons,
+        _mock_orphan_records,
         capsys,
     ):
         """Doctor reports issues when queue is full and auth is expired."""
+        mock_scan_daemons.return_value = SimpleNamespace(
+            orphan_count=0,
+            orphan_processes=[],
+        )
         mock_queue = MagicMock()
         mock_queue.get_queue_stats.return_value = QueueStats(
             total_queued=DEFAULT_MAX_QUEUE_SIZE,

--- a/uv.lock
+++ b/uv.lock
@@ -657,9 +657,9 @@ socks = [
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-20T02:52:57.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-20T02:52:55.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc18"
+version = "3.2.0rc19"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- mock live daemon singleton scans in sync doctor tests
- keep the healthy doctor scenario independent from this machine's currently running daemon processes
- cover both healthy and issue-reporting smoke tests with clean daemon state

Fixes #1135

## Tests
- `uv run pytest tests/sync/test_sync_doctor.py::TestDoctorCommand::test_doctor_healthy tests/sync/test_sync_doctor.py::TestDoctorCommand::test_doctor_full_queue_expired_auth -q`