### PR TITLE
Add WP review anti-pattern checklist

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -59,8 +59,9 @@ from specify_cli.review.prompt_metadata import (
     validate_review_prompt_metadata,
     write_review_prompt_with_metadata,
 )
-from specify_cli.status.locking import feature_status_lock
+from specify_cli.review.antipattern_checklist import render_wp_review_antipattern_checklist
 from specify_cli.review.cycle import REVIEW_FEEDBACK_SENTINELS, resolve_review_cycle_pointer
+from specify_cli.status.locking import feature_status_lock
 from specify_cli.status.models import AgentAssignment, Lane
 from specify_cli.status.work_package_lifecycle import (
     WorkPackageClaimConflict,
@@ -1776,6 +1777,8 @@ def review(
         lines.append("")
         lines.append("Review the implementation against the requirements below.")
         lines.append("Check code quality, tests, documentation, and adherence to spec.")
+        lines.append("")
+        lines.append(render_wp_review_antipattern_checklist())
         lines.append("")
 
         # WP content marker and content

--- a/src/specify_cli/missions/software-dev/command-templates/review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/review.md
@@ -186,6 +186,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/src/specify_cli/next/prompt_builder.py
+++ b/src/specify_cli/next/prompt_builder.py
@@ -29,6 +29,7 @@ from charter.mission_type_profiles import (
 from charter.resolver import GovernanceResolutionError, resolve_project_governance
 from specify_cli.core.paths import get_feature_target_branch
 from specify_cli.runtime.resolver import resolve_command
+from specify_cli.review.antipattern_checklist import render_wp_review_antipattern_checklist
 from specify_cli.status.wp_metadata import read_wp_frontmatter
 from specify_cli.workspace.context import resolve_workspace_for_wp
 
@@ -266,6 +267,8 @@ def _build_wp_prompt(
         else:
             lines.append(f"  git log {review_base}..HEAD --oneline{review_paths}")
             lines.append(f"  git diff {review_base}..HEAD --stat{review_paths}")
+        lines.append("")
+        lines.append(render_wp_review_antipattern_checklist())
         lines.append("")
 
     # WP content

--- a/src/specify_cli/review/antipattern_checklist.py
+++ b/src/specify_cli/review/antipattern_checklist.py
@@ -1,0 +1,50 @@
+"""WP-level review anti-pattern checklist rendering."""
+
+from __future__ import annotations
+
+
+def render_wp_review_antipattern_checklist() -> str:
+    """Return the required anti-pattern checklist for WP review prompts."""
+    return """## Anti-pattern checklist (WP-level cheap version of mission-review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+"""

--- a/src/specify_cli/skills/_user_input_block.py
+++ b/src/specify_cli/skills/_user_input_block.py
@@ -25,7 +25,7 @@ REPLACEMENT_BLOCK = (
     "(everything after the skill invocation token, e.g. after "
     "`/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input "
     "referenced elsewhere in these instructions.\n\n"
-    "You **MUST** consider this user input before proceeding (if not empty).\n"
+    "You **MUST** consider this user input before proceeding (if not empty).\n\n"
 )
 
 # Matches the "## User Input" heading (level-2 only, optional trailing space).

--- a/tests/agent/test_workflow_review_lane_gate.py
+++ b/tests/agent/test_workflow_review_lane_gate.py
@@ -398,3 +398,26 @@ def test_review_prompt_points_to_shared_mission_artifacts(workflow_repo: Path) -
     assert "📚 SHARED MISSION ARTIFACTS:" in content
     assert f"Spec, plan, tasks, and status live in main repo: {workflow_repo}/kitty-specs/{feature_slug}/" in content
     assert "Use this lane workspace for code/tests; do not expect shared mission artifacts here" in content
+
+
+def test_review_prompt_includes_mission_review_antipattern_checklist(workflow_repo: Path) -> None:
+    _wp_path, feature_slug = _setup_review_fixture(workflow_repo)
+
+    result = CliRunner().invoke(
+        workflow.app,
+        ["review", "WP01", "--mission", feature_slug, "--agent", "test-reviewer"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    prompt_file = _prompt_path_from_output(result.stdout)
+    content = prompt_file.read_text(encoding="utf-8")
+    assert "Anti-pattern checklist (WP-level cheap version of mission-review)" in content
+    assert "PASS / FAIL / N/A" in content
+    assert "Dead code" in content
+    assert "Synthetic-fixture test" in content
+    assert "Silent empty return" in content
+    assert "FR coverage" in content
+    assert "Frozen surface" in content
+    assert "Locked decision" in content
+    assert "Shared-file ownership" in content
+    assert "Production fragility" in content

--- a/tests/next/test_prompt_builder_unit.py
+++ b/tests/next/test_prompt_builder_unit.py
@@ -334,6 +334,23 @@ class TestBuildPromptWP:
         assert path.exists()
         path.unlink()
 
+    def test_review_prompt_includes_antipattern_checklist(self, feature_with_wp: Path) -> None:
+        repo_root = feature_with_wp.parent.parent
+        text, path = build_prompt(
+            action="review",
+            feature_dir=feature_with_wp,
+            mission_slug="042-test-feature",
+            wp_id="WP01",
+            agent="codex",
+            repo_root=repo_root,
+            mission_type="software-dev",
+        )
+        assert "Anti-pattern checklist (WP-level cheap version of mission-review)" in text
+        assert "PASS / FAIL / N/A" in text
+        assert "Dead code" in text
+        assert "Production fragility" in text
+        path.unlink()
+
     def test_implement_prompt_for_non_python_charter_contains_no_python_default_bias(
         self, feature_with_wp: Path
     ) -> None:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/review.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/review.prompt.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/review.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/review.toml
@@ -146,6 +146,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/review.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/review.toml
@@ -146,6 +146,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/review.md
@@ -147,6 +147,42 @@ For each subtask:
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
 
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
+
 ---
 
 ## Bulk Edit Compliance (if applicable)

--- a/tests/specify_cli/regression/test_twelve_agent_parity.py
+++ b/tests/specify_cli/regression/test_twelve_agent_parity.py
@@ -27,6 +27,7 @@ Commit the updated baseline files alongside the template change.
 from __future__ import annotations
 
 import os
+import tomllib
 from pathlib import Path
 from unittest.mock import patch
 
@@ -146,6 +147,20 @@ def test_command_output_unchanged(agent: str, command: str) -> None:
         f"  PYTEST_UPDATE_SNAPSHOTS=1 pytest tests/specify_cli/regression/ -v\n"
         f"then commit the updated baseline files alongside the template change."
     )
+
+
+@pytest.mark.parametrize(
+    "agent",
+    tuple(agent for agent in NON_MIGRATED_AGENTS if AGENT_COMMAND_CONFIG[agent]["ext"] == "toml"),
+)
+@pytest.mark.parametrize("command", CANONICAL_COMMANDS)
+def test_toml_command_output_is_parseable(agent: str, command: str) -> None:
+    """Rendered TOML command files must remain valid TOML."""
+    produced = _render_for_agent(agent, command)
+    try:
+        tomllib.loads(produced)
+    except tomllib.TOMLDecodeError as exc:
+        raise AssertionError(f"Rendered TOML for {agent}/{command} is invalid: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
@@ -8,6 +8,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Goal
 
 Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/tasks` has successfully produced a complete `tasks.md`.

--- a/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
@@ -10,6 +10,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Repo Scope
 
 `/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.

--- a/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
@@ -28,6 +28,7 @@ your `owned_files` boundaries.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Governance Payload Contract
 
 The prompt produced by `spec-kitty agent action implement` is guaranteed to

--- a/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
@@ -41,6 +41,7 @@ when the CLI needs a mission selector.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Commit Boundary (issue #846)
 
 `/spec-kitty.plan` will refuse to advance the plan phase unless **two**

--- a/tests/specify_cli/skills/__snapshots__/codex/research.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/research.SKILL.md
@@ -12,6 +12,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Location Pre-flight Check
 
 **BEFORE PROCEEDING:** Verify you are working in the repository root checkout.

--- a/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
@@ -28,6 +28,7 @@ your `owned_files` boundaries.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Governance Payload Contract
 
 The prompt produced by `spec-kitty agent action review` is guaranteed to carry
@@ -143,6 +144,42 @@ For each subtask:
   change, run the test, confirm it fails. If it does not fail, the error path
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
+
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
 
 ---
 

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -43,6 +43,7 @@ Before `mission create`, there is no mission handle yet.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Primary Invariant: What Are We Building?
 
 This workflow answers "What are we building?" before it creates artifacts. The

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
@@ -24,6 +24,7 @@ them, update WP frontmatter, and commit all task artifacts to the target branch.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Steps
 
 ### 1. Run Validate-Only Preflight

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-outline.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-outline.SKILL.md
@@ -42,6 +42,7 @@ break work into clear pieces, and write detailed guidance.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Context Resolution
 
 Before proceeding, resolve canonical command context:

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
@@ -28,6 +28,7 @@ This step assumes `wps.yaml` already exists with complete WP definitions.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Steps
 
 ### 1. Setup

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
@@ -52,6 +52,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Context Resolution (0.11.0+)
 
 Before proceeding, resolve canonical command context:

--- a/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
@@ -8,6 +8,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Goal
 
 Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/tasks` has successfully produced a complete `tasks.md`.

--- a/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
@@ -10,6 +10,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Repo Scope
 
 `/spec-kitty.charter` is a repo-scoped governance flow, not a per-mission flow.

--- a/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
@@ -28,6 +28,7 @@ your `owned_files` boundaries.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Governance Payload Contract
 
 The prompt produced by `spec-kitty agent action implement` is guaranteed to

--- a/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
@@ -41,6 +41,7 @@ when the CLI needs a mission selector.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Commit Boundary (issue #846)
 
 `/spec-kitty.plan` will refuse to advance the plan phase unless **two**

--- a/tests/specify_cli/skills/__snapshots__/vibe/research.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/research.SKILL.md
@@ -12,6 +12,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Location Pre-flight Check
 
 **BEFORE PROCEEDING:** Verify you are working in the repository root checkout.

--- a/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
@@ -28,6 +28,7 @@ your `owned_files` boundaries.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Governance Payload Contract
 
 The prompt produced by `spec-kitty agent action review` is guaranteed to carry
@@ -143,6 +144,42 @@ For each subtask:
   change, run the test, confirm it fails. If it does not fail, the error path
   is untested — the test validates structure, not behaviour. Restore the fix
   before proceeding.
+
+### 4a. Anti-pattern Checklist (WP-Level Cheap Version of Mission-Review)
+
+For each item below, state PASS / FAIL / N/A in your verdict. A FAIL on any
+item blocks approval.
+
+1. **Dead code**: every new public function, class, or module created by this
+   WP has at least one live caller from production code, excluding tests. For
+   each new module, run targeted import/call-site greps, for example
+   `grep -r -e "from <new_module> import" -e "import <new_module>" src/ --include="*.<ext>"`.
+   Zero production hits means dead code.
+2. **Synthetic-fixture test**: every test marked as covering an FR listed in
+   this WP's frontmatter actually invokes the production code path that would
+   produce the asserted shape. A test that constructs a literal dict matching
+   the assertion is a synthetic fixture. Ask: if I delete the implementation
+   code, does this test still pass? If yes, the FR is untested.
+3. **Silent empty return**: search every new code path for `except ...:
+   return ""`, `return None`, `return []`, `return {}`, or `pass`. Each hit
+   must have a documented reason; absent that, it is a silent failure
+   candidate.
+4. **FR coverage**: every FR in `requirement_refs` has at least one test
+   assertion that references the behavior it names, not just a comment or
+   frontmatter entry.
+5. **Frozen surface**: no commit in this WP modifies a file the spec,
+   contract, or WP prompt marks as frozen or untouchable. For each frozen file,
+   `git log --oneline <base>..HEAD -- <frozen-file>` must be empty.
+6. **Locked decision**: no new code path contradicts a `MUST NOT` clause in
+   `spec.md`, `plan.md`, or `contracts/`. Grep the diff for forbidden patterns
+   named by those clauses.
+7. **Shared-file ownership**: any file modified by this WP that is also
+   modified by another WP, visible in `lanes.json`, shared lane metadata, or
+   the same mission merge, has an explicit coordination note in the move-task
+   reason or review feedback.
+8. **Production fragility**: any new `raise` in a production code path has a
+   documented fail-loud rationale. A bare `raise` in a request handler, worker,
+   or CLI path that can fire on a transient race is a fragility risk.
 
 ---
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
@@ -43,6 +43,7 @@ Before `mission create`, there is no mission handle yet.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Primary Invariant: What Are We Building?
 
 This workflow answers "What are we building?" before it creates artifacts. The

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
@@ -24,6 +24,7 @@ them, update WP frontmatter, and commit all task artifacts to the target branch.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Steps
 
 ### 1. Run Validate-Only Preflight

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-outline.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-outline.SKILL.md
@@ -42,6 +42,7 @@ break work into clear pieces, and write detailed guidance.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Context Resolution
 
 Before proceeding, resolve canonical command context:

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
@@ -28,6 +28,7 @@ This step assumes `wps.yaml` already exists with complete WP definitions.
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Steps
 
 ### 1. Setup

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
@@ -52,6 +52,7 @@ user-invocable: true
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.
 
 You **MUST** consider this user input before proceeding (if not empty).
+
 ## Context Resolution (0.11.0+)
 
 Before proceeding, resolve canonical command context:

--- a/tests/specify_cli/skills/test_command_renderer.py
+++ b/tests/specify_cli/skills/test_command_renderer.py
@@ -475,7 +475,7 @@ def test_replacement_block_constant_unchanged() -> None:
         "(everything after the skill invocation token, e.g. after "
         "`/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input "
         "referenced elsewhere in these instructions.\n\n"
-        "You **MUST** consider this user input before proceeding (if not empty).\n"
+        "You **MUST** consider this user input before proceeding (if not empty).\n\n"
     )
     assert expected == REPLACEMENT_BLOCK, (
         "REPLACEMENT_BLOCK has drifted from its locked value. "


### PR DESCRIPTION
## Summary
- Add a shared WP review anti-pattern checklist renderer covering dead code, synthetic fixtures, silent empty returns, FR coverage, frozen surfaces, locked decisions, shared-file ownership, and production fragility
- Include the checklist in `spec-kitty agent action review` prompt files and `spec-kitty next` review prompts
- Update the software-dev review command template and rendered review snapshots/baselines

Fixes #1241

## Verification
- `uv run ruff check src/specify_cli/review/antipattern_checklist.py src/specify_cli/next/prompt_builder.py src/specify_cli/cli/commands/agent/workflow.py tests/agent/test_workflow_review_lane_gate.py tests/next/test_prompt_builder_unit.py`
- `uv run pytest tests/specify_cli/skills tests/agent/test_workflow_review_lane_gate.py tests/next/test_prompt_builder_unit.py tests/reviews/test_review_gate_activation.py tests/architectural/test_template_governance_payload_contract.py`
- `uv run pytest tests/specify_cli/regression/test_twelve_agent_parity.py::test_command_output_unchanged -k review`