### PR TITLE
Release 3.2.0rc27

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc26
+  version: 3.2.0rc27
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc27] - 2026-05-26
+
+3.2.0rc27 fixes a charter freshness/preflight false positive found in the
+post-rc26 mainline checks.
+
+### Fixed
+
+- Charter freshness now uses the same canonical hash semantics as
+  `charter sync`, so whitespace-normalized stored hashes do not falsely mark a
+  project stale.
+- Fresh built-in doctrine seeds now produce the charter synthesis manifest
+  expected by preflight, preventing new projects from failing with
+  `charter_source stale` before any local charter exists.
+- Synced charter bundles no longer become stale from source mtime drift when
+  metadata hashes and required bundle files already prove the source is fresh.
+
 ## [3.2.0rc26] - 2026-05-26
 
 Rolls up the charter preflight, built-in vocabulary, and CI stabilization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc26"
+version = "3.2.0rc27"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc26"
+version = "3.2.0rc27"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- bump spec-kitty-cli to 3.2.0rc27
- document the charter freshness/preflight false-positive fix from #1314
- sync project metadata and uv.lock

## Validation
- git diff --check
- uv lock --check
- uv run python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- uv run python -m pytest tests/release -q --tb=short
- uv run python -m build --outdir dist-rc27
- uv run twine check dist-rc27/*
- uv run python scripts/release/check_exact_install.py --package spec-kitty-cli --dist-dir dist-rc27