### PR TITLE
Fix configured command execution on Windows

### DIFF
--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -17,6 +17,7 @@ from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
+from specify_cli.configured_command import ConfiguredCommandUnsupported, run_configured_command
 from specify_cli.mission_metadata import mission_identity_fields, resolve_mission_identity
 
 
@@ -323,14 +324,33 @@ def _check_custom_command(repo_root: Path, ni: NegativeInvariant) -> NegativeInv
             extras=ni.extras,
         )
 
-    # User-authored acceptance matrices intentionally support shell snippets.
-    result = subprocess.run(  # noqa: S602
-        ni.verification_command,
-        shell=True,  # nosec B602
-        cwd=str(repo_root),
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = run_configured_command(
+            ni.verification_command,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+        )
+    except ConfiguredCommandUnsupported as exc:
+        return NegativeInvariant(
+            invariant_id=ni.invariant_id,
+            description=ni.description,
+            verification_method=ni.verification_method,
+            verification_command=ni.verification_command,
+            result="pending",
+            evidence=str(exc),
+            extras=ni.extras,
+        )
+    except OSError as exc:
+        return NegativeInvariant(
+            invariant_id=ni.invariant_id,
+            description=ni.description,
+            verification_method=ni.verification_method,
+            verification_command=ni.verification_command,
+            result="still_present",
+            evidence=f"Command failed to start: {exc}",
+            extras=ni.extras,
+        )
     if result.returncode == 0:
         return NegativeInvariant(
             invariant_id=ni.invariant_id,

--- a/src/specify_cli/configured_command.py
+++ b/src/specify_cli/configured_command.py
@@ -1,0 +1,228 @@
+"""Run user-configured commands without ``shell=True``.
+
+POSIX commands keep their historical shell semantics through an explicit
+``sh -c`` argv. Windows runs simple commands without ``cmd.exe`` and fails
+closed when POSIX shell syntax is detected.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+
+class ConfiguredCommandUnsupported(RuntimeError):
+    """Raised when a configured command cannot run on the current platform."""
+
+
+_ENV_ASSIGNMENT_RE = re.compile(r"^\s*[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _has_unquoted_posix_shell_syntax(command: str) -> bool:
+    """Return True when command uses operators that require a POSIX shell."""
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for index, char in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and not in_single:
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if in_single:
+            continue
+        if char == "$":
+            next_char = command[index + 1] if index + 1 < len(command) else ""
+            if next_char in "({" or next_char == "_" or next_char.isalpha():
+                return True
+        if in_double:
+            continue
+        if char in "\n|&;<>`!*?[":
+            return True
+    return bool(_ENV_ASSIGNMENT_RE.match(command))
+
+
+def _uses_posix_single_quotes(command: str) -> bool:
+    """Detect single-quoted argv syntax that ``cmd.exe`` does not honor."""
+    in_double = False
+    escaped = False
+    for char in command:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            in_double = not in_double
+            continue
+        if char == "'" and not in_double:
+            return True
+    return False
+
+
+def _unsupported_windows_message() -> str:
+    return (
+        "Configured command uses POSIX shell syntax that is not supported on Windows. "
+        "Use a native Windows command or a simple argv-style command without pipes, "
+        "redirection, environment assignments, control operators, command expansion, "
+        "backticks, or single-quoted arguments."
+    )
+
+
+def _run_args(
+    args: str | list[str],
+    *,
+    cwd: str | Path,
+    capture_output: bool,
+    text: bool,
+    check: bool,
+    timeout: float | None,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - command is explicit user/project configuration.
+        args,
+        cwd=str(cwd),
+        capture_output=capture_output,
+        text=text,
+        check=check,
+        timeout=timeout,
+        env=dict(env) if env is not None else None,
+    )
+
+
+def _substitution_env_name(key: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_]", "_", key).upper()
+    return f"SPEC_KITTY_CMD_{normalized}"
+
+
+def _format_shell_template_with_env(
+    command_template: str,
+    substitutions: Mapping[str, str],
+) -> tuple[str, dict[str, str]]:
+    """Replace ``{name}`` placeholders with shell-safe environment references."""
+    env_names = {key: _substitution_env_name(key) for key in substitutions}
+    env = {env_names[key]: value for key, value in substitutions.items()}
+    placeholders = {f"{{{key}}}": key for key in substitutions}
+
+    formatted: list[str] = []
+    index = 0
+    in_single = False
+    in_double = False
+    escaped = False
+    while index < len(command_template):
+        matched_key: str | None = None
+        matched_placeholder = ""
+        for placeholder, key in placeholders.items():
+            if command_template.startswith(placeholder, index):
+                matched_key = key
+                matched_placeholder = placeholder
+                break
+
+        if matched_key is not None:
+            env_name = env_names[matched_key]
+            if in_single:
+                formatted.append(f"'\"${{{env_name}}}\"'")
+            elif in_double:
+                formatted.append(f"${{{env_name}}}")
+            else:
+                formatted.append(f"\"${{{env_name}}}\"")
+            index += len(matched_placeholder)
+            escaped = False
+            continue
+
+        char = command_template[index]
+        formatted.append(char)
+        if escaped:
+            escaped = False
+        elif char == "\\" and not in_single:
+            escaped = True
+        elif char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        index += 1
+
+    return "".join(formatted), env
+
+
+def run_configured_command(
+    command: str,
+    *,
+    cwd: str | Path,
+    capture_output: bool = True,
+    text: bool = True,
+    check: bool = False,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a user/config-authored command without ``shell=True``."""
+    if sys.platform == "win32":
+        requires_posix_shell = _has_unquoted_posix_shell_syntax(command)
+        if requires_posix_shell or _uses_posix_single_quotes(command):
+            raise ConfiguredCommandUnsupported(_unsupported_windows_message())
+        args: str | list[str] = command
+    else:
+        args = ["sh", "-c", command]
+
+    return _run_args(
+        args,
+        cwd=cwd,
+        capture_output=capture_output,
+        text=text,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def run_configured_command_template(
+    command_template: str,
+    substitutions: Mapping[str, str | Path],
+    *,
+    cwd: str | Path,
+    capture_output: bool = True,
+    text: bool = True,
+    check: bool = False,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a configured command template with shell-safe placeholder handling."""
+    raw_substitutions = {key: str(value) for key, value in substitutions.items()}
+    env: Mapping[str, str] | None = None
+    if sys.platform == "win32":
+        requires_posix_shell = _has_unquoted_posix_shell_syntax(command_template)
+        if requires_posix_shell or _uses_posix_single_quotes(command_template):
+            raise ConfiguredCommandUnsupported(_unsupported_windows_message())
+        try:
+            template_args = shlex.split(command_template)
+        except ValueError as exc:
+            raise ConfiguredCommandUnsupported(f"Configured command could not be parsed: {exc}") from exc
+        args: str | list[str] = [arg.format(**raw_substitutions) for arg in template_args]
+    else:
+        shell_command, substitution_env = _format_shell_template_with_env(
+            command_template,
+            raw_substitutions,
+        )
+        env = {**os.environ, **substitution_env}
+        args = ["sh", "-c", shell_command]
+
+    return _run_args(
+        args,
+        cwd=cwd,
+        capture_output=capture_output,
+        text=text,
+        check=check,
+        timeout=timeout,
+        env=env,
+    )

--- a/src/specify_cli/review/baseline.py
+++ b/src/specify_cli/review/baseline.py
@@ -24,6 +24,8 @@ from datetime import datetime, timezone, UTC
 from pathlib import Path
 from typing import Any
 
+from specify_cli.configured_command import ConfiguredCommandUnsupported, run_configured_command_template
+
 logger = logging.getLogger(__name__)
 
 
@@ -284,18 +286,19 @@ def capture_baseline(
             return _make_sentinel(wp_id, base_branch, base_commit)
 
         try:
-            # Build the final command string with output_file substituted
-            cmd_str = test_command.format(output_file=str(junit_xml_path))
             try:
-                run_result = subprocess.run(
-                    cmd_str,
-                    shell=True,  # nosec B602 — test_command is user-authored config string, shell required for pipes/redirects
+                run_result = run_configured_command_template(
+                    test_command,
+                    {"output_file": junit_xml_path},
                     cwd=str(tmp_worktree),
                     capture_output=True,
                     text=True,
                     check=False,
                     timeout=300,  # 5 minute timeout
                 )
+            except ConfiguredCommandUnsupported as exc:
+                logger.warning("Test command is not supported on this platform: %s", exc)
+                return _make_sentinel(wp_id, base_branch, base_commit)
             except Exception as exc:
                 logger.warning("Test command failed to execute: %s", exc)
                 return _make_sentinel(wp_id, base_branch, base_commit)

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -1,6 +1,7 @@
 """Tests for acceptance matrix, evidence validation, and negative invariants."""
 
 import json
+import sys
 
 import pytest
 
@@ -266,10 +267,23 @@ class TestNegativeInvariants:
             NegativeInvariant(
                 "NI-01", "No stale files",
                 "custom_command",
-                verification_command="true",  # always exits 0
+                verification_command=f'"{sys.executable}" -c "import sys; sys.exit(0)"',
             ),
         ]
         results = enforce_negative_invariants(tmp_path, invariants)
+        assert results[0].result == "confirmed_absent"
+
+    def test_custom_command_preserves_posix_command_substitution(self, tmp_path):
+        invariants = [
+            NegativeInvariant(
+                "NI-01", "No stale files",
+                "custom_command",
+                verification_command='test -z "$(printf \'\')"',
+            ),
+        ]
+
+        results = enforce_negative_invariants(tmp_path, invariants)
+
         assert results[0].result == "confirmed_absent"
 
     def test_custom_command_fail(self, tmp_path):
@@ -277,11 +291,40 @@ class TestNegativeInvariants:
             NegativeInvariant(
                 "NI-01", "Check fails",
                 "custom_command",
-                verification_command="false",  # always exits 1
+                verification_command=f'"{sys.executable}" -c "import sys; sys.exit(1)"',
             ),
         ]
         results = enforce_negative_invariants(tmp_path, invariants)
         assert results[0].result == "still_present"
+
+    def test_custom_command_missing_executable_returns_evidence(self, tmp_path):
+        invariants = [
+            NegativeInvariant(
+                "NI-01", "Check fails",
+                "custom_command",
+                verification_command="definitely-not-a-spec-kitty-command",
+            ),
+        ]
+
+        results = enforce_negative_invariants(tmp_path, invariants)
+
+        assert results[0].result == "still_present"
+        assert "not found" in (results[0].evidence or "")
+
+    @pytest.mark.windows_ci
+    def test_custom_command_posix_shell_syntax_fails_clear_on_windows(self, tmp_path):
+        invariants = [
+            NegativeInvariant(
+                "NI-01", "No stale files",
+                "custom_command",
+                verification_command='python -c "print(1)" && echo done',
+            ),
+        ]
+
+        results = enforce_negative_invariants(tmp_path, invariants)
+
+        assert results[0].result == "pending"
+        assert "POSIX shell syntax" in (results[0].evidence or "")
 
     def test_enforcement_preserves_negative_invariant_extensions(self, tmp_path):
         repo_root = tmp_path / "repo"

--- a/tests/review/test_baseline.py
+++ b/tests/review/test_baseline.py
@@ -151,12 +151,11 @@ class TestCaptureBaseline:
             result.stdout = "abc1234def5\n"
             result.stderr = ""
             # Detect JUnit XML write
-            if isinstance(cmd, str) and "--junitxml=" in cmd:
-                # Extract output file path from the command string
-                import re
-                m = re.search(r"--junitxml=(\S+)", cmd)
-                if m:
-                    Path(m.group(1)).write_text(SAMPLE_JUNIT_XML, encoding="utf-8")
+            cmd_text = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if isinstance(cmd_text, str) and "--junitxml=" in cmd_text:
+                output_file = kwargs.get("env", {}).get("SPEC_KITTY_CMD_OUTPUT_FILE")
+                if output_file:
+                    Path(output_file).write_text(SAMPLE_JUNIT_XML, encoding="utf-8")
             return result
 
         with patch("subprocess.run", side_effect=fake_run):
@@ -239,6 +238,150 @@ class TestCaptureBaseline:
 
         assert result is not None
         assert result.failed == -1, "Sentinel result expected when capture fails"
+
+    def test_capture_baseline_preserves_posix_command_substitution(self, tmp_path: Path) -> None:
+        repo, feature_dir, _wp_task_dir = self._make_wp_dir(tmp_path)
+        shell_commands: list[str] = []
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "abc1234def5\n"
+            result.stderr = ""
+            if isinstance(cmd, list) and cmd[:2] == ["sh", "-c"]:
+                shell_commands.append(cmd[2])
+                output_file = kwargs["env"]["SPEC_KITTY_CMD_OUTPUT_FILE"]
+                Path(output_file).write_text(SAMPLE_JUNIT_XML, encoding="utf-8")
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = capture_baseline(
+                worktree_path=repo,
+                base_branch="main",
+                wp_id="WP04",
+                mission_slug="066-test",
+                feature_dir=feature_dir,
+                wp_slug="WP04-test",
+                test_command='custom-runner --junitxml={output_file} --marker "$(printf ok)"',
+            )
+
+        assert result is not None
+        assert result.failed == 1
+        assert any("$(printf ok)" in command for command in shell_commands)
+
+    def test_capture_baseline_output_path_does_not_trigger_shell(self, tmp_path: Path) -> None:
+        repo, feature_dir, _wp_task_dir = self._make_wp_dir(tmp_path)
+        proof_path = tmp_path / "proof-created-by-shell"
+        injected_tmp = tmp_path / "tmp;touch proof-created-by-shell #"
+        injected_tmp.mkdir()
+
+        class FakeTemporaryDirectory:
+            def __enter__(self) -> str:
+                return str(injected_tmp)
+
+            def __exit__(self, exc_type, exc, tb) -> None:
+                return None
+
+        shell_commands: list[str] = []
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "abc1234def5\n"
+            result.stderr = ""
+            if isinstance(cmd, list) and cmd[:2] == ["sh", "-c"]:
+                shell_commands.append(cmd[2])
+                output_file = kwargs["env"]["SPEC_KITTY_CMD_OUTPUT_FILE"]
+                Path(output_file).write_text(SAMPLE_JUNIT_XML, encoding="utf-8")
+            return result
+
+        with (
+            patch("tempfile.TemporaryDirectory", return_value=FakeTemporaryDirectory()),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = capture_baseline(
+                worktree_path=repo,
+                base_branch="main",
+                wp_id="WP04",
+                mission_slug="066-test",
+                feature_dir=feature_dir,
+                wp_slug="WP04-test",
+                test_command="custom-runner --junitxml={output_file}",
+            )
+
+        assert result is not None
+        assert result.failed == 1
+        assert shell_commands == ['custom-runner --junitxml="${SPEC_KITTY_CMD_OUTPUT_FILE}"']
+        assert not proof_path.exists()
+
+    def test_capture_baseline_preserves_quoted_output_file_template(self, tmp_path: Path) -> None:
+        repo, feature_dir, _wp_task_dir = self._make_wp_dir(tmp_path)
+        injected_tmp = tmp_path / "parent with space"
+        injected_tmp.mkdir()
+
+        class FakeTemporaryDirectory:
+            def __enter__(self) -> str:
+                return str(injected_tmp)
+
+            def __exit__(self, exc_type, exc, tb) -> None:
+                return None
+
+        shell_commands: list[str] = []
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "abc1234def5\n"
+            result.stderr = ""
+            if isinstance(cmd, list) and cmd[:2] == ["sh", "-c"]:
+                shell_commands.append(cmd[2])
+                output_file = kwargs["env"]["SPEC_KITTY_CMD_OUTPUT_FILE"]
+                Path(output_file).write_text(SAMPLE_JUNIT_XML, encoding="utf-8")
+            return result
+
+        with (
+            patch("tempfile.TemporaryDirectory", return_value=FakeTemporaryDirectory()),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            result = capture_baseline(
+                worktree_path=repo,
+                base_branch="main",
+                wp_id="WP04",
+                mission_slug="066-test",
+                feature_dir=feature_dir,
+                wp_slug="WP04-test",
+                test_command='custom-runner --junitxml="{output_file}"',
+            )
+
+        assert result is not None
+        assert result.failed == 1
+        assert shell_commands == ['custom-runner --junitxml="${SPEC_KITTY_CMD_OUTPUT_FILE}"']
+
+    @pytest.mark.windows_ci
+    def test_capture_baseline_posix_shell_syntax_returns_sentinel_on_windows(self, tmp_path: Path) -> None:
+        """Windows reports a clear unsupported command instead of invoking cmd.exe."""
+        repo, feature_dir, _wp_task_dir = self._make_wp_dir(tmp_path)
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "abc1234\n"
+            result.stderr = ""
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = capture_baseline(
+                worktree_path=repo,
+                base_branch="main",
+                wp_id="WP04",
+                mission_slug="066-test",
+                feature_dir=feature_dir,
+                wp_slug="WP04-test",
+                test_command='custom-runner --junitxml={output_file} && echo done',
+            )
+
+        assert result is not None
+        assert result.failed == -1
 
 
 # ---------------------------------------------------------------------------
@@ -648,10 +791,11 @@ class TestCoverageEdgeCases:
             result.returncode = 0
             result.stdout = "abc1234\n"
             result.stderr = ""
-            if isinstance(cmd, str) and "{output_file}" not in cmd:
+            cmd_text = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if isinstance(cmd_text, str) and "{output_file}" not in cmd_text:
                 # Write empty JUnit XML for the test run
                 import re
-                m = re.search(r"--output=(\S+)", cmd)
+                m = re.search(r"--output=(\S+)", cmd_text)
                 if m:
                     Path(m.group(1)).write_text(
                         '<?xml version="1.0"?><testsuites><testsuite tests="1">'
@@ -665,9 +809,10 @@ class TestCoverageEdgeCases:
             result.returncode = 0
             result.stdout = "abc1234\n"
             result.stderr = ""
-            if isinstance(cmd, str) and "myrunner" in cmd:
+            cmd_text = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if isinstance(cmd_text, str) and "myrunner" in cmd_text:
                 import re
-                m = re.search(r"--output=(\S+)", cmd)
+                m = re.search(r"--output=(\S+)", cmd_text)
                 if m:
                     Path(m.group(1)).write_text(
                         '<?xml version="1.0"?><testsuites><testsuite tests="1">'

--- a/tests/specify_cli/test_configured_command.py
+++ b/tests/specify_cli/test_configured_command.py
@@ -1,0 +1,140 @@
+"""Tests for user-configured command execution."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from specify_cli.configured_command import (
+    ConfiguredCommandUnsupported,
+    run_configured_command,
+    run_configured_command_template,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def _completed() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def test_simple_posix_command_uses_explicit_sh_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    command = 'runner --flag "two words"'
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command(command, cwd=tmp_path)
+    args, kwargs = run.call_args
+
+    assert args[0] == ["sh", "-c", command]
+    assert "shell" not in kwargs
+
+
+def test_posix_shell_syntax_uses_explicit_sh_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    command = "echo start && echo done"
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command(command, cwd=tmp_path)
+
+    args, kwargs = run.call_args
+    assert args[0] == ["sh", "-c", command]
+    assert "shell" not in kwargs
+
+
+def test_quoted_command_substitution_uses_explicit_sh_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    command = 'test -z "$(printf \'\')"'
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command(command, cwd=tmp_path)
+
+    args, kwargs = run.call_args
+    assert args[0] == ["sh", "-c", command]
+    assert "shell" not in kwargs
+
+
+@pytest.mark.parametrize("command", ["! grep forbidden file.txt", "test -e *.py"])
+def test_other_posix_shell_forms_use_explicit_sh_argv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command: str,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command(command, cwd=tmp_path)
+
+    args, kwargs = run.call_args
+    assert args[0] == ["sh", "-c", command]
+    assert "shell" not in kwargs
+
+
+def test_simple_windows_command_uses_native_string_without_shell(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    command = 'python -m pytest --junitxml="C:\\tmp\\junit.xml"'
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command(command, cwd=tmp_path)
+
+    args, kwargs = run.call_args
+    assert args[0] == command
+    assert "shell" not in kwargs
+
+
+def test_windows_posix_shell_syntax_fails_before_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    with (
+        patch("specify_cli.configured_command.subprocess.run") as run,
+        pytest.raises(ConfiguredCommandUnsupported, match="POSIX shell syntax"),
+    ):
+        run_configured_command("echo start && echo done", cwd=tmp_path)
+
+    run.assert_not_called()
+
+
+def test_template_substitution_is_shell_quoted_on_posix(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    output_file = tmp_path / "tmp;touch proof #" / "junit.xml"
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command_template(
+            "runner --junitxml={output_file}",
+            {"output_file": output_file},
+            cwd=tmp_path,
+        )
+
+    args, kwargs = run.call_args
+    assert args[0] == ["sh", "-c", 'runner --junitxml="${SPEC_KITTY_CMD_OUTPUT_FILE}"']
+    assert "shell" not in kwargs
+    assert kwargs["env"]["SPEC_KITTY_CMD_OUTPUT_FILE"] == str(output_file)
+
+
+def test_quoted_template_placeholder_uses_env_without_double_quoting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    output_file = tmp_path / "parent with space" / "junit.xml"
+
+    with patch("specify_cli.configured_command.subprocess.run", return_value=_completed()) as run:
+        run_configured_command_template(
+            'runner --junitxml="{output_file}"',
+            {"output_file": output_file},
+            cwd=tmp_path,
+        )
+
+    args, kwargs = run.call_args
+    assert args[0] == ["sh", "-c", 'runner --junitxml="${SPEC_KITTY_CMD_OUTPUT_FILE}"']
+    assert kwargs["env"]["SPEC_KITTY_CMD_OUTPUT_FILE"] == str(output_file)


### PR DESCRIPTION
## Summary
- replace the two issue #630 `shell=True` call sites with a shared configured-command runner
- keep POSIX command compatibility via explicit `sh -c` argv without Python `shell=True`
- run Windows simple configured commands without `cmd.exe`; fail closed with clear evidence/sentinel behavior when POSIX shell syntax is configured
- substitute generated `{output_file}` through an environment variable so both quoted and unquoted templates handle spaces/metacharacters safely
- add focused unit coverage plus `windows_ci` regressions for baseline capture and acceptance matrix custom commands

Fixes #630

## Validation
- `uv run ruff check src/specify_cli/configured_command.py src/specify_cli/review/baseline.py src/specify_cli/acceptance/matrix.py tests/specify_cli/test_configured_command.py tests/lanes/test_acceptance_matrix.py tests/review/test_baseline.py`
- `uv run pytest tests/specify_cli/test_configured_command.py tests/lanes/test_acceptance_matrix.py tests/review/test_baseline.py -q` (`67 passed, 2 skipped`)
- `rg -n "shell=True|nosec B602|S602" src/specify_cli/review/baseline.py src/specify_cli/acceptance/matrix.py src/specify_cli/configured_command.py tests/specify_cli/test_configured_command.py tests/lanes/test_acceptance_matrix.py tests/review/test_baseline.py` (only helper docstring mentions remain)
