### PR TITLE
docs: add PlanBridge artifact review guide

### DIFF
--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2525,6 +2525,16 @@
   current_target: true
   citation_refs: []
   notes: How-to; provisional current — confirm in WP08 IA review.
+- path: docs/how-to/review-artifacts-with-planbridge.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: C
+  current_target: true
+  citation_refs:
+    - https://plan.contextbridge.ai/recipes/spec-kitty/
+    - https://plan.contextbridge.ai/install/
+    - https://github.com/contextbridge/planbridge
+  notes: How-to; external PlanBridge review recipe for Spec Kitty planning artifacts.
 - path: docs/how-to/review-work-package.md
   tag: current
   divio_type: how-to

--- a/docs/how-to/review-artifacts-with-planbridge.md
+++ b/docs/how-to/review-artifacts-with-planbridge.md
@@ -1,0 +1,109 @@
+# Review Spec Kitty Artifacts with PlanBridge
+
+Use this guide when you want inline browser comments on the `spec.md`, `plan.md`, and `tasks.md` files that Spec Kitty creates before implementation begins.
+
+## Overview
+
+[PlanBridge](https://plan.contextbridge.ai/) opens agent plans or local markdown files in a local browser review UI. You highlight text, add comments, approve or request changes, and the feedback returns to your coding harness so the agent can revise the artifact.
+
+Spec Kitty writes planning artifacts under `kitty-specs/<feature>/`:
+
+- `kitty-specs/<feature>/spec.md` after `/spec-kitty.specify`
+- `kitty-specs/<feature>/plan.md` after `/spec-kitty.plan`
+- `kitty-specs/<feature>/tasks.md` after `/spec-kitty.tasks`
+
+Spec Kitty already has `/spec-kitty.review` for completed code. PlanBridge complements that upstream by reviewing the spec, plan, and task markdown before code is written.
+
+## Install
+
+Install PlanBridge from [plan.contextbridge.ai](https://plan.contextbridge.ai/install/) or from the [contextbridge/planbridge GitHub repository](https://github.com/contextbridge/planbridge).
+
+The shortest install path is:
+
+```bash
+/bin/sh -c "$(curl -fsSL https://downloads.contextbridge.ai/cli/install.sh)"
+```
+
+For a manual install with Homebrew:
+
+```bash
+brew install contextbridge/tap/cli
+contextbridge install
+```
+
+Verify the install:
+
+```bash
+contextbridge --version
+contextbridge install status
+```
+
+Codex CLI users may need to trust newly installed hooks before PlanBridge can open inside Codex. Follow the PlanBridge Codex setup notes after `contextbridge install`.
+
+## Manual
+
+After `/spec-kitty.specify`, open the generated spec for review.
+
+Claude Code:
+
+```text
+/planbridge-open the spec you just wrote
+```
+
+Codex CLI:
+
+```text
+$planbridge-open the spec you just wrote
+```
+
+The agent resolves the path under `kitty-specs/<feature>/`, sends the markdown to PlanBridge, and revises from your inline comments.
+
+Do the same after `/spec-kitty.plan` and `/spec-kitty.tasks`.
+
+Claude Code:
+
+```text
+/planbridge-open kitty-specs/my-feature/plan.md
+/planbridge-open kitty-specs/my-feature/tasks.md
+```
+
+Codex CLI:
+
+```text
+$planbridge-open kitty-specs/my-feature/plan.md
+$planbridge-open kitty-specs/my-feature/tasks.md
+```
+
+## Automatic
+
+To review each artifact without asking, append a snippet to your global agent instructions.
+
+Claude Code:
+
+```bash
+cat <<'EOF' >> ~/.claude/CLAUDE.md
+
+## Spec Kitty + PlanBridge
+When `/spec-kitty.specify`, `/spec-kitty.plan`, or `/spec-kitty.tasks` creates a file in `kitty-specs/<feature>/`, open that file with `/planbridge-open`. Use the returned annotations as review feedback, revise the artifact, and only then continue to the next Spec Kitty phase.
+
+EOF
+```
+
+Codex CLI:
+
+```bash
+cat <<'EOF' >> ~/.codex/AGENTS.md
+
+## Spec Kitty + PlanBridge
+When `/spec-kitty.specify`, `/spec-kitty.plan`, or `/spec-kitty.tasks` creates a file in `kitty-specs/<feature>/`, open that file with `$planbridge-open`. Use the returned annotations as review feedback, revise the artifact, and only then continue to the next Spec Kitty phase.
+
+EOF
+```
+
+## See Also
+
+- [Create a Specification](create-specification.md)
+- [Create a Plan](create-plan.md)
+- [Generate Tasks](generate-tasks.md)
+- [Review Work Packages](review-work-package.md)
+- [PlanBridge Spec Kitty recipe](https://plan.contextbridge.ai/recipes/spec-kitty/)

--- a/docs/how-to/toc.yml
+++ b/docs/how-to/toc.yml
@@ -18,6 +18,8 @@
   href: harnesses/
 - name: Set Up Codex Launcher
   href: setup-codex-spec-kitty-launcher.md
+- name: Review Artifacts with PlanBridge
+  href: review-artifacts-with-planbridge.md
 - name: Create a Specification
   href: create-specification.md
 - name: Keep Main Clean


### PR DESCRIPTION
## Summary
- add a how-to guide for using PlanBridge to review Spec Kitty spec, plan, and task artifacts
- link PlanBridge install/source locations and mirror the manual/automatic recipe commands
- add the page to the How-To TOC and docs inventory

## Verification
- docfx docfx.json (from docs/) — passes; existing unrelated InvalidFileLink warnings remain
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NO_UPGRADE_CHECK=1 PYTHONPATH=. uv run python scripts/docs/check_docs_freshness.py --ci --report /tmp/spec-kitty-docs-freshness-planbridge.json --link-check none