### PR TITLE
fix: address upgrade contract and Sonar regressions

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -85,6 +85,8 @@ from specify_cli.workspace.context import resolve_workspace_for_wp
 logger = logging.getLogger(__name__)
 
 _REVIEW_FEEDBACK_SENTINELS = REVIEW_FEEDBACK_SENTINELS
+_STATUS_EVENTS_FILENAME = "status.events.jsonl"
+_STATUS_FILENAME = "status.json"
 
 
 # ---------------------------------------------------------------------------
@@ -138,12 +140,8 @@ def _restore_status_artifacts(
         if events_path.exists():
             with events_path.open("ab") as _fh:
                 _fh.truncate(pre_emit_event_size)
-    except OSError as truncate_exc:
-        logger.error(
-            "Could not truncate %s on commit failure: %s",
-            events_path,
-            truncate_exc,
-        )
+    except OSError:
+        logger.exception("Could not truncate %s on commit failure", events_path)
 
     try:
         if pre_emit_status_bytes is None:
@@ -151,12 +149,8 @@ def _restore_status_artifacts(
         else:
             status_path.parent.mkdir(parents=True, exist_ok=True)
             status_path.write_bytes(pre_emit_status_bytes)
-    except OSError as restore_exc:
-        logger.error(
-            "Could not restore %s on commit failure: %s",
-            status_path,
-            restore_exc,
-        )
+    except OSError:
+        logger.exception("Could not restore %s on commit failure", status_path)
 
 
 def _safe_commit_recovery_commit_sha(exc: BaseException) -> str | None:
@@ -208,6 +202,93 @@ def _load_coord_branch_meta(feature_dir: Path) -> tuple[str | None, str | None, 
     return (coord, mid, mid8)
 
 
+def _commit_via_coordination_transaction(
+    *,
+    coord_branch: str,
+    repo_root: Path,
+    mission_slug: str,
+    paths: list[Path],
+    message: str,
+    operation: str,
+    mission_id: str,
+    mid8: str,
+    wp_id: str,
+) -> None:
+    """Commit workflow changes via BookkeepingTransaction."""
+    from specify_cli.coordination.transaction import (
+        BookkeepingPolicyRefused,
+        BookkeepingTransaction,
+    )
+
+    try:
+        with BookkeepingTransaction.acquire(
+            repo_root=repo_root,
+            mission_id=mission_id,
+            mission_slug=mission_slug,
+            mid8=mid8,
+            destination_ref=coord_branch,
+            operation=operation,
+        ) as txn:
+            for path in paths:
+                if not path.exists():
+                    continue
+                txn_path = _transaction_path_for(
+                    source_path=path,
+                    repo_root=repo_root,
+                    worktree_root=txn.worktree_root,
+                )
+                if txn_path.resolve() == path.resolve():
+                    txn.stage_path(path)
+                else:
+                    txn.write_artifact(txn_path, path.read_bytes())
+            receipt = txn.commit(message)
+    except BookkeepingPolicyRefused as policy_exc:
+        _record_receipt(
+            coord_branch,
+            message,
+            "refused",
+            wp_id=wp_id,
+        )
+        print(
+            f"Error: Bookkeeping policy refused {operation}: "
+            f"{policy_exc.verdict.error_code}: {policy_exc.verdict.message}"
+        )
+        raise typer.Exit(1) from policy_exc
+
+    _record_receipt(
+        coord_branch,
+        message,
+        "committed",
+        sha=receipt.commit_sha,
+        wp_id=wp_id,
+    )
+
+
+def _commit_via_legacy_safe_commit(
+    *,
+    repo_root: Path,
+    target_branch: str,
+    paths: list[Path],
+    message: str,
+    wp_id: str,
+) -> None:
+    """Commit workflow changes directly on legacy mission branches."""
+    result = safe_commit(
+        repo_root=repo_root,
+        worktree_root=repo_root,
+        destination_ref=target_branch,
+        message=message,
+        paths=tuple(paths),
+    )
+    _record_receipt(
+        target_branch,
+        message,
+        "committed",
+        sha=getattr(result, "sha", None),
+        wp_id=wp_id,
+    )
+
+
 def _commit_workflow_change(
     *,
     repo_root: Path,
@@ -240,60 +321,23 @@ def _commit_workflow_change(
         typer.Exit(1): On commit failure (after rollback).
     """
     coord_branch, mission_id, mid8 = _load_coord_branch_meta(feature_dir)
-    events_path = feature_dir / "status.events.jsonl"
-    status_path = feature_dir / "status.json"
+    events_path = feature_dir / _STATUS_EVENTS_FILENAME
+    status_path = feature_dir / _STATUS_FILENAME
 
     if coord_branch and mission_id and mid8:
-        # Modern path: BookkeepingTransaction owns the lock, policy gate,
-        # event-log rollback, and the commit. We stage operational paths
-        # (WP files, status artifacts) so they ride along with the
-        # bookkeeping commit on the coord branch.
-        from specify_cli.coordination.transaction import (
-            BookkeepingPolicyRefused,
-            BookkeepingTransaction,
-        )
-
         try:
-            with BookkeepingTransaction.acquire(
+            _commit_via_coordination_transaction(
+                coord_branch=str(coord_branch),
                 repo_root=repo_root,
                 mission_id=str(mission_id),
                 mission_slug=mission_slug,
                 mid8=str(mid8),
-                destination_ref=str(coord_branch),
+                paths=paths,
+                message=message,
                 operation=operation,
-            ) as txn:
-                for path in paths:
-                    if path.exists():
-                        txn_path = _transaction_path_for(
-                            source_path=path,
-                            repo_root=repo_root,
-                            worktree_root=txn.worktree_root,
-                        )
-                        if txn_path.resolve() == path.resolve():
-                            txn.stage_path(path)
-                        else:
-                            txn.write_artifact(txn_path, path.read_bytes())
-                receipt = txn.commit(message)
-            _record_receipt(
-                str(coord_branch),
-                message,
-                "committed",
-                sha=receipt.commit_sha,
                 wp_id=wp_id,
             )
             return
-        except BookkeepingPolicyRefused as policy_exc:
-            _record_receipt(
-                str(coord_branch),
-                message,
-                "refused",
-                wp_id=wp_id,
-            )
-            print(
-                f"Error: Bookkeeping policy refused {operation}: "
-                f"{policy_exc.verdict.error_code}: {policy_exc.verdict.message}"
-            )
-            raise typer.Exit(1) from policy_exc
         except Exception as exc:  # noqa: BLE001 — surface + exit
             recovery_commit_sha = _safe_commit_recovery_commit_sha(exc)
             if recovery_commit_sha is None:
@@ -317,18 +361,11 @@ def _commit_workflow_change(
 
     # Legacy fallback (TODO(WP08): replace with the legacy bridge).
     try:
-        result = safe_commit(
+        _commit_via_legacy_safe_commit(
             repo_root=repo_root,
-            worktree_root=repo_root,
-            destination_ref=target_branch,
+            target_branch=target_branch,
+            paths=paths,
             message=message,
-            paths=tuple(paths),
-        )
-        _record_receipt(
-            target_branch,
-            message,
-            "committed",
-            sha=getattr(result, "sha", None),
             wp_id=wp_id,
         )
     except Exception as exc:  # noqa: BLE001 — surface + truncate + exit
@@ -992,8 +1029,8 @@ def implement(
             # the byte-for-byte rollback that closes #1348 for the
             # legacy path; the modern path (coord branch) gets the same
             # contract via BookkeepingTransaction.
-            _events_path_pre = _impl_feature_dir / "status.events.jsonl"
-            _status_path_pre = _impl_feature_dir / "status.json"
+            _events_path_pre = _impl_feature_dir / _STATUS_EVENTS_FILENAME
+            _status_path_pre = _impl_feature_dir / _STATUS_FILENAME
             _pre_emit_event_size = (
                 _events_path_pre.stat().st_size if _events_path_pre.exists() else 0
             )
@@ -1799,8 +1836,8 @@ def review(
             with feature_status_lock(main_repo_root, mission_slug):
                 # WP06 T027: capture pre-emit event-log size for
                 # surgical rollback on commit failure.
-                _events_path_pre_rev = feature_dir / "status.events.jsonl"
-                _status_path_pre_rev = feature_dir / "status.json"
+                _events_path_pre_rev = feature_dir / _STATUS_EVENTS_FILENAME
+                _status_path_pre_rev = feature_dir / _STATUS_FILENAME
                 _pre_emit_event_size_rev = (
                     _events_path_pre_rev.stat().st_size
                     if _events_path_pre_rev.exists()
@@ -2029,8 +2066,8 @@ def review(
                             [
                                 f":(exclude){mission_root}tasks/**",
                                 f":(exclude){mission_root}tasks.md",
-                                f":(exclude){mission_root}status.events.jsonl",
-                                f":(exclude){mission_root}status.json",
+                                f":(exclude){mission_root}{_STATUS_EVENTS_FILENAME}",
+                                f":(exclude){mission_root}{_STATUS_FILENAME}",
                             ]
                         )
                     review_paths = " -- " + " ".join(review_pathspecs)
@@ -2214,8 +2251,8 @@ def review(
                         [
                             f":(exclude){mission_root}tasks/**",
                             f":(exclude){mission_root}tasks.md",
-                            f":(exclude){mission_root}status.events.jsonl",
-                            f":(exclude){mission_root}status.json",
+                            f":(exclude){mission_root}{_STATUS_EVENTS_FILENAME}",
+                            f":(exclude){mission_root}{_STATUS_FILENAME}",
                         ]
                     )
                 review_paths = " -- " + " ".join(review_pathspecs) if review_pathspecs else ""

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -338,6 +338,8 @@ def _commit_workflow_change(
                 wp_id=wp_id,
             )
             return
+        except typer.Exit:
+            raise
         except Exception as exc:  # noqa: BLE001 — surface + exit
             recovery_commit_sha = _safe_commit_recovery_commit_sha(exc)
             if recovery_commit_sha is None:

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -77,6 +77,8 @@ logger = logging.getLogger(__name__)
 
 TARGET_BRANCH_NOT_SYNCHRONIZED = "TARGET_BRANCH_NOT_SYNCHRONIZED"
 TARGET_BRANCH_SYNC_INVARIANT = "local_target_branch_must_match_tracking_branch"
+_STATUS_EVENTS_FILENAME = "status.events.jsonl"
+_STATUS_FILENAME = "status.json"
 
 # T011 — FR-009: push-error parser tokens (locked tuple — do not reorder or extend without a spec change)
 LINEAR_HISTORY_REJECTION_TOKENS: tuple[str, ...] = (
@@ -1104,7 +1106,7 @@ def _enforce_canonical_status_history(
     if not wp_ids:
         return
 
-    log_path = feature_dir / "status.events.jsonl"
+    log_path = feature_dir / _STATUS_EVENTS_FILENAME
     if not log_path.exists():
         return
 
@@ -1441,8 +1443,8 @@ def _run_lane_based_merge_locked(
     # If the final bookkeeping commit fails after done events are emitted,
     # restore the canonical status artifacts to their pre-emit bytes. This
     # keeps the merge path aligned with the #1348 dangling-event invariant.
-    _merge_events_path = feature_dir / "status.events.jsonl"
-    _merge_status_path = feature_dir / "status.json"
+    _merge_events_path = feature_dir / _STATUS_EVENTS_FILENAME
+    _merge_status_path = feature_dir / _STATUS_FILENAME
     _pre_done_event_size = (
         _merge_events_path.stat().st_size if _merge_events_path.exists() else 0
     )
@@ -1489,8 +1491,8 @@ def _run_lane_based_merge_locked(
     )
     if _ret_status == 0:
         expected_paths = {
-            f"kitty-specs/{mission_slug}/status.events.jsonl",
-            f"kitty-specs/{mission_slug}/status.json",
+            f"kitty-specs/{mission_slug}/{_STATUS_EVENTS_FILENAME}",
+            f"kitty-specs/{mission_slug}/{_STATUS_FILENAME}",
         }
         if baseline_meta_path is not None:
             expected_paths.add(str(baseline_meta_path.relative_to(main_repo)))
@@ -1529,8 +1531,8 @@ def _run_lane_based_merge_locked(
 
     # -- T012: FR-019 — Persist done events to git BEFORE any worktree removal --
     files_to_commit = [
-        feature_dir / "status.events.jsonl",
-        feature_dir / "status.json",
+        feature_dir / _STATUS_EVENTS_FILENAME,
+        feature_dir / _STATUS_FILENAME,
     ]
     if baseline_meta_path is not None:
         files_to_commit.append(baseline_meta_path)
@@ -1693,7 +1695,8 @@ def _run_lane_based_merge_locked(
                     mission_slug,
                     _mid8_for_teardown,
                 )
-        except Exception as _coord_teardown_exc:  # noqa: BLE001 — teardown is best-effort cleanup, never block the successful merge
+        # Teardown is best-effort cleanup; never block a successful merge.
+        except Exception as _coord_teardown_exc:  # noqa: BLE001
             logger.warning(
                 "Coordination worktree teardown failed (non-fatal): %s",
                 _coord_teardown_exc,

--- a/src/specify_cli/cli/commands/safe_commit_cmd.py
+++ b/src/specify_cli/cli/commands/safe_commit_cmd.py
@@ -28,10 +28,7 @@ from specify_cli.core.git_ops import get_current_branch
 from specify_cli.git import ProtectedBranchCommitError, assert_not_protected_branch, safe_commit
 from specify_cli.git.commit_helpers import (
     SafeCommitBackstopError,
-    SafeCommitDestinationNotFound,
-    SafeCommitDestinationRefShape,
-    SafeCommitHeadMismatch,
-    SafeCommitNotAWorktree,
+    SafeCommitError,
 )
 from specify_cli.task_utils import TaskCliError, find_repo_root
 
@@ -189,12 +186,9 @@ def safe_commit_command(
         else:
             console.print("[yellow]No requested changes to commit[/yellow]")
     except (
+        SafeCommitError,
         ProtectedBranchCommitError,
         SafeCommitBackstopError,
-        SafeCommitDestinationNotFound,
-        SafeCommitDestinationRefShape,
-        SafeCommitHeadMismatch,
-        SafeCommitNotAWorktree,
         TaskCliError,
         ValueError,
         RuntimeError,

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -38,7 +38,6 @@ See also: docs/how-to/install-and-upgrade.md
 
 from __future__ import annotations
 
-import inspect
 import json
 import subprocess
 import sys
@@ -198,75 +197,21 @@ def _auto_commit_upgrade_changes(
         destination_ref = "main"
 
     try:
-        commit_success = _call_safe_commit_for_upgrade(
-            project_path=project_path,
-            destination_ref=destination_ref,
-            commit_message=commit_message,
-            files_to_commit=tuple(files_to_commit),
-        )
-    except Exception:
-        commit_success = False
-
-    if commit_success:
-        return True, committed_paths, None
-
-    return (
-        False,
-        committed_paths,
-        "Could not auto-commit upgrade changes; please review and commit manually.",
-    )
-
-
-def _call_safe_commit_for_upgrade(
-    *,
-    project_path: Path,
-    destination_ref: str,
-    commit_message: str,
-    files_to_commit: tuple[Path, ...],
-) -> bool:
-    """Call ``safe_commit`` using the best available supported signature.
-
-    Production code uses the current keyword-only signature. Tests may still
-    monkeypatch ``safe_commit`` with historical helper shapes, so this helper
-    keeps upgrade auto-commit behavior stable without reintroducing invalid
-    production call sites.
-    """
-    parameters = inspect.signature(safe_commit).parameters
-    parameter_names = tuple(parameters)
-    accepts_var_kwargs = any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD
-        for parameter in parameters.values()
-    )
-
-    if accepts_var_kwargs or {
-        "repo_root",
-        "worktree_root",
-        "destination_ref",
-        "message",
-        "paths",
-    } <= set(parameter_names):
-        return safe_commit(
+        safe_commit(
             repo_root=project_path,
             worktree_root=project_path,
             destination_ref=destination_ref,
             message=commit_message,
-            paths=files_to_commit,
+            paths=tuple(files_to_commit),
+        )
+    except Exception:
+        return (
+            False,
+            committed_paths,
+            "Could not auto-commit upgrade changes; please review and commit manually.",
         )
 
-    if {"repo_path", "files_to_commit", "commit_message"} <= set(parameter_names):
-        return safe_commit(
-            repo_path=project_path,
-            files_to_commit=list(files_to_commit),
-            commit_message=commit_message,
-            allow_empty=False,
-        )
-
-    return safe_commit(
-        project_path,
-        list(files_to_commit),
-        commit_message,
-        False,
-    )
+    return True, committed_paths, None
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/compat/_detect/install_method.py
+++ b/src/specify_cli/compat/_detect/install_method.py
@@ -264,7 +264,38 @@ def _is_user_site(
 _SYSTEM_PACKAGE_INSTALLERS = frozenset({"apt", "dnf", "pacman", "yum", "zypper"})
 
 
-def detect_install_method(  # noqa: C901
+def _detect_with_guard(detector: Callable[[], InstallMethod | None]) -> InstallMethod | None:
+    """Run a detection probe and swallow probe-local exceptions."""
+    try:
+        return detector()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _detect_system_package(
+    executable: str,
+    distribution_loader: Callable[[str], importlib.metadata.Distribution],
+) -> InstallMethod | None:
+    if not executable.startswith("/usr/bin/python"):
+        return None
+    installer = _get_installer(distribution_loader)
+    if installer in _SYSTEM_PACKAGE_INSTALLERS:
+        return InstallMethod.SYSTEM_PACKAGE
+    return None
+
+
+def _detect_pip_install(
+    distribution_loader: Callable[[str], importlib.metadata.Distribution],
+) -> InstallMethod | None:
+    installer = _get_installer(distribution_loader)
+    if installer != "pip":
+        return None
+    if _is_user_site(distribution_loader):
+        return InstallMethod.PIP_USER
+    return InstallMethod.PIP_SYSTEM
+
+
+def detect_install_method(
     *,
     executable: str | None = None,
     distribution_loader: Callable[[str], importlib.metadata.Distribution] | None = None,
@@ -305,52 +336,17 @@ def detect_install_method(  # noqa: C901
     if distribution_loader is None:
         distribution_loader = importlib.metadata.distribution
 
-    # 1. Source / dev install.
-    try:
-        if _is_source_install():
-            return InstallMethod.SOURCE
-    except Exception:  # noqa: BLE001
-        pass
-
-    # 2. uv tool.
-    try:
-        if _is_uv_tool_install(executable):
-            return InstallMethod.UV_TOOL
-    except Exception:  # noqa: BLE001
-        pass
-
-    # 3. pipx.
-    try:
-        if _is_pipx_install(executable):
-            return InstallMethod.PIPX
-    except Exception:  # noqa: BLE001
-        pass
-
-    # 4. Homebrew.
-    try:
-        if _is_brew_install(executable):
-            return InstallMethod.BREW
-    except Exception:  # noqa: BLE001
-        pass
-
-    # 5. System package manager.
-    try:
-        if executable.startswith("/usr/bin/python"):
-            installer = _get_installer(distribution_loader)
-            if installer in _SYSTEM_PACKAGE_INSTALLERS:
-                return InstallMethod.SYSTEM_PACKAGE
-    except Exception:  # noqa: BLE001
-        pass
-
-    # 6 & 7. pip (user vs system).
-    try:
-        installer = _get_installer(distribution_loader)
-        if installer == "pip":
-            if _is_user_site(distribution_loader):
-                return InstallMethod.PIP_USER
-            return InstallMethod.PIP_SYSTEM
-    except Exception:  # noqa: BLE001
-        pass
+    detectors = (
+        lambda: InstallMethod.SOURCE if _is_source_install() else None,
+        lambda: InstallMethod.UV_TOOL if _is_uv_tool_install(executable) else None,
+        lambda: InstallMethod.PIPX if _is_pipx_install(executable) else None,
+        lambda: InstallMethod.BREW if _is_brew_install(executable) else None,
+        lambda: _detect_system_package(executable, distribution_loader),
+        lambda: _detect_pip_install(distribution_loader),
+    )
+    for detector in detectors:
+        if detected := _detect_with_guard(detector):
+            return detected
 
     # 7. Fallback.
     return InstallMethod.UNKNOWN

--- a/src/specify_cli/dashboard/handlers/glossary.py
+++ b/src/specify_cli/dashboard/handlers/glossary.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from specify_cli.core.constants import KITTIFY_DIR
 from specify_cli.glossary.exceptions import SeedFileValidationError
 from specify_cli.glossary.semantic_events import iter_semantic_conflicts
 
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 _GLOSSARY_HTML_PATH = Path(__file__).resolve().parents[1] / "templates" / "glossary.html"
 _GLOSSARY_HTML_BYTES: bytes = _GLOSSARY_HTML_PATH.read_bytes()
+_KITTIFY_PATH = Path(KITTIFY_DIR)
 
 
 def _count_orphaned_terms(project_dir: Path) -> int:
@@ -31,7 +33,7 @@ def _count_orphaned_terms(project_dir: Path) -> int:
     try:
         import yaml  # ruamel.yaml or pyyaml
 
-        drg_path = project_dir / ".kittify" / "doctrine" / "graph.yaml"
+        drg_path = project_dir / _KITTIFY_PATH / "doctrine" / "graph.yaml"
         if not drg_path.exists():
             return 0
         with drg_path.open(encoding="utf-8") as fh:
@@ -135,7 +137,7 @@ def _recover_valid_senses(
         from specify_cli.glossary.scope import _parse_sense_status
         from specify_cli.glossary.seed_schema import GlossarySeedTerm
 
-        seed_path = repo_root / ".kittify" / "glossaries" / f"{scope.value}.yaml"
+        seed_path = repo_root / _KITTIFY_PATH / "glossaries" / f"{scope.value}.yaml"
         if not seed_path.exists():
             return []
         yaml = YAML()
@@ -225,7 +227,7 @@ class GlossaryHandler(DashboardHandler):
                 if conflict.timestamp:
                     last_at = max(last_at, conflict.timestamp) if last_at else conflict.timestamp
 
-            entity_pages_dir = project_dir / ".kittify" / "charter" / "compiled" / "glossary"
+            entity_pages_dir = project_dir / _KITTIFY_PATH / "charter" / "compiled" / "glossary"
             entity_pages_generated = entity_pages_dir.exists() and any(entity_pages_dir.iterdir())
 
             response: GlossaryHealthResponse = {

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -336,13 +336,14 @@ class ProtectedBranchCommitError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 _DEFAULT_PROTECTED_BRANCHES = frozenset({"main", "master"})
+_MERGE_BOOKKEEPING_PREFIX = "chore("
 
 # Documented exceptions kept on purpose. See module docstring for rationale.
 # DO NOT add spec-kitty-internal entries here. New exceptions require a
 # doctrine-level decision (DIRECTIVE_003).
 _PROTECTED_BRANCH_COMMIT_EXCEPTIONS = (
     "chore: apply spec-kitty upgrade changes",  # upgrade flow
-    "chore(",  # merge bookkeeping; narrowed by _is_protected_branch_exception
+    _MERGE_BOOKKEEPING_PREFIX,  # merge bookkeeping; narrowed by _is_protected_branch_exception
     "chore: release ",  # release flow
     "release: ",  # alternate release flow
 )
@@ -449,11 +450,15 @@ def assert_not_protected_branch(repo_path: Path, *, operation: str = "commit") -
 
 
 def _is_protected_branch_exception(commit_message: str) -> bool:
-    if commit_message.startswith("chore("):
+    if commit_message.startswith(_MERGE_BOOKKEEPING_PREFIX):
         first_line = commit_message.splitlines()[0]
         return first_line.endswith("): record done transitions for merged WPs")
     return commit_message.startswith(
-        tuple(prefix for prefix in _PROTECTED_BRANCH_COMMIT_EXCEPTIONS if prefix != "chore(")
+        tuple(
+            prefix
+            for prefix in _PROTECTED_BRANCH_COMMIT_EXCEPTIONS
+            if prefix != _MERGE_BOOKKEEPING_PREFIX
+        )
     )
 
 

--- a/tests/specify_cli/cli/commands/agent/test_workflow.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow.py
@@ -453,6 +453,67 @@ class TestTransactionPathFor:
         assert mid8 == "01ABCDEF"
 
 
+class TestCommitWorkflowChange:
+    """``_commit_workflow_change`` preserves helper-level exit semantics."""
+
+    def test_modern_policy_exit_is_not_rehandled(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+        import typer
+        from specify_cli.cli.commands.agent import workflow
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "meta.json").write_text(
+            json.dumps({
+                "mission_id": "01ABCDEFGHJKMNPQRSTVWXYZ12",
+                "mid8": "01ABCDEF",
+                "coordination_branch": "kitty/mission-test-01ABCDEF",
+            }),
+            encoding="utf-8",
+        )
+        restore_calls: list[object] = []
+
+        def _raise_exit(**kwargs: object) -> None:
+            workflow._record_receipt(
+                str(kwargs["coord_branch"]),
+                str(kwargs["message"]),
+                "refused",
+                wp_id=str(kwargs["wp_id"]),
+            )
+            raise typer.Exit(1)
+
+        monkeypatch.setattr(workflow, "_commit_via_coordination_transaction", _raise_exit)
+        monkeypatch.setattr(
+            workflow,
+            "_restore_status_artifacts",
+            lambda **kwargs: restore_calls.append(kwargs),
+        )
+
+        workflow._reset_workflow_receipts()
+        with pytest.raises(typer.Exit):
+            workflow._commit_workflow_change(
+                repo_root=tmp_path,
+                feature_dir=feature_dir,
+                mission_slug="001-test",
+                target_branch="main",
+                paths=[],
+                message="chore: WP01 claimed [claude]",
+                operation="implement",
+                wp_id="WP01",
+                pre_emit_event_size=0,
+                pre_emit_status_bytes=None,
+            )
+
+        assert len(workflow._WORKFLOW_COMMIT_RECEIPTS) == 1
+        assert workflow._WORKFLOW_COMMIT_RECEIPTS[0]["outcome"] == "refused"
+        assert restore_calls == []
+        workflow._reset_workflow_receipts()
+
+
 class TestPrintCommitSummary:
     """The T029 terminal summary formats receipts correctly."""
 

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -284,20 +284,9 @@ def test_auto_commit_upgrade_changes_calls_safe_commit(
 
     captured: dict[str, object] = {}
 
-    def _fake_safe_commit(
-        *,
-        repo_root: Path,
-        worktree_root: Path,
-        destination_ref: str,
-        message: str,
-        paths: tuple[Path, ...],
-    ) -> bool:
-        captured["repo_root"] = repo_root
-        captured["worktree_root"] = worktree_root
-        captured["destination_ref"] = destination_ref
-        captured["message"] = message
-        captured["paths"] = paths
-        return True
+    def _fake_safe_commit(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
 
     monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
     monkeypatch.setattr(
@@ -333,7 +322,7 @@ def test_auto_commit_returns_warning_on_safe_commit_failure(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    """When safe_commit returns False the caller gets a warning string."""
+    """When safe_commit raises the caller gets a warning string."""
     project_path = tmp_path / "project"
     project_path.mkdir()
 
@@ -345,7 +334,7 @@ def test_auto_commit_returns_warning_on_safe_commit_failure(
     monkeypatch.setattr(
         upgrade_cmd,
         "safe_commit",
-        lambda **_kw: False,
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
     committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
@@ -359,107 +348,6 @@ def test_auto_commit_returns_warning_on_safe_commit_failure(
     assert warning is not None
     assert "review and commit manually" in warning
     assert committed_paths == ["kitty-specs/001/WP01.md"]
-
-
-def test_auto_commit_upgrade_changes_supports_legacy_keyword_stub(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    project_path = tmp_path / "project"
-    project_path.mkdir()
-
-    monkeypatch.setattr(
-        upgrade_cmd,
-        "_prepare_upgrade_commit_files",
-        lambda _project, baseline_paths: [Path("kitty-specs/001/WP01.md")],
-    )
-
-    captured: dict[str, object] = {}
-
-    def _legacy_safe_commit(
-        *,
-        repo_path: Path,
-        files_to_commit: list[Path],
-        commit_message: str,
-        allow_empty: bool = False,
-    ) -> bool:
-        captured["repo_path"] = repo_path
-        captured["files_to_commit"] = files_to_commit
-        captured["commit_message"] = commit_message
-        captured["allow_empty"] = allow_empty
-        return True
-
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _legacy_safe_commit)
-    monkeypatch.setattr(
-        subprocess,
-        "check_output",
-        lambda *_args, **_kwargs: "main\n",
-    )
-
-    committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
-        project_path=project_path,
-        from_version="0.13.0",
-        to_version="0.14.0",
-        baseline_paths=set(),
-    )
-
-    assert committed is True
-    assert warning is None
-    assert committed_paths == ["kitty-specs/001/WP01.md"]
-    assert captured["repo_path"] == project_path
-    assert captured["files_to_commit"] == [Path("kitty-specs/001/WP01.md")]
-    assert "0.13.0 -> 0.14.0" in str(captured["commit_message"])
-    assert captured["allow_empty"] is False
-
-
-def test_auto_commit_upgrade_changes_supports_legacy_positional_stub(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    project_path = tmp_path / "project"
-    project_path.mkdir()
-
-    monkeypatch.setattr(
-        upgrade_cmd,
-        "_prepare_upgrade_commit_files",
-        lambda _project, baseline_paths: [Path("kitty-specs/001/WP01.md")],
-    )
-
-    captured: dict[str, object] = {}
-
-    def _legacy_safe_commit(
-        repo_path: Path,
-        files_to_commit: list[Path],
-        commit_message: str,
-        allow_empty: bool = False,
-    ) -> bool:
-        captured["repo_path"] = repo_path
-        captured["files_to_commit"] = files_to_commit
-        captured["commit_message"] = commit_message
-        captured["allow_empty"] = allow_empty
-        return True
-
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _legacy_safe_commit)
-    monkeypatch.setattr(
-        subprocess,
-        "check_output",
-        lambda *_args, **_kwargs: "main\n",
-    )
-
-    committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
-        project_path=project_path,
-        from_version="0.13.0",
-        to_version="0.14.0",
-        baseline_paths=set(),
-    )
-
-    assert committed is True
-    assert warning is None
-    assert committed_paths == ["kitty-specs/001/WP01.md"]
-    assert captured["repo_path"] == project_path
-    assert captured["files_to_commit"] == [Path("kitty-specs/001/WP01.md")]
-    assert "0.13.0 -> 0.14.0" in str(captured["commit_message"])
-    assert captured["allow_empty"] is False
 
 
 def test_auto_commit_noop_when_no_new_files(
@@ -575,7 +463,7 @@ def test_upgrade_no_migrations_json_includes_auto_commit_fields(
     monkeypatch.setattr(
         upgrade_cmd,
         "safe_commit",
-        lambda **_kwargs: True,
+        lambda **_kw: object(),
     )
 
     upgrade_cmd.upgrade(
@@ -644,20 +532,9 @@ def test_upgrade_no_migrations_stamps_missing_schema_version(
 
     safe_commit_calls: list[list[str]] = []
 
-    def _fake_safe_commit(
-        *,
-        repo_root: Path,
-        worktree_root: Path,
-        destination_ref: str,
-        message: str,
-        paths: tuple[Path, ...],
-    ) -> bool:
-        assert repo_root == project_path
-        assert worktree_root == project_path
-        assert destination_ref == "main"
-        assert "3.2.0rc14 -> 3.2.0rc14" in message
-        safe_commit_calls.append([str(path) for path in paths])
-        return True
+    def _fake_safe_commit(**kwargs: object) -> object:
+        safe_commit_calls.append([str(path) for path in kwargs["paths"]])
+        return object()
 
     monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
     monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
@@ -859,7 +736,7 @@ def test_upgrade_no_migrations_rich_output_shows_auto_commit(
     monkeypatch.setattr(
         upgrade_cmd,
         "safe_commit",
-        lambda **_kwargs: True,
+        lambda **_kw: object(),
     )
 
     captured_output: list[str] = []
@@ -891,7 +768,7 @@ def test_upgrade_no_migrations_safe_commit_failure_shows_warning(
     monkeypatch,
     capsys,
 ) -> None:
-    """When safe_commit fails, the JSON output includes a warning."""
+    """When safe_commit raises, the JSON output includes a warning."""
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
 
@@ -907,7 +784,7 @@ def test_upgrade_no_migrations_safe_commit_failure_shows_warning(
     monkeypatch.setattr(
         upgrade_cmd,
         "safe_commit",
-        lambda **_kwargs: False,
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
     upgrade_cmd.upgrade(


### PR DESCRIPTION
## Summary
- fix `upgrade` auto-commit to use the current keyword-only `safe_commit` contract instead of legacy positional fallbacks
- reduce Sonar noise in workflow/install-method/merge/glossary helpers with extracted helpers, constants, and exception logging fixes
- align upgrade auto-commit tests with the current `safe_commit` API

## Findings triaged
- GitHub dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud nightly `main` delta: 25 new issues on 2026-05-29
- Sonar hotspots still open on `main`: 2 historical `http` loopback findings (`dashboard/server.py`, `sync/daemon.py`) that appear to require Sonar UI review / product decision rather than a safe code-only flip in this tranche

## Validation
- `pytest tests/upgrade/test_upgrade_auto_commit_unit.py tests/specify_cli/cli/commands/test_safe_commit_cmd.py tests/specify_cli/cli/commands/agent/test_workflow.py tests/specify_cli/compat/test_install_method.py -q`
- `ruff check src/specify_cli/cli/commands/agent/tasks.py src/specify_cli/cli/commands/safe_commit_cmd.py src/specify_cli/cli/commands/upgrade.py src/specify_cli/dashboard/handlers/glossary.py src/specify_cli/git/commit_helpers.py src/specify_cli/compat/_detect/install_method.py src/specify_cli/cli/commands/merge.py src/specify_cli/cli/commands/agent/workflow.py tests/upgrade/test_upgrade_auto_commit_unit.py`
- `python -m compileall src/specify_cli/cli/commands/agent/workflow.py src/specify_cli/cli/commands/upgrade.py src/specify_cli/cli/commands/safe_commit_cmd.py src/specify_cli/compat/_detect/install_method.py src/specify_cli/cli/commands/merge.py src/specify_cli/dashboard/handlers/glossary.py src/specify_cli/git/commit_helpers.py`
