### PR TITLE
fix: suppress localhost-only sonar security hotspots

### DIFF
--- a/src/specify_cli/auth/loopback/callback_server.py
+++ b/src/specify_cli/auth/loopback/callback_server.py
@@ -10,8 +10,11 @@ after the user consents. This module implements a tiny HTTP server that:
 - exposes an ``async wait_for_callback()`` that the main login loop awaits
 - times out after 5 minutes with :class:`CallbackTimeoutError`
 
-The server deliberately avoids any external dependency; the stdlib
-``http.server.BaseHTTPRequestHandler`` is plenty for a single callback.
+The server deliberately uses HTTP on loopback because OAuth native-app
+callbacks cannot terminate TLS on a local ephemeral port. Binding is
+restricted to ``127.0.0.1`` only, matching RFC 8252 loopback guidance.
+The stdlib ``http.server.BaseHTTPRequestHandler`` is plenty for a single
+callback.
 """
 
 from __future__ import annotations
@@ -112,7 +115,7 @@ class CallbackServer:
     @property
     def callback_url(self) -> str:
         """The full ``http://127.0.0.1:<port>/callback`` URL."""
-        return f"http://{_HOST}:{self.port}/callback"
+        return f"http://{_HOST}:{self.port}/callback"  # NOSONAR -- OAuth loopback redirect URI is localhost-only by design
 
     def start(self) -> str:
         """Start the HTTP server on an available port.
@@ -121,7 +124,7 @@ class CallbackServer:
             The full callback URL (``http://127.0.0.1:<port>/callback``).
         """
         self._port = self._find_port()
-        self._server = HTTPServer((_HOST, self._port), _CallbackHTTPHandler)
+        self._server = HTTPServer((_HOST, self._port), _CallbackHTTPHandler)  # NOSONAR -- binds to 127.0.0.1 only for OAuth loopback callback
         self._server.callback_params = None  # type: ignore[attr-defined]
         self._thread = Thread(
             target=self._server.serve_forever,

--- a/src/specify_cli/dashboard/server.py
+++ b/src/specify_cli/dashboard/server.py
@@ -71,7 +71,7 @@ def run_dashboard_server(project_dir: Path, port: int, project_token: str | None
         logger.warning("Global sync daemon check failed: %s", exc)
 
     handler_class = _build_handler_class(project_dir, project_token)
-    server = HTTPServer(('127.0.0.1', port), handler_class)
+    server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
     server.serve_forever()
 
 

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -588,7 +588,7 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
         (SyncDaemonHandler,),
         {"daemon_token": daemon_token},
     )
-    server = HTTPServer(("127.0.0.1", port), handler_class)
+    server = HTTPServer(("127.0.0.1", port), handler_class)  # NOSONAR -- sync daemon control plane binds to localhost only
 
     # Bind succeeded — record ownership BEFORE accepting traffic so any
     # health probe that arrives in the first scheduling slice already sees


### PR DESCRIPTION
## Summary
- add targeted `NOSONAR` annotations for loopback-only HTTP endpoints in the OAuth callback server, dashboard server, and sync daemon
- document why plaintext HTTP is intentional for localhost-only control planes and OAuth native-app loopback redirects
- keep the suppression scope narrow to the exact lines Sonar misclassifies

## Context
The latest scheduled `CI Quality` run on `main` from May 24, 2026 failed its SonarCloud quality gate. GitHub Dependabot and code-scanning alerts are currently empty. The actionable security findings were SonarCloud hotspots on localhost-only HTTP surfaces:
- `src/specify_cli/auth/loopback/callback_server.py`
- `src/specify_cli/dashboard/server.py`
- `src/specify_cli/sync/daemon.py`

These endpoints are intentionally bound to `127.0.0.1` only. For the OAuth callback, HTTP loopback is the expected native-app pattern; for dashboard/sync, the control plane is machine-local and not remotely reachable.

## Why suppression is necessary
Sonar flags these as insecure protocol usage even though the code is restricted to loopback-only transport. Replacing them with HTTPS would be incorrect for the OAuth loopback callback and disproportionate for the internal localhost control plane. The suppression is therefore limited to the specific loopback HTTP lines and justified inline.

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/auth/test_loopback_callback.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/test_dashboard/test_server.py tests/test_dashboard/test_lifecycle.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/sync/test_daemon_singleton.py tests/sync/test_daemon_replace_on_version_mismatch.py tests/cli/commands/test_sync_status_singleton_diagnostics.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run ruff check src/specify_cli/auth/loopback/callback_server.py src/specify_cli/dashboard/server.py src/specify_cli/sync/daemon.py`
