### PR TITLE
test: run e2e ceremonies off protected main

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,6 +20,7 @@ from tests.test_isolation_helpers import get_installed_version, run_cli_subproce
 from specify_cli.migration.schema_version import MAX_SUPPORTED_SCHEMA, SCHEMA_CAPABILITIES
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+E2E_CEREMONY_BRANCH = "e2e-ceremony"
 
 
 @pytest.fixture(autouse=True)
@@ -185,6 +186,16 @@ def format_subprocess_failure(
     )
 
 
+def _checkout_e2e_ceremony_branch(project: Path) -> None:
+    """Run ceremony-writing E2E workflows away from protected main/master."""
+    subprocess.run(
+        ["git", "checkout", "-b", E2E_CEREMONY_BRANCH],
+        cwd=project,
+        check=True,
+        capture_output=True,
+    )
+
+
 @pytest.fixture()
 def e2e_project(tmp_path: Path) -> Path:
     """Create a temporary Spec Kitty project with git and .kittify initialized.
@@ -193,6 +204,7 @@ def e2e_project(tmp_path: Path) -> Path:
     - Copies .kittify from the real repo root
     - Copies missions from src/specify_cli/missions/
     - Initializes git with main branch and initial commit
+    - Checks out an E2E ceremony branch for workflow write operations
     - Aligns metadata version with source to avoid mismatch errors
     """
     project = tmp_path / "e2e-project"
@@ -280,6 +292,7 @@ def e2e_project(tmp_path: Path) -> Path:
         check=True,
         capture_output=True,
     )
+    _checkout_e2e_ceremony_branch(project)
 
     return project
 
@@ -354,5 +367,6 @@ def fresh_e2e_project(tmp_path: Path) -> Path:
         check=True,
         capture_output=True,
     )
+    _checkout_e2e_ceremony_branch(project)
 
     return project


### PR DESCRIPTION
## Summary

Fixes the post-merge main CI `e2e-cross-cutting` failure after #1287 by checking out a non-protected fixture branch before E2E tests invoke ceremony-writing mission commands.

The product guard is correct: `setup-plan`/`finalize-tasks` should not create ceremony commits on protected `main`/`master`. These workflow E2E fixtures now model the intended operator context instead of running those commands on `main`.

## Verification

- [x] `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python -m pytest tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_setup_plan tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_full_workflow_sequence tests/e2e/test_charter_epic_golden_path.py::test_charter_epic_golden_path -q` — 3 passed
- [x] `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python -m pytest -v tests/e2e/ tests/cross_cutting/ -m "not distribution and not windows_ci" --cov=src/specify_cli --cov=src/charter --cov=src/doctrine --cov-report=xml:out/reports/coverage/coverage-e2e.xml --junitxml=out/reports/xunit-reports/xunit-result-e2e-local.xml` — original protected-branch failures pass; local environment lacks `mypy`, causing only `test_mission_step_contracts_executor_is_mypy_strict_clean` to fail locally before completion
