### PR TITLE
fix(acceptance): ignore matrix in grep_absence checks

### DIFF
--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -229,7 +229,15 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
         )
 
     result = subprocess.run(
-        ["grep", "-r", ni.verification_command, "."],
+        [
+            "grep",
+            "-r",
+            "--exclude=acceptance-matrix.json",
+            "--exclude-dir=.git",
+            "--",
+            ni.verification_command,
+            ".",
+        ],
         cwd=str(repo_root),
         capture_output=True,
         text=True,

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -163,6 +163,35 @@ class TestNegativeInvariants:
         results = enforce_negative_invariants(tmp_path, invariants)
         assert results[0].result == "still_present"
 
+    def test_grep_absence_ignores_matrix_file(self, tmp_path):
+        """grep_absence should not match its own acceptance-matrix definition."""
+        feature_dir = tmp_path / "kitty-specs" / "test-mission"
+        feature_dir.mkdir(parents=True)
+        pattern = "old_legacy_route"
+        (feature_dir / MATRIX_FILENAME).write_text(
+            "{\n"
+            '  "mission_slug": "test-mission",\n'
+            '  "negative_invariants": [\n'
+            f'    {{"verification_method": "grep_absence", "verification_command": "{pattern}"}}\n'
+            "  ]\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        results = enforce_negative_invariants(
+            tmp_path,
+            [
+                NegativeInvariant(
+                    "NI-01",
+                    "No legacy route",
+                    "grep_absence",
+                    verification_command=pattern,
+                ),
+            ],
+        )
+
+        assert results[0].result == "confirmed_absent"
+
     def test_custom_command_pass(self, tmp_path):
         invariants = [
             NegativeInvariant(


### PR DESCRIPTION
## Summary
- exclude acceptance-matrix.json from grep_absence scans so invariants do not match their own definitions
- pass grep patterns after `--` to avoid option-like patterns being treated as flags
- add regression coverage for the self-reference case

Fixes #1147

## Tests
- `uv run pytest tests/lanes/test_acceptance_matrix.py::TestNegativeInvariants -q`