### PR TITLE
fix(ci): clear Sonar findings and rc22 lock drift

### DIFF
--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -153,10 +153,16 @@ _DEPENDS_ON = re.compile(
 
 # Explicit-declaration format only (not prose inference).
 # Pattern 2: "**Dependencies**: WP01" / "Dependencies: WP01, WP02"
-# Matches a declaration field at the start of a line or after a pipe delimiter.
-_DEPS_COLON = re.compile(
-    r"(?:^\s*(?:[-*]\s*)?|\|\s*)\*?\*?Dependencies\*?\*?\s*:\s*(?P<value>[^|\n]*)",
-    re.IGNORECASE | re.MULTILINE,
+# Match either a standalone declaration line or a pipe-delimited metadata field.
+_DEPS_COLON_PATTERNS = (
+    re.compile(
+        r"^\s*(?:[-*]\s*)?\*?\*?Dependencies\*?\*?\s*:\s*(?P<value>[^|\n]*)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    re.compile(
+        r"\|\s*\*?\*?Dependencies\*?\*?\s*:\s*(?P<value>[^|\n]*)",
+        re.IGNORECASE,
+    ),
 )
 
 # Explicit-declaration format only (not prose inference).
@@ -220,7 +226,15 @@ def _parse_section_deps(section_content: str) -> list[str]:
 
     # Pattern 2 — "**Dependencies**: WP01, WP02"
     # Skip lines that are *only* a heading (those are Pattern 3 territory).
-    for match in _DEPS_COLON.finditer(section_content):
+    colon_matches = sorted(
+        (
+            match
+            for pattern in _DEPS_COLON_PATTERNS
+            for match in pattern.finditer(section_content)
+        ),
+        key=lambda match: match.start(),
+    )
+    for match in colon_matches:
         line = match.group(0)
         # If the line also matches _DEPS_HEADING it is a bullet-list heading —
         # don't double-count it here.

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -417,7 +417,6 @@ def create_mission_core(
             mission_type=str(meta.get("mission_type") or mission or "software-dev"),
             target_branch=planning_branch,
             wp_count=0,
-            actor="spec-kitty mission create",
             project_uuid=str(_identity.project_uuid) if _identity.project_uuid else None,
             project_slug=_identity.project_slug,
             friendly_name=normalized_friendly_name,

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -374,7 +374,6 @@ def emit_mission_created_local(
     mission_type: str,
     target_branch: str,
     wp_count: int = 0,
-    actor: str = "cli",
     project_uuid: str | None = None,
     project_slug: str | None = None,
     friendly_name: str | None = None,
@@ -388,13 +387,12 @@ def emit_mission_created_local(
     ``status.events.jsonl`` is created on first call.
 
     ``mission_type`` and ``wp_count`` are required by the canonical
-    ``mission_created_payload`` schema (events 5.1.0). The ``actor``
-    parameter is intentionally NOT placed in the payload — the schema
-    declares ``additionalProperties: false`` with no ``actor`` property.
+    ``mission_created_payload`` schema (events 5.1.0). This helper does not
+    take an actor because the payload schema declares ``additionalProperties:
+    false`` with no ``actor`` property.
     See Priivacy-ai/spec-kitty#1199 for the full required-field surface.
     """
     log_path = mission_event_log_path(feature_dir)
-    del actor  # captured by the surrounding StatusEvent envelope; not in payload (see #1190)
     payload: dict[str, Any] = {
         "mission_slug": mission_slug,
         "mission_number": mission_number,

--- a/src/specify_cli/sync/__init__.py
+++ b/src/specify_cli/sync/__init__.py
@@ -22,6 +22,9 @@ must fetch bearer tokens via
 deletion).
 """
 
+_EVENTS_MODULE = ".events"
+_FEATURE_FLAGS_MODULE = ".feature_flags"
+
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # Keep package init cheap. Importing a sync submodule such as
     # ``runtime_event_emitter`` still initializes this package first, so
@@ -30,22 +33,22 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LamportClock": (".clock", "LamportClock"),
     "generate_node_id": (".clock", "generate_node_id"),
     "emit_diagnostic": (".diagnose", "emit_diagnostic"),
-    "get_emitter": (".events", "get_emitter"),
-    "reset_emitter": (".events", "reset_emitter"),
-    "emit_wp_status_changed": (".events", "emit_wp_status_changed"),
-    "emit_wp_created": (".events", "emit_wp_created"),
-    "emit_wp_assigned": (".events", "emit_wp_assigned"),
-    "emit_mission_created": (".events", "emit_mission_created"),
-    "emit_mission_closed": (".events", "emit_mission_closed"),
-    "emit_history_added": (".events", "emit_history_added"),
-    "emit_error_logged": (".events", "emit_error_logged"),
-    "emit_dependency_resolved": (".events", "emit_dependency_resolved"),
-    "emit_token_usage_recorded": (".events", "emit_token_usage_recorded"),
-    "emit_diff_summary_recorded": (".events", "emit_diff_summary_recorded"),
+    "get_emitter": (_EVENTS_MODULE, "get_emitter"),
+    "reset_emitter": (_EVENTS_MODULE, "reset_emitter"),
+    "emit_wp_status_changed": (_EVENTS_MODULE, "emit_wp_status_changed"),
+    "emit_wp_created": (_EVENTS_MODULE, "emit_wp_created"),
+    "emit_wp_assigned": (_EVENTS_MODULE, "emit_wp_assigned"),
+    "emit_mission_created": (_EVENTS_MODULE, "emit_mission_created"),
+    "emit_mission_closed": (_EVENTS_MODULE, "emit_mission_closed"),
+    "emit_history_added": (_EVENTS_MODULE, "emit_history_added"),
+    "emit_error_logged": (_EVENTS_MODULE, "emit_error_logged"),
+    "emit_dependency_resolved": (_EVENTS_MODULE, "emit_dependency_resolved"),
+    "emit_token_usage_recorded": (_EVENTS_MODULE, "emit_token_usage_recorded"),
+    "emit_diff_summary_recorded": (_EVENTS_MODULE, "emit_diff_summary_recorded"),
     "OfflineQueue": (".queue", "OfflineQueue"),
-    "SAAS_SYNC_ENV_VAR": (".feature_flags", "SAAS_SYNC_ENV_VAR"),
-    "is_saas_sync_enabled": (".feature_flags", "is_saas_sync_enabled"),
-    "saas_sync_disabled_message": (".feature_flags", "saas_sync_disabled_message"),
+    "SAAS_SYNC_ENV_VAR": (_FEATURE_FLAGS_MODULE, "SAAS_SYNC_ENV_VAR"),
+    "is_saas_sync_enabled": (_FEATURE_FLAGS_MODULE, "is_saas_sync_enabled"),
+    "saas_sync_disabled_message": (_FEATURE_FLAGS_MODULE, "saas_sync_disabled_message"),
     # Lazy-loaded names that require heavier optional/runtime dependencies.
     "BatchEventResult": (".batch", "BatchEventResult"),
     "BatchSyncResult": (".batch", "BatchSyncResult"),

--- a/tests/core/test_dependency_parser.py
+++ b/tests/core/test_dependency_parser.py
@@ -126,6 +126,17 @@ class TestInlineDependenciesColonFormat:
         result = parse_dependencies_from_tasks_md(content)
         assert result["WP02"] == []
 
+    def test_colon_dependencies_preserve_order_across_line_shapes(self) -> None:
+        content = _make_tasks_md(
+            (
+                "WP05",
+                "**Priority**: High | **Dependencies**: WP02 | **Subtasks**: 1\n\n"
+                "Dependencies: WP01\n",
+            ),
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP05"] == ["WP02", "WP01"]
+
 
 # ---------------------------------------------------------------------------
 # Format 3: bullet-list under "### Dependencies" heading

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -107,7 +107,6 @@ def test_mission_created_local_appended_before_any_saas_fan_out(
         mission_number=None,
         mission_type="software-dev",
         target_branch="main",
-        actor="test",
     )
 
     assert envelope is not None
@@ -152,7 +151,6 @@ def test_mission_created_payload_contains_required_fields(feature_dir: Path) -> 
         mission_type="software-dev",
         target_branch="main",
         wp_count=0,
-        actor="spec-kitty mission create",
         friendly_name="Demo Mission",
         purpose_tldr="Demo TLDR",
         purpose_context="Demo context paragraph.",

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc21"
+version = "3.2.0rc22"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- update `uv.lock` so `spec-kitty-cli` matches the `3.2.0rc22` release metadata on `main`
- resolve the new Sonar reliability/code-smell findings introduced on `main`
- keep the sync package lazy-import table behavior unchanged while removing duplicated literals

## Details
- rewrote the dependency parser's `Dependencies:` regex matching into two explicit patterns so Sonar no longer flags ambiguous alternation precedence
- removed the unused `actor` parameter from `emit_mission_created_local()` because the lifecycle envelope already carries actor information and the payload schema forbids it
- replaced repeated lazy-import module path literals in `specify_cli.sync.__init__` with module constants

## Validation
- `uv run pytest tests/core/test_dependency_parser.py tests/status/test_lifecycle_events.py -q`
- `uv run python - <<'PY' ... sync lazy imports ok ... PY`
- `uv run ruff check src/specify_cli/core/dependency_parser.py src/specify_cli/sync/__init__.py src/specify_cli/status/lifecycle_events.py src/specify_cli/core/mission_creation.py tests/status/test_lifecycle_events.py`
- `uv lock --check`

## Sonar / security context
- GitHub code-scanning alerts: none open as of 2026-05-21
- GitHub Dependabot alerts: none open as of 2026-05-21
- SonarCloud `main` quality gate also shows `new_security_hotspots_reviewed = 0.0`, but the remaining hotspots are older loopback/localhost `http` findings and were not code-actionable in this patch
