### PR TITLE
fix: reduce recent Sonar new-code findings

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1849,10 +1849,15 @@ jobs:
       # on the established 90% floor and use the full-diff step as advisory.
       - name: "diff-coverage (critical-path, enforced)"
         run: |
-          # Full fetch (no --depth) so diff-cover can compute the merge-base
-          # between HEAD and origin/<base>. A shallow fetch breaks
-          # `origin/<base>...HEAD` with "no merge base".
-          git fetch origin "${{ github.base_ref }}"
+          # actions/checkout@v6 already performs a full fetch here. Only
+          # hydrate the remote-tracking base ref when it is missing, and do
+          # that fetch with the workflow token so PR jobs do not fail on an
+          # unauthenticated HTTPS remote.
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${{ github.base_ref }}"; then
+            git -c http.extraheader="AUTHORIZATION: bearer ${{ github.token }}" \
+              fetch origin \
+              "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          fi
 
           critical_paths=(
             'src/kernel/*'


### PR DESCRIPTION
## Summary
- refactor recent new-code control-flow hotspots in upgrade UX, nag cache reading, and acceptance workflow evidence parsing
- preserve behavior while reducing duplicated branches and deeply nested validation paths
- investigate current GitHub security/code-scanning alerts and SonarCloud findings

## Validation
- pytest tests/readiness/test_upgrade_ux.py
- pytest tests/specify_cli/compat/test_cache.py
- pytest tests/specify_cli/test_acceptance_regressions.py
- ruff check src/specify_cli/readiness/upgrade_ux.py src/specify_cli/compat/cache.py src/specify_cli/acceptance/__init__.py

## Notes
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud quality gate failure on main is currently driven by new-code coverage and hotspot review state; the remaining localhost/loopback HTTP hotspots are low-probability loopback cases and were not suppressed here because they are review-state items, not remote-exposure defects.