### PR TITLE
docs: add orchestrator Divio guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Start here:
 
 - [Getting Started](docs/tutorials/getting-started.md)
 - [Your First Feature](docs/tutorials/your-first-feature.md)
+- [Orchestrator Quickstart](docs/tutorials/orchestrator-quickstart.md)
 - [CLI Command Reference](docs/reference/cli-commands.md)
 - [Slash Commands](docs/reference/slash-commands.md)
 - [Supported Agents](docs/reference/supported-agents.md)

--- a/docs/development/3-2-information-architecture.md
+++ b/docs/development/3-2-information-architecture.md
@@ -4,7 +4,7 @@
 **Work package:** WP08 (T025, T026)
 **Requirements:** FR-011 (IA spine), FR-012 (gap list)
 **Inputs:**
-- `docs/development/3-2-page-inventory.yaml` (WP02 — 401 rows)
+- `docs/development/3-2-page-inventory.yaml` (WP02 — 402 rows)
 - `docs/reference/cli-commands.md` (WP07 — rebuilt reference)
 - `kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/spec.md`, `plan.md` (Project Structure §)
 
@@ -162,7 +162,7 @@ Disposition values:
 - `migrate-note` — page is 3.1 and becomes a migration note per plan default.
 - `new` — page does not exist; create during this mission's implement phase.
 
-### 6.1 `docs/tutorials/` (7 existing pages)
+### 6.1 `docs/tutorials/` (8 existing pages)
 
 | Existing page | Inventory tag | Disposition | Target IA slot |
 |---------------|---------------|-------------|----------------|
@@ -172,6 +172,7 @@ Disposition values:
 | `docs/tutorials/getting-started.md` | current | rewrite | replaced by `tutorials/install-and-first-mission.md` |
 | `docs/tutorials/missions-overview.md` | current | rewrite | conceptual material moves to `explanation/mission-model.md`; tutorial slot retired |
 | `docs/tutorials/multi-agent-workflow.md` | current | rewrite | replaced by `tutorials/multi-harness-workflow.md` |
+| `docs/tutorials/orchestrator-quickstart.md` | current | reuse | `tutorials/orchestrator-quickstart` |
 | `docs/tutorials/your-first-feature.md` | current | rewrite | replaced by `tutorials/install-and-first-mission.md` (note: title also de-features per Terminology Canon) |
 
 ### 6.2 `docs/how-to/` (38 existing pages)
@@ -262,11 +263,11 @@ Disposition values:
 
 | Divio directory | Existing pages assessed |
 |-----------------|------------------------|
-| `docs/tutorials/` | 7 |
+| `docs/tutorials/` | 8 |
 | `docs/how-to/` | 38 |
 | `docs/reference/` | 16 |
 | `docs/explanation/` | 15 |
-| **Total** | **76** |
+| **Total** | **77** |
 
 ---
 
@@ -301,7 +302,7 @@ Explanation count breakdown:
 
 - [x] IA doc covers all four Divio directories (§2, §3, §4, §5).
 - [x] Every CLI page in the WP07 reference is referenced in the IA (`docs/reference/cli-commands.md` is the canonical reference slot; `agent-subcommands.md`, `slash-commands.md`, `charter-commands.md` are referenced explicitly in §4).
-- [x] Gap list dispositions are explicit for every existing page across all four Divio directories (§6.1–§6.4 — 76 rows total).
+- [x] Gap list dispositions are explicit for every existing page across all four Divio directories (§6.1–§6.4 — 77 rows total).
 - [x] No files outside `owned_files` are modified by this WP (this file is the sole owned target).
 
 ## 9. Notes for downstream WPs

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2913,6 +2913,13 @@
   current_target: true
   citation_refs: []
   notes: Tutorial; provisional current — confirm in WP08 IA review.
+- path: docs/tutorials/orchestrator-quickstart.md
+  tag: current
+  divio_type: tutorial
+  owning_workstream: C
+  current_target: true
+  citation_refs: []
+  notes: Tutorial; external orchestrator quickstart for host-compatible provider builds.
 - path: docs/tutorials/your-first-feature.md
   tag: current
   divio_type: tutorial

--- a/docs/explanation/multi-agent-orchestration.md
+++ b/docs/explanation/multi-agent-orchestration.md
@@ -8,15 +8,18 @@ description: Coordination model for multi-agent delivery with a host-owned workf
 Spec Kitty supports multi-agent delivery through a host/provider split:
 
 - `spec-kitty` owns workflow state, lane validation, and git-safe mutations.
-- External providers orchestrate agent execution and call `spec-kitty orchestrator-api`.
+- external providers such as `spec-kitty-orchestrator` run agents and call
+  `spec-kitty orchestrator-api`.
 
 This replaces in-core orchestration commands. The core CLI does not provide `spec-kitty orchestrate`.
 
-## Why this model
+## Why this model exists
 
 1. Security boundary: autonomous orchestration is optional and can be disallowed by policy.
 2. Extensibility: multiple provider strategies can exist without branching core CLI behavior.
 3. Operational clarity: one host contract for state transitions and lifecycle events.
+4. Review independence: one agent can implement while a different agent reviews
+   without either agent owning the mission state machine.
 
 ## Core Principles
 
@@ -24,6 +27,7 @@ This replaces in-core orchestration commands. The core CLI does not provide `spe
 2. One worktree per WP.
 3. Lane transitions validated by the host state model.
 4. External providers drive automation through API calls, not direct file edits.
+5. Activity logs and run state are audit artifacts, not the source of truth.
 
 ## Two orchestration styles
 
@@ -55,6 +59,20 @@ Provider loop responsibilities:
 3. Transition WPs through review cycles.
 4. Accept when WPs are accepted-ready (`approved` or `done`), then merge.
 
+The common local pattern is:
+
+```bash
+spec-kitty-orchestrator orchestrate \
+  --mission 034-my-feature \
+  --impl-agent claude-code \
+  --review-agent codex \
+  --max-concurrent 1
+```
+
+That means Claude Code receives the WP prompt and writes the implementation;
+Codex receives the same WP context after implementation and acts as reviewer.
+The host, not either agent, decides which lane transitions are legal.
+
 ## Host API boundary
 
 All state-changing automation calls flow through `spec-kitty orchestrator-api`.
@@ -67,6 +85,10 @@ All state-changing automation calls flow through `spec-kitty orchestrator-api`.
 - `merge-mission`
 
 The host returns a stable JSON envelope with `success` and `error_code` for deterministic provider control flow.
+
+The provider can be replaced. The boundary cannot. A custom orchestrator may
+use a different scheduler, model router, queue, or CI runner, but it still must
+call the same host API.
 
 ## Lane semantics
 
@@ -86,6 +108,35 @@ Compatibility mapping:
 - API `in_progress` maps to internal `doing`.
 - `planned`, `for_review`, `in_review`, `approved`, and `done` map directly.
 
+Current external review flow is:
+
+```text
+in_progress -> for_review -> in_review -> done
+```
+
+A rejected review moves back to implementation:
+
+```text
+in_review -> in_progress -> for_review
+```
+
+Providers should preserve a review reference for both approval and rejection so
+humans can trace why a WP moved.
+
+## Worktrees and Protected Branches
+
+The orchestrator model assumes protected branches stay clean:
+
+- mission planning artifacts live on the main project branch
+- implementation runs in WP worktrees
+- provider state lives under `.kittify/`
+- host lane events are appended by the host API
+
+This matters because activity-log updates may be committed by the host. A
+provider that invokes mutation commands directly from protected `main` can hit
+branch-protection errors. The reference orchestrator avoids that by preparing
+mission and WP worktrees before mutating state or spawning agents.
+
 ## Policy metadata and mutation authority
 
 Run-affecting operations require policy metadata (`--policy`) and are validated by the host.
@@ -101,9 +152,12 @@ This ensures:
 - Teams that want full automation can run an external provider.
 - Teams with strict security constraints can keep orchestration manual.
 - Teams can build custom providers while preserving a consistent workflow model.
+- Teams can test automation safely with deterministic fake-agent e2e before
+  enabling real agent CLIs on a trusted machine.
 
 ## See Also
 
+- [Orchestrator Quickstart](../tutorials/orchestrator-quickstart.md)
 - [Run the External Orchestrator](../how-to/run-external-orchestrator.md)
 - [Build a Custom Orchestrator](../how-to/build-custom-orchestrator.md)
 - [Orchestrator API Reference](../reference/orchestrator-api.md)

--- a/docs/explanation/multi-agent-orchestration.md
+++ b/docs/explanation/multi-agent-orchestration.md
@@ -45,6 +45,8 @@ spec-kitty agent tasks move-task WP01 --to done
 ### 2) External automated orchestration
 
 Automated coordination is run by external providers such as `spec-kitty-orchestrator`.
+Use a provider build that explicitly supports the current host API. The PyPI
+`spec-kitty-orchestrator` `0.1.0` release is not compatible with current hosts.
 
 ```bash
 spec-kitty orchestrator-api contract-version
@@ -52,10 +54,10 @@ spec-kitty-orchestrator orchestrate --mission 034-my-feature --dry-run
 spec-kitty-orchestrator orchestrate --mission 034-my-feature
 ```
 
-Provider loop responsibilities:
+Host-compatible provider loop responsibilities:
 
 1. Discover ready WPs via host API.
-2. Start implementation and run agents in worktrees.
+2. Start implementation, prepare usable worktrees, and run agents there.
 3. Transition WPs through review cycles.
 4. Accept when WPs are accepted-ready (`approved` or `done`), then merge.
 
@@ -108,7 +110,7 @@ Compatibility mapping:
 - API `in_progress` maps to internal `doing`.
 - `planned`, `for_review`, `in_review`, `approved`, and `done` map directly.
 
-Current external review flow is:
+Current host review flow is:
 
 ```text
 in_progress -> for_review -> in_review -> done
@@ -134,7 +136,7 @@ The orchestrator model assumes protected branches stay clean:
 
 This matters because activity-log updates may be committed by the host. A
 provider that invokes mutation commands directly from protected `main` can hit
-branch-protection errors. The reference orchestrator avoids that by preparing
+branch-protection errors. A compatible provider must create or reuse the
 mission and WP worktrees before mutating state or spawning agents.
 
 ## Policy metadata and mutation authority

--- a/docs/explanation/multi-agent-orchestration.md
+++ b/docs/explanation/multi-agent-orchestration.md
@@ -46,7 +46,8 @@ spec-kitty agent tasks move-task WP01 --to done
 
 Automated coordination is run by external providers such as `spec-kitty-orchestrator`.
 Use a provider build that explicitly supports the current host API. The PyPI
-`spec-kitty-orchestrator` `0.1.0` release is not compatible with current hosts.
+`spec-kitty-orchestrator` `0.1.0` release appends `--json` to host API calls
+and is not compatible with current hosts.
 
 ```bash
 spec-kitty orchestrator-api contract-version

--- a/docs/how-to/build-custom-orchestrator.md
+++ b/docs/how-to/build-custom-orchestrator.md
@@ -20,8 +20,8 @@ Your orchestrator must:
 1. Check API compatibility.
 2. Poll for ready WPs.
 3. Start implementation for selected WPs.
-4. Transition WPs through review/complete loops.
-5. Accept when all WPs are accepted-ready (`approved` or `done`), then merge to record `done`.
+4. Transition WPs through implementation, review, approval, and rework loops.
+5. Accept when all WPs are terminal/accepted, then merge through your normal landing process.
 
 ### 1. Check compatibility
 
@@ -56,16 +56,28 @@ spec-kitty orchestrator-api transition \
   --mission <slug> --wp WP01 --to for_review \
   --actor my-orchestrator --policy '<json>' \
   --subtasks-complete --implementation-evidence-present
-# review approved
-spec-kitty orchestrator-api transition \
-  --mission <slug> --wp WP01 --to approved \
-  --actor reviewer-bot \
-  --review-ref review/WP01/attempt-1 \
-  --evidence-json '{"review":{"reviewer":"reviewer-bot","verdict":"approved","reference":"review/WP01/attempt-1"}}'
-# review rejected -> rework
+# reviewer claims active review
 spec-kitty orchestrator-api start-review \
   --mission <slug> --wp WP01 --actor my-orchestrator \
-  --policy '<json>' --review-ref review/WP01/attempt-2
+  --policy '<json>' --review-ref review/WP01/attempt-1
+
+# review approved
+spec-kitty orchestrator-api transition \
+  --mission <slug> --wp WP01 --to done \
+  --actor my-orchestrator \
+  --policy '<json>' \
+  --review-ref review/WP01/attempt-1 \
+  --force \
+  --note "Approved by reviewer-bot"
+
+# review rejected -> rework
+spec-kitty orchestrator-api transition \
+  --mission <slug> --wp WP01 --to in_progress \
+  --actor my-orchestrator \
+  --policy '<json>' \
+  --review-ref review/WP01/attempt-1 \
+  --force \
+  --note "Rejected by reviewer-bot; rework required"
 ```
 
 ### 5. Finalize
@@ -114,8 +126,9 @@ while true:
     run implementation agent
     transition(wp, for_review)
     run reviewer
-    if approved: transition(wp, approved)
-    else: start-review(wp, review_ref)
+    start-review(wp, review_ref)
+    if approved: transition(wp, done, force=True)
+    else: transition(wp, in_progress, force=True)
 accept-mission(mission)
 merge-mission(mission)
 ```

--- a/docs/how-to/run-external-orchestrator.md
+++ b/docs/how-to/run-external-orchestrator.md
@@ -26,19 +26,13 @@ This is the supported automation model:
 ## Version Compatibility
 
 The current host API requires a compatible provider implementation. PyPI
-currently publishes `spec-kitty-orchestrator` `0.1.0`; that release is not
-compatible with current `spec-kitty orchestrator-api` behavior and should not
-be used for this workflow.
+currently publishes `spec-kitty-orchestrator` `0.1.0`; that release appends
+`--json` to host API calls and is not compatible with current
+`spec-kitty orchestrator-api` behavior.
 
-Until a newer compatible release is published, install the orchestrator from
-the current source repository:
-
-```bash
-python -m pip install "git+https://github.com/Priivacy-ai/spec-kitty-orchestrator.git"
-```
-
-After a compatible release newer than `0.1.0` is published, installing from
-PyPI is expected to be the normal path.
+Install only a release, branch, or pinned commit that explicitly documents
+support for the current JSON-default host API. Do not assume an unverified
+default-branch install is compatible.
 
 For the common "Claude implements, Codex reviews" workflow, install and
 authenticate both CLIs before starting:
@@ -178,7 +172,8 @@ Expected for `spec-kitty` core CLI. Use:
 If `contract-version` returns mismatch, upgrade either host (`spec-kitty`) or provider (`spec-kitty-orchestrator`) so versions are compatible.
 
 If a run fails with `No such option: --json`, you are using an incompatible
-provider release. Install a host-compatible source build or a newer release.
+provider build. Install a provider build that no longer appends `--json` to
+`spec-kitty orchestrator-api` calls.
 
 ### Policy validation failures
 

--- a/docs/how-to/run-external-orchestrator.md
+++ b/docs/how-to/run-external-orchestrator.md
@@ -18,16 +18,27 @@ This is the supported automation model:
 ## Prerequisites
 
 - `spec-kitty` installed and available on `PATH`
-- `spec-kitty-orchestrator` installed and available on `PATH`
+- a host-compatible `spec-kitty-orchestrator` build installed and available on `PATH`
 - A prepared mission (`spec.md`, `plan.md`, `tasks.md`, and `tasks/WP*.md`)
 - At least one supported agent CLI installed
 - A clean enough git repository for worktree creation
 
-Install the released orchestrator package from PyPI:
+## Version Compatibility
+
+The current host API requires a compatible provider implementation. PyPI
+currently publishes `spec-kitty-orchestrator` `0.1.0`; that release is not
+compatible with current `spec-kitty orchestrator-api` behavior and should not
+be used for this workflow.
+
+Until a newer compatible release is published, install the orchestrator from
+the current source repository:
 
 ```bash
-pip install spec-kitty-orchestrator
+python -m pip install "git+https://github.com/Priivacy-ai/spec-kitty-orchestrator.git"
 ```
+
+After a compatible release newer than `0.1.0` is published, installing from
+PyPI is expected to be the normal path.
 
 For the common "Claude implements, Codex reviews" workflow, install and
 authenticate both CLIs before starting:
@@ -99,18 +110,19 @@ spec-kitty-orchestrator orchestrate \
   --max-concurrent 1
 ```
 
-The orchestrator loop will typically:
+With a host-compatible provider build, the orchestrator loop will typically:
 
 1. Read ready WPs via `list-ready`.
 2. Claim/start via `start-implementation`.
-3. Run the implementation agent in the WP worktree.
+3. Prepare a usable WP worktree and run the implementation agent there.
 4. Transition to `for_review`.
 5. Run the reviewer.
 6. Claim `in_review`.
-7. Transition to `done` on approval, or back to `in_progress` for rework.
+7. Transition to `done` on approval with the required review evidence, or back to `in_progress` for rework.
 
-The provider prepares worktrees before spawning agents. The host remains the
-source of truth for lane events.
+The host returns the intended workspace path. The provider must ensure that
+path exists and is usable before spawning an agent. The host remains the source
+of truth for lane events.
 
 ## 5. Monitor or Recover
 
@@ -164,6 +176,9 @@ Expected for `spec-kitty` core CLI. Use:
 ### Contract mismatch
 
 If `contract-version` returns mismatch, upgrade either host (`spec-kitty`) or provider (`spec-kitty-orchestrator`) so versions are compatible.
+
+If a run fails with `No such option: --json`, you are using an incompatible
+provider release. Install a host-compatible source build or a newer release.
 
 ### Policy validation failures
 

--- a/docs/how-to/run-external-orchestrator.md
+++ b/docs/how-to/run-external-orchestrator.md
@@ -5,9 +5,11 @@ description: Use spec-kitty-orchestrator with spec-kitty orchestrator-api to aut
 
 # Run the External Orchestrator
 
-Use this guide to run `spec-kitty-orchestrator` against a mission managed by `spec-kitty`.
+Use this guide to run `spec-kitty-orchestrator` against a mission managed by
+`spec-kitty`. This is the right page when you want a normal operator workflow:
+Claude implements, Codex reviews, and Spec Kitty remains the workflow host.
 
-This is the supported automation model in `1.x` and `2.x`:
+This is the supported automation model:
 
 - Host workflow state is owned by `spec-kitty`.
 - Automation runtime is external (`spec-kitty-orchestrator` or your own provider).
@@ -19,8 +21,23 @@ This is the supported automation model in `1.x` and `2.x`:
 - `spec-kitty-orchestrator` installed and available on `PATH`
 - A prepared mission (`spec.md`, `plan.md`, `tasks.md`, and `tasks/WP*.md`)
 - At least one supported agent CLI installed
+- A clean enough git repository for worktree creation
 
-## 1. Verify Host Contract
+Install the released orchestrator package from PyPI:
+
+```bash
+pip install spec-kitty-orchestrator
+```
+
+For the common "Claude implements, Codex reviews" workflow, install and
+authenticate both CLIs before starting:
+
+```bash
+claude --version
+codex --version
+```
+
+## 1. Verify the Host Contract
 
 ```bash
 spec-kitty orchestrator-api contract-version
@@ -29,47 +46,111 @@ spec-kitty orchestrator-api contract-version
 Expected result:
 
 - `success: true`
-- `data.api_version` present
+- `data.api_version` is present
 - `data.min_supported_provider_version` present
 
-## 2. Run a Dry-Run
+Do this before debugging provider behavior. If the host contract cannot be
+queried, the external orchestrator cannot safely mutate mission state.
+
+## 2. Choose Implementer and Reviewer Agents
+
+The most common pairing is Claude Code for implementation and Codex for review:
 
 ```bash
-spec-kitty-orchestrator orchestrate --mission 034-my-feature --dry-run
+spec-kitty-orchestrator orchestrate \
+  --mission 034-my-feature \
+  --impl-agent claude-code \
+  --review-agent codex \
+  --max-concurrent 1 \
+  --dry-run
+```
+
+Useful pairings:
+
+| Implementer | Reviewer | When to use |
+|---|---|---|
+| `claude-code` | `codex` | Default local automation: broad implementation, independent review. |
+| `codex` | `claude-code` | Codex implementation with Claude review. |
+| `claude-code` | `opencode` | Only when OpenCode has a working local model/provider config. |
+
+`--max-concurrent 1` is a conservative first run. Increase it after the first
+mission succeeds and your agents handle parallel work safely.
+
+## 3. Run a Dry Run
+
+```bash
+spec-kitty-orchestrator orchestrate \
+  --mission 034-my-feature \
+  --impl-agent claude-code \
+  --review-agent codex \
+  --max-concurrent 1 \
+  --dry-run
 ```
 
 Use this to validate configuration before mutating WP lanes.
 
-## 3. Start Orchestration
+## 4. Start Orchestration
 
 ```bash
-spec-kitty-orchestrator orchestrate --mission 034-my-feature
+spec-kitty-orchestrator orchestrate \
+  --mission 034-my-feature \
+  --impl-agent claude-code \
+  --review-agent codex \
+  --max-concurrent 1
 ```
 
 The orchestrator loop will typically:
 
 1. Read ready WPs via `list-ready`.
 2. Claim/start via `start-implementation`.
-3. Transition through `for_review`, `in_review`, and `approved` via host API calls.
-4. Continue until all WPs are accepted-ready (`approved` or `done`); merge later records `done`.
+3. Run the implementation agent in the WP worktree.
+4. Transition to `for_review`.
+5. Run the reviewer.
+6. Claim `in_review`.
+7. Transition to `done` on approval, or back to `in_progress` for rework.
 
-## 4. Monitor or Recover
+The provider prepares worktrees before spawning agents. The host remains the
+source of truth for lane events.
+
+## 5. Monitor or Recover
 
 ```bash
 spec-kitty-orchestrator status
 spec-kitty-orchestrator resume
-spec-kitty-orchestrator abort
+spec-kitty-orchestrator abort --cleanup-worktrees
 ```
 
-Use `resume` after interruption. Use `abort` to mark the provider run as stopped.
+Use `resume` after interruption. Use `abort --cleanup-worktrees` to remove the
+provider-local run state. This does not rewrite the mission event log.
 
-## 5. Confirm Host State
+Agent logs are written under:
+
+```text
+.kittify/logs/
+```
+
+## 6. Confirm Host State
 
 ```bash
 spec-kitty orchestrator-api mission-state --mission 034-my-feature
 ```
 
 This is the authoritative source of lane state.
+
+## 7. Accept and Merge After Orchestration
+
+If your workflow separates orchestration from merge, finish with the normal
+accept/merge process:
+
+```bash
+spec-kitty orchestrator-api accept-mission \
+  --mission 034-my-feature \
+  --actor spec-kitty-orchestrator
+```
+
+Then use your project’s normal merge path. The reference orchestrator can drive
+WP implementation and review, but the team should still decide when the mission
+is ready to land.
 
 ## Troubleshooting
 
@@ -88,7 +169,21 @@ If `contract-version` returns mismatch, upgrade either host (`spec-kitty`) or pr
 
 Mutation calls may fail with `POLICY_METADATA_REQUIRED` or `POLICY_VALIDATION_FAILED`. Ensure the provider sends required policy fields and does not include secret-like values.
 
+### OpenCode exits before review
+
+If an OpenCode-backed run blocks with an error such as `Model not found`, fix
+the local OpenCode provider/model configuration and rerun. The orchestrator
+will surface the agent error, but it cannot repair an unavailable model.
+
+### Protected branch commit errors
+
+Status-writing commands should run through orchestrator-managed worktrees, not
+directly on protected `main`. If a custom provider invokes `append-history`
+from `main`, the host may reject the commit. Use a lane/worktree branch for
+mutation calls.
+
 ## See Also
 
+- [Orchestrator Quickstart](../tutorials/orchestrator-quickstart.md)
 - [Orchestrator API Reference](../reference/orchestrator-api.md)
 - [How to Build a Custom Orchestrator](build-custom-orchestrator.md)

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -13,6 +13,7 @@ It is intentionally stricter than the human-facing CLI:
 - use `--mission`, never `--feature`
 - expect one JSON envelope on stdout for both success and failure
 - treat `error_code` as the stable machine discriminator
+- do not append `--json`; JSON is the default output for this command group
 
 ## Canonical Terms
 
@@ -81,17 +82,17 @@ Forbidden at the CLI boundary:
 
 ## Commands
 
-| Command | Purpose |
-|---|---|
-| `contract-version` | Check API compatibility |
-| `mission-state` | Query mission state and WP lanes |
-| `list-ready` | List WPs ready to start |
-| `start-implementation` | Atomically move a WP into implementation |
-| `start-review` | Claim review for a WP |
-| `transition` | Emit one explicit lane transition |
-| `append-history` | Append a WP activity-log note |
-| `accept-mission` | Record mission acceptance without closing approved WPs |
-| `merge-mission` | Merge the mission into its target branch |
+| Command | Mutates state | Purpose |
+|---|---:|---|
+| `contract-version` | no | Check API compatibility. |
+| `mission-state` | no | Query mission state and WP lanes. |
+| `list-ready` | no | List WPs ready to start. |
+| `start-implementation` | yes | Atomically move a WP into implementation. |
+| `start-review` | yes | Claim active review for a WP. |
+| `transition` | yes | Emit one explicit lane transition. |
+| `append-history` | yes | Append a WP activity-log note. |
+| `accept-mission` | yes | Record mission acceptance. |
+| `merge-mission` | yes | Merge the mission into its target branch. |
 
 Legacy command names such as `feature-state`, `accept-feature`, and
 `merge-feature` are forbidden.
@@ -115,6 +116,48 @@ Run-affecting commands also require `--policy`, whose JSON object must include:
 - `dangerous_flags`
 
 Secret-like values in `--policy` are rejected.
+
+Minimal policy example:
+
+```json
+{
+  "orchestrator_id": "spec-kitty-orchestrator",
+  "orchestrator_version": "0.1.0",
+  "agent_family": "claude",
+  "approval_mode": "full_auto",
+  "sandbox_mode": "workspace_write",
+  "network_mode": "none",
+  "dangerous_flags": []
+}
+```
+
+## Lane Model for Orchestrators
+
+External providers should treat these lanes as the public orchestration model:
+
+| Lane | Meaning |
+|---|---|
+| `planned` | WP exists but has not started. |
+| `claimed` | WP is claimed by an actor as part of implementation start. |
+| `in_progress` | Implementation or rework is active. |
+| `for_review` | Implementation is ready for review. |
+| `in_review` | A reviewer has claimed active review. |
+| `approved` | Review accepted but integration may still be pending. |
+| `done` | WP is complete. |
+| `blocked` | WP cannot continue without intervention. |
+| `canceled` | WP was intentionally canceled. |
+
+The reference orchestrator normally drives:
+
+```text
+planned -> claimed -> in_progress -> for_review -> in_review -> done
+```
+
+Rejected review cycles move back through:
+
+```text
+in_review -> in_progress -> for_review
+```
 
 ## Acceptance Payload
 
@@ -143,6 +186,101 @@ spec-kitty orchestrator-api start-implementation \
   --policy '{"orchestrator_id":"local","orchestrator_version":"1.0.0","agent_family":"codex","approval_mode":"never","sandbox_mode":"danger-full-access","network_mode":"enabled","dangerous_flags":[]}'
 ```
 
+### Start implementation
+
+```bash
+spec-kitty orchestrator-api start-implementation \
+  --mission 077-mission-terminology-cleanup \
+  --wp WP12 \
+  --actor spec-kitty-orchestrator \
+  --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"claude","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}'
+```
+
+Important response fields:
+
+| Field | Meaning |
+|---|---|
+| `workspace_path` | Path where the provider should run the implementation agent. |
+| `prompt_path` | WP markdown prompt file to feed to the implementation agent. |
+| `to_lane` | Expected to be `in_progress` on a fresh start. |
+| `no_op` | `true` when the same actor already owns the compatible state. |
+
+### Mark implementation ready for review
+
+```bash
+spec-kitty orchestrator-api transition \
+  --mission 077-mission-terminology-cleanup \
+  --wp WP12 \
+  --to for_review \
+  --actor spec-kitty-orchestrator \
+  --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"claude","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}' \
+  --subtasks-complete \
+  --implementation-evidence-present \
+  --note "Implementation complete"
+```
+
+`in_progress -> for_review` requires evidence that the implementation handoff
+is ready. A provider may use `--force` with a clear `--note` when it has its own
+reviewable evidence model.
+
+### Claim review
+
+```bash
+spec-kitty orchestrator-api start-review \
+  --mission 077-mission-terminology-cleanup \
+  --wp WP12 \
+  --actor spec-kitty-orchestrator \
+  --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"codex","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}' \
+  --review-ref review/WP12/attempt-1
+```
+
+On current hosts this moves `for_review -> in_review`.
+
+### Complete approved review
+
+```bash
+spec-kitty orchestrator-api transition \
+  --mission 077-mission-terminology-cleanup \
+  --wp WP12 \
+  --to done \
+  --actor spec-kitty-orchestrator \
+  --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"codex","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}' \
+  --review-ref review/WP12/attempt-1 \
+  --force \
+  --note "Codex review approved"
+```
+
+Use `--force` with an audit note for the current external-review completion
+path. The provider is responsible for keeping the review artifact reference in
+`--review-ref` stable enough for later audit.
+
+### Send rejected review back to rework
+
+```bash
+spec-kitty orchestrator-api transition \
+  --mission 077-mission-terminology-cleanup \
+  --wp WP12 \
+  --to in_progress \
+  --actor spec-kitty-orchestrator \
+  --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"codex","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}' \
+  --review-ref review/WP12/attempt-1 \
+  --force \
+  --note "Review rejected; rework required"
+```
+
+Then rerun the implementation agent with the review feedback and transition
+back to `for_review`.
+
+## Worktree Expectations
+
+The host returns the workspace path. The provider is responsible for ensuring
+the path is usable for the agent process. The reference orchestrator creates or
+reuses git worktrees before spawning agents.
+
+State mutation commands should not be run from a protected main branch when
+they need to commit activity-log updates. Use a mission lane/worktree branch for
+provider-owned mutation calls.
+
 ## Error Codes
 
 Current machine-readable error codes:
@@ -158,6 +296,16 @@ Current machine-readable error codes:
 - `PREFLIGHT_FAILED`
 - `CONTRACT_VERSION_MISMATCH`
 - `UNSUPPORTED_STRATEGY`
+
+## Provider Rules
+
+- Call `contract-version` once before mutating state.
+- Use only `orchestrator-api` for lane changes.
+- Keep retry decisions based on `error_code`, not prose.
+- Preserve `review_ref` values in logs and issue/PR links.
+- Treat `mission-state` as authoritative after every recovery.
+- Keep agent stdout/stderr in provider logs; do not stuff full logs into WP
+  history entries.
 
 ## Migration Notes
 

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -105,7 +105,12 @@ The tracked-mission selector is always:
 spec-kitty orchestrator-api mission-state --mission 077-mission-terminology-cleanup
 ```
 
-Run-affecting commands also require `--policy`, whose JSON object must include:
+Run-affecting implementation and review mutations require `--policy`. Today
+that means `start-implementation`, `start-review`, and `transition` when the
+target lane is run-affecting. `append-history`, `accept-mission`, and
+`merge-mission` do not accept `--policy`.
+
+The policy JSON object must include:
 
 - `orchestrator_id`
 - `orchestrator_version`

--- a/docs/reference/orchestrator-api.md
+++ b/docs/reference/orchestrator-api.md
@@ -274,8 +274,8 @@ back to `for_review`.
 ## Worktree Expectations
 
 The host returns the workspace path. The provider is responsible for ensuring
-the path is usable for the agent process. The reference orchestrator creates or
-reuses git worktrees before spawning agents.
+the path exists and is usable for the agent process before spawning an agent.
+Do not treat the returned string as proof that a worktree already exists.
 
 State mutation commands should not be run from a protected main branch when
 they need to commit activity-log updates. Use a mission lane/worktree branch for

--- a/docs/tutorials/orchestrator-quickstart.md
+++ b/docs/tutorials/orchestrator-quickstart.md
@@ -1,0 +1,161 @@
+---
+title: Orchestrator Quickstart
+description: Learn how Spec Kitty and spec-kitty-orchestrator work together to run a small mission through implementation and review.
+---
+
+# Orchestrator Quickstart
+
+This tutorial shows the external orchestration model end to end:
+
+- `spec-kitty` owns mission state and lane transitions.
+- `spec-kitty-orchestrator` runs agents and calls `spec-kitty orchestrator-api`.
+- Implementation and review happen in git worktrees, not on protected `main`.
+
+By the end, you will know how to check the host contract, run the reference
+orchestrator, watch mission state, and recover from a stopped run.
+
+## Prerequisites
+
+You need:
+
+- a git repository initialized with Spec Kitty
+- `spec-kitty` on `PATH`
+- `spec-kitty-orchestrator` on `PATH`
+- at least one agent CLI supported by the orchestrator, such as Claude Code,
+  Codex, or OpenCode
+- a mission with at least one `tasks/WP*.md` file
+
+If you do not have a mission yet, finish [Your First Feature](your-first-feature.md)
+first.
+
+## 1. Confirm the host API works
+
+Run this from the project root:
+
+```bash
+spec-kitty orchestrator-api contract-version
+```
+
+The output is a JSON envelope. For a compatible host it includes:
+
+```json
+{
+  "success": true,
+  "data": {
+    "api_version": "1.0.0"
+  }
+}
+```
+
+The orchestrator performs this check at startup too, but running it yourself
+confirms that the host CLI is installed and that JSON output is available.
+
+## 2. Find your mission slug
+
+Use the dashboard, `kitty-specs/`, or the mission commands to identify the
+mission slug:
+
+```bash
+ls kitty-specs
+```
+
+Examples look like:
+
+```text
+034-payment-retry-flow
+099-orchestrator-e2e
+```
+
+The orchestrator API selector is always `--mission`, even when the selector is
+a slug, mission id, or short mission id.
+
+## 3. Inspect ready work
+
+```bash
+spec-kitty orchestrator-api list-ready --mission 034-payment-retry-flow
+```
+
+Ready work packages are WPs in `planned` whose dependencies are already `done`.
+If no WPs are ready, inspect the whole mission:
+
+```bash
+spec-kitty orchestrator-api mission-state --mission 034-payment-retry-flow
+```
+
+## 4. Dry-run the orchestrator
+
+```bash
+spec-kitty-orchestrator orchestrate \
+  --mission 034-payment-retry-flow \
+  --impl-agent claude-code \
+  --review-agent codex \
+  --max-concurrent 1 \
+  --dry-run
+```
+
+Use `--dry-run` before the first real run. It validates configuration without
+moving WP lanes.
+
+## 5. Run implementation and review
+
+```bash
+spec-kitty-orchestrator orchestrate \
+  --mission 034-payment-retry-flow \
+  --impl-agent claude-code \
+  --review-agent codex \
+  --max-concurrent 1
+```
+
+The reference orchestrator will:
+
+1. call `list-ready`
+2. call `start-implementation` for a ready WP
+3. run the implementation agent in the WP worktree
+4. transition the WP to `for_review`
+5. run the review agent
+6. claim `in_review` and transition to `done` when the review passes
+7. move rejected work back to `in_progress` for rework
+
+The orchestrator writes its local run state under `.kittify/` and agent logs
+under `.kittify/logs/`.
+
+## 6. Check progress
+
+In another terminal:
+
+```bash
+spec-kitty-orchestrator status
+spec-kitty orchestrator-api mission-state --mission 034-payment-retry-flow
+```
+
+Use `mission-state` as the source of truth for WP lanes. Use
+`spec-kitty-orchestrator status` for provider-local details such as retry
+counts and the last agent log path.
+
+## 7. Resume or abort
+
+If the process is interrupted:
+
+```bash
+spec-kitty-orchestrator resume
+```
+
+If you need to stop tracking the run state:
+
+```bash
+spec-kitty-orchestrator abort --cleanup-worktrees
+```
+
+`abort --cleanup-worktrees` removes provider-local state. It does not rewrite
+authoritative mission lane history.
+
+## What to read next
+
+- [Run the External Orchestrator](../how-to/run-external-orchestrator.md) for
+  operational commands and troubleshooting.
+- [Build a Custom Orchestrator](../how-to/build-custom-orchestrator.md) if you
+  want to write your own provider loop.
+- [Orchestrator API Reference](../reference/orchestrator-api.md) for command
+  flags and JSON payloads.
+- [Multi-Agent Orchestration](../explanation/multi-agent-orchestration.md) for
+  the host/provider model.

--- a/docs/tutorials/orchestrator-quickstart.md
+++ b/docs/tutorials/orchestrator-quickstart.md
@@ -20,13 +20,22 @@ You need:
 
 - a git repository initialized with Spec Kitty
 - `spec-kitty` on `PATH`
-- `spec-kitty-orchestrator` on `PATH`
+- a host-compatible `spec-kitty-orchestrator` build on `PATH`
 - at least one agent CLI supported by the orchestrator, such as Claude Code,
   Codex, or OpenCode
 - a mission with at least one `tasks/WP*.md` file
 
 If you do not have a mission yet, finish [Your First Feature](your-first-feature.md)
 first.
+
+## Version compatibility
+
+PyPI currently publishes `spec-kitty-orchestrator` `0.1.0`, which is not
+compatible with the current host API. Do not use that release for this
+tutorial. Install a current source build of
+[`Priivacy-ai/spec-kitty-orchestrator`](https://github.com/Priivacy-ai/spec-kitty-orchestrator)
+or a later release that explicitly documents compatibility with the current
+`spec-kitty orchestrator-api`.
 
 ## 1. Confirm the host API works
 
@@ -106,15 +115,16 @@ spec-kitty-orchestrator orchestrate \
   --max-concurrent 1
 ```
 
-The reference orchestrator will:
+With a host-compatible provider build, the orchestrator loop will:
 
 1. call `list-ready`
 2. call `start-implementation` for a ready WP
-3. run the implementation agent in the WP worktree
+3. prepare a usable WP worktree and run the implementation agent there
 4. transition the WP to `for_review`
 5. run the review agent
-6. claim `in_review` and transition to `done` when the review passes
-7. move rejected work back to `in_progress` for rework
+6. claim `in_review` before completing approved review
+7. transition to `done` with the required review evidence when the review passes
+8. move rejected work back to `in_progress` for rework
 
 The orchestrator writes its local run state under `.kittify/` and agent logs
 under `.kittify/logs/`.

--- a/docs/tutorials/orchestrator-quickstart.md
+++ b/docs/tutorials/orchestrator-quickstart.md
@@ -30,12 +30,11 @@ first.
 
 ## Version compatibility
 
-PyPI currently publishes `spec-kitty-orchestrator` `0.1.0`, which is not
-compatible with the current host API. Do not use that release for this
-tutorial. Install a current source build of
-[`Priivacy-ai/spec-kitty-orchestrator`](https://github.com/Priivacy-ai/spec-kitty-orchestrator)
-or a later release that explicitly documents compatibility with the current
-`spec-kitty orchestrator-api`.
+PyPI currently publishes `spec-kitty-orchestrator` `0.1.0`, which appends
+`--json` to host API calls and is not compatible with the current host API. Do
+not use that release for this tutorial. Install only a release, branch, or
+pinned commit that explicitly documents compatibility with the current
+JSON-default `spec-kitty orchestrator-api`.
 
 ## 1. Confirm the host API works
 

--- a/docs/tutorials/toc.yml
+++ b/docs/tutorials/toc.yml
@@ -4,6 +4,8 @@
   href: your-first-feature.md
 - name: Multi-Agent Workflow
   href: multi-agent-workflow.md
+- name: Orchestrator Quickstart
+  href: orchestrator-quickstart.md
 - name: Missions Overview
   href: missions-overview.md
 - name: Claude Code Integration

--- a/tests/contract/test_terminology_guards.py
+++ b/tests/contract/test_terminology_guards.py
@@ -247,6 +247,27 @@ def test_no_removed_orchestrator_api_command_names_in_live_docs():
                 )
 
 
+def test_orchestrator_api_docs_do_not_teach_removed_json_flag_or_unpinned_provider_source():
+    """Live docs must not teach host/provider patterns known to fail today.
+
+    Authority: orchestrator-api JSON-default contract and host/provider
+    compatibility boundary.
+    """
+    forbidden_patterns = (
+        r"spec-kitty orchestrator-api[^\n]*--json",
+        r"--json[^\n]*spec-kitty orchestrator-api",
+        r"git\+https://github\.com/Priivacy-ai/spec-kitty-orchestrator\.git",
+    )
+    for path, content in _live_doc_scan_targets():
+        for pattern in forbidden_patterns:
+            for match in re.finditer(pattern, content):
+                line = _line_number(content, match.start())
+                pytest.fail(
+                    f"{path.relative_to(REPO_ROOT)}:{line}: doc teaches an incompatible orchestrator provider pattern. "
+                    "Fix: orchestrator-api output is JSON by default and provider installs must be pinned to a compatible build."
+                )
+
+
 def test_no_mission_used_to_mean_mission_type_in_cli_commands():
     """CLI command files must not declare --mission with mission-type semantics.
 


### PR DESCRIPTION
## Summary

Adds orchestrator-specific documentation across the four Divio documentation types:

- Tutorial: new `docs/tutorials/orchestrator-quickstart.md`
- How-to: expanded `docs/how-to/run-external-orchestrator.md`
- Reference: expanded `docs/reference/orchestrator-api.md`
- Explanation: expanded `docs/explanation/multi-agent-orchestration.md`

Also updates `docs/how-to/build-custom-orchestrator.md`, `docs/tutorials/toc.yml`, and the README docs list.

## Notes

The docs now explicitly cover the normal reference-provider workflow where Claude Code implements, Codex reviews, and Spec Kitty remains the host via `spec-kitty orchestrator-api`. They also document PyPI installation, current lane flow (`for_review -> in_review -> done`), no `--json`, worktree expectations, protected-branch gotchas, and custom-provider API rules.

## Validation

- `uv run pytest tests/docs -q` -> 585 passed, 1 warning
- `uv run pytest tests/contract/test_orchestrator_api.py tests/contract/test_terminology_guards.py -q` -> 23 passed, 1 warning
