### PR TITLE
fix(acceptance): preserve matrix extension fields

### DIFF
--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -255,6 +255,7 @@ def _check_invariant(repo_root: Path, ni: NegativeInvariant) -> NegativeInvarian
             verification_command=ni.verification_command,
             result="pending",
             evidence=f"Unknown verification method: {ni.verification_method}",
+            extras=ni.extras,
         )
 
 
@@ -268,6 +269,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="pending",
             evidence="No grep pattern specified in verification_command",
+            extras=ni.extras,
         )
 
     result = subprocess.run(
@@ -293,6 +295,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="confirmed_absent",
             evidence="grep found zero matches",
+            extras=ni.extras,
         )
     else:
         matches = result.stdout.strip().splitlines()[:5]
@@ -303,6 +306,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="still_present",
             evidence=f"grep found matches: {'; '.join(matches)}",
+            extras=ni.extras,
         )
 
 
@@ -316,6 +320,7 @@ def _check_custom_command(repo_root: Path, ni: NegativeInvariant) -> NegativeInv
             verification_command=ni.verification_command,
             result="pending",
             evidence="No command specified in verification_command",
+            extras=ni.extras,
         )
 
     # User-authored acceptance matrices intentionally support shell snippets.
@@ -334,6 +339,7 @@ def _check_custom_command(repo_root: Path, ni: NegativeInvariant) -> NegativeInv
             verification_command=ni.verification_command,
             result="confirmed_absent",
             evidence=f"Command exited 0: {result.stdout.strip()[:200]}",
+            extras=ni.extras,
         )
     else:
         return NegativeInvariant(
@@ -343,4 +349,5 @@ def _check_custom_command(repo_root: Path, ni: NegativeInvariant) -> NegativeInv
             verification_command=ni.verification_command,
             result="still_present",
             evidence=f"Command exited {result.returncode}: {result.stderr.strip()[:200]}",
+            extras=ni.extras,
         )

--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -13,11 +13,24 @@ from __future__ import annotations
 
 import json
 import subprocess
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
 from specify_cli.mission_metadata import mission_identity_fields, resolve_mission_identity
+
+
+def _split_known_fields(
+    cls: type[Any],
+    data: dict[str, Any],
+    *,
+    exclude: set[str] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    excluded = exclude or set()
+    known = {f.name for f in fields(cls)} - {"extras"} - excluded
+    kwargs = {key: value for key, value in data.items() if key in known}
+    extras = {key: value for key, value in data.items() if key not in known and key not in excluded}
+    return kwargs, extras
 
 
 @dataclass
@@ -32,6 +45,18 @@ class AcceptanceCriterion:
     verified_by: str | None = None
     verified_at: str | None = None
     notes: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AcceptanceCriterion:
+        kwargs, extras = _split_known_fields(cls, data)
+        return cls(**kwargs, extras=extras)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        extras = data.pop("extras", {}) or {}
+        data.update(extras)
+        return data
 
 
 @dataclass
@@ -44,6 +69,18 @@ class NegativeInvariant:
     verification_command: str | None = None
     result: str = "pending"  # "confirmed_absent" | "still_present" | "pending"
     evidence: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NegativeInvariant:
+        kwargs, extras = _split_known_fields(cls, data)
+        return cls(**kwargs, extras=extras)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        extras = data.pop("extras", {}) or {}
+        data.update(extras)
+        return data
 
 
 @dataclass
@@ -60,6 +97,7 @@ class AcceptanceMatrix:
     negative_invariants: list[NegativeInvariant] = field(default_factory=list)
     mission_number: str | None = None
     mission_type: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
 
     @property
     def overall_verdict(self) -> str:
@@ -74,19 +112,22 @@ class AcceptanceMatrix:
         return "pass"
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             **mission_identity_fields(
                 self.mission_slug,
                 self.mission_number,
                 self.mission_type,
             ),
             "overall_verdict": self.overall_verdict,
-            "criteria": [asdict(c) for c in self.criteria],
-            "negative_invariants": [asdict(ni) for ni in self.negative_invariants],
+            "criteria": [c.to_dict() for c in self.criteria],
+            "negative_invariants": [ni.to_dict() for ni in self.negative_invariants],
         }
+        data.update(self.extras)
+        return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AcceptanceMatrix:
+        kwargs, extras = _split_known_fields(cls, data, exclude={"overall_verdict"})
         identity = mission_identity_fields(
             data["mission_slug"],
             data.get("mission_number"),
@@ -95,13 +136,14 @@ class AcceptanceMatrix:
         return cls(
             mission_slug=identity["mission_slug"],
             criteria=[
-                AcceptanceCriterion(**c) for c in data.get("criteria", [])
+                AcceptanceCriterion.from_dict(c) for c in data.get("criteria", [])
             ],
             negative_invariants=[
-                NegativeInvariant(**ni) for ni in data.get("negative_invariants", [])
+                NegativeInvariant.from_dict(ni) for ni in data.get("negative_invariants", [])
             ],
-            mission_number=identity["mission_number"],
-            mission_type=identity["mission_type"],
+            mission_number=kwargs.get("mission_number", identity["mission_number"]),
+            mission_type=kwargs.get("mission_type", identity["mission_type"]),
+            extras=extras,
         )
 
 

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -282,3 +282,39 @@ class TestNegativeInvariants:
         ]
         results = enforce_negative_invariants(tmp_path, invariants)
         assert results[0].result == "still_present"
+
+    def test_enforcement_preserves_negative_invariant_extensions(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / "src").mkdir()
+        (repo_root / "src" / "app.py").write_text("def main(): pass\n")
+
+        feature_dir = tmp_path / "kitty-specs" / "010-feat"
+        feature_dir.mkdir(parents=True)
+        matrix_data = {
+            "mission_slug": "010-feat",
+            "criteria": [],
+            "negative_invariants": [
+                {
+                    "invariant_id": "NI-01",
+                    "description": "No legacy route",
+                    "verification_method": "grep_absence",
+                    "verification_command": "old_legacy_route",
+                    "result": "pending",
+                    "verification_pattern": "operator-authored extension",
+                },
+            ],
+        }
+        (feature_dir / MATRIX_FILENAME).write_text(json.dumps(matrix_data), encoding="utf-8")
+
+        matrix = read_acceptance_matrix(feature_dir)
+        assert matrix is not None
+        matrix.negative_invariants = enforce_negative_invariants(
+            repo_root,
+            matrix.negative_invariants,
+        )
+        write_acceptance_matrix(feature_dir, matrix)
+
+        restored = json.loads((feature_dir / MATRIX_FILENAME).read_text(encoding="utf-8"))
+        assert restored["negative_invariants"][0]["result"] == "confirmed_absent"
+        assert restored["negative_invariants"][0]["verification_pattern"] == "operator-authored extension"

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -1,5 +1,7 @@
 """Tests for acceptance matrix, evidence validation, and negative invariants."""
 
+import json
+
 import pytest
 
 from specify_cli.acceptance_matrix import (
@@ -96,6 +98,73 @@ class TestPersistence:
 
     def test_missing_returns_none(self, tmp_path):
         assert read_acceptance_matrix(tmp_path) is None
+
+    def test_preserves_extension_fields_on_round_trip(self, tmp_path):
+        matrix_data = {
+            "mission_slug": "010-feat",
+            "narrowed_acceptance_counter": 23,
+            "substitutions": [
+                {
+                    "criterion_id": "AC-01",
+                    "substitute_evidence": "vitest contract coverage",
+                },
+            ],
+            "criteria": [
+                {
+                    "criterion_id": "AC-01",
+                    "description": "Test passes",
+                    "proof_type": "automated_test",
+                    "pass_fail": "pass",
+                    "scope_note": "Narrowed acceptance rationale",
+                    "deferred_findings_ref": "docs/backlog/follow-ups.md",
+                },
+            ],
+            "negative_invariants": [
+                {
+                    "invariant_id": "NI-01",
+                    "description": "No legacy route",
+                    "verification_method": "grep_absence",
+                    "verification_command": "/old-route",
+                    "result": "confirmed_absent",
+                    "verification_pattern": "operator-authored extension",
+                },
+            ],
+        }
+        (tmp_path / MATRIX_FILENAME).write_text(json.dumps(matrix_data), encoding="utf-8")
+
+        matrix = read_acceptance_matrix(tmp_path)
+        assert matrix is not None
+        write_acceptance_matrix(tmp_path, matrix)
+
+        restored = json.loads((tmp_path / MATRIX_FILENAME).read_text(encoding="utf-8"))
+        assert restored["narrowed_acceptance_counter"] == 23
+        assert restored["substitutions"] == matrix_data["substitutions"]
+        assert restored["criteria"][0]["scope_note"] == "Narrowed acceptance rationale"
+        assert restored["criteria"][0]["deferred_findings_ref"] == "docs/backlog/follow-ups.md"
+        assert restored["negative_invariants"][0]["verification_pattern"] == "operator-authored extension"
+
+    def test_round_trip_without_extensions_does_not_emit_extras_key(self, tmp_path):
+        matrix = AcceptanceMatrix(
+            mission_slug="010-feat",
+            criteria=[
+                AcceptanceCriterion("AC-01", "Test passes", "automated_test", pass_fail="pass"),
+            ],
+            negative_invariants=[
+                NegativeInvariant("NI-01", "No legacy route", "grep_absence", result="confirmed_absent"),
+            ],
+        )
+
+        write_acceptance_matrix(tmp_path, matrix)
+        first_write = (tmp_path / MATRIX_FILENAME).read_text(encoding="utf-8")
+        restored = read_acceptance_matrix(tmp_path)
+        assert restored is not None
+        write_acceptance_matrix(tmp_path, restored)
+
+        assert (tmp_path / MATRIX_FILENAME).read_text(encoding="utf-8") == first_write
+        data = json.loads((tmp_path / MATRIX_FILENAME).read_text(encoding="utf-8"))
+        assert "extras" not in data
+        assert "extras" not in data["criteria"][0]
+        assert "extras" not in data["negative_invariants"][0]
 
 
 class TestManualEvidence:


### PR DESCRIPTION
## Summary
- preserve unknown acceptance-matrix top-level fields during read/write cycles
- preserve unknown per-criterion and per-negative-invariant fields instead of raising TypeError
- add regression coverage for extension-field round trips and stable no-extension output

Targets v3.2.0rc23. Fixes #1249.

## Verification
- PYTHONPATH=src pytest -q tests/lanes/test_acceptance_matrix.py tests/contract/test_machine_facing_canonical_fields.py
- uv run ruff check src/specify_cli/acceptance/matrix.py tests/lanes/test_acceptance_matrix.py