### PR TITLE
fix(upgrade): stamp schema on current semver for 3.1.9

### DIFF
--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -260,6 +260,12 @@ def upgrade(  # noqa: C901
             metadata.save(kittify_dir)
 
         if not dry_run:
+            from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
+
+            if REQUIRED_SCHEMA_VERSION is not None:
+                MigrationRunner._stamp_schema_version(kittify_dir, REQUIRED_SCHEMA_VERSION)
+
+        if not dry_run:
             auto_committed, auto_commit_paths, auto_commit_warning = _auto_commit_upgrade_changes(
                 project_path=project_path,
                 from_version=current_version,

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -454,6 +454,74 @@ def test_upgrade_no_migrations_json_includes_auto_commit_fields(
     assert data["warnings"] == []
 
 
+def test_upgrade_no_migrations_stamps_missing_schema_version(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Regression for issue #1158: up-to-date semver must still repair schema metadata."""
+    import yaml
+
+    import specify_cli.migration.schema_version as schema_version
+    from specify_cli.migration.schema_version import (
+        check_compatibility,
+        get_project_schema_version,
+    )
+
+    required_schema_version = 3
+    monkeypatch.setattr(schema_version, "REQUIRED_SCHEMA_VERSION", required_schema_version)
+    project_path = _setup_upgrade_project(tmp_path)
+    metadata_path = project_path / ".kittify" / "metadata.yaml"
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+
+    status_calls = {"count": 0}
+
+    def _fake_status(_repo_path: Path) -> set[str]:
+        status_calls["count"] += 1
+        if status_calls["count"] == 1:
+            return set()
+        return {".kittify/metadata.yaml"}
+
+    safe_commit_calls: list[list[str]] = []
+
+    def _fake_safe_commit(
+        *,
+        repo_path: Path,
+        files_to_commit: list[Path],
+        commit_message: str,
+        allow_empty: bool = False,
+    ) -> bool:
+        safe_commit_calls.append([str(path) for path in files_to_commit])
+        return True
+
+    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
+
+    assert get_project_schema_version(project_path) is None
+
+    upgrade_cmd.upgrade(
+        dry_run=False,
+        force=True,
+        target="1.0.0a1",
+        json_output=True,
+        verbose=False,
+        no_worktrees=True,
+    )
+
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["status"] == "up_to_date"
+    assert data["auto_committed"] is True
+    assert data["auto_commit_paths"] == [".kittify/metadata.yaml"]
+
+    metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["spec_kitty"]["schema_version"] == required_schema_version
+    assert check_compatibility(
+        get_project_schema_version(project_path),
+        required_schema_version,
+    ).is_compatible
+    assert safe_commit_calls == [[".kittify/metadata.yaml"]]
+
+
 def test_upgrade_dry_run_skips_auto_commit(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- backport #1159 source behavior to the 3.1 release line
- ensure no-migration upgrade runs still stamp required schema metadata when schema gating is enabled
- adapt the regression test to the 3.1 upgrade command signature

Targets v3.1.9.

## Verification
- PYTHONPATH=src pytest -q tests/upgrade/test_upgrade_auto_commit_unit.py