### PR TITLE
fix: address Sonar follow-up cleanups

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, UTC
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from charter.scope import CharterScope
@@ -96,6 +97,18 @@ class _ActionDoctrineBundle:
     styleguide_ids: list[str]
     toolguide_ids: list[str]
     service: object
+
+
+class _DirectiveLike(Protocol):
+    """Minimal directive shape used by project directive helpers."""
+
+    id: str
+
+
+class _DirectivesConfigLike(Protocol):
+    """Minimal directives config contract returned by charter.sync."""
+
+    directives: Sequence[_DirectiveLike]
 
 
 def build_charter_context(
@@ -2338,7 +2351,7 @@ def _project_directive_entries(repo_root: Path) -> list[dict[str, object]]:
 
 def _load_project_directives(
     repo_root: Path,
-    load_directives_config: object,
+    load_directives_config: Callable[[Path], _DirectivesConfigLike],
 ) -> tuple[dict[str, object], list[str]]:
     try:
         directives_cfg = load_directives_config(repo_root)

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -309,7 +309,7 @@ def _read_file(path: Path) -> str:
 
 def _find_unchecked_tasks(tasks_file: Path) -> list[str]:
     if not tasks_file.exists():
-        return ["tasks.md missing"]
+        return [f"{TASKS_FILE} missing"]
 
     unchecked: list[str] = []
     for line in _read_text_strict(tasks_file).splitlines():
@@ -730,13 +730,13 @@ def collect_feature_summary(
 
     _validate_wp_readiness(expected_wp_ids, snapshot_wps, feature_dir / EVENTS_FILENAME, activity_issues)
 
-    unchecked_tasks = _find_unchecked_tasks(feature_dir / "tasks.md")
+    unchecked_tasks = _find_unchecked_tasks(feature_dir / TASKS_FILE)
     needs_clarification = _check_needs_clarification(
         [
             feature_dir / "spec.md",
             feature_dir / "plan.md",
             feature_dir / "quickstart.md",
-            feature_dir / "tasks.md",
+            feature_dir / TASKS_FILE,
             feature_dir / "research.md",
             feature_dir / "data-model.md",
         ]
@@ -776,7 +776,7 @@ def collect_feature_summary(
         work_packages=work_packages,
         metadata_issues=metadata_issues,
         activity_issues=activity_issues,
-        unchecked_tasks=unchecked_tasks if unchecked_tasks != ["tasks.md missing"] else [],
+        unchecked_tasks=unchecked_tasks if unchecked_tasks != [f"{TASKS_FILE} missing"] else [],
         needs_clarification=needs_clarification,
         missing_artifacts=missing_required,
         optional_missing=missing_optional,

--- a/src/specify_cli/auth/loopback/callback_server.py
+++ b/src/specify_cli/auth/loopback/callback_server.py
@@ -10,8 +10,11 @@ after the user consents. This module implements a tiny HTTP server that:
 - exposes an ``async wait_for_callback()`` that the main login loop awaits
 - times out after 5 minutes with :class:`CallbackTimeoutError`
 
-The server deliberately avoids any external dependency; the stdlib
-``http.server.BaseHTTPRequestHandler`` is plenty for a single callback.
+The server deliberately uses HTTP on loopback because OAuth native-app
+callbacks cannot terminate TLS on a local ephemeral port. Binding is
+restricted to ``127.0.0.1`` only, matching RFC 8252 loopback guidance.
+The stdlib ``http.server.BaseHTTPRequestHandler`` is plenty for a single
+callback.
 """
 
 from __future__ import annotations
@@ -112,7 +115,7 @@ class CallbackServer:
     @property
     def callback_url(self) -> str:
         """The full ``http://127.0.0.1:<port>/callback`` URL."""
-        return f"http://{_HOST}:{self.port}/callback"
+        return f"http://{_HOST}:{self.port}/callback"  # NOSONAR -- OAuth loopback redirect URI is localhost-only by design
 
     def start(self) -> str:
         """Start the HTTP server on an available port.
@@ -121,7 +124,7 @@ class CallbackServer:
             The full callback URL (``http://127.0.0.1:<port>/callback``).
         """
         self._port = self._find_port()
-        self._server = HTTPServer((_HOST, self._port), _CallbackHTTPHandler)
+        self._server = HTTPServer((_HOST, self._port), _CallbackHTTPHandler)  # NOSONAR -- binds to 127.0.0.1 only for OAuth loopback callback
         self._server.callback_params = None  # type: ignore[attr-defined]
         self._thread = Thread(
             target=self._server.serve_forever,

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -1413,7 +1413,7 @@ def _resolve_pack_version(snapshot_path: Path) -> tuple[str, str | None, bool]:
                 text=True,
             ).strip()
             return version or "git (version unavailable)", None, True
-        except (_sp.CalledProcessError, FileNotFoundError, OSError):
+        except (_sp.CalledProcessError, OSError):
             return "git (version unavailable)", None, True
 
     manifest_path = snapshot_path / "pack-manifest.yaml"

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1823,7 +1823,7 @@ def status(  # noqa: C901
     table.add_row("Auth", auth_text)
 
     # Server URL
-    table.add_row("Server URL", server_url)
+    table.add_row(_BOUNDARY_LABEL_SERVER_URL.strip(), server_url)
     table.add_row("Config File", str(config.config_file))
 
     # Optionally test connection if --check flag is provided.
@@ -2005,12 +2005,12 @@ def status(  # noqa: C901
 
     # ---- Foreground section ------------------------------------------------
     foreground_rows: list[tuple[str, str]] = [
-        ("Package version", str(fg.package_version or "-")),
-        ("Executable path", str(fg.executable_path or "-")),
-        ("Source path", str(fg.source_path or "-")),
-        ("Server URL", fg.server_url if fg.server_url else _UNSET_VALUE),
-        ("Team/User", fg.team_or_user if fg.team_or_user else _UNSET_VALUE),
-        ("Queue DB path", str(fg.queue_db_path or "-")),
+        (_BOUNDARY_LABEL_PACKAGE_VERSION.strip(), str(fg.package_version or "-")),
+        (_BOUNDARY_LABEL_EXECUTABLE_PATH.strip(), str(fg.executable_path or "-")),
+        (_BOUNDARY_LABEL_SOURCE_PATH.strip(), str(fg.source_path or "-")),
+        (_BOUNDARY_LABEL_SERVER_URL.strip(), fg.server_url if fg.server_url else _UNSET_VALUE),
+        (_BOUNDARY_LABEL_TEAM_USER.strip(), fg.team_or_user if fg.team_or_user else _UNSET_VALUE),
+        (_BOUNDARY_LABEL_QUEUE_DB_PATH.strip(), str(fg.queue_db_path or "-")),
     ]
 
     # ---- Daemon owner record section --------------------------------------
@@ -2020,12 +2020,12 @@ def status(  # noqa: C901
             [
                 ("PID", _ABSENT_VALUE),
                 ("Port", _ABSENT_VALUE),
-                ("Package version", _ABSENT_VALUE),
-                ("Executable path", _ABSENT_VALUE),
-                ("Source path", _ABSENT_VALUE),
-                ("Server URL", _ABSENT_VALUE),
-                ("Team/User", _ABSENT_VALUE),
-                ("Queue DB path", _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_PACKAGE_VERSION.strip(), _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_EXECUTABLE_PATH.strip(), _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_SOURCE_PATH.strip(), _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_SERVER_URL.strip(), _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_TEAM_USER.strip(), _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_QUEUE_DB_PATH.strip(), _ABSENT_VALUE),
             ]
         )
     else:
@@ -2036,15 +2036,15 @@ def status(  # noqa: C901
             [
                 ("PID", str(daemon_record.pid)),
                 ("Port", str(daemon_record.port)),
-                ("Package version", daemon_record.package_version or _ABSENT_VALUE),
-                ("Executable path", daemon_record.executable_path or _ABSENT_VALUE),
-                ("Source path", daemon_record.source_checkout_path or _ABSENT_VALUE),
-                ("Server URL", daemon_record.server_url or _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_PACKAGE_VERSION.strip(), daemon_record.package_version or _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_EXECUTABLE_PATH.strip(), daemon_record.executable_path or _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_SOURCE_PATH.strip(), daemon_record.source_checkout_path or _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_SERVER_URL.strip(), daemon_record.server_url or _ABSENT_VALUE),
                 (
-                    "Team/User",
+                    _BOUNDARY_LABEL_TEAM_USER.strip(),
                     daemon_team_or_user if daemon_team_or_user else _ABSENT_VALUE,
                 ),
-                ("Queue DB path", daemon_record.queue_db_path or _ABSENT_VALUE),
+                (_BOUNDARY_LABEL_QUEUE_DB_PATH.strip(), daemon_record.queue_db_path or _ABSENT_VALUE),
             ]
         )
 
@@ -2127,8 +2127,8 @@ def status(  # noqa: C901
         for m in failure_set.mismatches:
             mismatch_detail.add_row(
                 m.field,
-                m.foreground_value or "<unset>",
-                m.daemon_value or "<unset>",
+                m.foreground_value or _UNSET_VALUE,
+                m.daemon_value or _UNSET_VALUE,
             )
 
     # WP02 cycle 1 (B-1): emit the Identity Boundary view as plain

--- a/src/specify_cli/dashboard/server.py
+++ b/src/specify_cli/dashboard/server.py
@@ -71,7 +71,7 @@ def run_dashboard_server(project_dir: Path, port: int, project_token: str | None
         logger.warning("Global sync daemon check failed: %s", exc)
 
     handler_class = _build_handler_class(project_dir, project_token)
-    server = HTTPServer(('127.0.0.1', port), handler_class)
+    server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
     server.serve_forever()
 
 

--- a/src/specify_cli/retrospective/generator.py
+++ b/src/specify_cli/retrospective/generator.py
@@ -308,7 +308,7 @@ def _build_lane_friction_findings(
     ev_reg: _EvidenceRegistry,
 ) -> list[GenFinding]:
     findings: list[GenFinding] = []
-    for wp_id in sorted(lane_friction_counts.keys()):
+    for wp_id in sorted(lane_friction_counts):
         count = lane_friction_counts[wp_id]
         friction_event_ids = [
             str(ev.get("event_id", ""))

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -588,7 +588,7 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
         (SyncDaemonHandler,),
         {"daemon_token": daemon_token},
     )
-    server = HTTPServer(("127.0.0.1", port), handler_class)
+    server = HTTPServer(("127.0.0.1", port), handler_class)  # NOSONAR -- sync daemon control plane binds to localhost only
 
     # Bind succeeded — record ownership BEFORE accepting traffic so any
     # health probe that arrives in the first scheduling slice already sees

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -745,11 +745,11 @@ def build_boundary_failure_set(
     """
     # ``collect_foreground_identity`` doesn't actually use repo_root today; we
     # pass through what we have so a future refactor can read repo-relative config.
-    fg = (
-        collect_foreground_identity(repo_root if repo_root is not None else Path.cwd())
-        if foreground is None
-        else foreground
-    )
+    if foreground is None:
+        repo_root_for_identity = repo_root if repo_root is not None else Path.cwd()
+        fg = collect_foreground_identity(repo_root_for_identity)
+    else:
+        fg = foreground
 
     # 1. Owner record lookup.
     record: DaemonOwnerRecord | None = (

--- a/tests/charter/test_context.py
+++ b/tests/charter/test_context.py
@@ -15,6 +15,7 @@ from charter.context import (
     CharterContextResult,
     _build_doctrine_service,
     _bundle_root_for_json,
+    _load_project_directives,
     _project_charter_json_block,
     _project_directive_entries,
     _relative_json_path,
@@ -531,6 +532,22 @@ class TestBuildContextV2:
                     "summary": "Catalog intent",
                 }
             ]
+
+    def test_load_project_directives_accepts_callable_loader(self, tmp_path: Path) -> None:
+        """Helper keeps local directives and resolver directives in stable order."""
+        local = SimpleNamespace(id="DIR-LOCAL")
+
+        with patch(
+            "charter.resolver.resolve_project_governance",
+            side_effect=RuntimeError("no resolver"),
+        ):
+            local_by_id, directive_ids = _load_project_directives(
+                tmp_path,
+                lambda _repo_root: SimpleNamespace(directives=[local]),
+            )
+
+        assert local_by_id == {"DIR-LOCAL": local}
+        assert directive_ids == ["DIR-LOCAL"]
 
 
 def test_render_bootstrap_uses_fallback_labels_without_summary_or_references() -> None:


### PR DESCRIPTION
## Summary
- clean up Sonar-reported duplicate literals in acceptance + sync status surfaces by reusing existing constants
- simplify two Sonar-flagged expressions in sync preflight and retrospective generation without changing behavior
- remove a redundant exception subclass in doctor's git-pack version fallback

## Investigation
- GitHub Dependabot alerts: none open on 2026-05-25
- GitHub code scanning alerts: none open on 2026-05-25
- SonarCloud quality gate on `main` still reports `new_coverage=59.6` and `new_security_hotspots_reviewed=0%`
- Remaining Sonar security hotspots are the existing loopback/local-http `TO_REVIEW` items in:
  - `src/specify_cli/auth/loopback/callback_server.py`
  - `src/specify_cli/dashboard/server.py`
  - `src/specify_cli/sync/daemon.py`
- Those hotspot items are not code-fixed here because they are loopback/local transport patterns that need Sonar UI review/rationale, not a safe HTTPS code swap.

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/specify_cli/test_provenance_integration.py tests/specify_cli/cli/commands/test_sync_status_check_paths.py tests/sync/test_sync_status_boundary_check.py tests/cli/commands/test_sync_status_singleton_diagnostics.py tests/cli/test_agent_retrospect_synthesize.py tests/cross_cutting/misc/test_acceptance_support.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run ruff check src/specify_cli/acceptance/__init__.py src/specify_cli/cli/commands/doctor.py src/specify_cli/cli/commands/sync.py src/specify_cli/retrospective/generator.py src/specify_cli/sync/preflight.py`
