### PR TITLE
Fix charter JSON error envelopes

### DIFF
--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -209,7 +209,7 @@ def sync(
         )
 
     except Exception as e:
-        logger.exception("Sync failed: %s", e)
+        logger.error("Sync failed: %s", e)
         return SyncResult(
             synced=False,
             stale_before=False,

--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -209,7 +209,7 @@ def sync(
         )
 
     except Exception as e:
-        logger.error("Sync failed: %s", e)
+        logger.debug("Sync failed: %s", e, exc_info=True)
         return SyncResult(
             synced=False,
             stale_before=False,

--- a/src/specify_cli/cli/commands/charter/context.py
+++ b/src/specify_cli/cli/commands/charter/context.py
@@ -8,6 +8,7 @@ import typer
 from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
+from specify_cli.cli.commands.charter._common import _emit_error
 
 # Test-patch shim — see ``synthesize.py``.
 import specify_cli.cli.commands.charter as _charter_pkg
@@ -104,8 +105,8 @@ def context(
         console.print(result.text)
 
     except TaskCliError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e), unexpected=True)
         raise typer.Exit(code=1) from e

--- a/src/specify_cli/cli/commands/charter/interview.py
+++ b/src/specify_cli/cli/commands/charter/interview.py
@@ -18,6 +18,7 @@ from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
 from specify_cli.cli.commands.charter._common import (
+    _emit_error,
     _interview_path,
     _parse_csv_option,
     _resolve_actor,
@@ -349,8 +350,8 @@ def interview(  # noqa: C901
         console.print(f"Profile: {interview_data.profile}")
 
     except (TaskCliError, ValueError) as e:
-        console.print(f"[red]Error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e), unexpected=True)
         raise typer.Exit(code=1) from e

--- a/src/specify_cli/cli/commands/charter/interview.py
+++ b/src/specify_cli/cli/commands/charter/interview.py
@@ -106,14 +106,19 @@ def interview(  # noqa: C901
         # surfaces it; existing answers are preserved. Required directives are
         # pre-selected. Failure here is non-fatal (org packs are optional).
         # ------------------------------------------------------------------
+        org_prefill_messages: list[str] = []
+        org_prefill_warning: str | None = None
         try:
             from specify_cli.doctrine.org_charter import apply_org_charter_to_interview
 
             org_prefill_messages = apply_org_charter_to_interview(interview_data, repo_root)
-            for msg in org_prefill_messages:
-                console.print(f"[cyan]Org charter:[/cyan] {msg}")
+            if not json_output:
+                for msg in org_prefill_messages:
+                    console.print(f"[cyan]Org charter:[/cyan] {msg}")
         except Exception as exc:  # noqa: BLE001 — org-charter is best-effort, never blocks interview
-            console.print(f"[yellow]Org charter pre-fill skipped:[/yellow] {exc}")
+            org_prefill_warning = str(exc)
+            if not json_output:
+                console.print(f"[yellow]Org charter pre-fill skipped:[/yellow] {exc}")
 
         # Resolve actor for Decision Moment events (non-fatal fallback)
         actor = _resolve_actor()
@@ -338,6 +343,8 @@ def interview(  # noqa: C901
                         "selected_paradigms": interview_data.selected_paradigms,
                         "selected_directives": interview_data.selected_directives,
                         "available_tools": interview_data.available_tools,
+                        "org_prefill_messages": org_prefill_messages,
+                        "org_prefill_warning": org_prefill_warning,
                     },
                     indent=2,
                 )

--- a/src/specify_cli/cli/commands/charter/lint.py
+++ b/src/specify_cli/cli/commands/charter/lint.py
@@ -8,6 +8,7 @@ import typer
 from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
+from specify_cli.cli.commands.charter._common import _emit_error
 
 # Test-patch shim — see ``synthesize.py``.
 import specify_cli.cli.commands.charter as _charter_pkg
@@ -96,7 +97,7 @@ def charter_lint(
     try:
         repo_root = _charter_pkg.find_repo_root()
     except TaskCliError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        _emit_error(console, json_output=output_json, message=str(e))
         raise typer.Exit(code=1) from e
 
     # Resolve canonical --mission, accepting hidden --feature as a deprecated alias.
@@ -139,12 +140,14 @@ def charter_lint(
         from charter.drg import OrgDRGConflictError, OrgPackMissingError
 
         if isinstance(exc, (OrgPackMissingError, OrgDRGConflictError)):
-            console.print(f"[red]Charter Lint:[/red] org-layer load failed: {exc}")
+            message = f"Charter Lint: org-layer load failed: {exc}"
+            _emit_error(console, json_output=output_json, message=message)
             raise typer.Exit(code=1) from exc
         # Unknown failure shape — log and continue without org layer.
-        console.print(
-            f"[yellow]warning:[/yellow] org-layer skipped (load error): {exc}"
-        )
+        if not output_json:
+            console.print(
+                f"[yellow]warning:[/yellow] org-layer skipped (load error): {exc}"
+            )
 
     # When org packs are configured, exercise ``merge_three_layers``
     # against an empty built-in graph so any pack-level conflict (layer
@@ -179,6 +182,20 @@ def charter_lint(
             # re-format with the conflict kind named so operators see
             # which org pack(s) misbehaved.
             conflicts: list[OrgDRGConflict] = list(exc.conflicts)
+            if output_json:
+                details = "; ".join(
+                    f"kind={c.kind} target_id={c.target_id} layers={c.conflicting_layers}"
+                    for c in conflicts
+                )
+                _emit_error(
+                    console,
+                    json_output=True,
+                    message=(
+                        f"Charter Lint: {len(conflicts)} org-layer conflict(s) detected"
+                        + (f": {details}" if details else "")
+                    ),
+                )
+                raise typer.Exit(code=1) from exc
             console.print(
                 f"[red]Charter Lint:[/red] {len(conflicts)} org-layer "
                 f"conflict(s) detected"

--- a/src/specify_cli/cli/commands/charter/resynthesize.py
+++ b/src/specify_cli/cli/commands/charter/resynthesize.py
@@ -15,6 +15,7 @@ from specify_cli.cli.commands.charter._app import (
     charter_app,
     console,
 )
+from specify_cli.cli.commands.charter._common import _emit_error
 # See ``synthesize.py`` for the package-module pattern: patches of
 # ``specify_cli.cli.commands.charter.<name>`` must be visible here too. We route
 # ``_assert_bundle_compatible``, ``_build_synthesis_request``,
@@ -194,23 +195,29 @@ def charter_resynthesize(  # noqa: C901
         panel_body += (
             "\n\nRun 'spec-kitty charter resynthesize --list-topics' to see all valid selectors."
         )
-        err_console.print(
-            Panel(
-                Text(panel_body),
-                title=f'[bold red]Cannot resolve --topic "{e.raw}"[/]',
-                border_style="red",
+        if json_output:
+            _emit_error(console, json_output=True, message=panel_body)
+        else:
+            err_console.print(
+                Panel(
+                    Text(panel_body),
+                    title=f'[bold red]Cannot resolve --topic "{e.raw}"[/]',
+                    border_style="red",
+                )
             )
-        )
         raise typer.Exit(code=2) from e
     except SynthesisError as e:
-        render_error_panel(e, err_console)
+        if json_output:
+            _emit_error(console, json_output=True, message=str(e))
+        else:
+            render_error_panel(e, err_console)
         raise typer.Exit(code=1) from e
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except TaskCliError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e), unexpected=True)
         raise typer.Exit(code=1) from e

--- a/src/specify_cli/cli/commands/charter/resynthesize.py
+++ b/src/specify_cli/cli/commands/charter/resynthesize.py
@@ -104,8 +104,10 @@ def charter_resynthesize(  # noqa: C901
             skip_code_evidence=skip_code_evidence,
             skip_corpus=skip_corpus,
         )
-        for warning in evidence_result.warnings:
-            console.print(f"[yellow]⚠ {warning}[/yellow]")
+        warnings_collected = [str(warning) for warning in evidence_result.warnings]
+        if not json_output:
+            for warning in warnings_collected:
+                console.print(f"[yellow]⚠ {warning}[/yellow]")
 
         request, syn_adapter = _charter_pkg._build_synthesis_request(repo_root, adapter, evidence=evidence_result.bundle)
 
@@ -115,6 +117,7 @@ def charter_resynthesize(  # noqa: C901
                 print(json.dumps({
                     "result": "success",
                     "topics": topics,
+                    "warnings": warnings_collected,
                 }, indent=2))
                 return
 
@@ -157,6 +160,7 @@ def charter_resynthesize(  # noqa: C901
                     "diagnostic": result.diagnostic,
                     "matched_form": result.resolved_topic.matched_form,
                     "targets_count": 0,
+                    "warnings": warnings_collected,
                 }, indent=2))
                 return
             console.print(f"[yellow]No-op:[/yellow] {result.diagnostic}")
@@ -176,6 +180,7 @@ def charter_resynthesize(  # noqa: C901
                 "regenerated": regenerated,
                 "run_id": result.manifest.run_id,
                 "manifest_artifacts": len(result.manifest.artifacts),
+                "warnings": warnings_collected,
             }, indent=2))
             return
 

--- a/src/specify_cli/cli/commands/charter/sync.py
+++ b/src/specify_cli/cli/commands/charter/sync.py
@@ -32,6 +32,9 @@ def sync(
         result = sync_charter(charter_path, output_dir, force=force)
 
         if json_output:
+            if result.error:
+                _emit_error(console, json_output=True, message=str(result.error))
+                raise typer.Exit(code=1)
             data = {
                 "result": "success" if result.synced else "noop",
                 "success": result.synced,
@@ -56,6 +59,8 @@ def sync(
         else:
             console.print("[blue]Charter already in sync[/blue] (use --force to re-extract)")
 
+    except typer.Exit:
+        raise
     except TaskCliError as e:
         _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e

--- a/src/specify_cli/cli/commands/charter/sync.py
+++ b/src/specify_cli/cli/commands/charter/sync.py
@@ -8,7 +8,7 @@ import typer
 from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
-from specify_cli.cli.commands.charter._common import _resolve_charter_path
+from specify_cli.cli.commands.charter._common import _emit_error, _resolve_charter_path
 
 # Test-patch shim — see ``synthesize.py``.
 import specify_cli.cli.commands.charter as _charter_pkg
@@ -57,8 +57,8 @@ def sync(
             console.print("[blue]Charter already in sync[/blue] (use --force to re-extract)")
 
     except TaskCliError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {e}")
+        _emit_error(console, json_output=json_output, message=str(e), unexpected=True)
         raise typer.Exit(code=1) from e

--- a/src/specify_cli/cli/commands/charter_bundle.py
+++ b/src/specify_cli/cli/commands/charter_bundle.py
@@ -334,8 +334,18 @@ def validate(
     try:
         canonical_root = resolve_canonical_repo_root(Path.cwd())
     except (NotInsideRepositoryError, GitCommonDirUnavailableError) as exc:
-        # Exit 2: resolver failure. Message on stderr per contract.
-        err_console.print(f"[red]Error:[/red] {exc}")
+        # Exit 2: resolver failure. ``--json`` still emits one parseable
+        # stdout envelope for machine consumers.
+        if json_output:
+            sys.stdout.write(
+                _json.dumps(
+                    {"result": "error", "success": False, "error": str(exc)},
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        else:
+            err_console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=2) from exc
 
     # FR-009: Incompatible bundles fail validation, but --json still emits the

--- a/tests/cli/commands/test_charter_json_error_contract.py
+++ b/tests/cli/commands/test_charter_json_error_contract.py
@@ -124,6 +124,39 @@ def test_sync_json_error_result_is_parseable_and_nonzero(tmp_path: Path) -> None
     assert payload["error"] == "charter parse failed"
 
 
+def test_interview_json_keeps_org_prefill_messages_inside_payload(tmp_path: Path) -> None:
+    interview_data = SimpleNamespace(
+        mission="software-dev",
+        profile="minimal",
+        answers={},
+        selected_paradigms=[],
+        selected_directives=[],
+        available_tools=[],
+    )
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.charter.default_interview", return_value=interview_data),
+        patch(
+            "specify_cli.doctrine.org_charter.apply_org_charter_to_interview",
+            return_value=["applied org default"],
+        ),
+        patch("charter.interview.write_interview_answers"),
+        patch("charter.interview.apply_answer_overrides", return_value=interview_data),
+        patch("charter.interview.MINIMAL_QUESTION_ORDER", []),
+        patch("charter.interview.QUESTION_ORDER", []),
+        patch("charter.interview.QUESTION_PROMPTS", {}),
+        patch("specify_cli.cli.commands.charter._get_widen_prereqs_absent", return_value=None),
+    ):
+        result = runner.invoke(charter_app, ["interview", "--defaults", "--profile", "minimal", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["result"] == "success"
+    assert payload["org_prefill_messages"] == ["applied org default"]
+    assert payload["org_prefill_warning"] is None
+
+
 def test_bundle_validate_json_resolver_error_is_parseable() -> None:
     with patch(
         "specify_cli.cli.commands.charter_bundle.resolve_canonical_repo_root",

--- a/tests/cli/commands/test_charter_json_error_contract.py
+++ b/tests/cli/commands/test_charter_json_error_contract.py
@@ -16,7 +16,7 @@ from specify_cli.cli.commands.charter import app as charter_app
 from specify_cli.cli.commands.charter_bundle import app as bundle_app
 from specify_cli.task_utils import TaskCliError
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.fast]
 
 runner = CliRunner()
 
@@ -56,7 +56,7 @@ def test_charter_json_commands_emit_parseable_error_when_repo_root_missing(
 
 
 def test_resynthesize_json_unresolved_topic_error_is_parseable(tmp_path: Path) -> None:
-    evidence_result = SimpleNamespace(warnings=[], bundle=SimpleNamespace())
+    evidence_result = SimpleNamespace(warnings=["corpus unavailable"], bundle=SimpleNamespace())
     unresolved = TopicSelectorUnresolvedError(
         raw="does-not-exist",
         candidates=("directive:PROJECT_001",),
@@ -75,6 +75,53 @@ def test_resynthesize_json_unresolved_topic_error_is_parseable(tmp_path: Path) -
     payload = _assert_json_error(result.output)
     assert "does-not-exist" in str(payload["error"])
     assert "directive:PROJECT_001" in str(payload["error"])
+
+
+def test_resynthesize_json_keeps_evidence_warnings_inside_payload(tmp_path: Path) -> None:
+    evidence_result = SimpleNamespace(warnings=["corpus unavailable"], bundle=SimpleNamespace())
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.charter._collect_evidence_result", return_value=evidence_result),
+        patch("specify_cli.cli.commands.charter._build_synthesis_request", return_value=(SimpleNamespace(), SimpleNamespace())),
+        patch(
+            "specify_cli.cli.commands.charter._list_resynthesis_topics",
+            return_value={
+                "project_artifacts": [],
+                "drg_urns": [],
+                "interview_sections": [],
+            },
+        ),
+    ):
+        result = runner.invoke(charter_app, ["resynthesize", "--list-topics", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["result"] == "success"
+    assert payload["warnings"] == ["corpus unavailable"]
+
+
+def test_sync_json_error_result_is_parseable_and_nonzero(tmp_path: Path) -> None:
+    charter_dir = tmp_path / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True)
+    (charter_dir / "charter.md").write_text("# Charter\n", encoding="utf-8")
+    sync_result = SimpleNamespace(
+        synced=False,
+        stale_before=False,
+        files_written=[],
+        extraction_mode="llm",
+        error="charter parse failed",
+    )
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path),
+        patch("charter.sync.sync", return_value=sync_result),
+    ):
+        result = runner.invoke(charter_app, ["sync", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = _assert_json_error(result.output)
+    assert payload["error"] == "charter parse failed"
 
 
 def test_bundle_validate_json_resolver_error_is_parseable() -> None:

--- a/tests/cli/commands/test_charter_json_error_contract.py
+++ b/tests/cli/commands/test_charter_json_error_contract.py
@@ -1,0 +1,89 @@
+"""Regression coverage for charter ``--json`` error-path parseability."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from charter.resolution import NotInsideRepositoryError
+from charter.synthesizer.errors import TopicSelectorUnresolvedError
+from specify_cli.cli.commands.charter import app as charter_app
+from specify_cli.cli.commands.charter_bundle import app as bundle_app
+from specify_cli.task_utils import TaskCliError
+
+pytestmark = [pytest.mark.unit]
+
+runner = CliRunner()
+
+
+def _assert_json_error(output: str) -> dict[str, object]:
+    payload = json.loads(output)
+    assert payload["result"] == "error"
+    assert payload["success"] is False
+    assert isinstance(payload["error"], str)
+    assert payload["error"]
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("argv", "exit_code"),
+    [
+        (["context", "--action", "specify", "--json"], 1),
+        (["interview", "--defaults", "--profile", "minimal", "--json"], 1),
+        (["sync", "--json"], 1),
+        (["resynthesize", "--list-topics", "--json"], 1),
+        (["lint", "--json"], 1),
+    ],
+)
+def test_charter_json_commands_emit_parseable_error_when_repo_root_missing(
+    argv: list[str],
+    exit_code: int,
+) -> None:
+    with patch(
+        "specify_cli.cli.commands.charter.find_repo_root",
+        side_effect=TaskCliError("repo root unavailable"),
+    ):
+        result = runner.invoke(charter_app, argv)
+
+    assert result.exit_code == exit_code, result.output
+    payload = _assert_json_error(result.output)
+    assert payload["error"] == "repo root unavailable"
+
+
+def test_resynthesize_json_unresolved_topic_error_is_parseable(tmp_path: Path) -> None:
+    evidence_result = SimpleNamespace(warnings=[], bundle=SimpleNamespace())
+    unresolved = TopicSelectorUnresolvedError(
+        raw="does-not-exist",
+        candidates=("directive:PROJECT_001",),
+        attempted_forms=("kind_slug",),
+    )
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.charter._collect_evidence_result", return_value=evidence_result),
+        patch("specify_cli.cli.commands.charter._build_synthesis_request", return_value=(SimpleNamespace(), SimpleNamespace())),
+        patch("charter.synthesizer.resynthesize_pipeline.run", side_effect=unresolved),
+    ):
+        result = runner.invoke(charter_app, ["resynthesize", "--topic", "does-not-exist", "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = _assert_json_error(result.output)
+    assert "does-not-exist" in str(payload["error"])
+    assert "directive:PROJECT_001" in str(payload["error"])
+
+
+def test_bundle_validate_json_resolver_error_is_parseable() -> None:
+    with patch(
+        "specify_cli.cli.commands.charter_bundle.resolve_canonical_repo_root",
+        side_effect=NotInsideRepositoryError("not a repo"),
+    ):
+        result = runner.invoke(bundle_app, ["validate", "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = _assert_json_error(result.output)
+    assert "not a repo" in str(payload["error"])

--- a/tests/cli/commands/test_charter_json_error_contract.py
+++ b/tests/cli/commands/test_charter_json_error_contract.py
@@ -124,6 +124,20 @@ def test_sync_json_error_result_is_parseable_and_nonzero(tmp_path: Path) -> None
     assert payload["error"] == "charter parse failed"
 
 
+def test_sync_json_filesystem_failure_does_not_log_to_stderr(tmp_path: Path) -> None:
+    charter_dir = tmp_path / ".kittify" / "charter"
+    (charter_dir / "governance.yaml").mkdir(parents=True)
+    (charter_dir / "charter.md").write_text("# Charter\n", encoding="utf-8")
+
+    with patch("specify_cli.cli.commands.charter.find_repo_root", return_value=tmp_path):
+        result = runner.invoke(charter_app, ["sync", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = _assert_json_error(result.stdout)
+    assert "governance.yaml" in str(payload["error"])
+    assert result.stderr == ""
+
+
 def test_interview_json_keeps_org_prefill_messages_inside_payload(tmp_path: Path) -> None:
     interview_data = SimpleNamespace(
         mission="software-dev",


### PR DESCRIPTION
## Summary
- route charter context/interview/sync/resynthesize/lint error handlers through JSON-aware envelopes when `--json` is set
- make `charter bundle validate --json` emit a parseable resolver-failure envelope on stdout
- add regression coverage for the six affected charter subcommands and unresolved resynthesis topics

Closes #1336.

## Verification
- `uv run ruff check src/specify_cli/cli/commands/charter/context.py src/specify_cli/cli/commands/charter/interview.py src/specify_cli/cli/commands/charter/sync.py src/specify_cli/cli/commands/charter/resynthesize.py src/specify_cli/cli/commands/charter/lint.py src/specify_cli/cli/commands/charter_bundle.py tests/cli/commands/test_charter_json_error_contract.py`
- `uv run pytest tests/cli/commands/test_charter_orchestration.py tests/specify_cli/cli/commands/test_charter_lint.py tests/cli/commands/test_charter_bundle_coverage.py tests/agent/cli/commands/test_charter_resynthesize_cli.py tests/cli/commands/test_charter_json_error_contract.py`
- live missing-repo JSON sweep for: `charter context`, `charter interview`, `charter sync`, `charter resynthesize`, `charter lint`, `charter bundle validate`
