### PR TITLE
Fix idempotent squash merge retry

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -337,6 +337,101 @@ def _assert_merged_wps_reached_done(
         raise typer.Exit(1)
 
 
+def _reconcile_completed_wps_for_resume(
+    *,
+    feature_dir: Path,
+    merge_state: MergeState,
+    repo_root: Path,
+) -> set[str]:
+    """Return completed WPs that still have canonical done evidence on disk.
+
+    A retry can happen after the target ref advanced but before the final
+    status-event housekeeping commit. If the operator repairs the checkout
+    back to HEAD, state.json may still list a WP as completed even though its
+    uncommitted done event is gone. Drop those stale completions so the retry
+    re-emits done evidence instead of skipping the WP and failing validation.
+    """
+    if not merge_state.completed_wps:
+        return set()
+
+    confirmed = [
+        wp_id
+        for wp_id in merge_state.completed_wps
+        if _has_transition_to(feature_dir, wp_id, "done")
+    ]
+    if len(confirmed) != len(merge_state.completed_wps):
+        dropped = sorted(set(merge_state.completed_wps) - set(confirmed))
+        logger.info(
+            "Re-emitting done events for WPs whose resume state outlived on-disk evidence: %s",
+            ", ".join(dropped),
+        )
+        merge_state.completed_wps = confirmed
+        save_state(merge_state, repo_root)
+    return set(confirmed)
+
+
+def _refresh_primary_checkout_after_merge(repo_root: Path) -> None:
+    """Force the primary checkout's tracked files to match HEAD.
+
+    The target ref is advanced from a detached merge worktree, so the primary
+    checkout's index/worktree can lag behind the new HEAD. A path checkout does
+    not remove rename sources in sparse-checkout repos; hard reset does.
+    Merge preflight requires a clean tracked worktree before this point, so this
+    must only discard stale tracked state created by the ref update.
+    """
+    ret_reset, out_reset, err_reset = run_command(
+        ["git", "reset", "--hard", "HEAD"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    if ret_reset != 0:
+        console.print(
+            f"[yellow]Warning:[/yellow] post-merge working-tree refresh failed: "
+            f"{(err_reset or out_reset or '').strip()}"
+        )
+        return
+
+    ret_refresh, out_refresh, err_refresh = run_command(
+        ["git", "update-index", "--refresh"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    if ret_refresh != 0:
+        # Non-zero is expected when files truly differ from HEAD. The invariant
+        # check below is the contract; this refresh is just stat reconciliation.
+        logger.debug(
+            "post-merge index refresh reported divergence (this is informational): %s",
+            (out_refresh or err_refresh or "").strip(),
+        )
+
+
+def _paths_have_status_changes(repo_root: Path, paths: list[Path]) -> bool:
+    """Return True when any requested path differs from HEAD or is untracked."""
+    normalized: list[str] = []
+    for path in paths:
+        candidate = path
+        if candidate.is_absolute():
+            with contextlib.suppress(ValueError):
+                candidate = candidate.relative_to(repo_root)
+        normalized.append(str(candidate))
+
+    ret_status, out_status, err_status = run_command(
+        ["git", "status", "--porcelain", "--", *normalized],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    if ret_status != 0:
+        logger.warning(
+            "Could not inspect post-merge bookkeeping paths before commit: %s",
+            (err_status or "").strip(),
+        )
+        return True
+    return bool((out_status or "").strip())
+
+
 def _already_baked(merge_state: MergeState | None) -> bool:
     """Resume short-circuit predicate (T026 / FR-012).
 
@@ -1208,7 +1303,7 @@ def _run_lane_based_merge_locked(
     all_wp_ids = [wp for lane in lanes_manifest.lanes for wp in lane.wp_ids]
     state = load_state(main_repo, canonical_id)
     is_resume = False
-    if state is not None and state.completed_wps:
+    if state is not None:
         is_resume = True
         console.print(f"[bold cyan]Resuming[/bold cyan] merge for {mission_slug} ({len(state.completed_wps)}/{len(state.wp_order)} WPs already done)")
     else:
@@ -1308,7 +1403,14 @@ def _run_lane_based_merge_locked(
 
     # -- Mission-to-target merge (T010: honor strategy for this step only) --
     console.print(f"  [dim]Merging mission branch into {lanes_manifest.target_branch}...[/dim]")
-    mission_result = merge_mission_to_target(main_repo, mission_slug, lanes_manifest, strategy=strategy)
+    mission_result = merge_mission_to_target(
+        main_repo,
+        mission_slug,
+        lanes_manifest,
+        strategy=strategy,
+        allow_already_applied=is_resume,
+    )
+    mission_already_applied = getattr(mission_result, "already_applied", False) is True
     if not mission_result.success:
         # T005: tolerate already-merged on retry
         already_merged = any("already" in e.lower() or "up to date" in e.lower() for e in mission_result.errors)
@@ -1320,50 +1422,16 @@ def _run_lane_based_merge_locked(
             raise typer.Exit(1)
     else:
         console.print(f"\n[green]✓[/green] {lanes_manifest.mission_branch} → {lanes_manifest.target_branch}")
+        if mission_already_applied:
+            console.print("  [dim]Mission changes already present on target; continuing bookkeeping.[/dim]")
         if mission_result.commit:
             console.print(f"  Commit: {mission_result.commit[:7]}")
 
     # -- WP05/T006 FR-013: Post-merge working-tree refresh --
-    # Re-sync the primary checkout against HEAD so any paths that git left out
-    # (the observed legacy sparse-checkout case — Priivacy-ai/spec-kitty#588)
-    # are restored before we record done transitions and persist the final
-    # housekeeping commit. Running this refresh after writing status.events.jsonl
-    # would clobber the freshly-recorded done transitions back to HEAD.
-    # This is a no-op on a clean full checkout. Do not abort on failure: the
-    # WP01 commit-layer backstop is the final safety net.
-    _ret_checkout, _out_checkout, _err_checkout = run_command(
-        ["git", "checkout", "HEAD", "--", "."],
-        capture=True,
-        check_return=False,
-        cwd=main_repo,
-    )
-    if _ret_checkout != 0:
-        console.print(
-            f"[yellow]Warning:[/yellow] post-merge working-tree refresh failed: "
-            f"{(_err_checkout or '').strip()}"
-        )
-
-    # -- WP01/T003 FR-003: Refresh the index against on-disk reality --
-    # ``git checkout HEAD -- .`` restores file content to match HEAD, but the
-    # cached stat info in the index can still trail real on-disk state after
-    # worktree churn (mtime/inode changes), producing phantom ``D ``/`` M``
-    # entries in subsequent ``git status`` calls. ``git update-index
-    # --refresh`` reconciles the index stats with the working tree without
-    # touching any blobs. Treat divergence as informational — never fail.
-    _ret_refresh, _out_refresh, _err_refresh = run_command(
-        ["git", "update-index", "--refresh"],
-        capture=True,
-        check_return=False,
-        cwd=main_repo,
-    )
-    if _ret_refresh != 0:
-        # Non-zero is expected when files truly differ from HEAD (e.g.
-        # the two status files we are about to safe_commit). Log and move
-        # on — the working-tree invariant check below is the contract.
-        logger.debug(
-            "post-merge index refresh reported divergence (this is informational): %s",
-            (_out_refresh or _err_refresh or "").strip(),
-        )
+    # Re-sync the primary checkout against HEAD before done-event bookkeeping.
+    # A path checkout does not remove stale rename sources in sparse-checkout
+    # repos; the helper uses a tracked-file hard refresh instead.
+    _refresh_primary_checkout_after_merge(main_repo)
 
     baseline_meta_path = _record_baseline_merge_commit(
         feature_dir,
@@ -1384,6 +1452,11 @@ def _run_lane_based_merge_locked(
 
     # -- T001: Mark WPs done with per-WP state tracking --
     console.print("  [dim]Recording merged work packages as done...[/dim]")
+    completed_set = _reconcile_completed_wps_for_resume(
+        feature_dir=feature_dir,
+        merge_state=state,
+        repo_root=main_repo,
+    )
     for lane in lanes_manifest.lanes:
         for wp_id in lane.wp_ids:
             if wp_id in completed_set:
@@ -1462,26 +1535,31 @@ def _run_lane_based_merge_locked(
     if baseline_meta_path is not None:
         files_to_commit.append(baseline_meta_path)
 
-    try:
-        safe_commit(
-            repo_root=main_repo,
-            worktree_root=main_repo,
-            destination_ref=lanes_manifest.target_branch,
-            message=f"chore({mission_slug}): record done transitions for merged WPs",
-            paths=tuple(files_to_commit),
-        )
-    except Exception as exc:
-        if not (isinstance(exc, SafeCommitRecoveryFailed) and exc.commit_sha is not None):
-            with contextlib.suppress(OSError):
-                if _merge_events_path.exists():
-                    with _merge_events_path.open("ab") as _fh:
-                        _fh.truncate(_pre_done_event_size)
-            with contextlib.suppress(OSError):
-                if _pre_done_status_bytes is None:
-                    _merge_status_path.unlink(missing_ok=True)
-                else:
-                    _merge_status_path.write_bytes(_pre_done_status_bytes)
-        raise
+    has_bookkeeping_changes = _paths_have_status_changes(main_repo, files_to_commit)
+    may_skip_empty_bookkeeping = is_resume or mission_already_applied
+    if has_bookkeeping_changes or not may_skip_empty_bookkeeping:
+        try:
+            safe_commit(
+                repo_root=main_repo,
+                worktree_root=main_repo,
+                destination_ref=lanes_manifest.target_branch,
+                message=f"chore({mission_slug}): record done transitions for merged WPs",
+                paths=tuple(files_to_commit),
+            )
+        except Exception as exc:
+            if not (isinstance(exc, SafeCommitRecoveryFailed) and exc.commit_sha is not None):
+                with contextlib.suppress(OSError):
+                    if _merge_events_path.exists():
+                        with _merge_events_path.open("ab") as _fh:
+                            _fh.truncate(_pre_done_event_size)
+                with contextlib.suppress(OSError):
+                    if _pre_done_status_bytes is None:
+                        _merge_status_path.unlink(missing_ok=True)
+                    else:
+                        _merge_status_path.write_bytes(_pre_done_status_bytes)
+            raise
+    else:
+        console.print("  [dim]No post-merge bookkeeping changes to commit; continuing cleanup.[/dim]")
 
     console.print("  [dim]Syncing dossier state for the merged mission...[/dim]")
     trigger_feature_dossier_sync_if_enabled(

--- a/src/specify_cli/lanes/merge.py
+++ b/src/specify_cli/lanes/merge.py
@@ -47,6 +47,7 @@ class MissionMergeResult:
     mission_branch: str
     target_branch: str
     commit: str | None = None
+    already_applied: bool = False
     errors: list[str] = field(default_factory=list)
 
 
@@ -171,6 +172,7 @@ def merge_mission_to_target(
     lanes_manifest: LanesManifest | None = None,
     *,
     strategy: MergeStrategy = MergeStrategy.SQUASH,
+    allow_already_applied: bool = False,
 ) -> MissionMergeResult:
     """Merge the mission integration branch into the target branch (e.g., main).
 
@@ -207,7 +209,13 @@ def merge_mission_to_target(
 
     try:
         # T010: honor strategy for mission→target only; lane→mission is not touched
-        _merge_branch_into(repo_root, mission_branch, target_branch, strategy=strategy)
+        changed = _merge_branch_into(
+            repo_root,
+            mission_branch,
+            target_branch,
+            strategy=strategy,
+            allow_noop_squash=allow_already_applied,
+        )
     except RuntimeError as e:
         return MissionMergeResult(
             success=False, mission_branch=mission_branch,
@@ -215,11 +223,14 @@ def merge_mission_to_target(
         )
 
     # Get the merge commit.
-    commit = _rev_parse(repo_root, target_branch)
+    commit = _rev_parse(repo_root, target_branch) if changed else None
 
     return MissionMergeResult(
-        success=True, mission_branch=mission_branch,
-        target_branch=target_branch, commit=commit,
+        success=True,
+        mission_branch=mission_branch,
+        target_branch=target_branch,
+        commit=commit,
+        already_applied=not changed,
     )
 
 
@@ -292,7 +303,8 @@ def _merge_branch_into(
     target_branch: str,
     *,
     strategy: MergeStrategy = MergeStrategy.MERGE,
-) -> None:
+    allow_noop_squash: bool = False,
+) -> bool:
     """Merge source_branch into target_branch using a temporary worktree.
 
     Creates a detached worktree at the target branch tip, merges source
@@ -341,6 +353,28 @@ def _merge_branch_into(
                 raise RuntimeError(
                     f"Squash merge of {source_branch} into {target_branch} failed: "
                     f"{result.stderr.strip() or result.stdout.strip()}"
+                )
+            # Squash merges do not record ancestry. On retry after a previous
+            # successful squash, Git reports a clean index and a plain commit
+            # would fail in this detached worktree with "Not currently on any
+            # branch." Only explicit resume callers may treat that as
+            # idempotent success; ordinary callers need a real merge result.
+            staged = subprocess.run(
+                ["git", "diff", "--cached", "--quiet"],
+                cwd=str(tmp_path), capture_output=True, text=True,
+            )
+            if staged.returncode == 0:
+                if allow_noop_squash:
+                    return False
+                raise RuntimeError(
+                    f"Squash merge of {source_branch} into {target_branch} "
+                    "produced no changes; target may already contain this tree. "
+                    "Retry with merge resume if recovering an interrupted merge."
+                )
+            if staged.returncode not in (0, 1):
+                raise RuntimeError(
+                    f"Could not inspect squash merge result for {source_branch} "
+                    f"into {target_branch}: {staged.stderr.strip()}"
                 )
             # Commit the squashed result.
             result = subprocess.run(
@@ -399,7 +433,7 @@ def _merge_branch_into(
                     f"Failed to fast-forward {target_branch} after rebase: "
                     f"{result.stderr.strip()}"
                 )
-            return  # early return — ref already updated
+            return True  # early return — ref already updated
         else:
             # MERGE strategy (default for lane→mission): no-ff merge commit.
             result = subprocess.run(
@@ -432,6 +466,7 @@ def _merge_branch_into(
             raise RuntimeError(
                 f"Failed to update {target_branch} ref: {result.stderr.strip()}"
             )
+        return True
     finally:
         subprocess.run(
             ["git", "worktree", "remove", str(tmp_path), "--force"],

--- a/tests/integration/sparse_checkout/test_merge_refresh_and_invariant.py
+++ b/tests/integration/sparse_checkout/test_merge_refresh_and_invariant.py
@@ -11,7 +11,7 @@ violation and must raise a merge-specific error.
 
 These tests drive ``_run_lane_based_merge_locked`` indirectly through
 ``_run_lane_based_merge`` with the heavy merge helpers patched out, so we can
-verify the two git subprocess calls (``git checkout HEAD -- .`` and
+verify the two git subprocess calls (``git reset --hard HEAD`` and
 ``git status --porcelain``) fire between ``merge_mission_to_target`` and
 ``safe_commit``.
 """
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 
 from specify_cli.cli.commands.merge import _run_lane_based_merge
 from specify_cli.merge.config import MergeStrategy
@@ -86,8 +87,8 @@ class TestPostMergeRefreshAndInvariant:
 
         def fake_run_command(cmd, *args, **kwargs):  # noqa: ANN001
             ordered_calls.append(("run_command", tuple(cmd)))
-            if "checkout" in cmd and "HEAD" in cmd:
-                call_log.append("checkout_refresh")
+            if "reset" in cmd and "--hard" in cmd and "HEAD" in cmd:
+                call_log.append("hard_refresh")
                 return (0, "", "")
             if "status" in cmd and "--porcelain" in cmd:
                 call_log.append("status_check")
@@ -147,9 +148,9 @@ class TestPostMergeRefreshAndInvariant:
                 strategy=MergeStrategy.SQUASH,
             )
 
-        # Required ordering: checkout_refresh → mark_done → status_check → safe_commit.
-        assert "checkout_refresh" in call_log, (
-            f"FR-013: post-merge `git checkout HEAD -- .` must fire; call_log={call_log}"
+        # Required ordering: hard_refresh → mark_done → status_check → safe_commit.
+        assert "hard_refresh" in call_log, (
+            f"FR-013: post-merge `git reset --hard HEAD` must fire; call_log={call_log}"
         )
         assert "mark_done" in call_log, "Merged WPs must be recorded as done after refresh"
         assert "status_check" in call_log, (
@@ -157,7 +158,7 @@ class TestPostMergeRefreshAndInvariant:
         )
         assert "safe_commit" in call_log, "safe_commit must still fire after refresh/invariant"
 
-        refresh_idx = call_log.index("checkout_refresh")
+        refresh_idx = call_log.index("hard_refresh")
         mark_done_idx = call_log.index("mark_done")
         status_idx = call_log.index("status_check")
         commit_idx = call_log.index("safe_commit")
@@ -187,8 +188,8 @@ class TestPostMergeRefreshAndInvariant:
         call_log: list[str] = []
 
         def fake_run_command(cmd, *args, **kwargs):  # noqa: ANN001
-            if "checkout" in cmd and "HEAD" in cmd:
-                call_log.append("checkout_refresh")
+            if "reset" in cmd and "--hard" in cmd and "HEAD" in cmd:
+                call_log.append("hard_refresh")
                 return (0, "", "")
             if "status" in cmd and "--porcelain" in cmd:
                 call_log.append("status_check")
@@ -202,8 +203,6 @@ class TestPostMergeRefreshAndInvariant:
         def fake_safe_commit(**kwargs):  # noqa: ANN001
             call_log.append("safe_commit")
             return True
-
-        import click
 
         with (
             patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
@@ -239,7 +238,7 @@ class TestPostMergeRefreshAndInvariant:
             policy.merge_gates = []
             mock_policy.return_value = policy
 
-            with pytest.raises(click.exceptions.Exit):
+            with pytest.raises(typer.Exit):
                 _run_lane_based_merge(
                     repo_root=tmp_path,
                     mission_slug=slug,

--- a/tests/integration/test_merge_resume.py
+++ b/tests/integration/test_merge_resume.py
@@ -19,6 +19,7 @@ Pins two contracts on resume:
 from __future__ import annotations
 
 import contextlib
+import json
 import subprocess
 import time
 from pathlib import Path
@@ -67,6 +68,28 @@ def _make_manifest(slug: str, lane_count: int = 10) -> MagicMock:
         lanes.append(lane)
     manifest.lanes = lanes
     return manifest
+
+
+def _write_done_events(feature_dir: Path, wp_ids: list[str]) -> None:
+    events = []
+    for wp_id in wp_ids:
+        events.append(
+            json.dumps(
+                {
+                    "event_id": f"01TEST{wp_id}",
+                    "mission_slug": feature_dir.name,
+                    "wp_id": wp_id,
+                    "from_lane": "approved",
+                    "to_lane": "done",
+                    "at": "2026-04-06T12:00:00+00:00",
+                    "actor": "merge",
+                    "force": False,
+                    "execution_mode": "worktree",
+                },
+                sort_keys=True,
+            )
+        )
+    (feature_dir / "status.events.jsonl").write_text("\n".join(events) + "\n", encoding="utf-8")
 
 
 def _patches(
@@ -143,6 +166,7 @@ class TestMergeResumeIdempotence:
         feature_dir.mkdir(parents=True)
 
         manifest = _make_manifest(slug, lane_count=3)
+        _write_done_events(feature_dir, ["WP01", "WP02", "WP03"])
 
         # State says all three WPs are completed already.
         existing = MergeState(
@@ -216,6 +240,7 @@ class TestMergeResumeAfterInterruption:
         feature_dir.mkdir(parents=True)
 
         manifest = _make_manifest(slug, lane_count=3)
+        _write_done_events(feature_dir, ["WP01"])
         # WP01 completed; WP02 and WP03 remaining.
         existing = MergeState(
             mission_id=slug,

--- a/tests/integration/test_post_merge_index_refresh.py
+++ b/tests/integration/test_post_merge_index_refresh.py
@@ -149,7 +149,7 @@ class TestPostMergeIndexRefresh:
         refresh_calls = [c for c in call_log if c[:2] == ("git", "update-index") or "update-index" in c]
         assert refresh_calls, (
             "FR-003 regression: merge did not invoke `git update-index --refresh`. "
-            "After post-merge `git checkout HEAD -- .`, the index stat cache must "
+            "After post-merge `git reset --hard HEAD`, the index stat cache must "
             "be reconciled against the working tree to prevent phantom deletions."
         )
 
@@ -158,8 +158,8 @@ class TestPostMergeIndexRefresh:
             "update-index" in c and "--refresh" in c for c in call_log
         ), f"Did not see `git update-index --refresh`: {call_log!r}"
 
-    def test_refresh_runs_after_checkout_before_status_check(self, tmp_path: Path) -> None:
-        """Order matters: the refresh must run AFTER `checkout HEAD -- .` and
+    def test_refresh_runs_after_hard_reset_before_status_check(self, tmp_path: Path) -> None:
+        """Order matters: the refresh must run AFTER `reset --hard HEAD` and
         BEFORE the post-merge `git status --porcelain` invariant check, so
         the invariant assertion sees a clean stat-cache."""
         slug = "test-index-refresh-order"
@@ -172,16 +172,16 @@ class TestPostMergeIndexRefresh:
                     return i
             return -1
 
-        checkout_idx = _idx(lambda cmd: "checkout" in cmd and "HEAD" in cmd and "--" in cmd)
+        hard_reset_idx = _idx(lambda cmd: "reset" in cmd and "--hard" in cmd and "HEAD" in cmd)
         refresh_idx = _idx(lambda cmd: "update-index" in cmd and "--refresh" in cmd)
         status_idx = _idx(lambda cmd: "status" in cmd and "--porcelain" in cmd)
 
-        assert checkout_idx >= 0 and refresh_idx >= 0 and status_idx >= 0, (
-            f"Missing one of checkout/refresh/status in call log: {call_log!r}"
+        assert hard_reset_idx >= 0 and refresh_idx >= 0 and status_idx >= 0, (
+            f"Missing one of hard-reset/refresh/status in call log: {call_log!r}"
         )
-        assert checkout_idx < refresh_idx < status_idx, (
-            f"Wrong order: checkout={checkout_idx}, refresh={refresh_idx}, "
-            f"status={status_idx}. Expected checkout < refresh < status. "
+        assert hard_reset_idx < refresh_idx < status_idx, (
+            f"Wrong order: hard_reset={hard_reset_idx}, refresh={refresh_idx}, "
+            f"status={status_idx}. Expected hard reset < refresh < status. "
             f"Full log: {call_log!r}"
         )
 

--- a/tests/integration/test_post_merge_unrelated_untracked.py
+++ b/tests/integration/test_post_merge_unrelated_untracked.py
@@ -20,8 +20,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
+import typer
 
 from specify_cli.cli.commands.merge import (
     _classify_porcelain_lines,
@@ -259,7 +259,7 @@ class TestMergeToleratesUntrackedFiles:
             policy.merge_gates = []
             mocks[12].return_value = policy
 
-            with pytest.raises(click.exceptions.Exit):
+            with pytest.raises(typer.Exit):
                 _run_lane_based_merge(
                     repo_root=tmp_path,
                     mission_slug=slug,

--- a/tests/lanes/test_merge.py
+++ b/tests/lanes/test_merge.py
@@ -11,6 +11,7 @@ from specify_cli.lanes.merge import (
     merge_mission_to_target,
 )
 from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.merge.config import MergeStrategy
 
 pytestmark = pytest.mark.git_repo
 
@@ -164,6 +165,93 @@ class TestMergeMissionToTarget:
         assert result.success is True
         assert result.commit is not None
         assert result.target_branch == "main"
+
+    def test_squash_noop_fails_without_resume_permission(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        manifest = _make_manifest()
+
+        _run(["git", "branch", "kitty/mission-010-feat"], repo)
+        _run(["git", "checkout", "kitty/mission-010-feat"], repo)
+        _commit(repo, "src/feature.py", "feature\n", "feature work")
+        _run(["git", "checkout", "main"], repo)
+
+        first = merge_mission_to_target(
+            repo,
+            "010-feat",
+            manifest,
+            strategy=MergeStrategy.SQUASH,
+        )
+        commits_after_first = subprocess.run(
+            ["git", "rev-list", "--count", "main"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        retry = merge_mission_to_target(
+            repo,
+            "010-feat",
+            manifest,
+            strategy=MergeStrategy.SQUASH,
+        )
+        commits_after_retry = subprocess.run(
+            ["git", "rev-list", "--count", "main"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        assert first.success is True
+        assert retry.success is False
+        assert "produced no changes" in retry.errors[0]
+        assert commits_after_retry == commits_after_first
+
+    def test_squash_retry_is_idempotent_when_resume_allows_already_applied(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        manifest = _make_manifest()
+
+        _run(["git", "branch", "kitty/mission-010-feat"], repo)
+        _run(["git", "checkout", "kitty/mission-010-feat"], repo)
+        _commit(repo, "src/feature.py", "feature\n", "feature work")
+        _run(["git", "checkout", "main"], repo)
+
+        first = merge_mission_to_target(
+            repo,
+            "010-feat",
+            manifest,
+            strategy=MergeStrategy.SQUASH,
+        )
+        commits_after_first = subprocess.run(
+            ["git", "rev-list", "--count", "main"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        retry = merge_mission_to_target(
+            repo,
+            "010-feat",
+            manifest,
+            strategy=MergeStrategy.SQUASH,
+            allow_already_applied=True,
+        )
+        commits_after_retry = subprocess.run(
+            ["git", "rev-list", "--count", "main"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        assert first.success is True
+        assert retry.success is True
+        assert retry.already_applied is True
+        assert retry.commit is None
+        assert retry.errors == []
+        assert commits_after_retry == commits_after_first
 
     def test_merge_self_heals_event_log_merge_driver_config(self, tmp_path):
         repo = _make_repo(tmp_path)

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock
 
-import click
 import pytest
+import typer
 
 from specify_cli.cli.commands.merge import (
     _assert_merged_wps_reached_done,
@@ -222,5 +222,5 @@ def test_assert_merged_wps_reached_done_fails_when_wp_not_done(
         lambda _feature_dir, wp_id: lanes[wp_id],
     )
 
-    with pytest.raises(click.exceptions.Exit):
+    with pytest.raises(typer.Exit):
         _assert_merged_wps_reached_done(tmp_path, "021-test", ["WP01", "WP02"])

--- a/tests/merge/test_merge_post_merge_invariant.py
+++ b/tests/merge/test_merge_post_merge_invariant.py
@@ -9,9 +9,15 @@ Exercises _classify_porcelain_lines() to verify that:
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
-from specify_cli.cli.commands.merge import _classify_porcelain_lines
+from specify_cli.cli.commands.merge import (
+    _classify_porcelain_lines,
+    _refresh_primary_checkout_after_merge,
+)
 
 pytestmark = pytest.mark.fast
 
@@ -96,3 +102,57 @@ def test_classify_multiple_untracked_directories() -> None:
     offending, skipped = _classify_porcelain_lines(lines, set())
     assert offending == []
     assert skipped == 7
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_refresh_primary_checkout_removes_sparse_rename_source(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    old_path = repo / "scripts" / "google" / "authorize-calendar.py"
+    new_path = repo / "docs" / "archive" / "scripts" / "authorize-calendar.py"
+    old_path.parent.mkdir(parents=True)
+    old_path.write_text("authorize\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+
+    _git(repo, "sparse-checkout", "init", "--no-cone")
+    (repo / ".git" / "info" / "sparse-checkout").write_text("/*\n", encoding="utf-8")
+    _git(repo, "read-tree", "-mu", "HEAD")
+
+    _git(repo, "switch", "-c", "kitty/mission-rename")
+    new_path.parent.mkdir(parents=True, exist_ok=True)
+    _git(repo, "mv", "scripts/google/authorize-calendar.py", "docs/archive/scripts/authorize-calendar.py")
+    _git(repo, "commit", "-m", "rename script")
+    _git(repo, "switch", "main")
+
+    new_tree = _git(repo, "rev-parse", "kitty/mission-rename^{tree}").stdout.strip()
+    new_commit = _git(repo, "commit-tree", new_tree, "-p", "main", "-m", "squash").stdout.strip()
+    _git(repo, "update-ref", "refs/heads/main", new_commit)
+
+    checkout_only = subprocess.run(
+        ["git", "checkout", "HEAD", "--", "."],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert checkout_only.returncode == 0
+    assert "A  scripts/google/authorize-calendar.py" in _git(repo, "status", "--porcelain").stdout
+
+    _refresh_primary_checkout_after_merge(repo)
+
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert not old_path.exists()
+    assert new_path.exists()

--- a/tests/merge/test_merge_recovery.py
+++ b/tests/merge/test_merge_recovery.py
@@ -302,6 +302,76 @@ class TestEventDedupGuard:
         assert _has_transition_to(feature_dir, "WP01", "done") is False
         assert _has_transition_to(feature_dir, "WP02", "done") is True
 
+    def test_reconcile_completed_wps_drops_missing_done_evidence(self, tmp_path: Path):
+        """Resume state cannot skip a WP when its uncommitted done event was lost."""
+        from specify_cli.cli.commands.merge import _reconcile_completed_wps_for_resume
+
+        feature_dir = tmp_path / "kitty-specs" / MISSION_ID
+        feature_dir.mkdir(parents=True)
+        state = MergeState(
+            mission_id=MISSION_ID,
+            mission_slug=MISSION_ID,
+            target_branch="main",
+            wp_order=["WP01"],
+            completed_wps=["WP01"],
+        )
+        save_state(state, tmp_path)
+
+        confirmed = _reconcile_completed_wps_for_resume(
+            feature_dir=feature_dir,
+            merge_state=state,
+            repo_root=tmp_path,
+        )
+
+        assert confirmed == set()
+        loaded = load_state(tmp_path, MISSION_ID)
+        assert loaded is not None
+        assert loaded.completed_wps == []
+
+    def test_reconcile_completed_wps_keeps_existing_done_evidence(self, tmp_path: Path):
+        """Resume state remains complete when the canonical done event survived."""
+        from specify_cli.cli.commands.merge import _reconcile_completed_wps_for_resume
+
+        feature_dir = tmp_path / "kitty-specs" / MISSION_ID
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "status.events.jsonl").write_text(
+            json.dumps(
+                {
+                    "event_id": "01TESTDONE",
+                    "mission_slug": MISSION_ID,
+                    "wp_id": "WP01",
+                    "from_lane": "approved",
+                    "to_lane": "done",
+                    "at": "2026-04-06T12:00:00+00:00",
+                    "actor": "merge",
+                    "force": False,
+                    "execution_mode": "worktree",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        state = MergeState(
+            mission_id=MISSION_ID,
+            mission_slug=MISSION_ID,
+            target_branch="main",
+            wp_order=["WP01"],
+            completed_wps=["WP01"],
+        )
+        save_state(state, tmp_path)
+
+        confirmed = _reconcile_completed_wps_for_resume(
+            feature_dir=feature_dir,
+            merge_state=state,
+            repo_root=tmp_path,
+        )
+
+        assert confirmed == {"WP01"}
+        loaded = load_state(tmp_path, MISSION_ID)
+        assert loaded is not None
+        assert loaded.completed_wps == ["WP01"]
+
 
 # ---------------------------------------------------------------------------
 # T004: Resume / Abort


### PR DESCRIPTION
## Summary
- Treat a no-op `git merge --squash` as idempotent success instead of trying to commit from a detached temp worktree
- Add regression coverage for retrying mission-to-target squash after the target tree already contains the mission changes

Closes #1039

## Validation
- `uv run pytest tests/lanes/test_merge.py -q`
- `uv run pytest tests/merge/test_merge_recovery.py tests/merge/test_merge_post_merge_invariant.py tests/integration/test_merge_resume.py -q`
- `uv run ruff check src/specify_cli/lanes/merge.py tests/lanes/test_merge.py`
- `git diff --check`