### PR TITLE
ci: pin canonical lint checkout ref

### DIFF
--- a/.github/workflows/canonical-producer-lint.yml
+++ b/.github/workflows/canonical-producer-lint.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/canonical-producer-lint.yml
+++ b/.github/workflows/canonical-producer-lint.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python


### PR DESCRIPTION
## Summary
- checkout canonical-producer-lint on the PR head SHA instead of the synthetic pull/N/merge ref
- keep push runs pinned to github.sha via the same expression fallback

Refs Priivacy-ai/spec-kitty#1295.

## Verification
- python YAML parse for canonical-producer-lint.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/canonical-producer-lint.yml