### PR TITLE
fix(acceptance): ignore matrix in grep_absence checks for 3.1.9

### DIFF
--- a/src/specify_cli/acceptance_matrix.py
+++ b/src/specify_cli/acceptance_matrix.py
@@ -225,7 +225,15 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
         )
 
     result = subprocess.run(
-        ["grep", "-r", ni.verification_command, "."],
+        [
+            "grep",
+            "-r",
+            "--exclude=acceptance-matrix.json",
+            "--exclude-dir=.git",
+            "--",
+            ni.verification_command,
+            ".",
+        ],
         cwd=str(repo_root),
         capture_output=True,
         text=True,

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -5,6 +5,7 @@ import pytest
 from specify_cli.acceptance_matrix import (
     AcceptanceCriterion,
     AcceptanceMatrix,
+    MATRIX_FILENAME,
     NegativeInvariant,
     enforce_negative_invariants,
     read_acceptance_matrix,
@@ -157,6 +158,35 @@ class TestNegativeInvariants:
         ]
         results = enforce_negative_invariants(tmp_path, invariants)
         assert results[0].result == "still_present"
+
+    def test_grep_absence_ignores_matrix_file(self, tmp_path):
+        """grep_absence should not match its own acceptance-matrix definition."""
+        feature_dir = tmp_path / "kitty-specs" / "test-mission"
+        feature_dir.mkdir(parents=True)
+        pattern = "old_legacy_route"
+        (feature_dir / MATRIX_FILENAME).write_text(
+            "{\n"
+            '  "mission_slug": "test-mission",\n'
+            '  "negative_invariants": [\n'
+            f'    {{"verification_method": "grep_absence", "verification_command": "{pattern}"}}\n'
+            "  ]\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        results = enforce_negative_invariants(
+            tmp_path,
+            [
+                NegativeInvariant(
+                    "NI-01",
+                    "No legacy route",
+                    "grep_absence",
+                    verification_command=pattern,
+                ),
+            ],
+        )
+
+        assert results[0].result == "confirmed_absent"
 
     def test_custom_command_pass(self, tmp_path):
         invariants = [


### PR DESCRIPTION
## Summary
- backport #1205 to the 3.1 release line
- exclude acceptance-matrix.json and .git from grep_absence checks
- add regression coverage showing a matrix definition does not match itself

Targets v3.1.9.

## Verification
- PYTHONPATH=src pytest -q tests/lanes/test_acceptance_matrix.py