### PR TITLE
test(tasks): avoid rendered help truncation

### DIFF
--- a/tests/specify_cli/cli/commands/agent/test_tasks.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
+from typer.main import get_command
 
 from specify_cli.cli.commands.agent.tasks import (
     _get_latest_review_cycle_verdict,
@@ -38,12 +39,19 @@ def test_move_task_help_surfaces_review_artifact_override_audit_path() -> None:
 
     assert result.exit_code == 0, result.output
     help_text = " ".join(result.output.split())
+    click_command = get_command(app).commands["move-task"]
+    skip_review_help = next(
+        param.help
+        for param in click_command.params
+        if param.name == "skip_review_artifact_check"
+    )
+
     assert "rejected" in help_text
     assert "review artifact" in help_text
     assert "arbiter-approving" in help_text
-    assert "requires --note" in help_text
-    assert "records override" in help_text
-    assert "evidence" in help_text
+    assert "requires --note" in skip_review_help
+    assert "records override" in skip_review_help
+    assert "evidence" in skip_review_help
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make the move-task help test assert full audit-path wording from Typer command metadata
- keep rendered help assertions for the user-visible discovery terms

## Verification
- uv run --python python3.12 --extra test python -m pytest tests/specify_cli/cli/commands/agent/test_tasks.py::test_move_task_help_surfaces_review_artifact_override_audit_path -q
- uv run --python python3.12 --extra test python -m pytest tests/specify_cli/cli/commands/agent/test_tasks.py -q --tb=short
- uv run --python python3.12 --extra test python -m pytest --ignore=tests/doctrine --ignore=tests/kernel --ignore=tests/status --ignore=tests/specify_cli/status --ignore=tests/sync --ignore=tests/merge --ignore=tests/missions --ignore=tests/post_merge --ignore=tests/release --ignore=tests/review --ignore=tests/next --ignore=tests/specify_cli/next --ignore=tests/lanes --ignore=tests/test_dashboard --ignore=tests/upgrade --ignore=tests/cli --ignore=tests/runtime --ignore=tests/charter --ignore=tests/agent -m "fast and not windows_ci" -q --tb=short --cov=src/specify_cli --cov-report=xml:out/reports/coverage/coverage-fast-core-misc.xml
- uv run --python python3.12 ruff check tests/specify_cli/cli/commands/agent/test_tasks.py