### PR TITLE
fix(tasks): avoid dependency prose false positives for 3.1.9

### DIFF
--- a/kitty-specs/064-complete-mission-identity-cutover/contracts/upstream-3.0.0-shape.json
+++ b/kitty-specs/064-complete-mission-identity-cutover/contracts/upstream-3.0.0-shape.json
@@ -5,7 +5,7 @@
   "_schema_version": "3.0.0",
   "envelope": {
     "required_fields": ["schema_version", "build_id", "aggregate_type", "event_type"],
-    "forbidden_fields": ["feature_slug", "feature_number"],
+    "forbidden_fields": ["feature_slug", "feature_number", "from_lane", "to_lane", "actor", "force", "reason", "review_ref", "execution_mode", "evidence"],
     "aggregate_type": {
       "allowed": ["Build", "Mission", "WorkPackage", "MissionDossier"],
       "forbidden": ["Feature"]

--- a/kitty-specs/064-complete-mission-identity-cutover/contracts/upstream-3.0.0-shape.json
+++ b/kitty-specs/064-complete-mission-identity-cutover/contracts/upstream-3.0.0-shape.json
@@ -5,7 +5,7 @@
   "_schema_version": "3.0.0",
   "envelope": {
     "required_fields": ["schema_version", "build_id", "aggregate_type", "event_type"],
-    "forbidden_fields": ["feature_slug", "feature_number", "from_lane", "to_lane", "actor", "force", "reason", "review_ref", "execution_mode", "evidence"],
+    "forbidden_fields": ["feature_slug", "feature_number"],
     "aggregate_type": {
       "allowed": ["Build", "Mission", "WorkPackage", "MissionDossier"],
       "forbidden": ["Feature"]

--- a/src/specify_cli/core/dependency_parser.py
+++ b/src/specify_cli/core/dependency_parser.py
@@ -135,16 +135,16 @@ def _split_wp_sections(tasks_content: str) -> dict[str, str]:
 # Matches the literal phrase "Depends on" (or "Depend on") followed by WP IDs.
 # No free-form sentence scanning; the phrase must start with the keyword.
 _DEPENDS_ON = re.compile(
-    r"Depends?\s+on\s+(WP\d{2}(?:\s*,\s*WP\d{2})*)",
-    re.IGNORECASE,
+    r"^\s*(?:[-*]\s*)?Depends?\s+on\s+(WP\d{2}(?:\s*,\s*WP\d{2})*)\b",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 # Explicit-declaration format only (not prose inference).
 # Pattern 2: "**Dependencies**: WP01" / "Dependencies: WP01, WP02"
-# Matches a header-colon line with one or more WP IDs on the same line.
+# Matches a declaration field at the start of a line or after a pipe delimiter.
 _DEPS_COLON = re.compile(
-    r"\*?\*?Dependencies\*?\*?\s*:\s*(.+)",
-    re.IGNORECASE,
+    r"(?:^\s*(?:[-*]\s*)?|\|\s*)\*?\*?Dependencies\*?\*?\s*:\s*(?P<value>[^|\n]*)",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 # Explicit-declaration format only (not prose inference).
@@ -160,6 +160,32 @@ _BULLET_WP = re.compile(r"^\s*[-*]\s*(WP\d{2})")
 
 # Helper: any WP ID anywhere in a string
 _WP_ID = re.compile(r"WP\d{2}")
+
+
+def _parse_colon_dependency_value(value: str) -> list[str]:
+    """Parse the right side of a ``Dependencies:`` declaration line."""
+    stripped = value.strip()
+    normalized = stripped.lower()
+    if (
+        not stripped
+        or normalized == "[]"
+        or normalized.startswith("none")
+        or normalized.startswith("no deps")
+        or normalized.startswith("no dependencies")
+    ):
+        return []
+
+    if depends_match := _DEPENDS_ON.match(stripped):
+        return _WP_ID.findall(depends_match.group(1))
+
+    list_match = re.match(
+        r"^(WP\d{2}(?:\s*,\s*WP\d{2})*)\b(?=\s*(?:$|[.;(#]))",
+        stripped,
+        re.IGNORECASE,
+    )
+    if list_match is None:
+        return []
+    return _WP_ID.findall(list_match.group(1))
 
 
 def _parse_section_deps(section_content: str) -> list[str]:
@@ -188,7 +214,7 @@ def _parse_section_deps(section_content: str) -> list[str]:
         # don't double-count it here.
         if _DEPS_HEADING.match(line.strip()):
             continue
-        explicit_deps.extend(_WP_ID.findall(match.group(1)))
+        explicit_deps.extend(_parse_colon_dependency_value(match.group("value")))
 
     # Pattern 3 — bullet list under a "### Dependencies" heading
     for heading_match in _DEPS_HEADING.finditer(section_content):

--- a/tests/core/test_dependency_parser.py
+++ b/tests/core/test_dependency_parser.py
@@ -57,6 +57,13 @@ class TestInlineDependsOnFormat:
         result = parse_dependencies_from_tasks_md(content)
         assert result["WP02"] == ["WP01"]
 
+    def test_depends_on_prose_is_not_a_declaration(self) -> None:
+        content = _make_tasks_md(
+            ("WP02", "This implementation depends on WP01 vocabulary for examples.\n"),
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP02"] == []
+
 
 # ---------------------------------------------------------------------------
 # Format 2: "**Dependencies**: WP##" header-line colon
@@ -84,6 +91,36 @@ class TestInlineDependenciesColonFormat:
         )
         result = parse_dependencies_from_tasks_md(content)
         assert result["WP02"] == ["WP01"]
+
+    def test_none_with_parallelism_prose_does_not_extract_wp_mentions(self) -> None:
+        content = _make_tasks_md(
+            ("WP02", "**Dependencies**: none (parallel-safe with WP01 and WP03).\n"),
+            ("WP03", "**Dependencies**: none (parallel-safe with WP01 and WP02).\n"),
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP02"] == []
+        assert result["WP03"] == []
+
+    def test_parenthetical_note_after_declared_dep_does_not_add_extra_dep(self) -> None:
+        content = _make_tasks_md(
+            ("WP02", "**Dependencies**: WP01 (review alongside WP03 docs).\n"),
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP02"] == ["WP01"]
+
+    def test_metadata_line_dependencies_field_is_parsed(self) -> None:
+        content = _make_tasks_md(
+            ("WP04", "**Priority**: High | **Dependencies**: WP01, WP03 | **Subtasks**: 7\n"),
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP04"] == ["WP01", "WP03"]
+
+    def test_metadata_line_none_with_parallelism_prose_is_empty(self) -> None:
+        content = _make_tasks_md(
+            ("WP02", "**Priority**: High | **Dependencies**: none (parallel-safe with WP01 and WP03) | **Subtasks**: 4\n"),
+        )
+        result = parse_dependencies_from_tasks_md(content)
+        assert result["WP02"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- backport #1212 to the 3.1 release line
- tighten dependency declaration parsing so prose mentions do not create false WP dependencies
- preserve explicit `Dependencies:` and `Depends on` declarations

Targets v3.1.9.

## Verification
- PYTHONPATH=src pytest -q tests/core/test_dependency_parser.py