### PR TITLE
fix(tasks): clarify rejected review override

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -1389,7 +1389,7 @@ def move_task(
         bool,
         typer.Option(
             "--skip-review-artifact-check",
-            help="Override a rejected latest review artifact when arbiter-approving; requires --note.",
+            help="Override a rejected latest review artifact when arbiter-approving; requires --note and records override evidence.",
         ),
     ] = False,
     auto_commit: Annotated[

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -1389,7 +1389,7 @@ def move_task(
         bool,
         typer.Option(
             "--skip-review-artifact-check",
-            help="Override a rejected latest review artifact; requires --note and records audit evidence.",
+            help="Override a rejected latest review artifact when arbiter-approving; requires --note.",
         ),
     ] = False,
     auto_commit: Annotated[
@@ -1494,9 +1494,9 @@ def move_task(
                 if not skip_review_artifact_check:
                     _output_error(
                         json_output,
-                        f"{task_id} {_artifact_path.name} has verdict: rejected.\n"
-                        "Run another review cycle, move the WP out of approved/done, "
-                        "or pass --skip-review-artifact-check with --note to record an override.",
+                        f"{task_id} has a rejected review artifact ({_artifact_path.name}). "
+                        "Re-run with --skip-review-artifact-check --note <reason> "
+                        "to record an arbiter override.",
                     )
                     raise typer.Exit(1)
                 override_reason = note.strip() if isinstance(note, str) else ""

--- a/tests/specify_cli/cli/commands/agent/test_tasks.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks.py
@@ -245,6 +245,8 @@ class TestVerdictGuardInMoveTask:
         assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}. Output:\n{result.output}"
         assert "review-cycle-1.md" in result.output, f"Expected artifact name in output:\n{result.output}"
         assert "rejected" in result.output, f"Expected 'rejected' in output:\n{result.output}"
+        assert "--skip-review-artifact-check --note <reason>" in result.output
+        assert "arbiter override" in result.output
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
     @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")

--- a/tests/specify_cli/cli/commands/agent/test_tasks.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks.py
@@ -32,6 +32,20 @@ pytestmark = pytest.mark.fast
 runner = CliRunner()
 
 
+def test_move_task_help_surfaces_review_artifact_override_audit_path() -> None:
+    """Help keeps the rejected-artifact override path discoverable."""
+    result = runner.invoke(app, ["move-task", "--help"], terminal_width=160)
+
+    assert result.exit_code == 0, result.output
+    help_text = " ".join(result.output.split())
+    assert "rejected" in help_text
+    assert "review artifact" in help_text
+    assert "arbiter-approving" in help_text
+    assert "requires --note" in help_text
+    assert "records override" in help_text
+    assert "evidence" in help_text
+
+
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make the rejected-review-artifact error state the exact rerun flags near the front of the message
- clarify the help text for `--skip-review-artifact-check`
- add regression coverage for the discoverable override wording

Fixes #1148

## Tests
- `uv run pytest tests/specify_cli/cli/commands/agent/test_tasks.py::TestVerdictGuardInMoveTask::test_approve_blocked_by_rejected_verdict_without_force tests/specify_cli/cli/commands/agent/test_tasks.py::TestVerdictGuardInMoveTask::test_force_done_blocked_by_rejected_verdict tests/specify_cli/cli/commands/agent/test_tasks.py::TestSkipReviewArtifactCheck -q`