### PR TITLE
docs(WS6): launch auth, sync, and upgrade readiness docs (#1095)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add pre-launch and launch-readiness operator docs for hosted SaaS
+  sync (#1095). Public docs remain local-first; hosted readiness
+  stays opt-in via `SPEC_KITTY_ENABLE_SAAS_SYNC=1`. The new
+  `docs/how-to/internal-hosted-readiness.md` covers the dogfooding
+  workflow for internal / pre-launch operators, and the new
+  `docs/explanation/launch-readiness-future.md` stages the launch-day
+  behavior shift behind an explicit "Status: pre-launch" banner.
+
 ## [3.2.0rc23] - 2026-05-21
 
 Rolls up the autonomous-runtime safety sweep needed before the 3.2.0

--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ Deeper topics:
 - [External Orchestrator Runbook](docs/how-to/run-external-orchestrator.md)
 - [Hosted Sync Workspaces](docs/how-to/sync-workspaces.md)
 
+Hosted auth, sync, and tracker flows remain opt-in today. Internal /
+pre-launch operators dogfooding the hidden hosted-readiness mode behind
+`SPEC_KITTY_ENABLE_SAAS_SYNC=1` should read
+[Internal Hosted-Readiness (Pre-Launch)](docs/how-to/internal-hosted-readiness.md).
+The launch-day behavior that will replace today's defaults is staged
+under [Launch-Readiness Behavior (Coming Soon)](docs/explanation/launch-readiness-future.md).
+
 ## Development
 
 ```bash

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2227,6 +2227,13 @@
   current_target: true
   citation_refs: []
   notes: "MANUAL_REVIEW: explanation page kanban-workflow.md may quote 2.x material; WP08 IA review must reclassify current/supported/migration."
+- path: docs/explanation/launch-readiness-future.md
+  tag: current
+  divio_type: explanation
+  owning_workstream: none
+  current_target: true
+  citation_refs: []
+  notes: "Future-launch behavior delta for Teamspace readiness; explicitly labeled pre-launch."
 - path: docs/explanation/mission-system.md
   tag: current
   divio_type: explanation
@@ -2374,6 +2381,13 @@
   current_target: true
   citation_refs: []
   notes: Install/lifecycle how-to; provisional current — confirm install matrix in WP10/WP11.
+- path: docs/how-to/internal-hosted-readiness.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: none
+  current_target: true
+  citation_refs: []
+  notes: "Internal/pre-launch dogfooding playbook for SPEC_KITTY_ENABLE_SAAS_SYNC=1; intentionally not surfaced in public IA."
 - path: docs/how-to/keep-main-clean.md
   tag: current
   divio_type: how-to

--- a/docs/explanation/launch-readiness-future.md
+++ b/docs/explanation/launch-readiness-future.md
@@ -1,0 +1,136 @@
+---
+type: explanation
+audience: launch coordinators
+---
+
+# Launch-Readiness Behavior (Coming Soon)
+
+> **Status: pre-launch.** This page describes the behavior the Spec
+> Kitty CLI will adopt at the public Teamspace launch milestone.
+> **None of this is in effect today.** For today's local-first
+> experience, see the [README](../../README.md). For the internal
+> hosted-readiness preview that lets contributors dogfood the hidden
+> mode now, see
+> [Internal Hosted-Readiness Mode (Pre-Launch)](../how-to/internal-hosted-readiness.md).
+
+## Why this doc exists
+
+The Spec Kitty CLI today is local-first. Hosted auth, sync, and
+tracker flows are opt-in behind the `SPEC_KITTY_ENABLE_SAAS_SYNC=1`
+environment variable. At the public Teamspace launch, the user-facing
+defaults change. This doc is the reference the launch coordinator
+flips on. Until that flip happens, treat every section below as a
+**design intent**, not a description of current behavior.
+
+If you are an end user today, you will not see any of this. The
+public docs and the CLI's defaults continue to describe the
+local-first experience.
+
+## What changes at launch
+
+The table below frames the launch as a delta from today. **"Today"
+columns describe behavior on `main` right now; "At launch" columns
+describe behavior that will ship at the launch milestone.**
+
+| Dimension | Today (pre-launch) | At launch |
+|---|---|---|
+| `SPEC_KITTY_ENABLE_SAAS_SYNC` | **Opt-in gate.** Unset / falsy = local-first; truthy = hidden hosted-readiness mode for internal operators. | **Override only.** Hosted readiness is on by default; the variable becomes an internal escape hatch (e.g., `SPEC_KITTY_ENABLE_SAAS_SYNC=0` to force local-only). |
+| Default SaaS URL | Operators must set `SPEC_KITTY_SAAS_URL` explicitly to dial dev / staging. There is no user-facing default. | A user-facing default URL ships baked into the CLI. End users do not set `SPEC_KITTY_SAAS_URL`. |
+| Sync default | Sync commands no-op unless hosted mode is explicitly enabled. | Sync runs by default for Teamspace-connected repos. The same suppression contract still applies (interactive / non-interactive / machine-output). |
+| Tracker discovery | Tracker calls only happen behind the opt-in gate. | Tracker discovery happens by default for Teamspace-connected repos; unreachable-tracker states surface via the readiness coordinator. |
+| `spec-kitty auth login` | Documented as the canonical hosted login flow for internal operators dogfooding the hidden mode. | Documented as the canonical hosted login flow for **all** users joining a Teamspace. |
+| Public docs framing | Local-first. Hosted is "optional / opt-in / later". | Local-first remains the on-ramp; Teamspace becomes "available" — never retroactively backdated as "always was". |
+
+## Dev / staging overrides still apply after launch
+
+`SPEC_KITTY_SAAS_URL` and the other operator-only overrides survive
+the launch flip. They remain internal developer tools — they are not
+user behavior either before or after launch. Internal contributors
+who need to point a session at a dev or staging hosted environment
+continue to use the workflow documented in
+[Internal Hosted-Readiness Mode (Pre-Launch)](../how-to/internal-hosted-readiness.md).
+
+In other words: **the dev/staging override path is the same forever;
+only the user-facing defaults change at launch.**
+
+## Launch-day remediation commands
+
+These commands are what end users will run at launch in each
+readiness scenario the coordinator surfaces. They are copy-pasteable;
+each appears on its own line so a CLI nag panel can render them
+verbatim.
+
+```bash
+spec-kitty auth login
+```
+
+```bash
+spec-kitty upgrade --cli
+```
+
+```bash
+spec-kitty sync doctor
+```
+
+| Scenario at launch | Command users will run |
+|---|---|
+| Logged out on a connected Teamspace | `spec-kitty auth login` |
+| CLI upgrade required for compatibility with the hosted side | `spec-kitty upgrade --cli` |
+| Sync / tracker subsystem unreachable | `spec-kitty sync doctor` |
+
+The exact wording the CLI prints in each case is set by the
+readiness coordinator and its sister modules. This doc does not
+restate the byte-stable strings; it points the reader at them.
+
+## Operator playbook for the launch flip
+
+This is the high-level launch coordinator checklist, not a
+release-cut runbook. Exact versions, dates, and step ordering live
+in the release-cut documentation in `architecture/` and the
+`spec-kitty-saas` repo.
+
+1. Confirm the hosted side is generally available and the readiness
+   coordinator has clean dogfooding evidence behind
+   `SPEC_KITTY_ENABLE_SAAS_SYNC=1`.
+2. Cut a CLI release where the **default** behavior of the rollout
+   gate inverts: hosted readiness is on unless explicitly disabled.
+3. Update public docs (README, `docs/index.md`, the relevant
+   tutorials) to introduce Teamspace as **available** — never as
+   "always was". The current pre-launch local-first framing remains
+   the on-ramp.
+4. Move this doc from `docs/explanation/` to a launch-day "what's
+   new" location, or update its banner from
+   `Status: pre-launch` to `Status: launched` once the flip is
+   live. **Do not retroactively edit this doc as if its content
+   were always current.**
+5. Keep the internal hosted-readiness how-to in place; rewrite its
+   "When this page applies" section to reflect that the dev /
+   staging override path is now the only thing it covers.
+
+Step 3's "available — never as 'always was'" line is the load-bearing
+editorial rule. It is what keeps the launch honest.
+
+## What this doc deliberately does not specify
+
+- **Exact dates or version numbers.** Those live in the release-cut
+  runbook, not in a conceptual explanation doc.
+- **Server-side behavior.** Hosted-side changes are owned by the
+  `spec-kitty-saas` repo and its release notes.
+- **Marketing copy.** This doc speaks to operators planning the
+  flip; user-facing announcement copy is owned elsewhere.
+- **Migration steps for users who set `SPEC_KITTY_ENABLE_SAAS_SYNC=1`
+  pre-launch.** Their setup keeps working; the variable becomes a
+  no-op-redundant override at launch. If a deprecation is needed,
+  it ships in a separate release-cut PR.
+
+## Related
+
+- [Internal Hosted-Readiness Mode (Pre-Launch)](../how-to/internal-hosted-readiness.md)
+  — the active dogfooding doc for today.
+- [Recovery: Logged out on a connected teamspace](../recovery/logged-out-teamspace.md)
+  — the recovery contract that ships at launch unchanged.
+- [Environment variables reference](../reference/environment-variables.md)
+  — the canonical entries for `SPEC_KITTY_ENABLE_SAAS_SYNC` and
+  `SPEC_KITTY_SAAS_URL`.
+- [Upgrade the Spec Kitty CLI](../how-to/upgrade-cli.md)
+  — backs the `spec-kitty upgrade --cli` remediation snippet.

--- a/docs/explanation/toc.yml
+++ b/docs/explanation/toc.yml
@@ -30,3 +30,5 @@
   href: governed-profile-invocation.md
 - name: Understanding the Retrospective Learning Loop
   href: retrospective-learning-loop.md
+- name: Launch-Readiness Behavior (Coming Soon)
+  href: launch-readiness-future.md

--- a/docs/how-to/internal-hosted-readiness.md
+++ b/docs/how-to/internal-hosted-readiness.md
@@ -1,0 +1,165 @@
+---
+type: how-to
+audience: internal / pre-launch operators
+---
+
+# Internal Hosted-Readiness Mode (Pre-Launch)
+
+> **Audience:** internal contributors and dev operators who are dogfooding
+> the hidden hosted-readiness path. This page is **not** for end users.
+> The public Spec Kitty experience remains local-first; see the
+> [README](../../README.md) for the current default workflow.
+
+## When this page applies
+
+Read on if all of the following hold:
+
+- You are running a build of `spec-kitty-cli` that includes the SaaS
+  rollout gate (`src/specify_cli/saas/rollout.py`).
+- You want the CLI to surface Teamspace-aware readiness output —
+  hosted auth status, sync compatibility, tracker reachability — from
+  any `spec-kitty` command.
+- You accept that everything below is **pre-launch** and may change
+  without a deprecation window.
+
+If none of that applies, you want the local-first quick start, not this
+page.
+
+## How the hidden mode works (one-paragraph mental model)
+
+A single environment variable, `SPEC_KITTY_ENABLE_SAAS_SYNC`, gates every
+hosted code path. With the variable unset (or any non-truthy value), the
+central CLI startup readiness coordinator is a no-op: no Teamspace-labeled
+output, no hosted auth probe, no tracker calls. With the variable set
+to a truthy value (`1`, `true`, `yes`, `on`, case-insensitive), the
+coordinator wakes up and the hosted readiness states become observable.
+The byte-stable disabled-state message and the truthy-value contract are
+defined in [`src/specify_cli/saas/rollout.py`](../../src/specify_cli/saas/rollout.py)
+and asserted by tests; do not paraphrase that message in your own
+tooling.
+
+## Enable hosted readiness locally
+
+Run this in the shell where you want hosted output:
+
+```bash
+export SPEC_KITTY_ENABLE_SAAS_SYNC=1
+spec-kitty auth login
+```
+
+`spec-kitty auth login` is the canonical entry point for the hosted
+auth flow. It opens the browser-based login and persists credentials
+to the local keyring. After it succeeds, every subsequent `spec-kitty`
+command in the same shell session benefits from the hosted readiness
+output.
+
+To disable, unset the variable in the shell:
+
+```bash
+unset SPEC_KITTY_ENABLE_SAAS_SYNC
+```
+
+The coordinator goes back to no-op on the next command.
+
+## Point at a dev or staging hosted environment
+
+The internal dev / staging environments live at non-default URLs.
+`SPEC_KITTY_SAAS_URL` overrides the base URL the auth, tracker, and
+sync clients dial.
+
+```bash
+export SPEC_KITTY_ENABLE_SAAS_SYNC=1
+export SPEC_KITTY_SAAS_URL=https://spec-kitty-dev.fly.dev
+spec-kitty auth login
+```
+
+> **Important framing.** `SPEC_KITTY_SAAS_URL` is an internal **dev /
+> staging override**. It is not user behavior. End users — today and
+> at launch — never set it. If you are documenting end-user behavior,
+> reference the [launch-readiness-future](../explanation/launch-readiness-future.md)
+> doc, which describes the user-facing default URL.
+
+## Readiness states the coordinator surfaces
+
+With `SPEC_KITTY_ENABLE_SAAS_SYNC=1`, the coordinator (and its
+companion auth probe) classify the session into one of the buckets
+below. Sister missions are widening this enum; the table captures the
+operator-visible behavior, not the enum literal.
+
+| Session state | What the operator sees | Remediation |
+|---|---|---|
+| Hosted mode disabled (variable unset / falsy) | No Teamspace-labeled output. Coordinator is a no-op. The stable disabled-message string is emitted only by commands that explicitly ask for it (e.g., `spec-kitty sync now` without opt-in). | None — this is the local-first default. |
+| Hosted mode enabled, authenticated | Hosted output flows normally. | None. |
+| Hosted mode enabled, logged out on a connected Teamspace | Interactive: a Rich panel offers `[L]ogin / [S]kip / [Q]uit`. Non-interactive: a stable stderr line plus exit code `4`. See [Recovery: Logged out on a connected teamspace](../recovery/logged-out-teamspace.md). | `spec-kitty auth login` |
+| Hosted mode enabled, tracker unreachable | The relevant sync / tracker command surfaces the failure with a doctor pointer. | `spec-kitty sync doctor` |
+| Hosted mode enabled, CLI upgrade required | The startup-readiness path nag-renders the upgrade guidance (already gated by the Wave 1 suppression contract). | `spec-kitty upgrade --cli` |
+
+## Diagnose hosted readiness
+
+```bash
+spec-kitty sync doctor
+```
+
+`sync doctor` is the most informative single command in the
+hosted-mode-enabled path. It prints which sub-systems are reachable,
+what credentials are available, and which command would resolve each
+broken state. When the readiness coordinator fires the
+"logged out on a connected Teamspace" path, `sync doctor` will also
+offer the interactive recovery prompt.
+
+## Suppression contract
+
+The readiness coordinator honors the **Wave 1 suppression contract**
+byte-for-byte across three buckets:
+
+| Output policy | When it applies |
+|---|---|
+| `INTERACTIVE` | `stdin` is a TTY and `SPEC_KITTY_NON_INTERACTIVE` is not set. |
+| `NON_INTERACTIVE` | `stdin` is not a TTY, or `SPEC_KITTY_NON_INTERACTIVE=1`. |
+| `MACHINE_OUTPUT` | Commands that emit JSON or other machine surfaces; suppression is the default. |
+
+The canonical source for the policy precedence is the data-model
+section of the mission spec for the readiness coordinator
+(`kitty-specs/cli-startup-readiness-coordinator-skeleton-01KS7JRV/data-model.md`).
+The recovery doc covers the operator-visible behavior of each bucket;
+see [Recovery: Logged out on a connected teamspace](../recovery/logged-out-teamspace.md).
+
+## Verify locally end-to-end
+
+A minimal "did it really wire up?" recipe:
+
+```bash
+# 1. Confirm the variable is set and truthy in this shell.
+echo "${SPEC_KITTY_ENABLE_SAAS_SYNC}"
+
+# 2. Confirm the CLI sees hosted mode as enabled.
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 spec-kitty sync doctor
+
+# 3. Confirm the logged-out recovery surfaces in non-interactive mode.
+#    Expect exit code 4 and the structured stderr line documented in
+#    docs/recovery/logged-out-teamspace.md.
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NON_INTERACTIVE=1 \
+  spec-kitty sync now < /dev/null
+echo "exit=$?"
+```
+
+If step 2 prints local-only output, the variable did not propagate to
+the CLI's subprocess. Re-export and retry.
+
+## Related
+
+- [Recovery: Logged out on a connected teamspace](../recovery/logged-out-teamspace.md)
+- [Environment variables reference](../reference/environment-variables.md)
+  — full entries for `SPEC_KITTY_ENABLE_SAAS_SYNC` and
+  `SPEC_KITTY_SAAS_URL`.
+- [Upgrade the Spec Kitty CLI](upgrade-cli.md) — for the
+  `spec-kitty upgrade --cli` probe shown in the upgrade-required
+  scenario above.
+
+## Not for end users
+
+If you are documenting what end users will see, **stop reading this
+page** and switch to
+[Launch-Readiness Behavior (Coming Soon)](../explanation/launch-readiness-future.md).
+That doc owns the at-launch user-facing semantics; this doc owns the
+pre-launch internal operator experience.

--- a/docs/how-to/toc.yml
+++ b/docs/how-to/toc.yml
@@ -72,3 +72,5 @@
   href: use-retrospective-learning.md
 - name: Troubleshoot Charter Failures
   href: troubleshoot-charter.md
+- name: Internal Hosted-Readiness (Pre-Launch)
+  href: internal-hosted-readiness.md

--- a/docs/recovery/logged-out-teamspace.md
+++ b/docs/recovery/logged-out-teamspace.md
@@ -87,4 +87,7 @@ existing flows.
 - `spec-kitty auth login` -- the underlying login flow invoked by `L`.
 - `spec-kitty sync doctor` -- the most informative diagnostic when sync
   appears broken; will offer the recovery prompt when applicable.
+- [Internal Hosted-Readiness (Pre-Launch)](../how-to/internal-hosted-readiness.md)
+  -- the operator how-to for dogfooding the hidden hosted-readiness
+  mode that surfaces this recovery path.
 - Issue: [Priivacy-ai/spec-kitty#829](https://github.com/Priivacy-ai/spec-kitty/issues/829).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -82,6 +82,14 @@ export SPEC_KITTY_ENABLE_SAAS_SYNC=1
 spec-kitty auth login
 ```
 
+**See also**:
+- [Internal Hosted-Readiness (Pre-Launch)](../how-to/internal-hosted-readiness.md)
+  for the full operator walkthrough of the hidden hosted-readiness
+  mode this flag enables today.
+- [Launch-Readiness Behavior (Coming Soon)](../explanation/launch-readiness-future.md)
+  for how this variable's meaning changes at the public Teamspace
+  launch.
+
 ### SPEC_KITTY_SAAS_URL
 
 Override the Spec Kitty SaaS base URL.
@@ -93,6 +101,14 @@ Override the Spec Kitty SaaS base URL.
 export SPEC_KITTY_SAAS_URL=https://spec-kitty-dev.fly.dev
 spec-kitty auth login
 ```
+
+**See also**:
+- [Internal Hosted-Readiness (Pre-Launch)](../how-to/internal-hosted-readiness.md)
+  -- this URL override is a dev / staging tool used by internal
+  operators, not user behavior.
+- [Launch-Readiness Behavior (Coming Soon)](../explanation/launch-readiness-future.md)
+  -- the override remains internal-only after launch; only the
+  user-facing default URL changes.
 
 ---
 

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/meta.json
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/meta.json
@@ -1,0 +1,20 @@
+{
+  "created_at": "2026-05-22T11:24:49.444970+00:00",
+  "documentation_state": {
+    "coverage_percentage": 0.0,
+    "divio_types_selected": [],
+    "generators_configured": [],
+    "iteration_mode": "initial",
+    "last_audit_date": null,
+    "target_audience": "developers"
+  },
+  "friendly_name": "Launch Auth, Sync, and Upgrade Readiness Docs",
+  "mission_id": "01KS7PWKD4TRNYFV571XXW9KXG",
+  "mission_number": null,
+  "mission_slug": "launch-auth-sync-upgrade-readiness-docs-01KS7PWK",
+  "mission_type": "documentation",
+  "purpose_context": "Wave 1 (#1093) shipped the central CLI startup readiness coordinator and a stubbed AuthStatus enum behind SPEC_KITTY_ENABLE_SAAS_SYNC. Sister missions C/D/E widen the runtime surface. This mission writes the operator docs that explain (a) how pre-launch / internal operators dogfood the hidden hosted-readiness mode, (b) what behavior flips at the eventual public launch, (c) which copy-pasteable remediation commands resolve each readiness scenario. Docs-only, no code/test changes.",
+  "purpose_tldr": "Stage pre-launch operator + future-launch readiness docs for hosted SaaS sync without implying Teamspace is launched.",
+  "slug": "launch-auth-sync-upgrade-readiness-docs-01KS7PWK",
+  "target_branch": "main"
+}

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/plan.md
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan — Launch Auth, Sync, and Upgrade Readiness Docs
+
+Driven directly from `spec.md`. No interview questions; brief-intake mode.
+
+## Doc-site structure and audience separation
+
+The repo's docs follow the Diátaxis 4-quadrant layout under `docs/`:
+
+| Quadrant | Folder | Audience |
+|---|---|---|
+| Tutorials | `docs/tutorials/` | New users learning Spec Kitty. |
+| How-to | `docs/how-to/` | Operators solving a specific task. |
+| Reference | `docs/reference/` | Lookups (CLI, env vars, config). |
+| Explanation | `docs/explanation/` | Background / "why" / architecture. |
+
+Audience routing for this mission:
+
+- **Internal / pre-launch operators** — task-oriented, copy-pasteable
+  recipes. Belongs in `docs/how-to/`.
+- **Launch coordinators / readers thinking about the launch flip** —
+  conceptual background on what will change. Belongs in
+  `docs/explanation/`.
+
+The two docs cross-link to each other to keep the routes obvious from
+either entry point.
+
+## File surface
+
+| Action | Path | Type |
+|---|---|---|
+| Create | `docs/how-to/internal-hosted-readiness.md` | how-to (internal-audience) |
+| Create | `docs/explanation/launch-readiness-future.md` | explanation (future-launch labeled) |
+| Edit | `README.md` | one-line gating note next to the existing "Hosted Sync Workspaces" link |
+| Edit | `docs/how-to/toc.yml` | add the new how-to entry |
+| Edit | `docs/explanation/toc.yml` | add the new explanation entry |
+| Edit | `docs/recovery/logged-out-teamspace.md` | append a single "see also" bullet |
+| Edit | `docs/reference/environment-variables.md` | cross-link notes on `SPEC_KITTY_ENABLE_SAAS_SYNC` and `SPEC_KITTY_SAAS_URL` |
+| Edit | `CHANGELOG.md` | single `[Unreleased]` bullet |
+
+No other paths are touched. No code, no tests, no templates, no
+slash commands, no migrations.
+
+## Audience separation contract
+
+| Doc | Reader assumption | Allowed language |
+|---|---|---|
+| `README.md`, `docs/index.md` | End user, today, local-first. | "Optional", "opt-in", "later", "internal preview", "hosted is not yet generally available". Never: "launched", "now available", "generally available". |
+| `docs/how-to/internal-hosted-readiness.md` | Internal operator who has cloned the repo or has commit access; willing to set env vars. | "Pre-launch", "dev / staging", "internal hosted mode", "behind `SPEC_KITTY_ENABLE_SAAS_SYNC=1`". |
+| `docs/explanation/launch-readiness-future.md` | Reader planning the launch flip. | "At launch", "post-launch", "future", with a prominent banner that the doc describes behavior **not in effect today**. |
+
+This separation is the load-bearing structural decision of the mission.
+Every editorial choice in the WPs below must defer to this table.
+
+## Content outline — internal-hosted-readiness.md
+
+```markdown
+---
+type: how-to
+audience: internal / pre-launch operators
+---
+
+# Internal hosted-readiness mode (pre-launch)
+
+> Audience: internal contributors and dev operators dogfooding the
+> hidden hosted-readiness path. This page is **not** for end users —
+> see the public Quick Start for local-first usage.
+
+## When this page applies
+- The repo set you're testing has the SaaS rollout gate available
+  (`src/specify_cli/saas/rollout.py`).
+- You want the CLI to surface Teamspace-aware readiness output.
+
+## Enable the hidden hosted mode
+```bash
+export SPEC_KITTY_ENABLE_SAAS_SYNC=1
+spec-kitty auth login
+```
+
+(Then a "Verify locally" section, an "Override the SaaS URL" section
+for `SPEC_KITTY_SAAS_URL`, a readiness-state table, suppression-contract
+pointer, and "Not for end users" cross-link to the launch-future doc.)
+```
+
+## Content outline — launch-readiness-future.md
+
+```markdown
+---
+type: explanation
+audience: launch coordinators
+---
+
+# Launch-readiness behavior (coming soon)
+
+> **Status: pre-launch.** This page describes the Teamspace launch
+> behavior that the Spec Kitty CLI will adopt at the public launch
+> milestone. **None of this is in effect today.** For today's
+> local-first experience, see the [README](../../README.md). For the
+> internal hosted-readiness preview, see
+> [Internal hosted-readiness mode (pre-launch)](../how-to/internal-hosted-readiness.md).
+
+## What flips at launch
+- (Table of today vs at-launch for: SaaS URL default, sync default,
+  meaning of `SPEC_KITTY_ENABLE_SAAS_SYNC`, default tracker.)
+
+## Launch-day remediation commands
+```bash
+spec-kitty auth login
+spec-kitty upgrade --cli
+```
+
+(Then "Operator playbook for the flip", "Dev / staging overrides
+remain in effect — see internal doc", and a closing "out of scope"
+section.)
+```
+
+## Test strategy
+
+- **Render check:** the two new docs are valid Markdown and follow the
+  same fence / heading style as their siblings in `docs/how-to/` and
+  `docs/explanation/`.
+- **Cross-link check:** every relative link in the two new docs
+  resolves to a file that exists in this PR's tree.
+- **TOC check:** `docs/how-to/toc.yml` and `docs/explanation/toc.yml`
+  list the new files.
+- **Leakage check (AC-7):**
+  ```bash
+  grep -niE 'teamspace.*launch(ed)?|launched.*teamspace|now (generally|publicly) available' README.md docs/index.md
+  grep -niE 'spec-kitty.*saas.*launched|hosted.*generally available' README.md docs/index.md
+  ```
+  Both must return zero matches.
+- **CHANGELOG check:** `CHANGELOG.md` `[Unreleased]` section has the
+  new bullet and no other modifications.
+
+These checks are manual / grep-based, performed during phase 8 of the
+mission workflow (final intent-vs-outcome). They do not require new
+automated tests because the mission ships no code surface.
+
+## Dependencies
+
+| WP depends on | Lane hint |
+|---|---|
+| WP02 (launch doc) → WP01 (internal doc) | WP02 cross-links into WP01's file path, so WP01 lands first. |
+| WP03 (cross-links + CHANGELOG) → WP01 + WP02 | WP03 references both doc paths. |
+
+A single lane is sufficient (no real parallelism gain — every WP
+touches a small file set and depends on the prior).
+
+## Non-goals
+
+- No edits to `docs/1x/`, `docs/2x/`, or `docs/3x/` — those are
+  versioned archive surfaces with their own rules.
+- No edits to sister missions' draft mission directories under
+  `kitty-specs/`. If they leak files into the working tree during
+  concurrent execution, they belong to those missions, not this one.
+- No edits to existing public docs other than the one-line gating
+  note on the README, the env-var cross-links, and the recovery
+  see-also.
+
+## Risks (plan-level)
+
+- The README change must not balloon — keep it to a single sentence
+  next to the existing "Hosted Sync Workspaces" link.
+- The launch doc's banner must be visually unmistakable. Use a
+  blockquote with bold "Status: pre-launch" inside the first 5 lines
+  of the file.

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/spec.md
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/spec.md
@@ -1,0 +1,228 @@
+# Specification — Launch Auth, Sync, and Upgrade Readiness Docs
+
+**Mission slug**: `launch-auth-sync-upgrade-readiness-docs-01KS7PWK`
+**Mission type**: `documentation`
+**Target branch**: `main`
+**Tracking issue**: [Priivacy-ai/spec-kitty#1095](https://github.com/Priivacy-ai/spec-kitty/issues/1095) (Workstream 6)
+**Wave 1 dependency**: [#1093](https://github.com/Priivacy-ai/spec-kitty/issues/1093) — central CLI startup readiness coordinator (already merged)
+
+## TL;DR
+
+Stage two operator-facing docs — one for **internal / pre-launch** operators
+who dogfood the hidden hosted-readiness mode behind
+`SPEC_KITTY_ENABLE_SAAS_SYNC=1`, and one **future-launch** readiness doc
+that documents the launch-day behavior shift (labeled "coming soon /
+launch"). Keep the public README and docs index local-first; do not
+imply Teamspace is launched. Add copy-pasteable remediation snippets.
+
+## Problem statement
+
+Wave 1 (#1093) landed the central CLI startup readiness coordinator and a
+stubbed `AuthStatus` enum that fires only when `SPEC_KITTY_ENABLE_SAAS_SYNC`
+is truthy. Sister missions widen `AuthStatus`, render guidance from any
+command, surface a Teamspace-aware sync compatibility check, and reshape
+the upgrade-readiness UX. The runtime surface for these readiness states
+will exist on `main` before any public launch.
+
+Today there is no canonical operator doc explaining:
+
+1. How an internal / pre-launch operator turns the hidden hosted-readiness
+   mode on, what guidance the CLI surfaces, and how to verify locally.
+2. What behavior will flip on at the public launch (default SaaS URL,
+   sync-by-default, the meaning of the env var post-launch) so the
+   launch handoff has a reference doc to flip on.
+3. Which exact copy-pasteable commands a user runs in each readiness
+   scenario (logged out, tracker unreachable, upgrade required, …).
+
+Without these docs, internal operators cannot dogfood the readiness work
+that sister missions are landing, and the eventual launch has no
+operator-facing playbook ready to ship.
+
+## Operating rules (hard constraints)
+
+These constraints are inherited from `start-me-start-here.md` (WS6) and
+issue #1095, and are non-negotiable:
+
+- **Docs-only.** No CLI logic changes. No test changes. No new code
+  surfaces. The mission touches Markdown / YAML doc files only.
+- **Public docs MUST NOT imply Teamspace is launched.** The top-level
+  README and the public `docs/index.md` remain local-first. They may
+  link to the new internal / launch docs, but the link text must signal
+  that hosted is opt-in today and labeled future-launch for the launch
+  doc.
+- **Internal doc** describes `SPEC_KITTY_ENABLE_SAAS_SYNC=1` as an
+  internal / dev / pre-launch hosted mode. It must clearly distinguish
+  dev / staging URL overrides (`SPEC_KITTY_SAAS_URL`) from the future
+  launch-day user behavior.
+- **Launch doc** carries an explicit "coming soon / launch" header so
+  it cannot be mistaken for current behavior.
+- **Remediation commands are copy-pasteable** code blocks
+  (`spec-kitty auth login`, `spec-kitty upgrade --cli`, …) — not prose.
+- `unset GITHUB_TOKEN` before any `gh` writes.
+- No direct push to `main`. PR-bound.
+
+## Acceptance criteria
+
+Each criterion below maps to a verifiable artifact in this PR.
+
+### AC-1: Public docs stay local-first
+
+- The README's "Is It For You?" / "What It Provides" / "Quick Start"
+  copy continues to frame hosted as **optional / opt-in / later**.
+- The README's existing "Documentation → Hosted Sync Workspaces" link
+  carries a one-line gating note pointing readers to the internal
+  pre-launch doc when they need to know how the hidden mode behaves
+  today.
+- `grep -i -E 'teamspace.*launch(ed)?|launched.*teamspace|now (generally |publicly )?available' README.md docs/index.md` returns no
+  occurrences that imply current launched status.
+
+### AC-2: Internal / pre-launch operator doc exists
+
+Path: `docs/how-to/internal-hosted-readiness.md` (Diátaxis: how-to;
+audience: internal / pre-launch operators).
+
+Contents must include, at minimum:
+
+- An explicit header that this doc is for **internal / pre-launch
+  operators and core contributors**, not end users.
+- The single source of truth for `SPEC_KITTY_ENABLE_SAAS_SYNC` —
+  truthy values, byte-wise-stable disabled message reference, and a
+  note that with the flag unset the coordinator is a no-op.
+- How to enable hosted readiness locally:
+  ```bash
+  export SPEC_KITTY_ENABLE_SAAS_SYNC=1
+  spec-kitty auth login
+  ```
+- How to point a session at a dev / staging hosted environment via
+  `SPEC_KITTY_SAAS_URL` (clearly framed as a dev override, not a user
+  behavior).
+- Which readiness scenarios the CLI surfaces today (auth status:
+  logged-out-on-connected-teamspace, disabled, future widened states
+  from sister missions) with a one-line summary of what the coordinator
+  emits in each state.
+- A "verify locally" recipe an internal operator can run end-to-end.
+- Suppression contract pointer: a note that the coordinator honors the
+  Wave 1 suppression contract (interactive / non-interactive /
+  machine-output) byte-for-byte; link to the existing recovery doc and
+  the rollout-contract module.
+- "Not for end users — see [launch-readiness-future] for the
+  launch-day playbook" cross-link.
+
+### AC-3: Launch-readiness future doc exists
+
+Path: `docs/explanation/launch-readiness-future.md` (Diátaxis:
+explanation; audience: launch coordinators + operators planning the
+flip).
+
+Contents must include, at minimum:
+
+- A **prominent, unmistakable** future-launch banner at the top of the
+  doc (e.g., a blockquote `> Status: pre-launch — describes behavior
+  that ships at the public Teamspace launch; not in effect today.`).
+- The behavior shift the launch flips on, framed as a delta from
+  today's local-first default:
+  - The default SaaS URL on launch.
+  - The role of `SPEC_KITTY_ENABLE_SAAS_SYNC` post-launch (override
+    only — does **not** toggle availability for end users).
+  - Sync defaults and what "Teamspace-connected" means at launch.
+- Operator playbook for the launch flip itself (release-cut order,
+  what becomes user-facing, what stays internal).
+- Explicit "dev / staging URL overrides remain in effect for internal
+  hosted environments after launch; see [internal-hosted-readiness]
+  for details" cross-link.
+- Remediation commands users will see at launch (copy-pasteable):
+  ```bash
+  spec-kitty auth login
+  spec-kitty upgrade --cli
+  ```
+
+### AC-4: Remediation snippets are copy-pasteable
+
+Every remediation command appears in a fenced code block on its own
+line (no prose substitution required), in both the internal doc and
+the launch doc:
+
+- `spec-kitty auth login` — for hosted-tracker / connected-Teamspace
+  logged-out recovery.
+- `spec-kitty upgrade --cli` — the canonical CLI upgrade probe (prints
+  the right installer command for the detected install method, per
+  `docs/how-to/upgrade-cli.md`).
+- `spec-kitty sync doctor` — diagnostic in the hosted-mode-enabled
+  path.
+
+### AC-5: Cross-links from existing surfaces
+
+- `docs/how-to/toc.yml` lists the new internal doc.
+- `docs/explanation/toc.yml` lists the new launch-future doc.
+- `docs/recovery/logged-out-teamspace.md` gets a "see also" link to the
+  internal doc (one line, end of file).
+- `docs/reference/environment-variables.md`'s
+  `SPEC_KITTY_ENABLE_SAAS_SYNC` and `SPEC_KITTY_SAAS_URL` entries each
+  gain a "see [internal-hosted-readiness] for the full operator
+  walkthrough; see [launch-readiness-future] for launch-day behavior"
+  cross-link.
+
+### AC-6: CHANGELOG entry
+
+A single `[Unreleased]` bullet added per repo convention:
+
+```
+- Add pre-launch and launch-readiness operator docs for hosted SaaS
+  sync (#1095). Public docs remain local-first; hosted readiness
+  stays opt-in via SPEC_KITTY_ENABLE_SAAS_SYNC=1.
+```
+
+### AC-7: Operator leakage check passes
+
+The following commands run from the repo root return no
+launch-implying matches in public docs:
+
+```bash
+grep -niE 'teamspace.*launch(ed)?|launched.*teamspace|now (generally|publicly) available' README.md docs/index.md
+grep -niE 'spec-kitty.*saas.*launched|hosted.*generally available' README.md docs/index.md
+```
+
+The launch doc is allowed (and required) to use launch-implying
+language because it is explicitly labeled future-launch.
+
+## In scope
+
+- `README.md` — selectively. Only the existing hosted-sync / tracker
+  link area, to add a gating note.
+- `docs/how-to/internal-hosted-readiness.md` — new.
+- `docs/explanation/launch-readiness-future.md` — new.
+- `docs/how-to/toc.yml`, `docs/explanation/toc.yml` — TOC updates.
+- `docs/recovery/logged-out-teamspace.md` — single see-also link.
+- `docs/reference/environment-variables.md` — cross-link additions on
+  the two hosted env-var entries.
+- `CHANGELOG.md` — single `[Unreleased]` bullet.
+
+## Out of scope
+
+- Coordinator code in `src/specify_cli/readiness/` (Wave 1 + sister
+  missions C/D own that).
+- Tracker client behavior (Mission E owns that).
+- SaaS-side docs (separate repo — `spec-kitty-saas`).
+- Marketing copy. The mission writes technical operator-facing prose
+  only.
+- Renaming or removing existing public docs. Additive only on the
+  public surface.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Launch doc leaks as current behavior if banner is missed | AC-3 mandates a prominent banner; AC-7 leakage check verifies public docs separately. |
+| Internal doc becomes stale when sister missions widen `AuthStatus` | Internal doc references the rollout-contract module and existing recovery doc rather than restating enum values; that keeps it stable across sister-mission landings. |
+| Concurrent sister missions touch the same files | This mission only touches docs, README sync-link area, CHANGELOG, env-var reference, and recovery see-also. None of those are sister-mission targets. |
+| CHANGELOG conflicts on merge | Single `[Unreleased]` bullet — conflicts are trivial. |
+
+## References
+
+- WS6 brief: `start-me-start-here.md`
+- Wave 1 PR: #1282 (commit `77c1647e7`)
+- Recovery doc baseline: `docs/recovery/logged-out-teamspace.md`
+- Env-var reference: `docs/reference/environment-variables.md`
+- Upgrade-CLI doc: `docs/how-to/upgrade-cli.md`
+- Rollout contract module: `src/specify_cli/saas/rollout.py`
+- Readiness coordinator module: `src/specify_cli/readiness/coordinator.py`

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks.md
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks.md
@@ -1,0 +1,118 @@
+# Tasks — Launch Auth, Sync, and Upgrade Readiness Docs
+
+## Work package decomposition
+
+Three small WPs, sequenced.
+
+| WP | Title | Owned files | Depends on |
+|---|---|---|---|
+| WP01 | Author internal / pre-launch hosted-readiness how-to | `docs/how-to/internal-hosted-readiness.md` | — |
+| WP02 | Author launch-readiness-future explanation doc | `docs/explanation/launch-readiness-future.md` | WP01 |
+| WP03 | Cross-links + README gating note + env-var cross-links + CHANGELOG | `README.md`, `docs/how-to/toc.yml`, `docs/explanation/toc.yml`, `docs/recovery/logged-out-teamspace.md`, `docs/reference/environment-variables.md`, `CHANGELOG.md` | WP01, WP02 |
+
+All WPs land in a single execution lane.
+
+## WP01 — Internal / pre-launch hosted-readiness how-to
+
+**Goal:** ship `docs/how-to/internal-hosted-readiness.md` per the
+content outline in `plan.md`.
+
+**Acceptance:**
+
+- Frontmatter declares `type: how-to`, `audience: internal /
+  pre-launch operators`.
+- Opens with an explicit "Audience: internal contributors and dev
+  operators" blockquote.
+- Contains exactly these copy-pasteable code blocks (verbatim):
+  - `export SPEC_KITTY_ENABLE_SAAS_SYNC=1` followed by
+    `spec-kitty auth login`.
+  - `export SPEC_KITTY_SAAS_URL=https://spec-kitty-dev.fly.dev`
+    framed explicitly as a dev / staging override.
+  - `spec-kitty sync doctor` as the diagnostic recipe.
+- Includes a readiness-state table summarizing the coordinator's
+  output buckets (disabled, enabled / authenticated, enabled /
+  logged-out-on-connected-teamspace, …).
+- Points at `src/specify_cli/saas/rollout.py` and
+  `docs/recovery/logged-out-teamspace.md` as authoritative for byte-
+  stable wording.
+- Closing "Not for end users — see [launch-readiness-future]"
+  cross-link is present (target file will exist after WP02).
+
+**Non-goals:** no enum value restatement; no CLI behavior changes; no
+new env vars.
+
+## WP02 — Launch-readiness future explanation doc
+
+**Goal:** ship `docs/explanation/launch-readiness-future.md` per the
+content outline in `plan.md`.
+
+**Acceptance:**
+
+- Frontmatter declares `type: explanation`, `audience: launch
+  coordinators`.
+- First non-frontmatter line is a blockquote banner:
+  `> **Status: pre-launch.** This page describes behavior that ships
+  at the public Teamspace launch milestone. **None of this is in
+  effect today.**`
+- Contains a today-vs-at-launch table covering: default SaaS URL,
+  sync default, meaning of `SPEC_KITTY_ENABLE_SAAS_SYNC`, default
+  tracker, default `spec-kitty auth login` flow.
+- Operator playbook section enumerates the launch-flip steps at a
+  high level (release-cut order, what becomes user-facing, what
+  stays internal). No exact dates or version numbers — those belong
+  to a release-cut runbook, not this conceptual doc.
+- Cross-links to `docs/how-to/internal-hosted-readiness.md` for the
+  dev / staging override path.
+- Closing "Out of scope" section lists what this doc deliberately
+  does not specify.
+
+## WP03 — Cross-links + README gating note + env-var cross-links + CHANGELOG
+
+**Goal:** stitch the new docs into the rest of the site and ship the
+CHANGELOG entry.
+
+**Acceptance:**
+
+1. `README.md`: the existing "Hosted Sync Workspaces" link entry under
+   "Deeper topics" gains a one-line gating note (e.g.,
+   `Internal / pre-launch operators dogfooding the hidden hosted
+   mode: see Internal hosted-readiness mode (pre-launch).`) pointing
+   at the new internal doc. No other README edits.
+2. `docs/how-to/toc.yml`: a new entry
+   `- name: Internal Hosted-Readiness (Pre-Launch)` /
+   `href: internal-hosted-readiness.md` is added in an
+   audience-appropriate spot (near the other operator / install
+   entries; not at the very top of the user how-to list).
+3. `docs/explanation/toc.yml`: a new entry
+   `- name: Launch-Readiness Behavior (Coming Soon)` /
+   `href: launch-readiness-future.md` is added.
+4. `docs/recovery/logged-out-teamspace.md`: append one line to the
+   "Related" list pointing to the internal doc.
+5. `docs/reference/environment-variables.md`:
+   - `SPEC_KITTY_ENABLE_SAAS_SYNC` section gets one closing line
+     pointing to the internal doc and the launch-future doc.
+   - `SPEC_KITTY_SAAS_URL` section gets one closing line pointing to
+     the same two docs.
+6. `CHANGELOG.md`: a single bullet under `[Unreleased]`:
+   ```
+   - Add pre-launch and launch-readiness operator docs for hosted SaaS
+     sync (#1095). Public docs remain local-first; hosted readiness
+     stays opt-in via SPEC_KITTY_ENABLE_SAAS_SYNC=1.
+   ```
+
+**Leakage gate (final WP03 check):**
+
+```bash
+grep -niE 'teamspace.*launch(ed)?|launched.*teamspace|now (generally|publicly) available' README.md docs/index.md
+```
+
+Must return zero matches before the WP closes.
+
+## Sequencing
+
+```
+WP01 ─▶ WP02 ─▶ WP03
+```
+
+Single lane; each WP fully closes before the next opens to keep the
+cross-links coherent.

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks/WP01.md
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks/WP01.md
@@ -1,0 +1,34 @@
+---
+wp_id: WP01
+title: Author internal / pre-launch hosted-readiness how-to
+depends_on: []
+owned_files:
+  - docs/how-to/internal-hosted-readiness.md
+lane: a
+---
+
+# WP01 — Internal / pre-launch hosted-readiness how-to
+
+See `kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks.md`
+for acceptance criteria.
+
+## Scope
+
+Ship `docs/how-to/internal-hosted-readiness.md`. Audience: internal /
+pre-launch operators. Diátaxis quadrant: how-to.
+
+## Acceptance
+
+- Frontmatter `type: how-to`, audience marked.
+- "Audience" blockquote at top.
+- Copy-pasteable code blocks for:
+  - enabling the hidden hosted mode (`SPEC_KITTY_ENABLE_SAAS_SYNC=1`
+    + `spec-kitty auth login`),
+  - dev/staging URL override (`SPEC_KITTY_SAAS_URL`),
+  - diagnostic (`spec-kitty sync doctor`).
+- Readiness-state table covering disabled vs enabled vs logged-out
+  scenarios.
+- Pointer to `src/specify_cli/saas/rollout.py` for byte-stable
+  wording.
+- Closing "Not for end users" cross-link to the launch-future doc
+  (path will exist after WP02).

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks/WP02.md
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks/WP02.md
@@ -1,0 +1,33 @@
+---
+wp_id: WP02
+title: Author launch-readiness-future explanation doc
+depends_on: [WP01]
+owned_files:
+  - docs/explanation/launch-readiness-future.md
+lane: a
+---
+
+# WP02 — Launch-readiness future explanation doc
+
+See `kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks.md`
+for acceptance criteria.
+
+## Scope
+
+Ship `docs/explanation/launch-readiness-future.md`. Audience: launch
+coordinators + operators planning the flip. Diátaxis quadrant:
+explanation.
+
+## Acceptance
+
+- Frontmatter `type: explanation`, audience marked.
+- First non-frontmatter line: prominent blockquote labeled
+  `**Status: pre-launch.**` that states the doc is **not in effect
+  today**.
+- Today-vs-at-launch table covering: default SaaS URL, sync default,
+  meaning of `SPEC_KITTY_ENABLE_SAAS_SYNC`, default tracker, default
+  `spec-kitty auth login` flow.
+- Operator playbook: launch-flip steps, what becomes user-facing,
+  what stays internal.
+- Cross-link to the WP01 internal doc for dev/staging override.
+- Closing "Out of scope" section.

--- a/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks/WP03.md
+++ b/kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks/WP03.md
@@ -1,0 +1,46 @@
+---
+wp_id: WP03
+title: Cross-links + README gating note + env-var cross-links + CHANGELOG
+depends_on: [WP01, WP02]
+owned_files:
+  - README.md
+  - docs/how-to/toc.yml
+  - docs/explanation/toc.yml
+  - docs/recovery/logged-out-teamspace.md
+  - docs/reference/environment-variables.md
+  - CHANGELOG.md
+lane: a
+---
+
+# WP03 — Cross-links, gating note, CHANGELOG
+
+See `kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/tasks.md`
+for acceptance criteria.
+
+## Scope
+
+Stitch the WP01/WP02 docs into the rest of the site and add the
+CHANGELOG entry. Pure cross-linking + one-line edits.
+
+## Acceptance
+
+- README gets a one-line gating note next to the existing "Hosted
+  Sync Workspaces" link entry. No other README copy changes.
+- Both TOCs (`docs/how-to/toc.yml`, `docs/explanation/toc.yml`) list
+  the new docs.
+- `docs/recovery/logged-out-teamspace.md` "Related" list appends one
+  link to the internal doc.
+- `docs/reference/environment-variables.md`:
+  `SPEC_KITTY_ENABLE_SAAS_SYNC` and `SPEC_KITTY_SAAS_URL` entries
+  each gain one closing line cross-linking to both new docs.
+- `CHANGELOG.md` `[Unreleased]` gets one bullet announcing the docs.
+
+## Leakage gate
+
+Before closing the WP, run:
+
+```bash
+grep -niE 'teamspace.*launch(ed)?|launched.*teamspace|now (generally|publicly) available' README.md docs/index.md
+```
+
+Must return zero matches.


### PR DESCRIPTION
## Summary

Stages two new operator-facing docs and a small set of cross-link
edits so internal / pre-launch operators can dogfood the hidden
hosted-readiness mode behind \`SPEC_KITTY_ENABLE_SAAS_SYNC=1\`, and
so the public Teamspace launch has a ready operator playbook
behind an explicit "coming soon / launch" banner. **No code or
test changes.**

- \`docs/how-to/internal-hosted-readiness.md\` (new) — pre-launch
  internal operator how-to. Copy-pasteable enable command,
  \`SPEC_KITTY_SAAS_URL\` dev/staging override framing, readiness-state
  table, \`spec-kitty sync doctor\` recipe, suppression-contract
  pointer to \`docs/recovery/logged-out-teamspace.md\` and
  \`src/specify_cli/saas/rollout.py\`.
- \`docs/explanation/launch-readiness-future.md\` (new) — future-launch
  conceptual doc with a prominent \`Status: pre-launch\` blockquote at
  the top. Today-vs-at-launch delta table, launch playbook, copy-
  pasteable remediation snippets (\`spec-kitty auth login\`,
  \`spec-kitty upgrade --cli\`, \`spec-kitty sync doctor\`).
- \`README.md\` — single one-line gating note next to the existing
  "Hosted Sync Workspaces" link entry.
- \`docs/how-to/toc.yml\` and \`docs/explanation/toc.yml\` — TOC entries
  for the two new docs.
- \`docs/recovery/logged-out-teamspace.md\` — single "see also"
  pointer to the internal doc.
- \`docs/reference/environment-variables.md\` — cross-link blocks on
  the \`SPEC_KITTY_ENABLE_SAAS_SYNC\` and \`SPEC_KITTY_SAAS_URL\` entries.
- \`CHANGELOG.md\` — single Unreleased bullet.
- \`kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/\`
  — mission brief, spec, plan, three WPs.

Closes the docs slice of [WS6 / issue #1095](https://github.com/Priivacy-ai/spec-kitty/issues/1095). Builds on
[#1093](https://github.com/Priivacy-ai/spec-kitty/issues/1093)
(central CLI startup readiness coordinator).

## Evidence

- Mission: \`kitty-specs/launch-auth-sync-upgrade-readiness-docs-01KS7PWK/\`
- AC-7 leakage gate on \`README.md\` and \`docs/index.md\`: clean (no
  launch-implying matches).
- Public-docs framing: README continues to say "optional / opt-in /
  later"; the launch doc carries an explicit
  \`Status: pre-launch\` banner; the internal doc opens with an
  "internal contributors only" callout.
- Cross-links: env-var reference, recovery doc, README, and both
  TOCs all point at the two new docs.
- Intent-vs-outcome: every acceptance criterion in
  \`spec.md\` is satisfied by the files in the diff.

## Test plan

- [ ] Render the new docs in your local docs viewer (or open them as
      plain Markdown on GitHub) and confirm the
      \`docs/explanation/launch-readiness-future.md\` banner is
      visually unmistakable.
- [ ] Re-run AC-7 leakage gate:
      \`grep -niE 'teamspace.*launch(ed)?|launched.*teamspace|now (generally|publicly) available' README.md docs/index.md\` — must return zero matches.
- [ ] Confirm every relative link in the two new docs resolves to a
      file that exists in this PR's tree.
- [ ] Confirm \`CHANGELOG.md\` \`[Unreleased]\` has exactly one new bullet
      and no other modifications.

## Operating-rule compliance

- Docs-only change. No CLI logic edits, no test edits.
- \`unset GITHUB_TOKEN\` was used before opening this PR.
- PR targets \`main\`; no direct push.
- Pre-launch language is contained to the internal/launch docs;
  public surfaces remain local-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)