### PR TITLE
Fix charter freshness preflight false positives

### DIFF
--- a/src/specify_cli/charter_runtime/freshness/computer.py
+++ b/src/specify_cli/charter_runtime/freshness/computer.py
@@ -33,7 +33,6 @@ report it produces).
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -136,6 +135,13 @@ def _doctrine_graph_path(repo_root: Path) -> Path:
     return repo_root / DOCTRINE_DIR / _GRAPH_FILENAME
 
 
+def _doctrine_dir() -> Path:
+    """Return the canonical project doctrine directory via lazy chokepoint import."""
+    from charter.bundle import DOCTRINE_DIR  # noqa: PLC0415
+
+    return DOCTRINE_DIR
+
+
 def _safe_load_yaml(path: Path) -> dict[str, object] | None:
     """Load a YAML file as a dict; return None when missing or unreadable.
 
@@ -185,12 +191,17 @@ def _load_synthesis_manifest_via_chokepoint(repo_root: Path) -> SynthesisManifes
         return None
 
 
-def _sha256_of(path: Path) -> str | None:
-    """Return SHA-256 hex digest of a file, or None when missing."""
+def _charter_hash_of(path: Path) -> str | None:
+    """Return the canonical charter-content hash hex digest, or None when missing."""
     if not path.exists():
         return None
     try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
+        from charter.hasher import hash_content  # noqa: PLC0415
+
+        hashed = hash_content(path.read_text(encoding="utf-8"))
+        if hashed.startswith("sha256:"):
+            return hashed.split(":", 1)[1]
+        return hashed
     except OSError:
         return None
 
@@ -219,19 +230,6 @@ def _latest_mtime(paths: list[Path]) -> str | None:
     return datetime.fromtimestamp(max(stamps), tz=UTC).isoformat()
 
 
-def _oldest_mtime(paths: list[Path]) -> float | None:
-    stamps: list[float] = []
-    for p in paths:
-        if p.exists():
-            try:
-                stamps.append(p.stat().st_mtime)
-            except OSError:
-                continue
-    if not stamps:
-        return None
-    return min(stamps)
-
-
 # ---------------------------------------------------------------------------
 # Sub-state computers
 # ---------------------------------------------------------------------------
@@ -248,7 +246,7 @@ def _compute_charter_source(repo_root: Path) -> FreshnessSubState:
             remediation="spec-kitty charter sync",
         )
 
-    current_hash = _sha256_of(charter_path)
+    current_hash = _charter_hash_of(charter_path)
     last_change = _mtime_iso(charter_path)
 
     metadata = _safe_load_yaml(metadata_path)
@@ -316,27 +314,10 @@ def _compute_synced_bundle(
             remediation="spec-kitty charter sync",
         )
 
-    # charter_source is fresh → require every bundle file's mtime to be at
-    # least as recent as charter_source.last_change.
-    charter_last = charter_source.last_change
-    if charter_last is None:
-        return FreshnessSubState(state="fresh", last_change=last_change, remediation=None)
-
-    oldest_bundle = _oldest_mtime(existing)
-    try:
-        charter_ts = datetime.fromisoformat(charter_last).timestamp()
-    except ValueError:
-        return FreshnessSubState(state="fresh", last_change=last_change, remediation=None)
-
-    # Allow a tiny epsilon to tolerate single-call sync that writes charter
-    # and metadata within the same second.
-    if oldest_bundle is not None and oldest_bundle + 1.0 < charter_ts:
-        return FreshnessSubState(
-            state="stale",
-            last_change=last_change,
-            remediation="spec-kitty charter sync",
-        )
-
+    # charter_source already proves the canonical charter hash matches
+    # metadata.yaml.  Treat the bundle as fresh once required files exist;
+    # mtimes can move independently when git checks out or restages identical
+    # content, and must not make a synced bundle fail preflight.
     return FreshnessSubState(state="fresh", last_change=last_change, remediation=None)
 
 
@@ -356,6 +337,8 @@ def _compute_synthesized_drg(
     built_in_only = bool(manifest.built_in_only) if manifest is not None else False
     graph_exists = graph_path.exists()
     manifest_exists = manifest is not None
+
+    legacy_fresh_seed = repo_root / _doctrine_dir() / "PROVENANCE.md"
 
     # Conflict resolution (data-model §6): built_in_only=true AND graph.yaml
     # present is an inconsistent stale-residue state.
@@ -379,6 +362,13 @@ def _compute_synthesized_drg(
         )
 
     if not graph_exists:
+        if _looks_like_legacy_fresh_seed(legacy_fresh_seed):
+            return FreshnessSubState(
+                state="built_in_only",
+                last_change=_mtime_iso(legacy_fresh_seed),
+                remediation=None,
+                detail="legacy fresh-project seed marker; re-run `spec-kitty charter synthesize` to write synthesis-manifest.yaml",
+            )
         # No graph + manifest does not opt into built_in_only → missing.
         return FreshnessSubState(
             state="missing",
@@ -431,6 +421,22 @@ def _compute_synthesized_drg(
         )
 
     return FreshnessSubState(state="fresh", last_change=graph_mtime_iso, remediation=None)
+
+
+def _looks_like_legacy_fresh_seed(path: Path) -> bool:
+    """Return True for pre-manifest fresh-seed provenance files."""
+    if not path.exists():
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    lowered = text.lower()
+    return (
+        "fresh project seed" in lowered
+        and "llm-authored yaml" in lowered
+        and "built-in doctrine" in lowered
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/cli/commands/charter/_fresh_doctrine.py
+++ b/src/specify_cli/cli/commands/charter/_fresh_doctrine.py
@@ -7,6 +7,7 @@ LLM-authored YAMLs are present (see issue #839 / WP06 T031-T033).
 """
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 # T031 (#839 minimal artifact set): the runtime consumes ``.kittify/doctrine/``
@@ -22,10 +23,13 @@ from pathlib import Path
 #   2. ``.kittify/doctrine/PROVENANCE.md``    — human-readable provenance note
 #                                                  describing the seed source
 #                                                  (REQUIRED for auditability)
+#   3. ``.kittify/charter/synthesis-manifest.yaml`` — machine-readable marker
+#                                                  declaring built_in_only=true
 #
-# Anything beyond this set (per-directive YAML, project-layer DRG graph,
-# provenance sidecars, synthesis manifest) is produced ONLY when an LLM-authored
-# corpus exists under ``.kittify/charter/generated/`` and is out of WP06 scope.
+# Project-layer DRG graph artifacts are produced ONLY when an LLM-authored
+# corpus exists under ``.kittify/charter/generated/``. The fresh-seed manifest
+# is the authoritative "built-in doctrine fallback is intended" marker used by
+# charter freshness/preflight.
 # See spec.md FR-015 / Spec Assumption A2 / GitHub issue #839.
 _MINIMAL_FRESH_DOCTRINE_PROVENANCE_TEMPLATE = """\
 # Spec Kitty Doctrine — Fresh Project Seed
@@ -48,6 +52,36 @@ References
 """
 
 
+def _fresh_seed_manifest_text() -> str:
+    """Build the deterministic built-in-only synthesis manifest text."""
+    from importlib.metadata import version as _pkg_version
+
+    from charter.synthesizer.manifest import SynthesisManifest
+    from charter.synthesizer.synthesize_pipeline import canonical_yaml
+
+    try:
+        synthesizer_version = _pkg_version("spec-kitty-cli")
+    except Exception:
+        synthesizer_version = "unknown"
+
+    without_hash = {
+        "schema_version": "2",
+        "mission_id": None,
+        "created_at": "1970-01-01T00:00:00+00:00",
+        "run_id": "fresh-project-seed",
+        "adapter_id": "fresh-seed",
+        "adapter_version": synthesizer_version,
+        "synthesizer_version": synthesizer_version,
+        "artifacts": [],
+        "built_in_only": True,
+    }
+    manifest_hash = hashlib.sha256(canonical_yaml(without_hash)).hexdigest()
+    manifest = SynthesisManifest.model_validate(
+        {**without_hash, "manifest_hash": manifest_hash}
+    )
+    return canonical_yaml(manifest.model_dump(mode="python")).decode("utf-8")
+
+
 def _materialize_fresh_doctrine(repo_root: Path) -> list[str]:
     """Materialize the minimal ``.kittify/doctrine/`` artifact set.
 
@@ -60,7 +94,9 @@ def _materialize_fresh_doctrine(repo_root: Path) -> list[str]:
     list of repo-relative paths written.
     """
     doctrine_dir = repo_root / ".kittify" / "doctrine"
+    charter_dir = repo_root / ".kittify" / "charter"
     doctrine_dir.mkdir(parents=True, exist_ok=True)
+    charter_dir.mkdir(parents=True, exist_ok=True)
 
     provenance_path = doctrine_dir / "PROVENANCE.md"
     # Idempotency: only write if content differs (avoids needless mtime churn,
@@ -69,8 +105,14 @@ def _materialize_fresh_doctrine(repo_root: Path) -> list[str]:
     if not provenance_path.exists() or provenance_path.read_bytes() != new_bytes:
         provenance_path.write_bytes(new_bytes)
 
+    manifest_path = charter_dir / "synthesis-manifest.yaml"
+    manifest_text = _fresh_seed_manifest_text()
+    if not manifest_path.exists() or manifest_path.read_text(encoding="utf-8") != manifest_text:
+        manifest_path.write_text(manifest_text, encoding="utf-8")
+
     return [
         str(provenance_path.relative_to(repo_root)),
+        str(manifest_path.relative_to(repo_root)),
     ]
 
 
@@ -82,6 +124,8 @@ def _planned_fresh_doctrine_paths(repo_root: Path) -> list[str]:
     output of :func:`_materialize_fresh_doctrine` exactly.
     """
     doctrine_dir = repo_root / ".kittify" / "doctrine"
+    charter_dir = repo_root / ".kittify" / "charter"
     return [
         str((doctrine_dir / "PROVENANCE.md").relative_to(repo_root)),
+        str((charter_dir / "synthesis-manifest.yaml").relative_to(repo_root)),
     ]

--- a/tests/integration/test_charter_status_freshness.py
+++ b/tests/integration/test_charter_status_freshness.py
@@ -13,7 +13,6 @@ Covers four canonical scenarios:
 
 from __future__ import annotations
 
-import hashlib
 import json
 from pathlib import Path
 from textwrap import dedent
@@ -21,6 +20,8 @@ from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
+
+from charter.hasher import hash_content
 
 pytestmark = [pytest.mark.integration]
 
@@ -63,7 +64,7 @@ def _write_charter_and_metadata(
     charter_path = charter_dir / "charter.md"
     metadata_path = charter_dir / "metadata.yaml"
     charter_path.write_text("# Charter\n", encoding="utf-8")
-    digest = hashlib.sha256(charter_path.read_bytes()).hexdigest()
+    digest = hash_content(charter_path.read_text(encoding="utf-8")).split(":", 1)[1]
     if mismatched_hash:
         digest = "0" * 64
     # NOTE: omit ``timestamp_utc`` — ruamel's safe loader parses ISO

--- a/tests/integration/test_charter_synthesize_fresh.py
+++ b/tests/integration/test_charter_synthesize_fresh.py
@@ -152,6 +152,14 @@ def test_synthesize_on_fresh_project_via_public_cli(tmp_path: Path) -> None:
     assert payload.get("success") is True
     assert payload.get("mode") == "fresh_project_seed"
     assert ".kittify/doctrine/PROVENANCE.md" in payload.get("files_written", [])
+    assert ".kittify/charter/synthesis-manifest.yaml" in payload.get("files_written", [])
+
+    manifest_path = tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    assert manifest_path.is_file(), (
+        "fresh-project synthesize must write the built-in-only manifest "
+        "that charter preflight uses as its freshness marker"
+    )
+    assert "built_in_only: true" in manifest_path.read_text(encoding="utf-8")
 
     # WP02 / FR-002: the four contracted envelope fields are present
     # unconditionally — even on the fresh-project seed code path
@@ -232,6 +240,7 @@ def test_synthesize_dry_run_on_fresh_project_does_not_fall_through(
     assert payload.get("success") is True
     assert payload.get("mode") == "fresh_project_seed_dry_run"
     assert ".kittify/doctrine/PROVENANCE.md" in payload.get("files_planned", [])
+    assert ".kittify/charter/synthesis-manifest.yaml" in payload.get("files_planned", [])
 
     # WP02 / FR-002 contracted-fields presence:
     assert "adapter" in payload

--- a/tests/specify_cli/charter_freshness/test_computer.py
+++ b/tests/specify_cli/charter_freshness/test_computer.py
@@ -16,7 +16,6 @@ Covers each documented sub-state:
 
 from __future__ import annotations
 
-import hashlib
 import time
 from pathlib import Path
 from textwrap import dedent
@@ -28,6 +27,7 @@ from specify_cli.charter_freshness import (
     FreshnessSubState,
     compute_freshness,
 )
+from charter.hasher import hash_content
 
 
 pytestmark = [pytest.mark.fast]
@@ -47,7 +47,7 @@ def _seed_charter(repo: Path, body: str = "# Charter\n\nHello") -> tuple[Path, P
 
 
 def _write_metadata(metadata_path: Path, charter_path: Path, *, mismatched: bool = False) -> None:
-    digest = hashlib.sha256(charter_path.read_bytes()).hexdigest()
+    digest = hash_content(charter_path.read_text(encoding="utf-8")).split(":", 1)[1]
     if mismatched:
         digest = "0" * 64
     metadata_path.write_text(
@@ -176,6 +176,28 @@ def test_synced_bundle_stale_when_charter_is_newer(tmp_path: Path) -> None:
     assert result.synced_bundle.state == "stale"
 
 
+def test_charter_source_uses_sync_hash_normalization(tmp_path: Path) -> None:
+    charter_path, metadata_path = _seed_charter(tmp_path, "# Charter\n\nHello\n\n")
+    _write_metadata(metadata_path, charter_path)
+
+    result = compute_freshness(tmp_path)
+
+    assert result.charter_source.state == "fresh"
+
+
+def test_synced_bundle_fresh_when_matching_hash_but_bundle_mtime_older(tmp_path: Path) -> None:
+    charter_path, metadata_path = _seed_charter(tmp_path)
+    _write_metadata(metadata_path, charter_path)
+    _seed_bundle_files(tmp_path)
+
+    time.sleep(0.01)
+    charter_path.write_text("# Charter\n\nHello\n\n", encoding="utf-8")
+    result = compute_freshness(tmp_path)
+
+    assert result.charter_source.state == "fresh"
+    assert result.synced_bundle.state == "fresh"
+
+
 def test_synthesized_drg_missing_when_no_graph_no_manifest(tmp_path: Path) -> None:
     charter_path, metadata_path = _seed_charter(tmp_path)
     _write_metadata(metadata_path, charter_path)
@@ -191,6 +213,24 @@ def test_synthesized_drg_built_in_only_when_manifest_declares_it(tmp_path: Path)
     _seed_bundle_files(tmp_path)
     _seed_manifest(tmp_path, built_in_only=True)
     result = compute_freshness(tmp_path)
+    assert result.synthesized_drg.state == "built_in_only"
+    assert result.synthesized_drg.remediation is None
+
+
+def test_synthesized_drg_built_in_only_for_legacy_fresh_seed(tmp_path: Path) -> None:
+    charter_path, metadata_path = _seed_charter(tmp_path)
+    _write_metadata(metadata_path, charter_path)
+    _seed_bundle_files(tmp_path)
+    provenance = tmp_path / ".kittify" / "doctrine" / "PROVENANCE.md"
+    provenance.parent.mkdir(parents=True, exist_ok=True)
+    provenance.write_text(
+        "# Spec Kitty Doctrine — Fresh Project Seed\n\n"
+        "No LLM-authored YAML was present; using built-in doctrine.\n",
+        encoding="utf-8",
+    )
+
+    result = compute_freshness(tmp_path)
+
     assert result.synthesized_drg.state == "built_in_only"
     assert result.synthesized_drg.remediation is None
 


### PR DESCRIPTION
## Summary
- align charter freshness hashing with `charter sync` canonical `hash_content()` semantics
- stop treating a matching-hash bundle as stale solely due to file mtime churn
- write a built-in-only synthesis manifest for fresh-project seed mode, with legacy fresh-seed fallback

## Validation
- `git diff --check`
- `uv run ruff check src/specify_cli/charter_runtime/freshness/computer.py src/specify_cli/cli/commands/charter/_fresh_doctrine.py tests/specify_cli/charter_freshness/test_computer.py tests/integration/test_charter_status_freshness.py tests/integration/test_charter_synthesize_fresh.py`
- `uv run python -m pytest tests/specify_cli/charter_freshness/test_computer.py tests/integration/test_charter_status_freshness.py tests/integration/test_charter_synthesize_fresh.py tests/e2e/test_charter_epic_golden_path.py::test_charter_epic_golden_path tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_full_workflow_sequence -q --tb=short`