### PR TITLE
Release 3.2.0rc26

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc25
+  version: 3.2.0rc26
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc26] - 2026-05-26
+
+Rolls up the charter preflight, built-in vocabulary, and CI stabilization
+guardrails merged after rc25.
+
 ### Breaking changes
 
 - **`shipped` → `built-in` vocabulary rename.** Public CLI JSON surfaces that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc25"
+version = "3.2.0rc26"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc25"
+version = "3.2.0rc26"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- Prepare spec-kitty-cli 3.2.0rc26 release metadata
- Promote current Unreleased charter preflight, built-in vocabulary, and CI stabilization notes
- Sync .kittify metadata and uv.lock package version

## Local validation
- git diff --check
- uv lock --check
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv run python -m pytest tests/release -q --tb=short
- uv run python -m build
- uv run twine check dist/*
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli