### PR TITLE
fix(docs): align harness matrix with command skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ src/specify_cli/missions/*/command-templates/*.md  (SOURCE - edit here!)
 
 ## Supported AI Agents
 
-Spec Kitty supports **15 AI agents** total: 13 use the slash-command pipeline (Amazon Q/`q` retained as legacy alongside its rebrand Kiro) and 2 use the Agent Skills pipeline. When adding features that affect slash commands, migrations, or templates, ensure all command-layer agents are updated.
+Spec Kitty supports **17 AI agents** total: 13 use the slash-command pipeline (Amazon Q/`q` retained as legacy alongside its rebrand Kiro) and 4 use the Agent Skills pipeline. When adding features that affect slash commands, migrations, or templates, ensure all command-layer agents are updated.
 
 ### Slash-Command Agents (13)
 
@@ -54,14 +54,16 @@ Spec Kitty supports **15 AI agents** total: 13 use the slash-command pipeline (A
 | Kiro | `.kiro/` | `prompts/` | `/spec-kitty.*` |
 | Google Antigravity | `.agent/` | `workflows/` | `/spec-kitty.*` |
 
-### Agent Skills Agents (2)
+### Agent Skills Agents (4)
 
 | Agent | Skills Root | Command Surface | Key |
 |-------|-------------|-----------------|-----|
 | Codex CLI | `.agents/skills/` | `$spec-kitty.<command>` | `codex` |
 | Mistral Vibe | `.agents/skills/` via `.vibe/config.toml` `skill_paths` | `/spec-kitty.<command>` | `vibe` |
+| Pi | `.agents/skills/` | `/skill:spec-kitty.<command>` | `pi` |
+| Letta Code | `.agents/skills/` | Agent Skills | `letta` |
 
-Codex and Vibe share a single installation under `.agents/skills/spec-kitty.<command>/SKILL.md`. Codex reads that tree directly; Vibe is configured to read it via `.vibe/config.toml`. The manifest at `.kittify/command-skills-manifest.json` tracks which agents reference each skill package.
+Codex, Vibe, Pi, and Letta share a single installation under `.agents/skills/spec-kitty.<command>/SKILL.md`. Codex, Pi, and Letta read that tree directly; Vibe is configured to read it via `.vibe/config.toml`. The manifest at `.kittify/command-skills-manifest.json` tracks which agents reference each skill package.
 
 **New modules (mission 083):**
 - `src/specify_cli/skills/command_renderer.py` — renders source templates into Agent Skills format

--- a/docs/development/3-2-harness-research-method.md
+++ b/docs/development/3-2-harness-research-method.md
@@ -4,14 +4,14 @@
 
 **Sources of authority:**
 - [`CLAUDE.md`](../../CLAUDE.md) §"Supported AI Agents" — canonical list of installed surfaces.
-- [`kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md) §"Supported Harness Research" — 16 candidate subjects.
+- [`kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md) §"Supported Harness Research" plus the current CLI agent registry — 17 candidate subjects.
 - [`data-model.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/data-model.md) §"HarnessEntry" — schema each row must satisfy.
 
 **Access date for all citations in this revision:** 2026-05-21.
 
 ---
 
-## 1. Subject list — 16 candidate harnesses
+## 1. Subject list — 17 candidate harnesses
 
 | # | Harness | Key |
 |---|---------|-----|
@@ -22,7 +22,7 @@
 | 5 | Google Gemini CLI | `gemini` |
 | 6 | Pi TUI | `pi` |
 | 7 | Qwen Code | `qwen` |
-| 8 | Amazon Q CLI | `amazonq` |
+| 8 | Amazon Q CLI | `q` |
 | 9 | GitHub Copilot | `copilot` |
 | 10 | Augment Code (Auggie) | `augment` |
 | 11 | Roo Cline | `roo` |
@@ -31,8 +31,9 @@
 | 14 | Windsurf | `windsurf` |
 | 15 | Mistral Vibe | `vibe` |
 | 16 | Letta Code | `letta` |
+| 17 | Google Antigravity | `antigravity` |
 
-The set is the union of (a) directories present in the repo, (b) entries in `CLAUDE.md`'s slash-command and Agent Skills tables, and (c) entries in `start-here.md` §"Supported Harness Research" (per R-003).
+The set is the union of (a) directories present in the repo, (b) entries in `CLAUDE.md`'s command-surface and command-skill tables, (c) entries in `src/specify_cli/core/config.py`'s `AI_CHOICES`, and (d) entries in `start-here.md` §"Supported Harness Research" (per R-003).
 
 ---
 
@@ -71,7 +72,7 @@ done
 | OpenCode | `.opencode/command/` | yes | `spec-kitty-standalone.md` |
 | Cursor | `.cursor/commands/` | yes | `spec-kitty-standalone.md` |
 | Gemini CLI | `.gemini/commands/` | yes | `spec-kitty-standalone.md` |
-| Pi TUI | (no installed surface) | no | — |
+| Pi TUI | `.agents/skills/spec-kitty.*` | yes (skills) | shared command-skill packages |
 | Qwen Code | `.qwen/commands/` | yes | `spec-kitty-standalone.md` |
 | Amazon Q | `.amazonq/prompts/` | yes | `spec-kitty-standalone.md` |
 | GitHub Copilot | `.github/prompts/` | yes | `spec-kitty-standalone.md` |
@@ -82,12 +83,12 @@ done
 | Windsurf | `.windsurf/workflows/` | yes | `spec-kitty-standalone.md` |
 | Google Antigravity | `.agent/workflows/` | yes | `spec-kitty-standalone.md` |
 | Vibe | `.agents/skills/` via `.vibe/config.toml` | yes (shared with Codex) | shares `.agents/skills/spec-kitty.advise` |
-| Letta Code | (no installed surface) | no | — |
+| Letta Code | `.agents/skills/spec-kitty.*` | yes (skills) | shared command-skill packages |
 
 **Notes:**
 - `spec-kitty-standalone.md` is the lane-bootstrap surface; the full `/spec-kitty.*` command set lives at the source under `src/specify_cli/missions/*/command-templates/` and is materialized by `spec-kitty agent config sync` (see `CLAUDE.md` §"Adding/Removing Agents").
-- `.agents/skills/spec-kitty.advise/` is the Agent Skills package shared between Codex CLI and Mistral Vibe (per `CLAUDE.md` §"Agent Skills Agents").
-- "Google Antigravity" (`.agent/workflows/`) is not in the 16-candidate list but is present on disk; it is noted here for completeness and excluded from the matrix.
+- `.agents/skills/spec-kitty.advise/` is the Agent Skills package shared between Codex CLI, Mistral Vibe, Pi, and Letta Code (per `CLAUDE.md` §"Agent Skills Agents").
+- Google Antigravity (`.agent/workflows/`) is present in the current CLI agent registry and is included in the matrix.
 
 ---
 
@@ -100,7 +101,7 @@ Each row in the support matrix records exactly one `mechanism` value from the `H
 | `slash_command` | The harness exposes user-typed `/...` commands. | Claude Code `.claude/commands/`, Cursor `.cursor/commands/`. |
 | `prompt` | The harness reads prompt files at runtime. | Amazon Q `.amazonq/prompts/`, Kiro `.kiro/prompts/`, GitHub Copilot `.github/prompts/`. |
 | `workflow` | The harness drives multi-step workflows defined by YAML/Markdown. | Windsurf `.windsurf/workflows/`, Kilo Code `.kilocode/workflows/`, Google Antigravity `.agent/workflows/`. |
-| `skill` | The harness loads Agent Skills packages with `SKILL.md`. | Codex CLI, Mistral Vibe (both via `.agents/skills/`). |
+| `skill` | The harness loads Agent Skills packages with `SKILL.md`. | Codex CLI, Mistral Vibe, Pi, Letta Code (via `.agents/skills/`). |
 | `command_file` | The harness reads command files outside a `commands/` directory. | reserved; no current harness uses this mode. |
 | `config` | The harness needs an additional config-file edit before commands are visible. | Vibe (`.vibe/config.toml` `skill_paths`). |
 
@@ -121,7 +122,7 @@ Every harness row at tier ≥ `supported` requires at least one current public-d
 | OpenCode | https://opencode.ai/docs |
 | Cursor | https://cursor.com/docs |
 | Gemini CLI | https://github.com/google-gemini/gemini-cli |
-| Pi TUI | (no primary public doc located — classify `partial` or lower) |
+| Pi TUI | https://pi.dev/docs/latest/skills |
 | Qwen Code | https://github.com/QwenLM/qwen-code |
 | Amazon Q CLI | https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/ |
 | GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot |
@@ -130,8 +131,9 @@ Every harness row at tier ≥ `supported` requires at least one current public-d
 | Kilo Code | https://kilocode.ai/docs |
 | Kiro | https://kiro.dev/docs |
 | Windsurf | https://docs.windsurf.com/windsurf/cascade/workflows |
-| Mistral Vibe | https://github.com/openai/codex (shared-skill source; see Codex citation per `CLAUDE.md`) |
-| Letta Code | https://docs.letta.com/ (status uncertain — classify `experimental` or `archived`) |
+| Google Antigravity | https://antigravity.im/documentation |
+| Mistral Vibe | https://docs.mistral.ai/mistral-vibe/terminal/quickstart |
+| Letta Code | https://docs.letta.com/letta-code/skills |
 
 ### 4.2 Citation rule
 
@@ -156,7 +158,7 @@ Every harness row at tier ≥ `supported` requires at least one current public-d
 - `support_tier in {first_class, supported}` ⇒ `external_doc_citations` is non-empty.
 - `support_tier == archived` ⇒ `page_path` is under `docs/migration/` or absent.
 - `key` is unique across the matrix.
-- Every row's `repo_directory` matches the directory in `CLAUDE.md` or is documented as absent (Pi TUI, Letta Code).
+- Every row's `repo_directory` matches the directory in `CLAUDE.md` or is explicitly documented as a partial-tier exception.
 
 ---
 
@@ -203,16 +205,17 @@ The matrix in [`docs/reference/supported-harnesses.md`](../reference/supported-h
 | `cursor` | Cursor | slash_command | supported | https://cursor.com/docs | `.cursor/commands/` installed. |
 | `gemini` | Google Gemini CLI | slash_command | supported | https://github.com/google-gemini/gemini-cli | `.gemini/commands/` installed. |
 | `qwen` | Qwen Code | slash_command | supported | https://github.com/QwenLM/qwen-code | `.qwen/commands/` installed. |
-| `amazonq` | Amazon Q CLI | prompt | supported | https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/ | `.amazonq/prompts/`; legacy alongside Kiro rebrand per `CLAUDE.md`. |
+| `q` | Amazon Q CLI | prompt | supported | https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/ | `.amazonq/prompts/`; legacy alongside Kiro rebrand per `CLAUDE.md`. |
 | `copilot` | GitHub Copilot | prompt | supported | https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot | `.github/prompts/` installed. |
 | `augment` | Augment Code (Auggie) | slash_command | supported | https://docs.augmentcode.com/auggie/overview | `.augment/commands/` installed. |
 | `roo` | Roo Cline | slash_command | supported | https://docs.roocode.com/ | `.roo/commands/` installed. |
 | `kilocode` | Kilo Code | workflow | supported | https://kilocode.ai/docs | `.kilocode/workflows/` installed. |
 | `windsurf` | Windsurf | workflow | supported | https://docs.windsurf.com/windsurf/cascade/workflows | `.windsurf/workflows/` installed. |
 | `kiro` | Kiro | prompt | partial | https://kiro.dev/docs | `.kiro/prompts/` installed but coverage is the standalone bootstrap only; promote once full `/spec-kitty.*` surface is verified. |
-| `pi` | Pi TUI | (none) | partial | (none located) | No on-disk surface; no current public doc located. |
-| `vibe` | Mistral Vibe | skill | experimental | https://github.com/openai/codex (shared-skill source per `CLAUDE.md`) | Requires `.vibe/config.toml` `skill_paths` edit; depends on Codex shared installation. |
-| `letta` | Letta Code | (none) | archived | https://docs.letta.com/ (status uncertain) | No on-disk surface; classified `archived` until upstream status is reconfirmed. |
+| `antigravity` | Google Antigravity | workflow | partial | https://antigravity.im/documentation | `.agent/workflows/` installed; keep partial until full command-set smoke evidence is recorded. |
+| `pi` | Pi TUI | skill | partial | https://pi.dev/docs/latest/skills | `.agents/skills/spec-kitty.*/SKILL.md` installed; Pi docs confirm project `.agents/skills/` discovery and `/skill:<name>` invocation. |
+| `vibe` | Mistral Vibe | skill | experimental | https://docs.mistral.ai/mistral-vibe/terminal/quickstart | Requires `.vibe/config.toml` `skill_paths` edit; depends on the shared command-skill installation. |
+| `letta` | Letta Code | skill | partial | https://docs.letta.com/letta-code/skills | `.agents/skills/spec-kitty.*/SKILL.md` installed; keep partial until full command-set smoke evidence is recorded. |
 
 ---
 

--- a/docs/how-to/harnesses/pi-tui.md
+++ b/docs/how-to/harnesses/pi-tui.md
@@ -1,48 +1,73 @@
 # Use Spec Kitty in Pi TUI
 
-> **Tier:** **partial** — no on-disk installer surface located in 3.2, and no current canonical public documentation could be confirmed at the access date.
-> **Citation (accessed 2026-05-21):** *(none located 2026-05-21 — see [supported-harnesses matrix](../../reference/supported-harnesses.md))*
+> **Tier:** **partial** — Spec Kitty installs Pi command-skill packages in 3.2, but real-session smoke evidence is not yet recorded.
+> **Citation (accessed 2026-05-21):** <https://pi.dev/docs/latest/skills>
 
 ## Partial-tier note
 
 Pi TUI is classified `partial` in the 3.2 [support matrix](../../reference/supported-harnesses.md) because:
 
-1. The Spec Kitty installer does **not** currently produce an on-disk command surface for Pi TUI (no `.pi/` or equivalent directory is created by `spec-kitty init`).
-2. No current canonical public documentation URL could be located at the access date 2026-05-21.
+1. The Spec Kitty installer produces command-skill packages under `.agents/skills/spec-kitty.*/SKILL.md`.
+2. Pi's current skills documentation says project `.agents/skills/` directories are discovered, and that skills register as `/skill:<name>` commands.
+3. A real-session smoke test for the complete Spec Kitty command set has not yet been recorded, so the row remains `partial` instead of `supported`.
 
-Until a stable installer target and external citation land, this page intentionally does **not** prescribe an invocation syntax. Promotion to `supported` requires (a) an installer that produces a complete `/spec-kitty.*` set, (b) a current external citation, and (c) at least one documented smoke test (see [`docs/development/3-2-harness-research-method.md`](../../development/3-2-harness-research-method.md) §6).
+Promotion to `supported` requires at least one documented smoke test against a real Pi session; the full rule is maintained in `docs/development/3-2-harness-research-method.md` §6.
 
 ## Prerequisites
 
 - **Spec Kitty CLI installed.** See [Install Spec Kitty](../install-spec-kitty.md).
-- **Project initialized.** Note that `spec-kitty init --ai pi` is **not** a supported configuration in 3.2 — initialize with a configured harness instead (Claude Code, Codex, OpenCode, etc.), then dogfood Pi TUI against the resulting `kitty-specs/` artifacts manually.
+- **Project initialized for this harness:**
+  ```bash
+  spec-kitty init --ai pi
+  ```
+- **Pi installed.** Follow the Pi documentation at <https://pi.dev/docs/latest> for the current install path and authentication flow.
 
 ## Where Spec Kitty installs files
 
-**None.** Per the [supported-harnesses matrix](../../reference/supported-harnesses.md), Pi TUI has no installed surface in 3.2.
+Per the [supported-harnesses matrix](../../reference/supported-harnesses.md), Pi consumes Spec Kitty as Agent Skills. Spec Kitty installs:
+
+- **Directory:** `.agents/skills/spec-kitty.<command>/`
+- **Files:** one `SKILL.md` per command (`spec-kitty.specify/SKILL.md`, `spec-kitty.plan/SKILL.md`, `spec-kitty.tasks/SKILL.md`, `spec-kitty.implement/SKILL.md`, etc.).
+- **Manifest:** `.kittify/command-skills-manifest.json` records that Pi references each command-skill package.
 
 ## Canonical invocation
 
-**Not yet defined.** Do not fabricate a slash-command or skill syntax for Pi TUI; consult the Pi TUI project directly when a stable public reference becomes available.
+Pi's skills documentation says skills register as `/skill:<name>` commands. For Spec Kitty command-skill packages, use that form:
+
+```text
+/skill:spec-kitty.specify "<one-line mission description>"
+/skill:spec-kitty.plan
+/skill:spec-kitty.tasks
+/skill:spec-kitty.implement WP01
+```
 
 ## Worked example
 
-Until installer support lands, use Pi TUI as a **read-only** view onto Spec Kitty artifacts:
+Until full smoke evidence lands, treat Pi TUI as a **partial-tier** host and verify command behavior on a low-risk mission first:
 
-1. From your project root, drive a normal mission lifecycle through any configured harness (for example, Claude Code: `/spec-kitty.specify "a hello world page"`).
+1. From your project root, run Pi.
+2. At the prompt, type:
+   ```text
+   /skill:spec-kitty.specify "a hello world page"
+   ```
+3. Answer the Spec Kitty interview prompts inline.
+4. When asked for a kebab-case slug, supply something short, e.g. `hello-world-page`.
+5. The mission spec lands at `kitty-specs/hello-world-page-<mid8>/spec.md`.
+
+If Pi does not expose the command in your installed version, the artifacts remain harness-agnostic:
+
+1. Drive the mission lifecycle through another configured harness (for example, Claude Code: `/spec-kitty.specify "a hello world page"`).
 2. The mission spec lands at `kitty-specs/hello-world-page-<mid8>/spec.md` on disk.
 3. Open Pi TUI against the same project directory and inspect the `kitty-specs/` tree as plain files.
-
-This is the only flow we can confirm at 2026-05-21.
 
 ## Troubleshooting
 
 - **No `/spec-kitty.*` commands inside Pi TUI.**
-  Expected — Pi TUI is `partial` in 3.2 with no installer surface. Drive Spec Kitty from a supported harness (Claude Code, Codex, OpenCode, Cursor, Gemini, Qwen, Amazon Q, Copilot, Augment, Roo, Kilo, Kiro, Windsurf) and read the artifacts back from disk in Pi TUI.
+  Expected — Pi is a skill host, not a slash-command host for Spec Kitty. Use `/skill:spec-kitty.<command>` and confirm `.agents/skills/spec-kitty.*/SKILL.md` exists.
 
 - **Profile not loading.**
-  The `/ad-hoc-profile-load` workflow assumes a slash-command host. Until Pi TUI has an installer surface, use the helper from your other configured harness and reuse the same `kitty-specs/<mission>/` tree.
+  The `/ad-hoc-profile-load` workflow assumes a slash-command host. If your Pi build does not expose equivalent profile loading, use the helper from your other configured harness and reuse the same `kitty-specs/<mission>/` tree.
 
 ## Where to learn more about Pi TUI
 
-No current canonical public documentation could be located at 2026-05-21. The matrix row in [`docs/reference/supported-harnesses.md`](../../reference/supported-harnesses.md) is the authoritative tracker — promotion (and a citation) will land here when evidence is recorded.
+Authoritative documentation: <https://pi.dev/docs/latest/skills> (accessed 2026-05-21). The matrix row in [`docs/reference/supported-harnesses.md`](../../reference/supported-harnesses.md) remains the promotion tracker.

--- a/docs/how-to/non-interactive-init.md
+++ b/docs/how-to/non-interactive-init.md
@@ -54,6 +54,10 @@ spec-kitty init .
 | `copilot` | GitHub Copilot |
 | `q` | Amazon Q Developer CLI (legacy; rebranded to Kiro) |
 | `kiro` | Kiro CLI (formerly Amazon Q Developer CLI) |
+| `antigravity` | Google Antigravity |
+| `vibe` | Mistral Vibe |
+| `pi` | Pi |
+| `letta` | Letta Code |
 
 **Case-sensitive**: Use lowercase exactly as shown
 
@@ -154,9 +158,9 @@ When you specify agents with `--ai`, spec-kitty creates:
 
 ### For `--ai codex`
 
-- `.codex/prompts/spec-kitty.*.md` (13 command files)
-- `.kittify/AGENTS.md` (auto-loaded by Codex)
-- No extra context files needed (native AGENTS.md support!)
+- `.agents/skills/spec-kitty.*/SKILL.md` (command-skill packages)
+- `.kittify/command-skills-manifest.json` (records Codex as a skill package consumer)
+- `.kittify/AGENTS.md` (project guidance used by Spec Kitty worktrees)
 
 ### For `--ai claude`
 
@@ -226,6 +230,27 @@ When you specify agents with `--ai`, spec-kitty creates:
 - `.kittify/AGENTS.md`
 - Note: May have discovery issues (known bug)
 
+### For `--ai antigravity`
+
+- `.agent/workflows/spec-kitty.*.md` (workflow files)
+- `.kittify/AGENTS.md`
+
+### For `--ai vibe`
+
+- `.agents/skills/spec-kitty.*/SKILL.md` (command-skill packages)
+- `.vibe/config.toml` with a `skill_paths` entry pointing at `.agents/skills/`
+- `.kittify/command-skills-manifest.json` (records Vibe as a skill package consumer)
+
+### For `--ai pi`
+
+- `.agents/skills/spec-kitty.*/SKILL.md` (command-skill packages)
+- `.kittify/command-skills-manifest.json` (records Pi as a skill package consumer)
+
+### For `--ai letta`
+
+- `.agents/skills/spec-kitty.*/SKILL.md` (command-skill packages)
+- `.kittify/command-skills-manifest.json` (records Letta as a skill package consumer)
+
 ## Always Created (Regardless of Agent Selection)
 
 - `.kittify/` directory structure
@@ -265,11 +290,11 @@ After non-interactive init, verify with:
 # Check what was created
 ls -la | grep -E "^(l|-).*AGENTS|rules$"
 
-# Check command files for specific agent
-ls .codex/prompts/          # Codex
+# Check command or skill files for specific agents
+ls .agents/skills/          # Codex, Vibe, Pi, Letta command skills
 ls .claude/commands/        # Claude
 ls .cursor/commands/        # Cursor
-ls .gemini/commands/        # Gemini (TOML)
+ls .gemini/commands/        # Gemini
 ```
 
 ## Troubleshooting

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -251,7 +251,13 @@ _Charter bundle validation commands._
 │                                               [required]                     │
 │    --mark-loaded    --no-mark-loaded          Persist first-load state       │
 │                                               [default: mark-loaded]         │
-│    --json                                     Output JSON                    │
+│    --json                                     Output JSON. `directives` is   │
+│                                               action-scoped;                 │
+│                                               `all_directives` and           │
+│                                               `project_charter` describe the │
+│                                               project-local charter, while   │
+│                                               `org_charter` describes        │
+│                                               imported org packs.            │
 │    --help                                     Show this message and exit.    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -1371,13 +1377,13 @@ _Glossary management commands_
 
  What Gets Created:
  - .kittify/ - Project scaffold (memory, config)
- - Agent commands (.claude/commands/, .codex/prompts/, etc.)
+ - Agent command and skill surfaces (.claude/commands/, .agents/skills/, etc.)
  - .gitignore and .claudeignore
 
  Specifying AI Assistants (--ai flag):
  Use comma-separated agent keys (no spaces). Valid keys include:
  codex, claude, gemini, cursor, qwen, opencode, windsurf, kilocode,
- auggie, roo, copilot, q, kiro, pi, letta.
+ auggie, roo, copilot, q, kiro, antigravity, vibe, pi, letta.
 
  Template Discovery (Development Mode):
  Set SPEC_KITTY_TEMPLATE_ROOT to override bundled templates for local

--- a/docs/reference/init-lifecycle.md
+++ b/docs/reference/init-lifecycle.md
@@ -19,7 +19,7 @@ spec-kitty init [PROJECT_NAME] [OPTIONS]
 
 | Option | Description |
 |---|---|
-| `--ai <keys>` | Comma-separated agent keys (`claude`, `codex`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `auggie`, `roo`, `copilot`, `q`, `kiro`, `pi`, `letta`). Required in non-interactive mode. |
+| `--ai <keys>` | Comma-separated agent keys (`claude`, `codex`, `gemini`, `cursor`, `qwen`, `opencode`, `windsurf`, `kilocode`, `auggie`, `roo`, `copilot`, `q`, `kiro`, `antigravity`, `vibe`, `pi`, `letta`). Required in non-interactive mode. |
 | `--non-interactive` / `--yes` / `-y` | Skip all prompts. Equivalent to setting `SPEC_KITTY_NON_INTERACTIVE=1`. |
 | `--help` | Show full help (this page is a curated summary). |
 
@@ -38,7 +38,7 @@ Holds spec-kitty's per-project configuration and runtime state. Key contents:
 | `.kittify/config.yaml` | Single source of truth for configured agents and feature flags. |
 | `.kittify/metadata.yaml` | Project schema version, used by the upgrade gate. |
 | `.kittify/memory/` | Long-lived memory used by the runtime. |
-| `.kittify/command-skills-manifest.json` | Tracks which agents reference each skill package (Codex/Vibe). |
+| `.kittify/command-skills-manifest.json` | Tracks which agents reference each command-skill package (Codex/Vibe/Pi/Letta). |
 
 ### `kitty-specs/` — mission artifacts
 
@@ -46,7 +46,7 @@ Empty at init time. Populated by `/spec-kitty.specify`, `/spec-kitty.plan`, and 
 
 ### Agent command directories
 
-One directory per agent selected via `--ai`. Spec Kitty supports 15 agents total — 13 slash-command agents and 2 Agent Skills agents:
+One directory per agent selected via `--ai`. Spec Kitty supports 17 agents total — 13 command-surface agents and 4 command-skill agents:
 
 | Agent key | Directory created | Command surface |
 |---|---|---|
@@ -62,11 +62,13 @@ One directory per agent selected via `--ai`. Spec Kitty supports 15 agents total
 | `roo` | `.roo/commands/` | `/spec-kitty.*` |
 | `q` | `.amazonq/prompts/` | `/spec-kitty.*` |
 | `kiro` | `.kiro/prompts/` | `/spec-kitty.*` |
-| `pi` (Antigravity) | `.agent/workflows/` | `/spec-kitty.*` |
+| `antigravity` | `.agent/workflows/` | `/spec-kitty.*` |
 | `codex` | `.agents/skills/spec-kitty.*/` | `$spec-kitty.<command>` |
-| `letta` (Vibe) | `.agents/skills/...` via `.vibe/config.toml` | `/spec-kitty.<command>` |
+| `vibe` | `.agents/skills/spec-kitty.*/` plus `.vibe/config.toml` | `/spec-kitty.<command>` |
+| `pi` | `.agents/skills/spec-kitty.*/` | `/skill:spec-kitty.<command>` |
+| `letta` | `.agents/skills/spec-kitty.*/` | Agent Skills |
 
-Codex and Vibe share a single installation tree under `.agents/skills/`; both are pointed at it. Only the agents you list in `--ai` get directories.
+Codex, Vibe, Pi, and Letta share a single installation tree under `.agents/skills/`; Vibe also gets a `.vibe/config.toml` `skill_paths` entry pointing at that tree. Only the agents you list in `--ai` get directories.
 
 ### Ignore files
 

--- a/docs/reference/supported-harnesses.md
+++ b/docs/reference/supported-harnesses.md
@@ -1,6 +1,6 @@
 # Supported Harnesses
 
-This page is the canonical 5-tier support matrix for AI coding harnesses ("agents") that Spec Kitty integrates with. Each row conforms to the `HarnessEntry` schema in [`data-model.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/data-model.md). The research procedure that backs each classification lives at [`docs/development/3-2-harness-research-method.md`](../development/3-2-harness-research-method.md).
+This page is the canonical 5-tier support matrix for AI coding harnesses ("agents") that Spec Kitty integrates with. Each row conforms to the `HarnessEntry` schema in `kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/data-model.md`. The research procedure that backs each classification lives in `docs/development/3-2-harness-research-method.md`.
 
 **Access date for citations:** 2026-05-21.
 
@@ -16,7 +16,7 @@ This page is the canonical 5-tier support matrix for AI coding harnesses ("agent
 | **experimental** | Provisional coverage that may break without notice; typically depends on another harness's installation. |
 | **archived** | No longer covered by the installer, or the upstream project is deprecated; coverage (if any) lives in `docs/migration/`. |
 
-Full tier criteria and promotion rules are at [`docs/development/3-2-harness-research-method.md`](../development/3-2-harness-research-method.md) §5 and §6.
+Full tier criteria and promotion rules are maintained in `docs/development/3-2-harness-research-method.md` §5 and §6.
 
 ---
 
@@ -30,16 +30,17 @@ Full tier criteria and promotion rules are at [`docs/development/3-2-harness-res
 | Cursor | `cursor` | `.cursor/commands/` | slash_command | **supported** | https://cursor.com/docs | `/spec-kitty.*` command set installed via standard installer. |
 | Google Gemini CLI | `gemini` | `.gemini/commands/` | slash_command | **supported** | https://github.com/google-gemini/gemini-cli | `/spec-kitty.*` command set installed via standard installer. |
 | Qwen Code | `qwen` | `.qwen/commands/` | slash_command | **supported** | https://github.com/QwenLM/qwen-code | `/spec-kitty.*` command set installed via standard installer. |
-| Amazon Q CLI | `amazonq` | `.amazonq/prompts/` | prompt | **supported** | https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/ | Retained as legacy alongside Kiro rebrand per `CLAUDE.md`. |
+| Amazon Q CLI | `q` | `.amazonq/prompts/` | prompt | **supported** | https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/ | Retained as legacy alongside Kiro rebrand per `CLAUDE.md`. |
 | GitHub Copilot | `copilot` | `.github/prompts/` | prompt | **supported** | https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot | Prompt-file mechanism; `/spec-kitty.*` set installed. |
 | Augment Code (Auggie) | `augment` | `.augment/commands/` | slash_command | **supported** | https://docs.augmentcode.com/auggie/overview | `/spec-kitty.*` command set installed via standard installer. |
 | Roo Cline | `roo` | `.roo/commands/` | slash_command | **supported** | https://docs.roocode.com/ | `/spec-kitty.*` command set installed via standard installer. |
 | Kilo Code | `kilocode` | `.kilocode/workflows/` | workflow | **supported** | https://kilocode.ai/docs | Workflow mechanism; `/spec-kitty.*` set installed. |
 | Windsurf | `windsurf` | `.windsurf/workflows/` | workflow | **supported** | https://docs.windsurf.com/windsurf/cascade/workflows | Workflow mechanism; `/spec-kitty.*` set installed. |
 | Kiro | `kiro` | `.kiro/prompts/` | prompt | **partial** | https://kiro.dev/docs | Bootstrap-only surface in this lane; promote to `supported` once full `/spec-kitty.*` set is verified end-to-end. |
-| Pi TUI | `pi` | (no installed surface) | (none) | **partial** | (none located 2026-05-21) | No on-disk surface; no current canonical public documentation located. Promote once a stable installer target and citation land. |
-| Mistral Vibe | `vibe` | `.agents/skills/` via `.vibe/config.toml` `skill_paths` | skill | **experimental** | https://github.com/openai/codex (shared-skill source per `CLAUDE.md`) | Depends on Codex CLI's `.agents/skills/spec-kitty.*` installation plus a `.vibe/config.toml` `skill_paths` entry. Behaviour may change with Vibe upstream. |
-| Letta Code | `letta` | (no installed surface) | (none) | **archived** | https://docs.letta.com/ (status uncertain 2026-05-21) | No on-disk surface and upstream coverage status is uncertain; classified `archived` until evidence lands. |
+| Google Antigravity | `antigravity` | `.agent/workflows/` | workflow | **partial** | https://antigravity.im/documentation | Installer surface exists, but end-to-end smoke evidence for the full command set is not yet recorded. |
+| Pi TUI | `pi` | `.agents/skills/spec-kitty.*/SKILL.md` | skill | **partial** | https://pi.dev/docs/latest/skills | Installer-supported command-skill packages; keep partial until a real-session smoke test is recorded. |
+| Mistral Vibe | `vibe` | `.agents/skills/` via `.vibe/config.toml` `skill_paths` | skill | **experimental** | https://docs.mistral.ai/mistral-vibe/terminal/quickstart | Uses the shared `.agents/skills/spec-kitty.*` packages plus a `.vibe/config.toml` `skill_paths` entry. Behaviour may change with Vibe upstream. |
+| Letta Code | `letta` | `.agents/skills/spec-kitty.*/SKILL.md` | skill | **partial** | https://docs.letta.com/letta-code/skills | Installer-supported command-skill packages; keep partial until a real-session smoke test is recorded. |
 
 ---
 
@@ -49,16 +50,16 @@ Full tier criteria and promotion rules are at [`docs/development/3-2-harness-res
 |------|-------|---------|
 | first_class | 2 | Claude Code, Codex CLI |
 | supported | 10 | OpenCode, Cursor, Gemini CLI, Qwen Code, Amazon Q CLI, GitHub Copilot, Augment Code, Roo Cline, Kilo Code, Windsurf |
-| partial | 2 | Kiro, Pi TUI |
+| partial | 4 | Kiro, Google Antigravity, Pi TUI, Letta Code |
 | experimental | 1 | Mistral Vibe |
-| archived | 1 | Letta Code |
-| **Total** | **16** | |
+| archived | 0 | |
+| **Total** | **17** | |
 
 ---
 
 ## Promotion path
 
-A harness moves up tiers only when new evidence lands. See [`docs/development/3-2-harness-research-method.md`](../development/3-2-harness-research-method.md) §6 for the full rule. Summary:
+A harness moves up tiers only when new evidence lands. See `docs/development/3-2-harness-research-method.md` §6 for the full rule. Summary:
 
 1. **`partial` → `supported`** when (a) the installer produces a full `/spec-kitty.*` set, (b) a current external citation is recorded, and (c) at least one smoke test has been documented.
 2. **`supported` → `first_class`** when (a) integration tests exercise the harness end-to-end, (b) the mechanism is the harness's canonical UX, (c) the per-harness page under `docs/how-to/harnesses/<key>.md` is non-stub, and (d) the promotion is logged in CHANGELOG.
@@ -71,5 +72,5 @@ Tier moves are recorded in this matrix's row notes and the project CHANGELOG.
 ## Maintenance
 
 - The inventory step is re-run on every release; the citation step is re-run on every release as part of the freshness audit (WP13).
-- This matrix is the published artifact; the procedure that backs it is at [`docs/development/3-2-harness-research-method.md`](../development/3-2-harness-research-method.md).
+- This matrix is the published artifact; the procedure that backs it is maintained at `docs/development/3-2-harness-research-method.md`.
 - Per-harness "how-to" pages live at `docs/how-to/harnesses/<key>.md` and are promoted under the plan's matrix-first default (decision `01KS4KTS4V300M9MMTS1AJEGXY`).

--- a/src/specify_cli/cli/commands/init_help.py
+++ b/src/specify_cli/cli/commands/init_help.py
@@ -22,13 +22,13 @@ Non-Interactive Mode:
 
 What Gets Created:
 - .kittify/ - Project scaffold (memory, config)
-- Agent commands (.claude/commands/, .codex/prompts/, etc.)
+- Agent command and skill surfaces (.claude/commands/, .agents/skills/, etc.)
 - .gitignore and .claudeignore
 
 Specifying AI Assistants (--ai flag):
 Use comma-separated agent keys (no spaces). Valid keys include:
 codex, claude, gemini, cursor, qwen, opencode, windsurf, kilocode,
-auggie, roo, copilot, q, kiro, pi, letta.
+auggie, roo, copilot, q, kiro, antigravity, vibe, pi, letta.
 
 Template Discovery (Development Mode):
 Set SPEC_KITTY_TEMPLATE_ROOT to override bundled templates for local development.


### PR DESCRIPTION
## Summary
- align the 3.2 harness matrix and init lifecycle docs with the current 17-agent registry
- correct Pi, Vibe, Letta, and Antigravity command-surface documentation
- refresh generated CLI reference from live help text

## Validation
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NO_UPGRADE_CHECK=1 PYTHONPATH=. uv run python scripts/docs/check_docs_freshness.py --ci --report /tmp/spec-kitty-freshness-audit-polish.json --link-check none
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NO_UPGRADE_CHECK=1 PYTHONPATH=. uv run pytest tests/docs/test_build_cli_reference.py tests/docs/test_check_cli_reference_freshness.py tests/architectural/test_docs_cli_reference_parity.py tests/docs/test_check_docs_freshness.py tests/docs/test_version_leakage_check.py -q
- docfx docfx.json