### PR TITLE
fix: remove stale charter export

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -127,6 +127,7 @@ jobs:
             cli:
               - 'src/specify_cli/cli/**'
               - 'tests/cli/**'
+              - 'tests/specify_cli/cli/**'
             orchestrator_api:
               - 'src/specify_cli/orchestrator_api/**'
             core_misc:
@@ -1077,7 +1078,7 @@ jobs:
       - run: mkdir -p out/reports/coverage
       - name: "Run fast tests — cli"
         run: |
-          python -m pytest tests/cli/ -m "fast and not windows_ci" -q --tb=short \
+          python -m pytest tests/cli/ tests/specify_cli/cli/ -m "fast and not windows_ci" -q --tb=short \
             --cov=src/specify_cli/cli \
             --cov-report=xml:out/reports/coverage/coverage-fast-cli.xml \
             || test $? -eq 5
@@ -1716,7 +1717,7 @@ jobs:
       - run: mkdir -p out/reports/coverage
       - name: "Run integration tests — cli"
         run: |
-          python -m pytest tests/cli/ \
+          python -m pytest tests/cli/ tests/specify_cli/cli/ \
             -m 'not windows_ci and (git_repo or integration)' \
             -q --tb=short \
             --cov=src/specify_cli/cli \

--- a/src/specify_cli/cli/commands/charter/__init__.py
+++ b/src/specify_cli/cli/commands/charter/__init__.py
@@ -142,7 +142,6 @@ __all__ = [
     # Subcommand handlers
     "interview",
     "generate",
-    "commit",
     "context",
     "sync",
     "status",

--- a/tests/specify_cli/cli/commands/test_charter.py
+++ b/tests/specify_cli/cli/commands/test_charter.py
@@ -42,6 +42,15 @@ MISSION_ID = "01KCHARTERTESTMISSION0001"
 runner = CliRunner()
 
 
+@pytest.mark.fast
+def test_charter_public_exports_are_defined() -> None:
+    """Every name listed in the charter package __all__ must resolve."""
+    import specify_cli.cli.commands.charter as charter_module
+
+    for name in charter_module.__all__:
+        assert hasattr(charter_module, name), f"{name} listed in __all__ but not defined"
+
+
 def _setup_repo(tmp_path: Path) -> Path:
     """Create a minimal repo structure with .kittify/ and mission meta.json."""
     kittify = tmp_path / ".kittify"


### PR DESCRIPTION
## Summary
- remove stale `commit` entry from `specify_cli.cli.commands.charter.__all__`
- add regression coverage that every charter package `__all__` entry resolves at import time
- addresses current SonarCloud `python:S5807` bug on `main`

## Findings reviewed
- GitHub dependabot alerts: none open
- GitHub code-scanning alerts: none open
- Latest scheduled `main` CI Quality run: `26558788745` on 2026-05-28; SonarCloud quality gate failed with `new_reliability_rating=5`, `new_coverage=56.3`, `new_security_hotspots_reviewed=0.0`
- Actionable code issue fixed here: SonarCloud bug `AZ5tWC_2Cv0_1Y1LNLp1` (`python:S5807`) at `src/specify_cli/cli/commands/charter/__init__.py:145`
- Existing security hotspots still present on `main` but unchanged / not code-actionable in this PR:
  - `src/specify_cli/dashboard/server.py:75`
  - `src/specify_cli/sync/daemon.py:647`
  Both are localhost/dev-only `http://` usages previously justified in earlier automation work; resolving the quality gate still requires hotspot review in SonarCloud UI.

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/cli/commands/test_charter.py -q -k public_exports_are_defined`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/cli/commands/test_charter.py -q`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run ruff check src/specify_cli/cli/commands/charter/__init__.py tests/specify_cli/cli/commands/test_charter.py`
