### PR TITLE
fix(glossary): render dashboard terms after schema strictening landed

### DIFF
--- a/src/specify_cli/dashboard/handlers/glossary.py
+++ b/src/specify_cli/dashboard/handlers/glossary.py
@@ -68,25 +68,132 @@ def _collect_all_senses(repo_root: Path) -> list[Any]:
     """Load all TermSense objects from seed files across all scopes.
 
     Returns a flat list of TermSense objects, or an empty list on any error.
-    Raises ``SeedFileValidationError`` if any scope has an invalid seed file.
+    Raises ``SeedFileValidationError`` if any scope has an invalid seed file
+    and per-term recovery yields nothing usable.
     """
+    senses, validation_errors = _collect_all_senses_with_errors(repo_root)
+    if not senses and validation_errors:
+        raise validation_errors[0]
+    return senses
+
+
+def _collect_all_senses_with_errors(repo_root: Path) -> tuple[list[Any], list[SeedFileValidationError]]:
+    """Load glossary senses and retain validation errors for health reporting."""
     try:
         from specify_cli.glossary.scope import GlossaryScope, load_seed_file
 
         senses = []
+        validation_errors: list[SeedFileValidationError] = []
         for scope in GlossaryScope:
             try:
                 senses.extend(load_seed_file(scope, repo_root))
-            except SeedFileValidationError:
-                raise  # Let validation errors propagate to handler
+            except SeedFileValidationError as exc:
+                # File-level validation rejected this scope as a whole. Try
+                # per-term recovery so a handful of bad entries cannot blank
+                # the entire glossary view in the dashboard.
+                recovered = _recover_valid_senses(scope, repo_root, exc)
+                if recovered:
+                    senses.extend(recovered)
+                validation_errors.append(exc)
             except Exception as exc:
                 logger.debug("Skipping scope %s: %s", scope.value, exc)
-        return senses
-    except SeedFileValidationError:
-        raise  # Re-raise through outer try
+        return senses, validation_errors
     except Exception as exc:
         logger.debug("Could not load glossary senses: %s", exc)
+        return [], []
+
+
+def _recover_valid_senses(
+    scope: Any,
+    repo_root: Path,
+    original_error: SeedFileValidationError,
+) -> list[Any]:
+    """Best-effort per-term load when file-level validation has failed.
+
+    Returns the subset of terms that pass schema validation individually.
+    Logs a warning naming the scope, the number recovered, and the indices
+    skipped so operators can see exactly which entries are malformed.
+    """
+    try:
+        if any(e.term_index is None for e in original_error.errors):
+            logger.warning(
+                "glossary scope %s: refusing per-term recovery after file-level "
+                "validation failure: %s",
+                scope.value, original_error,
+            )
+            return []
+
+        from datetime import datetime
+
+        from ruamel.yaml import YAML
+
+        from specify_cli.glossary.models import (
+            Provenance,
+            TermSense,
+            TermSurface,
+        )
+        from specify_cli.glossary.scope import _parse_sense_status
+        from specify_cli.glossary.seed_schema import GlossarySeedTerm
+
+        seed_path = repo_root / ".kittify" / "glossaries" / f"{scope.value}.yaml"
+        if not seed_path.exists():
+            return []
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        data = yaml.load(seed_path)
+        raw_terms = (data or {}).get("terms") or []
+
+        recovered: list[Any] = []
+        skipped: list[int] = []
+        for idx, term_data in enumerate(raw_terms):
+            try:
+                GlossarySeedTerm.model_validate(term_data)
+            except Exception:
+                skipped.append(idx)
+                continue
+            recovered.append(
+                TermSense(
+                    surface=TermSurface(term_data["surface"]),
+                    scope=scope.value,
+                    definition=term_data["definition"],
+                    provenance=Provenance(
+                        actor_id="system:seed_file",
+                        timestamp=datetime.now(),
+                        source="seed_file",
+                    ),
+                    confidence=term_data.get("confidence", 1.0),
+                    status=_parse_sense_status(term_data.get("status")),
+                )
+            )
+        if skipped:
+            logger.warning(
+                "glossary scope %s: recovered %d/%d terms; skipped indices %s "
+                "(file-level validation failed: %s)",
+                scope.value, len(recovered), len(raw_terms), skipped, original_error,
+            )
+        return recovered
+    except Exception as exc:
+        logger.debug("per-term recovery failed for scope %s: %s", scope.value, exc)
         return []
+
+
+def _format_validation_errors(
+    validation_errors: list[SeedFileValidationError],
+) -> list[dict[str, Any]] | None:
+    """Convert validation exceptions into the dashboard health JSON shape."""
+    if not validation_errors:
+        return None
+    return [
+        {
+            "file": str(error.file_path),
+            "term_index": item.term_index,
+            "term_surface": item.term_surface,
+            "field": item.field,
+            "message": item.message,
+        }
+        for error in validation_errors
+        for item in error.errors
+    ]
 
 
 class GlossaryHandler(DashboardHandler):
@@ -103,7 +210,7 @@ class GlossaryHandler(DashboardHandler):
             if self.project_dir is None:
                 raise RuntimeError("dashboard project_dir is not configured")
             project_dir = Path(self.project_dir)
-            senses = _collect_all_senses(project_dir)
+            senses, validation_errors = _collect_all_senses_with_errors(project_dir)
 
             active_count = sum(1 for t in senses if t.status.value == "active")
             draft_count = sum(1 for t in senses if t.status.value == "draft")
@@ -131,7 +238,7 @@ class GlossaryHandler(DashboardHandler):
                 "entity_pages_generated": entity_pages_generated,
                 "entity_pages_path": str(entity_pages_dir) if entity_pages_dir.exists() else None,
                 "last_conflict_at": last_at,
-                "validation_errors": None,
+                "validation_errors": _format_validation_errors(validation_errors),
             }
         except SeedFileValidationError as exc:
             logger.warning("glossary health: validation error in %s: %s", exc.file_path, exc)
@@ -145,16 +252,7 @@ class GlossaryHandler(DashboardHandler):
                 "entity_pages_generated": False,
                 "entity_pages_path": None,
                 "last_conflict_at": None,
-                "validation_errors": [
-                    {
-                        "file": str(e.file_path),
-                        "term_index": e.term_index,
-                        "term_surface": e.term_surface,
-                        "field": e.field,
-                        "message": e.message,
-                    }
-                    for e in exc.errors
-                ],
+                "validation_errors": _format_validation_errors([exc]),
             }
         except Exception as exc:
             logger.exception("glossary health error: %s", exc)

--- a/src/specify_cli/dashboard/templates/glossary.html
+++ b/src/specify_cli/dashboard/templates/glossary.html
@@ -168,6 +168,31 @@ body {
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
+.validation-banner {
+  margin: 18px 32px 0;
+  padding: 12px 14px;
+  background: #fff8db;
+  border: 1px solid #e6c84c;
+  border-left: 4px solid var(--yellow-dark);
+  border-radius: var(--radius-sm);
+  color: var(--text-bright);
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 0.9em;
+  box-shadow: var(--shadow-sm);
+}
+.validation-banner.hidden { display: none; }
+.validation-banner strong { font-weight: 700; }
+.validation-banner code {
+  font-family: var(--mono);
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(44,62,80,0.12);
+  border-radius: 4px;
+  padding: 2px 5px;
+}
+
 .search-wrap {
   position: relative;
   flex: 1;
@@ -474,6 +499,8 @@ body {
   <span class="result-count" id="result-count"></span>
 </div>
 
+<div class="validation-banner hidden" id="validation-banner" role="alert"></div>
+
 <!-- ALPHABET NAV -->
 <nav class="alpha-nav" id="alpha-nav" aria-label="Jump to letter"></nav>
 
@@ -489,6 +516,7 @@ body {
 
 <script>
 let TERMS = [];
+let VALIDATION_ERRORS = [];
 
 // ── State ─────────────────────────────────────────────────
 let filter = 'all';
@@ -504,9 +532,41 @@ async function loadTerms() {
     console.warn('glossary: could not load terms', e);
     TERMS = [];
   }
+  try {
+    const resp = await fetch('/api/glossary-health');
+    if (!resp.ok) throw new Error('health fetch failed');
+    const health = await resp.json();
+    VALIDATION_ERRORS = Array.isArray(health.validation_errors) ? health.validation_errors : [];
+  } catch (e) {
+    console.warn('glossary: could not load health', e);
+    VALIDATION_ERRORS = [];
+  }
+  renderValidationBanner();
   updateStats();
   buildAlphaNav();
   render();
+}
+
+function renderValidationBanner() {
+  const banner = document.getElementById('validation-banner');
+  if (!banner) return;
+  if (!VALIDATION_ERRORS.length) {
+    banner.classList.add('hidden');
+    banner.innerHTML = '';
+    return;
+  }
+  const first = VALIDATION_ERRORS[0] || {};
+  const count = VALIDATION_ERRORS.length;
+  const file = first.file ? String(first.file).split('/').pop() : 'seed file';
+  const where = first.term_index === null || first.term_index === undefined ? 'file' : `term ${first.term_index}`;
+  const field = first.field ? ` · ${first.field}` : '';
+  const more = count > 1 ? ` · ${count - 1} more` : '';
+  banner.classList.remove('hidden');
+  banner.innerHTML = `
+    <strong>Glossary validation warning</strong>
+    <span>${count} validation ${count === 1 ? 'error' : 'errors'}; showing recovered terms only.</span>
+    <code>${esc(file)} · ${esc(where)}${esc(field)}${esc(more)}</code>
+  `;
 }
 
 function updateStats() {

--- a/src/specify_cli/glossary/scope.py
+++ b/src/specify_cli/glossary/scope.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString, PreservedScalarString
 
 from .models import Provenance, SenseStatus, TermSense, TermSurface
+
+
+_SEED_METADATA_FIELDS = ("see_also", "synonyms_to_avoid", "introduced_in_mission")
 
 
 class GlossaryScope(Enum):
@@ -118,7 +123,23 @@ def load_seed_file(scope: GlossaryScope, repo_root: Path) -> list[TermSense]:
 
     yaml = YAML()
     yaml.preserve_quotes = True
-    data = yaml.load(seed_path)
+    try:
+        data = yaml.load(seed_path)
+    except Exception as exc:
+        from .exceptions import SeedFileValidationError, SeedValidationError
+
+        raise SeedFileValidationError(
+            seed_path,
+            [
+                SeedValidationError(
+                    file_path=seed_path,
+                    term_index=None,
+                    term_surface=None,
+                    field=None,
+                    message=f"YAML parse error: {exc}",
+                )
+            ],
+        ) from exc
 
     # Full Pydantic validation — raises SeedFileValidationError on failure
     from .seed_validation import validate_seed_file_data
@@ -144,23 +165,58 @@ def load_seed_file(scope: GlossaryScope, repo_root: Path) -> list[TermSense]:
     return senses
 
 
+def _default_header(scope: GlossaryScope) -> list[str]:
+    return [f"# Spec Kitty glossary seed — scope: {scope.value}", ""]
+
+
 def _needs_quoting(value: str) -> bool:
     return ": " in value or "'" in value
 
 
-def _yaml_scalar(value: str) -> str:
+def _seed_scalar_value(value: str) -> str:
+    if "\n" in value:
+        return PreservedScalarString(value)
     if _needs_quoting(value):
-        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-        return f'"{escaped}"'
+        return DoubleQuotedScalarString(value)
     return value
 
 
-def _confidence_str(conf: float) -> str:
-    return f"{conf:.1f}" if conf == int(conf) else str(round(conf, 4))
+def _load_existing_seed_metadata(seed_path: Path) -> dict[str, dict[str, Any]]:
+    """Return accepted metadata fields keyed by term surface from an existing seed."""
+    if not seed_path.exists():
+        return {}
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    try:
+        data = yaml.load(seed_path)
+    except Exception:
+        return {}
+
+    metadata: dict[str, dict[str, Any]] = {}
+    for term_data in (data or {}).get("terms") or []:
+        if not isinstance(term_data, dict):
+            continue
+        surface = term_data.get("surface")
+        if not isinstance(surface, str):
+            continue
+        preserved = {
+            field: term_data[field]
+            for field in _SEED_METADATA_FIELDS
+            if field in term_data
+        }
+        if preserved:
+            metadata[surface] = preserved
+    return metadata
 
 
-def _default_header(scope: GlossaryScope) -> list[str]:
-    return [f"# Spec Kitty glossary seed — scope: {scope.value}", ""]
+def _dump_seed_body(data: dict[str, Any]) -> str:
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.default_flow_style = False
+    stream = StringIO()
+    yaml.dump(data, stream)
+    return stream.getvalue()
 
 
 def save_seed_file(
@@ -176,21 +232,23 @@ def save_seed_file(
     seed_path = repo_root / ".kittify" / "glossaries" / f"{scope.value}.yaml"
     seed_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Validate the data that will be written
     from .seed_validation import validate_seed_file_data
 
-    validation_data = {
-        "terms": [
-            {
-                "surface": t.surface.surface_text,
-                "definition": t.definition,
-                "confidence": t.confidence,
-                "status": t.status.value,
-            }
-            for t in terms
-        ]
-    }
-    validate_seed_file_data(validation_data, seed_path)
+    existing_metadata = _load_existing_seed_metadata(seed_path)
+    sorted_terms = sorted(terms, key=lambda t: t.surface.surface_text.lower())
+
+    output_data: dict[str, Any] = {"terms": []}
+    for t in sorted_terms:
+        term_entry: dict[str, Any] = {
+            "surface": _seed_scalar_value(t.surface.surface_text),
+            "definition": _seed_scalar_value(t.definition),
+            "confidence": t.confidence,
+            "status": t.status.value,
+        }
+        term_entry.update(existing_metadata.get(t.surface.surface_text, {}))
+        output_data["terms"].append(term_entry)
+
+    validate_seed_file_data(output_data, seed_path)
 
     # Preserve existing header comment lines; fall back to a generated one.
     if seed_path.exists():
@@ -204,22 +262,12 @@ def save_seed_file(
     else:
         header = _default_header(scope)
 
-    sorted_terms = sorted(terms, key=lambda t: t.surface.surface_text.lower())
+    body = _dump_seed_body(output_data)
+    prefix = "\n".join(header)
+    if prefix and not prefix.endswith("\n"):
+        prefix += "\n"
 
-    lines: list[str] = list(header)
-    if not sorted_terms:
-        lines.append("terms: []")
-    else:
-        lines.append("terms:")
-    for sense in sorted_terms:
-        lines.append("")
-        lines.append(f"  - surface: {_yaml_scalar(sense.surface.surface_text)}")
-        lines.append(f"    definition: {_yaml_scalar(sense.definition)}")
-        lines.append(f"    confidence: {_confidence_str(sense.confidence)}")
-        lines.append(f"    status: {sense.status.value}")
-    lines.append("")
-
-    seed_path.write_text("\n".join(lines), encoding="utf-8")
+    seed_path.write_text(prefix + body, encoding="utf-8")
 
 
 def activate_scope(

--- a/src/specify_cli/glossary/seed_schema.py
+++ b/src/specify_cli/glossary/seed_schema.py
@@ -24,10 +24,9 @@ class GlossarySeedTerm(BaseModel):
     confidence: float = 1.0
     status: Literal["active", "draft", "deprecated"] = "draft"
 
-    # Optional provenance/relationship metadata written by authoring pipelines
-    # (e.g. charter vocabulary missions). Accepted at the schema layer so a
-    # single annotated term cannot reject the entire seed file; not yet
-    # propagated into TermSense / round-tripped by save_seed_file.
+    # Optional provenance/relationship metadata written by authoring pipelines.
+    # Accepted at the schema layer so a single annotated term cannot reject the
+    # entire seed file; preserved by save_seed_file when already present.
     see_also: list[dict[str, str]] | None = None
     synonyms_to_avoid: list[str] | None = None
     introduced_in_mission: str | None = None

--- a/src/specify_cli/glossary/seed_schema.py
+++ b/src/specify_cli/glossary/seed_schema.py
@@ -24,6 +24,14 @@ class GlossarySeedTerm(BaseModel):
     confidence: float = 1.0
     status: Literal["active", "draft", "deprecated"] = "draft"
 
+    # Optional provenance/relationship metadata written by authoring pipelines
+    # (e.g. charter vocabulary missions). Accepted at the schema layer so a
+    # single annotated term cannot reject the entire seed file; not yet
+    # propagated into TermSense / round-tripped by save_seed_file.
+    see_also: list[dict[str, str]] | None = None
+    synonyms_to_avoid: list[str] | None = None
+    introduced_in_mission: str | None = None
+
     @field_validator("surface")
     @classmethod
     def surface_must_be_normalized(cls, v: str) -> str:

--- a/tests/specify_cli/dashboard/test_glossary_handler.py
+++ b/tests/specify_cli/dashboard/test_glossary_handler.py
@@ -69,7 +69,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=terms):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=(terms, [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         handler.send_response.assert_called_once_with(200)
@@ -85,7 +85,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         handler.send_response.assert_called_once_with(200)
@@ -101,7 +101,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", side_effect=RuntimeError("boom")):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", side_effect=RuntimeError("boom")):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         handler.send_response.assert_called_once_with(200)
@@ -157,7 +157,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -170,7 +170,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -183,7 +183,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -202,7 +202,7 @@ class TestGlossaryHealth:
         terms = [_make_term("alpha", "def a", "active", 1.0)]
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=terms):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=(terms, [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -233,7 +233,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", side_effect=exc):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", side_effect=exc):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -258,12 +258,100 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", side_effect=RuntimeError("boom")):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", side_effect=RuntimeError("boom")):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
         assert data["total_terms"] == 0
         assert data["validation_errors"] is None
+
+    def test_health_reports_validation_errors_after_partial_recovery(self, tmp_path):
+        """Recovered dashboard terms must not hide seed validation errors."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: First letter\n"
+            "    status: active\n"
+            "  - surface: beta\n"
+            "    definition: Invalid extra field\n"
+            "    status: active\n"
+            "    bogus_extra_field: rejected\n"
+            "  - surface: gamma\n"
+            "    definition: Third letter\n"
+            "    status: draft\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 2
+        assert data["active_count"] == 1
+        assert data["draft_count"] == 1
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] == 1
+        assert data["validation_errors"][0]["term_surface"] == "beta"
+        assert data["validation_errors"][0]["field"] == "bogus_extra_field"
+
+    def test_health_reports_invalid_scope_even_when_lower_scope_loads(self, tmp_path):
+        """A valid lower-precedence scope must not mask an invalid higher scope."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "mission_local.yaml").write_text(
+            "terms:\n"
+            "  - surface: BadTerm\n"
+            "    definition: Invalid high-precedence term\n",
+            encoding="utf-8",
+        )
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: Valid core term\n"
+            "    status: active\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 1
+        assert data["active_count"] == 1
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] == 0
+        assert data["validation_errors"][0]["term_surface"] == "BadTerm"
+        assert data["validation_errors"][0]["field"] == "surface"
+
+    def test_health_refuses_recovery_for_root_level_validation_error(self, tmp_path):
+        """Root seed schema errors are file-level failures, not per-term recovery."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "version: 1\n"
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: Valid term in invalid file shape\n"
+            "    status: active\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 0
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] is None
+        assert data["validation_errors"][0]["field"] == "version"
 
 
 class TestGlossaryTerms:
@@ -367,10 +455,12 @@ class TestCollectAllSenses:
             )],
         )
 
-        with patch("specify_cli.dashboard.handlers.glossary.SeedFileValidationError", SeedFileValidationError):
-            with patch("specify_cli.glossary.scope.load_seed_file", side_effect=exc):
-                with pytest.raises(SeedFileValidationError):
-                    _collect_all_senses(tmp_path)
+        with (
+            patch("specify_cli.dashboard.handlers.glossary.SeedFileValidationError", SeedFileValidationError),
+            patch("specify_cli.glossary.scope.load_seed_file", side_effect=exc),
+            pytest.raises(SeedFileValidationError),
+        ):
+            _collect_all_senses(tmp_path)
 
     def test_other_exceptions_are_swallowed(self, tmp_path):
         """Non-validation exceptions are caught, returning empty list."""
@@ -380,6 +470,40 @@ class TestCollectAllSenses:
             result = _collect_all_senses(tmp_path)
 
         assert result == []
+
+    def test_recovers_valid_terms_when_file_validation_fails(self, tmp_path):
+        """Per-term recovery returns valid terms even when one entry is malformed."""
+        from specify_cli.dashboard.handlers.glossary import _collect_all_senses
+
+        # Write a seed file w/ two valid terms and one term with an
+        # extra-forbidden field, simulating the upstream schema drift
+        # that prompted this regression test.
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: First letter\n"
+            "    confidence: 0.9\n"
+            "    status: active\n"
+            "  - surface: beta\n"
+            "    definition: Second letter\n"
+            "    confidence: 0.9\n"
+            "    status: active\n"
+            "    bogus_extra_field: rejected\n"
+            "  - surface: gamma\n"
+            "    definition: Third letter\n"
+            "    confidence: 0.9\n"
+            "    status: active\n",
+            encoding="utf-8",
+        )
+
+        result = _collect_all_senses(tmp_path)
+
+        surfaces = sorted(t.surface.surface_text for t in result)
+        assert surfaces == ["alpha", "gamma"], (
+            f"recovery should keep alpha + gamma and skip beta; got {surfaces}"
+        )
 
 
 class TestGlossaryPage:
@@ -406,6 +530,9 @@ class TestGlossaryPage:
         body = handler.wfile.read()
         assert body  # non-empty
         assert b"<!DOCTYPE html>" in body or b"<html" in body
+        text = body.decode("utf-8")
+        assert 'id="validation-banner"' in text
+        assert "fetch('/api/glossary-health')" in text
 
     def test_glossary_page_uses_cached_bytes(self, tmp_path):
         """Module-level _GLOSSARY_HTML_BYTES is reused for each request."""

--- a/tests/specify_cli/dashboard/test_glossary_handler.py
+++ b/tests/specify_cli/dashboard/test_glossary_handler.py
@@ -353,6 +353,29 @@ class TestGlossaryHealth:
         assert data["validation_errors"][0]["term_index"] is None
         assert data["validation_errors"][0]["field"] == "version"
 
+    def test_health_reports_yaml_parse_error(self, tmp_path):
+        """Malformed YAML must not look like an empty healthy glossary."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: ok\n"
+            "    confidence: [unterminated\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 0
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] is None
+        assert "YAML parse error" in data["validation_errors"][0]["message"]
+
 
 class TestGlossaryTerms:
     """Tests for handle_glossary_terms() → GET /api/glossary-terms."""

--- a/tests/specify_cli/glossary/test_scope.py
+++ b/tests/specify_cli/glossary/test_scope.py
@@ -229,6 +229,23 @@ class TestLoadSeedFile:
         with pytest.raises(GlossaryError):
             load_seed_file(GlossaryScope.SPEC_KITTY_CORE, tmp_path)
 
+    def test_malformed_yaml_raises_seed_file_validation_error(self, tmp_path: Path) -> None:
+        """YAML parser failures are surfaced as seed validation errors."""
+        _write_seed(
+            tmp_path,
+            GlossaryScope.SPEC_KITTY_CORE,
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: ok\n"
+            "    confidence: [unterminated\n",
+        )
+
+        with pytest.raises(SeedFileValidationError) as exc_info:
+            load_seed_file(GlossaryScope.SPEC_KITTY_CORE, tmp_path)
+
+        assert exc_info.value.errors[0].term_index is None
+        assert "YAML parse error" in exc_info.value.errors[0].message
+
 
 # ---------------------------------------------------------------------------
 # save_seed_file (T013)
@@ -285,3 +302,38 @@ class TestSaveSeedFile:
         alpha_pos = content.index("alpha")
         zebra_pos = content.index("zebra")
         assert alpha_pos < zebra_pos
+
+    def test_preserves_metadata_and_writes_valid_multiline_yaml(self, tmp_path: Path) -> None:
+        """Loading then saving an annotated seed must not drop metadata or corrupt YAML."""
+        from ruamel.yaml import YAML
+
+        seed_path = _write_seed(
+            tmp_path,
+            GlossaryScope.SPEC_KITTY_CORE,
+            "terms:\n"
+            "  - surface: characterization test\n"
+            "    definition: >-\n"
+            "      A test that captures existing behavior as fixture-driven assertions,\n"
+            "      written before refactor work begins.\n"
+            "    confidence: 0.95\n"
+            "    status: active\n"
+            "    see_also:\n"
+            "      - fr: FR-008\n"
+            "        description: Wall-clock regression test requirement\n"
+            "    synonyms_to_avoid: [snapshot]\n"
+            "    introduced_in_mission: glossary-seed-file-schema-validation-01KSN752\n",
+        )
+        terms = load_seed_file(GlossaryScope.SPEC_KITTY_CORE, tmp_path)
+
+        save_seed_file(GlossaryScope.SPEC_KITTY_CORE, tmp_path, terms)
+
+        yaml = YAML()
+        data = yaml.load(seed_path)
+        [term] = data["terms"]
+        assert term["surface"] == "characterization test"
+        assert term["see_also"][0]["fr"] == "FR-008"
+        assert term["synonyms_to_avoid"] == ["snapshot"]
+        assert term["introduced_in_mission"] == "glossary-seed-file-schema-validation-01KSN752"
+        assert load_seed_file(GlossaryScope.SPEC_KITTY_CORE, tmp_path)[0].definition.startswith(
+            "A test that captures existing behavior"
+        )

--- a/tests/specify_cli/glossary/test_seed_schema.py
+++ b/tests/specify_cli/glossary/test_seed_schema.py
@@ -42,6 +42,25 @@ class TestGlossarySeedTermValid:
         assert term.confidence == 1.0
         assert term.status == "draft"
 
+    def test_known_metadata_fields_allowed(self) -> None:
+        term = GlossarySeedTerm(
+            surface="regex safety",
+            definition="Regex policy",
+            see_also=[
+                {
+                    "tactic": "secure-regex-catastrophic-backtracking",
+                    "path": "src/doctrine/tactics/shipped/secure-regex-catastrophic-backtracking.tactic.yaml",
+                },
+                {"fr": "FR-008", "description": "Wall-clock regression test requirement"},
+            ],
+            synonyms_to_avoid=["redos"],
+            introduced_in_mission="glossary-seed-file-schema-validation-01KSN752",
+        )
+        assert term.see_also is not None
+        assert term.see_also[0]["tactic"] == "secure-regex-catastrophic-backtracking"
+        assert term.synonyms_to_avoid == ["redos"]
+        assert term.introduced_in_mission == "glossary-seed-file-schema-validation-01KSN752"
+
     def test_boundary_confidence_zero(self) -> None:
         term = GlossarySeedTerm(
             surface="edge", definition="A graph edge", confidence=0.0
@@ -150,6 +169,14 @@ class TestGlossarySeedTermExtraForbid:
                 surface="term",
                 definition="Def",
                 extra_field="nope",  # type: ignore[call-arg]
+            )
+
+    def test_malformed_see_also_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="see_also"):
+            GlossarySeedTerm(
+                surface="term",
+                definition="Def",
+                see_also=[42],  # type: ignore[list-item]
             )
 
 

--- a/tests/specify_cli/glossary/test_seed_validation.py
+++ b/tests/specify_cli/glossary/test_seed_validation.py
@@ -70,12 +70,20 @@ class TestValidateSeedFileDataSuccess:
                     "definition": "An execution lane.",
                     "confidence": 0.95,
                     "status": "deprecated",
+                    "see_also": [
+                        {"fr": "FR-008", "description": "Wall-clock regression test requirement"}
+                    ],
+                    "synonyms_to_avoid": ["track"],
+                    "introduced_in_mission": "glossary-seed-file-schema-validation-01KSN752",
                 }
             ]
         }
         result = validate_seed_file_data(data, SEED_PATH)
         assert result.terms[0].confidence == 0.95
         assert result.terms[0].status == "deprecated"
+        assert result.terms[0].see_also == [
+            {"fr": "FR-008", "description": "Wall-clock regression test requirement"}
+        ]
 
 
 # ---- validate_seed_file_data: failure cases ---------------------------------
@@ -187,6 +195,24 @@ class TestValidateSeedFileDataFailure:
 
         assert any(
             e.term_index == 0 for e in exc_info.value.errors
+        )
+
+    def test_malformed_see_also_rejected(self) -> None:
+        data = {
+            "terms": [
+                {
+                    "surface": "term",
+                    "definition": "Def",
+                    "see_also": [42],
+                }
+            ]
+        }
+        with pytest.raises(SeedFileValidationError) as exc_info:
+            validate_seed_file_data(data, SEED_PATH)
+
+        assert any(
+            e.term_index == 0 and e.field == "see_also"
+            for e in exc_info.value.errors
         )
 
     def test_multiple_errors_collected(self) -> None:

--- a/tests/test_dashboard/test_glossary_handler.py
+++ b/tests/test_dashboard/test_glossary_handler.py
@@ -297,6 +297,29 @@ class TestGlossaryHealth:
         assert data["validation_errors"][0]["term_index"] is None
         assert data["validation_errors"][0]["field"] == "version"
 
+    def test_health_reports_yaml_parse_error(self, tmp_path):
+        """Malformed YAML must not look like an empty healthy glossary."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: ok\n"
+            "    confidence: [unterminated\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 0
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] is None
+        assert "YAML parse error" in data["validation_errors"][0]["message"]
+
 
 class TestGlossaryTerms:
     """Tests for handle_glossary_terms() → GET /api/glossary-terms."""

--- a/tests/test_dashboard/test_glossary_handler.py
+++ b/tests/test_dashboard/test_glossary_handler.py
@@ -68,7 +68,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=terms):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=(terms, [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         handler.send_response.assert_called_once_with(200)
@@ -84,7 +84,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         handler.send_response.assert_called_once_with(200)
@@ -100,7 +100,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", side_effect=RuntimeError("boom")):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", side_effect=RuntimeError("boom")):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         handler.send_response.assert_called_once_with(200)
@@ -172,7 +172,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -185,7 +185,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -198,7 +198,7 @@ class TestGlossaryHealth:
 
         handler = _make_handler(tmp_path)
 
-        with patch.object(gloss_module, "_collect_all_senses", return_value=[]):
+        with patch.object(gloss_module, "_collect_all_senses_with_errors", return_value=([], [])):
             gloss_module.GlossaryHandler.handle_glossary_health(handler)
 
         data = _read_response(handler)
@@ -208,6 +208,94 @@ class TestGlossaryHealth:
             "entity_pages_generated", "entity_pages_path", "last_conflict_at",
         }
         assert required_keys.issubset(data.keys())
+
+    def test_health_reports_validation_errors_after_partial_recovery(self, tmp_path):
+        """Recovered dashboard terms must not hide seed validation errors."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: First letter\n"
+            "    status: active\n"
+            "  - surface: beta\n"
+            "    definition: Invalid extra field\n"
+            "    status: active\n"
+            "    bogus_extra_field: rejected\n"
+            "  - surface: gamma\n"
+            "    definition: Third letter\n"
+            "    status: draft\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 2
+        assert data["active_count"] == 1
+        assert data["draft_count"] == 1
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] == 1
+        assert data["validation_errors"][0]["term_surface"] == "beta"
+        assert data["validation_errors"][0]["field"] == "bogus_extra_field"
+
+    def test_health_reports_invalid_scope_even_when_lower_scope_loads(self, tmp_path):
+        """A valid lower-precedence scope must not mask an invalid higher scope."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "mission_local.yaml").write_text(
+            "terms:\n"
+            "  - surface: BadTerm\n"
+            "    definition: Invalid high-precedence term\n",
+            encoding="utf-8",
+        )
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: Valid core term\n"
+            "    status: active\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 1
+        assert data["active_count"] == 1
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] == 0
+        assert data["validation_errors"][0]["term_surface"] == "BadTerm"
+        assert data["validation_errors"][0]["field"] == "surface"
+
+    def test_health_refuses_recovery_for_root_level_validation_error(self, tmp_path):
+        """Root seed schema errors are file-level failures, not per-term recovery."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "version: 1\n"
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: Valid term in invalid file shape\n"
+            "    status: active\n",
+            encoding="utf-8",
+        )
+        handler = _make_handler(tmp_path)
+
+        gloss_module.GlossaryHandler.handle_glossary_health(handler)
+
+        data = _read_response(handler)
+        assert data["total_terms"] == 0
+        assert data["validation_errors"] is not None
+        assert data["validation_errors"][0]["term_index"] is None
+        assert data["validation_errors"][0]["field"] == "version"
 
 
 class TestGlossaryTerms:
@@ -335,6 +423,8 @@ class TestGlossaryPage:
         assert 'class="sidebar"' in body
         assert 'href="/" title="Dashboard Overview"' in body
         assert 'class="sidebar-item active" href="/glossary"' in body
+        assert 'id="validation-banner"' in body
+        assert "fetch('/api/glossary-health')" in body
         assert "prefers-color-scheme: dark" not in body
 
 
@@ -439,6 +529,24 @@ edges:
         monkeypatch.setattr("builtins.__import__", fake_import)
 
         assert gloss_module._collect_all_senses(tmp_path) == []
+
+    def test_collect_all_senses_raises_when_root_level_recovery_refused(self, tmp_path):
+        """The compatibility helper still raises when no safe recovery exists."""
+        from specify_cli.dashboard.handlers import glossary as gloss_module
+        from specify_cli.glossary.exceptions import SeedFileValidationError
+
+        seed_dir = tmp_path / ".kittify" / "glossaries"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "spec_kitty_core.yaml").write_text(
+            "version: 1\n"
+            "terms:\n"
+            "  - surface: alpha\n"
+            "    definition: Valid term in invalid file shape\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(SeedFileValidationError):
+            gloss_module._collect_all_senses(tmp_path)
 
 
 class TestRouterRegistration:


### PR DESCRIPTION
## Summary

- Glossary dashboard rendered "0 terms / No terms match" because the strict Pydantic schema merged yesterday (a75a612a, mission `glossary-seed-file-schema-validation-01KSN752`) uses `extra="forbid"`, while the canonical seed already contained 3 undocumented fields from earlier missions (`see_also`, `synonyms_to_avoid`, `introduced_in_mission`).
- Validation rejected the whole file → loader raised → handler swallowed → empty page. Page chrome rendered correctly; only the data layer was dark.
- Fixes:
  1. Schema now accepts the 3 existing optional metadata fields while keeping `see_also` structured as a list of string maps, not arbitrary payloads.
  2. Dashboard terms read path attempts per-term recovery for term-level validation failures, so one malformed term cannot blank the whole view.
  3. Dashboard health still reports `validation_errors` when recovery succeeds, and refuses recovery for file/root-level schema errors.
  4. Glossary page now fetches health beside terms and renders a validation warning banner when recovered terms are being shown.

## Why this is the right shape

- **Schema follows the data without reopening `extra="forbid"`.** Three different missions have already written these fields; the schema now accepts the known shape while still rejecting unknown or malformed metadata.
- **Dashboard read path is resilient without laundering invalid state.** CLI `glossary validate` stays strict. The dashboard can render recovered terms, but `/api/glossary-health` and the glossary page preserve validation errors for operators.
- **Failure classes stay distinct.** Term-level drift can degrade gracefully; root/file-level schema errors fail closed instead of being silently treated as healthy.

## Test plan

- [x] `uv run ruff check src/specify_cli/dashboard/handlers/glossary.py src/specify_cli/glossary/seed_schema.py tests/specify_cli/dashboard/test_glossary_handler.py tests/test_dashboard/test_glossary_handler.py tests/specify_cli/glossary/test_seed_schema.py tests/specify_cli/glossary/test_seed_validation.py`
- [x] `uv run pytest tests/specify_cli/dashboard/test_glossary_handler.py tests/test_dashboard/test_glossary_handler.py tests/specify_cli/glossary/test_seed_schema.py tests/specify_cli/glossary/test_seed_validation.py tests/specify_cli/glossary/test_scope.py` — 135 passed
- [x] `uv run spec-kitty glossary validate .kittify/glossaries/spec_kitty_core.yaml` — Valid (91 terms)
- [x] Regression coverage: partial recovery reports `validation_errors`, invalid high-precedence scope cannot be hidden by valid lower scope, root-level schema errors refuse recovery, glossary page fetches health for validation warning display, malformed `see_also` rejects.

## Follow-ups (not in this PR)

- **Round-trip.** `save_seed_file()` still does not preserve `see_also`/`synonyms_to_avoid`/`introduced_in_mission` (they're accepted by the schema but not promoted into `TermSense` or written back). If autosave ever runs against the current core seed it will silently drop them. Tracked separately so the immediate render fix can ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
