### PR TITLE
fix: correct uv tool pytest remediation

### DIFF
--- a/src/specify_cli/cli/commands/review/ERROR_CODES.md
+++ b/src/specify_cli/cli/commands/review/ERROR_CODES.md
@@ -205,14 +205,15 @@ MISSION_REVIEW_MISSION_EXCEPTION_INVALID: mission-exception.md is present but mi
 **JSON stability**: this code string is stable across minor releases; consumers may match it as an opaque identifier.
 
 **Remediation**:
-1. Run `uv sync --extra test` to install the test extra in the current virtual environment.
-2. Verify with `python -c "import pytest; print(pytest.__version__)"`.
-3. If using a non-uv environment, install pytest directly: `pip install pytest`.
+1. Source/dev checkout: run `uv sync --extra test` to install the test extra in the current virtual environment.
+2. uv tool install: run `uv tool install --force --with pytest <current-tool-source>` to repair the tool environment. For PyPI installs this is `spec-kitty-cli==<current-version>`; for local/source tool installs this preserves the uv receipt source path.
+3. Verify with `python -c "import pytest; print(pytest.__version__)"` using the interpreter that runs `spec-kitty`.
+4. If using a non-uv environment, install pytest directly into the interpreter that runs `spec-kitty`.
 
 **Body example**:
 
 ```text
-MISSION_REVIEW_TEST_EXTRA_MISSING: pytest is not importable from the active Python interpreter. Run `uv sync --extra test` to install the test extra, then retry.
+MISSION_REVIEW_TEST_EXTRA_MISSING: pytest is not importable from the active Python interpreter. Run `<remediation command>` to install pytest into that interpreter, then retry.
 ```
 
 ---

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -16,7 +16,10 @@ See: src/specify_cli/cli/commands/review/ERROR_CODES.md (authored by WP03)
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess  # noqa: F401  (monkeypatched in tests)
+import sys
+import tomllib
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -26,8 +29,13 @@ from specify_cli.cli.commands._test_env_check import (  # noqa: F401
     TestExtraMissing,
     assert_pytest_available,
 )
+from specify_cli.compat._detect.install_method import (  # noqa: F401
+    InstallMethod,
+    detect_install_method,
+)
 from specify_cli.cli.selector_resolution import resolve_mission_handle  # noqa: F401
 from specify_cli.task_utils import TaskCliError, find_repo_root  # noqa: F401
+from specify_cli.version_utils import get_version  # noqa: F401
 
 from ._ble001_audit import (  # noqa: F401
     Ble001SuppressionFinding,
@@ -46,19 +54,94 @@ def _fail_missing_test_extra(console: object) -> None:
     import sys
 
     diagnostic_code = MissionReviewDiagnostic.TEST_EXTRA_MISSING
+    remediation = _missing_test_extra_remediation()
     diagnostic = {
         "diagnostic_code": str(diagnostic_code),
         "message": (
             "pytest is not importable from the active Python interpreter. "
-            "Run `uv sync --extra test` to install the test extra, then retry."
+            f"Run `{remediation}` to install pytest into that interpreter, then retry."
         ),
-        "remediation": "uv sync --extra test",
+        "remediation": remediation,
     }
     console.print(  # type: ignore[attr-defined]
         f"[red]Error:[/red] {diagnostic_code}: {diagnostic['message']}"
     )
     sys.stdout.write(json.dumps(diagnostic) + "\n")
     raise typer.Exit(1)
+
+
+def _missing_test_extra_remediation() -> str:
+    try:
+        install_method = detect_install_method()
+    except Exception:  # noqa: BLE001
+        install_method = InstallMethod.UNKNOWN
+
+    if install_method == InstallMethod.UV_TOOL:
+        package = _uv_tool_reinstall_target() or _versioned_package()
+        return f"{_uv_tool_dir_env_prefix()}uv tool install --force --with pytest {package}"
+
+    return "uv sync --extra test"
+
+
+def _versioned_package() -> str:
+    version = get_version()
+    package = "spec-kitty-cli"
+    if version and version != "0.0.0-dev":
+        package = f"{package}=={version}"
+    return package
+
+
+def _uv_tool_reinstall_target() -> str | None:
+    try:
+        executable_parent = Path(sys.executable).parent
+        if executable_parent.name.lower() not in {"bin", "scripts"}:
+            return None
+
+        receipt_path = executable_parent.parent / "uv-receipt.toml"
+        receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+        requirements = receipt.get("tool", {}).get("requirements", [])
+        if not isinstance(requirements, list):
+            return None
+
+        for requirement in requirements:
+            if not isinstance(requirement, dict) or requirement.get("name") != "spec-kitty-cli":
+                continue
+            directory = requirement.get("directory")
+            if isinstance(directory, str) and directory.strip():
+                return shlex.quote(directory)
+            specifier = requirement.get("specifier")
+            if isinstance(specifier, str) and specifier.strip():
+                return shlex.quote(f"spec-kitty-cli{specifier}")
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _uv_tool_dir_env_prefix() -> str:
+    tool_dir = _active_uv_tool_dir()
+    if tool_dir is None or _same_path(tool_dir, Path.home() / ".local" / "share" / "uv" / "tools"):
+        return ""
+    return f"UV_TOOL_DIR={shlex.quote(str(tool_dir))} "
+
+
+def _active_uv_tool_dir() -> Path | None:
+    try:
+        executable_parent = Path(sys.executable).parent
+        if executable_parent.name.lower() not in {"bin", "scripts"}:
+            return None
+        tool_env = executable_parent.parent
+        if not (tool_env / "uv-receipt.toml").exists():
+            return None
+        return tool_env.parent
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except Exception:  # noqa: BLE001
+        return left == right
 
 
 def _resolve_repo_root(console: object) -> Path:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -115,6 +115,7 @@ def _uv_tool_reinstall_command() -> str | None:
             return None
 
         args = ["uv", "tool", "install", "--force"]
+        args.extend(_uv_tool_python_args(receipt))
         args.extend(_uv_tool_with_args(requirements))
         args.extend(_uv_tool_package_args(tool_requirement))
         return f"{_uv_tool_env_prefix()}{' '.join(shlex.quote(arg) for arg in args)}"
@@ -226,6 +227,16 @@ def _uv_tool_package_args(requirement: dict[str, object]) -> list[str]:
         return [f"{_PACKAGE_NAME}{specifier}"]
 
     return [_PACKAGE_NAME]
+
+
+def _uv_tool_python_args(receipt: dict[str, object]) -> list[str]:
+    tool = receipt.get("tool", {})
+    if not isinstance(tool, dict):
+        return []
+    python = _nonempty_str(tool.get("python"))
+    if python is None:
+        return []
+    return ["--python", python]
 
 
 def _uv_git_source(git: str) -> str:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -95,6 +95,8 @@ def _versioned_package() -> str:
 
 
 def _fallback_uv_tool_reinstall_command() -> str:
+    if _active_uv_tool_receipt_path() is not None:
+        return "reinstall the same uv tool source with --with pytest"
     return f"{_uv_tool_env_prefix()}uv tool install --force --with pytest {_versioned_package()}"
 
 
@@ -122,14 +124,26 @@ def _uv_tool_reinstall_command() -> str | None:
 
 def _active_uv_tool_receipt() -> dict[str, object] | None:
     try:
+        receipt_path = _active_uv_tool_receipt_path()
+        if receipt_path is None:
+            return None
+        receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+        if isinstance(receipt, dict):
+            return receipt
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _active_uv_tool_receipt_path() -> Path | None:
+    try:
         executable_parent = Path(sys.executable).parent
         if executable_parent.name.lower() not in {"bin", "scripts"}:
             return None
 
         receipt_path = executable_parent.parent / "uv-receipt.toml"
-        receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
-        if isinstance(receipt, dict):
-            return receipt
+        if receipt_path.exists():
+            return receipt_path
     except Exception:  # noqa: BLE001
         return None
     return None
@@ -152,12 +166,22 @@ def _uv_tool_with_args(requirements: list[object]) -> list[str]:
             continue
         if requirement.get("name") == _PYTEST_NAME:
             has_pytest = True
-        requirement_arg = _uv_tool_requirement_arg(requirement)
-        if requirement_arg is not None:
-            args.extend(["--with", requirement_arg])
+        args.extend(_uv_tool_requirement_args(requirement))
     if not has_pytest:
         args.extend(["--with", _PYTEST_NAME])
     return args
+
+
+def _uv_tool_requirement_args(requirement: dict[str, object]) -> list[str]:
+    editable = _nonempty_str(requirement.get("editable"))
+    if editable is not None:
+        return ["--with-editable", editable]
+
+    requirement_arg = _uv_tool_requirement_arg(requirement)
+    if requirement_arg is not None:
+        return ["--with", requirement_arg]
+
+    return []
 
 
 def _uv_tool_requirement_arg(requirement: dict[str, object]) -> str | None:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -50,6 +50,10 @@ from ._mode import MissionReviewMode, ModeMismatchError, resolve_mode  # noqa: F
 from ._report import GateRecord, write_review_report  # noqa: F401
 
 
+_PACKAGE_NAME = "spec-kitty-cli"
+_PYTEST_NAME = "pytest"
+
+
 def _fail_missing_test_extra(console: object) -> None:
     import sys
 
@@ -77,8 +81,7 @@ def _missing_test_extra_remediation() -> str:
         install_method = InstallMethod.UNKNOWN
 
     if install_method == InstallMethod.UV_TOOL:
-        package = _uv_tool_reinstall_target() or _versioned_package()
-        return f"{_uv_tool_dir_env_prefix()}uv tool install --force --with pytest {package}"
+        return _uv_tool_reinstall_command() or _fallback_uv_tool_reinstall_command()
 
     return "uv sync --extra test"
 
@@ -91,7 +94,33 @@ def _versioned_package() -> str:
     return package
 
 
-def _uv_tool_reinstall_target() -> str | None:
+def _fallback_uv_tool_reinstall_command() -> str:
+    return f"{_uv_tool_env_prefix()}uv tool install --force --with pytest {_versioned_package()}"
+
+
+def _uv_tool_reinstall_command() -> str | None:
+    try:
+        receipt = _active_uv_tool_receipt()
+        if receipt is None:
+            return None
+
+        requirements = receipt.get("tool", {}).get("requirements", [])
+        if not isinstance(requirements, list):
+            return None
+
+        tool_requirement = _find_uv_tool_requirement(requirements)
+        if tool_requirement is None:
+            return None
+
+        args = ["uv", "tool", "install", "--force"]
+        args.extend(_uv_tool_with_args(requirements))
+        args.extend(_uv_tool_package_args(tool_requirement))
+        return f"{_uv_tool_env_prefix()}{' '.join(shlex.quote(arg) for arg in args)}"
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _active_uv_tool_receipt() -> dict[str, object] | None:
     try:
         executable_parent = Path(sys.executable).parent
         if executable_parent.name.lower() not in {"bin", "scripts"}:
@@ -99,22 +128,95 @@ def _uv_tool_reinstall_target() -> str | None:
 
         receipt_path = executable_parent.parent / "uv-receipt.toml"
         receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
-        requirements = receipt.get("tool", {}).get("requirements", [])
-        if not isinstance(requirements, list):
-            return None
-
-        for requirement in requirements:
-            if not isinstance(requirement, dict) or requirement.get("name") != "spec-kitty-cli":
-                continue
-            directory = requirement.get("directory")
-            if isinstance(directory, str) and directory.strip():
-                return shlex.quote(directory)
-            specifier = requirement.get("specifier")
-            if isinstance(specifier, str) and specifier.strip():
-                return shlex.quote(f"spec-kitty-cli{specifier}")
+        if isinstance(receipt, dict):
+            return receipt
     except Exception:  # noqa: BLE001
         return None
     return None
+
+
+def _find_uv_tool_requirement(requirements: list[object]) -> dict[str, object] | None:
+    for requirement in requirements:
+        if isinstance(requirement, dict) and requirement.get("name") == _PACKAGE_NAME:
+            return requirement
+    return None
+
+
+def _uv_tool_with_args(requirements: list[object]) -> list[str]:
+    args: list[str] = []
+    has_pytest = False
+    for requirement in requirements:
+        if not isinstance(requirement, dict):
+            continue
+        if requirement.get("name") == _PACKAGE_NAME:
+            continue
+        if requirement.get("name") == _PYTEST_NAME:
+            has_pytest = True
+        requirement_arg = _uv_tool_requirement_arg(requirement)
+        if requirement_arg is not None:
+            args.extend(["--with", requirement_arg])
+    if not has_pytest:
+        args.extend(["--with", _PYTEST_NAME])
+    return args
+
+
+def _uv_tool_requirement_arg(requirement: dict[str, object]) -> str | None:
+    directory = _nonempty_str(requirement.get("directory"))
+    if directory is not None:
+        return directory
+
+    path = _nonempty_str(requirement.get("path"))
+    if path is not None:
+        return path
+
+    git = _nonempty_str(requirement.get("git"))
+    if git is not None:
+        return _uv_git_source(git)
+
+    name = _nonempty_str(requirement.get("name"))
+    if name is None:
+        return None
+    specifier = _nonempty_str(requirement.get("specifier"))
+    return f"{name}{specifier or ''}"
+
+
+def _uv_tool_package_args(requirement: dict[str, object]) -> list[str]:
+    directory = _nonempty_str(requirement.get("directory"))
+    if directory is not None:
+        return [directory]
+
+    editable = _nonempty_str(requirement.get("editable"))
+    if editable is not None:
+        return ["--editable", editable]
+
+    path = _nonempty_str(requirement.get("path"))
+    if path is not None:
+        return [path]
+
+    git = _nonempty_str(requirement.get("git"))
+    if git is not None:
+        return [_PACKAGE_NAME, "--from", _uv_git_source(git)]
+
+    specifier = _nonempty_str(requirement.get("specifier"))
+    if specifier is not None:
+        return [f"{_PACKAGE_NAME}{specifier}"]
+
+    return [_PACKAGE_NAME]
+
+
+def _uv_git_source(git: str) -> str:
+    return git if git.startswith("git+") else f"git+{git}"
+
+
+def _nonempty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _uv_tool_env_prefix() -> str:
+    prefixes = [_uv_tool_dir_env_prefix(), _uv_tool_bin_dir_env_prefix()]
+    return "".join(prefix for prefix in prefixes if prefix)
 
 
 def _uv_tool_dir_env_prefix() -> str:
@@ -122,6 +224,13 @@ def _uv_tool_dir_env_prefix() -> str:
     if tool_dir is None or _same_path(tool_dir, Path.home() / ".local" / "share" / "uv" / "tools"):
         return ""
     return f"UV_TOOL_DIR={shlex.quote(str(tool_dir))} "
+
+
+def _uv_tool_bin_dir_env_prefix() -> str:
+    bin_dir = _active_uv_tool_bin_dir()
+    if bin_dir is None or _same_path(bin_dir, Path.home() / ".local" / "bin"):
+        return ""
+    return f"UV_TOOL_BIN_DIR={shlex.quote(str(bin_dir))} "
 
 
 def _active_uv_tool_dir() -> Path | None:
@@ -135,6 +244,25 @@ def _active_uv_tool_dir() -> Path | None:
         return tool_env.parent
     except Exception:  # noqa: BLE001
         return None
+
+
+def _active_uv_tool_bin_dir() -> Path | None:
+    try:
+        receipt = _active_uv_tool_receipt()
+        if receipt is None:
+            return None
+        entrypoints = receipt.get("tool", {}).get("entrypoints", [])
+        if not isinstance(entrypoints, list):
+            return None
+        for entrypoint in entrypoints:
+            if not isinstance(entrypoint, dict) or entrypoint.get("name") != "spec-kitty":
+                continue
+            install_path = _nonempty_str(entrypoint.get("install-path"))
+            if install_path is not None:
+                return Path(install_path).parent
+    except Exception:  # noqa: BLE001
+        return None
+    return None
 
 
 def _same_path(left: Path, right: Path) -> bool:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -239,22 +239,28 @@ def _nonempty_str(value: object) -> str | None:
 
 
 def _uv_tool_env_prefix() -> str:
-    prefixes = [_uv_tool_dir_env_prefix(), _uv_tool_bin_dir_env_prefix()]
-    return "".join(prefix for prefix in prefixes if prefix)
+    env_values = _uv_tool_env_values()
+    if sys.platform == "win32":
+        return "".join(
+            f"$env:{name}={_powershell_quote(str(value))}; "
+            for name, value in env_values
+        )
+    return "".join(f"{name}={shlex.quote(str(value))} " for name, value in env_values)
 
 
-def _uv_tool_dir_env_prefix() -> str:
+def _uv_tool_env_values() -> list[tuple[str, Path]]:
+    env_values: list[tuple[str, Path]] = []
     tool_dir = _active_uv_tool_dir()
-    if tool_dir is None or _same_path(tool_dir, Path.home() / ".local" / "share" / "uv" / "tools"):
-        return ""
-    return f"UV_TOOL_DIR={shlex.quote(str(tool_dir))} "
-
-
-def _uv_tool_bin_dir_env_prefix() -> str:
+    if tool_dir is not None and not _same_path(tool_dir, Path.home() / ".local" / "share" / "uv" / "tools"):
+        env_values.append(("UV_TOOL_DIR", tool_dir))
     bin_dir = _active_uv_tool_bin_dir()
-    if bin_dir is None or _same_path(bin_dir, Path.home() / ".local" / "bin"):
-        return ""
-    return f"UV_TOOL_BIN_DIR={shlex.quote(str(bin_dir))} "
+    if bin_dir is not None and not _same_path(bin_dir, Path.home() / ".local" / "bin"):
+        env_values.append(("UV_TOOL_BIN_DIR", bin_dir))
+    return env_values
+
+
+def _powershell_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
 
 
 def _active_uv_tool_dir() -> Path | None:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -21,7 +21,7 @@ import subprocess  # noqa: F401  (monkeypatched in tests)
 import sys
 import tomllib
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 import typer
 
@@ -106,7 +106,7 @@ def _uv_tool_reinstall_command() -> str | None:
         if receipt is None:
             return None
 
-        requirements = receipt.get("tool", {}).get("requirements", [])
+        requirements = _uv_tool_receipt_tool(receipt).get("requirements", [])
         if not isinstance(requirements, list):
             return None
 
@@ -148,6 +148,11 @@ def _active_uv_tool_receipt_path() -> Path | None:
     except Exception:  # noqa: BLE001
         return None
     return None
+
+
+def _uv_tool_receipt_tool(receipt: dict[str, object]) -> dict[str, object]:
+    tool = receipt.get("tool")
+    return tool if isinstance(tool, dict) else {}
 
 
 def _find_uv_tool_requirement(requirements: list[object]) -> dict[str, object] | None:
@@ -230,9 +235,7 @@ def _uv_tool_package_args(requirement: dict[str, object]) -> list[str]:
 
 
 def _uv_tool_python_args(receipt: dict[str, object]) -> list[str]:
-    tool = receipt.get("tool", {})
-    if not isinstance(tool, dict):
-        return []
+    tool = _uv_tool_receipt_tool(receipt)
     python = _nonempty_str(tool.get("python"))
     if python is None:
         return []
@@ -292,7 +295,7 @@ def _active_uv_tool_bin_dir() -> Path | None:
         receipt = _active_uv_tool_receipt()
         if receipt is None:
             return None
-        entrypoints = receipt.get("tool", {}).get("entrypoints", [])
+        entrypoints = _uv_tool_receipt_tool(receipt).get("entrypoints", [])
         if not isinstance(entrypoints, list):
             return None
         for entrypoint in entrypoints:
@@ -315,7 +318,7 @@ def _same_path(left: Path, right: Path) -> bool:
 
 def _resolve_repo_root(console: object) -> Path:
     try:
-        return find_repo_root()
+        return cast("Path", find_repo_root())
     except TaskCliError as exc:
         console.print(f"[red]Error:[/red] {exc}")  # type: ignore[attr-defined]
         raise typer.Exit(2) from exc
@@ -334,7 +337,8 @@ def _load_meta(feature_dir: Path) -> dict[str, object]:
     if not meta_path.exists():
         return {}
     try:
-        return json.loads(meta_path.read_text(encoding="utf-8"))
+        loaded = json.loads(meta_path.read_text(encoding="utf-8"))
+        return loaded if isinstance(loaded, dict) else {}
     except (json.JSONDecodeError, OSError):
         return {}
 
@@ -346,9 +350,12 @@ def _resolve_mode_or_exit(
     baseline_merge_commit: str | None,
 ) -> tuple[MissionReviewMode, bool]:
     try:
-        return resolve_mode(
-            cli_flag=cli_mode,
-            baseline_merge_commit=baseline_merge_commit,
+        return cast(
+            "tuple[MissionReviewMode, bool]",
+            resolve_mode(
+                cli_flag=cli_mode,
+                baseline_merge_commit=baseline_merge_commit,
+            ),
         )
     except ModeMismatchError as exc:
         diagnostic = {
@@ -389,7 +396,7 @@ def _run_lane_gate(
     gates_recorded: list[GateRecord],
 ) -> None:
     findings_before = len(findings)
-    check_wp_lanes(feature_dir, repo_root, console, findings)  # type: ignore[arg-type]
+    check_wp_lanes(feature_dir, repo_root, console, findings)
     result: Literal["pass", "fail"] = "fail" if len(findings) > findings_before else "pass"
     _record_gate(gates_recorded, gate_id="gate_1", name="wp_lane_check", result=result)
 
@@ -408,7 +415,7 @@ def _run_dead_code_gate(
     scan_dead_code(
         baseline_merge_commit,
         repo_root,
-        console,  # type: ignore[arg-type]
+        console,
         findings,
         mission_id=mission_id,
         mission_slug=mission_slug,

--- a/src/specify_cli/compat/_detect/install_method.py
+++ b/src/specify_cli/compat/_detect/install_method.py
@@ -2,17 +2,18 @@
 
 Public surface
 --------------
-InstallMethod  -- str enum with seven members.
+InstallMethod  -- str enum with eight members.
 detect_install_method  -- pure detection function; NEVER raises.
 
 Detection chain (first match wins, per research §R-03):
   1. SOURCE        -- package __file__ under cwd AND pyproject.toml present.
-  2. PIPX          -- executable under */pipx/venvs/spec-kitty* or ~/.local/pipx/venvs/.
-  3. BREW          -- executable under a Homebrew prefix.
-  4. SYSTEM_PACKAGE -- /usr/bin/python* executable AND system-manager INSTALLER.
-  5. PIP_USER      -- pip INSTALLER AND distribution under user site-packages.
-  6. PIP_SYSTEM    -- pip INSTALLER, not under user site-packages.
-  7. UNKNOWN       -- fallback.
+  2. UV_TOOL       -- executable under UV_TOOL_DIR, the default uv tools dir, or a uv tool receipt.
+  3. PIPX          -- executable under */pipx/venvs/spec-kitty* or ~/.local/pipx/venvs/.
+  4. BREW          -- executable under a Homebrew prefix.
+  5. SYSTEM_PACKAGE -- /usr/bin/python* executable AND system-manager INSTALLER.
+  6. PIP_USER      -- pip INSTALLER AND distribution under user site-packages.
+  7. PIP_SYSTEM    -- pip INSTALLER, not under user site-packages.
+  8. UNKNOWN       -- fallback.
 
 Security / reliability properties
 -----------------------------------
@@ -24,9 +25,11 @@ CHK032  Every branch is wrapped in try/except; the function MUST NOT raise.
 from __future__ import annotations
 
 import importlib.metadata
+import os
 import site
 import subprocess
 import sys
+import tomllib
 from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path
@@ -44,6 +47,7 @@ class InstallMethod(StrEnum):
     """
 
     PIPX = "pipx"
+    UV_TOOL = "uv-tool"
     PIP_USER = "pip-user"
     PIP_SYSTEM = "pip-system"
     BREW = "brew"
@@ -76,6 +80,55 @@ def _is_source_install() -> bool:
                 except ValueError:
                     pass
                 break
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
+def _is_uv_tool_install(executable: str) -> bool:
+    """Return True if *executable* looks like a uv tool-managed venv."""
+    try:
+        exe_path = Path(executable)
+        candidate_roots = [
+            os.environ.get("UV_TOOL_DIR"),
+            str(Path.home() / ".local" / "share" / "uv" / "tools"),
+        ]
+        for root_raw in candidate_roots:
+            if not root_raw:
+                continue
+            try:
+                relative = exe_path.relative_to(Path(root_raw))
+            except ValueError:
+                continue
+            if relative.parts[:1] == (_PACKAGE_NAME,):
+                return True
+
+        return _has_uv_tool_receipt(exe_path)
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
+def _has_uv_tool_receipt(exe_path: Path) -> bool:
+    """Return True when *exe_path* belongs to a uv tool environment."""
+    try:
+        executable_parent = exe_path.parent
+        if executable_parent.name.lower() not in {"bin", "scripts"}:
+            return False
+
+        tool_env = executable_parent.parent
+        receipt_path = tool_env / "uv-receipt.toml"
+        if not receipt_path.exists():
+            return False
+
+        receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+        requirements = receipt.get("tool", {}).get("requirements", [])
+        if isinstance(requirements, list):
+            for requirement in requirements:
+                if isinstance(requirement, dict) and requirement.get("name") == _PACKAGE_NAME:
+                    return True
+
+        return tool_env.name == _PACKAGE_NAME
     except Exception:  # noqa: BLE001
         pass
     return False
@@ -211,7 +264,7 @@ def _is_user_site(
 _SYSTEM_PACKAGE_INSTALLERS = frozenset({"apt", "dnf", "pacman", "yum", "zypper"})
 
 
-def detect_install_method(
+def detect_install_method(  # noqa: C901
     *,
     executable: str | None = None,
     distribution_loader: Callable[[str], importlib.metadata.Distribution] | None = None,
@@ -225,15 +278,17 @@ def detect_install_method(
 
     1. **SOURCE** -- the package's ``__file__`` is under ``cwd`` and a
        ``pyproject.toml`` exists at the package root.
-    2. **PIPX** -- ``executable`` matches ``*/pipx/venvs/spec-kitty*`` or lives
+    2. **UV_TOOL** -- ``executable`` lives under ``UV_TOOL_DIR``, the
+       default uv tools directory, or a uv tool receipt.
+    3. **PIPX** -- ``executable`` matches ``*/pipx/venvs/spec-kitty*`` or lives
        under ``~/.local/pipx/venvs/``.
-    3. **BREW** -- ``executable`` lives under a Homebrew prefix directory.
-    4. **SYSTEM_PACKAGE** -- ``executable`` starts with ``/usr/bin/python`` AND
+    4. **BREW** -- ``executable`` lives under a Homebrew prefix directory.
+    5. **SYSTEM_PACKAGE** -- ``executable`` starts with ``/usr/bin/python`` AND
        the distribution INSTALLER is a system package manager.
-    5. **PIP_USER** -- INSTALLER is ``pip`` AND the distribution is under the
+    6. **PIP_USER** -- INSTALLER is ``pip`` AND the distribution is under the
        user site-packages directory.
-    6. **PIP_SYSTEM** -- INSTALLER is ``pip`` (not under user site-packages).
-    7. **UNKNOWN** -- no branch matched.
+    7. **PIP_SYSTEM** -- INSTALLER is ``pip`` (not under user site-packages).
+    8. **UNKNOWN** -- no branch matched.
 
     Args:
         executable: Path to the Python interpreter to inspect.  Defaults to
@@ -257,21 +312,28 @@ def detect_install_method(
     except Exception:  # noqa: BLE001
         pass
 
-    # 2. pipx.
+    # 2. uv tool.
+    try:
+        if _is_uv_tool_install(executable):
+            return InstallMethod.UV_TOOL
+    except Exception:  # noqa: BLE001
+        pass
+
+    # 3. pipx.
     try:
         if _is_pipx_install(executable):
             return InstallMethod.PIPX
     except Exception:  # noqa: BLE001
         pass
 
-    # 3. Homebrew.
+    # 4. Homebrew.
     try:
         if _is_brew_install(executable):
             return InstallMethod.BREW
     except Exception:  # noqa: BLE001
         pass
 
-    # 4. System package manager.
+    # 5. System package manager.
     try:
         if executable.startswith("/usr/bin/python"):
             installer = _get_installer(distribution_loader)
@@ -280,7 +342,7 @@ def detect_install_method(
     except Exception:  # noqa: BLE001
         pass
 
-    # 5 & 6. pip (user vs system).
+    # 6 & 7. pip (user vs system).
     try:
         installer = _get_installer(distribution_loader)
         if installer == "pip":
@@ -301,6 +363,7 @@ def detect_install_method(
 _SAFE_AUTO_UPGRADE_METHODS: frozenset[InstallMethod] = frozenset(
     {
         InstallMethod.PIPX,
+        InstallMethod.UV_TOOL,
         InstallMethod.BREW,
         InstallMethod.PIP_USER,
         InstallMethod.PIP_SYSTEM,
@@ -315,6 +378,7 @@ def is_safe_for_auto_upgrade(method: InstallMethod) -> bool:
     operate without breaking the installer's own bookkeeping):
 
     - PIPX
+    - UV_TOOL
     - BREW
     - PIP_USER
     - PIP_SYSTEM

--- a/src/specify_cli/compat/_detect/install_method.py
+++ b/src/specify_cli/compat/_detect/install_method.py
@@ -128,7 +128,7 @@ def _has_uv_tool_receipt(exe_path: Path) -> bool:
                 if isinstance(requirement, dict) and requirement.get("name") == _PACKAGE_NAME:
                     return True
 
-        return tool_env.name == _PACKAGE_NAME
+        return False
     except Exception:  # noqa: BLE001
         pass
     return False

--- a/src/specify_cli/compat/upgrade_hint.py
+++ b/src/specify_cli/compat/upgrade_hint.py
@@ -77,6 +77,10 @@ _HINT_TABLE: dict[InstallMethod, tuple[str | None, str | None]] = {
         "pipx upgrade spec-kitty-cli",
         None,
     ),
+    InstallMethod.UV_TOOL: (
+        "uv tool upgrade spec-kitty-cli",
+        None,
+    ),
     InstallMethod.PIP_USER: (
         "pip install --user --upgrade spec-kitty-cli",
         None,

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -224,6 +224,9 @@ def _default_upgrade_runner(method: object) -> int:
     """
     from specify_cli.compat._detect.install_method import InstallMethod  # noqa: PLC0415
 
+    if not isinstance(method, InstallMethod):
+        return 1
+
     uv_tool_argv = ["uv", "tool", "upgrade"]
     uv_tool_argv.extend(_uv_tool_python_args())
     uv_tool_argv.append("spec-kitty-cli")

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -224,9 +224,12 @@ def _default_upgrade_runner(method: object) -> int:
     """
     from specify_cli.compat._detect.install_method import InstallMethod  # noqa: PLC0415
 
+    uv_tool_argv = ["uv", "tool", "upgrade"]
+    uv_tool_argv.extend(_uv_tool_python_args())
+    uv_tool_argv.append("spec-kitty-cli")
     argv_by_method = {
         InstallMethod.PIPX: ["pipx", "upgrade", "spec-kitty-cli"],
-        InstallMethod.UV_TOOL: ["uv", "tool", "upgrade", "spec-kitty-cli"],
+        InstallMethod.UV_TOOL: uv_tool_argv,
         InstallMethod.BREW: ["brew", "upgrade", "spec-kitty-cli"],
         InstallMethod.PIP_USER: [sys.executable, "-m", "pip", "install", "--user", "--upgrade", "spec-kitty-cli"],
         InstallMethod.PIP_SYSTEM: [sys.executable, "-m", "pip", "install", "--upgrade", "spec-kitty-cli"],
@@ -259,6 +262,37 @@ def _uv_tool_upgrade_env(method: object) -> dict[str, str] | None:
     env = dict(os.environ)
     env["UV_TOOL_DIR"] = str(tool_dir)
     return env
+
+
+def _uv_tool_python_args() -> list[str]:
+    receipt = _active_uv_tool_receipt()
+    if receipt is None:
+        return []
+    tool = receipt.get("tool", {})
+    if not isinstance(tool, dict):
+        return []
+    python = tool.get("python")
+    if not isinstance(python, str) or not python.strip():
+        return []
+    return ["--python", python]
+
+
+def _active_uv_tool_receipt() -> dict[str, object] | None:
+    try:
+        executable_parent = Path(sys.executable).parent
+        if executable_parent.name.lower() not in {"bin", "scripts"}:
+            return None
+        receipt_path = executable_parent.parent / "uv-receipt.toml"
+        if not receipt_path.exists():
+            return None
+        import tomllib  # noqa: PLC0415
+
+        receipt = tomllib.loads(receipt_path.read_text(encoding="utf-8"))
+        if isinstance(receipt, dict):
+            return receipt
+    except Exception:  # noqa: BLE001
+        return None
+    return None
 
 
 def _active_uv_tool_dir() -> Path | None:

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -27,10 +27,12 @@ from __future__ import annotations
 
 import os
 import subprocess  # noqa: S404 — required to invoke the existing `spec-kitty upgrade` binary
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
@@ -206,28 +208,77 @@ def is_currently_snoozed(
 # ---------------------------------------------------------------------------
 
 
-def _default_upgrade_runner() -> int:
-    """Invoke ``spec-kitty upgrade --yes`` via subprocess.
+def _default_upgrade_runner(method: object) -> int:
+    """Invoke the owning installer's upgrade command via subprocess.
 
     Returns the process exit code.  Never raises; on OSError / timeout
     returns a non-zero sentinel so the caller can treat it as "failed".
 
     Auto-upgrade safety:
 
-    - Uses ``--yes`` so the existing upgrade command runs non-interactively.
+    - Uses installer-specific commands so tool-env upgrades mutate the
+      installer-owned CLI environment, not the current project.
     - Hard 5-minute timeout (upgrades that take longer are pathological
       and should be observed by the user, not auto-driven).
     - ``check=False`` — caller inspects the return code.
     """
+    from specify_cli.compat._detect.install_method import InstallMethod  # noqa: PLC0415
+
+    argv_by_method = {
+        InstallMethod.PIPX: ["pipx", "upgrade", "spec-kitty-cli"],
+        InstallMethod.UV_TOOL: ["uv", "tool", "upgrade", "spec-kitty-cli"],
+        InstallMethod.BREW: ["brew", "upgrade", "spec-kitty-cli"],
+        InstallMethod.PIP_USER: [sys.executable, "-m", "pip", "install", "--user", "--upgrade", "spec-kitty-cli"],
+        InstallMethod.PIP_SYSTEM: [sys.executable, "-m", "pip", "install", "--upgrade", "spec-kitty-cli"],
+    }
+    argv = argv_by_method.get(method)
+    if argv is None:
+        return 1
+    env = _uv_tool_upgrade_env(method)
+
     try:
         completed = subprocess.run(  # noqa: S603,S607 — fixed argv; PATH lookup is intentional
-            ["spec-kitty", "upgrade", "--yes"],
+            argv,
             check=False,
+            env=env,
             timeout=300,
         )
         return completed.returncode
     except (OSError, subprocess.TimeoutExpired):
         return 1
+
+
+def _uv_tool_upgrade_env(method: object) -> dict[str, str] | None:
+    from specify_cli.compat._detect.install_method import InstallMethod  # noqa: PLC0415
+
+    if method != InstallMethod.UV_TOOL:
+        return None
+    tool_dir = _active_uv_tool_dir()
+    if tool_dir is None or _same_path(tool_dir, Path.home() / ".local" / "share" / "uv" / "tools"):
+        return None
+    env = dict(os.environ)
+    env["UV_TOOL_DIR"] = str(tool_dir)
+    return env
+
+
+def _active_uv_tool_dir() -> Path | None:
+    try:
+        executable_parent = Path(sys.executable).parent
+        if executable_parent.name.lower() not in {"bin", "scripts"}:
+            return None
+        tool_env = executable_parent.parent
+        if not (tool_env / "uv-receipt.toml").exists():
+            return None
+        return tool_env.parent
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except Exception:  # noqa: BLE001
+        return left == right
 
 
 # ---------------------------------------------------------------------------
@@ -415,10 +466,11 @@ def _run_auto_upgrade_if_safe(
     *,
     safe: bool,
     method: object,
-    upgrade_runner: Callable[[], int],
+    upgrade_runner: Callable[[], int] | None,
 ) -> tuple[bool, int | None, bool]:
     if safe:
-        return True, upgrade_runner(), False
+        runner_exit = _default_upgrade_runner(method) if upgrade_runner is None else upgrade_runner()
+        return True, runner_exit, False
     _print_unsafe_installer_guidance(str(method))
     return False, None, True
 
@@ -429,7 +481,7 @@ def _handle_always_preference(
     kwargs: dict[str, object],
     safe: bool,
     method: object,
-    upgrade_runner: Callable[[], int],
+    upgrade_runner: Callable[[], int] | None,
 ) -> UpgradeUxOutcome:
     attempted, exit_code, guidance_only = _run_auto_upgrade_if_safe(
         safe=safe,
@@ -455,7 +507,7 @@ def _handle_prompt_choice(
     now: datetime,
     safe: bool,
     method: object,
-    upgrade_runner: Callable[[], int],
+    upgrade_runner: Callable[[], int] | None,
 ) -> UpgradeUxOutcome:
     kwargs["last_shown_at"] = now
     new_kwargs = apply_choice(kwargs, choice=choice, current_latest=current_latest, now=now)
@@ -519,9 +571,6 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
         env = dict(os.environ)
     if prompt is None:
         prompt = _default_prompt
-    if upgrade_runner is None:
-        upgrade_runner = _default_upgrade_runner
-
     try:
         # Deferred imports.
         from specify_cli.compat import (  # noqa: PLC0415

--- a/tests/readiness/test_upgrade_ux.py
+++ b/tests/readiness/test_upgrade_ux.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import sys
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -169,6 +170,7 @@ class TestIsSafeForAutoUpgrade:
         "method",
         [
             InstallMethod.PIPX,
+            InstallMethod.UV_TOOL,
             InstallMethod.BREW,
             InstallMethod.PIP_USER,
             InstallMethod.PIP_SYSTEM,
@@ -718,6 +720,73 @@ class TestRunUpgradeUxAlwaysSafe:
         assert runs == [1]
         assert outcome.auto_upgrade_attempted is True
         assert outcome.prompted is False
+
+    def test_uv_tool_auto_upgrade_uses_uv_tool_upgrade(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["spec-kitty", "status"])
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        _patch_planner(monkeypatch, "ALLOW_WITH_NAG", latest="2.0")
+        _patch_cache_noop(monkeypatch)
+
+        calls: list[list[str]] = []
+
+        class _Completed:
+            returncode = 0
+
+        def _run(argv: list[str], **_: object) -> _Completed:
+            calls.append(argv)
+            return _Completed()
+
+        monkeypatch.setattr("specify_cli.readiness.upgrade_ux.subprocess.run", _run)
+
+        outcome = run_upgrade_ux(
+            None,
+            suppressed=False,
+            env={ENV_UPGRADE_AUTO: "1"},
+            prompt=lambda: pytest.fail("prompt must not fire on always-upgrade"),
+            installer_detector=lambda: InstallMethod.UV_TOOL,
+        )
+        assert calls == [["uv", "tool", "upgrade", "spec-kitty-cli"]]
+        assert outcome.auto_upgrade_attempted is True
+        assert outcome.auto_upgrade_exit_code == 0
+
+    def test_uv_tool_auto_upgrade_preserves_custom_uv_tool_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["spec-kitty", "status"])
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        _patch_planner(monkeypatch, "ALLOW_WITH_NAG", latest="2.0")
+        _patch_cache_noop(monkeypatch)
+
+        tool_dir = tmp_path / "custom-tools"
+        tool_env = tool_dir / "spec-kitty-cli"
+        (tool_env / "bin").mkdir(parents=True)
+        (tool_env / "uv-receipt.toml").write_text("[tool]\nrequirements = [{ name = \"spec-kitty-cli\" }]\n")
+        monkeypatch.setattr(sys, "executable", str(tool_env / "bin" / "python"))
+        calls: list[tuple[list[str], dict[str, str] | None]] = []
+
+        class _Completed:
+            returncode = 0
+
+        def _run(argv: list[str], **kwargs: object) -> _Completed:
+            env = kwargs.get("env")
+            calls.append((argv, env if isinstance(env, dict) else None))
+            return _Completed()
+
+        monkeypatch.setattr("specify_cli.readiness.upgrade_ux.subprocess.run", _run)
+
+        outcome = run_upgrade_ux(
+            None,
+            suppressed=False,
+            env={ENV_UPGRADE_AUTO: "1"},
+            prompt=lambda: pytest.fail("prompt must not fire on always-upgrade"),
+            installer_detector=lambda: InstallMethod.UV_TOOL,
+        )
+        assert calls[0][0] == ["uv", "tool", "upgrade", "spec-kitty-cli"]
+        assert calls[0][1] is not None
+        assert calls[0][1]["UV_TOOL_DIR"] == str(tool_dir)
+        assert outcome.auto_upgrade_attempted is True
 
 
 class TestRunUpgradeUxActiveSnooze:

--- a/tests/readiness/test_upgrade_ux.py
+++ b/tests/readiness/test_upgrade_ux.py
@@ -788,6 +788,44 @@ class TestRunUpgradeUxAlwaysSafe:
         assert calls[0][1]["UV_TOOL_DIR"] == str(tool_dir)
         assert outcome.auto_upgrade_attempted is True
 
+    def test_uv_tool_auto_upgrade_preserves_receipt_python(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["spec-kitty", "status"])
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        _patch_planner(monkeypatch, "ALLOW_WITH_NAG", latest="2.0")
+        _patch_cache_noop(monkeypatch)
+
+        tool_dir = tmp_path / "custom-tools"
+        tool_env = tool_dir / "spec-kitty-cli"
+        (tool_env / "bin").mkdir(parents=True)
+        (tool_env / "uv-receipt.toml").write_text(
+            "[tool]\n"
+            'requirements = [{ name = "spec-kitty-cli" }]\n'
+            'python = "3.13"\n'
+        )
+        monkeypatch.setattr(sys, "executable", str(tool_env / "bin" / "python"))
+        calls: list[list[str]] = []
+
+        class _Completed:
+            returncode = 0
+
+        def _run(argv: list[str], **_: object) -> _Completed:
+            calls.append(argv)
+            return _Completed()
+
+        monkeypatch.setattr("specify_cli.readiness.upgrade_ux.subprocess.run", _run)
+
+        outcome = run_upgrade_ux(
+            None,
+            suppressed=False,
+            env={ENV_UPGRADE_AUTO: "1"},
+            prompt=lambda: pytest.fail("prompt must not fire on always-upgrade"),
+            installer_detector=lambda: InstallMethod.UV_TOOL,
+        )
+        assert calls[0] == ["uv", "tool", "upgrade", "--python", "3.13", "spec-kitty-cli"]
+        assert outcome.auto_upgrade_attempted is True
+
 
 class TestRunUpgradeUxActiveSnooze:
     def test_active_snooze_suppresses_prompt(

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -367,7 +367,7 @@ def test_uv_tool_remediation_preserves_directory_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Local/git-style uv tool installs must not be rewritten to a PyPI pin."""
+    """Local directory uv tool installs must not be rewritten to a PyPI pin."""
     import specify_cli.cli.commands.review as review_mod
 
     tool_env = tmp_path / "tool" / "spec-kitty-cli"
@@ -389,6 +389,100 @@ def test_uv_tool_remediation_preserves_directory_receipt(
 
     assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
         f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --with pytest {source_dir!s}"
+    )
+
+
+def test_uv_tool_remediation_preserves_git_receipt_and_existing_with(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Git uv tool installs must preserve source provenance and injected deps."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        "requirements = [\n"
+        '  { name = "spec-kitty-cli", git = "file:///tmp/spec-kitty" },\n'
+        '  { name = "click" },\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --with click "
+        "--with pytest spec-kitty-cli --from git+file:///tmp/spec-kitty"
+    )
+
+
+def test_uv_tool_remediation_preserves_editable_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Editable uv tool installs must stay editable when adding pytest."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    source_dir = tmp_path / "source-checkout"
+    source_dir.mkdir()
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        f'requirements = [{{ name = "spec-kitty-cli", editable = "{source_dir}" }}]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --with pytest --editable {source_dir!s}"
+    )
+
+
+def test_uv_tool_remediation_preserves_custom_bin_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reinstall remediation must not move shims out of a custom uv bin dir."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    shim_dir = tmp_path / "custom-bin"
+    shim_dir.mkdir()
+    shim_path = shim_dir / "spec-kitty"
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", specifier = "==3.2.0rc25" }]\n'
+        "entrypoints = [\n"
+        f'  {{ name = "spec-kitty", install-path = "{shim_path}" }},\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} UV_TOOL_BIN_DIR={shim_dir!s} "
+        "uv tool install --force --with pytest spec-kitty-cli==3.2.0rc25"
     )
 
 

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -423,6 +423,101 @@ def test_uv_tool_remediation_preserves_git_receipt_and_existing_with(
     )
 
 
+def test_uv_tool_remediation_preserves_editable_with_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Injected editable deps must stay editable when pytest is added."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    extra_dir = tmp_path / "extra-dep"
+    extra_dir.mkdir()
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        "requirements = [\n"
+        '  { name = "spec-kitty-cli", specifier = "==3.2.0rc25" },\n'
+        f'  {{ name = "extra-dep", editable = "{extra_dir}" }},\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force "
+        f"--with-editable {extra_dir!s} --with pytest spec-kitty-cli==3.2.0rc25"
+    )
+
+
+def test_uv_tool_remediation_does_not_duplicate_existing_pytest_with(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing pytest injection should not become duplicate --with pytest."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        "requirements = [\n"
+        '  { name = "spec-kitty-cli", specifier = "==3.2.0rc25" },\n'
+        '  { name = "pytest" },\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --with pytest "
+        "spec-kitty-cli==3.2.0rc25"
+    )
+
+
+def test_uv_tool_remediation_with_unmapped_receipt_does_not_pin_to_pypi(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Present-but-unmapped receipts must fail conservative, not rewrite source."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "other-tool" }]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.get_version",
+        lambda: "3.2.0rc25",
+    )
+
+    remediation = review_mod._missing_test_extra_remediation()  # noqa: SLF001
+    assert "spec-kitty-cli==3.2.0rc25" not in remediation
+    assert "same uv tool source" in remediation
+
+
 def test_uv_tool_remediation_preserves_editable_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -321,6 +321,128 @@ def test_review_emits_json_diagnostic_when_pytest_missing(
     assert "uv sync --extra test" in result.output
 
 
+def test_review_emits_uv_tool_remediation_when_pytest_missing_in_uv_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """uv tool installs must repair the tool interpreter, not the consumer repo."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+
+    from specify_cli.cli.commands.review import InstallMethod, TestExtraMissing
+
+    def _raise_missing(_: Path) -> None:
+        raise TestExtraMissing("MISSION_REVIEW_TEST_EXTRA_MISSING")
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.assert_pytest_available",
+        _raise_missing,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.get_version",
+        lambda: "3.2.0rc25",
+    )
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG])
+
+    assert result.exit_code == 1, result.output
+    assert '"diagnostic_code": "MISSION_REVIEW_TEST_EXTRA_MISSING"' in result.output
+    assert "uv tool install --force --with pytest spec-kitty-cli==3.2.0rc25" in result.output
+    assert '"remediation": "uv tool install --force --with pytest spec-kitty-cli==3.2.0rc25"' in result.output
+
+
+def test_uv_tool_remediation_preserves_directory_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local/git-style uv tool installs must not be rewritten to a PyPI pin."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    source_dir = tmp_path / "source-checkout"
+    source_dir.mkdir()
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        f'requirements = [{{ name = "spec-kitty-cli", directory = "{source_dir}" }}]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --with pytest {source_dir!s}"
+    )
+
+
+def test_uv_tool_remediation_quotes_specifier_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Specifier receipts must remain copy/paste safe in POSIX shells."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", specifier = ">=3.0" }]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --with pytest 'spec-kitty-cli>=3.0'"
+    )
+
+
+def test_uv_tool_remediation_omits_uv_tool_dir_for_default_tool_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default uv tool installs should keep the short copy/paste command."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = Path.home() / ".local" / "share" / "uv" / "tools" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.get_version",
+        lambda: "3.2.0rc25",
+    )
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        "uv tool install --force --with pytest spec-kitty-cli==3.2.0rc25"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Internal helper
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -581,6 +581,42 @@ def test_uv_tool_remediation_preserves_custom_bin_dir(
     )
 
 
+def test_uv_tool_remediation_uses_powershell_env_prefix_on_windows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows remediation must be pasteable in PowerShell, not POSIX-only."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool dir" / "spec-kitty-cli"
+    bin_dir = tool_env / "Scripts"
+    bin_dir.mkdir(parents=True)
+    shim_dir = tmp_path / "custom bin"
+    shim_dir.mkdir()
+    shim_path = shim_dir / "spec-kitty.exe"
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", specifier = "==3.2.0rc25" }]\n'
+        "entrypoints = [\n"
+        f'  {{ name = "spec-kitty", install-path = "{shim_path}" }},\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python.exe"))
+    monkeypatch.setattr(review_mod.sys, "platform", "win32")
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"$env:UV_TOOL_DIR='{tool_env.parent!s}'; "
+        f"$env:UV_TOOL_BIN_DIR='{shim_dir!s}'; "
+        "uv tool install --force --with pytest spec-kitty-cli==3.2.0rc25"
+    )
+
+
 def test_uv_tool_remediation_quotes_specifier_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -581,6 +581,34 @@ def test_uv_tool_remediation_preserves_custom_bin_dir(
     )
 
 
+def test_uv_tool_remediation_preserves_receipt_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reinstall remediation must keep the uv tool Python interpreter."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", specifier = "==3.2.0rc25" }]\n'
+        'python = "3.13"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force --python 3.13 --with pytest spec-kitty-cli==3.2.0rc25"
+    )
+
+
 def test_uv_tool_remediation_uses_powershell_env_prefix_on_windows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/specify_cli/compat/test_install_method.py
+++ b/tests/specify_cli/compat/test_install_method.py
@@ -154,6 +154,26 @@ class TestUvToolBranch:
             )
         assert result == InstallMethod.UV_TOOL
 
+    def test_uv_tool_receipt_must_bind_spec_kitty_package(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tool_env = tmp_path / "custom-tools" / "spec-kitty-cli"
+        bin_dir = tool_env / "bin"
+        bin_dir.mkdir(parents=True)
+        (tool_env / "uv-receipt.toml").write_text(
+            "[tool]\n"
+            'requirements = [{ name = "other-tool" }]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+
+        with _no_source():
+            result = detect_install_method(
+                executable=str(bin_dir / "python"),
+                distribution_loader=_loader_returning(None),
+            )
+        assert result == InstallMethod.UNKNOWN
+
     def test_uv_tool_detected_via_default_uv_tools_path(self) -> None:
         executable = str(Path.home() / ".local" / "share" / "uv" / "tools" / "spec-kitty-cli" / "bin" / "python")
         with _no_source():

--- a/tests/specify_cli/compat/test_install_method.py
+++ b/tests/specify_cli/compat/test_install_method.py
@@ -118,7 +118,64 @@ class TestSourceBranch:
 
 
 # ---------------------------------------------------------------------------
-# Branch 2 — PIPX
+# Branch 2 — UV_TOOL
+# ---------------------------------------------------------------------------
+
+
+class TestUvToolBranch:
+    def test_uv_tool_detected_via_uv_tool_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        tool_dir = tmp_path / "uv-tools"
+        executable = str(tool_dir / "spec-kitty-cli" / "bin" / "python")
+        monkeypatch.setenv("UV_TOOL_DIR", str(tool_dir))
+        with _no_source():
+            result = detect_install_method(
+                executable=executable,
+                distribution_loader=_loader_returning(None),
+            )
+        assert result == InstallMethod.UV_TOOL
+
+    def test_uv_tool_detected_via_receipt_when_uv_tool_dir_env_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tool_env = tmp_path / "custom-tools" / "spec-kitty-cli"
+        bin_dir = tool_env / "bin"
+        bin_dir.mkdir(parents=True)
+        (tool_env / "uv-receipt.toml").write_text(
+            "[tool]\n"
+            'requirements = [{ name = "spec-kitty-cli", directory = "/tmp/spec-kitty" }]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+
+        with _no_source():
+            result = detect_install_method(
+                executable=str(bin_dir / "python"),
+                distribution_loader=_loader_returning(None),
+            )
+        assert result == InstallMethod.UV_TOOL
+
+    def test_uv_tool_detected_via_default_uv_tools_path(self) -> None:
+        executable = str(Path.home() / ".local" / "share" / "uv" / "tools" / "spec-kitty-cli" / "bin" / "python")
+        with _no_source():
+            result = detect_install_method(
+                executable=executable,
+                distribution_loader=_loader_returning(None),
+            )
+        assert result == InstallMethod.UV_TOOL
+
+    def test_uv_tool_not_detected_from_loose_path_without_receipt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        executable = "/tmp/uv/tools/spec-kitty-cli/bin/python"
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+        with _no_source():
+            result = detect_install_method(
+                executable=executable,
+                distribution_loader=_loader_returning(None),
+            )
+        assert result == InstallMethod.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Branch 3 — PIPX
 # ---------------------------------------------------------------------------
 
 

--- a/tests/specify_cli/compat/test_upgrade_hint.py
+++ b/tests/specify_cli/compat/test_upgrade_hint.py
@@ -49,6 +49,7 @@ class TestCommandHints:
         "method,expected_fragment",
         [
             (InstallMethod.PIPX, "pipx upgrade"),
+            (InstallMethod.UV_TOOL, "uv tool upgrade"),
             (InstallMethod.PIP_USER, "pip install --user --upgrade"),
             (InstallMethod.PIP_SYSTEM, "pip install --upgrade"),
             (InstallMethod.BREW, "brew upgrade"),
@@ -62,7 +63,13 @@ class TestCommandHints:
 
     @pytest.mark.parametrize(
         "method",
-        [InstallMethod.PIPX, InstallMethod.PIP_USER, InstallMethod.PIP_SYSTEM, InstallMethod.BREW],
+        [
+            InstallMethod.PIPX,
+            InstallMethod.UV_TOOL,
+            InstallMethod.PIP_USER,
+            InstallMethod.PIP_SYSTEM,
+            InstallMethod.BREW,
+        ],
     )
     def test_command_does_not_contain_ansi(self, method: InstallMethod) -> None:
         hint = build_upgrade_hint(method)


### PR DESCRIPTION
## Summary
- add `uv-tool` install detection and upgrade hint coverage
- make `MISSION_REVIEW_TEST_EXTRA_MISSING` emit uv-tool repair guidance when the active interpreter belongs to a uv tool env
- keep source/dev remediation as `uv sync --extra test` and update review error-code docs

Fixes #1339.

## Verification
- `uv run ruff check src/specify_cli/compat/_detect/install_method.py src/specify_cli/compat/upgrade_hint.py src/specify_cli/cli/commands/review/__init__.py tests/specify_cli/compat/test_install_method.py tests/specify_cli/compat/test_upgrade_hint.py tests/specify_cli/cli/commands/test_review.py tests/readiness/test_upgrade_ux.py`
- `uv run pytest tests/specify_cli/cli/commands/test_review.py tests/specify_cli/compat/test_install_method.py tests/specify_cli/compat/test_upgrade_hint.py tests/readiness/test_upgrade_ux.py::TestIsSafeForAutoUpgrade tests/specify_cli/cli/commands/review/test_diagnostic_codes_documented.py`
- Local uv-tool repro from patched checkout without pytest now emits `uv tool install --force --with pytest spec-kitty-cli==3.2.0rc28`
- Reinstalling the patched uv tool with `--with pytest` passes the pytest preflight and reaches missing-mission resolution
