### PR TITLE
Fix ceremony commit and workflow evidence gates

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -45,6 +45,8 @@ QUICKSTART_FILE = "quickstart.md"
 DATA_MODEL_FILE = "data-model.md"
 RESEARCH_FILE = "research.md"
 WORKFLOW_EVIDENCE_FILE = "workflow-evidence.md"
+WORKFLOW_RUN_URL_RE = re.compile(r"https://github\.com/[\w.-]+/[\w.-]+/actions/runs/\d+\b")
+WORKFLOW_RUN_ID_RE = re.compile(r"(?im)^\s*(?:successful\s+)?(?:github\s+actions\s+)?run(?:\s+id)?\s*[:#-]?\s*\d{5,}\s*$")
 PRIMARY_ARTIFACT_FILES = (
     SPEC_FILE,
     PLAN_FILE,
@@ -588,7 +590,9 @@ def _workflow_evidence_missing(feature_dir: Path) -> bool:
     if not evidence_path.is_file():
         return True
     text = evidence_path.read_text(encoding="utf-8", errors="replace")
-    return not bool(text.strip())
+    if not text.strip():
+        return True
+    return WORKFLOW_RUN_URL_RE.search(text) is None and WORKFLOW_RUN_ID_RE.search(text) is None
 
 
 def _check_workflow_run_evidence(

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -16,6 +16,7 @@ from specify_cli.core.agent_config import get_auto_commit_default
 from specify_cli.core.paths import require_explicit_feature as _require_explicit_feature
 from specify_cli.decisions.models import DecisionStatus
 from specify_cli.decisions.store import load_index
+from specify_cli.git.commit_helpers import assert_not_protected_branch
 from specify_cli.mission import MissionError, get_mission_for_feature
 from specify_cli.mission_metadata import load_meta, record_acceptance, resolve_mission_identity, write_meta
 from specify_cli.status.models import Lane
@@ -43,6 +44,7 @@ TASKS_FILE = "tasks.md"
 QUICKSTART_FILE = "quickstart.md"
 DATA_MODEL_FILE = "data-model.md"
 RESEARCH_FILE = "research.md"
+WORKFLOW_EVIDENCE_FILE = "workflow-evidence.md"
 PRIMARY_ARTIFACT_FILES = (
     SPEC_FILE,
     PLAN_FILE,
@@ -540,6 +542,70 @@ def _check_lane_gates(
         activity_issues.append("Acceptance matrix verdict is 'pending' — criteria or invariants have not been verified")
 
 
+def _target_branch_for_feature(feature_dir: Path) -> str | None:
+    meta = load_meta(feature_dir) or {}
+    value = meta.get("target_branch")
+    return str(value) if value else None
+
+
+def _git_ref_exists(repo_root: Path, ref: str) -> bool:
+    return run_git(["rev-parse", "--verify", "--quiet", ref], cwd=repo_root, check=False).returncode == 0
+
+
+def _changed_workflow_files(repo_root: Path, feature_dir: Path, branch: str | None) -> list[str]:
+    """Return workflow files changed by the current mission branch."""
+    target_branch = _target_branch_for_feature(feature_dir)
+    if not target_branch or branch == target_branch:
+        return []
+
+    base_ref = target_branch if _git_ref_exists(repo_root, target_branch) else f"origin/{target_branch}"
+    if not _git_ref_exists(repo_root, base_ref):
+        return []
+
+    merge_base = run_git(["merge-base", "HEAD", base_ref], cwd=repo_root, check=False)
+    if merge_base.returncode != 0 or not merge_base.stdout.strip():
+        return []
+
+    diff = run_git(
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=AMR",
+            f"{merge_base.stdout.strip()}...HEAD",
+            "--",
+            ".github/workflows",
+        ],
+        cwd=repo_root,
+        check=False,
+    )
+    if diff.returncode != 0:
+        return []
+    return sorted({line.strip() for line in diff.stdout.splitlines() if line.strip()})
+
+
+def _workflow_evidence_missing(feature_dir: Path) -> bool:
+    evidence_path = feature_dir / WORKFLOW_EVIDENCE_FILE
+    if not evidence_path.is_file():
+        return True
+    text = evidence_path.read_text(encoding="utf-8", errors="replace")
+    return not bool(text.strip())
+
+
+def _check_workflow_run_evidence(
+    repo_root: Path,
+    feature_dir: Path,
+    branch: str | None,
+    activity_issues: list[str],
+) -> None:
+    changed = _changed_workflow_files(repo_root, feature_dir, branch)
+    if changed and _workflow_evidence_missing(feature_dir):
+        activity_issues.append(
+            "Workflow run evidence required: this mission changes "
+            + ", ".join(changed)
+            + f". Add a successful real GitHub Actions run ID or URL to {feature_dir.name}/{WORKFLOW_EVIDENCE_FILE}."
+        )
+
+
 def collect_feature_summary(
     repo_root: Path,
     feature: str,
@@ -635,6 +701,7 @@ def collect_feature_summary(
         warnings.append("Path conventions not satisfied.")
 
     _check_lane_gates(repo_root, feature_dir, branch, activity_issues)
+    _check_workflow_run_evidence(repo_root, feature_dir, branch, activity_issues)
 
     return AcceptanceSummary(
         feature=feature,
@@ -679,6 +746,8 @@ def _commit_acceptance_meta(
     mode: AcceptanceMode,
 ) -> tuple[str | None, str | None, bool]:
     """Record acceptance in meta.json and commit; return (parent_commit, accept_commit, commit_created)."""
+    assert_not_protected_branch(summary.repo_root, operation="record acceptance")
+
     try:
         parent_commit: str | None = run_git(["rev-parse", "HEAD"], cwd=summary.repo_root, check=False).stdout.strip() or None
     except TaskCliError:

--- a/src/specify_cli/git/__init__.py
+++ b/src/specify_cli/git/__init__.py
@@ -1,5 +1,5 @@
 """Git helper utilities for spec-kitty."""
 
-from .commit_helpers import safe_commit
+from .commit_helpers import ProtectedBranchCommitError, assert_not_protected_branch, safe_commit
 
-__all__ = ["safe_commit"]
+__all__ = ["ProtectedBranchCommitError", "assert_not_protected_branch", "safe_commit"]

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -65,6 +65,83 @@ class SafeCommitBackstopError(RuntimeError):
         super().__init__("\n".join(message_lines))
 
 
+class ProtectedBranchCommitError(RuntimeError):
+    """Raised when a Spec Kitty ceremony commit would land on a protected branch."""
+
+
+_DEFAULT_PROTECTED_BRANCHES = frozenset({"main", "master"})
+_PROTECTED_BRANCH_COMMIT_EXCEPTIONS = (
+    "chore: apply spec-kitty upgrade changes",
+    "chore: release ",
+    "release: ",
+)
+
+
+def _run_git_text(repo_path: Path, args: list[str]) -> str | None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _is_spec_kitty_project(repo_path: Path) -> bool:
+    return (repo_path / ".kittify").is_dir()
+
+
+def _current_branch(repo_path: Path) -> str | None:
+    branch = _run_git_text(repo_path, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if not branch or branch == "HEAD":
+        return None
+    return branch
+
+
+def _remote_default_branch(repo_path: Path) -> str | None:
+    symbolic_ref = _run_git_text(repo_path, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"])
+    if symbolic_ref and "/" in symbolic_ref:
+        return symbolic_ref.rsplit("/", 1)[1]
+
+    remote_show = _run_git_text(repo_path, ["remote", "show", "origin"])
+    if remote_show:
+        for line in remote_show.splitlines():
+            if "HEAD branch:" in line:
+                return line.rsplit(":", 1)[1].strip() or None
+    return None
+
+
+def protected_branches(repo_path: Path) -> frozenset[str]:
+    """Return branch names that must not receive Spec Kitty ceremony commits."""
+    branches = set(_DEFAULT_PROTECTED_BRANCHES)
+    if default_branch := _remote_default_branch(repo_path):
+        branches.add(default_branch)
+    return frozenset(branches)
+
+
+def assert_not_protected_branch(repo_path: Path, *, operation: str = "commit") -> None:
+    """Fail loudly before a Spec Kitty ceremony commit can pollute local main."""
+    repo_path = repo_path.resolve()
+    if not _is_spec_kitty_project(repo_path):
+        return
+
+    branch = _current_branch(repo_path)
+    if branch and branch in protected_branches(repo_path):
+        raise ProtectedBranchCommitError(
+            f"Refusing to {operation} on protected branch '{branch}' in {repo_path}. "
+            "Run ceremony write operations from the mission lane branch/worktree."
+        )
+
+
+def _is_protected_branch_exception(commit_message: str) -> bool:
+    return commit_message.startswith(_PROTECTED_BRANCH_COMMIT_EXCEPTIONS)
+
+
 def assert_staging_area_matches_expected(
     repo_path: Path,
     expected_paths: Sequence[str],
@@ -253,6 +330,9 @@ def safe_commit(
         ... )
         True
     """
+    if not _is_protected_branch_exception(commit_message):
+        assert_not_protected_branch(repo_path, operation=f"create commit '{commit_message}'")
+
     # Normalize file paths to be relative to repo_path
     normalized_files = []
     for file in files_to_commit:

--- a/src/specify_cli/missions/software-dev/command-templates/implement.md
+++ b/src/specify_cli/missions/software-dev/command-templates/implement.md
@@ -307,6 +307,16 @@ persona automatically.
 3. Commit the updated frontmatter together with your implementation changes **before**
    running `spec-kitty agent tasks move-task WPxx --to for_review`.
 
+### GitHub Actions Workflow Changes
+
+If this WP adds or modifies `.github/workflows/*`, use a draft PR before review hand-off:
+
+1. Push the WP branch.
+2. Open a draft PR so the workflow runs on a real GitHub Actions runner.
+3. Iterate on the draft PR until the changed workflow has a successful run.
+4. Record the successful run ID or Actions URL in `kitty-specs/<mission>/workflow-evidence.md`.
+5. Only then move the WP to `for_review`.
+
 The reviewer will then use `/ad-hoc-profile-load` with the reviewer profile and apply
 its self-review gates automatically.
 

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -12,6 +12,7 @@ Error codes used:
   TRANSITION_REJECTED         -- transition not allowed by state machine
   WP_ALREADY_CLAIMED          -- WP claimed by a different actor
   MISSION_NOT_READY           -- not all WPs approved/done (for accept-mission)
+  WORKFLOW_EVIDENCE_REQUIRED  -- workflow files changed without runner proof
   PREFLIGHT_FAILED            -- preflight checks failed (for merge-mission)
   CONTRACT_VERSION_MISMATCH   -- provider version is below MIN_PROVIDER_VERSION
   UNSUPPORTED_STRATEGY        -- merge strategy not implemented
@@ -988,6 +989,24 @@ def accept_mission(
             {
                 **_mission_identity_payload(mission_dir),
                 "incomplete_wps": sorted(incomplete),
+            },
+        )
+        return
+
+    from specify_cli.acceptance import collect_feature_summary
+
+    summary = collect_feature_summary(main_repo_root, mission)
+    workflow_evidence_issues = [
+        issue for issue in summary.activity_issues if issue.startswith("Workflow run evidence required:")
+    ]
+    if workflow_evidence_issues:
+        _fail(
+            cmd,
+            "WORKFLOW_EVIDENCE_REQUIRED",
+            workflow_evidence_issues[0],
+            {
+                **_mission_identity_payload(mission_dir),
+                "required_evidence_path": str(mission_dir / "workflow-evidence.md"),
             },
         )
         return

--- a/tests/git_ops/test_safe_commit_helper_integration.py
+++ b/tests/git_ops/test_safe_commit_helper_integration.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from specify_cli.git.commit_helpers import safe_commit
+from specify_cli.git.commit_helpers import ProtectedBranchCommitError, safe_commit
 
 import pytest
 
@@ -100,6 +100,24 @@ def test_safe_commit_preserves_unrelated_staged_files(git_repo: Path):
         check=True,
     )
     assert "Update WP01 status to doing" in log_result.stdout
+
+
+def test_safe_commit_blocks_spec_kitty_ceremony_commit_on_protected_branch(git_repo: Path):
+    """Spec Kitty ceremony commits must fail loudly before polluting local main."""
+    subprocess.run(["git", "branch", "-M", "main"], cwd=git_repo, check=True)
+    (git_repo / ".kittify").mkdir()
+    (git_repo / ".kittify" / "config.json").write_text("{}\n")
+    protected_file = git_repo / "kitty-specs" / "099-demo" / "meta.json"
+    protected_file.parent.mkdir(parents=True)
+    protected_file.write_text("{}\n")
+
+    with pytest.raises(ProtectedBranchCommitError, match="protected branch 'main'"):
+        safe_commit(
+            repo_path=git_repo,
+            files_to_commit=[protected_file],
+            commit_message="Add meta for feature 099-demo",
+            allow_empty=False,
+        )
 
 def test_safe_commit_nothing_to_commit_graceful(git_repo: Path):
     """T046: Test 'nothing to commit' graceful handling.

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -203,6 +203,26 @@ def test_collect_feature_summary_allows_workflow_changes_with_runner_evidence(tm
     assert not any("Workflow run evidence required" in issue for issue in summary.activity_issues)
 
 
+def test_collect_feature_summary_rejects_placeholder_workflow_evidence(tmp_path: Path) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-b", "kitty/mission-workflow-lane-a"], check=True, capture_output=True)
+
+    workflow_path = repo_root / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text("name: CI\non: [pull_request]\njobs: {}\n")
+    (feature_dir / "workflow-evidence.md").write_text("n/a\n")
+    subprocess.run(
+        ["git", "-C", str(repo_root), "add", ".github/workflows/ci.yml", f"kitty-specs/{_FEATURE_SLUG}/workflow-evidence.md"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add workflow with placeholder evidence"], check=True, capture_output=True)
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG)
+    assert any("Workflow run evidence required" in issue for issue in summary.activity_issues)
+
+
 # ---------------------------------------------------------------------------
 # T013: accept_commit persisted to meta.json
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -168,6 +168,41 @@ def test_collect_feature_summary_does_not_dirty_repo(tmp_path: Path) -> None:
     assert summary2.git_dirty == [], f"Second call dirtied the repo: {summary2.git_dirty}"
 
 
+def test_collect_feature_summary_blocks_workflow_changes_without_runner_evidence(tmp_path: Path) -> None:
+    repo_root, _feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-b", "kitty/mission-workflow-lane-a"], check=True, capture_output=True)
+
+    workflow_path = repo_root / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text("name: CI\non: [pull_request]\njobs: {}\n")
+    subprocess.run(["git", "-C", str(repo_root), "add", ".github/workflows/ci.yml"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add workflow"], check=True, capture_output=True)
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG)
+    assert any("Workflow run evidence required" in issue for issue in summary.activity_issues)
+
+
+def test_collect_feature_summary_allows_workflow_changes_with_runner_evidence(tmp_path: Path) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-b", "kitty/mission-workflow-lane-a"], check=True, capture_output=True)
+
+    workflow_path = repo_root / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text("name: CI\non: [pull_request]\njobs: {}\n")
+    (feature_dir / "workflow-evidence.md").write_text("Successful run: https://github.com/acme/demo/actions/runs/123\n")
+    subprocess.run(
+        ["git", "-C", str(repo_root), "add", ".github/workflows/ci.yml", f"kitty-specs/{_FEATURE_SLUG}/workflow-evidence.md"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add workflow with evidence"], check=True, capture_output=True)
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG)
+    assert not any("Workflow run evidence required" in issue for issue in summary.activity_issues)
+
+
 # ---------------------------------------------------------------------------
 # T013: accept_commit persisted to meta.json
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- block Spec Kitty ceremony safe_commit/acceptance writes on protected branches such as main/master
- require workflow-run evidence before mission acceptance when a mission branch changes .github/workflows/*
- add the draft-PR-first workflow procedure to the software-dev implement template

Fixes #1270
Refs #1271

## Verification
- uv run pytest tests/git_ops/test_safe_commit_helper_integration.py tests/specify_cli/test_acceptance_regressions.py tests/agent/test_orchestrator_commands_integration.py::TestAcceptMission -q
- uv run ruff check src/specify_cli/git/commit_helpers.py src/specify_cli/acceptance/__init__.py src/specify_cli/orchestrator_api/commands.py tests/git_ops/test_safe_commit_helper_integration.py tests/specify_cli/test_acceptance_regressions.py