### PR TITLE
fix(doctrine): allow pack-relative toolguide paths for 3.1.9

### DIFF
--- a/src/doctrine/schemas/toolguide.schema.yaml
+++ b/src/doctrine/schemas/toolguide.schema.yaml
@@ -26,7 +26,7 @@ properties:
     minLength: 1
   guide_path:
     type: string
-    pattern: ^src/doctrine/.+\.md$
+    pattern: ^[^/].*\.md$
   summary:
     type: string
     minLength: 1

--- a/src/doctrine/schemas/toolguide.schema.yaml
+++ b/src/doctrine/schemas/toolguide.schema.yaml
@@ -26,7 +26,12 @@ properties:
     minLength: 1
   guide_path:
     type: string
-    pattern: ^[^/].*\.md$
+    pattern: "^[^/\\\\].*\\.md$"
+    not:
+      anyOf:
+        - pattern: "(^|[/\\\\])\\.\\.([/\\\\]|$)"
+        - pattern: "^[A-Za-z]:"
+        - pattern: "://"
   summary:
     type: string
     minLength: 1

--- a/src/doctrine/toolguides/models.py
+++ b/src/doctrine/toolguides/models.py
@@ -12,7 +12,7 @@ class Toolguide(BaseModel):
     schema_version: str = Field(pattern=r"^1\.0$")
     tool: str
     title: str
-    guide_path: str = Field(pattern=r"^src/doctrine/.+\.md$")
+    guide_path: str = Field(pattern=r"^[^/].*\.md$")
     summary: str
     commands: list[str] = Field(default_factory=list)
     applies_to_languages: list[str] = Field(default_factory=list)

--- a/src/doctrine/toolguides/models.py
+++ b/src/doctrine/toolguides/models.py
@@ -1,6 +1,18 @@
 """Toolguide domain model."""
 
-from pydantic import BaseModel, ConfigDict, Field
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _is_pack_relative_markdown_path(value: str) -> bool:
+    if not value.endswith(".md"):
+        return False
+    if value.startswith(("/", "\\")):
+        return False
+    if "://" in value or re.match(r"^[A-Za-z]:", value):
+        return False
+    return ".." not in value.replace("\\", "/").split("/")
 
 
 class Toolguide(BaseModel):
@@ -12,8 +24,15 @@ class Toolguide(BaseModel):
     schema_version: str = Field(pattern=r"^1\.0$")
     tool: str
     title: str
-    guide_path: str = Field(pattern=r"^[^/].*\.md$")
+    guide_path: str
     summary: str
     commands: list[str] = Field(default_factory=list)
     applies_to_languages: list[str] = Field(default_factory=list)
     last_updated: str | None = None
+
+    @field_validator("guide_path")
+    @classmethod
+    def validate_guide_path(cls, value: str) -> str:
+        if not _is_pack_relative_markdown_path(value):
+            raise ValueError("guide_path must be a pack-relative .md path")
+        return value

--- a/tests/doctrine/fixtures/toolguide/invalid/bad-guide-path.yaml
+++ b/tests/doctrine/fixtures/toolguide/invalid/bad-guide-path.yaml
@@ -2,5 +2,5 @@ schema_version: "1.0"
 id: powershell-syntax
 tool: powershell
 title: PowerShell Syntax Guide
-guide_path: docs/POWERSHELL_SYNTAX.md
+guide_path: /absolute/POWERSHELL_SYNTAX.md
 summary: PowerShell-specific syntax and parameter conventions.

--- a/tests/doctrine/toolguides/test_models.py
+++ b/tests/doctrine/toolguides/test_models.py
@@ -25,8 +25,26 @@ class TestToolguide:
         with pytest.raises(ValidationError):
             toolguide.title = "changed"  # type: ignore[misc]
 
+    def test_pack_relative_guide_path_accepted(self, sample_toolguide_data: dict) -> None:
+        """Pack-relative paths like toolguides/my-tool.md must be accepted (issue #1157)."""
+        sample_toolguide_data["guide_path"] = "toolguides/my-tool.md"
+        toolguide = Toolguide.model_validate(sample_toolguide_data)
+        assert toolguide.guide_path == "toolguides/my-tool.md"
+
+    def test_nested_pack_relative_guide_path_accepted(self, sample_toolguide_data: dict) -> None:
+        """Nested pack-relative paths must be accepted (issue #1157)."""
+        sample_toolguide_data["guide_path"] = "docs/guides/my-tool.md"
+        toolguide = Toolguide.model_validate(sample_toolguide_data)
+        assert toolguide.guide_path == "docs/guides/my-tool.md"
+
+    def test_absolute_guide_path_rejected(self, sample_toolguide_data: dict) -> None:
+        """Absolute paths must be rejected — they can never be pack-relative."""
+        sample_toolguide_data["guide_path"] = "/absolute/path.md"
+        with pytest.raises(ValidationError):
+            Toolguide.model_validate(sample_toolguide_data)
+
     def test_invalid_guide_path_pattern_raises(self, sample_toolguide_data: dict) -> None:
-        sample_toolguide_data["guide_path"] = "docs/guide.md"
+        sample_toolguide_data["guide_path"] = "/absolute/guide.md"
         with pytest.raises(ValidationError):
             Toolguide.model_validate(sample_toolguide_data)
 

--- a/tests/doctrine/toolguides/test_models.py
+++ b/tests/doctrine/toolguides/test_models.py
@@ -43,6 +43,20 @@ class TestToolguide:
         with pytest.raises(ValidationError):
             Toolguide.model_validate(sample_toolguide_data)
 
+    @pytest.mark.parametrize(
+        "guide_path",
+        [
+            "../outside.md",
+            "docs/../outside.md",
+            "http://example.com/guide.md",
+            "C:/tmp/guide.md",
+        ],
+    )
+    def test_non_pack_relative_guide_path_rejected(self, sample_toolguide_data: dict, guide_path: str) -> None:
+        sample_toolguide_data["guide_path"] = guide_path
+        with pytest.raises(ValidationError):
+            Toolguide.model_validate(sample_toolguide_data)
+
     def test_invalid_guide_path_pattern_raises(self, sample_toolguide_data: dict) -> None:
         sample_toolguide_data["guide_path"] = "/absolute/guide.md"
         with pytest.raises(ValidationError):
@@ -52,4 +66,3 @@ class TestToolguide:
         sample_toolguide_data["schema_version"] = "2.0"
         with pytest.raises(ValidationError):
             Toolguide.model_validate(sample_toolguide_data)
-

--- a/tests/doctrine/toolguides/test_validation.py
+++ b/tests/doctrine/toolguides/test_validation.py
@@ -20,8 +20,14 @@ class TestValidateToolguide:
         errors = validate_toolguide(data)
         assert len(errors) > 0
 
+    def test_pack_relative_guide_path_is_valid(self, sample_toolguide_data: dict) -> None:
+        """Pack-relative guide_path must pass JSON schema validation (issue #1157)."""
+        sample_toolguide_data["guide_path"] = "toolguides/my-tool.md"
+        errors = validate_toolguide(sample_toolguide_data)
+        assert errors == []
+
     def test_invalid_guide_path_pattern(self, sample_toolguide_data: dict) -> None:
-        sample_toolguide_data["guide_path"] = "docs/guide.md"
+        sample_toolguide_data["guide_path"] = "/absolute/guide.md"
         errors = validate_toolguide(sample_toolguide_data)
         assert any("guide_path" in e for e in errors)
 

--- a/tests/doctrine/toolguides/test_validation.py
+++ b/tests/doctrine/toolguides/test_validation.py
@@ -31,3 +31,16 @@ class TestValidateToolguide:
         errors = validate_toolguide(sample_toolguide_data)
         assert any("guide_path" in e for e in errors)
 
+    @pytest.mark.parametrize(
+        "guide_path",
+        [
+            "../outside.md",
+            "docs/../outside.md",
+            "http://example.com/guide.md",
+            "C:/tmp/guide.md",
+        ],
+    )
+    def test_non_pack_relative_guide_path_is_invalid(self, sample_toolguide_data: dict, guide_path: str) -> None:
+        sample_toolguide_data["guide_path"] = guide_path
+        errors = validate_toolguide(sample_toolguide_data)
+        assert any("guide_path" in e for e in errors)


### PR DESCRIPTION
## Summary
- backport #1157 to the 3.1 release line
- allow pack-relative `.md` guide_path values in Toolguide models and JSON schema
- keep absolute guide paths rejected

Targets v3.1.9.

## Verification
- PYTHONPATH=src pytest -q tests/doctrine/toolguides/test_models.py tests/doctrine/toolguides/test_validation.py