### PR TITLE
chore(release): prepare 3.2.0rc21

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc20
+  version: 3.2.0rc21
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc21] - 2026-05-20
+
+Rolls up the minor issue-queue cleanup selected before the 3.2.0
+stable release, plus the post-merge test hardening needed to keep
+`main` green after those fixes landed.
+
+- Fixes tasking help assertions to validate Typer option metadata
+  instead of Rich-rendered, platform-truncated help text, restoring
+  the full main test sweep after the task command cleanup.
+- Refreshes the rc20 lockfile metadata so branch and release
+  validation agree on the packaged dependency graph.
+- Improves task finalization and review-state behavior: rejected
+  review overrides are described with the canonical tasking language,
+  finalize-tasks dependency prose no longer produces false positives,
+  and the main test sweep covers those edge cases.
+- Tightens CI and repository hygiene by requiring PR suffixes in the
+  protect-main check and tracking research evidence logs.
+- Hardens sync, acceptance, retrospective, and dashboard edges found
+  during the pre-3.2.0 issue sweep: doctor daemon health checks are
+  isolated, acceptance clarification markers match the canonical
+  contract, retrospective event emission is materialized, and the
+  dashboard exposes the glossary shell.
+
 ## [3.2.0rc20] - 2026-05-20
 
 Closes the next dormant mask from epic `#1198`, surfaced by the

--- a/kitty-specs/test-feature-01KS35HB/meta.json
+++ b/kitty-specs/test-feature-01KS35HB/meta.json
@@ -1,0 +1,12 @@
+{
+  "created_at": "2026-05-20T17:04:37.403753+00:00",
+  "friendly_name": "123 test feature",
+  "mission_id": "01KS35HBGTZD5ZJ2QPMQ94TK33",
+  "mission_number": null,
+  "mission_slug": "test-feature-01KS35HB",
+  "mission_type": "software-dev",
+  "purpose_context": "This mission advances 123 test feature on release/3.2.0rc21 so stakeholders can track the work from mission creation onward.",
+  "purpose_tldr": "123 test feature",
+  "slug": "test-feature-01KS35HB",
+  "target_branch": "release/3.2.0rc21"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc20"
+version = "3.2.0rc21"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc20"
+version = "3.2.0rc21"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- bump CLI and Spec Kitty metadata to 3.2.0rc21
- add the 3.2.0rc21 changelog entry for the pre-3.2.0 cleanup rollup

## Validation
- python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- uv run --python python3.12 python -m pytest -v --import-mode=importlib tests/release
- uv run --python python3.12 python scripts/release/check_shared_package_drift.py --check-installed
- uv run --python python3.12 python scripts/release/check_shared_package_drift.py --check-installed --saas-pyproject ../spec-kitty-saas/pyproject.toml
- uv run --python python3.12 python -m build
- uv run --python python3.12 python scripts/release/check_exact_install.py --package spec-kitty-cli
- uv run --python python3.12 python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json
- uv run --python python3.12 twine check dist/*

Note: attempted full `uv run --python python3.12 python -m pytest`; stopped after local environment-dependent architectural/auth integration failures outside the tag release workflow.