### PR TITLE
ci: use Node 24 GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
           cat release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: release-notes.md


### PR DESCRIPTION
## Summary
- update the release workflow to use softprops/action-gh-release v3.0.0, which runs on Node 24
- removes the Node 20 deprecation warning seen during the v3.2.0rc29 release run

## Validation
- verified softprops/action-gh-release v3.0.0 action.yml declares runs.using: node24 via GitHub API
- main CI for v3.2.0rc29 is green after rerunning the transient macOS timing shard