### PR TITLE
docs: record schema-versioning operator closure

### DIFF
--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2227,6 +2227,17 @@
   current_target: false
   citation_refs: []
   notes: Post-mission pytest delta + WP landing summary + acceptance criteria roll-up.
+- path: docs/engineering_notes/triage/2026-05-29-schema-versioning-operator-closure.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs:
+    - https://github.com/Priivacy-ai/spec-kitty/issues/1198
+    - https://github.com/Priivacy-ai/spec-kitty/issues/1200
+    - https://github.com/Priivacy-ai/spec-kitty/issues/1203
+    - https://github.com/Priivacy-ai/spec-kitty/issues/1281
+  notes: Operator-closure evidence note for the schema-versioning launch cluster.
 - path: docs/engineering_notes/triage/README.md
   tag: internal
   divio_type: none

--- a/docs/engineering_notes/triage/2026-05-29-schema-versioning-operator-closure.md
+++ b/docs/engineering_notes/triage/2026-05-29-schema-versioning-operator-closure.md
@@ -1,0 +1,52 @@
+# Schema-Versioning Launch Cluster Operator Closure
+
+Date: 2026-05-29
+
+Issues:
+
+- Priivacy-ai/spec-kitty#1198
+- Priivacy-ai/spec-kitty#1200
+- Priivacy-ai/spec-kitty#1203
+- Priivacy-ai/spec-kitty#1281
+
+## Decision
+
+The schema-versioning launch cluster has launch evidence posted, operator
+closure accepted, and all four tracked `spec-kitty` issues closed. No additional
+implementation delta is required in `spec-kitty`.
+
+## Evidence Reviewed
+
+- Parent evidence comment:
+  <https://github.com/Priivacy-ai/spec-kitty/issues/1198#issuecomment-4525778364>
+- Child issue closure-evidence comments:
+  - <https://github.com/Priivacy-ai/spec-kitty/issues/1200#issuecomment-4525778553>
+  - <https://github.com/Priivacy-ai/spec-kitty/issues/1203#issuecomment-4525778603>
+  - <https://github.com/Priivacy-ai/spec-kitty/issues/1281#issuecomment-4525778646>
+
+The evidence records merged cross-repo PRs for canonical producer contracts,
+CLI producer refactor, SaaS legacy normalization, SaaS materializer follow-up,
+and end-to-end canary coverage.
+
+## Local Verification
+
+From a fresh `spec-kitty` workspace:
+
+```bash
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra test python -m pytest tests/status/test_producer_conformance.py
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra test python -m pytest tests/sync/test_event_emission.py tests/sync/test_events.py
+python scripts/lint_canonical_producers.py --paths src scripts tests --baseline scripts/canonical_producer_lint_baseline.txt
+```
+
+Results:
+
+- `tests/status/test_producer_conformance.py`: 22 passed.
+- `tests/sync/test_event_emission.py tests/sync/test_events.py`: 127 passed.
+- `canonical-producer-lint`: passed.
+
+## Follow-Up
+
+The only repo delta found during this closure pass was a stale
+`canonical-producer-lint` baseline entry for
+`src/specify_cli/next/_internal_runtime/engine.py::CP001`. This PR removes that
+entry while preserving the baseline rationale.

--- a/scripts/canonical_producer_lint_baseline.txt
+++ b/scripts/canonical_producer_lint_baseline.txt
@@ -12,11 +12,6 @@
 #
 # The remaining baseline entries are:
 #
-# - src/specify_cli/next/_internal_runtime/engine.py — internal runtime
-#   ``run.events.jsonl`` local-only log. It is not a SaaS-bound producer,
-#   and touching the file solely for an inline lint exemption needlessly
-#   activates unrelated next-command CI shards. Tracked under #1200.
-#
 # - tests/sync/test_*.py — synthetic envelopes built by test fixtures
 #   to feed the OfflineQueue/router directly without invoking the
 #   producer surface (we're testing the queue/drain, not the producer).
@@ -39,7 +34,6 @@
 # - scripts/benchmarks/bench_queue_enqueue.py — micro-bench harness;
 #   not a real producer. Tracked under #1200.
 scripts/benchmarks/bench_queue_enqueue.py::CP001
-src/specify_cli/next/_internal_runtime/engine.py::CP001
 tests/audit/test_audit_classifiers.py::CP001
 tests/contract/test_handoff_fixtures.py::CP001
 tests/dossier/test_events.py::CP001


### PR DESCRIPTION
## Summary

- records operator-closure evidence for the schema-versioning launch cluster
- prunes one stale canonical-producer lint baseline entry that no longer maps to a violation
- preserves operator-gated issue closure by using refs only

Refs #1198.
Refs #1200.
Refs #1203.
Refs #1281.

## Verification

- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra test python -m pytest tests/status/test_producer_conformance.py` -> 22 passed
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run --extra test python -m pytest tests/sync/test_event_emission.py tests/sync/test_events.py` -> 127 passed
- `python scripts/lint_canonical_producers.py --paths src scripts tests --baseline scripts/canonical_producer_lint_baseline.txt` -> passed
