### PR TITLE
fix: harden workflow evidence run-id detection

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -46,7 +46,6 @@ DATA_MODEL_FILE = "data-model.md"
 RESEARCH_FILE = "research.md"
 WORKFLOW_EVIDENCE_FILE = "workflow-evidence.md"
 WORKFLOW_RUN_URL_RE = re.compile(r"https://github\.com/[\w.-]+/[\w.-]+/actions/runs/\d+\b")
-WORKFLOW_RUN_ID_RE = re.compile(r"(?im)^\s*(?:successful\s+)?(?:github\s+actions\s+)?run(?:\s+id)?\s*[:#-]?\s*\d{5,}\s*$")
 PRIMARY_ARTIFACT_FILES = (
     SPEC_FILE,
     PLAN_FILE,
@@ -592,7 +591,33 @@ def _workflow_evidence_missing(feature_dir: Path) -> bool:
     text = evidence_path.read_text(encoding="utf-8", errors="replace")
     if not text.strip():
         return True
-    return WORKFLOW_RUN_URL_RE.search(text) is None and WORKFLOW_RUN_ID_RE.search(text) is None
+    return WORKFLOW_RUN_URL_RE.search(text) is None and not _contains_workflow_run_id(text)
+
+
+def _contains_workflow_run_id(text: str) -> bool:
+    """Return True when evidence text includes a standalone GitHub Actions run id."""
+
+    optional_prefixes = ("successful ", "github actions ")
+
+    for raw_line in text.splitlines():
+        normalized = " ".join(raw_line.strip().lower().split())
+        if not normalized:
+            continue
+        for prefix in optional_prefixes:
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix) :]
+        if normalized.startswith("run id"):
+            remainder = normalized[len("run id") :]
+        elif normalized.startswith("run"):
+            remainder = normalized[len("run") :]
+        else:
+            continue
+        remainder = remainder.lstrip()
+        if remainder[:1] in ":#-":
+            remainder = remainder[1:].lstrip()
+        if remainder.isdigit() and len(remainder) >= 5:
+            return True
+    return False
 
 
 def _check_workflow_run_evidence(

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -203,6 +203,39 @@ def test_collect_feature_summary_allows_workflow_changes_with_runner_evidence(tm
     assert not any("Workflow run evidence required" in issue for issue in summary.activity_issues)
 
 
+@pytest.mark.parametrize(
+    ("evidence", "expected"),
+    [
+        ("run: 12345\n", True),
+        ("Successful GitHub Actions Run ID - 12345\n", True),
+        ("github actions run # 67890\n", True),
+        ("run id: abc123\n", False),
+        ("run\n", False),
+    ],
+)
+def test_collect_feature_summary_parses_plain_workflow_run_ids(
+    tmp_path: Path, evidence: str, expected: bool
+) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-b", "kitty/mission-workflow-lane-a"], check=True, capture_output=True)
+
+    workflow_path = repo_root / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text("name: CI\non: [pull_request]\njobs: {}\n")
+    (feature_dir / "workflow-evidence.md").write_text(evidence)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "add", ".github/workflows/ci.yml", f"kitty-specs/{_FEATURE_SLUG}/workflow-evidence.md"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add workflow evidence variant"], check=True, capture_output=True)
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG)
+    has_issue = any("Workflow run evidence required" in issue for issue in summary.activity_issues)
+    assert has_issue is not expected
+
+
 def test_collect_feature_summary_rejects_placeholder_workflow_evidence(tmp_path: Path) -> None:
     repo_root, feature_dir = _create_test_feature(tmp_path)
     subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)


### PR DESCRIPTION
## Summary
- replace the acceptance workflow-evidence run-id regex with deterministic line parsing to avoid Sonar's regex backtracking hotspot
- add regression coverage for plain run-id evidence variants accepted by the acceptance checker
- verify the touched acceptance suites and focused lint checks locally

## Investigation
- GitHub dependabot alerts: none open
- GitHub code-scanning alerts: none open
- Latest nightly `CI Quality` on `main`: https://github.com/Priivacy-ai/spec-kitty/actions/runs/26271873020
- SonarCloud quality gate failure on `main`: `new_coverage=57.2%` and `new_security_hotspots_reviewed=0%`
- Actionable new code issue found in this run: hotspot `python:S5852` on `src/specify_cli/acceptance/__init__.py`

## Validation
- `pytest tests/specify_cli/test_acceptance_regressions.py -q`
- `pytest tests/cross_cutting/misc/test_acceptance_support.py -q`
- `ruff check src/specify_cli/acceptance/__init__.py tests/specify_cli/test_acceptance_regressions.py tests/cross_cutting/misc/test_acceptance_support.py`
