### PR TITLE
fix: record baseline merge commit metadata during merge

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -56,7 +56,7 @@ from specify_cli.merge.state import (
     release_merge_lock,
     save_state,
 )
-from specify_cli.mission_metadata import resolve_mission_identity, write_meta
+from specify_cli.mission_metadata import load_meta, resolve_mission_identity, write_meta
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace, get_merge_runtime_dir
 from specify_cli.post_merge.review_artifact_consistency import (
     REJECTED_REVIEW_ARTIFACT_CONFLICT,
@@ -787,6 +787,49 @@ def _emit_merge_diff_summary(
     )
 
 
+def _record_baseline_merge_commit(
+    feature_dir: Path,
+    baseline_commit: str | None,
+) -> Path | None:
+    """Persist the post-merge review baseline in mission meta.json.
+
+    ``baseline_merge_commit`` anchors post-merge review diffs. It should point
+    at the target-branch baseline before the mission lands, not at the final
+    housekeeping commit produced by merge.
+    """
+    if not baseline_commit or not baseline_commit.strip():
+        return None
+
+    meta_path = feature_dir / "meta.json"
+    if not meta_path.exists():
+        logger.warning(
+            "Cannot record baseline_merge_commit for %s: meta.json is missing",
+            feature_dir.name,
+        )
+        return None
+
+    try:
+        meta = load_meta(feature_dir)
+    except ValueError as exc:
+        logger.warning(
+            "Cannot record baseline_merge_commit for %s: %s",
+            feature_dir.name,
+            exc,
+        )
+        return None
+
+    if meta is None:
+        return None
+
+    existing = meta.get("baseline_merge_commit")
+    if existing and str(existing).strip():
+        return None
+
+    meta["baseline_merge_commit"] = baseline_commit.strip()
+    write_meta(feature_dir, meta, validate=False)
+    return meta_path
+
+
 def _validate_target_branch(
     repo_root: Path,
     mission_slug: str | None,
@@ -1223,14 +1266,14 @@ def _run_lane_based_merge_locked(
                     console.print(f"  [red]✗[/red] {lane.lane_id}: {error}")
                 raise typer.Exit(1)
 
-    # -- Capture merge-base SHA for post-merge stale-assertion check (T013) --
-    _ret, merge_base_sha, _err = run_command(
-        ["git", "merge-base", "HEAD", lanes_manifest.target_branch],
+    # -- Capture target baseline SHA for post-merge diff/review checks (T013) --
+    _ret, target_baseline_sha, _err = run_command(
+        ["git", "rev-parse", lanes_manifest.target_branch],
         capture=True,
         check_return=False,
         cwd=main_repo,
     )
-    merge_base_sha = merge_base_sha.strip() if _ret == 0 else "HEAD~1"
+    target_baseline_sha = target_baseline_sha.strip() if _ret == 0 else "HEAD~1"
 
     # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
     # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
@@ -1306,6 +1349,11 @@ def _run_lane_based_merge_locked(
             (_out_refresh or _err_refresh or "").strip(),
         )
 
+    baseline_meta_path = _record_baseline_merge_commit(
+        feature_dir,
+        target_baseline_sha,
+    )
+
     # -- T001: Mark WPs done with per-WP state tracking --
     console.print("  [dim]Recording merged work packages as done...[/dim]")
     for lane in lanes_manifest.lanes:
@@ -1343,6 +1391,8 @@ def _run_lane_based_merge_locked(
             f"kitty-specs/{mission_slug}/status.events.jsonl",
             f"kitty-specs/{mission_slug}/status.json",
         }
+        if baseline_meta_path is not None:
+            expected_paths.add(str(baseline_meta_path.relative_to(main_repo)))
         offending_lines, _skipped_untracked = _classify_porcelain_lines(
             (_out_status or "").splitlines(),
             expected_paths,
@@ -1377,12 +1427,16 @@ def _run_lane_based_merge_locked(
         )
 
     # -- T012: FR-019 — Persist done events to git BEFORE any worktree removal --
+    files_to_commit = [
+        feature_dir / "status.events.jsonl",
+        feature_dir / "status.json",
+    ]
+    if baseline_meta_path is not None:
+        files_to_commit.append(baseline_meta_path)
+
     safe_commit(
         repo_path=main_repo,
-        files_to_commit=[
-            feature_dir / "status.events.jsonl",
-            feature_dir / "status.json",
-        ],
+        files_to_commit=files_to_commit,
         commit_message=f"chore({mission_slug}): record done transitions for merged WPs",
         allow_empty=False,
     )
@@ -1398,7 +1452,7 @@ def _run_lane_based_merge_locked(
     console.print("  [dim]Running stale-assertion check...[/dim]")
     try:
         stale_report: StaleAssertionReport = run_check(
-            base_ref=merge_base_sha,
+            base_ref=target_baseline_sha,
             head_ref="HEAD",
             repo_root=main_repo,
         )
@@ -1490,7 +1544,7 @@ def _run_lane_based_merge_locked(
     _emit_merge_diff_summary(
         repo_root=main_repo,
         mission_id=canonical_id,
-        base_ref=merge_base_sha,
+        base_ref=target_baseline_sha,
     )
 
     emit_mission_closed(

--- a/tests/cli/commands/test_merge_status_commit.py
+++ b/tests/cli/commands/test_merge_status_commit.py
@@ -19,7 +19,11 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-from specify_cli.cli.commands.merge import _mark_wp_merged_done, _run_lane_based_merge
+from specify_cli.cli.commands.merge import (
+    _mark_wp_merged_done,
+    _record_baseline_merge_commit,
+    _run_lane_based_merge,
+)
 from specify_cli.merge.config import MergeStrategy
 
 pytestmark = pytest.mark.git_repo
@@ -86,6 +90,49 @@ def _seed_status_event(feature_dir: Path, mission_slug: str, wp_id: str, to_lane
     jsonl_path = feature_dir / "status.events.jsonl"
     with jsonl_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _write_meta(feature_dir: Path, mission_slug: str, **overrides: object) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {
+        "created_at": "2026-04-07T00:00:00+00:00",
+        "friendly_name": mission_slug.replace("-", " "),
+        "mission_id": "01KTESTMISSIONID00000000000",
+        "mission_number": None,
+        "mission_slug": mission_slug,
+        "mission_type": "software-dev",
+        "slug": mission_slug,
+        "target_branch": "main",
+    }
+    meta.update(overrides)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestBaselineMergeCommitMetadata:
+    def test_record_baseline_merge_commit_fills_blank_field(self, tmp_path: Path) -> None:
+        mission_slug = "068-baseline-meta"
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        _write_meta(feature_dir, mission_slug, baseline_merge_commit=None)
+
+        result = _record_baseline_merge_commit(feature_dir, "abc123def456")
+
+        assert result == feature_dir / "meta.json"
+        data = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert data["baseline_merge_commit"] == "abc123def456"
+
+    def test_record_baseline_merge_commit_preserves_existing_value(self, tmp_path: Path) -> None:
+        mission_slug = "068-baseline-preserve"
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        _write_meta(feature_dir, mission_slug, baseline_merge_commit="already-set")
+
+        result = _record_baseline_merge_commit(feature_dir, "new-value")
+
+        assert result is None
+        data = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert data["baseline_merge_commit"] == "already-set"
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +286,74 @@ class TestSafeCommitCalledAfterMarkDoneLoop:
             )
 
         mock_dossier.assert_called_once_with(feature_dir, mission_slug, tmp_path)
+
+    def test_merge_commits_baseline_merge_commit_metadata(self, tmp_path: Path) -> None:
+        mission_slug = "068-test-baseline"
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        feature_dir.mkdir(parents=True)
+        _write_meta(feature_dir, mission_slug, baseline_merge_commit=None)
+        _seed_mission_branch(tmp_path, mission_slug)
+
+        manifest = MagicMock()
+        manifest.target_branch = "main"
+        manifest.mission_branch = f"kitty/mission-{mission_slug}"
+
+        lane_a = MagicMock()
+        lane_a.lane_id = "lane-a"
+        lane_a.wp_ids = ["WP01"]
+        manifest.lanes = [lane_a]
+
+        lane_result = MagicMock(success=True, errors=[])
+        mission_result = MagicMock(success=True, commit="merged123", errors=[])
+
+        with (
+            patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
+            patch("specify_cli.cli.commands.merge.load_state", return_value=None),
+            patch("specify_cli.cli.commands.merge.save_state"),
+            patch("specify_cli.cli.commands.merge.get_main_repo_root", return_value=tmp_path),
+            patch("specify_cli.cli.commands.merge._enforce_target_branch_sync_preflight"),
+            patch("specify_cli.status.lane_reader.get_wp_lane", return_value="done"),
+            patch("specify_cli.lanes.merge.merge_lane_to_mission", return_value=lane_result),
+            patch("specify_cli.lanes.merge.merge_mission_to_target", return_value=mission_result),
+            patch("specify_cli.cli.commands.merge._mark_wp_merged_done"),
+            patch("specify_cli.cli.commands.merge.safe_commit", return_value=True) as mock_safe_commit,
+            patch("specify_cli.post_merge.stale_assertions.run_check") as mock_run_check,
+            patch("specify_cli.policy.merge_gates.evaluate_merge_gates") as mock_gates,
+            patch("specify_cli.policy.config.load_policy_config") as mock_policy,
+            patch("specify_cli.cli.commands.merge.run_command", return_value=(0, "base123", "")),
+            patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
+            patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
+            patch("specify_cli.cli.commands.merge.clear_state"),
+            patch("specify_cli.cli.commands.merge.emit_mission_closed"),
+            patch("specify_cli.merge.state.MergeState"),
+            patch("specify_cli.cli.commands.merge.trigger_feature_dossier_sync_if_enabled"),
+        ):
+            stale_report = MagicMock()
+            stale_report.findings = []
+            mock_run_check.return_value = stale_report
+
+            gate_eval = MagicMock()
+            gate_eval.overall_pass = True
+            gate_eval.gates = []
+            mock_gates.return_value = gate_eval
+
+            policy = MagicMock()
+            policy.merge_gates = []
+            mock_policy.return_value = policy
+
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=mission_slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+            )
+
+        data = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert data["baseline_merge_commit"] == "base123"
+        files = mock_safe_commit.call_args.kwargs["files_to_commit"]
+        assert feature_dir / "meta.json" in files
 
 
 class TestMergeDoneTransitions:


### PR DESCRIPTION
## Summary
- record `meta.json.baseline_merge_commit` during `spec-kitty merge` when it is missing or blank
- capture the target branch tip before the mission lands so review diffs have the correct baseline anchor
- include `meta.json` in the post-merge housekeeping commit alongside status files
- add regression coverage for blank-field population, existing-value preservation, and merge-flow commit inclusion

## Verification
- `uv run pytest tests/cli/commands/test_merge_status_commit.py tests/specify_cli/cli/commands/review/test_dead_code_baseline.py tests/specify_cli/cli/commands/review/test_mode_resolution.py -q`
- `uv run ruff check src/specify_cli/cli/commands/merge.py tests/cli/commands/test_merge_status_commit.py`
