### PR TITLE
Fix uv-tool pytest remediation provenance fallback

### DIFF
--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -53,7 +53,7 @@ from ._report import GateRecord, write_review_report  # noqa: F401
 _PACKAGE_NAME = "spec-kitty-cli"
 _PYTEST_NAME = "pytest"
 _SUPPORTED_UV_REQUIREMENT_KEYS = frozenset(
-    {"name", "specifier", "directory", "editable", "path", "git"}
+    {"name", "specifier", "directory", "editable", "path", "git", "url"}
 )
 
 
@@ -78,13 +78,19 @@ def _fail_missing_test_extra(console: object) -> None:
 
 
 def _missing_test_extra_remediation() -> str:
+    uv_tool_command = _uv_tool_reinstall_command()
+    if uv_tool_command is not None:
+        return uv_tool_command
+    if _active_uv_tool_receipt_has_spec_kitty():
+        return _fallback_uv_tool_reinstall_command()
+
     try:
         install_method = detect_install_method()
     except Exception:  # noqa: BLE001
         install_method = InstallMethod.UNKNOWN
 
     if install_method == InstallMethod.UV_TOOL:
-        return _uv_tool_reinstall_command() or _fallback_uv_tool_reinstall_command()
+        return _fallback_uv_tool_reinstall_command()
 
     return "uv sync --extra test"
 
@@ -173,6 +179,14 @@ def _find_uv_tool_requirement(requirements: list[object]) -> dict[str, object] |
     return None
 
 
+def _active_uv_tool_receipt_has_spec_kitty() -> bool:
+    receipt = _active_uv_tool_receipt()
+    if receipt is None:
+        return False
+    requirements = _uv_tool_receipt_tool(receipt).get("requirements", [])
+    return isinstance(requirements, list) and _find_uv_tool_requirement(requirements) is not None
+
+
 def _uv_tool_with_args(requirements: list[object]) -> list[str] | None:
     args: list[str] = []
     has_pytest = False
@@ -220,6 +234,10 @@ def _uv_tool_requirement_arg(requirement: dict[str, object]) -> str | None:
     if git is not None:
         return _uv_git_source(git)
 
+    url = _nonempty_str(requirement.get("url"))
+    if url is not None:
+        return url
+
     name = _nonempty_str(requirement.get("name"))
     if name is None:
         return None
@@ -246,6 +264,10 @@ def _uv_tool_package_args(requirement: dict[str, object]) -> list[str] | None:
     git = _nonempty_str(requirement.get("git"))
     if git is not None:
         return [_PACKAGE_NAME, "--from", _uv_git_source(git)]
+
+    url = _nonempty_str(requirement.get("url"))
+    if url is not None:
+        return [url]
 
     specifier = _nonempty_str(requirement.get("specifier"))
     if specifier is not None:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -52,6 +52,9 @@ from ._report import GateRecord, write_review_report  # noqa: F401
 
 _PACKAGE_NAME = "spec-kitty-cli"
 _PYTEST_NAME = "pytest"
+_SUPPORTED_UV_REQUIREMENT_KEYS = frozenset(
+    {"name", "specifier", "directory", "editable", "path", "git"}
+)
 
 
 def _fail_missing_test_extra(console: object) -> None:
@@ -96,7 +99,10 @@ def _versioned_package() -> str:
 
 def _fallback_uv_tool_reinstall_command() -> str:
     if _active_uv_tool_receipt_path() is not None:
-        return "reinstall the same uv tool source with --with pytest"
+        return (
+            "Spec Kitty could not preserve uv receipt provenance automatically; "
+            "reinstall the same uv tool source with --with pytest"
+        )
     return f"{_uv_tool_env_prefix()}uv tool install --force --with pytest {_versioned_package()}"
 
 
@@ -114,10 +120,15 @@ def _uv_tool_reinstall_command() -> str | None:
         if tool_requirement is None:
             return None
 
+        with_args = _uv_tool_with_args(requirements)
+        package_args = _uv_tool_package_args(tool_requirement)
+        if with_args is None or package_args is None:
+            return None
+
         args = ["uv", "tool", "install", "--force"]
         args.extend(_uv_tool_python_args(receipt))
-        args.extend(_uv_tool_with_args(requirements))
-        args.extend(_uv_tool_package_args(tool_requirement))
+        args.extend(with_args)
+        args.extend(package_args)
         return f"{_uv_tool_env_prefix()}{' '.join(shlex.quote(arg) for arg in args)}"
     except Exception:  # noqa: BLE001
         return None
@@ -162,7 +173,7 @@ def _find_uv_tool_requirement(requirements: list[object]) -> dict[str, object] |
     return None
 
 
-def _uv_tool_with_args(requirements: list[object]) -> list[str]:
+def _uv_tool_with_args(requirements: list[object]) -> list[str] | None:
     args: list[str] = []
     has_pytest = False
     for requirement in requirements:
@@ -172,13 +183,19 @@ def _uv_tool_with_args(requirements: list[object]) -> list[str]:
             continue
         if requirement.get("name") == _PYTEST_NAME:
             has_pytest = True
-        args.extend(_uv_tool_requirement_args(requirement))
+        requirement_args = _uv_tool_requirement_args(requirement)
+        if requirement_args is None:
+            return None
+        args.extend(requirement_args)
     if not has_pytest:
         args.extend(["--with", _PYTEST_NAME])
     return args
 
 
-def _uv_tool_requirement_args(requirement: dict[str, object]) -> list[str]:
+def _uv_tool_requirement_args(requirement: dict[str, object]) -> list[str] | None:
+    if not _uv_tool_requirement_is_supported(requirement):
+        return None
+
     editable = _nonempty_str(requirement.get("editable"))
     if editable is not None:
         return ["--with-editable", editable]
@@ -187,7 +204,7 @@ def _uv_tool_requirement_args(requirement: dict[str, object]) -> list[str]:
     if requirement_arg is not None:
         return ["--with", requirement_arg]
 
-    return []
+    return None
 
 
 def _uv_tool_requirement_arg(requirement: dict[str, object]) -> str | None:
@@ -210,7 +227,10 @@ def _uv_tool_requirement_arg(requirement: dict[str, object]) -> str | None:
     return f"{name}{specifier or ''}"
 
 
-def _uv_tool_package_args(requirement: dict[str, object]) -> list[str]:
+def _uv_tool_package_args(requirement: dict[str, object]) -> list[str] | None:
+    if not _uv_tool_requirement_is_supported(requirement):
+        return None
+
     directory = _nonempty_str(requirement.get("directory"))
     if directory is not None:
         return [directory]
@@ -232,6 +252,10 @@ def _uv_tool_package_args(requirement: dict[str, object]) -> list[str]:
         return [f"{_PACKAGE_NAME}{specifier}"]
 
     return [_PACKAGE_NAME]
+
+
+def _uv_tool_requirement_is_supported(requirement: dict[str, object]) -> bool:
+    return set(requirement).issubset(_SUPPORTED_UV_REQUIREMENT_KEYS)
 
 
 def _uv_tool_python_args(receipt: dict[str, object]) -> list[str]:

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -518,6 +518,73 @@ def test_uv_tool_remediation_with_unmapped_receipt_does_not_pin_to_pypi(
     assert "same uv tool source" in remediation
 
 
+def test_uv_tool_remediation_with_unsupported_main_requirement_is_conservative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown main-package receipt shapes must not collapse to PyPI names."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", url = "https://example.test/pkg.whl" }]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.get_version",
+        lambda: "3.2.0rc25",
+    )
+
+    remediation = review_mod._missing_test_extra_remediation()  # noqa: SLF001
+    assert "uv tool install --force" not in remediation
+    assert "spec-kitty-cli==3.2.0rc25" not in remediation
+    assert "same uv tool source" in remediation
+
+
+def test_uv_tool_remediation_with_unsupported_existing_dep_is_conservative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown injected deps must not be silently dropped from remediation."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        "requirements = [\n"
+        '  { name = "spec-kitty-cli", specifier = "==3.2.0rc25" },\n'
+        '  { name = "extra-dep", url = "https://example.test/extra.whl" },\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.get_version",
+        lambda: "3.2.0rc25",
+    )
+
+    remediation = review_mod._missing_test_extra_remediation()  # noqa: SLF001
+    assert "uv tool install --force" not in remediation
+    assert "extra-dep" not in remediation
+    assert "same uv tool source" in remediation
+
+
 def test_uv_tool_remediation_preserves_editable_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -392,6 +392,33 @@ def test_uv_tool_remediation_preserves_directory_receipt(
     )
 
 
+def test_uv_tool_remediation_prefers_active_receipt_over_source_detection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A uv-tool executable must repair the tool even when cwd looks like source."""
+    import specify_cli.cli.commands.review as review_mod
+
+    repo_root = Path(__file__).resolve().parents[4]
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", specifier = "==3.2.0rc25" }]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod.detect_install_method() == review_mod.InstallMethod.SOURCE
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} "
+        "uv tool install --force --with pytest spec-kitty-cli==3.2.0rc25"
+    )
+
+
 def test_uv_tool_remediation_preserves_git_receipt_and_existing_with(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -530,7 +557,7 @@ def test_uv_tool_remediation_with_unsupported_main_requirement_is_conservative(
     bin_dir.mkdir(parents=True)
     (tool_env / "uv-receipt.toml").write_text(
         "[tool]\n"
-        'requirements = [{ name = "spec-kitty-cli", url = "https://example.test/pkg.whl" }]\n',
+        'requirements = [{ name = "spec-kitty-cli", unknown-source = "opaque" }]\n',
         encoding="utf-8",
     )
 
@@ -564,7 +591,7 @@ def test_uv_tool_remediation_with_unsupported_existing_dep_is_conservative(
         "[tool]\n"
         "requirements = [\n"
         '  { name = "spec-kitty-cli", specifier = "==3.2.0rc25" },\n'
-        '  { name = "extra-dep", url = "https://example.test/extra.whl" },\n'
+        '  { name = "extra-dep", unknown-source = "opaque" },\n'
         "]\n",
         encoding="utf-8",
     )
@@ -583,6 +610,65 @@ def test_uv_tool_remediation_with_unsupported_existing_dep_is_conservative(
     assert "uv tool install --force" not in remediation
     assert "extra-dep" not in remediation
     assert "same uv tool source" in remediation
+
+
+def test_uv_tool_remediation_preserves_url_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wheel URL uv tool installs must stay URL-based when adding pytest."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "spec-kitty-cli", url = "https://example.test/pkg.whl" }]\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} "
+        "uv tool install --force --with pytest https://example.test/pkg.whl"
+    )
+
+
+def test_uv_tool_remediation_preserves_url_with_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Injected URL deps must not be dropped when pytest is added."""
+    import specify_cli.cli.commands.review as review_mod
+
+    tool_env = tmp_path / "tool" / "spec-kitty-cli"
+    bin_dir = tool_env / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_env / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        "requirements = [\n"
+        '  { name = "spec-kitty-cli", specifier = "==3.2.0rc25" },\n'
+        '  { name = "extra-dep", url = "https://example.test/extra.whl" },\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.detect_install_method",
+        lambda: review_mod.InstallMethod.UV_TOOL,
+    )
+    monkeypatch.setattr(review_mod.sys, "executable", str(bin_dir / "python"))
+
+    assert review_mod._missing_test_extra_remediation() == (  # noqa: SLF001
+        f"UV_TOOL_DIR={tool_env.parent!s} uv tool install --force "
+        "--with https://example.test/extra.whl --with pytest spec-kitty-cli==3.2.0rc25"
+    )
 
 
 def test_uv_tool_remediation_preserves_editable_receipt(


### PR DESCRIPTION
## Summary

- keep uv-tool remediation conservative when receipt requirement shapes are unsupported
- avoid rendering `uv tool install` commands that would drop source or injected dependency provenance
- make manual fallback explicitly say Spec Kitty could not preserve uv receipt provenance
- add regression coverage for unsupported main-package and existing injected dependency receipt shapes

Closes #1359

## Tests

- `uv run pytest tests/specify_cli/cli/commands/test_review.py -q`
- `uv run pytest tests/specify_cli/cli/commands/test_review.py -k "uv_tool_remediation or pytest_missing_in_uv_tool" -q`
- `uv run pytest tests/specify_cli/compat/test_install_method.py -k "uv_tool" -q`
- `uv run ruff check src/specify_cli/cli/commands/review/__init__.py tests/specify_cli/cli/commands/test_review.py`
- `git diff --check`