### PR TITLE
Make Getting Started the docs home

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -76,7 +76,7 @@
     "globalMetadata": {
       "_appTitle": "Spec Kitty Documentation",
       "_appName": "Spec Kitty",
-      "_appFooter": "Spec Kitty documentation — tutorials, how-to guides, reference, and explanations",
+      "_appFooter": "Spec Kitty documentation — tutorials, how-to guides, reference, and explanations · <a href=\"https://docs.spec-kitty.ai/1x/\">1.x docs</a> · <a href=\"https://docs.spec-kitty.ai/2x/\">2.x docs</a>",
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,27 +1,6 @@
-# Spec Kitty Documentation
+# Redirecting to Getting Started
 
-Spec-kitty is a spec-driven development tool that coordinates AI agents through structured workflows. This documentation is organised using the [Divio documentation system](explanation/divio-documentation.md).
+<meta http-equiv="refresh" content="0; url=https://docs.spec-kitty.ai/tutorials/getting-started.html">
+<link rel="canonical" href="https://docs.spec-kitty.ai/tutorials/getting-started.html">
 
-## Documentation Categories
-
-| Category | Purpose | Start here |
-|---|---|---|
-| **Tutorials** | Step-by-step lessons to learn spec-kitty from scratch. | [Getting Started](tutorials/getting-started.md) |
-| **How-To Guides** | Task-oriented recipes for solving specific problems. | [Install & Upgrade](how-to/install-spec-kitty.md) |
-| **Reference** | Precise descriptions of CLI commands, configuration, and APIs. | [CLI Commands](reference/cli-commands.md) |
-| **Explanation** | Background concepts, architecture, and design decisions. | [Spec-Driven Development](explanation/spec-driven-development.md) |
-
-## Version Tracks
-
-| Track | Use when | Entry point |
-|---|---|---|
-| `3.x` (current) | New projects and all projects on `main` or PyPI. | This documentation |
-| `1.x` | Maintaining a deprecated legacy workflow (maintenance-only). | Archive retained under `docs/1x/` |
-
-## Verification Notes
-
-Versioned docs are tested for:
-
-1. Relative-link integrity.
-2. Required version-track pages.
-3. Exclusion of out-of-scope hosted-platform terminology in `docs/1x/` and `docs/2x/`.
+[Continue to Getting Started](tutorials/getting-started.md).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,5 +1,3 @@
-- name: Home
-  href: index.md
 - name: Tutorials
   href: tutorials/
 - name: How-To Guides
@@ -12,7 +10,3 @@
   href: migration/
 - name: 3.x Docs (Current)
   href: 3x/
-- name: 1.x Docs
-  href: 1x/
-- name: 2.x Docs (Archive)
-  href: 2x/


### PR DESCRIPTION
## Summary
- remove the Home entry from the docs top-level TOC
- make the docs root redirect to the Getting Started tutorial
- move 1.x and 2.x archive docs links from top navigation into the global footer

## Tests
- uv run pytest tests/docs/test_versioned_docs_integrity.py tests/docs/test_check_docs_freshness.py -q
- docfx docfx.json (from docs/)

Note: local DocFX build still reports 7 pre-existing InvalidFileLink warnings outside this change.