### PR TITLE
Fix Codex implement-review dispatch sandbox

### DIFF
--- a/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
@@ -61,7 +61,7 @@ the agent's CLI capabilities:
 | Agent | Config Key | CLI Dispatch | Can Run move-task | Tier |
 |-------|-----------|--------------|-------------------|------|
 | Claude Code | `claude` | `claude -p "prompt" --output-format json` | Yes | 1 |
-| GitHub Codex | `codex` | `codex exec --full-auto -C <dir> -` (stdin) | Yes | 1 |
+| GitHub Codex | `codex` | `codex exec --sandbox danger-full-access -C <dir> -` (stdin) | Yes | 1 |
 | Google Gemini | `gemini` | `gemini -p "prompt" --yolo --output-format json` | Yes | 1 |
 | GitHub Copilot | `copilot` | `copilot -p "prompt" --yolo --silent` | Yes | 1 |
 | OpenCode | `opencode` | `opencode run "prompt" --format json` | Yes | 1 |
@@ -251,7 +251,8 @@ PROMPT_CONTENT=$(cat "$PROMPT_FILE")
 claude -p "$PROMPT_CONTENT" --output-format json -C "$WORKSPACE"
 
 # GitHub Codex:
-printf '%s' "$PROMPT_CONTENT" | codex exec --full-auto -C "$WORKSPACE" -
+# move-task writes git/status locks and may touch local sync state; workspace-write/full-auto is too narrow.
+printf '%s' "$PROMPT_CONTENT" | codex exec --sandbox danger-full-access -C "$WORKSPACE" -
 
 # Google Gemini:
 gemini -p "$PROMPT_CONTENT" --yolo --output-format json -C "$WORKSPACE"
@@ -371,7 +372,7 @@ cat "$REVIEW_PROMPT" >> /tmp/review-prompt-WP##.md
 
 # Dispatch to configured reviewer (same CLI patterns as Step 1b)
 # Example for codex:
-cat /tmp/review-prompt-WP##.md | codex exec --full-auto \
+cat /tmp/review-prompt-WP##.md | codex exec --sandbox danger-full-access \
   -C "$WORKTREE" --add-dir "$(pwd)" \
   -o "/tmp/review-result-WP##.md" -
 
@@ -835,9 +836,11 @@ orchestrator should run the force-move manually.
 `timeout 600 cursor agent -p --force "prompt"`. If still hanging, kill and
 re-dispatch to a different agent.
 
-**Auto-commit warnings from sandboxed agents**: Some agents (codex) run in
-sandboxes that cannot write to `.git/index.lock`. The lane change is written
-to status files but needs manual commit from the repository root checkout:
+**Auto-commit warnings from sandboxed agents**: Codex dispatch must use
+`--sandbox danger-full-access` so terminal `move-task` can write git/status
+locks and commit status artifacts. If a locally patched or stale skill still
+uses `--full-auto`/`workspace-write`, the lane change may be written to status
+files but still need manual commit from the repository root checkout:
 `git add kitty-specs/ && git commit -m "chore: status update"`
 
 **Stale WP (in_progress but no agent activity)**: Force back to planned and

--- a/src/doctrine/skills/spec-kitty-implement-review/references/agent-dispatch-matrix.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/references/agent-dispatch-matrix.md
@@ -10,7 +10,7 @@ including `spec-kitty agent tasks move-task`.
 | Agent | Config Key | CLI Template | Notes |
 |-------|-----------|--------------|-------|
 | Claude Code | `claude` | `claude -p "<prompt>" --output-format json -C <dir>` | Gold standard. Supports `--allowedTools`. |
-| GitHub Codex | `codex` | `cat prompt.md \| codex exec --full-auto -C <dir> -` | Stdin only (no positional prompt with `-C`). Use `--add-dir` for read access to the repository root checkout. |
+| GitHub Codex | `codex` | `cat prompt.md \| codex exec --sandbox danger-full-access -C <dir> -` | Stdin only (no positional prompt with `-C`). Use `--add-dir` for read access to the repository root checkout. `move-task` writes git/status locks, so `workspace-write`/`--full-auto` is too narrow. |
 | Google Gemini | `gemini` | `gemini -p "<prompt>" --yolo --output-format json -C <dir>` | Large context window (1M tokens). |
 | GitHub Copilot | `copilot` | `copilot -p "<prompt>" --yolo --silent` | Requires GitHub Copilot subscription. |
 | OpenCode | `opencode` | `opencode run "<prompt>" --format json -C <dir>` | Multi-provider support. |

--- a/tests/doctrine/test_codex_dispatch_flags.py
+++ b/tests/doctrine/test_codex_dispatch_flags.py
@@ -1,0 +1,45 @@
+"""Regression checks for Codex dispatch flags in shipped doctrine skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.doctrine.conftest import DOCTRINE_SOURCE_ROOT, REPO_ROOT
+
+pytestmark = pytest.mark.doctrine
+
+
+def _skill_markdown_files() -> list[Path]:
+    return sorted((DOCTRINE_SOURCE_ROOT / "skills").rglob("*.md"))
+
+
+def test_shipped_doctrine_skills_do_not_dispatch_codex_with_full_auto() -> None:
+    """Codex --full-auto aliases workspace-write and breaks terminal move-task."""
+    violations: list[str] = []
+    for path in _skill_markdown_files():
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if "codex exec --full-auto" in line:
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{line_number}: {line.strip()}")
+
+    assert violations == []
+
+
+def test_implement_review_codex_dispatch_uses_explicit_git_capable_sandbox() -> None:
+    skill_path = DOCTRINE_SOURCE_ROOT / "skills" / "spec-kitty-implement-review" / "SKILL.md"
+    matrix_path = (
+        DOCTRINE_SOURCE_ROOT
+        / "skills"
+        / "spec-kitty-implement-review"
+        / "references"
+        / "agent-dispatch-matrix.md"
+    )
+
+    skill = skill_path.read_text(encoding="utf-8")
+    matrix = matrix_path.read_text(encoding="utf-8")
+
+    assert "codex exec --full-auto" not in skill
+    assert "codex exec --full-auto" not in matrix
+    assert skill.count("codex exec --sandbox danger-full-access") == 3
+    assert matrix.count("codex exec --sandbox danger-full-access") == 1


### PR DESCRIPTION
## Summary
- replace Codex `--full-auto` dispatch in the implement-review skill with explicit `--sandbox danger-full-access`
- update the dispatch matrix and troubleshooting note to explain why `workspace-write` is too narrow for terminal `move-task`
- add doctrine regression tests that block `codex exec --full-auto` from shipped skill dispatches

Fixes #1324

## Verification
- `uv run ruff check tests/doctrine/test_codex_dispatch_flags.py`
- `uv run pytest tests/doctrine/test_codex_dispatch_flags.py tests/doctrine/test_package_smoke.py -q`
- `git diff --check`