### PR TITLE
Fix finalize-tasks dependency source precedence

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -154,6 +154,20 @@ def _owned_files_yaml_is_explicit_empty_list(wp_raw_content: str) -> bool:
     return bool(_EXPLICIT_EMPTY_OWNED_FILES_RE.search(frontmatter))
 
 
+def _raw_frontmatter_has_field(wp_raw_content: str, field_name: str) -> bool:
+    """Return True when raw WP frontmatter explicitly declares ``field_name``."""
+    if not wp_raw_content.startswith("---"):
+        return False
+    parts = wp_raw_content.split("---", 2)
+    if len(parts) < 3:
+        return False
+    return re.search(
+        rf"^\s*{re.escape(field_name)}\s*:",
+        parts[1],
+        re.MULTILINE,
+    ) is not None
+
+
 def _invalid_kitty_specs_owned_files(
     frontmatter_by_wp: dict[str, WPMetadata],
 ) -> list[dict[str, str]]:
@@ -1924,11 +1938,14 @@ def finalize_tasks(
             raise typer.Exit(1)
 
         # ─── TIER 1+: existing dependency resolution ──────────────────────────
-        # Parse dependencies and requirement refs using 2-tier priority:
-        # 1. WP frontmatter (primary — map-requirements writes here directly)
-        # 2. tasks.md text parsing (backward compat for pre-API projects)
+        # Parse dependencies and requirement refs using 3-tier priority:
+        # 1. wps.yaml manifest when present
+        # 2. explicit WP frontmatter dependencies (including explicit [])
+        # 3. tasks.md text parsing as a legacy fallback only when frontmatter
+        #    lacks the dependencies field entirely
         tasks_md = feature_dir / TASKS_MD_FILENAME
         wp_dependencies: dict[str, list[str]] = {}
+        tasks_md_dependencies: dict[str, list[str]] = {}
         wp_requirement_refs: dict[str, list[str]] = {}
 
         if wps_manifest is not None:
@@ -1943,13 +1960,14 @@ def finalize_tasks(
         wp_requirement_refs = _parse_requirement_refs_from_wp_files(wp_files)
 
         if wps_manifest is None and tasks_md.exists():
-            # Read tasks.md and parse dependency mapping (always needed)
+            # Read tasks.md and parse dependency mapping for legacy WP files
+            # that do not yet carry dependencies in frontmatter.
             tasks_content = tasks_md.read_text(encoding="utf-8")
             from specify_cli.core.dependency_parser import parse_dependencies_from_tasks_md as _shared_parse_deps
 
-            wp_dependencies = _shared_parse_deps(tasks_content)
-            missing_wp_sections = [wp_id for wp_id in expected_wp_ids if wp_id not in wp_dependencies]
-            extra_wp_sections = sorted(set(wp_dependencies) - set(expected_wp_ids))
+            tasks_md_dependencies = _shared_parse_deps(tasks_content)
+            missing_wp_sections = [wp_id for wp_id in expected_wp_ids if wp_id not in tasks_md_dependencies]
+            extra_wp_sections = sorted(set(tasks_md_dependencies) - set(expected_wp_ids))
             if missing_wp_sections or extra_wp_sections:
                 error_msg = (
                     "tasks.md work package coverage is incomplete. "
@@ -1978,6 +1996,18 @@ def finalize_tasks(
             for wp_id, refs in tasks_md_refs.items():
                 if refs and not wp_requirement_refs.get(wp_id):
                     wp_requirement_refs[wp_id] = refs
+
+            for wp_file in wp_files:
+                wp_id_match = re.match(r"^(WP\d{2})(?:[-_.]|$)", wp_file.name)
+                if not wp_id_match:
+                    continue
+                wp_id = wp_id_match.group(1)
+                raw_content = wp_file.read_text(encoding="utf-8")
+                wp_meta, _ = read_wp_frontmatter(wp_file)
+                if _raw_frontmatter_has_field(raw_content, "dependencies"):
+                    wp_dependencies[wp_id] = list(wp_meta.dependencies)
+                else:
+                    wp_dependencies[wp_id] = list(tasks_md_dependencies.get(wp_id, []))
 
         # Validate dependencies (detect cycles, invalid references)
         if wp_dependencies:
@@ -2124,14 +2154,8 @@ def finalize_tasks(
 
             # Detect whether dependencies field exists in raw frontmatter
             raw_content = wp_file.read_text(encoding="utf-8")
-            has_dependencies_line = False
-            has_requirement_refs_line = False
-            if raw_content.startswith("---"):
-                parts = raw_content.split("---", 2)
-                if len(parts) >= 3:
-                    frontmatter_text = parts[1]
-                    has_dependencies_line = re.search(r"^\s*dependencies\s*:", frontmatter_text, re.MULTILINE) is not None
-                    has_requirement_refs_line = re.search(r"^\s*requirement_refs\s*:", frontmatter_text, re.MULTILINE) is not None
+            has_dependencies_line = _raw_frontmatter_has_field(raw_content, "dependencies")
+            has_requirement_refs_line = _raw_frontmatter_has_field(raw_content, "requirement_refs")
 
             # Read current frontmatter (typed)
             try:

--- a/src/specify_cli/lanes/compute.py
+++ b/src/specify_cli/lanes/compute.py
@@ -170,14 +170,21 @@ def _transitive_deps(
     Returns a mapping of WP ID → set of all WPs it transitively depends on.
     """
     cache: dict[str, set[str]] = {}
+    visiting: set[str] = set()
 
     def _reach(wp_id: str) -> set[str]:
         if wp_id in cache:
             return cache[wp_id]
+        if wp_id in visiting:
+            return set()
+        visiting.add(wp_id)
         direct = set(dependency_graph.get(wp_id, []))
         result: set[str] = set(direct)
-        for dep in direct:
-            result.update(_reach(dep))
+        try:
+            for dep in direct:
+                result.update(_reach(dep))
+        finally:
+            visiting.discard(wp_id)
         cache[wp_id] = result
         return result
 
@@ -191,6 +198,8 @@ def _count_independent_collapses(
     dependency_graph: dict[str, list[str]],
 ) -> int:
     """Count events where wp_a and wp_b have no direct or transitive dependency relationship."""
+    if not events:
+        return 0
     transitive = _transitive_deps(dependency_graph)
     count = 0
     for event in events:

--- a/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
+++ b/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
@@ -438,11 +438,19 @@ class TestWP01Regressions:
                 continue
         pytest.fail("No JSON output with 'result': 'validation_passed' found")
 
-    def test_non_empty_disagreement_fails(self, tmp_path: Path) -> None:
-        """Non-empty dep disagreement between tasks.md and frontmatter → exit 1."""
+    def test_explicit_frontmatter_dependencies_beat_tasks_md_parser(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Explicit WP frontmatter deps are authoritative over tasks.md prose."""
         mission_slug = "060-test-feature"
-        # WP02 frontmatter says [WP99] but tasks.md says "Depends on WP01"
-        _setup_feature_with_existing_deps(tmp_path, mission_slug, wp02_existing_deps=["WP99"])
+        # WP02 frontmatter says [] but tasks.md says "Depends on WP01".
+        _setup_feature_with_existing_deps(
+            tmp_path,
+            mission_slug,
+            wp02_existing_deps=[],
+        )
 
         patches = _common_patches(tmp_path, mission_slug)
         patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(return_value=_make_bootstrap_result())
@@ -452,16 +460,63 @@ class TestWP01Regressions:
         ctx_patches = {k: patch(k, v) for k, v in patches.items()}
         for p in ctx_patches.values():
             p.start()
-        exit_code = None
         try:
-            finalize_tasks(feature=mission_slug, json_output=False, validate_only=False)
-        except (typer.Exit, SystemExit) as exc:
-            exit_code = getattr(exc, "code", 1) or 1
+            finalize_tasks(feature=mission_slug, json_output=True, validate_only=False)
         finally:
             for p in ctx_patches.values():
                 p.stop()
 
-        assert exit_code == 1, "Dependency disagreement must exit with code 1"
+        captured = capsys.readouterr()
+        for line in captured.out.strip().splitlines():
+            try:
+                data = json.loads(line)
+                if data.get("result") == "success":
+                    assert data["dependencies_parsed"]["WP02"] == []
+                    return
+            except json.JSONDecodeError:
+                continue
+        pytest.fail("No JSON success payload found")
+
+    def test_explicit_empty_frontmatter_ignores_tasks_md_cycle(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Explicit dependencies: [] must not be overwritten by parsed back-edges."""
+        mission_slug = "060-test-feature"
+        feature_dir = _setup_feature(tmp_path, mission_slug)
+        (feature_dir / "tasks.md").write_text(
+            "# Tasks\n\n"
+            "## WP01\n\n**Dependencies**: WP02\n\n"
+            "## WP02\n\n**Dependencies**: WP01\n",
+            encoding="utf-8",
+        )
+
+        patches = _common_patches(tmp_path, mission_slug)
+        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(return_value=_make_bootstrap_result())
+
+        from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+        ctx_patches = {k: patch(k, v) for k, v in patches.items()}
+        for p in ctx_patches.values():
+            p.start()
+        try:
+            finalize_tasks(feature=mission_slug, json_output=True, validate_only=True)
+        finally:
+            for p in ctx_patches.values():
+                p.stop()
+
+        captured = capsys.readouterr()
+        for line in captured.out.strip().splitlines():
+            try:
+                data = json.loads(line)
+                if data.get("result") == "validation_passed":
+                    assert data["would_modify"]
+                    assert "Circular dependencies detected" not in captured.out
+                    return
+            except json.JSONDecodeError:
+                continue
+        pytest.fail("No JSON validation payload found")
 
     def test_empty_parse_preserves_existing_deps(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """When parser finds no deps but frontmatter has deps, preserve existing."""

--- a/tests/specify_cli/lanes/test_compute_lane_depths_cycle_safety.py
+++ b/tests/specify_cli/lanes/test_compute_lane_depths_cycle_safety.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import pytest
 
-from specify_cli.lanes.compute import _compute_lane_depths
+from specify_cli.lanes.compute import _compute_lane_depths, compute_lanes
 from specify_cli.lanes.models import ExecutionLane
+from specify_cli.ownership.models import ExecutionMode, OwnershipManifest
 
 
 pytestmark = [pytest.mark.fast]
@@ -84,3 +85,26 @@ def test_independent_lanes_get_depth_zero():
     }
     depths = _compute_lane_depths(lanes, lane_deps)
     assert depths == {"lane-a": 0, "lane-b": 0, "lane-c": 0}
+
+
+def test_compute_lanes_cycle_does_not_recurse_when_no_collapses():
+    """A lane-level cycle with no collapse events must not hit RecursionError."""
+    graph = {"WP01": ["WP02"], "WP02": ["WP01"]}
+    manifests = {
+        "WP01": OwnershipManifest(
+            execution_mode=ExecutionMode.CODE_CHANGE,
+            owned_files=("src/a/**",),
+            authoritative_surface="src/a/",
+        ),
+        "WP02": OwnershipManifest(
+            execution_mode=ExecutionMode.CODE_CHANGE,
+            owned_files=("src/b/**",),
+            authoritative_surface="src/b/",
+        ),
+    }
+
+    result = compute_lanes(graph, manifests, "cycle-demo")
+
+    assert {lane.wp_ids[0] for lane in result.lanes} == {"WP01", "WP02"}
+    assert result.collapse_report is not None
+    assert result.collapse_report.independent_wps_collapsed == 0


### PR DESCRIPTION
## Summary
- make explicit WP frontmatter `dependencies` authoritative for legacy finalize-tasks flows
- use `tasks.md` dependency parsing only as fallback when frontmatter lacks the field
- harden lane collapse accounting so cyclic lane graphs do not recurse while computing collapse reports

Fixes #1117
Fixes #1096

## Validation
- `uv run pytest tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py tests/specify_cli/lanes/test_compute_lane_depths_cycle_safety.py tests/agent/test_dependency_graph.py tests/tasks/test_finalize_tasks_lanes_disjoint_fan_in.py`
- `uv run pytest tests/tasks/test_finalize_tasks_json_output_unit.py tests/tasks/test_finalize_tasks_wps_yaml_unit.py tests/core/test_dependency_parser.py tests/lanes/test_compute.py`
- `uv run ruff check src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/agent/tasks.py src/specify_cli/lanes/compute.py tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py tests/specify_cli/lanes/test_compute_lane_depths_cycle_safety.py`