### PR TITLE
fix(#662): dedupe release readiness checks

### DIFF
--- a/.github/workflows/check-spec-kitty-events-alignment.yml
+++ b/.github/workflows/check-spec-kitty-events-alignment.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install script dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install packaging
+          python -m pip install build packaging
 
       - name: Fetch compatibility references
         id: fetch_refs
@@ -54,20 +54,36 @@ jobs:
             exit 0
           fi
 
-          URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/pyproject.toml?ref=main"
+          SAAS_PYPROJECT_URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/pyproject.toml?ref=main"
+          CONSUMER_CONTRACT_URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/contracts/consumer-compatibility.json?ref=main"
+
           if curl -fsSL \
             -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
             -H "Accept: application/vnd.github.raw" \
-            "$URL" \
+            "$SAAS_PYPROJECT_URL" \
             -o /tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml; then
-            echo "saas_fetched=true" >> "$GITHUB_OUTPUT"
-            echo "saas_pyproject=/tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml" >> "$GITHUB_OUTPUT"
+            echo "Fetched spec-kitty-saas/pyproject.toml."
           else
-            echo "saas_fetched=false" >> "$GITHUB_OUTPUT"
             echo "Unable to fetch spec-kitty-saas/pyproject.toml from main."
             echo "Configure SPEC_KITTY_SAAS_READ_TOKEN secret with read access to private repo ${REPO_OWNER}/spec-kitty-saas."
             exit 1
           fi
+
+          if curl -fsSL \
+            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "$CONSUMER_CONTRACT_URL" \
+            -o /tmp/spec-kitty-release-contracts/consumer-compatibility.json; then
+            echo "Fetched spec-kitty-saas/contracts/consumer-compatibility.json."
+          else
+            echo "Unable to fetch spec-kitty-saas/contracts/consumer-compatibility.json from main."
+            echo "Configure SPEC_KITTY_SAAS_READ_TOKEN secret with read access to private repo ${REPO_OWNER}/spec-kitty-saas."
+            exit 1
+          fi
+
+          echo "saas_fetched=true" >> "$GITHUB_OUTPUT"
+          echo "saas_pyproject=/tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml" >> "$GITHUB_OUTPUT"
+          echo "consumer_contract=/tmp/spec-kitty-release-contracts/consumer-compatibility.json" >> "$GITHUB_OUTPUT"
 
       - name: Validate shared package drift
         run: |
@@ -80,3 +96,14 @@ jobs:
           fi
 
           python scripts/release/check_shared_package_drift.py "${ARGS[@]}"
+
+      - name: Build candidate wheel for consumer compatibility
+        if: steps.fetch_refs.outputs.saas_fetched == 'true'
+        run: python -m build --wheel
+
+      - name: Validate candidate against SaaS consumer contract
+        if: steps.fetch_refs.outputs.saas_fetched == 'true'
+        run: |
+          python scripts/release/check_candidate_consumer_compat.py \
+            --package spec-kitty-cli \
+            --consumer-contract "${{ steps.fetch_refs.outputs.consumer_contract }}"

--- a/.github/workflows/check-spec-kitty-events-alignment.yml
+++ b/.github/workflows/check-spec-kitty-events-alignment.yml
@@ -15,47 +15,75 @@ on:
       - 'uv.lock'
       - 'scripts/release/**'
       - '.github/workflows/check-spec-kitty-events-alignment.yml'
+  schedule:
+    # Nightly shared-package and SaaS pin drift monitor.
+    - cron: '11 2 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  prepare-candidate-metadata:
+    name: Prepare candidate package metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Upload candidate package metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: candidate-package-metadata
+          path: |
+            pyproject.toml
+            uv.lock
+          retention-days: 1
+
   verify-drift:
     name: Verify shared package drift
     runs-on: ubuntu-latest
+    needs: [prepare-candidate-metadata]
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       # For public spec-kitty -> private spec-kitty-saas comparisons, add
       # SPEC_KITTY_SAAS_READ_TOKEN (repo:read) as a repository secret.
-      CROSS_REPO_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' && secrets.SPEC_KITTY_SAAS_READ_TOKEN || github.token }}
       HAS_SAAS_READ_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out trusted validation scripts
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
-      - name: Install script dependencies
+      - name: Install validation dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build packaging
+          python -m pip install packaging
+
+      - name: Download candidate package metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: candidate-package-metadata
+          path: candidate
 
       - name: Fetch compatibility references
         id: fetch_refs
+        env:
+          CROSS_REPO_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' && secrets.SPEC_KITTY_SAAS_READ_TOKEN || github.token }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/spec-kitty-release-contracts
 
           if [ "${HAS_SAAS_READ_TOKEN}" != "true" ]; then
-            echo "saas_fetched=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::SPEC_KITTY_SAAS_READ_TOKEN is not configured; skipping private SaaS parity portion of the drift check."
-            exit 0
+            echo "::error::SPEC_KITTY_SAAS_READ_TOKEN is required for shared-package and SaaS pin drift evidence."
+            exit 1
           fi
 
           SAAS_PYPROJECT_URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/pyproject.toml?ref=main"
-          CONSUMER_CONTRACT_URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/contracts/consumer-compatibility.json?ref=main"
 
           if curl -fsSL \
             -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
@@ -69,41 +97,11 @@ jobs:
             exit 1
           fi
 
-          if curl -fsSL \
-            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
-            -H "Accept: application/vnd.github.raw" \
-            "$CONSUMER_CONTRACT_URL" \
-            -o /tmp/spec-kitty-release-contracts/consumer-compatibility.json; then
-            echo "Fetched spec-kitty-saas/contracts/consumer-compatibility.json."
-          else
-            echo "Unable to fetch spec-kitty-saas/contracts/consumer-compatibility.json from main."
-            echo "Configure SPEC_KITTY_SAAS_READ_TOKEN secret with read access to private repo ${REPO_OWNER}/spec-kitty-saas."
-            exit 1
-          fi
-
-          echo "saas_fetched=true" >> "$GITHUB_OUTPUT"
           echo "saas_pyproject=/tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml" >> "$GITHUB_OUTPUT"
-          echo "consumer_contract=/tmp/spec-kitty-release-contracts/consumer-compatibility.json" >> "$GITHUB_OUTPUT"
 
       - name: Validate shared package drift
         run: |
-          ARGS=()
-
-          if [ "${{ steps.fetch_refs.outputs.saas_fetched }}" = "true" ]; then
-            ARGS+=(
-              --saas-pyproject "${{ steps.fetch_refs.outputs.saas_pyproject }}"
-            )
-          fi
-
-          python scripts/release/check_shared_package_drift.py "${ARGS[@]}"
-
-      - name: Build candidate wheel for consumer compatibility
-        if: steps.fetch_refs.outputs.saas_fetched == 'true'
-        run: python -m build --wheel
-
-      - name: Validate candidate against SaaS consumer contract
-        if: steps.fetch_refs.outputs.saas_fetched == 'true'
-        run: |
-          python scripts/release/check_candidate_consumer_compat.py \
-            --package spec-kitty-cli \
-            --consumer-contract "${{ steps.fetch_refs.outputs.consumer_contract }}"
+          python scripts/release/check_shared_package_drift.py \
+            --pyproject candidate/pyproject.toml \
+            --lockfile candidate/uv.lock \
+            --saas-pyproject "${{ steps.fetch_refs.outputs.saas_pyproject }}"

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2489,6 +2489,7 @@ jobs:
   # ---------------------------------------------------------------------------
   quality-gate:
     needs:
+      - changes
       - lint
       - diff-coverage
       - kernel-tests
@@ -2522,6 +2523,7 @@ jobs:
       - integration-tests-upgrade
       - integration-tests-cli
       - integration-tests-agent
+      - build-wheel
       - clean-install-verification
       - consumer-compatibility
       - uv-lock-check
@@ -2533,6 +2535,7 @@ jobs:
           echo "All upstream jobs completed."
           # Fail if any required job failed (skipped is OK)
           for result in \
+            "${{ needs.changes.result }}" \
             "${{ needs.lint.result }}" \
             "${{ needs.diff-coverage.result }}" \
             "${{ needs.kernel-tests.result }}" \
@@ -2567,11 +2570,27 @@ jobs:
             "${{ needs.integration-tests-upgrade.result }}" \
             "${{ needs.integration-tests-cli.result }}" \
             "${{ needs.integration-tests-agent.result }}" \
+            "${{ needs.build-wheel.result }}" \
             "${{ needs.clean-install-verification.result }}" \
             "${{ needs.consumer-compatibility.result }}" \
             "${{ needs.uv-lock-check.result }}"; do
-            if [ "$result" = "failure" ]; then
-              echo "A required job failed."
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "A required job failed or was cancelled."
               exit 1
             fi
           done
+
+          if [ "${{ needs.changes.outputs.release }}" = "true" ]; then
+            for result in \
+              "${{ needs.build-wheel.result }}" \
+              "${{ needs.clean-install-verification.result }}" \
+              "${{ needs.consumer-compatibility.result }}" \
+              "${{ needs.fast-tests-release.result }}" \
+              "${{ needs.integration-tests-release.result }}" \
+              "${{ needs.uv-lock-check.result }}"; do
+              if [ "$result" != "success" ]; then
+                echo "A release-required job did not complete successfully."
+                exit 1
+              fi
+            done
+          fi

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -11,8 +11,13 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'CHANGELOG.md'
+      - 'RELEASE_CHECKLIST.md'
+      - 'scripts/release/**'
       - 'ruff.toml'
       - '.github/workflows/ci-quality.yml'
+      - '.github/workflows/release-readiness.yml'
+      - '.github/workflows/check-spec-kitty-events-alignment.yml'
   push:
     branches:
       - main
@@ -23,8 +28,13 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'CHANGELOG.md'
+      - 'RELEASE_CHECKLIST.md'
+      - 'scripts/release/**'
       - 'ruff.toml'
       - '.github/workflows/ci-quality.yml'
+      - '.github/workflows/release-readiness.yml'
+      - '.github/workflows/check-spec-kitty-events-alignment.yml'
   schedule:
     # Nightly Sonar run on the default branch. Offset from the top of the hour
     # to avoid GitHub Actions' busiest scheduling window.
@@ -102,6 +112,13 @@ jobs:
             release:
               - 'src/specify_cli/release/**'
               - 'tests/release/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'CHANGELOG.md'
+              - 'RELEASE_CHECKLIST.md'
+              - 'scripts/release/**'
+              - '.github/workflows/release-readiness.yml'
+              - '.github/workflows/check-spec-kitty-events-alignment.yml'
             status:
               - 'src/specify_cli/status/**'
               - 'tests/status/**'
@@ -2397,6 +2414,76 @@ jobs:
             --runs 5
 
   # ---------------------------------------------------------------------------
+  # consumer-compatibility: validates the CI-built wheel against the private
+  # SaaS consumer contract using trusted validation scripts from the base commit.
+  # The private contract is never exposed to PR-controlled checkout code.
+  # ---------------------------------------------------------------------------
+  consumer-compatibility:
+    name: SaaS consumer compatibility
+    runs-on: ubuntu-latest
+    needs: [changes, build-wheel]
+    if: always() && needs.changes.outputs.release == 'true' && needs.build-wheel.result == 'success'
+    env:
+      REPO_OWNER: ${{ github.repository_owner }}
+      HAS_SAAS_READ_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' }}
+    steps:
+      - name: Check out trusted validation scripts
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+
+      - name: Download CLI wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: spec-kitty-cli-wheel
+          path: dist/
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install packaging
+
+      - name: Fetch SaaS consumer contract
+        id: fetch_contract
+        env:
+          CROSS_REPO_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' && secrets.SPEC_KITTY_SAAS_READ_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/spec-kitty-release-contracts
+
+          if [ "${HAS_SAAS_READ_TOKEN}" != "true" ]; then
+            echo "::error::SPEC_KITTY_SAAS_READ_TOKEN is required for SaaS consumer compatibility evidence."
+            exit 1
+          fi
+
+          CONSUMER_CONTRACT_URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/contracts/consumer-compatibility.json?ref=main"
+
+          if curl -fsSL \
+            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "$CONSUMER_CONTRACT_URL" \
+            -o /tmp/spec-kitty-release-contracts/consumer-compatibility.json; then
+            echo "Fetched spec-kitty-saas/contracts/consumer-compatibility.json."
+          else
+            echo "Unable to fetch spec-kitty-saas/contracts/consumer-compatibility.json from main."
+            echo "Configure SPEC_KITTY_SAAS_READ_TOKEN secret with read access to private repo ${REPO_OWNER}/spec-kitty-saas."
+            exit 1
+          fi
+
+          echo "consumer_contract=/tmp/spec-kitty-release-contracts/consumer-compatibility.json" >> "$GITHUB_OUTPUT"
+
+      - name: Validate candidate against SaaS consumer contract
+        run: |
+          python scripts/release/check_candidate_consumer_compat.py \
+            --package spec-kitty-cli \
+            --consumer-contract "${{ steps.fetch_contract.outputs.consumer_contract }}"
+
+  # ---------------------------------------------------------------------------
   # quality-gate: single check that aggregates all required job results.
   # Skipped jobs are OK; only failures block.
   # ---------------------------------------------------------------------------
@@ -2436,6 +2523,7 @@ jobs:
       - integration-tests-cli
       - integration-tests-agent
       - clean-install-verification
+      - consumer-compatibility
       - uv-lock-check
     runs-on: ubuntu-latest
     if: always()
@@ -2480,6 +2568,7 @@ jobs:
             "${{ needs.integration-tests-cli.result }}" \
             "${{ needs.integration-tests-agent.result }}" \
             "${{ needs.clean-install-verification.result }}" \
+            "${{ needs.consumer-compatibility.result }}" \
             "${{ needs.uv-lock-check.result }}"; do
             if [ "$result" = "failure" ]; then
               echo "A required job failed."

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -85,14 +85,14 @@ jobs:
             echo "- Changelog entry exists and is populated" >> $GITHUB_STEP_SUMMARY
             echo "- Version progression is monotonic" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This workflow validates release metadata only. CI Quality owns tests, wheel build, and exact-install checks; Check Shared Package Drift owns shared-package and SaaS consumer compatibility checks." >> $GITHUB_STEP_SUMMARY
-            echo "Do not summarize a release as green until all required branch checks on the same commit are also green." >> $GITHUB_STEP_SUMMARY
+            echo "This workflow validates release metadata only. CI Quality owns tests, wheel build, exact-install, and SaaS consumer compatibility checks; Check Shared Package Drift owns shared-package pin drift checks." >> $GITHUB_STEP_SUMMARY
+            echo "Do not summarize a release as green until CI Quality and Check Shared Package Drift have also passed on the same commit." >> $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.metadata_changes.outputs.release_metadata }}" != "true" ]]; then
             echo "✅ **Release metadata validation skipped**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Release metadata validation was skipped because this pull request does not modify \`pyproject.toml\`." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This workflow no longer repeats CI Quality or shared-package drift work. Use the required branch checks on the same commit for test, package, and compatibility evidence." >> $GITHUB_STEP_SUMMARY
+            echo "This workflow no longer repeats CI Quality or shared-package drift work. Use CI Quality and Check Shared Package Drift on the same commit for test, package, and compatibility evidence." >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ **Readiness checks failed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -7,7 +7,6 @@ on:
       - 2.x
     paths:
       - pyproject.toml
-      - uv.lock
       - CHANGELOG.md
       - scripts/release/**
       - RELEASE_CHECKLIST.md
@@ -19,7 +18,7 @@ on:
         required: false
         type: string
   schedule:
-    # Run nightly to monitor drift
+    # Run nightly to monitor release metadata drift
     - cron: '0 2 * * *'
 
 concurrency:
@@ -33,10 +32,6 @@ permissions:
 jobs:
   check-readiness:
     runs-on: ubuntu-latest
-    env:
-      REPO_OWNER: ${{ github.repository_owner }}
-      CROSS_REPO_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' && secrets.SPEC_KITTY_SAAS_READ_TOKEN || github.token }}
-      HAS_SAAS_READ_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -49,52 +44,10 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Setup SSH for private repository access
-        # Purpose: spec-kitty depends on private spec-kitty-events library.
-        # Uses SSH deploy key stored in GitHub Actions secrets.
-        # See docs/development/ssh-deploy-keys.md for setup instructions.
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SPEC_KITTY_EVENTS_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-        shell: bash
-
-      - name: Install dependencies
+      - name: Install validator dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build tomli packaging pytest
-          pip install -e .[test]
-
-      - name: Verify test isolation
-        run: |
-          cat > verify_isolation.py << 'EOF'
-          import sys
-          import tomllib
-          from pathlib import Path
-
-          # Get source version from pyproject.toml
-          with open("pyproject.toml", "rb") as f:
-              source_version = tomllib.load(f)["project"]["version"]
-
-          # Try to get installed version
-          try:
-              from importlib.metadata import version
-              installed_version = version("spec-kitty-cli")
-          except Exception:
-              print(f"✅ No installed version detected (source: {source_version})")
-              sys.exit(0)
-
-          # Check if versions match
-          if installed_version == source_version:
-              print(f"✅ Version match: {source_version}")
-              sys.exit(0)
-          else:
-              print(f"❌ Version mismatch! Source: {source_version}, Installed: {installed_version}")
-              print("Tests may fail due to version inconsistency.")
-              sys.exit(1)
-          EOF
-          python verify_isolation.py
+          pip install pyyaml
 
       - name: Detect release metadata changes
         if: github.event_name == 'pull_request'
@@ -104,20 +57,6 @@ jobs:
           filters: |
             release_metadata:
               - 'pyproject.toml'
-
-      - name: Run release workflow tests
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "::group::Running targeted release test suite"
-          python -m pytest -v --import-mode=importlib tests/release
-          echo "::endgroup::"
-
-      - name: Run release workflow tests
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "::group::Running targeted release test suite"
-          python -m pytest -v --import-mode=importlib tests/release
-          echo "::endgroup::"
 
       - name: Validate release metadata
         if: github.event_name != 'pull_request' || steps.metadata_changes.outputs.release_metadata == 'true'
@@ -132,62 +71,6 @@ jobs:
             python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
           fi
 
-      - name: Test packaging
-        run: |
-          echo "::group::Building wheel to catch packaging issues"
-          python -m build --wheel
-          echo "::endgroup::"
-
-      - name: Fetch compatibility references
-        id: fetch_refs
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/spec-kitty-release-contracts
-
-          if [ "${HAS_SAAS_READ_TOKEN}" != "true" ]; then
-            echo "saas_fetched=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::SPEC_KITTY_SAAS_READ_TOKEN is not configured; skipping private SaaS compatibility fetches."
-            exit 0
-          fi
-
-          curl -fsSL \
-            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
-            -H "Accept: application/vnd.github.raw" \
-            "https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/pyproject.toml?ref=main" \
-            -o /tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml
-
-          curl -fsSL \
-            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
-            -H "Accept: application/vnd.github.raw" \
-            "https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/contracts/consumer-compatibility.json?ref=main" \
-            -o /tmp/spec-kitty-release-contracts/consumer-compatibility.json
-
-          echo "saas_fetched=true" >> "$GITHUB_OUTPUT"
-          echo "saas_pyproject=/tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml" >> "$GITHUB_OUTPUT"
-          echo "consumer_contract=/tmp/spec-kitty-release-contracts/consumer-compatibility.json" >> "$GITHUB_OUTPUT"
-
-      - name: Validate shared package drift
-        run: |
-          ARGS=()
-
-          if [ "${{ steps.fetch_refs.outputs.saas_fetched }}" = "true" ]; then
-            ARGS+=(
-              --saas-pyproject "${{ steps.fetch_refs.outputs.saas_pyproject }}"
-            )
-          fi
-
-          python scripts/release/check_shared_package_drift.py --check-installed "${ARGS[@]}"
-
-      - name: Verify exact installability from built wheel
-        run: python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version
-
-      - name: Validate candidate against SaaS consumer contract
-        if: steps.fetch_refs.outputs.saas_fetched == 'true'
-        run: |
-          python scripts/release/check_candidate_consumer_compat.py \
-            --package spec-kitty-cli \
-            --consumer-contract "${{ steps.fetch_refs.outputs.consumer_contract }}"
-
       - name: Generate readiness summary
         if: always()
         run: |
@@ -201,24 +84,15 @@ jobs:
             echo "- Version is properly bumped" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog entry exists and is populated" >> $GITHUB_STEP_SUMMARY
             echo "- Version progression is monotonic" >> $GITHUB_STEP_SUMMARY
-            echo "- Release validation tests pass" >> $GITHUB_STEP_SUMMARY
-            echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
-            echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
-            echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This report covers release-readiness checks for this workflow only. Do not summarize a release as green until the required branch checks on the same commit are also green." >> $GITHUB_STEP_SUMMARY
+            echo "This workflow validates release metadata only. CI Quality owns tests, wheel build, and exact-install checks; Check Shared Package Drift owns shared-package and SaaS consumer compatibility checks." >> $GITHUB_STEP_SUMMARY
+            echo "Do not summarize a release as green until all required branch checks on the same commit are also green." >> $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.metadata_changes.outputs.release_metadata }}" != "true" ]]; then
-            echo "✅ **Release workflow checks passed**" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Release metadata validation skipped**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Release metadata validation was skipped because this pull request does not modify \`pyproject.toml\`." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This branch is ready to merge from a release-readiness workflow perspective:" >> $GITHUB_STEP_SUMMARY
-            echo "- Targeted release workflow tests pass" >> $GITHUB_STEP_SUMMARY
-            echo "- Package builds successfully" >> $GITHUB_STEP_SUMMARY
-            echo "- Shared-package drift check passes" >> $GITHUB_STEP_SUMMARY
-            echo "- Candidate wheel installs via plain pip" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This report covers release-workflow checks only. Do not summarize a release as green until the required branch checks on the same commit are also green." >> $GITHUB_STEP_SUMMARY
+            echo "This workflow no longer repeats CI Quality or shared-package drift work. Use the required branch checks on the same commit for test, package, and compatibility evidence." >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ **Readiness checks failed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -123,11 +123,11 @@ gh pr create --base main --title "Release X.Y.Z" --fill
 ### 4. Wait for CI and Review
 
 - [ ] `Release Readiness Check` passes for release metadata.
-- [ ] `CI Quality` passes for tests, wheel build, lockfile, and install evidence
-  or has explicitly accepted non-blocking failures with
+- [ ] `CI Quality` passes for tests, wheel build, lockfile, exact install, and
+  SaaS consumer compatibility evidence or has explicitly accepted non-blocking failures with
   issue links.
 - [ ] `Check Shared Package Drift` passes against the current SaaS consumer
-  pins and consumer compatibility contract.
+  pins.
 - [ ] `Protect Main Branch` is expected to pass for the eventual merge or
   tagged release commit path.
 - [ ] Maintainer approval is recorded.
@@ -183,9 +183,9 @@ package first, verify it is installable from PyPI, and only then tag the CLI.
 - [ ] Verify the publishing workflow result separately from branch health.
   A successful PyPI/GitHub release proves publication only; it does not prove
   that `main` is green.
-- [ ] Verify all required checks on the released commit are green, or record
-  every failing check with an issue link before using the release as launch-gate
-  evidence:
+- [ ] Verify CI Quality, Check Shared Package Drift, and other release evidence
+  checks on the released commit are green, or record every failing check with an
+  issue link before using the release as launch-gate evidence:
   ```bash
   gh run list --commit "$(git rev-parse HEAD)" --limit 20
   ```

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -122,11 +122,12 @@ gh pr create --base main --title "Release X.Y.Z" --fill
 
 ### 4. Wait for CI and Review
 
-- [ ] `Release Readiness Check` passes.
-- [ ] `CI Quality` passes or has explicitly accepted non-blocking failures with
+- [ ] `Release Readiness Check` passes for release metadata.
+- [ ] `CI Quality` passes for tests, wheel build, lockfile, and install evidence
+  or has explicitly accepted non-blocking failures with
   issue links.
 - [ ] `Check Shared Package Drift` passes against the current SaaS consumer
-  pins.
+  pins and consumer compatibility contract.
 - [ ] `Protect Main Branch` is expected to pass for the eventual merge or
   tagged release commit path.
 - [ ] Maintainer approval is recorded.

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -94,10 +94,18 @@ python scripts/release/check_candidate_consumer_compat.py \
 
 ## Workflow Integration
 
-- PR checks: `.github/workflows/release-readiness.yml`
+- PR release metadata validation: `.github/workflows/release-readiness.yml`
+- PR/package CI: `.github/workflows/ci-quality.yml`
+- PR shared-package and SaaS consumer compatibility: `.github/workflows/check-spec-kitty-events-alignment.yml`
 - Tag releases: `.github/workflows/release.yml` (triggers on stable and prerelease `v*.*.*` tags)
 
-Release workflow sequence:
+Release PR check ownership:
+
+1. `Release Readiness Check` validates release metadata only: version, changelog, and tag progression.
+2. `CI Quality` owns tests, wheel build, lockfile checks, and exact install verification.
+3. `Check Shared Package Drift` owns shared-package drift and SaaS consumer compatibility evidence.
+
+Tag-time publish workflow sequence:
 
 1. run tests
 2. validate release metadata

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -95,15 +95,15 @@ python scripts/release/check_candidate_consumer_compat.py \
 ## Workflow Integration
 
 - PR release metadata validation: `.github/workflows/release-readiness.yml`
-- PR/package CI: `.github/workflows/ci-quality.yml`
-- PR shared-package and SaaS consumer compatibility: `.github/workflows/check-spec-kitty-events-alignment.yml`
+- PR/package CI and SaaS consumer compatibility: `.github/workflows/ci-quality.yml`
+- PR shared-package pin drift: `.github/workflows/check-spec-kitty-events-alignment.yml`
 - Tag releases: `.github/workflows/release.yml` (triggers on stable and prerelease `v*.*.*` tags)
 
 Release PR check ownership:
 
 1. `Release Readiness Check` validates release metadata only: version, changelog, and tag progression.
-2. `CI Quality` owns tests, wheel build, lockfile checks, and exact install verification.
-3. `Check Shared Package Drift` owns shared-package drift and SaaS consumer compatibility evidence.
+2. `CI Quality` owns tests, wheel build, lockfile checks, exact install verification, and SaaS consumer compatibility evidence.
+3. `Check Shared Package Drift` owns shared-package pin drift evidence.
 
 Tag-time publish workflow sequence:
 
@@ -160,8 +160,8 @@ git push origin v3.1.0
 
 Treat publish success and branch health as separate evidence. The tag-time
 publish workflow proves PyPI/GitHub release publication; release summaries
-should only call `main` green after the required branch checks on the same
-commit have also passed. If SaaS consumes a shared-package bump after the CLI
+should only call `main` green after CI Quality and Check Shared Package Drift
+on the same commit have also passed. If SaaS consumes a shared-package bump after the CLI
 candidate commit, rerun the shared-package drift workflow or the local drift
 command against the updated SaaS `main` before recording release-health
 evidence.

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -95,3 +95,27 @@ def test_ci_quality_consumer_compatibility_reuses_ci_wheel_with_trusted_scripts(
 
     fetch_step = next(step for step in job["steps"] if step.get("id") == "fetch_contract")
     assert "CROSS_REPO_TOKEN" in fetch_step["env"]
+
+
+def test_quality_gate_fails_closed_for_release_required_package_jobs() -> None:
+    workflow = load_workflow("ci-quality.yml")
+    quality_gate = workflow["jobs"]["quality-gate"]
+    needs = set(quality_gate["needs"])
+
+    release_required = {
+        "changes",
+        "build-wheel",
+        "clean-install-verification",
+        "consumer-compatibility",
+        "fast-tests-release",
+        "integration-tests-release",
+        "uv-lock-check",
+    }
+    assert not release_required - needs
+
+    script = quality_gate["steps"][0]["run"]
+    assert 'failure" ] || [ "$result" = "cancelled' in script
+    assert "needs.changes.outputs.release" in script
+    assert 'if [ "$result" != "success" ]; then' in script
+    for job_name in release_required - {"changes"}:
+        assert f"needs.{job_name}.result" in script

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -1,0 +1,97 @@
+"""Release workflow ownership regression tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+RELEASE_OWNER_PATHS = {
+    "pyproject.toml",
+    "uv.lock",
+    "CHANGELOG.md",
+    "RELEASE_CHECKLIST.md",
+    "scripts/release/**",
+    ".github/workflows/release-readiness.yml",
+    ".github/workflows/check-spec-kitty-events-alignment.yml",
+}
+
+
+def load_workflow(name: str) -> dict[str, Any]:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def on_section(workflow: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML still treats the YAML 1.1 key "on" as boolean True.
+    return workflow.get("on") or workflow[True]
+
+
+def event_paths(workflow: dict[str, Any], event: str) -> set[str]:
+    return set(on_section(workflow)[event]["paths"])
+
+
+def path_filter_text(workflow: dict[str, Any]) -> str:
+    changes_steps = workflow["jobs"]["changes"]["steps"]
+    filter_step = next(step for step in changes_steps if step.get("id") == "filter")
+    return filter_step["with"]["filters"]
+
+
+def test_ci_quality_runs_for_release_owned_paths() -> None:
+    workflow = load_workflow("ci-quality.yml")
+
+    for event in ("pull_request", "push"):
+        missing = RELEASE_OWNER_PATHS - event_paths(workflow, event)
+        assert not missing, f"CI Quality {event} trigger misses release paths: {sorted(missing)}"
+
+
+def test_ci_quality_release_slice_covers_release_owned_paths() -> None:
+    filters = path_filter_text(load_workflow("ci-quality.yml"))
+
+    for path in RELEASE_OWNER_PATHS:
+        assert f"- '{path}'" in filters, f"release path filter misses {path}"
+
+
+def test_shared_drift_has_scheduled_and_manual_monitoring() -> None:
+    workflow_on = on_section(load_workflow("check-spec-kitty-events-alignment.yml"))
+
+    assert "schedule" in workflow_on
+    assert "workflow_dispatch" in workflow_on
+
+
+def test_shared_drift_secret_job_uses_trusted_scripts_only() -> None:
+    workflow = load_workflow("check-spec-kitty-events-alignment.yml")
+    jobs = workflow["jobs"]
+
+    prepare_dump = repr(jobs["prepare-candidate-metadata"])
+    assert "SPEC_KITTY_SAAS_READ_TOKEN" not in prepare_dump
+    assert "python -m build" not in prepare_dump
+
+    verify = jobs["verify-drift"]
+    verify_dump = repr(verify)
+    assert "github.event.pull_request.base.sha" in verify_dump
+    assert "CROSS_REPO_TOKEN" not in repr(verify.get("env", {}))
+    assert "check_candidate_consumer_compat.py" not in verify_dump
+
+    fetch_step = next(step for step in verify["steps"] if step.get("id") == "fetch_refs")
+    assert "CROSS_REPO_TOKEN" in fetch_step["env"]
+
+
+def test_ci_quality_consumer_compatibility_reuses_ci_wheel_with_trusted_scripts() -> None:
+    workflow = load_workflow("ci-quality.yml")
+    job = workflow["jobs"]["consumer-compatibility"]
+    job_dump = repr(job)
+
+    assert job["needs"] == ["changes", "build-wheel"]
+    assert "needs.changes.outputs.release == 'true'" in job["if"]
+    assert "github.event.pull_request.base.sha" in job_dump
+    assert "spec-kitty-cli-wheel" in job_dump
+    assert "CROSS_REPO_TOKEN" not in repr(job.get("env", {}))
+    assert "check_candidate_consumer_compat.py" in job_dump
+
+    fetch_step = next(step for step in job["steps"] if step.get("id") == "fetch_contract")
+    assert "CROSS_REPO_TOKEN" in fetch_step["env"]


### PR DESCRIPTION
## Summary
- narrow Release Readiness to release metadata validation only
- move release tests/build/exact-install/SaaS consumer compatibility into CI Quality, with release-path triggers and fail-closed quality-gate aggregation
- keep Check Shared Package Drift as the single shared-package pin drift owner, with scheduled/manual monitoring and trusted-script private-token handling
- document PR check ownership across Release Readiness, CI Quality, and Check Shared Package Drift

Closes #662.

## Validation
- Parsed `.github/workflows/release-readiness.yml`, `.github/workflows/check-spec-kitty-events-alignment.yml`, and `.github/workflows/ci-quality.yml` with PyYAML
- `python -m pytest tests/release -q`
- `git diff --check`
- Subagent adversarial re-review: Bug Falsifier, Domain Boundary, Failure Atomicity, Machine Contract, Security & Provenance, and Test & CI all reported SAFE on `a19602499`
- GitHub checks green on `a19602499`, including CI Quality `quality-gate`, `Build wheel`, `Clean install verification`, `SaaS consumer compatibility`, `fast-tests-release`, `integration-tests-release`, and `Verify shared package drift`