### PR TITLE
Fix direct-main review blockers

### DIFF
--- a/src/specify_cli/glossary/seed_schema.py
+++ b/src/specify_cli/glossary/seed_schema.py
@@ -7,7 +7,7 @@ for domain invariants.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -41,6 +41,13 @@ class GlossarySeedTerm(BaseModel):
     def definition_must_not_be_empty(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("definition must not be empty")
+        return v
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def confidence_must_be_number(cls, v: Any) -> Any:
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise ValueError("confidence must be a number")
         return v
 
     @field_validator("confidence")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,15 +12,40 @@ import subprocess
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 import yaml
 
 from tests.test_isolation_helpers import get_installed_version, run_cli_subprocess
 from specify_cli.migration.schema_version import MAX_SUPPORTED_SCHEMA, SCHEMA_CAPABILITIES
+from charter.sync import sync as sync_charter
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 E2E_CEREMONY_BRANCH = "e2e-ceremony"
+
+
+def _write_built_in_only_manifest(project: Path) -> None:
+    """Seed fresh-project doctrine state for local workflow E2E fixtures."""
+    manifest_path = project / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        dedent(
+            """\
+            schema_version: '2'
+            mission_id: null
+            created_at: '2099-01-01T00:00:00+00:00'
+            run_id: 01JTESTRUNIDXXXXXXXXXXXXXX
+            adapter_id: test
+            adapter_version: '0.0.0'
+            synthesizer_version: '0.0.0'
+            manifest_hash: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            artifacts: []
+            built_in_only: true
+            """
+        ),
+        encoding="utf-8",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -216,6 +241,10 @@ def e2e_project(tmp_path: Path) -> Path:
         project / ".kittify",
         symlinks=True,
     )
+    charter_path = project / ".kittify" / "charter" / "charter.md"
+    if charter_path.exists():
+        sync_charter(charter_path, charter_path.parent, force=True)
+    _write_built_in_only_manifest(project)
 
     # Copy missions from source location
     missions_src = REPO_ROOT / "src" / "specify_cli" / "missions"

--- a/tests/integration/test_quickstart_end_to_end.py
+++ b/tests/integration/test_quickstart_end_to_end.py
@@ -31,7 +31,6 @@ Runtime budget: <30s on a typical dev laptop. Skips are explicit and named.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from pathlib import Path
 from textwrap import dedent
@@ -40,6 +39,8 @@ from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
+
+from charter.hasher import hash_content
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
@@ -87,13 +88,13 @@ def _write_charter_and_metadata(repo: Path) -> None:
     charter_path = charter_dir / "charter.md"
     metadata_path = charter_dir / "metadata.yaml"
     charter_path.write_text("# Charter\n", encoding="utf-8")
-    digest = hashlib.sha256(charter_path.read_bytes()).hexdigest()
+    digest = hash_content(charter_path.read_text(encoding="utf-8"))
     # Use a plain-string timestamp to dodge the ruamel-->datetime
     # serialisation issue called out by test_charter_status_freshness.py.
     metadata_path.write_text(
         dedent(
             f"""\
-            charter_hash: sha256:{digest}
+            charter_hash: {digest}
             extracted_at: "2026-01-01T00:00:00+00:00"
             """
         ),

--- a/tests/specify_cli/glossary/test_seed_schema.py
+++ b/tests/specify_cli/glossary/test_seed_schema.py
@@ -114,6 +114,22 @@ class TestGlossarySeedTermConfidenceValidation:
         with pytest.raises(ValidationError, match="confidence must be 0.0..1.0"):
             GlossarySeedTerm(surface="term", definition="Def", confidence=1.01)
 
+    def test_string_confidence_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="confidence must be a number"):
+            GlossarySeedTerm(
+                surface="term",
+                definition="Def",
+                confidence="0.5",  # type: ignore[arg-type]
+            )
+
+    def test_bool_confidence_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="confidence must be a number"):
+            GlossarySeedTerm(
+                surface="term",
+                definition="Def",
+                confidence=True,  # type: ignore[arg-type]
+            )
+
 
 class TestGlossarySeedTermStatusValidation:
     """Status enum validator tests."""


### PR DESCRIPTION
## Summary
- fixes blockers found while reviewing the direct-main commit batch starting at 552ab1e19665a3370d21b3a4e7b4b479bcbcecb1
- enforces strict numeric glossary seed confidence values instead of accepting Pydantic-coerced strings/bools
- refreshes E2E fixture charter metadata from copied templates and writes the built-in-only synthesis manifest expected by preflight
- keeps branch based on current origin/main, including the latest charter prose policy commit

## Validation
- uv run pytest tests/specify_cli/glossary/test_seed_schema.py tests/specify_cli/glossary/test_seed_validation.py tests/specify_cli/cli/commands/test_glossary_validate.py
- uv run pytest tests/integration/test_quickstart_end_to_end.py::TestStep2_PreflightBlocksAndAutoRefresh::test_step2_preflight_json_blocks_with_reason
- uv run pytest tests/e2e/test_cli_smoke.py::TestFullCLIWorkflow::test_full_workflow_sequence
- uv run pytest tests/integration/test_quickstart_end_to_end.py tests/e2e/test_cli_smoke.py
- uv run ruff check src/specify_cli/glossary/seed_schema.py tests/specify_cli/glossary/test_seed_schema.py tests/integration/test_quickstart_end_to_end.py tests/e2e/conftest.py
- git diff --check