### PR TITLE
Harden release install smoke test

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -179,7 +179,7 @@ jobs:
           python scripts/release/check_shared_package_drift.py --check-installed "${ARGS[@]}"
 
       - name: Verify exact installability from built wheel
-        run: python scripts/release/check_exact_install.py --package spec-kitty-cli
+        run: python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version
 
       - name: Validate candidate against SaaS consumer contract
         if: steps.fetch_refs.outputs.saas_fetched == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           python scripts/release/check_shared_package_drift.py --check-installed "${ARGS[@]}"
 
       - name: Verify exact installability from built wheel
-        run: python scripts/release/check_exact_install.py --package spec-kitty-cli
+        run: python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version
 
       - name: Validate candidate against SaaS consumer contract
         if: steps.fetch_refs.outputs.saas_fetched == 'true'

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -69,12 +69,16 @@ python scripts/release/check_shared_package_drift.py \
 
 ### `check_exact_install.py`
 
-Builds a clean temporary virtualenv and installs the built wheel with plain
-`pip` so release-time dependency metadata is exercised exactly as users will
-see it from PyPI.
+Builds a clean temporary virtualenv, installs the built wheel with plain
+`pip`, and can run an installed console script so release-time dependency
+metadata and entrypoint imports are exercised exactly as users will see them
+from PyPI.
 
 ```bash
-python scripts/release/check_exact_install.py --package spec-kitty-cli
+python scripts/release/check_exact_install.py \
+  --package spec-kitty-cli \
+  --console-script spec-kitty \
+  --console-arg=--version
 ```
 
 ### `check_candidate_consumer_compat.py`

--- a/scripts/release/check_exact_install.py
+++ b/scripts/release/check_exact_install.py
@@ -24,6 +24,19 @@ def parse_args() -> argparse.Namespace:
         default=sys.executable,
         help="Interpreter used to create the temporary virtualenv.",
     )
+    parser.add_argument(
+        "--console-script",
+        help="Installed console script to smoke-test after wheel installation.",
+    )
+    parser.add_argument(
+        "--console-arg",
+        action="append",
+        default=None,
+        help=(
+            "Argument passed to --console-script. May be repeated. Defaults to "
+            "--version when --console-script is set."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -62,6 +75,11 @@ def read_wheel_metadata(wheel_path: Path) -> email.message.Message:
 
 def venv_bin_dir(venv_dir: Path) -> Path:
     return venv_dir / ("Scripts" if os.name == "nt" else "bin")
+
+
+def console_script_path(venv_dir: Path, script_name: str) -> Path:
+    suffix = ".exe" if os.name == "nt" else ""
+    return venv_bin_dir(venv_dir) / f"{script_name}{suffix}"
 
 
 def run(
@@ -135,11 +153,30 @@ def main() -> int:
                 f"expected {expected_version}, got {installed_version}"
             )
 
+        console_args = args.console_arg
+        if args.console_script:
+            if console_args is None:
+                console_args = ["--version"]
+            smoke_command = [
+                str(console_script_path(venv_dir, args.console_script)),
+                *console_args,
+            ]
+            smoke = run(smoke_command)
+            require_success(
+                smoke,
+                "console script smoke test (" + " ".join(smoke_command) + ")",
+            )
+
         print("Exact Install Summary")
         print("---------------------")
         print(f"- wheel: {wheel_path.name}")
         print(f"- package: {args.package}")
         print(f"- version: {installed_version}")
+        if args.console_script:
+            print(
+                "- console-smoke: "
+                + " ".join([args.console_script, *(console_args or [])])
+            )
         if requires_dist:
             print("- requires-dist:")
             for requirement in requires_dist:

--- a/tests/release/test_check_exact_install.py
+++ b/tests/release/test_check_exact_install.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "release"
+    / "check_exact_install.py"
+)
+
+
+def load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_exact_install", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_wheel(dist_dir: Path, *, package: str, version: str) -> Path:
+    dist_dir.mkdir()
+    prefix = package.replace("-", "_")
+    wheel = dist_dir / f"{prefix}-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr(
+            f"{prefix}-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: {package}\nVersion: {version}\n",
+        )
+    return wheel
+
+
+def test_console_script_smoke_runs_after_exact_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_script_module()
+    write_wheel(tmp_path / "dist", package="spec-kitty-cli", version="3.2.0rc99")
+    calls: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str], *, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        stdout = "3.2.0rc99\n" if "-c" in cmd else ""
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--dist-dir",
+            str(tmp_path / "dist"),
+            "--package",
+            "spec-kitty-cli",
+            "--console-script",
+            "spec-kitty",
+            "--console-arg=--version",
+        ],
+    )
+
+    assert module.main() == 0
+
+    assert any(call[-3:] == ["install", "--upgrade", "pip"] for call in calls)
+    assert any(
+        "spec-kitty" in Path(call[0]).name and call[1:] == ["--version"]
+        for call in calls
+    )
+
+
+def test_console_script_smoke_failure_fails_release_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_script_module()
+    write_wheel(tmp_path / "dist", package="spec-kitty-cli", version="3.2.0rc99")
+
+    def fake_run(
+        cmd: list[str], *, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        if "spec-kitty" in Path(cmd[0]).name:
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="",
+                stderr="ModuleNotFoundError: No module named 'click'\n",
+            )
+        stdout = "3.2.0rc99\n" if "-c" in cmd else ""
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--dist-dir",
+            str(tmp_path / "dist"),
+            "--package",
+            "spec-kitty-cli",
+            "--console-script",
+            "spec-kitty",
+            "--console-arg=--version",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+
+    assert exc.value.code
+    assert "console script smoke test" in str(exc.value)
+    assert "No module named 'click'" in str(exc.value)


### PR DESCRIPTION
## Summary

- extend `check_exact_install.py` to optionally run an installed console script after clean wheel installation
- wire release and release-readiness workflows to run `spec-kitty --version` from the installed wheel env
- add release tests for passing and failing console-script smoke checks

Refs #1338.

## Verification

- `uv run ruff check scripts/release/check_exact_install.py tests/release/test_check_exact_install.py`
- `uv run pytest tests/release/test_check_exact_install.py -q`
- `uv run pytest tests/release -q`
- `uv run --with build python -m build && uv run python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version`
