### PR TITLE
fix: address SonarCloud maintainability follow-ups

### DIFF
--- a/src/charter/compiler.py
+++ b/src/charter/compiler.py
@@ -502,7 +502,7 @@ def _resolve_transitive_reference_graph(
                 return ResolveTransitiveRefsResult(directives=sorted(directives))
             merged = load_graph_or_dir(doctrine_root)
             assert_valid(merged)
-    except (FileNotFoundError, Exception):
+    except Exception:
         return ResolveTransitiveRefsResult(directives=sorted(directives))
 
     return resolve_transitive_refs(

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -2321,46 +2321,59 @@ def _project_directive_entries(repo_root: Path) -> list[dict[str, object]]:
     """Return every directive ID that the project-governance resolver exposes."""
     from charter.sync import load_directives_config
 
-    local_by_id: dict[str, object] = {}
-    directive_ids: list[str] = []
-    try:
-        directives_cfg = load_directives_config(repo_root)
-        local_by_id = {directive.id: directive for directive in directives_cfg.directives}
-        directive_ids = [directive.id for directive in directives_cfg.directives]
-    except Exception:  # noqa: BLE001 - fall through to resolver/catalog path
-        local_by_id = {}
-        directive_ids = []
-
-    try:
-        from charter.resolver import resolve_project_governance
-
-        resolution = resolve_project_governance(repo_root)
-        directive_ids = list(dict.fromkeys(list(resolution.directives) + directive_ids))
-    except Exception:  # noqa: BLE001 - keep any directly-loaded directive IDs
-        directive_ids = list(dict.fromkeys(directive_ids))
-
-    try:
-        service = _build_doctrine_service(repo_root)
-    except Exception:  # noqa: BLE001 - local directive IDs are still useful
-        service = None
+    local_by_id, directive_ids = _load_project_directives(repo_root, load_directives_config)
+    service = _maybe_build_doctrine_service(repo_root)
     entries: list[dict[str, object]] = []
     for directive_id in directive_ids:
         local = local_by_id.get(directive_id)
         if local is not None:
-            entry: dict[str, object] = {"id": directive_id, "source": "project"}
-            title = getattr(local, "title", None)
-            description = getattr(local, "description", None)
-            if isinstance(title, str) and title:
-                entry["title"] = title
-            if isinstance(description, str) and description:
-                entry["summary"] = description
-            entries.append(entry)
+            entries.append(_local_directive_entry(directive_id, local))
             continue
         if service is None:
             entries.append({"id": directive_id, "source": "builtin"})
             continue
         entries.extend(_collect_typed_artifacts(service.directives, [directive_id]))  # type: ignore[attr-defined]
     return entries
+
+
+def _load_project_directives(
+    repo_root: Path,
+    load_directives_config: object,
+) -> tuple[dict[str, object], list[str]]:
+    try:
+        directives_cfg = load_directives_config(repo_root)
+    except Exception:  # noqa: BLE001 - fall through to resolver/catalog path
+        local_by_id: dict[str, object] = {}
+        directive_ids: list[str] = []
+    else:
+        local_by_id = {directive.id: directive for directive in directives_cfg.directives}
+        directive_ids = [directive.id for directive in directives_cfg.directives]
+
+    try:
+        from charter.resolver import resolve_project_governance
+
+        resolution = resolve_project_governance(repo_root)
+    except Exception:  # noqa: BLE001 - keep any directly-loaded directive IDs
+        return local_by_id, list(dict.fromkeys(directive_ids))
+    return local_by_id, list(dict.fromkeys(list(resolution.directives) + directive_ids))
+
+
+def _maybe_build_doctrine_service(repo_root: Path) -> object | None:
+    try:
+        return _build_doctrine_service(repo_root)
+    except Exception:  # noqa: BLE001 - local directive IDs are still useful
+        return None
+
+
+def _local_directive_entry(directive_id: str, local: object) -> dict[str, object]:
+    entry: dict[str, object] = {"id": directive_id, "source": "project"}
+    title = getattr(local, "title", None)
+    description = getattr(local, "description", None)
+    if isinstance(title, str) and title:
+        entry["title"] = title
+    if isinstance(description, str) and description:
+        entry["summary"] = description
+    return entry
 
 
 _EMPTY_ORG_CHARTER: dict[str, object] = {"present": False, "packs": []}

--- a/src/specify_cli/cli/commands/_auth_doctor.py
+++ b/src/specify_cli/cli/commands/_auth_doctor.py
@@ -233,7 +233,8 @@ def _detect_persisted_drift(tm: Any, in_memory: Any) -> bool:
     """
     try:
         persisted = tm._storage.read()
-    except Exception:  # noqa: BLE001 - storage read failure makes drift check inconclusive, not fatal
+    except Exception:  # noqa: BLE001
+        # Storage read failure makes drift check inconclusive rather than fatal.
         return False
     if persisted is None:
         return False

--- a/src/specify_cli/retrospective/generator.py
+++ b/src/specify_cli/retrospective/generator.py
@@ -316,11 +316,12 @@ def _build_lane_friction_findings(
             if ev.get("wp_id") == wp_id
             and _is_lane_friction_event(ev)
         ]
-        range_str = (
-            f"{friction_event_ids[0]}..{friction_event_ids[-1]}"
-            if len(friction_event_ids) > 1
-            else (friction_event_ids[0] if friction_event_ids else "")
-        )
+        if len(friction_event_ids) > 1:
+            range_str = f"{friction_event_ids[0]}..{friction_event_ids[-1]}"
+        elif friction_event_ids:
+            range_str = friction_event_ids[0]
+        else:
+            range_str = ""
         ev_id = ev_reg.add_event_range(events_rel, range_str or "lane_friction", f"lane_friction_{wp_id}")
         findings.append(
             GenFinding(


### PR DESCRIPTION
## Summary
- address small Sonar maintainability findings in charter, retrospective, and auth doctor code paths
- keep the fixes narrow: remove a redundant exception tuple, flatten a nested conditional, and extract directive-entry helpers
- preserve auth doctor lint suppression while making the inline comment syntax Sonar-safe

## Validation
- `ruff check src/charter/compiler.py src/charter/context.py src/specify_cli/retrospective/generator.py src/specify_cli/cli/commands/_auth_doctor.py`
- `pytest tests/charter/test_compiler.py tests/charter/test_context.py tests/retrospective/test_generator.py tests/auth/test_auth_doctor_offline.py`
- `pytest tests/auth/test_auth_doctor_report.py tests/auth/test_auth_doctor_repair.py`

## Notes
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud `main` still fails its scheduled quality gate on 2026-05-24 for two reasons outside this patch's full control:
  - `new_coverage=59.6` vs threshold `80`
  - `new_security_hotspots_reviewed=0.0` vs threshold `100`, driven by four existing loopback/local HTTP hotspots that require review-state changes in SonarCloud UI
- This PR only addresses the code-actionable subset discovered in current Sonar findings.
