### PR TITLE
Release 3.2.0rc25

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc24
+  version: 3.2.0rc25
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/explanation/launch-readiness-future.md` stages the launch-day
   behavior shift behind an explicit "Status: pre-launch" banner.
 
+## [3.2.0rc25] - 2026-05-23
+
+Rolls up the post-rc24 static-analysis and upgrade UX type-boundary fixes.
+
+- Tightens acceptance package imports, compatibility cache typing, and
+  readiness upgrade UX helper boundaries after the overnight Sonar sweep.
+- Keeps the 3.2.0 stable release candidate line current with `main`
+  after `#1293`.
+
 ## [3.2.0rc24] - 2026-05-22
 
 Ships the canonical SaaS-bound producer refactor for CLI lifecycle,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc24"
+version = "3.2.0rc25"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc24"
+version = "3.2.0rc25"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Prepare the next Spec Kitty CLI release candidate, 3.2.0rc25, because origin/main is three commits ahead of v3.2.0rc24.

Includes:
- pyproject/uv lock editable version bump to 3.2.0rc25
- .kittify metadata version sync
- changelog entry for the post-rc24 Sonar/type-boundary fixes from #1293

## Validation

- uv run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv run python -m pytest -v --import-mode=importlib tests/release
- uv run python scripts/release/check_shared_package_drift.py --saas-pyproject ../spec-kitty-saas/pyproject.toml
- uv run python -m build
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli
- uv run python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json
- uv run twine check dist/*