### PR TITLE
fix(docs): repair live internal links

### DIFF
--- a/docs/explanation/org-doctrine-layer.md
+++ b/docs/explanation/org-doctrine-layer.md
@@ -151,7 +151,7 @@ artifact (kind, ID, higher layer, lower layer, field counts), or reports
 are in play. The same data is available as a `collisions` array under
 `--json`.
 
-See [ADR 2026-05-16-1](../../architecture/2.x/adr/2026-05-16-1-doctrine-layer-merge-semantics.md)
+See [ADR 2026-05-16-1](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-05-16-1-doctrine-layer-merge-semantics.md)
 for the rationale behind this design.
 
 ---

--- a/docs/explanation/retrospective-learning-loop.md
+++ b/docs/explanation/retrospective-learning-loop.md
@@ -199,4 +199,4 @@ to see details.
 
 - [How to Use Retrospective Learning](../how-to/use-retrospective-learning.md) — operator how-to
 - [Retrospective Schema Reference](../reference/retrospective-schema.md) — YAML and event schemas
-- [ADR: Retrospective Default-On Policy Architecture](../../architecture/3.x/adr/2026-05-19-1-retrospective-default-policy-architecture.md) — architectural decisions
+- [ADR: Retrospective Default-On Policy Architecture](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/3.x/adr/2026-05-19-1-retrospective-default-policy-architecture.md) — architectural decisions

--- a/docs/how-to/create-an-org-doctrine-pack.md
+++ b/docs/how-to/create-an-org-doctrine-pack.md
@@ -314,7 +314,7 @@ tar czf security-doctrine-v1.0.0.tar.gz -C my-pack .
 
 For organisations with an existing governance API server, expose pack contents under a
 base URL. The contract for that API is in
-[contracts/org-doctrine-source-api-contract.md](../../kitty-specs/layered-doctrine-org-layer-01KRNPEE/contracts/org-doctrine-source-api-contract.md)
+[contracts/org-doctrine-source-api-contract.md](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/layered-doctrine-org-layer-01KRNPEE/contracts/org-doctrine-source-api-contract.md)
 (in the mission's planning artifacts).
 
 ### Versioning strategy

--- a/docs/how-to/gstack-glossary-observations.md
+++ b/docs/how-to/gstack-glossary-observations.md
@@ -91,11 +91,11 @@ produce no `glossary_checked` line.
 Readers that encounter `"event": "glossary_checked"` in a trail file and do not
 recognise the event type may safely skip it.
 
-See [Trail Model — Glossary Check Event](../trail-model.md#glossary-check-event-conditional-tier-1)
+See [Trail Model — Glossary Check Event](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/trail-model.md#glossary-check-event-conditional-tier-1)
 for the full event schema.
 
 ## See Also
 
 - [Set Up a Codex Launcher for Spec Kitty](setup-codex-spec-kitty-launcher.md)
-- [Trail Model](../trail-model.md)
+- [Trail Model](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/trail-model.md)
 - [CLI Commands](../reference/cli-commands.md)

--- a/docs/how-to/harnesses/kiro.md
+++ b/docs/how-to/harnesses/kiro.md
@@ -16,7 +16,7 @@
 
 Kiro is the rebrand-target of Amazon Q. In 3.2 the Spec Kitty installer ships a **bootstrap-only** surface for Kiro — the directory layout is in place, but the full `/spec-kitty.*` command set is not yet integration-tested end-to-end against this harness. Expect feature parity with Amazon Q at the prompt-file level; verify each command before relying on it for production missions.
 
-The promotion criteria (`partial → supported`) are documented in [`docs/development/3-2-harness-research-method.md`](../../development/3-2-harness-research-method.md) §6.
+The promotion criteria (`partial → supported`) are maintained in `docs/development/3-2-harness-research-method.md` §6.
 
 ## Where Spec Kitty installs files
 

--- a/docs/how-to/install-and-upgrade.md
+++ b/docs/how-to/install-and-upgrade.md
@@ -1,6 +1,6 @@
 # How to Install and Upgrade Spec Kitty
 
-> **Formal requirements**: [`kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/spec.md`](../../kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/spec.md)
+> **Formal requirements**: [`kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/spec.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/spec.md)
 
 ---
 
@@ -215,7 +215,7 @@ spec-kitty upgrade --dry-run --json | jq '.pending_migrations | length'
 ```
 
 Schema (stable across patch releases):
-[`kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/contracts/compat-planner.json`](../../kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/contracts/compat-planner.json)
+[`kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/contracts/compat-planner.json`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/contracts/compat-planner.json)
 
 ---
 

--- a/docs/how-to/install-linux.md
+++ b/docs/how-to/install-linux.md
@@ -139,7 +139,7 @@ If `uv` is in `~/.cargo/bin` instead of `~/.local/bin`, add that path too.
 
 ## Next steps
 
-- [Initialize a project](install-and-upgrade.md#initialize-a-new-project)
+- [Initialize a project](non-interactive-init.md)
 - [Upgrade the CLI](upgrade-cli.md)
 - [macOS install guide](install-macos.md)
 - [Windows install guide](install-windows.md)

--- a/docs/how-to/install-macos.md
+++ b/docs/how-to/install-macos.md
@@ -132,7 +132,7 @@ pipx ensurepath
 
 ## Next steps
 
-- [Initialize a project](install-and-upgrade.md#initialize-a-new-project)
+- [Initialize a project](non-interactive-init.md)
 - [Upgrade the CLI](upgrade-cli.md)
 - [Linux install guide](install-linux.md)
 - [Windows install guide](install-windows.md)

--- a/docs/how-to/install-spec-kitty.md
+++ b/docs/how-to/install-spec-kitty.md
@@ -201,7 +201,7 @@ rm gcm-linux_amd64.2.6.1.deb
 
 - [`spec-kitty init`](../reference/cli-commands.md#spec-kitty-init)
 - [`spec-kitty upgrade`](../reference/cli-commands.md#spec-kitty-upgrade)
-- [`spec-kitty verify-setup`](../reference/cli-commands.md#spec-kitty-verify-setup)
+- [`spec-kitty verify-setup`](../reference/cli-commands.md#spec-kitty-verify_setup)
 
 ## See Also
 

--- a/docs/how-to/install-windows.md
+++ b/docs/how-to/install-windows.md
@@ -149,7 +149,7 @@ Plain `python` may resolve to a Microsoft Store stub on a fresh install; `py` al
 
 ## Next steps
 
-- [Initialize a project](install-and-upgrade.md#initialize-a-new-project)
+- [Initialize a project](non-interactive-init.md)
 - [Upgrade the CLI](upgrade-cli.md)
 - [macOS install guide](install-macos.md)
 - [Linux install guide](install-linux.md)

--- a/docs/how-to/manage-agents.md
+++ b/docs/how-to/manage-agents.md
@@ -74,7 +74,7 @@ Managed command surfaces are created and refreshed by CLI commands. You should n
 
 > **Why This Matters**: In spec-kitty 0.11.x and earlier, users could manually delete agent directories, but migrations would recreate them. Starting in 0.12.0, migrations respect `config.yaml` - if an agent is not listed in `available`, its directory stays deleted. See [Upgrading to 0.12.0](install-and-upgrade.md) for details.
 
-For architectural details, see [ADR #6: Config-Driven Agent Management](../../architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md).
+For architectural details, see [ADR #6: Config-Driven Agent Management](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md).
 
 ## Listing Agents
 
@@ -554,7 +554,7 @@ If your issue isn't covered here:
 
 1. Check [Supported AI Agents](../reference/supported-agents.md) for agent-specific requirements
 2. Review [Configuration Reference](../reference/configuration.md) for config.yaml schema
-3. Consult [CLI Commands Reference](../reference/cli-commands.md#spec-kitty-agent-config) for detailed command syntax
+3. Consult [CLI Commands Reference](../reference/agent-subcommands.md#spec-kitty-agent-config) for detailed command syntax
 4. Report bugs at [spec-kitty GitHub Issues](https://github.com/Priivacy-ai/spec-kitty/issues)
 
 ## See Also
@@ -563,7 +563,7 @@ For more information on agent management and related topics:
 
 ### Command Reference
 
-- [CLI Commands: spec-kitty agent config](../reference/cli-commands.md#spec-kitty-agent-config) - Detailed command syntax, flags, and options for all agent config subcommands
+- [CLI Commands: spec-kitty agent config](../reference/agent-subcommands.md#spec-kitty-agent-config) - Detailed command syntax, flags, and options for all agent config subcommands
 
 ### Supported Agents
 
@@ -575,7 +575,7 @@ For more information on agent management and related topics:
 
 ### Architecture
 
-- [ADR #6: Config-Driven Agent Management](../../architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) - Architectural decision record explaining why migrations now respect `config.yaml` and the config-driven model rationale
+- [ADR #6: Config-Driven Agent Management](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) - Architectural decision record explaining why migrations now respect `config.yaml` and the config-driven model rationale
 
 ### Migration Guides
 

--- a/docs/how-to/recover-from-implementation-crash.md
+++ b/docs/how-to/recover-from-implementation-crash.md
@@ -88,4 +88,4 @@ Address each finding before restarting implementation to avoid double-claiming a
 - [Recover from Interrupted Merge](recover-from-interrupted-merge.md) — when `spec-kitty merge` was interrupted
 - [CLI Reference: spec-kitty implement](../reference/cli-commands.md#spec-kitty-implement)
 - [CLI Reference: spec-kitty doctor](../reference/cli-commands.md#spec-kitty-doctor)
-- [Status Model](../status-model.md) — how lane transitions are recorded
+- [Status Model](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/status-model.md) — how lane transitions are recorded

--- a/docs/how-to/run-mutation-tests.md
+++ b/docs/how-to/run-mutation-tests.md
@@ -12,7 +12,7 @@ gate. Run it when:
 - You suspect a module has "happy-path-only" tests (coverage high, asserts flimsy).
 - You're reviewing a contributor PR and want to sanity-check their test discipline.
 
-See [ADR 2026-04-20-1](../../architecture/2.x/adr/2026-04-20-1-mutation-testing-as-local-only-quality-gate.md)
+See [ADR 2026-04-20-1](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-20-1-mutation-testing-as-local-only-quality-gate.md)
 for the decision to ship it local-only, and the curated doctrine set in
 `src/doctrine/tactics/shipped/mutation-testing-workflow.tactic.yaml` and
 `src/doctrine/styleguides/shipped/mutation-aware-test-design.styleguide.yaml` for
@@ -79,7 +79,7 @@ For each surviving mutant, classify it using the four-bucket taxonomy from
 
 For **Survived** mutants, the kill strategy depends on the mutation family. The
 full operator table lives in
-[`src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md`](../../src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md).
+[`src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md).
 Short version: comparison flips need boundary-value tests, arithmetic swaps need
 non-identity inputs (never `0` for `+`, never `1` for `*`), logical operator swaps
 need bi-directional cases (exactly one operand true/false).
@@ -205,14 +205,14 @@ mode:
 
 ## See also
 
-- [ADR 2026-04-20-1](../../architecture/2.x/adr/2026-04-20-1-mutation-testing-as-local-only-quality-gate.md)
+- [ADR 2026-04-20-1](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-20-1-mutation-testing-as-local-only-quality-gate.md)
   — the decision record covering scope, doctrine, and the `non_sandbox`/`flaky`
   marker taxonomy.
-- [`src/doctrine/tactics/shipped/mutation-testing-workflow.tactic.yaml`](../../src/doctrine/tactics/shipped/mutation-testing-workflow.tactic.yaml)
+- [`src/doctrine/tactics/shipped/mutation-testing-workflow.tactic.yaml`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/tactics/shipped/mutation-testing-workflow.tactic.yaml)
   — the five-step kill-the-survivor workflow.
-- [`src/doctrine/styleguides/shipped/mutation-aware-test-design.styleguide.yaml`](../../src/doctrine/styleguides/shipped/mutation-aware-test-design.styleguide.yaml)
+- [`src/doctrine/styleguides/shipped/mutation-aware-test-design.styleguide.yaml`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/styleguides/shipped/mutation-aware-test-design.styleguide.yaml)
   — boundary-pair, non-identity-inputs, bi-directional-logic patterns.
-- [`src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md`](../../src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md)
+- [`src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/toolguides/shipped/PYTHON_MUTATION_TOOLS.md)
   — full Python operator reference.
-- [`src/doctrine/toolguides/shipped/TYPESCRIPT_MUTATION_TOOLS.md`](../../src/doctrine/toolguides/shipped/TYPESCRIPT_MUTATION_TOOLS.md)
+- [`src/doctrine/toolguides/shipped/TYPESCRIPT_MUTATION_TOOLS.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/toolguides/shipped/TYPESCRIPT_MUTATION_TOOLS.md)
   — parallel guide for TypeScript projects using Stryker.

--- a/docs/how-to/setup-codex-spec-kitty-launcher.md
+++ b/docs/how-to/setup-codex-spec-kitty-launcher.md
@@ -293,7 +293,7 @@ apply the following rendering contract:
 
 A `glossary_checked` event is appended to the Tier 1 JSONL trail **only** when
 `all_conflicts` is non-empty OR `error_msg` is set. Clean invocations produce no
-`glossary_checked` line. See [Trail Model](../trail-model.md) for the full event
+`glossary_checked` line. See [Trail Model](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/trail-model.md) for the full event
 taxonomy.
 
 ## Command Reference

--- a/docs/how-to/setup-governance.md
+++ b/docs/how-to/setup-governance.md
@@ -338,7 +338,7 @@ automatically receive the current Charter context.
 - [Create a Specification](create-specification.md) -- Start a feature with governance active
 - [Switch Missions](switch-missions.md) -- How missions interact with governance
 - [Non-Interactive Init](non-interactive-init.md) -- Automated project setup including charter
-- [Doctrine Packs](../doctrine/README.md) -- Optional pack selections, including [SPDD and the REASONS Canvas](../doctrine/spdd-reasons.md)
+- [Doctrine Packs](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/doctrine/README.md) -- Optional pack selections, including [SPDD and the REASONS Canvas](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/doctrine/spdd-reasons.md)
 
 ## Background
 

--- a/docs/how-to/upgrade-to-0-12-0.md
+++ b/docs/how-to/upgrade-to-0-12-0.md
@@ -22,7 +22,7 @@ This change gives you **explicit control** over your agent configuration:
 - **Cleaner projects**: Remove agents you don't use without them reappearing
 - **Multi-agent workflows**: Configure exactly which agents are available
 
-See [ADR #6: Config-Driven Agent Management](../../architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) for technical details.
+See [ADR #6: Config-Driven Agent Management](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) for technical details.
 
 ## Migration Steps
 

--- a/docs/how-to/use-retrospective-learning.md
+++ b/docs/how-to/use-retrospective-learning.md
@@ -208,7 +208,7 @@ Durable config wins when both are present. Suppress the warning in CI with
 | `MISSION_AMBIGUOUS_SELECTOR` | Handle resolves to multiple missions | Use `mission_id` (ULID) or `mid8` instead of slug |
 | Mission completion blocks with `RETROSPECTIVE_GATE_BLOCKED` | Policy is `before_completion + block` and generation failed | Inspect `RetrospectiveCaptureFailed` event in `status.events.jsonl` for `remediation_hint`; address and retry |
 | Deprecation warning keeps firing | Env var set in shell or CI | Unset the env var; rely on `.kittify/config.yaml` |
-| `cannot import name 'normalize_event_id' from 'spec_kitty_events'` during pytest collection (locally only) | Local PEP 420 namespace-package corruption from a partial pip uninstall — NOT a wheel bug | `uv sync --reinstall-package spec-kitty-events` (see [CONTRIBUTING.md](../../CONTRIBUTING.md)) |
+| `cannot import name 'normalize_event_id' from 'spec_kitty_events'` during pytest collection (locally only) | Local PEP 420 namespace-package corruption from a partial pip uninstall — NOT a wheel bug | `uv sync --reinstall-package spec-kitty-events` (see [CONTRIBUTING.md](https://github.com/Priivacy-ai/spec-kitty/blob/main/CONTRIBUTING.md)) |
 
 ---
 
@@ -226,7 +226,7 @@ spec-kitty agent retrospect policy --json   # shows resolved policy + source map
 If `spec-kitty retrospect` reports "No such command", run `spec-kitty upgrade` and re-check.
 
 For the full operator quickstart including test-runner commands, see
-[quickstart.md](../../kitty-specs/retrospective-default-policy-01KS049J/quickstart.md).
+[quickstart.md](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/retrospective-default-policy-01KS049J/quickstart.md).
 
 ---
 
@@ -234,4 +234,4 @@ For the full operator quickstart including test-runner commands, see
 
 - [Understanding the Retrospective Learning Loop](../explanation/retrospective-learning-loop.md) — conceptual explanation
 - [Retrospective Schema Reference](../reference/retrospective-schema.md) — YAML and event schemas
-- [CLI Commands Reference](../reference/cli-commands.md#retrospect-commands) — flag reference
+- [CLI Commands Reference](../reference/cli-commands.md#spec-kitty-retrospect) — flag reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Spec Kitty 3.1.5 (released 2026-04-16) continues the `3.1.x` stable line with up
 
 **Upgrading from 3.0.x?** Run `spec-kitty upgrade` — all renames happen automatically.
 
-See the full [CHANGELOG](../CHANGELOG.md) for complete release notes.
+See the full [CHANGELOG](https://github.com/Priivacy-ai/spec-kitty/blob/main/CHANGELOG.md) for complete release notes.
 
 ## Version Tracks
 

--- a/docs/migration/cross-repo-e2e-gate.md
+++ b/docs/migration/cross-repo-e2e-gate.md
@@ -4,8 +4,8 @@
 
 **Status**: Active as of mission
 `stability-and-hygiene-hardening-2026-04-01KQ4ARB` (2026-04-26).
-**ADR**: [`architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md`](../../architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md)
-**Skill**: [`src/doctrine/skills/spec-kitty-mission-review/SKILL.md`](../../src/doctrine/skills/spec-kitty-mission-review/SKILL.md)
+**ADR**: [`architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md)
+**Skill**: [`src/doctrine/skills/spec-kitty-mission-review/SKILL.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/skills/spec-kitty-mission-review/SKILL.md)
 
 This guide tells operators how to run the cross-repo end-to-end gate
 that `spec-kitty-mission-review` now enforces, and how to handle the
@@ -163,12 +163,12 @@ blockers*, not for deferred bugs.
 ## Cross-references
 
 - ADR (the gate rationale, full alternatives table):
-  [`architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md`](../../architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md)
+  [`architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-26-3-e2e-hard-gate.md)
 - Skill source (the enforcement code path):
-  [`src/doctrine/skills/spec-kitty-mission-review/SKILL.md`](../../src/doctrine/skills/spec-kitty-mission-review/SKILL.md)
+  [`src/doctrine/skills/spec-kitty-mission-review/SKILL.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/doctrine/skills/spec-kitty-mission-review/SKILL.md)
 - Mission spec (FR-038, FR-039, FR-040, FR-041, NFR-006, C-010):
-  [`kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/spec.md`](../../kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/spec.md)
+  [`kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/spec.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/spec.md)
 - Issue matrix (the row-coverage gate input):
-  [`kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/issue-matrix.md`](../../kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/issue-matrix.md)
+  [`kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/issue-matrix.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/issue-matrix.md)
 - Research D1 (the matrix shape decision that this gate reads):
-  [`kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/research.md`](../../kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/research.md)
+  [`kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/research.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/stability-and-hygiene-hardening-2026-04-01KQ4ARB/research.md)

--- a/docs/migration/feature-flag-deprecation.md
+++ b/docs/migration/feature-flag-deprecation.md
@@ -79,7 +79,7 @@ Removal is a separate change. There is no date-based removal promise.
 
 ## References
 
-- [Mission spec](../../kitty-specs/077-mission-terminology-cleanup/spec.md)
-- [Mission Type / Mission / Mission Run Terminology Boundary ADR](../../architecture/2.x/adr/2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md)
-- [Mission Nomenclature Reconciliation initiative](../../architecture/2.x/initiatives/2026-04-mission-nomenclature-reconciliation/README.md)
+- [Mission spec](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/077-mission-terminology-cleanup/spec.md)
+- [Mission Type / Mission / Mission Run Terminology Boundary ADR](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md)
+- [Mission Nomenclature Reconciliation initiative](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/initiatives/2026-04-mission-nomenclature-reconciliation/README.md)
 - [Tracking issue #241](https://github.com/Priivacy-ai/spec-kitty/issues/241)

--- a/docs/migration/mission-id-canonical-identity.md
+++ b/docs/migration/mission-id-canonical-identity.md
@@ -3,7 +3,7 @@
 # Migration: Mission ID as Canonical Identity
 
 **Status**: Shipped with mission `083-mission-id-canonical-identity-migration`.
-**ADR**: [2026-04-09-1](../../architecture/adrs/2026-04-09-1-mission-identity-uses-ulid-not-sequential-prefix.md)
+**ADR**: [2026-04-09-1](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/adrs/2026-04-09-1-mission-identity-uses-ulid-not-sequential-prefix.md)
 **Issue**: [Priivacy-ai/spec-kitty#557](https://github.com/Priivacy-ai/spec-kitty/issues/557)
 **Audience**: Operators upgrading existing Spec Kitty projects to the 3.x line
 that ships the `mission_id` identity model.
@@ -248,9 +248,9 @@ any event log entries keyed off the original ULID will become orphaned.
 
 ## Related Documentation
 
-- [Mission Identity Model in `CLAUDE.md`](../../CLAUDE.md#mission-identity-model-083) — developer-facing contract summary.
+- [Mission Identity Model in `CLAUDE.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/CLAUDE.md#mission-identity-model-083) — developer-facing contract summary.
 - [Event Envelope Reference](../reference/event-envelope.md) — how `mission_id` flows into the machine contract.
 - [Orchestrator API Reference](../reference/orchestrator-api.md) — `--mission` selector semantics.
 - [Execution Lanes](../explanation/execution-lanes.md) — lane branch and worktree naming.
-- [Feature Detection architecture note](../architecture/feature-detection.md) — historical context for the pre-083 selector.
+- [Feature Detection architecture note](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/architecture/feature-detection.md) — historical context for the pre-083 selector.
 - [Feature Flag Deprecation](feature-flag-deprecation.md) — the earlier `--feature` → `--mission` migration.

--- a/docs/migration/mission-type-flag-deprecation.md
+++ b/docs/migration/mission-type-flag-deprecation.md
@@ -70,6 +70,6 @@ Removal is a separate follow-up change, not part of Mission 077.
 
 ## References
 
-- [Mission spec](../../kitty-specs/077-mission-terminology-cleanup/spec.md)
-- [Mission Type / Mission / Mission Run Terminology Boundary ADR](../../architecture/2.x/adr/2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md)
+- [Mission spec](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/077-mission-terminology-cleanup/spec.md)
+- [Mission Type / Mission / Mission Run Terminology Boundary ADR](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-04-2-mission-type-mission-and-mission-run-terminology-boundary.md)
 - [Tracking issue #241](https://github.com/Priivacy-ai/spec-kitty/issues/241)

--- a/docs/migration/retrospective-events-upstream.md
+++ b/docs/migration/retrospective-events-upstream.md
@@ -3,8 +3,8 @@
 # Cutover Runbook: Retrospective Events — Local to Upstream
 
 **Status**: Pending upstream release of `spec_kitty_events` with retrospective events.
-**Relevant ADR**: AD-004 in [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md`](../../kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md)
-**Events contract**: [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md`](../../kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md)
+**Relevant ADR**: AD-004 in [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md)
+**Events contract**: [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md)
 
 ---
 
@@ -43,9 +43,9 @@ The follow-up patch must:
 1. Open the actual GitHub issue against `spec_kitty_events` with title:
    "Add retrospective lifecycle events (8) to public surface." Body should
    link to
-   [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md`](../../kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md)
+   [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/plan.md)
    and
-   [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md`](../../kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md),
+   [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md),
    and paste the eight event names and their payload field minimums from the
    contract.
 2. Replace the `<TODO: WP12>` marker in
@@ -82,7 +82,7 @@ EOF
 ```
 
 Cross-check each field against
-[`contracts/retrospective_events_v1.md`](../../kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md).
+[`contracts/retrospective_events_v1.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md).
 If any field is missing or renamed, open a follow-up issue against
 `spec_kitty_events` before proceeding — do not paper over the mismatch with an
 adapter.
@@ -216,7 +216,7 @@ tranche's acceptance does not require the upstream release to land (AD-004).
 
 ## See also
 
-- Events contract: [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md`](../../kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md)
-- Shared package boundary ADR: [`architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md`](../../architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md)
+- Events contract: [`kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/mission-retrospective-learning-loop-01KQ6YEG/contracts/retrospective_events_v1.md)
+- Shared package boundary ADR: [`architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md)
 - Boundary test: `tests/architectural/test_retrospective_events_boundary.py`
-- Operator overview: [`docs/retrospective-learning-loop.md`](../retrospective-learning-loop.md)
+- Operator overview: [`docs/explanation/retrospective-learning-loop.md`](../explanation/retrospective-learning-loop.md)

--- a/docs/migration/shared-package-boundary-cutover.md
+++ b/docs/migration/shared-package-boundary-cutover.md
@@ -79,12 +79,12 @@ The repo's CI runs an automated equivalent of this check on every PR
 If you work across `spec-kitty-cli` and `spec-kitty-events` /
 `spec-kitty-tracker` simultaneously (e.g. testing an unreleased events
 contract change), see
-[`docs/development/local-overrides.md`](../development/local-overrides.md)
+[`docs/development/local-overrides.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/development/local-overrides.md)
 for editable-install patterns that don't pollute committed config.
 
 ## Why this happened
 
-See [ADR 2026-04-25-1: Shared Package Boundary](../../architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md)
+See [ADR 2026-04-25-1: Shared Package Boundary](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/2.x/adr/2026-04-25-1-shared-package-boundary.md)
 for the full decision rationale and the alternatives considered.
 
 ## Supersedes

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -331,8 +331,8 @@ agents:
 
 **See**:
 - [Managing AI Agents](../how-to/manage-agents.md) - Complete guide to agent management commands
-- [CLI Reference: spec-kitty agent config](cli-commands.md#spec-kitty-agent-config) - Command syntax and options
-- [ADR #6: Config-Driven Agent Management](../../architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) - Architectural decision rationale
+- [CLI Reference: spec-kitty agent config](agent-subcommands.md#spec-kitty-agent-config) - Command syntax and options
+- [ADR #6: Config-Driven Agent Management](https://github.com/Priivacy-ai/spec-kitty/blob/main/architecture/1.x/adr/2026-01-23-6-config-driven-agent-management.md) - Architectural decision rationale
 
 > **Legacy behavior**: Projects without `agents.available` field default to the full slash-command agent set for backward compatibility (currently 13 agent keys in the active CLI surface). To adopt config-driven model, use `spec-kitty agent config remove` to remove unwanted agents.
 

--- a/docs/reference/event-envelope.md
+++ b/docs/reference/event-envelope.md
@@ -1,7 +1,7 @@
 # Event Envelope Reference
 
 This document describes the vendored machine-facing contract enforced by
-[`src/specify_cli/core/upstream_contract.json`](../../src/specify_cli/core/upstream_contract.json)
+[`src/specify_cli/core/upstream_contract.json`](https://github.com/Priivacy-ai/spec-kitty/blob/main/src/specify_cli/core/upstream_contract.json)
 and `specify_cli.core.contract_gate.validate_outbound_payload()`.
 
 The current contract version is `3.0.0`.

--- a/docs/reference/missions.md
+++ b/docs/reference/missions.md
@@ -227,7 +227,7 @@ Custom missions appear as options during `/spec-kitty.specify`.
 
 ## Authoring Custom Missions
 
-Custom missions are project-authored mission definitions that the Local Custom Mission Loader discovers, validates, and runs through the same composition path used by the built-in `software-dev` mission. This section is the canonical reference for the `mission.yaml` format. For an operator-narrative walkthrough, see [`kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md`](../../kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md).
+Custom missions are project-authored mission definitions that the Local Custom Mission Loader discovers, validates, and runs through the same composition path used by the built-in `software-dev` mission. This section is the canonical reference for the `mission.yaml` format. For an operator-narrative walkthrough, see [`kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md).
 
 ### YAML shape
 
@@ -274,7 +274,7 @@ Every entry in `steps[]` is a `PromptStep`. The table below covers every author-
 
 Every custom mission MUST declare a final `PromptStep` whose `id == "retrospective"`. The validator checks one rule: the last entry of `steps[]` (after dependency-aware sort) has `id == "retrospective"`. Missing or misnamed markers are rejected with the stable error code `MISSION_RETROSPECTIVE_MISSING`.
 
-Execution semantics for the marker step are deferred to the retrospective-execution tranche (#506–#511); v1 only enforces the structural rule. See [research §R-001](../../kitty-specs/local-custom-mission-loader-01KQ2VNJ/research.md) for the rationale.
+Execution semantics for the marker step are deferred to the retrospective-execution tranche (#506–#511); v1 only enforces the structural rule. See [research §R-001](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/local-custom-mission-loader-01KQ2VNJ/research.md) for the rationale.
 
 ### Profile binding
 
@@ -283,7 +283,7 @@ A composed step needs a profile so the runtime knows which agent persona to disp
 - `agent_profile`: per-step inline declaration. The loader's contract synthesizer auto-generates a single-step `MissionStepContract` for the step. This is the ergonomic default for most authors.
 - `contract_ref`: reference to a pre-existing `MissionStepContract` ID in the on-disk repository. Use this when multiple missions share the same contract or when a contract's execution rules need to be authored separately. If the referenced contract does not resolve, the loader rejects with `MISSION_CONTRACT_REF_UNRESOLVED`.
 
-Declaring both `agent_profile` and `contract_ref` on the same step is rejected with `MISSION_STEP_AMBIGUOUS_BINDING`. Declaring neither (and having no `requires_inputs`) is rejected with `MISSION_STEP_NO_PROFILE_BINDING`. See [research §R-003](../../kitty-specs/local-custom-mission-loader-01KQ2VNJ/research.md) for the full rationale.
+Declaring both `agent_profile` and `contract_ref` on the same step is rejected with `MISSION_STEP_AMBIGUOUS_BINDING`. Declaring neither (and having no `requires_inputs`) is rejected with `MISSION_STEP_NO_PROFILE_BINDING`. See [research §R-003](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/local-custom-mission-loader-01KQ2VNJ/research.md) for the full rationale.
 
 YAML examples:
 
@@ -308,7 +308,7 @@ The following `mission.key` values are reserved for built-in missions and cannot
 - `documentation`
 - `plan`
 
-Any non-builtin discovery tier that produces a definition with one of these keys is rejected at load time with the stable error code `MISSION_KEY_RESERVED`. Built-in dispatch logic is hard-coded to these keys, so silent shadowing would be a footgun. To customize behavior of a built-in workflow, rename your mission to a non-reserved key. See [research §R-002](../../kitty-specs/local-custom-mission-loader-01KQ2VNJ/research.md) for the rationale.
+Any non-builtin discovery tier that produces a definition with one of these keys is rejected at load time with the stable error code `MISSION_KEY_RESERVED`. Built-in dispatch logic is hard-coded to these keys, so silent shadowing would be a footgun. To customize behavior of a built-in workflow, rename your mission to a non-reserved key. See [research §R-002](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/local-custom-mission-loader-01KQ2VNJ/research.md) for the rationale.
 
 ### Discovery precedence
 
@@ -359,7 +359,7 @@ Detail key conventions:
 
 ### Example: ERP integration mission
 
-The reference fixture used by the loader's test suite lives at [`tests/fixtures/missions/erp-integration/mission.yaml`](../../tests/fixtures/missions/erp-integration/mission.yaml). The fixture is the **authoritative** copy of this example: any drift between the fixture and the operator narrative in [quickstart.md](../../kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md) is resolved in favor of the fixture, since the fixture is what the test suite executes against.
+The reference fixture used by the loader's test suite lives at [`tests/fixtures/missions/erp-integration/mission.yaml`](https://github.com/Priivacy-ai/spec-kitty/blob/main/tests/fixtures/missions/erp-integration/mission.yaml). The fixture is the **authoritative** copy of this example: any drift between the fixture and the operator narrative in [quickstart.md](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md) is resolved in favor of the fixture, since the fixture is what the test suite executes against.
 
 Inline copy of the fixture:
 
@@ -453,7 +453,7 @@ $ spec-kitty mission run no-such-key --mission x --json
 
 Exit code 2. Validation errors do NOT start a run; the `kitty-specs/<slug>/` directory is not created.
 
-For the operator-narrative walkthrough (decision resolution, advancement, recovery from validation failures), see [`kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md`](../../kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md).
+For the operator-narrative walkthrough (decision resolution, advancement, recovery from validation failures), see [`kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/kitty-specs/local-custom-mission-loader-01KQ2VNJ/quickstart.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- replace public-site links to repo-only artifacts with durable GitHub blob URLs
- correct stale anchors and non-published development links that DocFX flagged
- reduce DocFX build from live-site warnings to zero warnings/errors

## Validation
- docfx docfx.json
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NO_UPGRADE_CHECK=1 PYTHONPATH=. uv run python scripts/docs/check_docs_freshness.py --ci --report /tmp/spec-kitty-freshness-live-links.json --link-check none
- git diff --check