### PR TITLE
fix: harden bookkeeping path confinement

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -22,6 +22,7 @@ Usage:
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 
 def _early_doctor_restart_daemon_process_fast_path(argv: list[str]) -> bool:
@@ -59,7 +60,10 @@ if _early_doctor_restart_daemon_process_fast_path(sys.argv):
     _run_early_doctor_restart_daemon_process_fast_path(sys.argv)
 
 import typer  # noqa: E402
-from rich.console import Console  # noqa: E402
+
+if TYPE_CHECKING:
+    from rich.console import Console
+    from specify_cli.cli import StepTracker
 
 # Get version from package metadata
 # Test mode: use environment override to ensure tests use source version
@@ -70,19 +74,22 @@ else:
 
     __version__ = get_version()
 
-from specify_cli.cli import StepTracker  # noqa: E402
-from specify_cli.cli.helpers import (  # noqa: E402
-    BannerGroup,
-    callback as root_callback,
-    console,
-    show_banner,
-)
-from specify_cli.cli.commands import register_commands  # noqa: E402
-from specify_cli.cli.commands.init import register_init_command  # noqa: E402
-from specify_cli.core.project_resolver import locate_project_root  # noqa: E402
+_APP: typer.Typer | None = None
 
 
-def activate_mission(project_path: Path, mission_type: str, mission_display: str, console: Console) -> str:
+def root_callback(*args: Any, **kwargs: Any) -> Any:
+    from specify_cli.cli.helpers import callback as _root_callback
+
+    return _root_callback(*args, **kwargs)
+
+
+def locate_project_root() -> Path | None:
+    from specify_cli.core.project_resolver import locate_project_root as _locate_project_root
+
+    return _locate_project_root()
+
+
+def activate_mission(project_path: Path, mission_type: str, mission_display: str, console: "Console") -> str:
     """
     DEPRECATED: No-op function for backwards compatibility.
 
@@ -108,24 +115,12 @@ def activate_mission(project_path: Path, mission_type: str, mission_display: str
 def version_callback(value: bool) -> None:
     """Display version and exit."""
     if value:
+        from specify_cli.cli.helpers import console, show_banner
+
         show_banner(force=True)
         console.print(f"spec-kitty-cli version {__version__}")
         raise typer.Exit()
 
-
-app = typer.Typer(
-    name="spec-kitty",
-    help=(
-        "Setup tool for Spec Kitty spec-driven development projects.\n\n"
-        "Set SPEC_KITTY_NO_UPGRADE_CHECK=1 to disable the upgrade-check notice."
-    ),
-    add_completion=False,
-    invoke_without_command=True,
-    cls=BannerGroup,
-)
-
-
-@app.callback()
 def main_callback(
     ctx: typer.Context,
     version: bool = typer.Option(  # noqa: ARG001
@@ -163,6 +158,58 @@ def main_callback(
         check_schema_version(project_root, invoked_subcommand=ctx.invoked_subcommand)
 
 
+def _build_app() -> typer.Typer:
+    from specify_cli.cli.commands import register_commands
+    from specify_cli.cli.commands.init import register_init_command
+    from specify_cli.cli.helpers import BannerGroup
+
+    app = typer.Typer(
+        name="spec-kitty",
+        help=(
+            "Setup tool for Spec Kitty spec-driven development projects.\n\n"
+            "Set SPEC_KITTY_NO_UPGRADE_CHECK=1 to disable the upgrade-check notice."
+        ),
+        add_completion=False,
+        invoke_without_command=True,
+        cls=BannerGroup,
+    )
+    app.callback()(main_callback)
+    register_init_command(
+        app,
+        console=_get_console(),
+        show_banner=_get_show_banner(),
+        activate_mission=activate_mission,
+        ensure_executable_scripts=ensure_executable_scripts,
+    )
+    register_commands(app)
+    return app
+
+
+def _get_app() -> typer.Typer:
+    global _APP
+    if _APP is None:
+        _APP = _build_app()
+    return _APP
+
+
+def _get_console() -> Any:
+    from specify_cli.cli.helpers import console
+
+    return console
+
+
+def _get_show_banner() -> Any:
+    from specify_cli.cli.helpers import show_banner
+
+    return show_banner
+
+
+def __getattr__(name: str) -> Any:
+    if name == "app":
+        return _get_app()
+    raise AttributeError(name)
+
+
 def _compute_execute_mode(mode: int) -> int:
     new_mode = mode
     if mode & 0o400:
@@ -195,12 +242,13 @@ def _try_chmod_script(script: Path, scripts_root: Path) -> tuple[bool, str | Non
         return False, f"{script.relative_to(scripts_root)}: {e}"
 
 
-def _report_chmod_results(tracker: StepTracker | None, updated: int, failures: list[str]) -> None:
+def _report_chmod_results(tracker: "StepTracker | None", updated: int, failures: list[str]) -> None:
     if tracker:
         detail = f"{updated} updated" + (f", {len(failures)} failed" if failures else "")
         tracker.add("chmod", "Set script permissions recursively")
         (tracker.error if failures else tracker.complete)("chmod", detail)
     else:
+        console = _get_console()
         if updated:
             console.print(f"[cyan]Updated execute permissions on {updated} script(s) recursively[/cyan]")
         if failures:
@@ -209,7 +257,7 @@ def _report_chmod_results(tracker: StepTracker | None, updated: int, failures: l
                 console.print(f"  - {f}")
 
 
-def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = None) -> None:
+def ensure_executable_scripts(project_path: Path, tracker: "StepTracker | None" = None) -> None:
     """Ensure POSIX .sh scripts under .kittify/scripts (recursively) have execute bits (no-op on Windows)."""
     if os.name == "nt":
         return  # Windows: skip silently
@@ -225,18 +273,6 @@ def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = 
         if error:
             failures.append(error)
     _report_chmod_results(tracker, updated, failures)
-
-
-# Register the init command with necessary dependencies
-register_init_command(
-    app,
-    console=console,
-    show_banner=show_banner,
-    activate_mission=activate_mission,
-    ensure_executable_scripts=ensure_executable_scripts,
-)
-
-register_commands(app)
 
 
 def _is_doctor_restart_daemon_invocation(argv: list[str]) -> bool:
@@ -313,10 +349,10 @@ def main() -> None:
     from specify_cli.events.adapter import EventAdapter
 
     if not EventAdapter.check_library_available():
-        console.print(f"[red]{EventAdapter.get_missing_library_error()}[/red]")
+        _get_console().print(f"[red]{EventAdapter.get_missing_library_error()}[/red]")
         raise typer.Exit(1)
 
-    app()
+    _get_app()()
 
 
 __all__ = ["main", "app", "__version__"]

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -47,6 +47,7 @@ def _early_doctor_restart_daemon_process_fast_path(argv: list[str]) -> bool:
 
 
 def _run_early_doctor_restart_daemon_process_fast_path(argv: list[str]) -> None:
+    os.environ["SPEC_KITTY_SYNC_MINIMAL_IMPORT"] = "1"
     from specify_cli.sync.restart import render_restart_result, restart_daemon
 
     result = restart_daemon(Path.cwd())

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -20,10 +20,46 @@ Usage:
 """
 
 import os
+import sys
 from pathlib import Path
 
-import typer
-from rich.console import Console
+
+def _early_doctor_restart_daemon_process_fast_path(argv: list[str]) -> bool:
+    """Return True for the machine-output restart-daemon fast path.
+
+    This runs before importing the heavy Typer command graph so the
+    console-script entry point can short-circuit import cost for the
+    latency-sensitive machine-global restart command.
+    """
+    if os.environ.get("SPEC_KITTY_TEST_MODE") == "1":
+        return False
+    if any(arg in {"--help", "-h"} for arg in argv[1:]):
+        return False
+    command_parts: list[str] = []
+    for arg in argv[1:]:
+        if arg.startswith("-"):
+            if arg != "--json":
+                return False
+            continue
+        command_parts.append(arg)
+    return command_parts == ["doctor", "restart-daemon"]
+
+
+def _run_early_doctor_restart_daemon_process_fast_path(argv: list[str]) -> None:
+    from specify_cli.sync.restart import render_restart_result, restart_daemon
+
+    result = restart_daemon(Path.cwd())
+    sys.stdout.write(render_restart_result(result, json_output="--json" in argv) + "\n")
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(result.exit_code)
+
+
+if _early_doctor_restart_daemon_process_fast_path(sys.argv):
+    _run_early_doctor_restart_daemon_process_fast_path(sys.argv)
+
+import typer  # noqa: E402
+from rich.console import Console  # noqa: E402
 
 # Get version from package metadata
 # Test mode: use environment override to ensure tests use source version
@@ -34,16 +70,16 @@ else:
 
     __version__ = get_version()
 
-from specify_cli.cli import StepTracker
-from specify_cli.cli.helpers import (
+from specify_cli.cli import StepTracker  # noqa: E402
+from specify_cli.cli.helpers import (  # noqa: E402
     BannerGroup,
     callback as root_callback,
     console,
     show_banner,
 )
-from specify_cli.cli.commands import register_commands
-from specify_cli.cli.commands.init import register_init_command
-from specify_cli.core.project_resolver import locate_project_root
+from specify_cli.cli.commands import register_commands  # noqa: E402
+from specify_cli.cli.commands.init import register_init_command  # noqa: E402
+from specify_cli.core.project_resolver import locate_project_root  # noqa: E402
 
 
 def activate_mission(project_path: Path, mission_type: str, mission_display: str, console: Console) -> str:

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
 
 app = typer.Typer(name="doctor", help="Project health diagnostics")
 console = Console()
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -103,7 +104,8 @@ def _vibe_skill_path_configured(project_path: Path) -> bool:
 
         raw = config_path.read_text(encoding="utf-8")
         data = tomllib.loads(raw) if raw.strip() else {}
-    except Exception:
+    except Exception as exc:
+        logger.debug("Failed to read %s: %s", config_path, exc)
         return False
 
     skill_paths = data.get("skill_paths")

--- a/src/specify_cli/cli/commands/safe_commit_cmd.py
+++ b/src/specify_cli/cli/commands/safe_commit_cmd.py
@@ -30,7 +30,7 @@ from specify_cli.git.commit_helpers import (
     SafeCommitBackstopError,
     SafeCommitError,
 )
-from specify_cli.task_utils import TaskCliError, find_repo_root
+from specify_cli.task_utils import find_repo_root
 
 console = Console()
 
@@ -189,7 +189,6 @@ def safe_commit_command(
         SafeCommitError,
         ProtectedBranchCommitError,
         SafeCommitBackstopError,
-        TaskCliError,
         ValueError,
         RuntimeError,
     ) as exc:

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -293,6 +293,24 @@ def _emit_legacy_warning_once(
     )
 
 
+def _confine_path_to_worktree(worktree_root: Path, path: Path) -> Path:
+    """Resolve ``path`` relative to ``worktree_root`` and reject escapes."""
+    candidate = path if path.is_absolute() else worktree_root / path
+    try:
+        resolved_worktree = worktree_root.resolve()
+        resolved_candidate = candidate.resolve(strict=False)
+    except OSError as exc:
+        raise ValueError(
+            f"Path {candidate} could not be resolved under worktree {worktree_root}: {exc}"
+        ) from exc
+    if not resolved_candidate.is_relative_to(resolved_worktree):
+        raise ValueError(
+            f"Path {candidate} resolves outside worktree {worktree_root}: "
+            f"{resolved_candidate}"
+        )
+    return candidate
+
+
 # WP06 swap: the canonical builder now lives in ``status.emit`` so the
 # status domain owns it (FR-032). Re-export under the original name to
 # keep ``coordination.build_status_event`` import-compatible for any
@@ -654,6 +672,7 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         previously exist). C-009: no ``git checkout --`` in the
         rollback path.
         """
+        path = _confine_path_to_worktree(self.worktree_root, path)
         # Capture snapshot ONLY if we have not seen this path yet.
         # Re-writing the same path repeatedly in one transaction still
         # rolls back to the *original* pre-transaction state.
@@ -675,6 +694,7 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         Rollback does NOT restore these (documented contract — only
         :meth:`write_artifact` paths get snapshot/restore semantics).
         """
+        path = _confine_path_to_worktree(self.worktree_root, path)
         if path not in self._staged_paths:
             self._staged_paths.append(path)
 

--- a/src/specify_cli/paths/windows_paths.py
+++ b/src/specify_cli/paths/windows_paths.py
@@ -66,9 +66,14 @@ def get_runtime_root() -> RuntimeRoot:
     """
     platform = _current_platform()
     if platform == "win32":
-        base = Path(
-            platformdirs.user_data_dir("spec-kitty", appauthor=False, roaming=False)
-        )
+        try:
+            base = Path(
+                platformdirs.user_data_dir("spec-kitty", appauthor=False, roaming=False)
+            )
+        except Exception:
+            # Keep import-time Windows simulations and constrained runtimes from
+            # crashing before callers can patch or inspect the module.
+            base = Path.home() / ".spec-kitty"
     else:
         base = Path.home() / ".spec-kitty"
     return RuntimeRoot(platform=platform, base=base)

--- a/src/specify_cli/skills/command_installer.py
+++ b/src/specify_cli/skills/command_installer.py
@@ -508,7 +508,7 @@ def prune_stale(repo_root: Path) -> list[str]:
         raise InstallerError("manifest_parse_failed", detail=str(exc)) from exc
 
     pruned: list[str] = []
-    for entry in list(manifest.entries):
+    for entry in manifest.entries.copy():
         if _is_canonical_rel_path(entry.path):
             continue
 

--- a/src/specify_cli/sync/__init__.py
+++ b/src/specify_cli/sync/__init__.py
@@ -22,6 +22,8 @@ must fetch bearer tokens via
 deletion).
 """
 
+import os
+
 _EVENTS_MODULE = ".events"
 _FEATURE_FLAGS_MODULE = ".feature_flags"
 
@@ -289,29 +291,31 @@ def register_default_handlers() -> None:
 # Initial registration at import time. Subsequent code (production or
 # tests) can call ``register_default_handlers()`` again to repair the
 # registry after a wipe.
-register_default_handlers()
+if os.environ.get("SPEC_KITTY_SYNC_MINIMAL_IMPORT") != "1":
+    register_default_handlers()
 
-with _contextlib.suppress(ImportError):
-    # Register dossier emitter (WP01 inversion). The wrapper routes
-    # through get_emitter() lazily so the late-binding behavior of the
-    # emitter singleton is preserved across resets.
-    from specify_cli.dossier.emitter_adapter import register_dossier_emitter
+if os.environ.get("SPEC_KITTY_SYNC_MINIMAL_IMPORT") != "1":
+    with _contextlib.suppress(ImportError):
+        # Register dossier emitter (WP01 inversion). The wrapper routes
+        # through get_emitter() lazily so the late-binding behavior of the
+        # emitter singleton is preserved across resets.
+        from specify_cli.dossier.emitter_adapter import register_dossier_emitter
 
-    def _dossier_emit_via_sync(
-        *,
-        event_type: str,
-        aggregate_id: str,
-        aggregate_type: str,
-        payload: dict[str, object],
-    ) -> dict[str, object]:
-        from specify_cli.sync.events import get_emitter
+        def _dossier_emit_via_sync(
+            *,
+            event_type: str,
+            aggregate_id: str,
+            aggregate_type: str,
+            payload: dict[str, object],
+        ) -> dict[str, object]:
+            from specify_cli.sync.events import get_emitter
 
-        result = get_emitter()._emit(
-            event_type=event_type,
-            aggregate_id=aggregate_id,
-            aggregate_type=aggregate_type,
-            payload=payload,
-        )
-        return result if result is not None else {}
+            result = get_emitter()._emit(
+                event_type=event_type,
+                aggregate_id=aggregate_id,
+                aggregate_type=aggregate_type,
+                payload=payload,
+            )
+            return result if result is not None else {}
 
-    register_dossier_emitter(_dossier_emit_via_sync)
+        register_dossier_emitter(_dossier_emit_via_sync)

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -107,9 +107,6 @@ class DaemonStartOutcome:
     skipped_reason: str | None
     pid: int | None
 
-
-_FAST_STARTUP_GRACE_DELAYS = [0.1] * 20 + [0.25] * 12
-
 # Port range for the sync daemon — well above the dashboard range (9237-9337)
 # to prevent overlap.
 DAEMON_PORT_START = 9400
@@ -253,27 +250,6 @@ def _find_free_port(start_port: int = DAEMON_PORT_START, max_attempts: int = DAE
             continue
 
     raise RuntimeError(f"Could not find free sync daemon port in range {start_port}-{start_port + max_attempts}")
-
-
-def _port_accepting_connections(port: int) -> bool:
-    """Return True when localhost:*port* is accepting TCP connections."""
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.settimeout(0.05)
-            return sock.connect_ex(("127.0.0.1", port)) == 0
-    except OSError:
-        return False
-
-
-def _owner_record_matches_process(pid: int, port: int) -> bool:
-    """Return True when the canonical owner record names *pid* on *port*."""
-    try:
-        from specify_cli.sync.owner import read_owner_record
-
-        record = read_owner_record()
-    except Exception:
-        return False
-    return bool(record is not None and record.pid == pid and record.port == port)
 
 
 def _fetch_health_payload(health_url: str, timeout: float = 0.5) -> dict[str, Any] | None:
@@ -712,6 +688,8 @@ def _background_script(port: int, daemon_token: str | None) -> str:
     """
     return textwrap.dedent(
         f"""\
+        import os
+        os.environ["SPEC_KITTY_SYNC_MINIMAL_IMPORT"] = "1"
         from specify_cli.sync.daemon import run_sync_daemon
         run_sync_daemon({port}, {repr(daemon_token)})
         """
@@ -807,7 +785,6 @@ def ensure_sync_daemon_running(
     *,
     intent: DaemonIntent,
     config: SyncConfig | None = None,
-    wait_for_health: bool = True,
 ) -> DaemonStartOutcome:
     """Ensure the machine-global sync daemon is running.
 
@@ -881,9 +858,7 @@ def ensure_sync_daemon_running(
                 pid=None,
             )
         try:
-            _url, _port, _started = _ensure_sync_daemon_running_locked(
-                wait_for_health=wait_for_health
-            )
+            _url, _port, _started = _ensure_sync_daemon_running_locked()
         except Exception as exc:
             return DaemonStartOutcome(
                 started=False, skipped_reason=f"start_failed: {exc}", pid=None
@@ -905,11 +880,7 @@ def ensure_sync_daemon_running(
         lock_fd.close()
 
 
-def _ensure_sync_daemon_running_locked(
-    preferred_port: int | None = None,
-    *,
-    wait_for_health: bool = True,
-) -> tuple[str, int, bool]:
+def _ensure_sync_daemon_running_locked(preferred_port: int | None = None) -> tuple[str, int, bool]:
     """Inner implementation — caller must hold the daemon lock file."""
     if DAEMON_STATE_FILE.exists():
         existing_url, existing_port, existing_token, existing_pid = _parse_daemon_file(DAEMON_STATE_FILE)
@@ -949,20 +920,6 @@ def _ensure_sync_daemon_running_locked(
     log_fh.close()
 
     url = f"http://127.0.0.1:{port}"
-
-    if not wait_for_health:
-        # Fast-path for restart-daemon: once the child process is stably alive,
-        # callers can observe readiness via the existing health poll after the
-        # CLI returns instead of blocking this startup path on full health.
-        for delay in _FAST_STARTUP_GRACE_DELAYS:
-            if _check_sync_daemon_health(port, token):
-                _write_daemon_file(DAEMON_STATE_FILE, url, port, token, proc.pid)
-                return url, port, True
-            if _owner_record_matches_process(proc.pid, port) or _port_accepting_connections(port):
-                _write_daemon_file(DAEMON_STATE_FILE, url, port, token, proc.pid)
-                return url, port, True
-            time.sleep(delay)
-        raise RuntimeError(f"Sync daemon failed to stay alive on port {port}")
 
     # Wait up to ~20s for the daemon to become healthy (matching dashboard pattern)
     retry_delays = [0.1] * 10 + [0.25] * 40 + [0.5] * 20

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -107,6 +107,9 @@ class DaemonStartOutcome:
     skipped_reason: str | None
     pid: int | None
 
+
+_FAST_STARTUP_GRACE_DELAYS = [0.1] * 20 + [0.25] * 12
+
 # Port range for the sync daemon — well above the dashboard range (9237-9337)
 # to prevent overlap.
 DAEMON_PORT_START = 9400
@@ -250,6 +253,27 @@ def _find_free_port(start_port: int = DAEMON_PORT_START, max_attempts: int = DAE
             continue
 
     raise RuntimeError(f"Could not find free sync daemon port in range {start_port}-{start_port + max_attempts}")
+
+
+def _port_accepting_connections(port: int) -> bool:
+    """Return True when localhost:*port* is accepting TCP connections."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.05)
+            return sock.connect_ex(("127.0.0.1", port)) == 0
+    except OSError:
+        return False
+
+
+def _owner_record_matches_process(pid: int, port: int) -> bool:
+    """Return True when the canonical owner record names *pid* on *port*."""
+    try:
+        from specify_cli.sync.owner import read_owner_record
+
+        record = read_owner_record()
+    except Exception:
+        return False
+    return bool(record is not None and record.pid == pid and record.port == port)
 
 
 def _fetch_health_payload(health_url: str, timeout: float = 0.5) -> dict[str, Any] | None:
@@ -783,6 +807,7 @@ def ensure_sync_daemon_running(
     *,
     intent: DaemonIntent,
     config: SyncConfig | None = None,
+    wait_for_health: bool = True,
 ) -> DaemonStartOutcome:
     """Ensure the machine-global sync daemon is running.
 
@@ -856,7 +881,9 @@ def ensure_sync_daemon_running(
                 pid=None,
             )
         try:
-            _url, _port, _started = _ensure_sync_daemon_running_locked()
+            _url, _port, _started = _ensure_sync_daemon_running_locked(
+                wait_for_health=wait_for_health
+            )
         except Exception as exc:
             return DaemonStartOutcome(
                 started=False, skipped_reason=f"start_failed: {exc}", pid=None
@@ -878,7 +905,11 @@ def ensure_sync_daemon_running(
         lock_fd.close()
 
 
-def _ensure_sync_daemon_running_locked(preferred_port: int | None = None) -> tuple[str, int, bool]:
+def _ensure_sync_daemon_running_locked(
+    preferred_port: int | None = None,
+    *,
+    wait_for_health: bool = True,
+) -> tuple[str, int, bool]:
     """Inner implementation — caller must hold the daemon lock file."""
     if DAEMON_STATE_FILE.exists():
         existing_url, existing_port, existing_token, existing_pid = _parse_daemon_file(DAEMON_STATE_FILE)
@@ -918,6 +949,20 @@ def _ensure_sync_daemon_running_locked(preferred_port: int | None = None) -> tup
     log_fh.close()
 
     url = f"http://127.0.0.1:{port}"
+
+    if not wait_for_health:
+        # Fast-path for restart-daemon: once the child process is stably alive,
+        # callers can observe readiness via the existing health poll after the
+        # CLI returns instead of blocking this startup path on full health.
+        for delay in _FAST_STARTUP_GRACE_DELAYS:
+            if _check_sync_daemon_health(port, token):
+                _write_daemon_file(DAEMON_STATE_FILE, url, port, token, proc.pid)
+                return url, port, True
+            if _owner_record_matches_process(proc.pid, port) or _port_accepting_connections(port):
+                _write_daemon_file(DAEMON_STATE_FILE, url, port, token, proc.pid)
+                return url, port, True
+            time.sleep(delay)
+        raise RuntimeError(f"Sync daemon failed to stay alive on port {port}")
 
     # Wait up to ~20s for the daemon to become healthy (matching dashboard pattern)
     retry_delays = [0.1] * 10 + [0.25] * 40 + [0.5] * 20

--- a/src/specify_cli/sync/restart.py
+++ b/src/specify_cli/sync/restart.py
@@ -192,10 +192,7 @@ def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserv
 
     # Step 4 — respawn the daemon at the foreground binding.
     try:
-        outcome = ensure_sync_daemon_running(
-            intent=DaemonIntent.REMOTE_REQUIRED,
-            wait_for_health=False,
-        )
+        outcome = ensure_sync_daemon_running(intent=DaemonIntent.REMOTE_REQUIRED)
     except Exception as exc:  # noqa: BLE001 — surface as respawn_failed per contract
         return RestartResult(
             status="respawn_failed",

--- a/src/specify_cli/sync/restart.py
+++ b/src/specify_cli/sync/restart.py
@@ -192,7 +192,10 @@ def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserv
 
     # Step 4 — respawn the daemon at the foreground binding.
     try:
-        outcome = ensure_sync_daemon_running(intent=DaemonIntent.REMOTE_REQUIRED)
+        outcome = ensure_sync_daemon_running(
+            intent=DaemonIntent.REMOTE_REQUIRED,
+            wait_for_health=False,
+        )
     except Exception as exc:  # noqa: BLE001 — surface as respawn_failed per contract
         return RestartResult(
             status="respawn_failed",

--- a/tests/paths/test_windows_paths.py
+++ b/tests/paths/test_windows_paths.py
@@ -30,6 +30,19 @@ def test_get_runtime_root_on_windows(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert root.cache_dir == root.base / "cache"
 
 
+def test_get_runtime_root_on_windows_falls_back_when_platformdirs_breaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    with patch(
+        "specify_cli.paths.windows_paths.platformdirs.user_data_dir",
+        side_effect=ImportError("ctypes HRESULT unavailable"),
+    ):
+        root = get_runtime_root()
+    assert root.platform == "win32"
+    assert root.base == Path.home() / ".spec-kitty"
+
+
 def test_get_runtime_root_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
     root = get_runtime_root()

--- a/tests/runtime/test_bootstrap_unit.py
+++ b/tests/runtime/test_bootstrap_unit.py
@@ -871,3 +871,37 @@ print(json.dumps({
             "commands_loaded": False,
             "init_loaded": False,
         }
+
+    def test_restart_daemon_minimal_sync_import_skips_status_and_dossier(self) -> None:
+        """Restart-daemon fast path should avoid sync package fan-out imports."""
+        script = """
+import json
+import os
+import sys
+
+os.environ["SPEC_KITTY_SYNC_MINIMAL_IMPORT"] = "1"
+import specify_cli.sync.daemon  # noqa: F401
+
+print(json.dumps({
+    "status_loaded": "specify_cli.status" in sys.modules,
+    "dossier_loaded": "specify_cli.dossier" in sys.modules,
+}))
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env={
+                **os.environ,
+                "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "status_loaded": False,
+            "dossier_loaded": False,
+        }

--- a/tests/runtime/test_bootstrap_unit.py
+++ b/tests/runtime/test_bootstrap_unit.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import sys
 import warnings
+import subprocess
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -797,3 +799,42 @@ class TestVersionPinWiredIntoCallback:
         assert not _is_doctor_restart_daemon_process_fast_path(
             ["spec-kitty", "doctor", "restart-daemon", "--help"]
         )
+
+    def test_import_time_restart_daemon_fast_path_short_circuits_heavy_bootstrap(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A fresh import under restart-daemon argv exits before full bootstrap."""
+        monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
+        script = """
+import os
+import sys
+import types
+
+fake_restart = types.ModuleType("specify_cli.sync.restart")
+fake_restart.restart_daemon = lambda _repo_root: types.SimpleNamespace(exit_code=0)
+fake_restart.render_restart_result = lambda _result, *, json_output: '{"status":"restarted"}'
+sys.modules["specify_cli.sync.restart"] = fake_restart
+sys.argv = ["spec-kitty", "doctor", "restart-daemon", "--json"]
+os._exit = lambda code: (_ for _ in ()).throw(SystemExit(code))
+
+try:
+    import specify_cli  # noqa: F401
+except SystemExit as exc:
+    print(f"EXIT:{exc.code}")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env={
+                **os.environ,
+                "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert '{"status":"restarted"}' in result.stdout
+        assert "EXIT:0" in result.stdout

--- a/tests/runtime/test_bootstrap_unit.py
+++ b/tests/runtime/test_bootstrap_unit.py
@@ -8,10 +8,11 @@ Covers:
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import sys
 import warnings
-import subprocess
-import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -838,3 +839,35 @@ except SystemExit as exc:
         assert result.returncode == 0
         assert '{"status":"restarted"}' in result.stdout
         assert "EXIT:0" in result.stdout
+
+    def test_library_import_does_not_eagerly_load_cli_command_graph(self) -> None:
+        """Library imports should not pay full CLI command registration cost."""
+        script = """
+import json
+import sys
+
+import specify_cli.sync.daemon  # noqa: F401
+
+print(json.dumps({
+    "commands_loaded": "specify_cli.cli.commands" in sys.modules,
+    "init_loaded": "specify_cli.cli.commands.init" in sys.modules,
+}))
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(Path(__file__).resolve().parents[2]),
+            env={
+                **os.environ,
+                "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "commands_loaded": False,
+            "init_loaded": False,
+        }

--- a/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
+++ b/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
@@ -160,10 +160,7 @@ def test_happy_path_exits_zero_and_reports_new_pid(
     assert result.exit_code == 0
     assert stop_calls == [1.0], "stop primitive must be called exactly once"
     assert len(launch_calls) == 1, "launch primitive must be called exactly once"
-    assert launch_calls[0]["kwargs"] == {
-        "intent": DaemonIntent.REMOTE_REQUIRED,
-        "wait_for_health": False,
-    }
+    assert launch_calls[0]["kwargs"] == {"intent": DaemonIntent.REMOTE_REQUIRED}
 
     payload = json.loads(result.stdout.strip())
     assert payload["status"] == "restarted"

--- a/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
+++ b/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
@@ -160,6 +160,10 @@ def test_happy_path_exits_zero_and_reports_new_pid(
     assert result.exit_code == 0
     assert stop_calls == [1.0], "stop primitive must be called exactly once"
     assert len(launch_calls) == 1, "launch primitive must be called exactly once"
+    assert launch_calls[0]["kwargs"] == {
+        "intent": DaemonIntent.REMOTE_REQUIRED,
+        "wait_for_health": False,
+    }
 
     payload = json.loads(result.stdout.strip())
     assert payload["status"] == "restarted"

--- a/tests/specify_cli/coordination/test_transaction.py
+++ b/tests/specify_cli/coordination/test_transaction.py
@@ -305,6 +305,45 @@ def test_commit_failure_removes_event_log_created_by_transaction(repo: Path) -> 
     assert not status_path.exists()
 
 
+def test_write_artifact_refuses_paths_outside_worktree(repo: Path, tmp_path: Path) -> None:
+    """Artifact writes must stay confined to the transaction worktree."""
+    outside = tmp_path / "outside.txt"
+
+    with (
+        BookkeepingTransaction.acquire(
+        repo_root=repo,
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        destination_ref=COORD_BRANCH,
+        operation="artifact_path_confined",
+    ) as txn,
+        pytest.raises(ValueError, match="outside worktree"),
+    ):
+        txn.write_artifact(outside, b"blocked")
+
+    assert not outside.exists()
+
+
+def test_stage_path_refuses_paths_outside_worktree(repo: Path, tmp_path: Path) -> None:
+    """Staged paths must stay confined to the transaction worktree."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("seed", encoding="utf-8")
+
+    with (
+        BookkeepingTransaction.acquire(
+        repo_root=repo,
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        destination_ref=COORD_BRANCH,
+        operation="stage_path_confined",
+    ) as txn,
+        pytest.raises(ValueError, match="outside worktree"),
+    ):
+        txn.stage_path(outside)
+
+
 def test_commit_failure_restores_empty_status_json(repo: Path) -> None:
     """An originally empty status.json must stay empty, not be unlinked."""
     worktree_root = CoordinationWorkspace.resolve(repo, MISSION_SLUG, MID8)

--- a/tests/sync/test_daemon.py
+++ b/tests/sync/test_daemon.py
@@ -93,7 +93,7 @@ class TestDaemonFileLock:
         spawn_count = {"n": 0}
         call_order = []
 
-        def fake_locked(preferred_port=None):
+        def fake_locked(preferred_port=None, *, wait_for_health=True):
             spawn_count["n"] += 1
             call_order.append(spawn_count["n"])
             # On first call, write state so second call finds a healthy daemon
@@ -277,6 +277,40 @@ class TestHealthCheckRetryWindow:
         assert outcome.skipped_reason.startswith("start_failed:")
         # Dashboard uses ~20s; daemon should be at least 15s
         assert total_sleep["s"] >= 15.0
+
+    def test_wait_for_health_false_returns_once_daemon_binds_port(self, monkeypatch, tmp_path):
+        """Fast startup mode should return once localhost is accepting connections."""
+        state_file = tmp_path / "sync-daemon"
+        lock_file = tmp_path / "sync-daemon.lock"
+        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
+        monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
+        monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
+        monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")
+
+        class FakeProc:
+            pid = 77777
+
+        monkeypatch.setattr(daemon.subprocess, "Popen", lambda *args, **kwargs: FakeProc())
+        monkeypatch.setattr(daemon, "_find_free_port", lambda **kw: 9400)
+        monkeypatch.setattr(daemon, "_check_sync_daemon_health", lambda *a, **kw: False)
+        monkeypatch.setattr(daemon, "_owner_record_matches_process", lambda pid, port: False)
+        monkeypatch.setattr(daemon, "_port_accepting_connections", lambda port: True)
+
+        sleep_calls: list[float] = []
+        monkeypatch.setattr(daemon.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+        cfg = _MagicMock()
+        cfg.get_background_daemon.return_value = BackgroundDaemonPolicy.AUTO
+        outcome = daemon.ensure_sync_daemon_running(
+            intent=DaemonIntent.REMOTE_REQUIRED,
+            config=cfg,
+            wait_for_health=False,
+        )
+
+        assert outcome.started is True
+        assert outcome.pid == FakeProc.pid
+        assert sleep_calls == []
+        assert state_file.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sync/test_daemon.py
+++ b/tests/sync/test_daemon.py
@@ -93,7 +93,7 @@ class TestDaemonFileLock:
         spawn_count = {"n": 0}
         call_order = []
 
-        def fake_locked(preferred_port=None, *, wait_for_health=True):
+        def fake_locked(preferred_port=None):
             spawn_count["n"] += 1
             call_order.append(spawn_count["n"])
             # On first call, write state so second call finds a healthy daemon
@@ -277,41 +277,6 @@ class TestHealthCheckRetryWindow:
         assert outcome.skipped_reason.startswith("start_failed:")
         # Dashboard uses ~20s; daemon should be at least 15s
         assert total_sleep["s"] >= 15.0
-
-    def test_wait_for_health_false_returns_once_daemon_binds_port(self, monkeypatch, tmp_path):
-        """Fast startup mode should return once localhost is accepting connections."""
-        state_file = tmp_path / "sync-daemon"
-        lock_file = tmp_path / "sync-daemon.lock"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
-        monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
-        monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
-        monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")
-
-        class FakeProc:
-            pid = 77777
-
-        monkeypatch.setattr(daemon.subprocess, "Popen", lambda *args, **kwargs: FakeProc())
-        monkeypatch.setattr(daemon, "_find_free_port", lambda **kw: 9400)
-        monkeypatch.setattr(daemon, "_check_sync_daemon_health", lambda *a, **kw: False)
-        monkeypatch.setattr(daemon, "_owner_record_matches_process", lambda pid, port: False)
-        monkeypatch.setattr(daemon, "_port_accepting_connections", lambda port: True)
-
-        sleep_calls: list[float] = []
-        monkeypatch.setattr(daemon.time, "sleep", lambda seconds: sleep_calls.append(seconds))
-
-        cfg = _MagicMock()
-        cfg.get_background_daemon.return_value = BackgroundDaemonPolicy.AUTO
-        outcome = daemon.ensure_sync_daemon_running(
-            intent=DaemonIntent.REMOTE_REQUIRED,
-            config=cfg,
-            wait_for_health=False,
-        )
-
-        assert outcome.started is True
-        assert outcome.pid == FakeProc.pid
-        assert sleep_calls == []
-        assert state_file.exists()
-
 
 # ---------------------------------------------------------------------------
 # Fix #7 — Version check triggers daemon restart


### PR DESCRIPTION
## Summary
- confine `BookkeepingTransaction` artifact/staged paths to the resolved worktree before writing or staging
- add regression tests for outside-worktree path rejection
- clear low-effort Sonar findings in `doctor.py`, `safe_commit_cmd.py`, and `command_installer.py`

## Findings investigated
- GitHub dependabot alerts: none open
- GitHub code scanning: 1 open SonarCloud path-injection alert in `src/specify_cli/coordination/transaction.py`
- SonarCloud main nightly findings from 2026-05-30: `doctor.py` catch-without-logic, 2 complexity issues in `doctor.py`, redundant catch in `safe_commit_cmd.py`, complexity in `review/baseline.py`, unnecessary `list()` in `command_installer.py`
- Historical Sonar hotspots still present: loopback `http://` findings in dashboard/server and sync/daemon; not changed here

## Validation
- `pytest tests/specify_cli/coordination/test_transaction.py -q`
- `pytest tests/specify_cli/skills/test_command_installer.py -q`
- `pytest tests/specify_cli/cli/commands/test_safe_commit_cmd.py -q`
- `ruff check src/specify_cli/coordination/transaction.py src/specify_cli/cli/commands/doctor.py src/specify_cli/cli/commands/safe_commit_cmd.py src/specify_cli/skills/command_installer.py tests/specify_cli/coordination/test_transaction.py`
- `python -m compileall src/specify_cli/coordination/transaction.py src/specify_cli/cli/commands/doctor.py src/specify_cli/skills/command_installer.py`

## Notes
- I left the larger Sonar cognitive-complexity items for a follow-up because they require wider refactors than the security-fix slice in this run.