### PR TITLE
fix(intake): show full brief hash for 3.1.9

### DIFF
--- a/src/specify_cli/cli/commands/intake.py
+++ b/src/specify_cli/cli/commands/intake.py
@@ -139,7 +139,7 @@ def intake(
             console.print(
                 f"[bold]Source:[/bold] {source.get('source_file', '')} "
                 f"  [bold]Ingested:[/bold] {source.get('ingested_at', '')} "
-                f"  [bold]Hash:[/bold] {source.get('brief_hash', '')[:16]}..."
+                f"  [bold]Hash:[/bold] {source.get('brief_hash', '')}"
             )
         if brief is not None:
             console.print(brief)

--- a/src/specify_cli/mission_brief.py
+++ b/src/specify_cli/mission_brief.py
@@ -132,5 +132,4 @@ def clear_mission_brief(repo_root: Path) -> None:
     """Remove both brief artefacts if they exist (idempotent)."""
     for filename in (MISSION_BRIEF_FILENAME, BRIEF_SOURCE_FILENAME):
         path = repo_root / ".kittify" / filename
-        if path.exists():
-            path.unlink()
+        path.unlink(missing_ok=True)

--- a/tests/specify_cli/cli/commands/test_intake_size_cap.py
+++ b/tests/specify_cli/cli/commands/test_intake_size_cap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pathlib import Path
 from specify_cli.cli.commands.intake import MAX_BRIEF_FILE_SIZE_BYTES
+from specify_cli.mission_brief import BRIEF_SOURCE_FILENAME, write_mission_brief
 
 
 def test_max_brief_file_size_bytes_is_importable():
@@ -33,3 +34,23 @@ def test_size_cap_accepts_file_at_limit(tmp_path):
     assert exact.stat().st_size == MAX_BRIEF_FILE_SIZE_BYTES
     # size check: file_size > MAX means "greater than" — at limit is ok
     assert not (exact.stat().st_size > MAX_BRIEF_FILE_SIZE_BYTES)
+
+
+def test_intake_show_prints_full_brief_hash(tmp_path, monkeypatch, capsys):
+    """--show prints the full stored SHA-256 hash for integrity checks."""
+    from specify_cli.cli.commands import intake as intake_module
+
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+    write_mission_brief(tmp_path, "# content", "plan.md")
+    source_text = (tmp_path / ".kittify" / BRIEF_SOURCE_FILENAME).read_text(encoding="utf-8")
+    full_hash = next(
+        line.split(": ", 1)[1].strip()
+        for line in source_text.splitlines()
+        if line.startswith("brief_hash: ")
+    )
+
+    intake_module.intake(show=True)
+
+    output = capsys.readouterr().out
+    assert full_hash in output
+    assert f"{full_hash[:16]}..." not in output

--- a/tests/specify_cli/test_mission_brief_resilient_write.py
+++ b/tests/specify_cli/test_mission_brief_resilient_write.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 import yaml
 from pathlib import Path
-from specify_cli.mission_brief import write_mission_brief, MISSION_BRIEF_FILENAME, BRIEF_SOURCE_FILENAME
+from specify_cli.mission_brief import (
+    BRIEF_SOURCE_FILENAME,
+    MISSION_BRIEF_FILENAME,
+    clear_mission_brief,
+    write_mission_brief,
+)
 
 
 def test_write_mission_brief_success(tmp_path):
@@ -69,3 +74,16 @@ def test_write_mission_brief_return_value(tmp_path):
     brief, source = result
     assert brief.name == MISSION_BRIEF_FILENAME
     assert source.name == BRIEF_SOURCE_FILENAME
+
+
+def test_clear_mission_brief_ignores_missing_pair_member(tmp_path):
+    """Clearing an already-partial brief state is race-safe and idempotent."""
+    kittify = tmp_path / ".kittify"
+    kittify.mkdir()
+    (kittify / MISSION_BRIEF_FILENAME).write_text("# content", encoding="utf-8")
+
+    clear_mission_brief(tmp_path)
+    clear_mission_brief(tmp_path)
+
+    assert not (kittify / MISSION_BRIEF_FILENAME).exists()
+    assert not (kittify / BRIEF_SOURCE_FILENAME).exists()


### PR DESCRIPTION
## Summary
- backport the intake source fix from 3dff8871a to the 3.1 release line
- print full stored brief hashes in `spec-kitty intake --show`
- make mission brief clearing idempotent when one artifact is already missing
- use focused 3.1-compatible regression tests instead of the 3.2-only CLI test file

Targets v3.1.9.

## Verification
- PYTHONPATH=src pytest -q tests/specify_cli/cli/commands/test_intake_size_cap.py tests/specify_cli/test_mission_brief_resilient_write.py