### PR TITLE
Fix retrospective create records for summary and synthesize

### DIFF
--- a/src/specify_cli/cli/commands/agent_retrospect.py
+++ b/src/specify_cli/cli/commands/agent_retrospect.py
@@ -33,7 +33,7 @@ from specify_cli.retrospective import (
     RetrospectiveActor,
 )
 from specify_cli.retrospective.lifecycle_events import Actor as LifecycleActor
-from specify_cli.retrospective.reader import SchemaError, YAMLParseError, read_record
+from specify_cli.retrospective.reader import SchemaError, YAMLParseError, read_gen_record, read_record
 from specify_cli.retrospective.schema import (
     ActorRef,
     GenActor,
@@ -386,6 +386,7 @@ def synthesize_cmd(
     # ------------------------------------------------------------------
     retro_file = _retro_path(repo_root, mission_id)
     outcome = "retrospective_synthesized"
+    generator_record = None
     try:
         record = read_record(retro_file)
     except FileNotFoundError as exc:
@@ -479,12 +480,26 @@ def synthesize_cmd(
             _err_console.print(f"[red]Error:[/red] {msg}")
             raise typer.Exit(3) from exc
     except (YAMLParseError, SchemaError) as exc:
-        msg = f"Retrospective record malformed: {exc}"
-        if json_only:
-            _err_console.print_json(json.dumps({"error": "record_malformed", "detail": str(exc)}))
+        try:
+            generator_record = read_gen_record(retro_file)
+            record = None
+        except (FileNotFoundError, YAMLParseError, SchemaError):
+            generator_record = None
         else:
-            _err_console.print(f"[red]Error:[/red] {msg}")
-        raise typer.Exit(3) from exc
+            outcome = "retrospective_synthesized"
+            if generator_record.proposals:
+                _err_console.print(
+                    "[yellow]Warning:[/yellow] This retrospective uses the generator record schema; "
+                    "proposal application is not available for generator-shape proposals yet, "
+                    "so synthesize will run as an empty dry-run batch."
+                )
+        if generator_record is None:
+            msg = f"Retrospective record malformed: {exc}"
+            if json_only:
+                _err_console.print_json(json.dumps({"error": "record_malformed", "detail": str(exc)}))
+            else:
+                _err_console.print(f"[red]Error:[/red] {msg}")
+            raise typer.Exit(3) from exc
     except OSError as exc:
         msg = f"I/O error reading retrospective: {exc}"
         if json_only:
@@ -502,7 +517,7 @@ def synthesize_cmd(
     # When --fabricate-empty created the record, _fabricated_empty is True and
     # record is not defined (the gen record format is incompatible with Pydantic
     # read_record). The fabricated record has no proposals by definition.
-    all_proposals = [] if locals().get("_fabricated_empty") else record.proposals
+    all_proposals = [] if locals().get("_fabricated_empty") or generator_record is not None else record.proposals
 
     if proposal_id:
         # --proposal-id filter: restrict approved_proposal_ids to those listed

--- a/src/specify_cli/retrospective/generator.py
+++ b/src/specify_cli/retrospective/generator.py
@@ -53,7 +53,6 @@ _NEEDS_CLARIFICATION_RE = re.compile(r"\[NEEDS CLARIFICATION:", re.IGNORECASE)
 # Regex to detect FR references in WP task files
 _FR_REF_RE = re.compile(r"\b(FR-\d{3,})\b")
 
-# Regex to detect rejection cycles in status events (for_review → planned or in_progress)
 _WP_ID_RE = re.compile(r"^\w{2,5}\d{2,3}$")
 
 
@@ -189,23 +188,73 @@ def _next_proposal_id(counter: list[int]) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _has_review_feedback(event: dict) -> bool:
+    """Return True when a lane event carries documented review feedback."""
+    if event.get("review_ref"):
+        return True
+    evidence = event.get("evidence")
+    if isinstance(evidence, dict):
+        review = evidence.get("review")
+        if isinstance(review, dict):
+            return bool(review.get("reference")) and review.get("verdict") == "changes_requested"
+    return isinstance(evidence, str) and bool(evidence.strip())
+
+
+_BACKWARD_LANE_MOVES: frozenset[tuple[str, str]] = frozenset({
+    ("for_review", "planned"),
+    ("for_review", "in_progress"),
+    ("for_review", "claimed"),
+    ("in_review", "planned"),
+    ("in_review", "in_progress"),
+    ("in_review", "claimed"),
+    ("in_progress", "planned"),
+    ("in_progress", "claimed"),
+})
+
+
+def _is_backward_lane_event(event: dict) -> bool:
+    return (event.get("from_lane", ""), event.get("to_lane", "")) in _BACKWARD_LANE_MOVES
+
+
+def _is_review_rejection_event(event: dict) -> bool:
+    return (
+        event.get("from_lane", "") == "in_review"
+        and event.get("to_lane", "") in ("planned", "in_progress", "claimed")
+        and _has_review_feedback(event)
+    )
+
+
+def _is_lane_friction_event(event: dict) -> bool:
+    return _is_backward_lane_event(event) and not _is_review_rejection_event(event)
+
+
 def _detect_rejection_cycles(events: list[dict]) -> dict[str, int]:
     """Return a mapping of wp_id -> rejection_cycle_count.
 
-    A rejection cycle is a transition from for_review back to planned (or
-    in_progress), indicating a WP was rejected during review.
+    A rejection cycle is a documented reviewer-feedback transition out of
+    in_review. Earlier for_review rewinds and force moves are lane friction, not
+    review rejections.
     """
     rejection_counts: dict[str, int] = {}
     for event in events:
-        from_lane = event.get("from_lane", "")
-        to_lane = event.get("to_lane", "")
         wp_id = event.get("wp_id", "")
         if not wp_id:
             continue
-        # A rejection is: was in for_review/in_review → went back to planned/in_progress
-        if from_lane in ("for_review", "in_review") and to_lane in ("planned", "in_progress", "claimed"):
+        if _is_review_rejection_event(event):
             rejection_counts[wp_id] = rejection_counts.get(wp_id, 0) + 1
     return rejection_counts
+
+
+def _detect_lane_friction(events: list[dict]) -> dict[str, int]:
+    """Return backward lane moves that are not documented reviewer rejections."""
+    friction_counts: dict[str, int] = {}
+    for event in events:
+        wp_id = event.get("wp_id", "")
+        if not wp_id:
+            continue
+        if _is_lane_friction_event(event):
+            friction_counts[wp_id] = friction_counts.get(wp_id, 0) + 1
+    return friction_counts
 
 
 def _detect_done_wps(events: list[dict]) -> set[str]:
@@ -248,6 +297,44 @@ def _classify_risk(suggested_action: str) -> tuple[str, bool]:
     if action_prefix in LOW_RISK_PROPOSAL_KINDS:
         return "low", False
     return "structural", False
+
+
+def _build_lane_friction_findings(
+    *,
+    events: list[dict],
+    lane_friction_counts: dict[str, int],
+    events_rel: str,
+    finding_id_counters: dict[str, list[int]],
+    ev_reg: _EvidenceRegistry,
+) -> list[GenFinding]:
+    findings: list[GenFinding] = []
+    for wp_id in sorted(lane_friction_counts.keys()):
+        count = lane_friction_counts[wp_id]
+        friction_event_ids = [
+            str(ev.get("event_id", ""))
+            for ev in events
+            if ev.get("wp_id") == wp_id
+            and _is_lane_friction_event(ev)
+        ]
+        range_str = (
+            f"{friction_event_ids[0]}..{friction_event_ids[-1]}"
+            if len(friction_event_ids) > 1
+            else (friction_event_ids[0] if friction_event_ids else "")
+        )
+        ev_id = ev_reg.add_event_range(events_rel, range_str or "lane_friction", f"lane_friction_{wp_id}")
+        findings.append(
+            GenFinding(
+                id=_next_finding_id("n", finding_id_counters),
+                category="process",
+                summary=f"{wp_id} had {count} lane bounce(s) before approval",
+                details=(
+                    f"WP {wp_id} moved backward across workflow lanes {count} time(s) "
+                    "outside the documented reviewer-feedback flow."
+                ),
+                evidence_refs=[ev_id],
+            )
+        )
+    return findings
 
 
 # ---------------------------------------------------------------------------
@@ -321,11 +408,16 @@ def _build_findings(
     proposals: list[GenProposal] = []
 
     rejection_counts = _detect_rejection_cycles(events)
+    lane_friction_counts = _detect_lane_friction(events)
     done_wps = _detect_done_wps(events)
 
     # --- Helped: WPs completed without rejection cycles (only notable by contrast)
-    clean_wps = [wp for wp in sorted(done_wps) if rejection_counts.get(wp, 0) == 0]
-    if rejection_counts:
+    clean_wps = [
+        wp
+        for wp in sorted(done_wps)
+        if rejection_counts.get(wp, 0) == 0 and lane_friction_counts.get(wp, 0) == 0
+    ]
+    if rejection_counts or lane_friction_counts:
         for wp_id in clean_wps:
             wp_file_name = f"{wp_id}.md"
             if wp_file_name in wp_evidence_ids:
@@ -371,6 +463,16 @@ def _build_findings(
                 evidence_refs=[ev_id],
             )
         )
+
+    not_helpful.extend(
+        _build_lane_friction_findings(
+            events=events,
+            lane_friction_counts=lane_friction_counts,
+            events_rel=events_rel,
+            finding_id_counters=finding_id_counters,
+            ev_reg=ev_reg,
+        )
+    )
 
     # --- Gaps: open [NEEDS CLARIFICATION:] markers in spec.md
     if spec_text:

--- a/src/specify_cli/retrospective/reader.py
+++ b/src/specify_cli/retrospective/reader.py
@@ -12,7 +12,17 @@ from pydantic import ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
-from specify_cli.retrospective.schema import RetrospectiveRecord
+from specify_cli.retrospective.schema import (
+    GenActor,
+    GenEvidenceRef,
+    GenFinding,
+    GenProposal,
+    GenProvenance,
+    GenRetrospectiveRecord,
+    RecordValidationError,
+    RetrospectiveRecord,
+    validate_record,
+)
 
 
 class YAMLParseError(Exception):
@@ -21,6 +31,280 @@ class YAMLParseError(Exception):
 
 class SchemaError(Exception):
     """The file contains valid YAML but fails schema validation."""
+
+
+_GEN_TOP_LEVEL_KEYS = frozenset({
+    "schema_version",
+    "mission_id",
+    "mission_slug",
+    "mission_number",
+    "friendly_name",
+    "mission_type",
+    "target_branch",
+    "created_at",
+    "created_by",
+    "provenance",
+    "policy_source",
+    "findings_status",
+    "helped",
+    "not_helpful",
+    "gaps",
+    "proposals",
+    "evidence_refs",
+    "generator_version",
+    "provenance_history",
+})
+_GEN_REQUIRED_KEYS = frozenset({
+    "schema_version",
+    "mission_id",
+    "mission_slug",
+    "mission_number",
+    "friendly_name",
+    "mission_type",
+    "target_branch",
+    "created_at",
+    "created_by",
+    "provenance",
+    "policy_source",
+    "findings_status",
+    "helped",
+    "not_helpful",
+    "gaps",
+    "proposals",
+    "evidence_refs",
+    "generator_version",
+})
+_ACTOR_KEYS = frozenset({"kind", "id", "display"})
+_PROVENANCE_KEYS = frozenset({"kind", "invoked_at", "policy_resolved_from", "command"})
+_EVIDENCE_KEYS = frozenset({"id", "kind", "path", "range", "url"})
+_FINDING_KEYS = frozenset({"id", "category", "summary", "evidence_refs", "details"})
+_PROPOSAL_KEYS = frozenset({
+    "id",
+    "category",
+    "risk_class",
+    "summary",
+    "evidence_refs",
+    "suggested_action",
+    "auto_applicable",
+    "details",
+})
+_ACTOR_KINDS = frozenset({"human", "agent", "runtime"})
+_PROVENANCE_KINDS = frozenset({
+    "runtime_post_completion",
+    "runtime_strict_gate",
+    "explicit_create",
+    "backfill",
+    "synthesize_fabricate",
+})
+_FINDING_CATEGORIES = frozenset({
+    "process",
+    "tooling",
+    "spec_quality",
+    "review_loop",
+    "design",
+    "implementation",
+    "doc",
+    "other",
+})
+_PROPOSAL_CATEGORIES = frozenset({"glossary", "drg", "doctrine", "tooling", "process", "other"})
+_EVIDENCE_KINDS = frozenset({"file", "event_range", "external"})
+_FINDINGS_STATUSES = frozenset({"has_findings", "ran_no_findings"})
+
+
+def _load_yaml_mapping(path: Path) -> dict:
+    raw_text = path.read_text(encoding="utf-8")
+    yaml = YAML(typ="safe")
+    try:
+        data = yaml.load(raw_text)
+    except YAMLError as exc:
+        raise YAMLParseError(f"Failed to parse YAML from {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SchemaError(f"Expected a YAML mapping at the top level of {path}, got {type(data).__name__}")
+    return data
+
+
+def _validate_keys(raw: dict, allowed: frozenset[str], *, label: str) -> None:
+    extra = sorted(set(raw) - allowed)
+    if extra:
+        raise ValueError(f"{label} has unsupported field(s): {', '.join(extra)}")
+
+
+def _validate_mapping(raw: object, *, label: str) -> dict:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return raw
+
+
+def _validate_string_list(raw: object, *, label: str) -> None:
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ValueError(f"{label} must be a list of strings")
+
+
+def _validate_gen_actor(raw: object, *, label: str) -> None:
+    actor = _validate_mapping(raw, label=label)
+    _validate_keys(actor, _ACTOR_KEYS, label=label)
+    if actor.get("kind") not in _ACTOR_KINDS:
+        raise ValueError(f"{label}.kind is invalid")
+    if not isinstance(actor.get("id"), str) or not actor.get("id"):
+        raise ValueError(f"{label}.id must be a non-empty string")
+
+
+def _validate_gen_provenance(raw: object, *, label: str) -> None:
+    provenance = _validate_mapping(raw, label=label)
+    _validate_keys(provenance, _PROVENANCE_KEYS, label=label)
+    if provenance.get("kind") not in _PROVENANCE_KINDS:
+        raise ValueError(f"{label}.kind is invalid")
+    if not isinstance(provenance.get("invoked_at"), str):
+        raise ValueError(f"{label}.invoked_at must be a string")
+    if not isinstance(provenance.get("policy_resolved_from", {}), dict):
+        raise ValueError(f"{label}.policy_resolved_from must be a mapping")
+
+
+def _validate_gen_evidence_ref(raw: object, *, label: str) -> None:
+    evidence_ref = _validate_mapping(raw, label=label)
+    _validate_keys(evidence_ref, _EVIDENCE_KEYS, label=label)
+    if evidence_ref.get("kind") not in _EVIDENCE_KINDS:
+        raise ValueError(f"{label}.kind is invalid")
+
+
+def _validate_gen_finding(raw: object, *, label: str) -> None:
+    finding = _validate_mapping(raw, label=label)
+    _validate_keys(finding, _FINDING_KEYS, label=label)
+    if finding.get("category") not in _FINDING_CATEGORIES:
+        raise ValueError(f"{label}.category is invalid")
+    _validate_string_list(finding.get("evidence_refs", []), label=f"{label}.evidence_refs")
+
+
+def _validate_gen_proposal(raw: object, *, label: str) -> None:
+    proposal = _validate_mapping(raw, label=label)
+    _validate_keys(proposal, _PROPOSAL_KEYS, label=label)
+    if proposal.get("category") not in _PROPOSAL_CATEGORIES:
+        raise ValueError(f"{label}.category is invalid")
+    if proposal.get("risk_class") not in {"low", "structural"}:
+        raise ValueError(f"{label}.risk_class is invalid")
+    if not isinstance(proposal.get("auto_applicable"), bool):
+        raise ValueError(f"{label}.auto_applicable must be boolean")
+    _validate_string_list(proposal.get("evidence_refs", []), label=f"{label}.evidence_refs")
+
+
+def _validate_gen_header(data: dict) -> None:
+    _validate_keys(data, _GEN_TOP_LEVEL_KEYS, label="record")
+    missing = sorted(_GEN_REQUIRED_KEYS - set(data))
+    if missing:
+        raise ValueError(f"Missing required generator record field(s): {', '.join(missing)}")
+    if data.get("schema_version") != 1:
+        raise ValueError("schema_version must be 1")
+    if data.get("findings_status") not in _FINDINGS_STATUSES:
+        raise ValueError("findings_status must be has_findings or ran_no_findings")
+
+
+def _validate_gen_mapping(data: dict) -> None:
+    _validate_gen_header(data)
+
+    _validate_gen_actor(data.get("created_by"), label="created_by")
+    _validate_gen_provenance(data.get("provenance"), label="provenance")
+    if not isinstance(data.get("policy_source", {}), dict):
+        raise ValueError("policy_source must be a mapping")
+    for collection in ("helped", "not_helpful", "gaps", "proposals", "evidence_refs", "provenance_history"):
+        if not isinstance(data.get(collection, []), list):
+            raise ValueError(f"{collection} must be a list")
+    for name in ("helped", "not_helpful", "gaps"):
+        for idx, item in enumerate(data.get(name, [])):
+            _validate_gen_finding(item, label=f"{name}[{idx}]")
+    for idx, item in enumerate(data.get("proposals", [])):
+        _validate_gen_proposal(item, label=f"proposals[{idx}]")
+    for idx, item in enumerate(data.get("evidence_refs", [])):
+        _validate_gen_evidence_ref(item, label=f"evidence_refs[{idx}]")
+    for idx, item in enumerate(data.get("provenance_history", [])):
+        _validate_gen_provenance(item, label=f"provenance_history[{idx}]")
+
+
+def _gen_record_from_mapping(data: dict) -> GenRetrospectiveRecord:
+    def _actor(raw: object) -> GenActor:
+        if not isinstance(raw, dict):
+            raw = {}
+        return GenActor(
+            kind=raw.get("kind", "runtime"),
+            id=raw.get("id", "unknown"),
+            display=raw.get("display"),
+        )
+
+    def _provenance(raw: object) -> GenProvenance:
+        if not isinstance(raw, dict):
+            raw = {}
+        return GenProvenance(
+            kind=raw.get("kind", "runtime_post_completion"),
+            invoked_at=raw.get("invoked_at", ""),
+            policy_resolved_from=dict(raw.get("policy_resolved_from", {})),
+            command=raw.get("command"),
+        )
+
+    def _evidence_ref(raw: dict) -> GenEvidenceRef:
+        return GenEvidenceRef(
+            id=raw["id"],
+            kind=raw["kind"],
+            path=raw.get("path"),
+            range=raw.get("range"),
+            url=raw.get("url"),
+        )
+
+    def _finding(raw: dict) -> GenFinding:
+        return GenFinding(
+            id=raw["id"],
+            category=raw["category"],
+            summary=raw["summary"],
+            evidence_refs=list(raw.get("evidence_refs", [])),
+            details=raw.get("details"),
+        )
+
+    def _proposal(raw: dict) -> GenProposal:
+        return GenProposal(
+            id=raw["id"],
+            category=raw["category"],
+            risk_class=raw["risk_class"],
+            summary=raw["summary"],
+            evidence_refs=list(raw.get("evidence_refs", [])),
+            suggested_action=raw["suggested_action"],
+            auto_applicable=raw["auto_applicable"],
+            details=raw.get("details"),
+        )
+
+    return GenRetrospectiveRecord(
+        schema_version=data.get("schema_version", 1),
+        mission_id=data.get("mission_id", ""),
+        mission_slug=data.get("mission_slug", ""),
+        mission_number=data.get("mission_number"),
+        friendly_name=data.get("friendly_name", ""),
+        mission_type=data.get("mission_type", ""),
+        target_branch=data.get("target_branch", ""),
+        created_at=data.get("created_at", ""),
+        created_by=_actor(data.get("created_by")),
+        provenance=_provenance(data.get("provenance")),
+        policy_source=dict(data.get("policy_source", {})),
+        findings_status=data.get("findings_status", "ran_no_findings"),
+        helped=[_finding(f) for f in data.get("helped", [])],
+        not_helpful=[_finding(f) for f in data.get("not_helpful", [])],
+        gaps=[_finding(f) for f in data.get("gaps", [])],
+        proposals=[_proposal(p) for p in data.get("proposals", [])],
+        evidence_refs=[_evidence_ref(e) for e in data.get("evidence_refs", [])],
+        generator_version=data.get("generator_version", ""),
+        provenance_history=[_provenance(p) for p in data.get("provenance_history", [])],
+    )
+
+
+def read_gen_record(path: Path) -> GenRetrospectiveRecord:
+    """Load the generator-shape retrospective record written by ``retrospect create``."""
+    data = _load_yaml_mapping(path)
+    try:
+        _validate_gen_mapping(data)
+        record = _gen_record_from_mapping(data)
+        validate_record(record)
+    except (KeyError, TypeError, ValueError, RecordValidationError) as exc:
+        raise SchemaError(
+            f"Generator schema validation failed for {path}:\n{exc}"
+        ) from exc
+    return record
 
 
 def read_record(path: Path, *, verify_evidence: bool = False) -> RetrospectiveRecord:
@@ -41,18 +325,7 @@ def read_record(path: Path, *, verify_evidence: bool = False) -> RetrospectiveRe
         SchemaError: The file parses as YAML but fails schema validation,
             or the record has status='pending' (not persistable).
     """
-    # Let FileNotFoundError propagate naturally from read_text.
-    raw_text = path.read_text(encoding="utf-8")
-
-    # Parse YAML.
-    yaml = YAML(typ="safe")
-    try:
-        data = yaml.load(raw_text)
-    except YAMLError as exc:
-        raise YAMLParseError(f"Failed to parse YAML from {path}: {exc}") from exc
-
-    if not isinstance(data, dict):
-        raise SchemaError(f"Expected a YAML mapping at the top level of {path}, got {type(data).__name__}")
+    data = _load_yaml_mapping(path)
 
     # Schema validation via Pydantic.
     try:

--- a/src/specify_cli/retrospective/summary.py
+++ b/src/specify_cli/retrospective/summary.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, ConfigDict
 from specify_cli.retrospective.reader import (
     SchemaError,
     YAMLParseError,
+    read_gen_record,
     read_record,
 )
 from specify_cli.retrospective.schema import MissionId
@@ -389,6 +390,39 @@ def build_summary(
         try:
             record = read_record(retro_path)
         except (YAMLParseError, SchemaError) as exc:
+            try:
+                gen_record = read_gen_record(retro_path)
+            except (YAMLParseError, SchemaError):
+                pass
+            else:
+                if since is not None:
+                    try:
+                        created_dt = datetime.fromisoformat(gen_record.created_at)
+                        if created_dt.date() < since:
+                            continue
+                    except (ValueError, AttributeError):
+                        pass
+
+                mission_count += 1
+                completed_count += 1
+
+                for finding in gen_record.not_helpful:
+                    not_helpful_counter[f"retrospective:not_helpful:{finding.category}"] += 1
+
+                for finding in gen_record.gaps:
+                    if finding.category == "doc":
+                        missing_terms_counter[finding.summary] += 1
+                    elif finding.category == "spec_quality":
+                        under_inclusion_counter[f"retrospective:gaps:{finding.category}"] += 1
+
+                total_proposals += len(gen_record.proposals)
+                pending_proposals += len(gen_record.proposals)
+
+                slug = gen_record.mission_slug
+                gen_evt, app_evt, rej_evt = _read_proposal_events(project_path, slug)
+                _ = (gen_evt, app_evt, rej_evt)
+                continue
+
             # Try to extract mission_id from raw YAML for the error entry
             try:
                 from ruamel.yaml import YAML as _YAML

--- a/tests/cli/test_agent_retrospect_synthesize.py
+++ b/tests/cli/test_agent_retrospect_synthesize.py
@@ -192,6 +192,75 @@ def test_valid_handle_dryrun_exit0() -> None:
     assert result.exit_code == 0, result.output
 
 
+def test_generator_record_dryrun_exit0(tmp_path: Path) -> None:
+    """A record authored by retrospect create is accepted by synthesize."""
+    root = tmp_path
+    retro_dir = root / ".kittify" / "missions" / FAKE_MISSION_ID
+    retro_dir.mkdir(parents=True)
+    (retro_dir / "retrospective.yaml").write_text(
+        f"""\
+schema_version: 1
+mission_id: {FAKE_MISSION_ID}
+mission_slug: {FAKE_SLUG}
+mission_number: 1
+friendly_name: Test Mission
+mission_type: software-dev
+target_branch: main
+created_at: "2026-05-21T08:09:55+00:00"
+created_by:
+  kind: human
+  id: cli
+  display: spec-kitty retrospect
+provenance:
+  kind: explicit_create
+  invoked_at: "2026-05-21T08:09:55+00:00"
+  policy_resolved_from: {{}}
+  command: spec-kitty retrospect create
+policy_source: {{}}
+findings_status: has_findings
+helped: []
+not_helpful:
+  - id: n-001
+    category: process
+    summary: lane bounce before approval
+    evidence_refs: [e-001]
+gaps: []
+proposals: []
+evidence_refs:
+  - id: e-001
+    kind: event_range
+    path: kitty-specs/{FAKE_SLUG}/status.events.jsonl
+    range: "event-1"
+generator_version: "1.0"
+provenance_history: []
+""",
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.locate_project_root",
+            return_value=root,
+        ),
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.resolve_mission_handle",
+            return_value=_make_resolved_mission(tmp_path=root),
+        ),
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.apply_proposals",
+            return_value=_good_result(),
+        ) as apply_mock,
+    ):
+        result = runner.invoke(
+            app,
+            ["retrospect", "synthesize", "--mission", FAKE_SLUG],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert apply_mock.call_args.kwargs["proposals"] == []
+
+
 def test_dryrun_is_default() -> None:
     """Default (no --apply flag) is dry-run."""
     result = _patched_invoke(

--- a/tests/retrospective/test_generator.py
+++ b/tests/retrospective/test_generator.py
@@ -178,18 +178,57 @@ class TestFindingsClassification:
         # No proposals from a clean mission
         assert record.proposals == [], "No proposals expected"
 
-    def test_mid_with_rejections_has_not_helpful(self) -> None:
-        """mid-with-rejections: WP02 and WP03 each had 1 rejection cycle."""
+    def test_reviewer_feedback_transition_is_review_loop(self) -> None:
+        """Only documented reviewer feedback counts as a rejection cycle."""
+        from specify_cli.retrospective.generator import (
+            _detect_lane_friction,
+            _detect_rejection_cycles,
+        )
+
+        events = [
+            {
+                "wp_id": "WP01",
+                "from_lane": "for_review",
+                "to_lane": "in_progress",
+                "actor": "user",
+                "force": True,
+                "event_id": "e1",
+            },
+            {
+                "wp_id": "WP02",
+                "from_lane": "in_review",
+                "to_lane": "planned",
+                "actor": "user",
+                "review_ref": "review-cycle://mission/WP02/review-cycle-1.md",
+                "event_id": "e2",
+            },
+            {
+                "wp_id": "WP03",
+                "from_lane": "in_progress",
+                "to_lane": "planned",
+                "actor": "user",
+                "force": True,
+                "event_id": "e3",
+            },
+        ]
+
+        assert _detect_rejection_cycles(events) == {"WP02": 1}
+        assert _detect_lane_friction(events) == {"WP01": 1, "WP03": 1}
+
+    def test_mid_with_backward_moves_has_lane_friction(self) -> None:
+        """Backward moves without reviewer feedback are process friction, not rejections."""
         policy = make_policy()
         record = generate_retrospective(MID_WITH_REJECTIONS, policy, FIXTURES_ROOT)
 
         not_helpful_wps = {f.summary for f in record.not_helpful}
-        assert any("WP02" in s for s in not_helpful_wps), "WP02 rejection expected"
-        assert any("WP03" in s for s in not_helpful_wps), "WP03 rejection expected"
+        assert any("WP02" in s for s in not_helpful_wps), "WP02 lane friction expected"
+        assert any("WP03" in s for s in not_helpful_wps), "WP03 lane friction expected"
         assert len(record.not_helpful) == 2
+        assert {f.category for f in record.not_helpful} == {"process"}
+        assert all("rejection" not in f.summary.lower() for f in record.not_helpful)
 
-    def test_mid_with_rejections_clean_wps_in_helped(self) -> None:
-        """mid-with-rejections: WP01 and WP04 completed cleanly (notable by contrast)."""
+    def test_mid_with_lane_friction_clean_wps_in_helped(self) -> None:
+        """WPs with no backward movement are still notable by contrast."""
         policy = make_policy()
         record = generate_retrospective(MID_WITH_REJECTIONS, policy, FIXTURES_ROOT)
 
@@ -218,14 +257,15 @@ class TestFindingsClassification:
         assert "FR-007" in unmapped_fr_ids, "FR-007 should be flagged as unmapped"
         assert "FR-008" in unmapped_fr_ids, "FR-008 should be flagged as unmapped"
 
-    def test_large_with_gaps_has_rejections(self) -> None:
-        """large-with-gaps: WP02 and WP04 had 1 rejection cycle each."""
+    def test_large_with_gaps_has_lane_friction(self) -> None:
+        """large-with-gaps: WP02 and WP04 had backward moves without reviewer feedback."""
         policy = make_policy()
         record = generate_retrospective(LARGE_WITH_GAPS, policy, FIXTURES_ROOT)
 
         not_helpful_wps = {f.summary for f in record.not_helpful}
         assert any("WP02" in s for s in not_helpful_wps)
         assert any("WP04" in s for s in not_helpful_wps)
+        assert {f.category for f in record.not_helpful} == {"process"}
 
     def test_all_findings_have_evidence_refs(self) -> None:
         """Every finding must carry ≥1 evidence_ref that resolves to top-level evidence_refs."""

--- a/tests/retrospective/test_reader_tolerance.py
+++ b/tests/retrospective/test_reader_tolerance.py
@@ -120,6 +120,78 @@ def test_valid_yaml_reads_correctly(tmp_path: Path) -> None:
     assert record.schema_version == "1"
 
 
+def _valid_generator_yaml() -> str:
+    return f"""\
+schema_version: 1
+mission_id: {MISSION_ID}
+mission_slug: test-mission
+mission_number: 7
+friendly_name: Test Mission
+mission_type: software-dev
+target_branch: main
+created_at: "2026-05-21T08:09:55+00:00"
+created_by:
+  kind: human
+  id: cli
+  display: spec-kitty retrospect
+provenance:
+  kind: explicit_create
+  invoked_at: "2026-05-21T08:09:55+00:00"
+  policy_resolved_from: {{}}
+  command: spec-kitty retrospect create
+policy_source: {{}}
+findings_status: has_findings
+helped: []
+not_helpful:
+  - id: n-001
+    category: process
+    summary: lane bounce before approval
+    evidence_refs: [e-001]
+gaps: []
+proposals: []
+evidence_refs:
+  - id: e-001
+    kind: event_range
+    path: kitty-specs/test-mission/status.events.jsonl
+    range: "event-1"
+generator_version: "1.0"
+provenance_history: []
+"""
+
+
+def test_generator_record_reads_correctly(tmp_path: Path) -> None:
+    """The generator record shape written by retrospect create is accepted."""
+    good = tmp_path / "retrospective.yaml"
+    good.write_text(_valid_generator_yaml(), encoding="utf-8")
+
+    from specify_cli.retrospective.reader import read_gen_record
+
+    record = read_gen_record(good)
+    assert record.findings_status == "has_findings"
+    assert record.mission_id == MISSION_ID
+
+
+@pytest.mark.parametrize(
+    "mutated_yaml",
+    [
+        _valid_generator_yaml().replace("schema_version: 1", "schema_version: 2"),
+        _valid_generator_yaml().replace("kind: human", "kind: alien", 1),
+        _valid_generator_yaml().replace("category: process", "category: nonsense"),
+        _valid_generator_yaml().replace("friendly_name: Test Mission\n", ""),
+        _valid_generator_yaml() + "unknown_field: no\n",
+    ],
+)
+def test_generator_record_schema_errors_are_rejected(tmp_path: Path, mutated_yaml: str) -> None:
+    """Generator reader rejects invalid enums, version drift, and extra fields."""
+    bad = tmp_path / "retrospective.yaml"
+    bad.write_text(mutated_yaml, encoding="utf-8")
+
+    from specify_cli.retrospective.reader import read_gen_record
+
+    with pytest.raises(SchemaError):
+        read_gen_record(bad)
+
+
 def test_extra_field_raises_schema_error(tmp_path: Path) -> None:
     """Extra unknown top-level field → SchemaError (extra='forbid')."""
     yaml_extra = VALID_YAML + "unknown_field: some_value\n"

--- a/tests/retrospective/test_summary_tolerance.py
+++ b/tests/retrospective/test_summary_tolerance.py
@@ -38,6 +38,7 @@ MISSION_ID_1 = "01KQ6YEGT4YBZ3GZF7X680KQ3V"
 MISSION_ID_2 = "01KQ6YEGT4YBZ3GZF7X680KQAA"
 MISSION_ID_3 = "01KQ6YEGT4YBZ3GZF7X680KQBB"
 MISSION_ID_4 = "01KQ6YEGT4YBZ3GZF7X680KQCC"
+MISSION_ID_5 = "01KQ6YEGT4YBZ3GZF7X680KQDD"
 
 
 def _make_completed_yaml(
@@ -133,6 +134,48 @@ provenance:
   runtime_version: "3.2.0"
   written_at: "{completed}"
   schema_version: "1"
+"""
+
+
+def _make_generator_yaml(
+    mission_id: str = MISSION_ID_5,
+    slug: str = "generator-mission",
+) -> str:
+    return f"""\
+schema_version: 1
+mission_id: {mission_id}
+mission_slug: {slug}
+mission_number: 5
+friendly_name: Generator Mission
+mission_type: software-dev
+target_branch: main
+created_at: "2026-05-21T08:09:55+00:00"
+created_by:
+  kind: human
+  id: cli
+  display: spec-kitty retrospect
+provenance:
+  kind: explicit_create
+  invoked_at: "2026-05-21T08:09:55+00:00"
+  policy_resolved_from: {{}}
+  command: spec-kitty retrospect create
+policy_source: {{}}
+findings_status: has_findings
+helped: []
+not_helpful:
+  - id: n-001
+    category: process
+    summary: lane bounce before approval
+    evidence_refs: [e-001]
+gaps: []
+proposals: []
+evidence_refs:
+  - id: e-001
+    kind: event_range
+    path: kitty-specs/{slug}/status.events.jsonl
+    range: "event-1"
+generator_version: "1.0"
+provenance_history: []
 """
 
 
@@ -358,6 +401,21 @@ class TestToleranceCategories:
         project = _build_corpus(tmp_path)
         snapshot = build_summary(project_path=project)
         assert len(snapshot.malformed) == 2
+
+    def test_generator_record_is_not_malformed(self, tmp_path: Path) -> None:
+        missions_root = tmp_path / ".kittify" / "missions"
+        missions_root.mkdir(parents=True)
+        mission_dir = missions_root / MISSION_ID_5
+        mission_dir.mkdir()
+        (mission_dir / "retrospective.yaml").write_text(
+            _make_generator_yaml(), encoding="utf-8"
+        )
+
+        snapshot = build_summary(project_path=tmp_path)
+
+        assert snapshot.completed_count == 1
+        assert snapshot.malformed == []
+        assert snapshot.not_helpful_top[0].urn == "retrospective:not_helpful:process"
 
     def test_malformed_entries_have_path_and_reason(self, tmp_path: Path) -> None:
         project = _build_corpus(tmp_path)


### PR DESCRIPTION
## Summary
- add a shared reader path for generator-shape retrospective records written by `spec-kitty retrospect create`
- make `agent retrospect synthesize` and `retrospect summary` accept those records instead of reporting them malformed
- separate documented reviewer-feedback rejections from non-review lane friction in generated retrospective findings

## Verification
- `uv run pytest tests/retrospective/test_reader_tolerance.py tests/retrospective/test_summary_tolerance.py tests/retrospective/test_generator.py tests/cli/test_agent_retrospect_synthesize.py -q`
- `uv run ruff check src/specify_cli/retrospective/reader.py src/specify_cli/retrospective/summary.py src/specify_cli/retrospective/generator.py src/specify_cli/cli/commands/agent_retrospect.py tests/retrospective/test_reader_tolerance.py tests/retrospective/test_summary_tolerance.py tests/retrospective/test_generator.py tests/cli/test_agent_retrospect_synthesize.py`

Fixes #1239
Fixes #1240