### PR TITLE
Fix charter package export surface

### DIFF
--- a/src/doctrine/drg/org_pack_config.py
+++ b/src/doctrine/drg/org_pack_config.py
@@ -19,7 +19,6 @@ from ruamel.yaml import YAML
 __all__ = [
     "OrgPackConfig",
     "PackRegistry",
-    "SourceType",
     "load_pack_registry",
     "resolve_org_roots",
     "save_pack_registry",

--- a/src/specify_cli/cli/commands/glossary.py
+++ b/src/specify_cli/cli/commands/glossary.py
@@ -768,7 +768,7 @@ def _validate_single_file(file_path: Path, json_output: bool) -> None:
             print(json_lib.dumps(result, indent=2))
         else:
             console.print(f"[red]YAML parse error in {file_path}: {exc}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
     try:
         validated = validate_seed_file_data(data, file_path)
@@ -811,7 +811,7 @@ def _validate_single_file(file_path: Path, json_output: bool) -> None:
                 loc = " → ".join(loc_parts) if loc_parts else "file"
                 console.print(f"  [red]✗[/red] {loc}: {e.message}")
             console.print(f"\n{len(exc.errors)} error(s) in {file_path}")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
 
 def _validate_directory(dir_path: Path, json_output: bool) -> None:

--- a/src/specify_cli/retrospective/__init__.py
+++ b/src/specify_cli/retrospective/__init__.py
@@ -48,10 +48,10 @@ from specify_cli.retrospective.reader import SchemaError, YAMLParseError, read_r
 # Generator record types (WP02): exported under canonical names
 from specify_cli.retrospective.schema import (
     GenActor as Actor,
-    GenEvidenceRef as EvidenceRef,
-    GenFinding as Finding,
+    GenEvidenceRef as EvidenceRef,  # noqa: F401 - direct import compatibility
+    GenFinding as Finding,  # noqa: F401 - direct import compatibility
     GenProposal as Proposal,
-    GenProvenance as Provenance,
+    GenProvenance as Provenance,  # noqa: F401 - direct import compatibility
     GenRetrospectiveRecord as RetrospectiveRecord,
     RecordValidationError,
 )
@@ -87,10 +87,7 @@ __all__ = [
     "RecordExistsError",
     # generator record schema (WP02 dataclass-based, canonical names)
     "RetrospectiveRecord",
-    "EvidenceRef",
     "Proposal",
-    "Finding",
-    "Provenance",
     "Actor",
     "RecordValidationError",
     "validate_record",

--- a/tests/cli/commands/test_charter_package_exports.py
+++ b/tests/cli/commands/test_charter_package_exports.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+import specify_cli.cli.commands.charter as charter_module
+
+
+@pytest.mark.fast
+def test_charter_all_exports_are_defined() -> None:
+    for name in charter_module.__all__:
+        assert hasattr(charter_module, name), f"{name} listed in __all__ but not defined"

--- a/tests/specify_cli/cli/commands/test_charter.py
+++ b/tests/specify_cli/cli/commands/test_charter.py
@@ -42,15 +42,6 @@ MISSION_ID = "01KCHARTERTESTMISSION0001"
 runner = CliRunner()
 
 
-@pytest.mark.fast
-def test_charter_public_exports_are_defined() -> None:
-    """Every name listed in the charter package __all__ must resolve."""
-    import specify_cli.cli.commands.charter as charter_module
-
-    for name in charter_module.__all__:
-        assert hasattr(charter_module, name), f"{name} listed in __all__ but not defined"
-
-
 def _setup_repo(tmp_path: Path) -> Path:
     """Create a minimal repo structure with .kittify/ and mission meta.json."""
     kittify = tmp_path / ".kittify"


### PR DESCRIPTION
## Summary
- keep charter package export regression coverage in the CI-exercised CLI test tree
- clear prior ruff B904 findings in glossary seed validation error handling
- clear the architectural dead-symbol baseline by removing unused `__all__` entries while preserving direct-import compatibility
- investigated mypy advisory: current strict run still stops on the pre-existing `built-in contains __init__.py but is not a valid Python package name` baseline; removing those package markers exposes a much larger existing strict-typing baseline, so this PR does not launder that advisory

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run ruff check src tests`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/cli/commands/test_charter_package_exports.py tests/specify_cli/cli/commands/test_charter.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/specify_cli/dashboard/test_glossary_handler.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/architectural/test_no_dead_symbols.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/retrospective/test_schema_roundtrip.py tests/retrospective/test_generator.py tests/doctrine/drg/migration/test_extractor.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run pytest tests/cli/ tests/specify_cli/cli/ -m "fast and not windows_ci" -q --tb=short`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv lock --check`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv build --wheel`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache uv run mypy --strict src/specify_cli src/charter src/doctrine` *(expected existing advisory: `built-in contains __init__.py but is not a valid Python package name`)*