### PR TITLE
docs: add PyPI install steps for orchestrator

### DIFF
--- a/docs/how-to/run-external-orchestrator.md
+++ b/docs/how-to/run-external-orchestrator.md
@@ -25,14 +25,54 @@ This is the supported automation model:
 
 ## Version Compatibility
 
-The current host API requires a compatible provider implementation. PyPI
-currently publishes `spec-kitty-orchestrator` `0.1.0`; that release appends
-`--json` to host API calls and is not compatible with current
-`spec-kitty orchestrator-api` behavior.
+The orchestrator is published on
+[PyPI as `spec-kitty-orchestrator`](https://pypi.org/project/spec-kitty-orchestrator/).
+Install the latest compatible package from PyPI, then verify the host contract
+before running a mission.
 
-Install only a release, branch, or pinned commit that explicitly documents
-support for the current JSON-default host API. Do not assume an unverified
-default-branch install is compatible.
+## Install from PyPI
+
+Use `pipx` for an isolated command-line install:
+
+```bash
+pipx install spec-kitty-orchestrator
+```
+
+If you already have it installed:
+
+```bash
+pipx upgrade spec-kitty-orchestrator
+```
+
+If you prefer `uv` tool management:
+
+```bash
+uv tool install spec-kitty-orchestrator
+```
+
+Or upgrade an existing uv-managed install:
+
+```bash
+uv tool upgrade spec-kitty-orchestrator
+```
+
+Then verify the installed console script:
+
+```bash
+spec-kitty-orchestrator --help
+spec-kitty-orchestrator orchestrate --help
+```
+
+If the command is not found, you installed into a Python environment whose
+script directory is not on `PATH`. Activate that environment or install from
+the environment where you run Spec Kitty.
+
+The source repository is
+[`Priivacy-ai/spec-kitty-orchestrator`](https://github.com/Priivacy-ai/spec-kitty-orchestrator)
+if you want to inspect code, issues, or release history. Do not install from
+GitHub unless you are intentionally testing unreleased provider changes.
+
+Run the rest of this guide from your Spec Kitty project root.
 
 For the common "Claude implements, Codex reviews" workflow, install and
 authenticate both CLIs before starting:
@@ -171,9 +211,8 @@ Expected for `spec-kitty` core CLI. Use:
 
 If `contract-version` returns mismatch, upgrade either host (`spec-kitty`) or provider (`spec-kitty-orchestrator`) so versions are compatible.
 
-If a run fails with `No such option: --json`, you are using an incompatible
-provider build. Install a provider build that no longer appends `--json` to
-`spec-kitty orchestrator-api` calls.
+If a run fails with a host API usage error, upgrade both `spec-kitty` and
+`spec-kitty-orchestrator`, then rerun `contract-version`.
 
 ### Policy validation failures
 

--- a/docs/tutorials/orchestrator-quickstart.md
+++ b/docs/tutorials/orchestrator-quickstart.md
@@ -30,13 +30,55 @@ first.
 
 ## Version compatibility
 
-PyPI currently publishes `spec-kitty-orchestrator` `0.1.0`, which appends
-`--json` to host API calls and is not compatible with the current host API. Do
-not use that release for this tutorial. Install only a release, branch, or
-pinned commit that explicitly documents compatibility with the current
-JSON-default `spec-kitty orchestrator-api`.
+The orchestrator is published on
+[PyPI as `spec-kitty-orchestrator`](https://pypi.org/project/spec-kitty-orchestrator/).
+Install the latest compatible package from PyPI, then verify the host contract
+before running a mission.
 
-## 1. Confirm the host API works
+## 1. Install the orchestrator
+
+Use `pipx` for an isolated command-line install:
+
+```bash
+pipx install spec-kitty-orchestrator
+```
+
+If you already have it installed:
+
+```bash
+pipx upgrade spec-kitty-orchestrator
+```
+
+If you prefer `uv` tool management:
+
+```bash
+uv tool install spec-kitty-orchestrator
+```
+
+Or upgrade an existing uv-managed install:
+
+```bash
+uv tool upgrade spec-kitty-orchestrator
+```
+
+Confirm the CLI is now available:
+
+```bash
+spec-kitty-orchestrator --help
+spec-kitty-orchestrator orchestrate --help
+```
+
+If either command is missing, check that the Python environment where you
+installed the package is on `PATH`.
+
+The source repository is
+[`Priivacy-ai/spec-kitty-orchestrator`](https://github.com/Priivacy-ai/spec-kitty-orchestrator)
+if you want to inspect code, issues, or release history. Do not install from
+GitHub unless you are intentionally testing unreleased provider changes.
+
+Return to your Spec Kitty project root before continuing.
+
+## 2. Confirm the host API works
 
 Run this from the project root:
 
@@ -58,7 +100,7 @@ The output is a JSON envelope. For a compatible host it includes:
 The orchestrator performs this check at startup too, but running it yourself
 confirms that the host CLI is installed and that JSON output is available.
 
-## 2. Find your mission slug
+## 3. Find your mission slug
 
 Use the dashboard, `kitty-specs/`, or the mission commands to identify the
 mission slug:
@@ -77,7 +119,7 @@ Examples look like:
 The orchestrator API selector is always `--mission`, even when the selector is
 a slug, mission id, or short mission id.
 
-## 3. Inspect ready work
+## 4. Inspect ready work
 
 ```bash
 spec-kitty orchestrator-api list-ready --mission 034-payment-retry-flow
@@ -90,7 +132,7 @@ If no WPs are ready, inspect the whole mission:
 spec-kitty orchestrator-api mission-state --mission 034-payment-retry-flow
 ```
 
-## 4. Dry-run the orchestrator
+## 5. Dry-run the orchestrator
 
 ```bash
 spec-kitty-orchestrator orchestrate \
@@ -104,7 +146,7 @@ spec-kitty-orchestrator orchestrate \
 Use `--dry-run` before the first real run. It validates configuration without
 moving WP lanes.
 
-## 5. Run implementation and review
+## 6. Run implementation and review
 
 ```bash
 spec-kitty-orchestrator orchestrate \
@@ -128,7 +170,7 @@ With a host-compatible provider build, the orchestrator loop will:
 The orchestrator writes its local run state under `.kittify/` and agent logs
 under `.kittify/logs/`.
 
-## 6. Check progress
+## 7. Check progress
 
 In another terminal:
 
@@ -141,7 +183,7 @@ Use `mission-state` as the source of truth for WP lanes. Use
 `spec-kitty-orchestrator status` for provider-local details such as retry
 counts and the last agent log path.
 
-## 7. Resume or abort
+## 8. Resume or abort
 
 If the process is interrupted:
 


### PR DESCRIPTION
## Summary

- Adds a concrete PyPI install step to the orchestrator quickstart, using `pipx install spec-kitty-orchestrator` as the primary path.
- Adds optional `uv tool install spec-kitty-orchestrator` instructions for users managing CLI tools with uv.
- Keeps a GitHub repository link only for source, issues, and release-history inspection; docs no longer advise installing from GitHub.

## Validation

- `UV_PROJECT_ENVIRONMENT=.venv-docs PYTHONPATH=. SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python scripts/docs/check_docs_freshness.py --ci --strict-mode --link-check none`
- `UV_PROJECT_ENVIRONMENT=.venv-docs SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/docs -q`