### PR TITLE
Fix charter context JSON project charter envelope

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -2257,6 +2257,112 @@ def _collect_typed_artifacts(
     return entries
 
 
+def _bundle_root_for_json(repo_root: Path) -> Path:
+    """Return the canonical charter bundle root, falling back to *repo_root*."""
+    try:
+        from charter.sync import ensure_charter_bundle_fresh
+
+        refresh_result = ensure_charter_bundle_fresh(repo_root)
+    except Exception:  # noqa: BLE001 - JSON metadata is best-effort
+        return repo_root
+    if refresh_result is not None and refresh_result.canonical_root is not None:
+        return refresh_result.canonical_root
+    return repo_root
+
+
+def _relative_json_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _project_charter_json_block(repo_root: Path) -> dict[str, object]:
+    """Describe the project-local charter loaded by the context renderer."""
+    bundle_root = _bundle_root_for_json(repo_root)
+    charter_dir = bundle_root / KITTIFY_DIRNAME / "charter"
+    charter_path = charter_dir / "charter.md"
+    metadata_path = charter_dir / "metadata.yaml"
+
+    block: dict[str, object] = {
+        "present": charter_path.exists(),
+        "path": _relative_json_path(charter_path, bundle_root),
+    }
+    if not charter_path.exists():
+        return block
+
+    block["bytes"] = charter_path.stat().st_size
+    if not metadata_path.exists():
+        return block
+
+    try:
+        data = YAML(typ="safe").load(metadata_path.read_text(encoding="utf-8")) or {}
+    except (OSError, YAMLError, ValueError):
+        return block
+    if not isinstance(data, dict):
+        return block
+
+    charter_hash = data.get("charter_hash")
+    if isinstance(charter_hash, str) and charter_hash:
+        block["hash"] = charter_hash
+    source_path = data.get("source_path")
+    if isinstance(source_path, str) and source_path:
+        block["source_path"] = source_path
+    bundle_schema_version = data.get("bundle_schema_version")
+    if isinstance(bundle_schema_version, int):
+        block["bundle_schema_version"] = bundle_schema_version
+    schema_version = data.get("schema_version")
+    if isinstance(schema_version, str) and schema_version:
+        block["schema_version"] = schema_version
+    return block
+
+
+def _project_directive_entries(repo_root: Path) -> list[dict[str, object]]:
+    """Return every directive ID that the project-governance resolver exposes."""
+    from charter.sync import load_directives_config
+
+    local_by_id: dict[str, object] = {}
+    directive_ids: list[str] = []
+    try:
+        directives_cfg = load_directives_config(repo_root)
+        local_by_id = {directive.id: directive for directive in directives_cfg.directives}
+        directive_ids = [directive.id for directive in directives_cfg.directives]
+    except Exception:  # noqa: BLE001 - fall through to resolver/catalog path
+        local_by_id = {}
+        directive_ids = []
+
+    try:
+        from charter.resolver import resolve_project_governance
+
+        resolution = resolve_project_governance(repo_root)
+        directive_ids = list(dict.fromkeys(list(resolution.directives) + directive_ids))
+    except Exception:  # noqa: BLE001 - keep any directly-loaded directive IDs
+        directive_ids = list(dict.fromkeys(directive_ids))
+
+    try:
+        service = _build_doctrine_service(repo_root)
+    except Exception:  # noqa: BLE001 - local directive IDs are still useful
+        service = None
+    entries: list[dict[str, object]] = []
+    for directive_id in directive_ids:
+        local = local_by_id.get(directive_id)
+        if local is not None:
+            entry: dict[str, object] = {"id": directive_id, "source": "project"}
+            title = getattr(local, "title", None)
+            description = getattr(local, "description", None)
+            if isinstance(title, str) and title:
+                entry["title"] = title
+            if isinstance(description, str) and description:
+                entry["summary"] = description
+            entries.append(entry)
+            continue
+        if service is None:
+            entries.append({"id": directive_id, "source": "builtin"})
+            continue
+        entries.extend(_collect_typed_artifacts(service.directives, [directive_id]))  # type: ignore[attr-defined]
+    return entries
+
+
 _EMPTY_ORG_CHARTER: dict[str, object] = {"present": False, "packs": []}
 
 
@@ -2273,9 +2379,14 @@ def build_charter_context_json(
     The payload contains:
 
     * ``action`` / ``mode`` — same surface as :class:`CharterContextResult`.
-    * ``directives`` / ``tactics`` / ``styleguides`` / ``toolguides`` — typed
-      artifact arrays, each entry carrying a ``"source"`` provenance field
-      (``"builtin"`` | ``"org"`` | ``"project"``).
+    * ``directives`` / ``tactics`` / ``styleguides`` / ``toolguides`` —
+      action-scoped typed artifact arrays, each entry carrying a ``"source"``
+      provenance field (``"builtin"`` | ``"org"`` | ``"project"``).
+    * ``all_directives`` — every directive ID exposed by the project
+      governance resolver, including directives extracted from the
+      project-local charter even when the action-scoped ``directives`` array
+      is empty.
+    * ``project_charter`` — the loaded project-local charter, when present.
     * ``org_charter`` — additive block describing org-layer governance
       policies (empty when no org pack ships an ``org-charter.yaml``).
 
@@ -2296,6 +2407,8 @@ def build_charter_context_json(
         "tactics": [],
         "styleguides": [],
         "toolguides": [],
+        "all_directives": _project_directive_entries(repo_root),
+        "project_charter": _project_charter_json_block(repo_root),
         "org_charter": (
             dict(org_charter_block) if org_charter_block is not None else dict(_EMPTY_ORG_CHARTER)
         ),

--- a/src/specify_cli/cli/commands/charter.py
+++ b/src/specify_cli/cli/commands/charter.py
@@ -1565,7 +1565,15 @@ def generate(
 def context(
     action: str = typer.Option(..., "--action", help="Workflow action (specify|plan|implement|review)"),
     mark_loaded: bool = typer.Option(True, "--mark-loaded/--no-mark-loaded", help="Persist first-load state"),
-    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help=(
+            "Output JSON. `directives` is action-scoped; `all_directives` and "
+            "`project_charter` describe the project-local charter, while "
+            "`org_charter` describes imported org packs."
+        ),
+    ),
 ) -> None:
     """Render charter context for a specific workflow action."""
     from charter.context import (
@@ -1601,6 +1609,7 @@ def context(
             structured = build_charter_context_json(
                 repo_root,
                 action=action,
+                depth=result.depth,
                 org_root=org_root,
                 org_charter_block=org_charter_block,
             )
@@ -1616,9 +1625,17 @@ def context(
                         "context": result.text,
                         "text": result.text,
                         "directives": structured.get("directives", []),
+                        "all_directives": structured.get("all_directives", []),
                         "tactics": structured.get("tactics", []),
                         "styleguides": structured.get("styleguides", []),
                         "toolguides": structured.get("toolguides", []),
+                        "project_charter": structured.get(
+                            "project_charter",
+                            {
+                                "present": False,
+                                "path": ".kittify/charter/charter.md",
+                            },
+                        ),
                         "org_charter": structured.get(
                             "org_charter", {"present": False, "packs": []}
                         ),

--- a/tests/charter/test_context.py
+++ b/tests/charter/test_context.py
@@ -6,6 +6,7 @@ import ast
 import inspect
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -13,9 +14,14 @@ import pytest
 from charter.context import (
     CharterContextResult,
     _build_doctrine_service,
+    _bundle_root_for_json,
+    _project_charter_json_block,
+    _project_directive_entries,
+    _relative_json_path,
     _render_action_scoped,
     _render_bootstrap,
     build_charter_context,
+    build_charter_context_json,
 )
 
 pytestmark = pytest.mark.fast
@@ -366,6 +372,165 @@ class TestBuildContextV2:
         for d in [1, 2, 3]:
             result = self._call(tmp_path, depth=d)
             assert result.depth == d
+
+    def test_json_compact_mode_reports_project_charter_and_all_directives(
+        self, tmp_path: Path
+    ) -> None:
+        """Compact JSON still exposes project-local charter facts."""
+        _setup_fixture_repo(tmp_path)
+        charter_dir = tmp_path / ".kittify" / "charter"
+        (charter_dir / "directives.yaml").write_text(
+            textwrap.dedent("""\
+                directives:
+                  - id: DIR-001
+                    title: First directive
+                    description: First rule
+                  - id: DIR-002
+                    title: Second directive
+                    description: Second rule
+            """),
+            encoding="utf-8",
+        )
+        (charter_dir / "metadata.yaml").write_text(
+            textwrap.dedent("""\
+                schema_version: 1.0.0
+                charter_hash: sha256:testhash
+                source_path: .kittify/charter/charter.md
+                bundle_schema_version: 2
+            """),
+            encoding="utf-8",
+        )
+
+        from charter.sync import SyncResult
+
+        sync_result = SyncResult(
+            synced=False,
+            stale_before=False,
+            files_written=[],
+            extraction_mode="",
+            canonical_root=tmp_path,
+        )
+        with patch("charter.sync.ensure_charter_bundle_fresh", return_value=sync_result):
+            payload = build_charter_context_json(tmp_path, action="plan", depth=1)
+
+        assert payload["directives"] == []
+        assert [entry["id"] for entry in payload["all_directives"]] == ["DIR-001", "DIR-002"]
+        assert payload["project_charter"] == {
+            "present": True,
+            "path": ".kittify/charter/charter.md",
+            "bytes": (charter_dir / "charter.md").stat().st_size,
+            "hash": "sha256:testhash",
+            "source_path": ".kittify/charter/charter.md",
+            "bundle_schema_version": 2,
+            "schema_version": "1.0.0",
+        }
+
+    def test_json_project_charter_metadata_fallbacks(self, tmp_path: Path) -> None:
+        """Project-charter JSON metadata degrades to explicit presence facts."""
+        assert _relative_json_path(Path("/outside/charter.md"), tmp_path) == "/outside/charter.md"
+
+        with patch("charter.sync.ensure_charter_bundle_fresh", side_effect=RuntimeError("boom")):
+            assert _bundle_root_for_json(tmp_path) == tmp_path
+
+        with patch("charter.sync.ensure_charter_bundle_fresh", return_value=None):
+            assert _bundle_root_for_json(tmp_path) == tmp_path
+
+        missing = _project_charter_json_block(tmp_path)
+        assert missing == {
+            "present": False,
+            "path": ".kittify/charter/charter.md",
+        }
+
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text("# Charter\n", encoding="utf-8")
+        from charter.sync import SyncResult
+
+        sync_result = SyncResult(
+            synced=False,
+            stale_before=False,
+            files_written=[],
+            extraction_mode="",
+            canonical_root=tmp_path,
+        )
+
+        with patch("charter.sync.ensure_charter_bundle_fresh", return_value=sync_result):
+            no_metadata = _project_charter_json_block(tmp_path)
+        assert no_metadata["present"] is True
+        assert no_metadata["bytes"] == 10
+        assert "hash" not in no_metadata
+
+        metadata = charter_dir / "metadata.yaml"
+        metadata.write_text("[not-a-mapping]\n", encoding="utf-8")
+        with patch("charter.sync.ensure_charter_bundle_fresh", return_value=sync_result):
+            non_mapping = _project_charter_json_block(tmp_path)
+        assert "hash" not in non_mapping
+
+        with (
+            patch("charter.sync.ensure_charter_bundle_fresh", return_value=sync_result),
+            patch("charter.context.YAML") as yaml_cls,
+        ):
+            yaml_cls.side_effect = ValueError("bad yaml")
+            unreadable = _project_charter_json_block(tmp_path)
+        assert "hash" not in unreadable
+
+    def test_project_directive_entries_fallbacks(self, tmp_path: Path) -> None:
+        """Directive JSON keeps IDs when optional loaders are unavailable."""
+        with (
+            patch("charter.sync.load_directives_config", side_effect=RuntimeError("no config")),
+            patch(
+                "charter.resolver.resolve_project_governance",
+                return_value=SimpleNamespace(directives=["DIRECTIVE_001"]),
+            ),
+            patch("charter.context._build_doctrine_service", side_effect=RuntimeError("no service")),
+        ):
+            assert _project_directive_entries(tmp_path) == [
+                {"id": "DIRECTIVE_001", "source": "builtin"}
+            ]
+
+        directive = SimpleNamespace(id="DIR-LOCAL", title="Local", description="")
+        with (
+            patch(
+                "charter.sync.load_directives_config",
+                return_value=SimpleNamespace(directives=[directive]),
+            ),
+            patch("charter.resolver.resolve_project_governance", side_effect=RuntimeError("no resolver")),
+            patch("charter.context._build_doctrine_service", side_effect=RuntimeError("no service")),
+        ):
+            assert _project_directive_entries(tmp_path) == [
+                {"id": "DIR-LOCAL", "source": "project", "title": "Local"}
+            ]
+
+        repo = SimpleNamespace(
+            get=lambda artifact_id: SimpleNamespace(
+                id=artifact_id,
+                title="Catalog directive",
+                intent="Catalog intent",
+            ),
+            get_provenance=lambda _artifact_id: "builtin",
+        )
+        with (
+            patch(
+                "charter.sync.load_directives_config",
+                return_value=SimpleNamespace(directives=[]),
+            ),
+            patch(
+                "charter.resolver.resolve_project_governance",
+                return_value=SimpleNamespace(directives=["DIRECTIVE_002"]),
+            ),
+            patch(
+                "charter.context._build_doctrine_service",
+                return_value=SimpleNamespace(directives=repo),
+            ),
+        ):
+            assert _project_directive_entries(tmp_path) == [
+                {
+                    "id": "DIRECTIVE_002",
+                    "source": "builtin",
+                    "title": "Catalog directive",
+                    "summary": "Catalog intent",
+                }
+            ]
 
 
 def test_render_bootstrap_uses_fallback_labels_without_summary_or_references() -> None:

--- a/tests/cli/commands/test_charter_rendering.py
+++ b/tests/cli/commands/test_charter_rendering.py
@@ -10,6 +10,7 @@ Structure: AAA (Arrange / Act / Assert).
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -238,6 +239,63 @@ def test_context_renders_action_name_in_output(tmp_path: Path) -> None:
     assert result.exit_code == 0
     # The context text should appear in stdout
     assert "Review context text here." in result.output or "review" in result.output.lower()
+
+
+def test_context_json_uses_same_depth_as_rendered_context(tmp_path: Path) -> None:
+    """JSON envelope must not recompute a different first-load mode than text."""
+    project = _project(tmp_path)
+
+    fake_ctx = MagicMock()
+    fake_ctx.action = "plan"
+    fake_ctx.mode = "bootstrap"
+    fake_ctx.first_load = True
+    fake_ctx.references_count = 0
+    fake_ctx.depth = 2
+    fake_ctx.text = "Action Doctrine (plan):\n  Directives:\n    - DIRECTIVE_001"
+
+    def _json_builder(
+        repo_root: Path,
+        *,
+        action: str,
+        depth: int | None,
+        org_root: Path | None,
+        org_charter_block: dict[str, object],
+    ) -> dict[str, object]:
+        assert repo_root == project
+        assert action == "plan"
+        assert depth == fake_ctx.depth
+        assert org_root is None
+        assert org_charter_block == {"present": False, "packs": []}
+        return {
+            "directives": [{"id": "DIRECTIVE_001", "source": "builtin"}],
+            "all_directives": [{"id": "DIRECTIVE_001", "source": "builtin"}],
+            "tactics": [],
+            "styleguides": [],
+            "toolguides": [],
+            "project_charter": {
+                "present": True,
+                "path": ".kittify/charter/charter.md",
+            },
+            "org_charter": {"present": False, "packs": []},
+        }
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=project),
+        patch("charter.context.build_charter_context", return_value=fake_ctx),
+        patch("charter.context.build_charter_context_json", side_effect=_json_builder),
+        patch("specify_cli.doctrine.config.resolve_org_roots", return_value=[]),
+        patch(
+            "specify_cli.doctrine.org_charter_loader.load_org_charter_json_block",
+            return_value={"present": False, "packs": []},
+        ),
+    ):
+        result = runner.invoke(app, ["context", "--action", "plan", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "bootstrap"
+    assert payload["directives"] == [{"id": "DIRECTIVE_001", "source": "builtin"}]
+    assert "DIRECTIVE_001" in payload["text"]
 
 
 def test_context_renders_error_on_task_cli_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add project_charter metadata to charter context JSON so consumers can distinguish project-local charters from org pack policy blocks.
- Add all_directives for project-governance directive IDs, including directives extracted from the project charter when action-scoped directives is empty.
- Clarify --json help text: directives is action-scoped; all_directives/project_charter are project-local; org_charter is imported org-pack governance.

Fixes #1242

## Tests
- uv run pytest tests/charter/test_context.py -q
- uv run pytest tests/specify_cli/doctrine/test_org_charter.py -q
- uv run ruff check src/charter/context.py src/specify_cli/cli/commands/charter.py tests/charter/test_context.py