### PR TITLE
fix(ci): restore merge status commit and acceptance marker scan

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -361,9 +361,9 @@ def _iter_clarification_decision_ids(text: str) -> Iterable[str]:
         decision_id_index = comment_body.find(_DECISION_ID_MARKER)
         if decision_id_index == -1:
             continue
-        decision_id = comment_body[decision_id_index + len(_DECISION_ID_MARKER) :].strip()
-        if decision_id:
-            yield decision_id
+        decision_id_text = comment_body[decision_id_index + len(_DECISION_ID_MARKER) :].strip()
+        if decision_id_text:
+            yield decision_id_text.split(maxsplit=1)[0]
 
 
 def _missing_artifacts(feature_dir: Path) -> tuple[list[str], list[str]]:

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -55,9 +55,7 @@ PRIMARY_ARTIFACT_FILES = (
     RESEARCH_FILE,
     DATA_MODEL_FILE,
 )
-NEEDS_CLARIFICATION_MARKER_RE = re.compile(
-    r"\[NEEDS CLARIFICATION:[^\]\n]+\]\s*<!--\s*decision_id:\s*(?P<decision_id>\S+)\s*-->"
-)
+_DECISION_ID_MARKER = "decision_id:"
 
 
 class AcceptanceError(TaskCliError):
@@ -332,18 +330,40 @@ def _check_needs_clarification(files: Sequence[Path]) -> list[str]:
 
 
 def _has_blocking_clarification_marker(file_path: Path, text: str) -> bool:
-    markers = list(NEEDS_CLARIFICATION_MARKER_RE.finditer(text))
+    markers = list(_iter_clarification_decision_ids(text))
     if not markers:
         return False
 
     index = load_index(file_path.parent)
     entries_by_id = {entry.decision_id: entry for entry in index.entries}
-    for marker in markers:
-        decision_id = marker.group("decision_id")
+    for decision_id in markers:
         entry = entries_by_id.get(decision_id)
         if entry is None or entry.status in {DecisionStatus.OPEN, DecisionStatus.DEFERRED}:
             return True
     return False
+
+
+def _iter_clarification_decision_ids(text: str) -> Iterable[str]:
+    for line in text.splitlines():
+        marker_start = line.find("[NEEDS CLARIFICATION:")
+        if marker_start == -1:
+            continue
+        marker_end = line.find("]", marker_start)
+        if marker_end == -1:
+            continue
+        comment_start = line.find("<!--", marker_end)
+        if comment_start == -1:
+            continue
+        comment_end = line.find("-->", comment_start + 4)
+        if comment_end == -1:
+            continue
+        comment_body = line[comment_start + 4 : comment_end]
+        decision_id_index = comment_body.find(_DECISION_ID_MARKER)
+        if decision_id_index == -1:
+            continue
+        decision_id = comment_body[decision_id_index + len(_DECISION_ID_MARKER) :].strip()
+        if decision_id:
+            yield decision_id
 
 
 def _missing_artifacts(feature_dir: Path) -> tuple[list[str], list[str]]:

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -75,6 +75,7 @@ _PROTECTED_BRANCH_COMMIT_EXCEPTIONS = (
     "chore: release ",
     "release: ",
 )
+_MERGED_WP_DONE_COMMIT_SUFFIX = ": record done transitions for merged WPs"
 
 
 def _run_git_text(repo_path: Path, args: list[str]) -> str | None:
@@ -139,7 +140,9 @@ def assert_not_protected_branch(repo_path: Path, *, operation: str = "commit") -
 
 
 def _is_protected_branch_exception(commit_message: str) -> bool:
-    return commit_message.startswith(_PROTECTED_BRANCH_COMMIT_EXCEPTIONS)
+    return commit_message.startswith(_PROTECTED_BRANCH_COMMIT_EXCEPTIONS) or commit_message.endswith(
+        _MERGED_WP_DONE_COMMIT_SUFFIX
+    )
 
 
 def assert_staging_area_matches_expected(

--- a/tests/git_ops/test_safe_commit_helper_integration.py
+++ b/tests/git_ops/test_safe_commit_helper_integration.py
@@ -119,6 +119,25 @@ def test_safe_commit_blocks_spec_kitty_ceremony_commit_on_protected_branch(git_r
             allow_empty=False,
         )
 
+
+def test_safe_commit_allows_merged_wp_done_commit_on_protected_branch(git_repo: Path):
+    """The merge workflow may persist done transitions after merging onto main."""
+    subprocess.run(["git", "branch", "-M", "main"], cwd=git_repo, check=True)
+    (git_repo / ".kittify").mkdir()
+    (git_repo / ".kittify" / "config.json").write_text("{}\n")
+    status_file = git_repo / "kitty-specs" / "099-demo" / "status.events.jsonl"
+    status_file.parent.mkdir(parents=True)
+    status_file.write_text("{\"to_lane\":\"done\"}\n")
+
+    result = safe_commit(
+        repo_path=git_repo,
+        files_to_commit=[status_file],
+        commit_message="chore(099-demo): record done transitions for merged WPs",
+        allow_empty=False,
+    )
+
+    assert result is True
+
 def test_safe_commit_nothing_to_commit_graceful(git_repo: Path):
     """T046: Test 'nothing to commit' graceful handling.
 

--- a/tests/specify_cli/test_acceptance_needs_clarification.py
+++ b/tests/specify_cli/test_acceptance_needs_clarification.py
@@ -56,6 +56,17 @@ def test_needs_clarification_flags_malformed_decision_marker(tmp_path: Path) -> 
     assert _check_needs_clarification([artifact]) == [str(artifact)]
 
 
+def test_needs_clarification_handles_long_non_matching_line(tmp_path: Path) -> None:
+    """Long prose near the marker syntax should not require regex backtracking."""
+    artifact = tmp_path / "spec.md"
+    artifact.write_text(
+        "[NEEDS CLARIFICATION: " + ("x" * 20000) + "] <!-- not-a-decision marker -->\n",
+        encoding="utf-8",
+    )
+
+    assert _check_needs_clarification([artifact]) == []
+
+
 def test_needs_clarification_ignores_closed_decision_marker(tmp_path: Path) -> None:
     """A stale marker for a closed decision no longer blocks acceptance."""
     decision_id = "01KS0ABCDEF0123456789ABCDE"

--- a/tests/specify_cli/test_acceptance_needs_clarification.py
+++ b/tests/specify_cli/test_acceptance_needs_clarification.py
@@ -99,3 +99,37 @@ def test_needs_clarification_ignores_closed_decision_marker(tmp_path: Path) -> N
     )
 
     assert _check_needs_clarification([artifact]) == []
+
+
+def test_needs_clarification_accepts_trailing_comment_metadata(tmp_path: Path) -> None:
+    """Decision IDs keep the previous first-token parsing semantics."""
+    decision_id = "01KS0ABCDEF0123456789ABCDE"
+    artifact = tmp_path / "spec.md"
+    artifact.write_text(
+        "The system accepted the plan default. "
+        f"[NEEDS CLARIFICATION: choose durable queue] <!-- decision_id: {decision_id} source: specify -->\n",
+        encoding="utf-8",
+    )
+    save_index(
+        tmp_path,
+        DecisionIndex(
+            mission_id="mission-id",
+            entries=(
+                IndexEntry(
+                    decision_id=decision_id,
+                    origin_flow=OriginFlow.SPECIFY,
+                    step_id="specify.queue",
+                    input_key="queue",
+                    question="Which queue?",
+                    status=DecisionStatus.RESOLVED,
+                    final_answer="accept plan default",
+                    created_at=datetime(2026, 5, 21, tzinfo=UTC),
+                    resolved_at=datetime(2026, 5, 21, tzinfo=UTC),
+                    mission_id="mission-id",
+                    mission_slug="mission-slug",
+                ),
+            ),
+        ),
+    )
+
+    assert _check_needs_clarification([artifact]) == []


### PR DESCRIPTION
## Summary
- allow the merge flow's own `record done transitions for merged WPs` housekeeping commit on protected branches while keeping the broader ceremony-commit guard in place
- replace the acceptance clarification marker regex sweep with deterministic line parsing to remove the new Sonar hotspot in `src/specify_cli/acceptance/__init__.py`
- add regression coverage for both behaviors

## Validation
- `uv run pytest tests/git_ops/test_safe_commit_helper_integration.py tests/cli/commands/test_merge_status_commit.py::TestDoneEventsCommittedToGit::test_done_events_committed_to_git tests/specify_cli/test_acceptance_needs_clarification.py -q`
- `uv run ruff check src/specify_cli/git/commit_helpers.py src/specify_cli/acceptance/__init__.py tests/git_ops/test_safe_commit_helper_integration.py tests/specify_cli/test_acceptance_needs_clarification.py`
- `uv run pytest tests/cli/ -m 'not windows_ci and (git_repo or integration)' -q --tb=short --cov=src/specify_cli/cli --cov-report=xml:out/reports/coverage/coverage-integration-cli.xml`
- `uv run pytest tests/specify_cli/test_acceptance_regressions.py -q`

## Context
- Nightly `main` run `26271873020` failed on `integration-tests-cli` because the new protected-branch commit guard blocked the merge workflow's post-merge done-transition commit.
- SonarCloud `main` quality gate also failed; the changed-file security item in scope was the new clarification-marker regex hotspot.
- Existing localhost `http` hotspots remain pre-existing and out of scope for this patch.
