### PR TITLE
fix: address overnight SonarCloud findings

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -617,27 +617,39 @@ def _workflow_evidence_missing(feature_dir: Path) -> bool:
 def _contains_workflow_run_id(text: str) -> bool:
     """Return True when evidence text includes a standalone GitHub Actions run id."""
 
-    optional_prefixes = ("successful ", "github actions ")
-
     for raw_line in text.splitlines():
-        normalized = " ".join(raw_line.strip().lower().split())
-        if not normalized:
+        normalized = _normalize_workflow_evidence_line(raw_line)
+        if normalized is None:
             continue
-        for prefix in optional_prefixes:
-            if normalized.startswith(prefix):
-                normalized = normalized[len(prefix) :]
-        if normalized.startswith("run id"):
-            remainder = normalized[len("run id") :]
-        elif normalized.startswith("run"):
-            remainder = normalized[len("run") :]
-        else:
+        remainder = _extract_workflow_run_remainder(normalized)
+        if remainder is None:
             continue
-        remainder = remainder.lstrip()
-        if remainder[:1] in ":#-":
-            remainder = remainder[1:].lstrip()
         if remainder.isdigit() and len(remainder) >= 5:
             return True
     return False
+
+
+def _normalize_workflow_evidence_line(raw_line: str) -> str | None:
+    normalized = " ".join(raw_line.strip().lower().split())
+    if not normalized:
+        return None
+    for prefix in ("successful ", "github actions "):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+    return normalized
+
+
+def _extract_workflow_run_remainder(normalized: str) -> str | None:
+    if normalized.startswith("run id"):
+        remainder = normalized[len("run id") :]
+    elif normalized.startswith("run"):
+        remainder = normalized[len("run") :]
+    else:
+        return None
+    remainder = remainder.lstrip()
+    if remainder[:1] in ":#-":
+        remainder = remainder[1:].lstrip()
+    return remainder
 
 
 def _check_workflow_run_evidence(

--- a/src/specify_cli/compat/cache.py
+++ b/src/specify_cli/compat/cache.py
@@ -33,6 +33,7 @@ _LOG = logging.getLogger(__name__)
 
 _MAX_FILE_BYTES: int = 65_536  # 64 KiB defensive bound
 _CACHE_FILE_NAME: str = "upgrade-nag.json"
+_VALID_LATEST_SOURCES: frozenset[str] = frozenset({"pypi", "none"})
 
 
 # ---------------------------------------------------------------------------
@@ -127,67 +128,22 @@ class NagCacheRecord:
             ValueError: If a field has an unexpected type or value.
         """
         cli_version_key = _require_str(data, "cli_version_key")
-        latest_version_raw = data.get("latest_version")
-        if latest_version_raw is not None and not isinstance(latest_version_raw, str):
-            raise ValueError(f"latest_version must be str or null, got {type(latest_version_raw)}")
-        # latest_version_raw is str after the isinstance check above (or None).
-        latest_version = latest_version_raw if isinstance(latest_version_raw, str) else None
+        latest_version = _optional_str(data, "latest_version")
         latest_source_raw = _require_str(data, "latest_source")
-        if latest_source_raw not in ("pypi", "none"):
+        if latest_source_raw not in _VALID_LATEST_SOURCES:
             raise ValueError(f"latest_source must be 'pypi' or 'none', got {latest_source_raw!r}")
         latest_source: Literal["pypi", "none"] = "pypi" if latest_source_raw == "pypi" else "none"
         fetched_at = _iso_to_dt(_require_str(data, "fetched_at"))
-        last_shown_at_raw = data.get("last_shown_at")
-        last_shown_at: datetime | None = None
-        if last_shown_at_raw is not None:
-            if not isinstance(last_shown_at_raw, str):
-                raise ValueError(f"last_shown_at must be str or null, got {type(last_shown_at_raw)}")
-            last_shown_at = _iso_to_dt(last_shown_at_raw)
+        last_shown_at_raw = _optional_str(data, "last_shown_at")
+        last_shown_at = _iso_to_dt(last_shown_at_raw) if last_shown_at_raw is not None else None
 
         # WS3 extensions — all optional with safe defaults for legacy files.
-        remote_version_seen_raw = data.get("remote_version_seen")
-        if remote_version_seen_raw is not None and not isinstance(remote_version_seen_raw, str):
-            raise ValueError(
-                f"remote_version_seen must be str or null, got {type(remote_version_seen_raw)}"
-            )
-        remote_version_seen = (
-            remote_version_seen_raw if isinstance(remote_version_seen_raw, str) else None
-        )
-
-        snooze_step_raw = data.get("snooze_step")
-        snooze_step: SnoozeStep | None
-        if snooze_step_raw is None:
-            snooze_step = None
-        elif isinstance(snooze_step_raw, str) and snooze_step_raw in _VALID_SNOOZE_STEPS:
-            if snooze_step_raw == "24h":
-                snooze_step = "24h"
-            elif snooze_step_raw == "48h":
-                snooze_step = "48h"
-            else:
-                snooze_step = "7d"
-        else:
-            raise ValueError(
-                f"snooze_step must be one of {sorted(_VALID_SNOOZE_STEPS)} or null, got {snooze_step_raw!r}"
-            )
-
-        snoozed_until_raw = data.get("snoozed_until")
-        snoozed_until: datetime | None = None
-        if snoozed_until_raw is not None:
-            if not isinstance(snoozed_until_raw, str):
-                raise ValueError(
-                    f"snoozed_until must be str or null, got {type(snoozed_until_raw)}"
-                )
-            snoozed_until = _iso_to_dt(snoozed_until_raw)
-
-        always_upgrade_raw = data.get("always_upgrade", False)
-        if not isinstance(always_upgrade_raw, bool):
-            raise ValueError(f"always_upgrade must be bool, got {type(always_upgrade_raw)}")
-        always_upgrade = always_upgrade_raw
-
-        never_ask_raw = data.get("never_ask", False)
-        if not isinstance(never_ask_raw, bool):
-            raise ValueError(f"never_ask must be bool, got {type(never_ask_raw)}")
-        never_ask = never_ask_raw
+        remote_version_seen = _optional_str(data, "remote_version_seen")
+        snooze_step = _parse_snooze_step(data.get("snooze_step"))
+        snoozed_until_raw = _optional_str(data, "snoozed_until")
+        snoozed_until = _iso_to_dt(snoozed_until_raw) if snoozed_until_raw is not None else None
+        always_upgrade = _require_bool(data, "always_upgrade", default=False)
+        never_ask = _require_bool(data, "never_ask", default=False)
 
         return cls(
             cli_version_key=cli_version_key,
@@ -201,6 +157,36 @@ class NagCacheRecord:
             always_upgrade=always_upgrade,
             never_ask=never_ask,
         )
+
+
+def _optional_str(data: dict[str, object], key: str) -> str | None:
+    raw_value = data.get(key)
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, str):
+        return raw_value
+    raise ValueError(f"{key} must be str or null, got {type(raw_value)}")
+
+
+def _parse_snooze_step(raw_value: object) -> SnoozeStep | None:
+    if raw_value is None:
+        return None
+    if raw_value not in _VALID_SNOOZE_STEPS:
+        raise ValueError(
+            f"snooze_step must be one of {sorted(_VALID_SNOOZE_STEPS)} or null, got {raw_value!r}"
+        )
+    if raw_value == "24h":
+        return "24h"
+    if raw_value == "48h":
+        return "48h"
+    return "7d"
+
+
+def _require_bool(data: dict[str, object], key: str, *, default: bool) -> bool:
+    raw_value = data.get(key, default)
+    if isinstance(raw_value, bool):
+        return raw_value
+    raise ValueError(f"{key} must be bool, got {type(raw_value)}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -338,6 +338,116 @@ class UpgradeUxOutcome:
     guidance_only: bool  # unsafe installer → printed guidance, no mutation
 
 
+def _inactive_outcome() -> UpgradeUxOutcome:
+    return UpgradeUxOutcome(False, False, None, False, None, False)
+
+
+def _noop_active_outcome() -> UpgradeUxOutcome:
+    return UpgradeUxOutcome(True, False, None, False, None, False)
+
+
+def _stash_plan_result(ctx: typer.Context | None, result: object) -> None:
+    if ctx is not None and ctx.obj is None:
+        ctx.obj = {}
+    if ctx is not None and isinstance(ctx.obj, dict):
+        ctx.obj["compat_plan_result"] = result
+
+
+def _build_record_kwargs(result: object, existing: object, now: datetime) -> dict[str, object]:
+    return {
+        "cli_version_key": result.cli_status.installed_version,
+        "latest_version": result.cli_status.latest_version,
+        "latest_source": result.cli_status.latest_source,
+        "fetched_at": now,
+        "last_shown_at": existing.last_shown_at if existing is not None else None,
+        "remote_version_seen": existing.remote_version_seen if existing is not None else None,
+        "snooze_step": existing.snooze_step if existing is not None else None,
+        "snoozed_until": existing.snoozed_until if existing is not None else None,
+        "always_upgrade": existing.always_upgrade if existing is not None else False,
+        "never_ask": existing.never_ask if existing is not None else False,
+    }
+
+
+def _reset_anchor_if_needed(kwargs: dict[str, object], current_latest: str | None) -> None:
+    if needs_reset(
+        record_remote_version=kwargs.get("remote_version_seen"),  # type: ignore[arg-type]
+        current_latest=current_latest,
+    ):
+        kwargs["snooze_step"] = None
+        kwargs["snoozed_until"] = None
+        kwargs["never_ask"] = False
+        kwargs["remote_version_seen"] = current_latest
+
+
+def _persist_and_return(cache: object, kwargs: dict[str, object], outcome: UpgradeUxOutcome) -> UpgradeUxOutcome:
+    _persist(cache, kwargs)
+    return outcome
+
+
+def _run_auto_upgrade_if_safe(
+    *,
+    safe: bool,
+    method: object,
+    upgrade_runner: Callable[[], int],
+) -> tuple[bool, int | None, bool]:
+    if safe:
+        return True, upgrade_runner(), False
+    _print_unsafe_installer_guidance(str(method))
+    return False, None, True
+
+
+def _handle_always_preference(
+    *,
+    cache: object,
+    kwargs: dict[str, object],
+    safe: bool,
+    method: object,
+    upgrade_runner: Callable[[], int],
+) -> UpgradeUxOutcome:
+    attempted, exit_code, guidance_only = _run_auto_upgrade_if_safe(
+        safe=safe,
+        method=method,
+        upgrade_runner=upgrade_runner,
+    )
+    if exit_code == 0:
+        kwargs["snooze_step"] = None
+        kwargs["snoozed_until"] = None
+    return _persist_and_return(
+        cache,
+        kwargs,
+        UpgradeUxOutcome(True, False, UpgradeChoice.UPGRADE_NOW if attempted else None, attempted, exit_code, guidance_only),
+    )
+
+
+def _handle_prompt_choice(
+    *,
+    cache: object,
+    kwargs: dict[str, object],
+    choice: UpgradeChoice,
+    current_latest: str | None,
+    now: datetime,
+    safe: bool,
+    method: object,
+    upgrade_runner: Callable[[], int],
+) -> UpgradeUxOutcome:
+    kwargs["last_shown_at"] = now
+    new_kwargs = apply_choice(kwargs, choice=choice, current_latest=current_latest, now=now)
+    auto_upgrade_attempted = False
+    exit_code: int | None = None
+    guidance_only = False
+    if choice in (UpgradeChoice.UPGRADE_NOW, UpgradeChoice.ALWAYS):
+        auto_upgrade_attempted, exit_code, guidance_only = _run_auto_upgrade_if_safe(
+            safe=safe,
+            method=method,
+            upgrade_runner=upgrade_runner,
+        )
+    return _persist_and_return(
+        cache,
+        new_kwargs,
+        UpgradeUxOutcome(True, True, choice, auto_upgrade_attempted, exit_code, guidance_only),
+    )
+
+
 def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrator with many short-circuit branches
     ctx: typer.Context | None,
     *,
@@ -374,7 +484,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
     and recorded as ``ran=False`` outcomes.
     """
     if suppressed:
-        return UpgradeUxOutcome(False, False, None, False, None, False)
+        return _inactive_outcome()
 
     if now is None:
         now = datetime.now(UTC)
@@ -404,54 +514,29 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
 
         # Kill switch (env-only; not persisted).
         if _truthy(env.get(ENV_UPGRADE_DISABLED)):
-            return UpgradeUxOutcome(False, False, None, False, None, False)
+            return _inactive_outcome()
 
         # Build invocation & planner output.
         inv = Invocation.from_argv()
         if inv.suppresses_nag():
             # Defence-in-depth — caller already supplied `suppressed`.
-            return UpgradeUxOutcome(False, False, None, False, None, False)
+            return _inactive_outcome()
 
         result = compat_plan(inv)
-
-        # Stash on ctx.obj so subcommands can read the planner output.
-        if ctx is not None and ctx.obj is None:
-            ctx.obj = {}
-        if ctx is not None and isinstance(ctx.obj, dict):
-            ctx.obj["compat_plan_result"] = result
+        _stash_plan_result(ctx, result)
 
         if result.decision != Decision.ALLOW_WITH_NAG:
-            return UpgradeUxOutcome(False, False, None, False, None, False)
+            return _inactive_outcome()
 
         # Load cache.
         cache = NagCache.default()
         existing = cache.read()
-
-        # Snapshot record kwargs we'll mutate.
-        kwargs: dict[str, object] = {
-            "cli_version_key": result.cli_status.installed_version,
-            "latest_version": result.cli_status.latest_version,
-            "latest_source": result.cli_status.latest_source,
-            "fetched_at": now,
-            "last_shown_at": existing.last_shown_at if existing is not None else None,
-            "remote_version_seen": existing.remote_version_seen if existing is not None else None,
-            "snooze_step": existing.snooze_step if existing is not None else None,
-            "snoozed_until": existing.snoozed_until if existing is not None else None,
-            "always_upgrade": existing.always_upgrade if existing is not None else False,
-            "never_ask": existing.never_ask if existing is not None else False,
-        }
+        kwargs = _build_record_kwargs(result, existing, now)
 
         current_latest = result.cli_status.latest_version
 
         # Anchor reset: a new remote version clears snooze + never_ask.
-        if needs_reset(
-            record_remote_version=kwargs.get("remote_version_seen"),  # type: ignore[arg-type]
-            current_latest=current_latest,
-        ):
-            kwargs["snooze_step"] = None
-            kwargs["snoozed_until"] = None
-            kwargs["never_ask"] = False  # bound to specific remote version
-            kwargs["remote_version_seen"] = current_latest
+        _reset_anchor_if_needed(kwargs, current_latest)
 
         # Resolve effective preferences (env can elevate but never demote).
         pref = resolve_effective_preference(
@@ -463,71 +548,42 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
         if pref.never_ask:
             # Honour preference; do not prompt.  Persist the anchor so a
             # new remote version naturally re-prompts.
-            _persist(cache, kwargs)
-            return UpgradeUxOutcome(True, False, None, False, None, False)
+            return _persist_and_return(cache, kwargs, _noop_active_outcome())
 
         # Active snooze?
         if is_currently_snoozed(
             snoozed_until=kwargs.get("snoozed_until"),  # type: ignore[arg-type]
             now=now,
         ):
-            _persist(cache, kwargs)
-            return UpgradeUxOutcome(True, False, None, False, None, False)
+            return _persist_and_return(cache, kwargs, _noop_active_outcome())
 
         method = installer_detector()
         safe = is_safe_for_auto_upgrade(method) if isinstance(method, InstallMethod) else False
 
         # Always-upgrade path: short-circuit the prompt.
         if pref.always_upgrade:
-            if safe:
-                exit_code = upgrade_runner()
-                # On success, clear cadence so a new remote restarts cleanly.
-                if exit_code == 0:
-                    kwargs["snooze_step"] = None
-                    kwargs["snoozed_until"] = None
-                _persist(cache, kwargs)
-                return UpgradeUxOutcome(
-                    True, False, UpgradeChoice.UPGRADE_NOW, True, exit_code, False
-                )
-            # Unsafe installer → guidance only.  Do NOT mutate beyond the
-            # anchor we set above.
-            _print_unsafe_installer_guidance(str(method))
-            _persist(cache, kwargs)
-            return UpgradeUxOutcome(True, False, None, False, None, True)
+            return _handle_always_preference(
+                cache=cache,
+                kwargs=kwargs,
+                safe=safe,
+                method=method,
+                upgrade_runner=upgrade_runner,
+            )
 
         # Interactive prompt path.
         choice = prompt()
-        kwargs["last_shown_at"] = now
-        new_kwargs = apply_choice(
-            kwargs, choice=choice, current_latest=current_latest, now=now
-        )
-
-        auto_upgrade_attempted = False
-        exit_code: int | None = None
-        guidance_only = False
-
-        if choice == UpgradeChoice.UPGRADE_NOW:
-            if safe:
-                auto_upgrade_attempted = True
-                exit_code = upgrade_runner()
-            else:
-                _print_unsafe_installer_guidance(str(method))
-                guidance_only = True
-        elif choice == UpgradeChoice.ALWAYS:
-            # If safe, eagerly upgrade in the same invocation.
-            if safe:
-                auto_upgrade_attempted = True
-                exit_code = upgrade_runner()
-            else:
-                _print_unsafe_installer_guidance(str(method))
-                guidance_only = True
-
-        _persist(cache, new_kwargs)
-        return UpgradeUxOutcome(
-            True, True, choice, auto_upgrade_attempted, exit_code, guidance_only
+        return _handle_prompt_choice(
+            cache=cache,
+            kwargs=kwargs,
+            choice=choice,
+            current_latest=current_latest,
+            now=now,
+            safe=safe,
+            method=method,
+            upgrade_runner=upgrade_runner,
         )
     except Exception:  # noqa: BLE001 — UX path must never raise out of the CLI.
-        return UpgradeUxOutcome(False, False, None, False, None, False)
+        return _inactive_outcome()
 
 
 def _persist(cache: object, kwargs: dict[str, object]) -> None:

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -27,15 +27,30 @@ from __future__ import annotations
 
 import os
 import subprocess  # noqa: S404 — required to invoke the existing `spec-kitty upgrade` binary
-import sys
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     import typer
+
+    from specify_cli.compat.cache import NagCacheRecord
+
+
+class _CliStatusLike(Protocol):
+    installed_version: str
+    latest_version: str | None
+    latest_source: str
+
+
+class _PlanResultLike(Protocol):
+    cli_status: _CliStatusLike
+
+
+class _NagCacheLike(Protocol):
+    def write(self, record: NagCacheRecord) -> None: ...
 
 # Public env keys (WS3 acceptance criterion 4).
 ENV_UPGRADE_AUTO = "SPEC_KITTY_UPGRADE_AUTO"
@@ -353,7 +368,11 @@ def _stash_plan_result(ctx: typer.Context | None, result: object) -> None:
         ctx.obj["compat_plan_result"] = result
 
 
-def _build_record_kwargs(result: object, existing: object, now: datetime) -> dict[str, object]:
+def _build_record_kwargs(
+    result: _PlanResultLike,
+    existing: NagCacheRecord | None,
+    now: datetime,
+) -> dict[str, object]:
     return {
         "cli_version_key": result.cli_status.installed_version,
         "latest_version": result.cli_status.latest_version,
@@ -368,9 +387,17 @@ def _build_record_kwargs(result: object, existing: object, now: datetime) -> dic
     }
 
 
+def _optional_str_value(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _optional_datetime_value(value: object) -> datetime | None:
+    return value if isinstance(value, datetime) else None
+
+
 def _reset_anchor_if_needed(kwargs: dict[str, object], current_latest: str | None) -> None:
     if needs_reset(
-        record_remote_version=kwargs.get("remote_version_seen"),  # type: ignore[arg-type]
+        record_remote_version=_optional_str_value(kwargs.get("remote_version_seen")),
         current_latest=current_latest,
     ):
         kwargs["snooze_step"] = None
@@ -379,7 +406,7 @@ def _reset_anchor_if_needed(kwargs: dict[str, object], current_latest: str | Non
         kwargs["remote_version_seen"] = current_latest
 
 
-def _persist_and_return(cache: object, kwargs: dict[str, object], outcome: UpgradeUxOutcome) -> UpgradeUxOutcome:
+def _persist_and_return(cache: _NagCacheLike, kwargs: dict[str, object], outcome: UpgradeUxOutcome) -> UpgradeUxOutcome:
     _persist(cache, kwargs)
     return outcome
 
@@ -398,7 +425,7 @@ def _run_auto_upgrade_if_safe(
 
 def _handle_always_preference(
     *,
-    cache: object,
+    cache: _NagCacheLike,
     kwargs: dict[str, object],
     safe: bool,
     method: object,
@@ -421,7 +448,7 @@ def _handle_always_preference(
 
 def _handle_prompt_choice(
     *,
-    cache: object,
+    cache: _NagCacheLike,
     kwargs: dict[str, object],
     choice: UpgradeChoice,
     current_latest: str | None,
@@ -491,7 +518,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
     if env is None:
         env = dict(os.environ)
     if prompt is None:
-        prompt = _default_prompt  # type: ignore[assignment]
+        prompt = _default_prompt
     if upgrade_runner is None:
         upgrade_runner = _default_upgrade_runner
 
@@ -510,7 +537,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
         )
 
         if installer_detector is None:
-            installer_detector = detect_install_method  # type: ignore[assignment]
+            installer_detector = detect_install_method
 
         # Kill switch (env-only; not persisted).
         if _truthy(env.get(ENV_UPGRADE_DISABLED)):
@@ -552,7 +579,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
 
         # Active snooze?
         if is_currently_snoozed(
-            snoozed_until=kwargs.get("snoozed_until"),  # type: ignore[arg-type]
+            snoozed_until=_optional_datetime_value(kwargs.get("snoozed_until")),
             now=now,
         ):
             return _persist_and_return(cache, kwargs, _noop_active_outcome())
@@ -586,7 +613,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
         return _inactive_outcome()
 
 
-def _persist(cache: object, kwargs: dict[str, object]) -> None:
+def _persist(cache: _NagCacheLike, kwargs: dict[str, object]) -> None:
     """Best-effort write of a NagCacheRecord to disk.
 
     Swallows any exception — cache mutation failure must not block the CLI.
@@ -595,8 +622,8 @@ def _persist(cache: object, kwargs: dict[str, object]) -> None:
         from specify_cli.compat import NagCacheRecord  # noqa: PLC0415
 
         # Defensive copy: ensure literal type for snooze_step.
-        record = NagCacheRecord(**kwargs)  # type: ignore[arg-type]
-        cache.write(record)  # type: ignore[attr-defined]
+        record = NagCacheRecord(**kwargs)
+        cache.write(record)
     except Exception:  # noqa: BLE001
         pass
 
@@ -616,8 +643,3 @@ __all__ = [
     "resolve_effective_preference",
     "run_upgrade_ux",
 ]
-
-
-# Keep import-time noise low.
-_ = replace  # ruff: re-export to acknowledge the deliberate import
-_ = sys  # ruff: avoid unused if all dependencies are deferred


### PR DESCRIPTION
## Summary
- refactor overnight SonarCloud findings in upgrade UX, compat cache, and workflow evidence parsing
- preserve behavior while reducing complexity and duplicate-branch noise without suppressions
- validate with targeted pytest suites plus ruff

## Sonar / Security context
- GitHub code-scanning alerts: none open
- GitHub Dependabot alerts: none open
- SonarCloud nightly `main` run on 2026-05-23 06:02 UTC failed the quality gate on coverage/hotspot review, but the actionable code issues from that run were maintainability findings in these files
- No suppressions were added

## Validation
- `uv run pytest tests/readiness/test_upgrade_ux.py tests/specify_cli/compat/test_cache.py`
- `uv run pytest tests/cli_gate/test_ci_determinism.py`
- `uv run pytest tests/specify_cli/test_acceptance_regressions.py -k "workflow_run_ids or workflow_changes_with_runner_evidence or placeholder_workflow_evidence"`
- `uv run ruff check src/specify_cli/acceptance/__init__.py src/specify_cli/compat/cache.py src/specify_cli/readiness/upgrade_ux.py`
- `uv run python -m compileall src/specify_cli/acceptance/__init__.py src/specify_cli/compat/cache.py src/specify_cli/readiness/upgrade_ux.py`