### PR TITLE
Fix docs and template drift issues

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -367,6 +367,38 @@ jobs:
           echo "Detected markdown changes in docs/architecture. Running consistency checks..."
           python -m pytest -m "not windows_ci" -q tests/docs/test_architecture_docs_consistency.py tests/docs/test_versioned_docs_integrity.py
 
+      - name: "[ENFORCED] Run template/compat regression tests on matching changes"
+        if: always()
+        run: |
+          FROM_SHA="${{ steps.commit_range.outputs.from }}"
+          TO_SHA="${{ steps.commit_range.outputs.to }}"
+
+          if [ -z "$FROM_SHA" ] || [ -z "$TO_SHA" ]; then
+            echo "No commit range available for this trigger. Skipping template/compat regression tests."
+            exit 0
+          fi
+
+          mapfile -d '' CHANGED_TEMPLATE_COMPAT < <(git diff --name-only -z --diff-filter=ACM "$FROM_SHA" "$TO_SHA" -- \
+            'src/specify_cli/template/**' \
+            'tests/test_template/**' \
+            'src/specify_cli/compat/**' \
+            'tests/specify_cli/compat/**' \
+            'src/specify_cli/migration/**' \
+            'tests/specify_cli/migration/**' \
+            'tests/specify_cli/regression/**')
+
+          if [ "${#CHANGED_TEMPLATE_COMPAT[@]}" -eq 0 ]; then
+            echo "No template/compat/migration changes detected. Skipping regression tests."
+            exit 0
+          fi
+
+          echo "Detected template/compat/migration changes. Running focused regression tests..."
+          python -m pytest -q --tb=short \
+            tests/test_template/test_asset_generator.py \
+            tests/specify_cli/migration/test_schema_version.py \
+            tests/specify_cli/compat/test_messages.py \
+            tests/specify_cli/regression/test_twelve_agent_parity.py::test_toml_command_output_is_parseable
+
       - name: "[ENFORCED] Check Contextive glossary files are up-to-date"
         if: always()
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (per-mission coordination worktree, `BookkeepingTransaction`,
   `WorkflowMutationPolicy`) ship in WPs 02-09.
 
+## [Unreleased - 3.2.0]
+
+### Changed
+
+- Documented the host-surface parity matrix and Mode of Work governance layer
+  so advise/ask/do behavior has a visible README entry point.
+- Clarified correlation link and projection policy / read-model policy coverage
+  for the 3.2.0 trail-model tranche, including deferred Tier 2 items.
+
+### Deferred
+
+- Continued tracking deferred follow-up work such as
+  [#534](https://github.com/Priivacy-ai/spec-kitty/issues/534) outside the
+  3.2.0 readiness tranche.
+
 ## [3.2.0rc29] - 2026-05-28
 
 3.2.0rc29 rerolls the coordination branch atomic event-log candidate after

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ It is probably overkill for one-off edits, tiny scripts, or teams that do not us
 | Integrate agents | Slash commands or skills for common AI coding tools |
 | Learn from missions | Every completed mission generates a retrospective by default. Tune via `.kittify/config.yaml#retrospective` or charter; see [how-to](docs/how-to/use-retrospective-learning.md). |
 
+## Governance layer
+
+Spec Kitty keeps runtime governance in the repo instead of treating it as
+agent-only prompt text. The trail model in [docs/trail-model.md](docs/trail-model.md)
+describes how `spec-kitty advise`, `spec-kitty ask`, and `spec-kitty do` map
+operator intent to runtime behavior, while
+[docs/host-surface-parity.md](docs/host-surface-parity.md) tracks parity across
+CLI, slash-command, and hosted surfaces.
+
 ## Quick Start
 
 Install the CLI:

--- a/scripts/release/extract_changelog.py
+++ b/scripts/release/extract_changelog.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 CHANGELOG_HEADING_RE = re.compile(
     r"^##\s*(?:\[\s*)?"
+    r"(?:(?:Unreleased)\s*-\s*)?"
     r"(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+|(?:alpha|beta)\d*)?)"
     r"(?:\s*\]|)(?:\s*-.*)?$",
     re.IGNORECASE,

--- a/scripts/release/validate_release.py
+++ b/scripts/release/validate_release.py
@@ -42,6 +42,7 @@ RELEASE_VERSION_RE = re.compile(
 )
 CHANGELOG_HEADING_RE = re.compile(
     r"^##\s*(?:\[\s*)?"
+    r"(?:(?:Unreleased)\s*-\s*)?"
     r"(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+|(?:alpha|beta)\d*)?)"
     r"(?:\s*\]|)(?:\s*-.*)?$",
     re.IGNORECASE,

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -360,8 +360,11 @@ def _check_project_not_too_new(
                 method = detect_install_method()
                 hint = build_upgrade_hint(method)
                 hint_str = hint.command if hint.command is not None else hint.note or "Upgrade your CLI."
-                console.print(f"[red]Error:[/red] This project uses schema version {schema_v}, but this CLI supports up to schema {MAX_SUPPORTED_SCHEMA}.")
-                console.print(f"[cyan]Upgrade the CLI:[/cyan] {hint_str}")
+                console.print(
+                    f"[red]Error:[/red] This project uses Spec Kitty project schema {schema_v}, "
+                    f"but this CLI supports up to schema {MAX_SUPPORTED_SCHEMA}."
+                )
+                console.print(f"[cyan]Upgrade your CLI:[/cyan] {hint_str}")
             raise typer.Exit(5)
     except typer.Exit:
         raise

--- a/src/specify_cli/compat/messages.py
+++ b/src/specify_cli/compat/messages.py
@@ -64,7 +64,9 @@ MESSAGES: dict[Fr023Case, str] = {
         "This project needs Spec Kitty project migrations before this command can run.\nRun: spec-kitty upgrade\nPreview first: spec-kitty upgrade --dry-run"
     ),
     Fr023Case.PROJECT_TOO_NEW_FOR_CLI: (
-        "This project uses Spec Kitty project schema {schema_version}, but this CLI supports up to schema {max_supported}.\nUpgrade the CLI: {hint_command_or_note}"
+        "This project uses Spec Kitty project schema {schema_version}, "
+        "but this CLI supports up to schema {max_supported}.\n"
+        "Upgrade your CLI: {hint_command_or_note}"
     ),
     Fr023Case.PROJECT_NOT_INITIALIZED: "This directory is not a Spec Kitty project. Run: spec-kitty init",
     Fr023Case.PROJECT_METADATA_CORRUPT: ("This project's .kittify/metadata.yaml is unreadable: {metadata_error}.\nRun: spec-kitty doctor"),

--- a/src/specify_cli/migration/schema_version.py
+++ b/src/specify_cli/migration/schema_version.py
@@ -165,7 +165,7 @@ def check_compatibility(
             project_version=project_version,
             cli_version=cli_version,
             message=(
-                f"Project schema version {project_version} is outdated. "
+                f"Spec Kitty project schema {project_version} is outdated. "
                 f"Run `spec-kitty upgrade` to update to version {cli_version}."
             ),
             exit_code=1,
@@ -177,10 +177,11 @@ def check_compatibility(
             project_version=project_version,
             cli_version=cli_version,
             message=(
-                f"Project schema version {project_version} is newer than this CLI "
+                f"Spec Kitty project schema {project_version} is newer than this CLI "
                 f"supports ({cli_version}). "
                 "Upgrade your CLI: `pipx upgrade spec-kitty-cli` or use the "
-                "upgrade command for your installer."
+                "upgrade command for your installer. For virtualenv installs, "
+                "run `pip install --upgrade spec-kitty-cli`."
             ),
             exit_code=1,
         )

--- a/src/specify_cli/template/asset_generator.py
+++ b/src/specify_cli/template/asset_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from pathlib import Path
@@ -23,6 +24,11 @@ def _get_cli_version() -> str:
         from specify_cli import __version__
 
         return __version__
+
+
+def _toml_basic_string(value: str) -> str:
+    """Return a TOML basic-string literal for a single-line value."""
+    return json.dumps(value, ensure_ascii=False)
 
 
 def prepare_command_templates(
@@ -172,13 +178,13 @@ def render_command_template(
         description_value = description
         if description_value.startswith('"') and description_value.endswith('"'):
             description_value = description_value[1:-1]
-        description_value = description_value.replace('"', '\\"')
+        description_literal = _toml_basic_string(description_value)
         body_text = rendered_body
         if not body_text.endswith("\n"):
             body_text += "\n"
         body_text = body_text.replace("\\", "\\\\").replace('"""', '""\\"')
         # For TOML files, embed the version marker as a comment in the prompt body
-        return f'description = "{description_value}"\n\nprompt = """\n{version_marker}{body_text}"""\n'
+        return f"description = {description_literal}\n\nprompt = \"\"\"\n{version_marker}{body_text}\"\"\"\n"
 
     # Markdown output: preserve the template's YAML frontmatter on line 1 so
     # agents (e.g. Claude Code) can read the `description` field for their

--- a/src/specify_cli/template/asset_generator.py
+++ b/src/specify_cli/template/asset_generator.py
@@ -176,6 +176,7 @@ def render_command_template(
         body_text = rendered_body
         if not body_text.endswith("\n"):
             body_text += "\n"
+        body_text = body_text.replace("\\", "\\\\").replace('"""', '""\\"')
         # For TOML files, embed the version marker as a comment in the prompt body
         return f'description = "{description_value}"\n\nprompt = """\n{version_marker}{body_text}"""\n'
 

--- a/tests/release/test_validate_changelog_entry.py
+++ b/tests/release/test_validate_changelog_entry.py
@@ -15,6 +15,7 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "release"))
+from extract_changelog import extract_changelog_section  # type: ignore[import]
 from validate_release import changelog_has_entry  # type: ignore[import]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -109,6 +110,31 @@ def test_changelog_has_entry_prerelease_version() -> None:
     )
     assert changelog_has_entry(changelog, "3.1.1a3") is True
     assert changelog_has_entry(changelog, "3.1.1") is False
+
+
+def test_changelog_has_entry_unreleased_version_tranche() -> None:
+    changelog = (
+        "# Changelog\n\n"
+        "## [Unreleased - 3.2.0]\n\n"
+        "### Changed\n- The tranche\n\n"
+        "## [3.2.0rc29] - 2026-05-28\n\n"
+        "### Fixed\n- Old release candidate\n"
+    )
+    assert changelog_has_entry(changelog, "3.2.0") is True
+    assert changelog_has_entry(changelog, "3.2.0rc29") is True
+
+
+def test_extract_changelog_section_unreleased_version_tranche() -> None:
+    changelog = (
+        "# Changelog\n\n"
+        "## [Unreleased - 3.2.0]\n\n"
+        "### Changed\n- The tranche\n\n"
+        "## [3.2.0rc29] - 2026-05-28\n\n"
+        "### Fixed\n- Old release candidate\n"
+    )
+    section = extract_changelog_section(changelog, "3.2.0")
+    assert "The tranche" in section
+    assert "Old release candidate" not in section
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/cli/commands/test_upgrade_command.py
+++ b/tests/specify_cli/cli/commands/test_upgrade_command.py
@@ -362,18 +362,40 @@ def test_project_migration_needed_project_dry_run_json_contract(tmp_path: Path) 
 # ---------------------------------------------------------------------------
 
 
+def _assert_too_new_project_human_output(output: str) -> None:
+    normalized = " ".join(output.split())
+    assert "This project uses Spec Kitty project schema 7" in output
+    assert "supports up to schema" in normalized
+    assert "Upgrade your CLI:" in output
+    assert "pip install --upgrade spec-kitty-cli" in output
+
+
 def test_project_too_new_for_cli_command_exit_5(tmp_path: Path) -> None:
     """Project schema 7 (too new): upgrade command exits 5 (CHK037)."""
+    from specify_cli.compat._detect.install_method import InstallMethod
+
     _make_compatible_project(tmp_path, schema_version=7)
-    result = _invoke_upgrade(["--project", "--dry-run"], cwd=tmp_path)
+    with patch(
+        "specify_cli.compat._detect.install_method.detect_install_method",
+        return_value=InstallMethod.PIP_SYSTEM,
+    ):
+        result = _invoke_upgrade(["--project", "--dry-run"], cwd=tmp_path)
     assert result.exit_code == 5, f"Expected exit 5 for too-new project, got {result.exit_code}. Output: {result.output}"
+    _assert_too_new_project_human_output(result.output)
 
 
 def test_project_too_new_for_cli_default_mode_exit_5(tmp_path: Path) -> None:
     """Project schema 7 (too new): default upgrade mode also exits 5."""
+    from specify_cli.compat._detect.install_method import InstallMethod
+
     _make_compatible_project(tmp_path, schema_version=7)
-    result = _invoke_upgrade(["--dry-run"], cwd=tmp_path)
+    with patch(
+        "specify_cli.compat._detect.install_method.detect_install_method",
+        return_value=InstallMethod.PIP_SYSTEM,
+    ):
+        result = _invoke_upgrade(["--dry-run"], cwd=tmp_path)
     assert result.exit_code == 5, f"Expected exit 5 for too-new project, got {result.exit_code}. Output: {result.output}"
+    _assert_too_new_project_human_output(result.output)
 
 
 def test_project_too_new_for_cli_yes_does_not_bypass(tmp_path: Path) -> None:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/implement.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/implement.toml
@@ -143,7 +143,7 @@ After all subtasks are complete:
   would have been caught by this step. Scope is the diff only so the implementer
   does not drown in pre-existing warnings owned by other WPs.
   ```bash
-  CHANGED_PY=$(git diff --name-only --diff-filter=AMR HEAD | rg '\.py$' || true)
+  CHANGED_PY=$(git diff --name-only --diff-filter=AMR HEAD | rg '\\.py$' || true)
   if [ -n "$CHANGED_PY" ]; then
     .venv/bin/ruff check $CHANGED_PY
   fi

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/implement.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/implement.toml
@@ -143,7 +143,7 @@ After all subtasks are complete:
   would have been caught by this step. Scope is the diff only so the implementer
   does not drown in pre-existing warnings owned by other WPs.
   ```bash
-  CHANGED_PY=$(git diff --name-only --diff-filter=AMR HEAD | rg '\.py$' || true)
+  CHANGED_PY=$(git diff --name-only --diff-filter=AMR HEAD | rg '\\.py$' || true)
   if [ -n "$CHANGED_PY" ]; then
     .venv/bin/ruff check $CHANGED_PY
   fi

--- a/tests/test_template/test_asset_generator.py
+++ b/tests/test_template/test_asset_generator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 from specify_cli.template.asset_generator import (
@@ -73,6 +74,22 @@ def test_render_command_template_handles_toml_extension(tmp_path: Path) -> None:
     assert 'prompt = """' in output
     assert "Run echo hi {{args}}  for gemini." in output
     assert "<!-- spec-kitty-command-version:" in output
+    assert tomllib.loads(output)["prompt"]
+
+
+def test_render_command_template_escapes_backslashes_in_toml(tmp_path: Path) -> None:
+    template_path = tmp_path / "demo.md"
+    _write_template_with_body(template_path, "Run `rg '\\.py$'` before review.\n")
+
+    output = render_command_template(
+        template_path,
+        script_type="sh",
+        agent_key="gemini",
+        arg_format="{{args}}",
+        extension="toml",
+    )
+
+    assert "Run `rg '\\.py$'` before review.\n" in tomllib.loads(output)["prompt"]
 
 
 def test_generate_agent_assets_creates_expected_files(tmp_path: Path) -> None:

--- a/tests/test_template/test_asset_generator.py
+++ b/tests/test_template/test_asset_generator.py
@@ -92,6 +92,30 @@ def test_render_command_template_escapes_backslashes_in_toml(tmp_path: Path) -> 
     assert "Run `rg '\\.py$'` before review.\n" in tomllib.loads(output)["prompt"]
 
 
+def test_render_command_template_escapes_description_backslashes_in_toml(tmp_path: Path) -> None:
+    template_path = tmp_path / "demo.md"
+    template_path.write_text(
+        """---
+description: 'Run C:\\Program Files\\Spec'
+scripts:
+  sh: echo hi
+---
+Body
+""",
+        encoding="utf-8",
+    )
+
+    output = render_command_template(
+        template_path,
+        script_type="sh",
+        agent_key="gemini",
+        arg_format="{{args}}",
+        extension="toml",
+    )
+
+    assert tomllib.loads(output)["description"] == r"Run C:\Program Files\Spec"
+
+
 def test_generate_agent_assets_creates_expected_files(tmp_path: Path) -> None:
     commands_dir = tmp_path / "commands"
     commands_dir.mkdir()


### PR DESCRIPTION
## Summary
- add the README Governance layer entry point and 3.2.0 unreleased changelog block
- escape rendered TOML prompt backslashes for Gemini/Qwen implement templates and update the affected baselines
- standardize schema-version wording around "Spec Kitty project schema" across compatibility/upgrade messages

Closes #1318.
Closes #1308.
Closes #1302.

## Verification
- uv run pytest tests/specify_cli/docs/test_readme_governance.py tests/specify_cli/docs/test_trail_model_doc.py::test_changelog_unreleased_has_both_tranches tests/specify_cli/migration/test_schema_version.py tests/test_template/test_asset_generator.py::test_render_command_template_handles_toml_extension tests/test_template/test_asset_generator.py::test_render_command_template_escapes_backslashes_in_toml tests/specify_cli/regression/test_twelve_agent_parity.py::test_toml_command_output_is_parseable --tb=short -q
- uv run pytest tests/specify_cli/cli/commands/test_upgrade_command.py::test_project_too_new_for_cli_command_exit_5 tests/specify_cli/cli/commands/test_upgrade_command.py::test_project_too_new_for_cli_default_mode_exit_5 tests/specify_cli/compat/test_messages.py::TestRenderHuman::test_project_too_new --tb=short -q
- uv run ruff check src/specify_cli/cli/commands/upgrade.py src/specify_cli/compat/messages.py src/specify_cli/migration/schema_version.py src/specify_cli/template/asset_generator.py tests/test_template/test_asset_generator.py

## Notes
- Full test_command_output_unchanged parity assertions still fail locally from pre-existing glossary comment injection across command baselines; this PR avoids that unrelated churn and verifies the TOML parse regression directly.