### PR TITLE
fix(docs): publish harness guide subtree

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -12,6 +12,8 @@
           "tutorials/*.md",
           "tutorials/toc.yml",
           "how-to/*.md",
+          "how-to/harnesses/*.md",
+          "how-to/harnesses/toc.yml",
           "how-to/toc.yml",
           "reference/*.md",
           "reference/toc.yml",

--- a/docs/explanation/toc.yml
+++ b/docs/explanation/toc.yml
@@ -20,6 +20,8 @@
   href: multi-agent-orchestration.md
 - name: Runtime Loop
   href: runtime-loop.md
+- name: Pip vs pipx vs uv
+  href: pip-vs-pipx-vs-uv.md
 - name: "Understanding Charter: Synthesis, DRG, and Governed Context"
   href: charter-synthesis-drg.md
 - name: Understanding the Org Doctrine Layer

--- a/docs/how-to/harnesses/toc.yml
+++ b/docs/how-to/harnesses/toc.yml
@@ -1,0 +1,28 @@
+- name: Claude Code
+  href: claude-code.md
+- name: Codex
+  href: codex.md
+- name: OpenCode
+  href: opencode.md
+- name: Cursor
+  href: cursor.md
+- name: Gemini
+  href: gemini.md
+- name: Pi TUI
+  href: pi-tui.md
+- name: Amazon Q
+  href: amazon-q.md
+- name: Augment
+  href: augment.md
+- name: GitHub Copilot
+  href: copilot.md
+- name: Kilo Code
+  href: kilocode.md
+- name: Kiro
+  href: kiro.md
+- name: Qwen
+  href: qwen.md
+- name: Roo
+  href: roo.md
+- name: Windsurf
+  href: windsurf.md

--- a/docs/how-to/toc.yml
+++ b/docs/how-to/toc.yml
@@ -1,7 +1,21 @@
 - name: Install & Upgrade
   href: install-spec-kitty.md
+- name: Install on macOS
+  href: install-macos.md
+- name: Install on Linux
+  href: install-linux.md
+- name: Install on Windows
+  href: install-windows.md
+- name: Upgrade the CLI
+  href: upgrade-cli.md
+- name: Upgrade a Project
+  href: upgrade-project.md
+- name: Uninstall
+  href: uninstall.md
 - name: Diagnose Installation Problems
   href: diagnose-installation.md
+- name: Harness Guides
+  href: harnesses/
 - name: Set Up Codex Launcher
   href: setup-codex-spec-kitty-launcher.md
 - name: Create a Specification

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,5 +1,11 @@
 - name: CLI Commands
   href: cli-commands.md
+- name: Init Lifecycle
+  href: init-lifecycle.md
+- name: Upgrade Lifecycle
+  href: upgrade-lifecycle.md
+- name: Supported Harnesses
+  href: supported-harnesses.md
 - name: Charter CLI Reference
   href: charter-commands.md
 - name: Profile Invocation Reference


### PR DESCRIPTION
## Summary
- include nested harness how-to pages in the DocFX build
- add TOC entries for 3.2 install lifecycle, harness, reference, and package-manager docs

## Verification
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NO_UPGRADE_CHECK=1 PYTHONPATH=. uv run python scripts/docs/check_docs_freshness.py --ci --report /tmp/spec-kitty-freshness-main-fix.json --link-check none
- cd docs && docfx docfx.json
- verified docs/_site/how-to/harnesses/codex.html contains spec-kitty init --ai codex