### PR TITLE
fix(retrospective): materialize emitted events

### DIFF
--- a/src/specify_cli/retrospective/events.py
+++ b/src/specify_cli/retrospective/events.py
@@ -219,5 +219,15 @@ def emit_retrospective_event(
         fh.write(line + "\n")
 
     logger.debug("Appended retrospective event %s (%s) to %s", event_id, event_name, events_path)
+    try:
+        from specify_cli.status.reducer import materialize
+
+        materialize(feature_dir)
+    except Exception as exc:  # noqa: BLE001 - append succeeded; keep event durable
+        logger.warning(
+            "Retrospective event %s was appended, but status.json materialization failed: %s",
+            event_id,
+            exc,
+        )
 
     return event_id

--- a/tests/retrospective/test_reducer_integration.py
+++ b/tests/retrospective/test_reducer_integration.py
@@ -19,6 +19,7 @@ import pytest
 
 from specify_cli.retrospective.events import (
     CompletedPayload,
+    ProposalAppliedPayload,
     RequestedPayload,
     StartedPayload,
     emit_retrospective_event,
@@ -463,6 +464,32 @@ class TestEmitRetrospectiveEvent:
             ),
         )
         assert len(event_id) == 26
+
+    def test_emit_materializes_status_json(self, tmp_path: Path) -> None:
+        """Retrospective emits refresh status.json so snapshots do not drift."""
+        feature_dir = tmp_path / "kitty-specs" / "test-mission"
+        feature_dir.mkdir(parents=True)
+
+        emit_retrospective_event(
+            feature_dir=feature_dir,
+            mission_slug=_MISSION_SLUG,
+            mission_id=_MISSION_ID,
+            mid8=_MID8,
+            actor=_RUNTIME_ACTOR,
+            event_name="retrospective.proposal.applied",
+            payload=ProposalAppliedPayload(
+                proposal_id="RP-001",
+                kind="add_glossary_term",
+                target_urn="glossary:term",
+                provenance_ref=".kittify/glossary/.provenance/workflow_probe.yaml",
+                applied_by=_RUNTIME_ACTOR,
+            ),
+        )
+
+        status_path = feature_dir / "status.json"
+        assert status_path.exists()
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status["retrospective"]["proposals_applied"] == 1
 
     def test_emit_rejects_unknown_event_name(self, tmp_path: Path) -> None:
         feature_dir = tmp_path / "kitty-specs" / "test-mission"

--- a/tests/retrospective/test_reducer_integration.py
+++ b/tests/retrospective/test_reducer_integration.py
@@ -20,6 +20,7 @@ import pytest
 from specify_cli.retrospective.events import (
     CompletedPayload,
     ProposalAppliedPayload,
+    ProposalRejectedPayload,
     RequestedPayload,
     StartedPayload,
     emit_retrospective_event,
@@ -490,6 +491,69 @@ class TestEmitRetrospectiveEvent:
         assert status_path.exists()
         status = json.loads(status_path.read_text(encoding="utf-8"))
         assert status["retrospective"]["proposals_applied"] == 1
+
+    def test_emit_materializes_rejected_proposal_status_json(self, tmp_path: Path) -> None:
+        """Conflict rejection events also refresh the derived retrospective snapshot."""
+        feature_dir = tmp_path / "kitty-specs" / "test-mission"
+        feature_dir.mkdir(parents=True)
+
+        emit_retrospective_event(
+            feature_dir=feature_dir,
+            mission_slug=_MISSION_SLUG,
+            mission_id=_MISSION_ID,
+            mid8=_MID8,
+            actor=_RUNTIME_ACTOR,
+            event_name="retrospective.proposal.rejected",
+            payload=ProposalRejectedPayload(
+                proposal_id="RP-002",
+                kind="add_glossary_term",
+                reason="conflict",
+                detail="target already changed",
+                rejected_by=_RUNTIME_ACTOR,
+            ),
+        )
+
+        status_path = feature_dir / "status.json"
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status["retrospective"]["proposals_rejected"] == 1
+
+    def test_emit_keeps_appended_event_when_materialization_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The event log is authoritative; status.json refresh failure must not roll it back."""
+        feature_dir = tmp_path / "kitty-specs" / "test-mission"
+        feature_dir.mkdir(parents=True)
+
+        def fail_materialize(feature_dir: Path) -> None:
+            raise RuntimeError(f"cannot materialize {feature_dir.name}")
+
+        monkeypatch.setattr("specify_cli.status.reducer.materialize", fail_materialize)
+
+        with caplog.at_level("WARNING", logger="specify_cli.retrospective.events"):
+            event_id = emit_retrospective_event(
+                feature_dir=feature_dir,
+                mission_slug=_MISSION_SLUG,
+                mission_id=_MISSION_ID,
+                mid8=_MID8,
+                actor=_RUNTIME_ACTOR,
+                event_name="retrospective.proposal.applied",
+                payload=ProposalAppliedPayload(
+                    proposal_id="RP-001",
+                    kind="add_glossary_term",
+                    target_urn="glossary:term",
+                    provenance_ref=".kittify/glossary/.provenance/workflow_probe.yaml",
+                    applied_by=_RUNTIME_ACTOR,
+                ),
+            )
+
+        events_path = feature_dir / "status.events.jsonl"
+        events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+        assert [event["event_id"] for event in events] == [event_id]
+        assert not (feature_dir / "status.json").exists()
+        assert "was appended, but status.json materialization failed" in caplog.text
 
     def test_emit_rejects_unknown_event_name(self, tmp_path: Path) -> None:
         feature_dir = tmp_path / "kitty-specs" / "test-mission"


### PR DESCRIPTION
## Summary
- refresh `status.json` after appending retrospective events
- keep retrospective event append durable if materialization fails, logging a warning instead of rolling back
- add regression coverage that a proposal-applied event updates the materialized retrospective snapshot

Fixes #1183

## Tests
- `uv run pytest tests/retrospective/test_reducer_integration.py::TestEmitRetrospectiveEvent tests/retrospective/test_reducer_integration.py::TestStatusSnapshotRetrospectiveField::test_materialize_attaches_non_absent_retrospective_snapshot -q`