### PR TITLE
fix(acceptance): match canonical clarification markers for 3.1.9

### DIFF
--- a/src/specify_cli/acceptance.py
+++ b/src/specify_cli/acceptance.py
@@ -34,6 +34,9 @@ from .tasks_support import (
 logger = logging.getLogger(__name__)
 
 AcceptanceMode = str  # Expected values: "pr", "local", "checklist"
+NEEDS_CLARIFICATION_MARKER_RE = re.compile(
+    r"\[NEEDS CLARIFICATION:[^\]\n]+\]\s*<!--\s*decision_id:\s*\S+\s*-->"
+)
 
 
 class AcceptanceError(TaskCliError):
@@ -301,7 +304,7 @@ def _check_needs_clarification(files: Sequence[Path]) -> list[str]:
     for file_path in files:
         if file_path.exists():
             text = _read_text_strict(file_path)
-            if "[NEEDS CLARIFICATION" in text:
+            if NEEDS_CLARIFICATION_MARKER_RE.search(text):
                 results.append(str(file_path))
     return results
 

--- a/src/specify_cli/acceptance.py
+++ b/src/specify_cli/acceptance.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 AcceptanceMode = str  # Expected values: "pr", "local", "checklist"
 NEEDS_CLARIFICATION_MARKER_RE = re.compile(
-    r"\[NEEDS CLARIFICATION:[^\]\n]+\]\s*<!--\s*decision_id:\s*\S+\s*-->"
+    r"\[NEEDS CLARIFICATION:[^\]\n]+\](?:\s*<!--\s*decision_id:\s*\S+\s*-->)?"
 )
 
 

--- a/tests/specify_cli/test_acceptance_needs_clarification.py
+++ b/tests/specify_cli/test_acceptance_needs_clarification.py
@@ -1,0 +1,36 @@
+"""Regression tests for acceptance clarification marker detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.acceptance import _check_needs_clarification
+
+pytestmark = pytest.mark.fast
+
+
+def test_needs_clarification_ignores_descriptive_prose(tmp_path: Path) -> None:
+    """Mentioning the marker syntax in prose is not an unresolved marker."""
+    artifact = tmp_path / "research.md"
+    artifact.write_text(
+        "| Spec marker | Resolution |\n"
+        "|-------------|------------|\n"
+        "| (no `[NEEDS CLARIFICATION]` markers in spec) | n/a |\n",
+        encoding="utf-8",
+    )
+
+    assert _check_needs_clarification([artifact]) == []
+
+
+def test_needs_clarification_flags_canonical_marker(tmp_path: Path) -> None:
+    """The acceptance gate still flags real deferred-decision markers."""
+    artifact = tmp_path / "spec.md"
+    artifact.write_text(
+        "The system must choose a queue backend. "
+        "[NEEDS CLARIFICATION: choose durable queue] <!-- decision_id: 01KS0ABCDEF0123456789ABCDE -->\n",
+        encoding="utf-8",
+    )
+
+    assert _check_needs_clarification([artifact]) == [str(artifact)]

--- a/tests/specify_cli/test_acceptance_needs_clarification.py
+++ b/tests/specify_cli/test_acceptance_needs_clarification.py
@@ -34,3 +34,15 @@ def test_needs_clarification_flags_canonical_marker(tmp_path: Path) -> None:
     )
 
     assert _check_needs_clarification([artifact]) == [str(artifact)]
+
+
+def test_needs_clarification_flags_legacy_marker(tmp_path: Path) -> None:
+    """The 3.1.8 template marker shape is still unresolved clarification."""
+    artifact = tmp_path / "legacy-spec.md"
+    artifact.write_text(
+        "The system must choose a queue backend. "
+        "[NEEDS CLARIFICATION: choose durable queue]\n",
+        encoding="utf-8",
+    )
+
+    assert _check_needs_clarification([artifact]) == [str(artifact)]


### PR DESCRIPTION
## Summary
- backport #1204 to the 3.1 release line
- only treat canonical `[NEEDS CLARIFICATION: ...] <!-- decision_id: ... -->` markers as unresolved clarification blockers
- add regression coverage for prose mentions vs real markers

Targets v3.1.9.

## Verification
- PYTHONPATH=src pytest -q tests/specify_cli/test_acceptance_needs_clarification.py