### PR TITLE
chore(lock): refresh lock for rc19

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc19"
+version = "3.2.0rc20"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- refresh uv.lock metadata for the current pyproject version after rc19
- fixes the post-merge CI Quality uv lock --check failure seen after #1205 landed

## Tests
- /tmp/spec-kitty-uv-latest/bin/uv lock --check
- uv run pytest tests/lanes/test_acceptance_matrix.py::TestNegativeInvariants -q