### PR TITLE
ci: require PR suffix in protect-main check

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -49,8 +49,10 @@ jobs:
 
           # Get commit message and metadata
           COMMIT_MSG="$HEAD_COMMIT_MESSAGE"
+          COMMIT_SUBJECT="${COMMIT_MSG%%$'\n'*}"
           COMMITTER="$HEAD_COMMITTER_NAME"
 
+          echo "Commit subject: $COMMIT_SUBJECT"
           echo "Commit message: $COMMIT_MSG"
           echo "Committer: $COMMITTER"
 
@@ -60,7 +62,7 @@ jobs:
           # 2. Commits from "GitHub" or "github-actions[bot]" (automated merges)
           # 3. Tag pushes (handled by release workflow, not direct commits)
 
-          if [[ "$COMMIT_MSG" =~ ^Merge\ pull\ request\ #[0-9]+ ]] || \
+          if [[ "$COMMIT_SUBJECT" =~ ^Merge\ pull\ request\ #[0-9]+ ]] || \
              [[ "$COMMITTER" == "GitHub" ]] || \
              [[ "$COMMITTER" == "github-actions[bot]" ]]; then
             echo "✅ Commit is from an approved PR merge or automated process"
@@ -70,7 +72,7 @@ jobs:
           # Check if this is a squash/rebase merge. GitHub appends the PR
           # number as an end-of-subject suffix; issue references in prose do
           # not count as PR merge evidence.
-          if [[ "$COMMIT_MSG" =~ \(#[0-9]+\)$ ]]; then
+          if [[ "$COMMIT_SUBJECT" =~ \(#[0-9]+\)$ ]]; then
             echo "✅ Commit is from a squash/rebase merge (PR reference suffix)"
             exit 0
           fi
@@ -79,9 +81,9 @@ jobs:
           # spec-kitty merge produces squash commits whose message references the
           # mission branch (kitty/mission-NNN-slug) or records mission state
           # transitions. These are the authorised automated merge path for this repo.
-          if [[ "$COMMIT_MSG" =~ kitty/mission- ]] || \
-             [[ "$COMMIT_MSG" =~ ^chore\([0-9]+-.*\):\ (record done|review feedback|Move WP|Start WP|Mark|WP.*claimed|planning artifact) ]] || \
-             [[ "$COMMIT_MSG" =~ ^chore:\ (review feedback|planning artifacts) ]]; then
+          if [[ "$COMMIT_SUBJECT" =~ kitty/mission- ]] || \
+             [[ "$COMMIT_SUBJECT" =~ ^chore\([0-9]+-.*\):\ (record done|review feedback|Move WP|Start WP|Mark|WP.*claimed|planning artifact) ]] || \
+             [[ "$COMMIT_SUBJECT" =~ ^chore:\ (review feedback|planning artifacts) ]]; then
             echo "✅ Commit is from spec-kitty mission merge workflow"
             exit 0
           fi
@@ -90,7 +92,7 @@ jobs:
           # tagged with the matching release tag. This keeps release publication
           # explicit while preventing untagged version/changelog commits from
           # bypassing the normal PR or mission merge paths.
-          if [[ "$COMMIT_MSG" =~ ^Release\ spec-kitty\ ([0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?)$ ]]; then
+          if [[ "$COMMIT_SUBJECT" =~ ^Release\ spec-kitty\ ([0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?)$ ]]; then
             RELEASE_VERSION="${BASH_REMATCH[1]}"
             RELEASE_TAG="v${RELEASE_VERSION}"
             git fetch --force --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" || true

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -67,10 +67,11 @@ jobs:
             exit 0
           fi
 
-          # Check if this is a squash/rebase merge
-          # GitHub squash merges include the PR number in the commit message
-          if [[ "$COMMIT_MSG" =~ \(#[0-9]+\) ]]; then
-            echo "✅ Commit is from a squash/rebase merge (contains PR reference)"
+          # Check if this is a squash/rebase merge. GitHub appends the PR
+          # number as an end-of-subject suffix; issue references in prose do
+          # not count as PR merge evidence.
+          if [[ "$COMMIT_MSG" =~ \(#[0-9]+\)$ ]]; then
+            echo "✅ Commit is from a squash/rebase merge (PR reference suffix)"
             exit 0
           fi
 

--- a/tests/release/test_protect_main_workflow.py
+++ b/tests/release/test_protect_main_workflow.py
@@ -1,0 +1,88 @@
+"""Regression tests for the protect-main merge compliance shell logic."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "protect-main.yml"
+
+
+def _protect_main_script() -> str:
+    lines = WORKFLOW_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
+    script_lines: list[str] = []
+    in_script = False
+
+    for line in lines:
+        if line == "        run: |\n":
+            in_script = True
+            continue
+        if not in_script:
+            continue
+        if line.startswith("          "):
+            script_lines.append(line[10:])
+        elif line.strip() == "":
+            script_lines.append("\n")
+        else:
+            break
+
+    assert script_lines, "protect-main workflow run block was not found"
+    return (
+        "".join(script_lines)
+        .replace("${{ github.event.before }}", "1111111111111111111111111111111111111111")
+        .replace("${{ github.repository }}", "Priivacy-ai/spec-kitty")
+    )
+
+
+def _run_protect_main(tmp_path: Path, message: str, committer: str = "A Contributor") -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HEAD_COMMIT_MESSAGE": message,
+            "HEAD_COMMITTER_NAME": committer,
+            "GITHUB_STEP_SUMMARY": str(tmp_path / "summary.md"),
+        }
+    )
+    return subprocess.run(
+        ["bash"],
+        input=f"set -euo pipefail\n{_protect_main_script()}",
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "feat: release fix (#123)",
+        "feat: release fix (#123)\n\nBody copied from the pull request.",
+        "Merge pull request #123 from Priivacy-ai/example\n\nfeat: release fix",
+    ],
+)
+def test_protect_main_accepts_pr_merge_subjects(tmp_path: Path, message: str) -> None:
+    result = _run_protect_main(tmp_path, message)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "feat: rework foo (see #123 for context)",
+        "feat: rework foo (#123) in prose",
+        "feat: direct push without PR suffix\n\nRefs (#123)",
+    ],
+)
+def test_protect_main_rejects_issue_references_outside_subject_suffix(tmp_path: Path, message: str) -> None:
+    result = _run_protect_main(tmp_path, message)
+
+    assert result.returncode == 1
+    assert "Direct push to main branch detected" in result.stderr + result.stdout


### PR DESCRIPTION
## Summary
- tighten the protect-main squash/rebase rule so PR references must be the end-of-subject suffix
- avoid accepting direct-push subjects that merely mention an issue or PR number in prose

Fixes #870

## Tests
- `bash -lc 'for msg in "feat: release fix (#123)" "feat: rework foo (see #123 for context)"; do if [[ "" =~ \(#[0-9]+\)$ ]]; then echo "PASS "; else echo "FAIL "; fi; done'`