### PR TITLE
Fix dependency gating for next and implement

### DIFF
--- a/.kittify/glossaries/spec_kitty_core.yaml
+++ b/.kittify/glossaries/spec_kitty_core.yaml
@@ -183,6 +183,44 @@ terms:
     confidence: 1.0
     status: active
 
+  - surface: dependency readiness
+    definition: >
+      The condition the dependency gate evaluates before a work package may be
+      claimed or implemented: every WP listed in its ``dependencies`` frontmatter
+      must be in the ``approved`` or ``done`` lane. ``approved`` is included
+      deliberately — ``done`` is emitted only by the whole-mission merge, so
+      requiring a dependency to be strictly ``done`` would deadlock every
+      same-mission dependency chain (the dependent WP could never start, so the
+      mission could never merge, so the dependency could never reach ``done``).
+      Computed by ``dependency_readiness_for_wp`` in
+      ``src/specify_cli/core/dependency_graph.py``; intentionally matches the
+      merge dependency gate (``policy/merge_gates.py`` treats ``{approved, done}``
+      as satisfied). ``for_review``, ``in_review``, ``blocked``, ``canceled``,
+      and missing status are not ready.
+    confidence: 1.0
+    status: active
+
+  - surface: dependency gate
+    definition: >
+      The pre-implementation enforcement point that refuses to start a work
+      package until it meets dependency readiness (all declared dependencies are
+      ``approved`` or ``done``). Enforced consistently at every claim path. The
+      read-only surfaces — the ``next`` claim-discovery preview
+      (``preview_claimable_wp``) and orchestrator-api ``list-ready`` — only ever
+      surface ``planned`` candidates, so a dependency-blocked planned WP is simply
+      withheld (preview returns ``dependencies_not_satisfied``; list-ready omits
+      it). The imperative claim verbs — ``agent action implement``, the low-level
+      ``implement`` command (before any workspace is created), and orchestrator-api
+      ``start-implementation`` — additionally apply a resume guard: they enforce
+      readiness only on the not-yet-started (``planned``/``claimed``) claim
+      transition, so re-invoking implement on an already ``in_progress`` WP is a
+      no-op resume, not a re-gated claim, and a dependency that later regresses out
+      of ``approved``/``done`` does not block resuming in-flight work. On block the
+      imperative verbs surface the stable ``dependencies_not_satisfied``
+      reason/error code.
+    confidence: 1.0
+    status: active
+
   - surface: machine-level runtime
     definition: "The ~/.kittify/ directory on a developer's machine, containing templates, global agent configs, and skills shared across all projects on that machine. Distinct from the per-project .kittify/ directory."
     confidence: 0.95

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,6 +605,31 @@ Alias: `doing` -> `in_progress` (resolved at input boundaries, never persisted i
 
 Terminal lanes: `done`, `canceled` (force required to leave).
 
+### Dependency Gating (WP claim readiness)
+
+A work package whose `dependencies` frontmatter is non-empty cannot be claimed or
+implemented until **every** declared dependency is in the `approved` **or** `done`
+lane. This is "dependency readiness," computed by
+`dependency_readiness_for_wp()` in `src/specify_cli/core/dependency_graph.py` and
+enforced by the **dependency gate** at every claim path: `next` claim discovery
+(`preview_claimable_wp`), `agent action implement`, the low-level `implement`
+command (before any worktree is created), and orchestrator-api
+`start-implementation` / `list-ready`.
+
+`approved` satisfies the gate on purpose. `done` is emitted **only** by the
+whole-mission `spec-kitty merge` (`_mark_wp_merged_done`), which itself refuses to
+complete until every WP has reached `done`. Gating strictly on `done` would
+therefore deadlock every same-mission dependency chain. This matches the merge
+dependency gate (`policy/merge_gates.py`), which already treats `{approved, done}`
+as satisfied. The read-only surfaces (`preview_claimable_wp`, `list-ready`) only
+surface `planned` candidates, so a blocked WP is simply withheld. The imperative
+verbs (`agent action implement`, `implement`, `start-implementation`) additionally
+apply a resume guard: they enforce readiness only on the not-yet-started
+(`planned`/`claimed`) claim transition, so re-invoking implement on an already
+`in_progress` WP is a no-op resume, never re-gated. A blocked claim surfaces the
+stable `dependencies_not_satisfied` reason/error. Independent WPs (no declared
+dependencies) continue to fan out in parallel.
+
 ### Phase Behavior (3.0: Phase 2 is active)
 
 Phase 2 (event-log authority) is the only active model as of 3.0. Phases 0 and 1 are historical.

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -20,10 +20,38 @@ Usage:
 """
 
 import os
+import sys
 from pathlib import Path
 
-import typer
-from rich.console import Console
+
+def _is_doctor_restart_daemon_process_fast_path(argv: list[str]) -> bool:
+    if any(arg in {"--help", "-h"} for arg in argv[1:]):
+        return False
+    command_parts: list[str] = []
+    for arg in argv[1:]:
+        if arg.startswith("-"):
+            if arg != "--json":
+                return False
+            continue
+        command_parts.append(arg)
+    return command_parts == ["doctor", "restart-daemon"]
+
+
+def _run_doctor_restart_daemon_process_fast_path(argv: list[str]) -> None:
+    from specify_cli.sync.restart import render_restart_result, restart_daemon
+
+    result = restart_daemon(Path.cwd())
+    sys.stdout.write(render_restart_result(result, json_output="--json" in argv) + "\n")
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(result.exit_code)
+
+
+if _is_doctor_restart_daemon_process_fast_path(sys.argv):
+    _run_doctor_restart_daemon_process_fast_path(sys.argv)
+
+import typer  # noqa: E402
+from rich.console import Console  # noqa: E402
 
 # Get version from package metadata
 # Test mode: use environment override to ensure tests use source version
@@ -34,16 +62,16 @@ else:
 
     __version__ = get_version()
 
-from specify_cli.cli import StepTracker
-from specify_cli.cli.helpers import (
+from specify_cli.cli import StepTracker  # noqa: E402
+from specify_cli.cli.helpers import (  # noqa: E402
     BannerGroup,
     callback as root_callback,
     console,
     show_banner,
 )
-from specify_cli.cli.commands import register_commands
-from specify_cli.cli.commands.init import register_init_command
-from specify_cli.core.project_resolver import locate_project_root
+from specify_cli.cli.commands import register_commands  # noqa: E402
+from specify_cli.cli.commands.init import register_init_command  # noqa: E402
+from specify_cli.core.project_resolver import locate_project_root  # noqa: E402
 
 
 def activate_mission(project_path: Path, mission_type: str, mission_display: str, console: Console) -> str:
@@ -216,40 +244,7 @@ def _is_doctor_restart_daemon_invocation(argv: list[str]) -> bool:
     return False
 
 
-def _is_doctor_restart_daemon_process_fast_path(argv: list[str]) -> bool:
-    if any(arg in {"--help", "-h"} for arg in argv[1:]):
-        return False
-    command_parts: list[str] = []
-    for arg in argv[1:]:
-        if arg.startswith("-"):
-            if arg != "--json":
-                return False
-            continue
-        command_parts.append(arg)
-    return command_parts == ["doctor", "restart-daemon"]
-
-
-def _run_doctor_restart_daemon_process_fast_path(argv: list[str]) -> None:
-    import os
-    import sys
-
-    from specify_cli.sync.restart import render_restart_result, restart_daemon
-
-    try:
-        located = locate_project_root()
-    except Exception:  # noqa: BLE001 — restart-daemon is machine-global today
-        located = None
-    repo_root = located if located is not None else Path.cwd()
-    result = restart_daemon(repo_root)
-    sys.stdout.write(render_restart_result(result, json_output="--json" in argv) + "\n")
-    sys.stdout.flush()
-    sys.stderr.flush()
-    os._exit(result.exit_code)
-
-
 def main() -> None:
-    import sys
-
     # FR-130 / FR-131: Install the CLI logging bootstrap early — before the
     # Typer app runs — so that warnings.warn(...) calls (including
     # CharterCatalogMissWarning from charter._catalog_miss) are routed through

--- a/src/specify_cli/cli/commands/agent/README.md
+++ b/src/specify_cli/cli/commands/agent/README.md
@@ -62,9 +62,10 @@ top_level_implement(wp_id=wp_id, ...)
 ```python
 @app.command(name="implement")
 def implement(wp_id: str | None, agent: str | None):
-    # Auto-detect WP if omitted
+    # Auto-detect WP if omitted (shared claimability discovery)
     if not wp_id:
-        wp_id = _find_first_planned_wp(repo_root, feature_slug)
+        preview = _preview_claimable_wp_for_mission(repo_root, feature_slug)
+        wp_id = getattr(preview, "wp_id", None)
 
     # Normalize format
     wp_id = _normalize_wp_id(wp_id)  # "wp01" → "WP01"

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -49,7 +49,11 @@ from charter.context import build_charter_context
 from specify_cli.cli.commands.agent.tasks import _collect_status_artifacts
 from specify_cli.cli.commands.implement import implement as top_level_implement
 from specify_cli.cli.selector_resolution import resolve_mission_handle, resolve_selector
-from specify_cli.core.dependency_graph import build_dependency_graph, get_dependents
+from specify_cli.core.dependency_graph import (
+    build_dependency_graph,
+    dependency_readiness_for_wp,
+    get_dependents,
+)
 from specify_cli.core.paths import get_main_repo_root, is_worktree_context, locate_project_root
 from specify_cli.core.utils import write_text_within_directory
 from specify_cli.git import safe_commit
@@ -917,6 +921,34 @@ def implement(
             raise typer.Exit(1)
         except Exception as e:
             print(f"Error locating work package: {e}")
+            raise typer.Exit(1)
+
+        try:
+            _dependency_wp_meta, _ = read_wp_frontmatter(wp.path)
+        except Exception as e:
+            print(f"Error reading work package metadata: {e}")
+            raise typer.Exit(1)
+
+        from specify_cli.status.reducer import reduce as _dep_reduce_events
+        from specify_cli.status.store import read_events as _dep_read_events
+
+        _dependency_feature_dir = main_repo_root / "kitty-specs" / mission_slug
+        _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
+        _dependency_lanes = {
+            _wp_id: Lane(_state.get("lane", Lane.PLANNED))
+            for _wp_id, _state in _dependency_snapshot.work_packages.items()
+        }
+        _dependency_readiness = dependency_readiness_for_wp(
+            normalized_wp_id,
+            _dependency_wp_meta.dependencies,
+            _dependency_lanes,
+        )
+        if not _dependency_readiness.satisfied:
+            blocked = ", ".join(_dependency_readiness.unsatisfied)
+            print(
+                f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
+                "all dependencies must be done before implementation can start"
+            )
             raise typer.Exit(1)
 
         workspace = resolve_workspace_for_wp(main_repo_root, mission_slug, normalized_wp_id)

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -923,34 +923,6 @@ def implement(
             print(f"Error locating work package: {e}")
             raise typer.Exit(1)
 
-        try:
-            _dependency_wp_meta, _ = read_wp_frontmatter(wp.path)
-        except Exception as e:
-            print(f"Error reading work package metadata: {e}")
-            raise typer.Exit(1)
-
-        from specify_cli.status.reducer import reduce as _dep_reduce_events
-        from specify_cli.status.store import read_events as _dep_read_events
-
-        _dependency_feature_dir = main_repo_root / "kitty-specs" / mission_slug
-        _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
-        _dependency_lanes = {
-            _wp_id: Lane(_state.get("lane", Lane.PLANNED))
-            for _wp_id, _state in _dependency_snapshot.work_packages.items()
-        }
-        _dependency_readiness = dependency_readiness_for_wp(
-            normalized_wp_id,
-            _dependency_wp_meta.dependencies,
-            _dependency_lanes,
-        )
-        if not _dependency_readiness.satisfied:
-            blocked = ", ".join(_dependency_readiness.unsatisfied)
-            print(
-                f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
-                "all dependencies must be done before implementation can start"
-            )
-            raise typer.Exit(1)
-
         workspace = resolve_workspace_for_wp(main_repo_root, mission_slug, normalized_wp_id)
         workspace_path = workspace.worktree_path
         status_execution_mode = "direct_repo" if workspace.resolution_kind == "repo_root" else "worktree"
@@ -995,6 +967,28 @@ def implement(
             if _is_missing_canonical_status_error(e):
                 raise RuntimeError(_missing_canonical_status_message(normalized_wp_id, mission_slug)) from e
             raise
+
+        from specify_cli.status.reducer import reduce as _dep_reduce_events
+        from specify_cli.status.store import read_events as _dep_read_events
+
+        _dependency_feature_dir = main_repo_root / "kitty-specs" / mission_slug
+        _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
+        _dependency_lanes = {
+            _wp_id: _state.get("lane", Lane.PLANNED)
+            for _wp_id, _state in _dependency_snapshot.work_packages.items()
+        }
+        _dependency_readiness = dependency_readiness_for_wp(
+            normalized_wp_id,
+            wp_meta.dependencies,
+            _dependency_lanes,
+        )
+        if not _dependency_readiness.satisfied:
+            blocked = ", ".join(_dependency_readiness.unsatisfied)
+            print(
+                f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
+                "all dependencies must be done before implementation can start"
+            )
+            raise typer.Exit(1)
 
         subtask_ids = [str(item) for item in wp_meta.subtasks if isinstance(item, str)]
         subtask_cmd = " ".join(subtask_ids) if subtask_ids else "<subtask-ids>"

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -764,34 +764,24 @@ def _normalize_wp_id(wp_arg: str) -> str:
         return f"WP{wp_upper.lstrip('WP')}"
 
 
-def _resolve_tasks_dir(cwd: Path, mission_slug: str, repo_root: Path) -> Path:
-    """Resolve the tasks directory for mission_slug from the current working directory."""
-    from specify_cli.core.paths import is_worktree_context
-
-    if not is_worktree_context(cwd):
-        return repo_root / "kitty-specs" / mission_slug / "tasks"
-
-    if (cwd / "kitty-specs" / mission_slug).exists():
-        return cwd / "kitty-specs" / mission_slug / "tasks"
-
-    current = cwd
-    while current != current.parent:
-        if (current / "kitty-specs" / mission_slug).exists():
-            return current / "kitty-specs" / mission_slug / "tasks"
-        current = current.parent
-
-    return repo_root / "kitty-specs" / mission_slug / "tasks"
-
-
 def _preview_claimable_wp_for_mission(repo_root: Path, mission_slug: str):
-    """Return the shared claimable preview for *mission_slug*, if tasks exist."""
+    """Return the shared claimable preview for *mission_slug*, if tasks exist.
+
+    The readiness preview is always computed against the repository-root
+    checkout's canonical status event log — never a worktree-local copy, which
+    may lag the latest status commit. This keeps the displayed auto-claim
+    candidate and ``selection_reason`` in agreement with the authoritative
+    dependency gate that governs the implement action (which also reads from the
+    repository-root checkout), so a genuinely-ready WP is never falsely reported
+    as ``dependencies_not_satisfied`` when this command runs from a stale
+    worktree.
+    """
     from specify_cli.next.discovery import preview_claimable_wp
 
-    cwd = Path.cwd().resolve()
-    tasks_dir = _resolve_tasks_dir(cwd, mission_slug, repo_root)
-    if not tasks_dir.exists():
+    feature_dir = get_main_repo_root(repo_root) / "kitty-specs" / mission_slug
+    if not (feature_dir / "tasks").is_dir():
         return None
-    return preview_claimable_wp(tasks_dir.parent)
+    return preview_claimable_wp(feature_dir)
 
 
 def _auto_claim_failure_message(preview: object | None) -> str:
@@ -800,29 +790,10 @@ def _auto_claim_failure_message(preview: object | None) -> str:
     if selection_reason == "dependencies_not_satisfied":
         return (
             "dependencies_not_satisfied: planned work packages are waiting on "
-            "dependencies; all dependencies must be done before implementation can start"
+            "dependencies; all dependencies must be approved or done before "
+            "implementation can start"
         )
     return "No planned work packages found. Specify a WP ID explicitly."
-
-
-def _find_first_planned_wp(repo_root: Path, mission_slug: str) -> str | None:
-    """Find the first WP file with lane: "planned".
-
-    Args:
-        repo_root: Repository root path
-        mission_slug: Feature slug
-
-    Returns:
-        WP ID of first planned task, or None if not found
-
-    Implementation note (issue #988, FR-003): this function delegates to the
-    shared, side-effect-free :func:`specify_cli.next.discovery.preview_claimable_wp`
-    so that ``next --json`` and ``agent action implement`` cannot drift in
-    their candidate-selection logic. Do not reintroduce a parallel
-    implementation here.
-    """
-    preview = _preview_claimable_wp_for_mission(repo_root, mission_slug)
-    return getattr(preview, "wp_id", None)
 
 
 @app.command(name="implement")
@@ -985,6 +956,7 @@ def implement(
 
         from specify_cli.status.reducer import reduce as _dep_reduce_events
         from specify_cli.status.store import read_events as _dep_read_events
+        from specify_cli.status.transitions import resolve_lane_alias as _dep_resolve_alias
 
         _dependency_feature_dir = main_repo_root / "kitty-specs" / mission_slug
         _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
@@ -992,18 +964,28 @@ def implement(
             _wp_id: _state.get("lane", Lane.PLANNED)
             for _wp_id, _state in _dependency_snapshot.work_packages.items()
         }
-        _dependency_readiness = dependency_readiness_for_wp(
-            normalized_wp_id,
-            wp_meta.dependencies,
-            _dependency_lanes,
-        )
-        if not _dependency_readiness.satisfied:
-            blocked = ", ".join(_dependency_readiness.unsatisfied)
-            print(
-                f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
-                "all dependencies must be done before implementation can start"
+        # Only gate the not-yet-started claim transition. Re-invoking implement on
+        # a WP that is already in_progress/for_review/.../approved (resume, prompt
+        # redisplay, fix-cycle) must not be rejected just because a dependency
+        # later regressed out of approved/done — the lifecycle treats those
+        # re-invocations as no-op resumes, not new claims.
+        try:
+            _self_lane = Lane(_dep_resolve_alias(str(_dependency_lanes.get(normalized_wp_id, Lane.PLANNED))))
+        except ValueError:
+            _self_lane = Lane.PLANNED
+        if _self_lane in (Lane.PLANNED, Lane.CLAIMED):
+            _dependency_readiness = dependency_readiness_for_wp(
+                normalized_wp_id,
+                wp_meta.dependencies,
+                _dependency_lanes,
             )
-            raise typer.Exit(1)
+            if not _dependency_readiness.satisfied:
+                blocked = ", ".join(_dependency_readiness.unsatisfied)
+                print(
+                    f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
+                    "all dependencies must be approved or done before implementation can start"
+                )
+                raise typer.Exit(1)
 
         subtask_ids = [str(item) for item in wp_meta.subtasks if isinstance(item, str)]
         subtask_cmd = " ".join(subtask_ids) if subtask_ids else "<subtask-ids>"

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -582,7 +582,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
             blocked = ", ".join(_dependency_readiness.unsatisfied)
             raise ValueError(
                 f"dependencies_not_satisfied: {wp_id} depends on {blocked}; "
-                "all dependencies must be done before implementation can start"
+                "all dependencies must be approved or done before implementation can start"
             )
 
         _ensure_planning_artifacts_committed_git(

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -595,7 +595,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         from specify_cli.status.store import read_events as _read_events
 
         _wp_lanes = {
-            _wp_id: Lane(_state.get("lane", Lane.PLANNED))
+            _wp_id: _state.get("lane", Lane.PLANNED)
             for _wp_id, _state in _reduce_events(_read_events(feature_dir)).work_packages.items()
         }
         _dependency_readiness = dependency_readiness_for_wp(wp_id, declared_deps, _wp_lanes)

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -505,7 +505,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
     See FR-503 and D-4 in the 3.1.1 spec.
     """
     from specify_cli.core.agent_config import get_auto_commit_default
-    from specify_cli.core.dependency_graph import parse_wp_dependencies
+    from specify_cli.core.dependency_graph import dependency_readiness_for_wp, parse_wp_dependencies
 
     if recover:
         _run_recover_mode(wp_id, mission, feature, json_output)
@@ -590,6 +590,21 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
                     border_style="yellow",
                 ))
                 raise typer.Exit(1)
+
+        from specify_cli.status.reducer import reduce as _reduce_events
+        from specify_cli.status.store import read_events as _read_events
+
+        _wp_lanes = {
+            _wp_id: Lane(_state.get("lane", Lane.PLANNED))
+            for _wp_id, _state in _reduce_events(_read_events(feature_dir)).work_packages.items()
+        }
+        _dependency_readiness = dependency_readiness_for_wp(wp_id, declared_deps, _wp_lanes)
+        if not _dependency_readiness.satisfied:
+            blocked = ", ".join(_dependency_readiness.unsatisfied)
+            raise ValueError(
+                f"dependencies_not_satisfied: {wp_id} depends on {blocked}; "
+                "all dependencies must be done before implementation can start"
+            )
 
         resolved_workspace = resolve_workspace_for_wp(repo_root, mission_slug, wp_id)
 

--- a/src/specify_cli/core/dependency_graph.py
+++ b/src/specify_cli/core/dependency_graph.py
@@ -16,6 +16,24 @@ from specify_cli.status.transitions import resolve_lane_alias
 from specify_cli.status.wp_metadata import read_wp_frontmatter
 
 
+# A dependency satisfies the readiness gate once its work is reviewed and
+# accepted. Both lanes count:
+#   * ``approved`` — review passed, merge pending. This is the pre-merge
+#     terminal lane a WP reaches during normal mission execution.
+#   * ``done`` — merged/integrated into the mission target branch.
+#
+# ``done`` is emitted ONLY by the whole-mission ``spec-kitty merge`` run
+# (``_mark_wp_merged_done`` in ``cli/commands/merge.py``), which itself refuses
+# to complete until every WP in the mission has reached ``done``. Requiring a
+# dependency to be strictly ``done`` would therefore deadlock every same-mission
+# dependency chain: a dependent WP could never start, so the mission could never
+# merge, so the dependency could never reach ``done``. Accepting ``approved`` as
+# well is what makes intra-mission dependency ordering possible, and it matches
+# the existing merge dependency gate (``policy/merge_gates.py`` treats
+# ``{approved, done}`` as satisfied) and the retrospective generator.
+_SATISFYING_DEPENDENCY_LANES: tuple[Lane, ...] = (Lane.APPROVED, Lane.DONE)
+
+
 @dataclass(frozen=True)
 class DependencyReadiness:
     """Dependency completion status for one work package."""
@@ -34,17 +52,23 @@ def dependency_readiness_for_wp(
     dependencies: Iterable[str],
     wp_lanes: Mapping[str, Lane | str],
 ) -> DependencyReadiness:
-    """Return whether all dependencies are in the canonical ``done`` lane.
+    """Return whether every dependency is in ``approved`` or ``done``.
 
-    This intentionally matches ``orchestrator-api list-ready`` semantics:
-    dependencies must be ``done``. ``approved``, ``for_review``, ``blocked``,
-    missing status, and every other lane are not ready.
+    A dependency is satisfied once its work is reviewed and accepted — i.e. its
+    lane is ``approved`` (review passed, merge pending) or ``done`` (merged).
+    ``for_review``, ``in_review``, ``blocked``, ``canceled``, missing status,
+    and every other lane are not ready.
+
+    The ``approved`` lane is deliberately included: ``done`` is emitted only by
+    the whole-mission merge, so gating strictly on ``done`` would deadlock every
+    same-mission dependency chain. See ``_SATISFYING_DEPENDENCY_LANES`` above and
+    the aligned merge gate in ``policy/merge_gates.py``.
     """
     deps = tuple(dependencies)
     unsatisfied = tuple(
         dep
         for dep in deps
-        if _dependency_lane(wp_lanes.get(dep, Lane.PLANNED)) != Lane.DONE
+        if _dependency_lane(wp_lanes.get(dep, Lane.PLANNED)) not in _SATISFYING_DEPENDENCY_LANES
     )
     return DependencyReadiness(
         wp_id=wp_id,

--- a/src/specify_cli/core/dependency_graph.py
+++ b/src/specify_cli/core/dependency_graph.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 from specify_cli.status.models import Lane
+from specify_cli.status.transitions import resolve_lane_alias
 from specify_cli.status.wp_metadata import read_wp_frontmatter
 
 
@@ -43,13 +44,21 @@ def dependency_readiness_for_wp(
     unsatisfied = tuple(
         dep
         for dep in deps
-        if Lane(wp_lanes.get(dep, Lane.PLANNED)) != Lane.DONE
+        if _dependency_lane(wp_lanes.get(dep, Lane.PLANNED)) != Lane.DONE
     )
     return DependencyReadiness(
         wp_id=wp_id,
         dependencies=deps,
         unsatisfied=unsatisfied,
     )
+
+
+def _dependency_lane(value: Lane | str) -> Lane | None:
+    """Normalize canonical/legacy dependency lanes without laundering invalid data."""
+    try:
+        return Lane(resolve_lane_alias(str(value)))
+    except ValueError:
+        return None
 
 
 def parse_wp_dependencies(wp_file: Path) -> list[str]:
@@ -355,6 +364,7 @@ def get_dependents(wp_id: str, graph: dict[str, list[str]]) -> list[str]:
 
 __all__ = [
     "build_dependency_graph",
+    "dependency_readiness_for_wp",
     "detect_cycles",
     "get_dependents",
     "parse_wp_dependencies",

--- a/src/specify_cli/core/dependency_graph.py
+++ b/src/specify_cli/core/dependency_graph.py
@@ -6,10 +6,50 @@ dependency relationships between work packages in Spec Kitty features.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 import re
 from pathlib import Path
 
+from specify_cli.status.models import Lane
 from specify_cli.status.wp_metadata import read_wp_frontmatter
+
+
+@dataclass(frozen=True)
+class DependencyReadiness:
+    """Dependency completion status for one work package."""
+
+    wp_id: str
+    dependencies: tuple[str, ...]
+    unsatisfied: tuple[str, ...]
+
+    @property
+    def satisfied(self) -> bool:
+        return not self.unsatisfied
+
+
+def dependency_readiness_for_wp(
+    wp_id: str,
+    dependencies: Iterable[str],
+    wp_lanes: Mapping[str, Lane | str],
+) -> DependencyReadiness:
+    """Return whether all dependencies are in the canonical ``done`` lane.
+
+    This intentionally matches ``orchestrator-api list-ready`` semantics:
+    dependencies must be ``done``. ``approved``, ``for_review``, ``blocked``,
+    missing status, and every other lane are not ready.
+    """
+    deps = tuple(dependencies)
+    unsatisfied = tuple(
+        dep
+        for dep in deps
+        if Lane(wp_lanes.get(dep, Lane.PLANNED)) != Lane.DONE
+    )
+    return DependencyReadiness(
+        wp_id=wp_id,
+        dependencies=deps,
+        unsatisfied=unsatisfied,
+    )
 
 
 def parse_wp_dependencies(wp_file: Path) -> list[str]:

--- a/src/specify_cli/next/discovery.py
+++ b/src/specify_cli/next/discovery.py
@@ -8,7 +8,7 @@ trust ``next --json`` as the canonical "what should I do next?" signal.
 
 This module exposes :func:`preview_claimable_wp`, the **single
 implementation path** for "which WP would the next implement action claim?".
-``_find_first_planned_wp`` in
+``_preview_claimable_wp_for_mission`` in
 ``specify_cli.cli.commands.agent.workflow`` delegates to this helper, so
 spec FR-003 ("claimability discovery MUST share a single implementation
 path with the explicit ``agent action implement`` claim logic, with no
@@ -69,9 +69,9 @@ class ClaimablePreview:
               ``for_review``, ``in_review``).
             * ``"dependencies_not_satisfied"`` — planned WPs exist, but every
               planned candidate is waiting on at least one dependency that is
-              not in ``done``.
+              not yet ``approved`` or ``done``.
         candidates: Ordered tuple of WP IDs the claim algorithm would have
-            considered (matches the order ``_find_first_planned_wp`` walks).
+            considered, in alphabetical ``WP*.md`` order.
     """
 
     wp_id: str | None
@@ -149,12 +149,11 @@ def preview_claimable_wp(feature_dir: Path) -> ClaimablePreview:
     """Return the WP that ``agent action implement`` would auto-claim, if any.
 
     Walks ``<feature_dir>/tasks/WP*.md`` in alphabetical order, reads each
-    file's YAML frontmatter ``work_package_id`` (matching the source-of-truth
-    used by :func:`_find_first_planned_wp`), then consults the canonical
+    file's YAML frontmatter ``work_package_id``, then consults the canonical
     status event log for current lane and the canonical dependency graph for
     dependency readiness. The first candidate whose lane is
-    :class:`Lane.PLANNED` and whose dependencies are all :class:`Lane.DONE` is
-    the WP the explicit action would claim.
+    :class:`Lane.PLANNED` and whose dependencies are all ``approved`` or
+    ``done`` is the WP the explicit action would claim.
 
     Args:
         feature_dir: Absolute path to ``kitty-specs/<mission_slug>/``.

--- a/src/specify_cli/next/discovery.py
+++ b/src/specify_cli/next/discovery.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from specify_cli.core.dependency_graph import build_dependency_graph, dependency_readiness_for_wp
 from specify_cli.status.models import Lane
 from specify_cli.status.reducer import reduce as _reduce_events
 from specify_cli.status.store import read_events as _read_events
@@ -65,6 +66,9 @@ class ClaimablePreview:
             * ``"all_wps_in_progress"`` — at least one candidate is in an
               active non-planned lane (``claimed``, ``in_progress``,
               ``for_review``, ``in_review``).
+            * ``"dependencies_not_satisfied"`` — planned WPs exist, but every
+              planned candidate is waiting on at least one dependency that is
+              not in ``done``.
         candidates: Ordered tuple of WP IDs the claim algorithm would have
             considered (matches the order ``_find_first_planned_wp`` walks).
     """
@@ -102,11 +106,24 @@ def _load_wp_lanes(feature_dir: Path) -> dict[str, Lane]:
     }
 
 
-def _preview_from_candidates(candidates: list[str], wp_lanes: dict[str, Lane]) -> ClaimablePreview:
+def _preview_from_candidates(
+    candidates: list[str],
+    wp_lanes: dict[str, Lane],
+    dependency_graph: dict[str, list[str]],
+) -> ClaimablePreview:
     has_active_candidate = False
+    has_dependency_blocked_candidate = False
     for wp_id in candidates:
         lane = wp_lanes.get(wp_id, Lane.PLANNED)
         if lane == Lane.PLANNED:
+            readiness = dependency_readiness_for_wp(
+                wp_id,
+                dependency_graph.get(wp_id, []),
+                wp_lanes,
+            )
+            if not readiness.satisfied:
+                has_dependency_blocked_candidate = True
+                continue
             return ClaimablePreview(
                 wp_id=wp_id,
                 selection_reason=None,
@@ -116,7 +133,13 @@ def _preview_from_candidates(candidates: list[str], wp_lanes: dict[str, Lane]) -
             has_active_candidate = True
     return ClaimablePreview(
         wp_id=None,
-        selection_reason="all_wps_in_progress" if has_active_candidate else "no_planned_wps",
+        selection_reason=(
+            "dependencies_not_satisfied"
+            if has_dependency_blocked_candidate
+            else "all_wps_in_progress"
+            if has_active_candidate
+            else "no_planned_wps"
+        ),
         candidates=tuple(candidates),
     )
 
@@ -127,8 +150,10 @@ def preview_claimable_wp(feature_dir: Path) -> ClaimablePreview:
     Walks ``<feature_dir>/tasks/WP*.md`` in alphabetical order, reads each
     file's YAML frontmatter ``work_package_id`` (matching the source-of-truth
     used by :func:`_find_first_planned_wp`), then consults the canonical
-    status event log for current lane. The first candidate whose lane is
-    :class:`Lane.PLANNED` is the WP the explicit action would claim.
+    status event log for current lane and the canonical dependency graph for
+    dependency readiness. The first candidate whose lane is
+    :class:`Lane.PLANNED` and whose dependencies are all :class:`Lane.DONE` is
+    the WP the explicit action would claim.
 
     Args:
         feature_dir: Absolute path to ``kitty-specs/<mission_slug>/``.
@@ -155,4 +180,8 @@ def preview_claimable_wp(feature_dir: Path) -> ClaimablePreview:
         )
 
     # Read lanes from the canonical status event log (lane is event-log-only).
-    return _preview_from_candidates(candidates, _load_wp_lanes(feature_dir))
+    return _preview_from_candidates(
+        candidates,
+        _load_wp_lanes(feature_dir),
+        build_dependency_graph(feature_dir),
+    )

--- a/src/specify_cli/next/discovery.py
+++ b/src/specify_cli/next/discovery.py
@@ -34,6 +34,7 @@ from specify_cli.core.dependency_graph import build_dependency_graph, dependency
 from specify_cli.status.models import Lane
 from specify_cli.status.reducer import reduce as _reduce_events
 from specify_cli.status.store import read_events as _read_events
+from specify_cli.status.wp_state import wp_state_for
 from specify_cli.task_utils.support import extract_scalar, split_frontmatter
 
 __all__ = ["ClaimablePreview", "preview_claimable_wp"]
@@ -101,7 +102,7 @@ def _load_wp_lanes(feature_dir: Path) -> dict[str, Lane]:
     except Exception:  # noqa: BLE001 — discovery is best-effort; on read failure default to PLANNED
         return {}
     return {
-        wp_id: Lane(state.get("lane", Lane.PLANNED))
+        wp_id: wp_state_for(state.get("lane", Lane.PLANNED)).lane
         for wp_id, state in snapshot.work_packages.items()
     }
 

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -642,6 +642,36 @@ def start_implementation(
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
 
+    from specify_cli.core.dependency_graph import dependency_readiness_for_wp, parse_wp_dependencies
+    from specify_cli.status.reducer import reduce
+    from specify_cli.status.store import read_events
+
+    wp_lanes = {
+        wp_id: state.get("lane", Lane.PLANNED)
+        for wp_id, state in reduce(read_events(mission_dir)).work_packages.items()
+    }
+    dependency_readiness = dependency_readiness_for_wp(
+        wp,
+        parse_wp_dependencies(wp_path),
+        wp_lanes,
+    )
+    if not dependency_readiness.satisfied:
+        blocked = ", ".join(dependency_readiness.unsatisfied)
+        _fail(
+            cmd,
+            "DEPENDENCIES_NOT_SATISFIED",
+            (
+                f"dependencies_not_satisfied: {wp} depends on {blocked}; "
+                "all dependencies must be done before implementation can start"
+            ),
+            {
+                **_mission_identity_payload(mission_dir),
+                "wp_id": wp,
+                "unsatisfied_dependencies": list(dependency_readiness.unsatisfied),
+            },
+        )
+        return
+
     from specify_cli.status.emit import TransitionError
     from specify_cli.status.work_package_lifecycle import WorkPackageClaimConflict, start_implementation_status
 

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -560,12 +560,16 @@ def list_ready(
 
     from specify_cli.status.reducer import reduce
     from specify_cli.status.store import read_events
-    from specify_cli.core.dependency_graph import build_dependency_graph
+    from specify_cli.core.dependency_graph import build_dependency_graph, dependency_readiness_for_wp
 
     # Query endpoint: reduce from event log without rewriting status.json.
     snapshot = reduce(read_events(mission_dir))
     dep_graph = build_dependency_graph(mission_dir)
     wp_states = snapshot.work_packages
+    wp_lanes = {
+        dep_id: wp_state_for(state.get("lane", Lane.PLANNED)).lane
+        for dep_id, state in wp_states.items()
+    }
 
     ready_wps = []
     for wp_id, deps in dep_graph.items():
@@ -575,18 +579,13 @@ def list_ready(
         if state.progress_bucket() != "not_started":
             continue
 
-        # Check all dependencies are done (completed, not merely terminal —
-        # canceled deps do NOT satisfy the dependency requirement).
-        all_deps_done = all(
-            wp_state_for(wp_states.get(dep, {}).get("lane", Lane.PLANNED)).lane == Lane.DONE
-            for dep in deps
-        )
+        readiness = dependency_readiness_for_wp(wp_id, deps, wp_lanes)
 
         ready_wps.append(
             {
                 "wp_id": wp_id,
                 "lane": lane,
-                "dependencies_satisfied": all_deps_done,
+                "dependencies_satisfied": readiness.satisfied,
             }
         )
 

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -547,7 +547,7 @@ def mission_state(
 def list_ready(
     mission: str = typer.Option(..., "--mission", help=_HELP_MISSION_SLUG),
 ) -> None:
-    """List WPs that are ready to start (planned and all deps done)."""
+    """List WPs that are ready to start (planned and all deps approved or done)."""
     main_repo_root = _get_main_repo_root()
     mission_dir = _resolve_mission_dir(main_repo_root, mission)
     if mission_dir is None:
@@ -650,27 +650,33 @@ def start_implementation(
         wp_id: state.get("lane", Lane.PLANNED)
         for wp_id, state in reduce(read_events(mission_dir)).work_packages.items()
     }
-    dependency_readiness = dependency_readiness_for_wp(
-        wp,
-        parse_wp_dependencies(wp_path),
-        wp_lanes,
-    )
-    if not dependency_readiness.satisfied:
-        blocked = ", ".join(dependency_readiness.unsatisfied)
-        _fail(
-            cmd,
-            "DEPENDENCIES_NOT_SATISFIED",
-            (
-                f"dependencies_not_satisfied: {wp} depends on {blocked}; "
-                "all dependencies must be done before implementation can start"
-            ),
-            {
-                **_mission_identity_payload(mission_dir),
-                "wp_id": wp,
-                "unsatisfied_dependencies": list(dependency_readiness.unsatisfied),
-            },
+    # Only gate the not-yet-started claim transition. Re-invoking start-implementation
+    # on a WP that is already in_progress/for_review/.../approved is a no-op resume
+    # in the lifecycle layer and must not be rejected just because a dependency later
+    # regressed out of approved/done.
+    _self_lane = wp_state_for(wp_lanes.get(wp, Lane.PLANNED)).lane
+    if _self_lane in (Lane.PLANNED, Lane.CLAIMED):
+        dependency_readiness = dependency_readiness_for_wp(
+            wp,
+            parse_wp_dependencies(wp_path),
+            wp_lanes,
         )
-        return
+        if not dependency_readiness.satisfied:
+            blocked = ", ".join(dependency_readiness.unsatisfied)
+            _fail(
+                cmd,
+                "DEPENDENCIES_NOT_SATISFIED",
+                (
+                    f"dependencies_not_satisfied: {wp} depends on {blocked}; "
+                    "all dependencies must be approved or done before implementation can start"
+                ),
+                {
+                    **_mission_identity_payload(mission_dir),
+                    "wp_id": wp,
+                    "unsatisfied_dependencies": list(dependency_readiness.unsatisfied),
+                },
+            )
+            return
 
     from specify_cli.status.emit import TransitionError
     from specify_cli.status.work_package_lifecycle import WorkPackageClaimConflict, start_implementation_status

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -612,6 +612,7 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
         pid=os.getpid(),
         port=port,
         token=daemon_token or "",
+        allow_network=False,
     )
     try:
         write_owner_record(record)
@@ -624,6 +625,16 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
             from specify_cli.sync.runtime import get_runtime
 
             get_runtime()
+            try:
+                enriched_record = build_record_for_current_process(
+                    pid=os.getpid(),
+                    port=port,
+                    token=daemon_token or "",
+                    allow_network=True,
+                )
+                write_owner_record(enriched_record)
+            except Exception:  # noqa: BLE001 — health remains valid with local-only owner data
+                logger.debug("Failed to enrich daemon owner record", exc_info=True)
         except Exception:  # noqa: BLE001 — health endpoint stays available
             logger.exception("Failed to start sync runtime")
 

--- a/src/specify_cli/sync/owner.py
+++ b/src/specify_cli/sync/owner.py
@@ -304,14 +304,15 @@ def _resolve_source_checkout_path() -> str:
     return str(Path(specify_cli.__file__).resolve().parents[2])
 
 
-def compute_foreground_identity() -> dict[str, Any]:
+def compute_foreground_identity(*, allow_network: bool = True) -> dict[str, Any]:
     """Build the foreground's view of the comparable identity fields.
 
     Returns a dict shaped like the subset of :class:`DaemonOwnerRecord`
-    that participates in :func:`mismatched_fields`. Fetches the scope-aware
-    auth/queue values from :mod:`specify_cli.sync.queue` lazily so that
-    callers without a configured environment (e.g. unit tests with a
-    tmp ``HOME``) still get a valid dict with ``None`` for missing pieces.
+    that participates in :func:`mismatched_fields`.
+
+    When ``allow_network`` is false, auth scope resolution must use only
+    local session/credential state. This keeps daemon control-plane startup
+    responsive; any SaaS membership rehydrate can run after health is live.
     """
     from specify_cli.sync.queue import (  # local import: cycle-safe
         _read_server_url_for_scope,
@@ -320,7 +321,7 @@ def compute_foreground_identity() -> dict[str, Any]:
         read_queue_scope_from_session,
     )
 
-    scope = read_queue_scope_from_session()
+    scope = read_queue_scope_from_session(allow_rehydrate=allow_network)
     if scope is None:
         scope = read_queue_scope_from_credentials()
 
@@ -341,7 +342,7 @@ def compute_foreground_identity() -> dict[str, Any]:
         "auth_principal": auth_principal,
         "auth_team": auth_team,
         "auth_scope": scope,
-        "queue_db_path": str(default_queue_db_path()),
+        "queue_db_path": str(default_queue_db_path(allow_rehydrate=allow_network)),
     }
 
 
@@ -465,6 +466,7 @@ def build_record_for_current_process(
     pid: int,
     port: int,
     token: str,
+    allow_network: bool = True,
 ) -> DaemonOwnerRecord:
     """Construct a :class:`DaemonOwnerRecord` for the current process.
 
@@ -472,8 +474,12 @@ def build_record_for_current_process(
     the daemon process *is* the foreground from its own perspective, so
     all the comparable fields are sourced from :func:`compute_foreground_identity`
     plus the supplied PID/port/token and the current UTC timestamp.
+
+    Daemon startup passes ``allow_network=False`` for the initial owner
+    record so TeamSpace membership rehydrate can never delay the first
+    health response.
     """
-    identity = compute_foreground_identity()
+    identity = compute_foreground_identity(allow_network=allow_network)
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S+00:00")
     return DaemonOwnerRecord(
         pid=pid,

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -436,7 +436,7 @@ def _read_server_url_for_scope() -> str:
     return str(value)
 
 
-def read_queue_scope_from_session() -> str | None:
+def read_queue_scope_from_session(*, allow_rehydrate: bool = True) -> str | None:
     """Read queue scope from the real encrypted auth session store.
 
     Returns None when the session is missing, unreadable, or incomplete, or
@@ -452,7 +452,7 @@ def read_queue_scope_from_session() -> str | None:
     # repeated /api/v1/me probes for a single shared-only session.
     try:
         from specify_cli.auth import get_token_manager
-        from specify_cli.sync._team import resolve_private_team_id_for_ingress
+        from specify_cli.auth.session import require_private_team_id
     except Exception as exc:  # noqa: BLE001 — explicit "log and skip" boundary
         import logging
 
@@ -466,10 +466,15 @@ def read_queue_scope_from_session() -> str | None:
     if session is None or not session.email:
         return None
 
-    team_id = resolve_private_team_id_for_ingress(
-        token_manager,
-        endpoint="/api/v1/events/batch/",
-    )
+    if allow_rehydrate:
+        from specify_cli.sync._team import resolve_private_team_id_for_ingress
+
+        team_id = resolve_private_team_id_for_ingress(
+            token_manager,
+            endpoint="/api/v1/events/batch/",
+        )
+    else:
+        team_id = require_private_team_id(session)
     if team_id is None:
         # Queue scope cannot be safely derived without a Private Teamspace;
         # leave events in any existing scoped queue and return None so
@@ -913,13 +918,17 @@ def detect_legacy_rows_for_scope(scope: str) -> LegacyRowCounts:
     )
 
 
-def default_queue_db_path(credentials_path: Path | None = None) -> Path:
+def default_queue_db_path(
+    credentials_path: Path | None = None,
+    *,
+    allow_rehydrate: bool = True,
+) -> Path:
     """Resolve default queue DB path.
 
     Unauthenticated sessions use legacy ~/.spec-kitty/queue.db.
     Authenticated sessions use scoped queues under ~/.spec-kitty/queues/.
     """
-    scope = read_queue_scope_from_session()
+    scope = read_queue_scope_from_session(allow_rehydrate=allow_rehydrate)
     if scope is None:
         scope = read_queue_scope_from_credentials(credentials_path=credentials_path)
     if scope:

--- a/tests/agent/test_dependency_graph.py
+++ b/tests/agent/test_dependency_graph.py
@@ -51,6 +51,60 @@ class TestDependencyReadiness:
         assert readiness.satisfied is False
         assert readiness.unsatisfied == ("WP01",)
 
+    def test_approved_dependency_is_satisfied(self) -> None:
+        # `done` is emitted only by the whole-mission merge, so an `approved`
+        # dependency must satisfy the gate or every dependency chain deadlocks.
+        readiness = dependency_readiness_for_wp(
+            "WP02",
+            ["WP01"],
+            {"WP01": "approved"},
+        )
+
+        assert readiness.satisfied is True
+        assert readiness.unsatisfied == ()
+
+    def test_for_review_dependency_is_unsatisfied(self) -> None:
+        readiness = dependency_readiness_for_wp(
+            "WP02",
+            ["WP01"],
+            {"WP01": "for_review"},
+        )
+
+        assert readiness.satisfied is False
+        assert readiness.unsatisfied == ("WP01",)
+
+    def test_multi_dependency_mixed_states_reports_only_unsatisfied_in_order(self) -> None:
+        # Two satisfied deps (approved/done) and one not (in_progress); the result
+        # must contain exactly the unsatisfied dep, preserving declaration order.
+        readiness = dependency_readiness_for_wp(
+            "WP04",
+            ["WP01", "WP02", "WP03"],
+            {"WP01": "approved", "WP02": "in_progress", "WP03": "done"},
+        )
+
+        assert readiness.satisfied is False
+        assert readiness.unsatisfied == ("WP02",)
+
+    def test_multi_dependency_all_satisfied_mix_of_approved_and_done(self) -> None:
+        readiness = dependency_readiness_for_wp(
+            "WP03",
+            ["WP01", "WP02"],
+            {"WP01": "approved", "WP02": "done"},
+        )
+
+        assert readiness.satisfied is True
+        assert readiness.unsatisfied == ()
+
+    def test_multi_dependency_preserves_unsatisfied_declaration_order(self) -> None:
+        readiness = dependency_readiness_for_wp(
+            "WP09",
+            ["WP03", "WP01"],
+            {"WP03": "planned", "WP01": "blocked"},
+        )
+
+        assert readiness.satisfied is False
+        assert readiness.unsatisfied == ("WP03", "WP01")
+
 
 # T001: Tests for dependency parsing
 class TestParseWpDependencies:

--- a/tests/agent/test_dependency_graph.py
+++ b/tests/agent/test_dependency_graph.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from specify_cli.core.dependency_graph import (
     build_dependency_graph,
+    dependency_readiness_for_wp,
     detect_cycles,
     get_dependents,
     parse_wp_dependencies,
@@ -17,6 +18,38 @@ from specify_cli.core.dependency_graph import (
 from specify_cli.frontmatter import FrontmatterError
 
 pytestmark = pytest.mark.fast
+
+
+class TestDependencyReadiness:
+    def test_legacy_doing_alias_is_unsatisfied_not_error(self) -> None:
+        readiness = dependency_readiness_for_wp(
+            "WP02",
+            ["WP01"],
+            {"WP01": "doing"},
+        )
+
+        assert readiness.satisfied is False
+        assert readiness.unsatisfied == ("WP01",)
+
+    def test_done_dependency_is_satisfied(self) -> None:
+        readiness = dependency_readiness_for_wp(
+            "WP02",
+            ["WP01"],
+            {"WP01": "done"},
+        )
+
+        assert readiness.satisfied is True
+        assert readiness.unsatisfied == ()
+
+    def test_invalid_dependency_lane_fails_closed(self) -> None:
+        readiness = dependency_readiness_for_wp(
+            "WP02",
+            ["WP01"],
+            {"WP01": "not-a-lane"},
+        )
+
+        assert readiness.satisfied is False
+        assert readiness.unsatisfied == ("WP01",)
 
 
 # T001: Tests for dependency parsing

--- a/tests/agent/test_implement_command.py
+++ b/tests/agent/test_implement_command.py
@@ -83,6 +83,26 @@ def create_lanes_json(feature_dir: Path, wp_ids: tuple[str, ...] = ("WP01",)) ->
     )
 
 
+def _append_lane_event(feature_dir: Path, wp_id: str, lane: str) -> None:
+    from specify_cli.status.models import Lane, StatusEvent
+    from specify_cli.status.store import append_event
+
+    append_event(
+        feature_dir,
+        StatusEvent(
+            event_id=f"seed-{wp_id}-{lane}",
+            mission_slug=feature_dir.name,
+            wp_id=wp_id,
+            from_lane=Lane.PLANNED,
+            to_lane=Lane(lane),
+            at="2026-05-30T08:30:00+00:00",
+            actor="fixture",
+            force=True,
+            execution_mode="worktree",
+        ),
+    )
+
+
 class TestDetectFeatureContext:
     def test_detect_with_explicit_flag(self) -> None:
         number, slug = detect_feature_context("010-lane-only-runtime")
@@ -265,6 +285,7 @@ class TestImplementCommand:
             "---\n# WP02",
             encoding="utf-8",
         )
+        _append_lane_event(feature_dir, "WP01", "done")
 
         with (
             patch("specify_cli.cli.commands.implement.find_repo_root", return_value=tmp_path),
@@ -300,6 +321,50 @@ class TestImplementCommand:
             kwargs = mock_create_lane_workspace.call_args.kwargs
             assert kwargs["wp_id"] == "WP02"
             assert kwargs["declared_deps"] == ["WP01"]
+
+    def test_implement_rejects_dependency_before_workspace_creation(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "010-feature"
+        create_meta_json(feature_dir)
+        create_lanes_json(feature_dir, wp_ids=("WP01", "WP02"))
+        wp_file = feature_dir / "tasks" / "WP02-api.md"
+        wp_file.parent.mkdir(parents=True)
+        wp_file.write_text(
+            "---\n"
+            "work_package_id: WP02\n"
+            "dependencies: [WP01]\n"
+            "execution_mode: code_change\n"
+            "owned_files:\n  - src/wp02/**\n"
+            "authoritative_surface: src/wp02/\n"
+            "---\n# WP02",
+            encoding="utf-8",
+        )
+
+        with (
+            patch("specify_cli.cli.commands.implement.find_repo_root", return_value=tmp_path),
+            patch(
+                "specify_cli.cli.commands.implement.detect_feature_context",
+                return_value=("010", "010-feature"),
+            ),
+            patch(
+                "specify_cli.cli.commands.implement.resolve_feature_target_branch",
+                return_value="main",
+            ),
+            patch(
+                "specify_cli.cli.commands.implement._ensure_planning_artifacts_committed_git",
+            ),
+            patch(
+                "specify_cli.cli.commands.implement.create_lane_workspace",
+            ) as mock_create_lane_workspace,
+        ):
+            with pytest.raises(typer.Exit):
+                implement("WP02", feature="010-feature", recover=False)
+
+        assert mock_create_lane_workspace.call_count == 0
+        assert "dependencies_not_satisfied" in capsys.readouterr().out
 
     def test_implement_allows_planning_artifact_in_lane_planning(self, tmp_path: Path) -> None:
         feature_dir = tmp_path / "kitty-specs" / "010-feature"

--- a/tests/agent/test_implement_command.py
+++ b/tests/agent/test_implement_command.py
@@ -366,7 +366,9 @@ class TestImplementCommand:
 
         assert mock_commit_planning.call_count == 0
         assert mock_create_lane_workspace.call_count == 0
-        assert "dependencies_not_satisfied" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "dependencies_not_satisfied" in out
+        assert "all dependencies must be approved or done" in out
 
     def test_implement_auto_commit_allows_safe_coordination_branch_when_target_is_protected(
         self,

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -357,6 +357,55 @@ class TestStartImplementation:
             ("claimed", "in_progress"),
         ]
 
+    def test_dependency_blocked_wp_rejected_without_events(self, tmp_path):
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+        wp02_path = mission_dir / "tasks" / "WP02.md"
+        wp02_path.write_text(
+            "---\n"
+            "work_package_id: WP02\n"
+            "title: Test WP02\n"
+            "lane: planned\n"
+            "dependencies: [WP01]\n"
+            "---\n\n"
+            "# WP02\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.status.emit import emit_status_transition
+        from specify_cli.status.store import read_events
+
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP01", to_lane="claimed", actor="seed"))
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP01", to_lane="in_progress", actor="seed"))
+        before_events = read_events(mission_dir)
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "start-implementation",
+                    "--mission",
+                    mission_slug,
+                    "--wp",
+                    "WP02",
+                    "--actor",
+                    "claude",
+                    "--policy",
+                    _valid_policy_json(),
+                ],
+            )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error_code"] == "DEPENDENCIES_NOT_SATISFIED"
+        assert data["data"]["wp_id"] == "WP02"
+        assert data["data"]["unsatisfied_dependencies"] == ["WP01"]
+        assert read_events(mission_dir) == before_events
+
     def test_claimed_same_actor_resumes_to_in_progress(self, tmp_path):
         repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
         mission_slug = "099-test-mission"

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -299,6 +299,54 @@ class TestListReady:
         assert result.exit_code == 0, result.output
         assert not status_path.exists()
 
+    def test_dep_blocked_wp_excluded_from_ready(self, tmp_path):
+        """A planned WP whose dependency is not approved/done is filtered out of ready."""
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+        (mission_dir / "tasks" / "WP02.md").write_text(
+            "---\nwork_package_id: WP02\ntitle: Test WP02\nlane: planned\ndependencies: [WP01]\n---\n\n# WP02\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.status.emit import emit_status_transition
+
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP01", to_lane="claimed", actor="test"))
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP01", to_lane="in_progress", actor="test"))
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(app, ["list-ready", "--mission", mission_slug])
+
+        assert result.exit_code == 0, result.output
+        ready_ids = {wp["wp_id"] for wp in json.loads(result.output)["data"]["ready_work_packages"]}
+        # WP01 is in_progress (not planned); WP02's dependency is unsatisfied. Neither ready.
+        assert ready_ids == set()
+
+    def test_dep_satisfied_by_approved_makes_wp_ready(self, tmp_path):
+        """An `approved` dependency (not yet merged) satisfies list-ready."""
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+        (mission_dir / "tasks" / "WP02.md").write_text(
+            "---\nwork_package_id: WP02\ntitle: Test WP02\nlane: planned\ndependencies: [WP01]\n---\n\n# WP02\n",
+            encoding="utf-8",
+        )
+        _emit_planned_to_approved(mission_dir, mission_slug, "WP01")
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(app, ["list-ready", "--mission", mission_slug])
+
+        assert result.exit_code == 0, result.output
+        ready_ids = {wp["wp_id"] for wp in json.loads(result.output)["data"]["ready_work_packages"]}
+        # WP01 is approved (not planned) so not itself ready; WP02's dependency is
+        # satisfied by `approved`, so WP02 is ready.
+        assert "WP02" in ready_ids
+        assert "WP01" not in ready_ids
+
 
 # ── start-implementation ──────────────────────────────────────────
 
@@ -405,6 +453,91 @@ class TestStartImplementation:
         assert data["data"]["wp_id"] == "WP02"
         assert data["data"]["unsatisfied_dependencies"] == ["WP01"]
         assert read_events(mission_dir) == before_events
+
+    def test_dependency_satisfied_by_approved_allows_start(self, tmp_path):
+        """An `approved` dependency unblocks starting the dependent WP.
+
+        ``done`` is emitted only by the whole-mission merge, so requiring it would
+        deadlock the chain; ``approved`` (review passed, merge pending) must allow
+        the dependent WP to start.
+        """
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+        (mission_dir / "tasks" / "WP02.md").write_text(
+            "---\nwork_package_id: WP02\ntitle: Test WP02\nlane: planned\ndependencies: [WP01]\n---\n\n# WP02\n",
+            encoding="utf-8",
+        )
+        _emit_planned_to_approved(mission_dir, mission_slug, "WP01")
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "start-implementation",
+                    "--mission",
+                    mission_slug,
+                    "--wp",
+                    "WP02",
+                    "--actor",
+                    "claude",
+                    "--policy",
+                    _valid_policy_json(),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["wp_id"] == "WP02"
+        assert data["data"]["to_lane"] == "in_progress"
+
+    def test_resume_in_progress_wp_not_blocked_by_unsatisfied_dependency(self, tmp_path):
+        """Re-running start on an already in_progress WP must not be dep-gated.
+
+        The dependency gate guards only the not-yet-started claim transition. A WP
+        that is already in_progress (e.g. its dependency's approval was later
+        reverted) must still resume as a no-op rather than being rejected.
+        """
+        repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
+        mission_slug = "099-test-mission"
+        (mission_dir / "tasks" / "WP02.md").write_text(
+            "---\nwork_package_id: WP02\ntitle: Test WP02\nlane: planned\ndependencies: [WP01]\n---\n\n# WP02\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.status.emit import emit_status_transition
+
+        # WP02 was started earlier; WP01 is still planned (its approval was reverted).
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP02", to_lane="claimed", actor="claude"))
+        emit_status_transition(TransitionRequest(feature_dir=mission_dir, mission_slug=mission_slug, wp_id="WP02", to_lane="in_progress", actor="claude"))
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "start-implementation",
+                    "--mission",
+                    mission_slug,
+                    "--wp",
+                    "WP02",
+                    "--actor",
+                    "claude",
+                    "--policy",
+                    _valid_policy_json(),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["wp_id"] == "WP02"
+        assert data["data"]["no_op"] is True
 
     def test_claimed_same_actor_resumes_to_in_progress(self, tmp_path):
         repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")

--- a/tests/next/test_next_claimable_payload.py
+++ b/tests/next/test_next_claimable_payload.py
@@ -31,7 +31,12 @@ def _init_repo(repo: Path) -> None:
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True, capture_output=True)
 
 
-def _scaffold(repo: Path, wps: dict[str, Lane]) -> tuple[Path, str]:
+def _scaffold(
+    repo: Path,
+    wps: dict[str, Lane],
+    *,
+    dependencies: dict[str, list[str]] | None = None,
+) -> tuple[Path, str]:
     _init_repo(repo)
     (repo / ".kittify").mkdir()
     mission_slug = "claimable-payload-mission-01KRKTT5"
@@ -49,8 +54,14 @@ def _scaffold(repo: Path, wps: dict[str, Lane]) -> tuple[Path, str]:
     (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
     write_single_lane_manifest(feature_dir, wp_ids=tuple(wps.keys()))
     for wp_id, lane in wps.items():
+        deps = dependencies.get(wp_id, []) if dependencies else []
         (tasks_dir / f"{wp_id}.md").write_text(
-            f"---\nwork_package_id: {wp_id}\ndependencies: []\ntitle: {wp_id}\n---\n# {wp_id}\n",
+            "---\n"
+            f"work_package_id: {wp_id}\n"
+            f"dependencies: {json.dumps(deps)}\n"
+            f"title: {wp_id}\n"
+            "---\n"
+            f"# {wp_id}\n",
             encoding="utf-8",
         )
         append_event(
@@ -161,6 +172,53 @@ def test_preview_claimable_wp_uses_frontmatter_id_not_filename(
     assert preview.wp_id == "WP01"
     assert preview.selection_reason is None
     assert preview.candidates == ("WP01",)
+
+
+def test_preview_claimable_wp_skips_dep_blocked_planned_wp(tmp_path: Path) -> None:
+    """Planned WPs are not claimable until every dependency reaches ``done``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    feature_dir, _ = _scaffold(
+        repo,
+        {"WP01": Lane.IN_PROGRESS, "WP02": Lane.PLANNED},
+        dependencies={"WP02": ["WP01"]},
+    )
+
+    preview = preview_claimable_wp(feature_dir)
+
+    assert preview.wp_id is None
+    assert preview.selection_reason == "dependencies_not_satisfied"
+    assert preview.candidates == ("WP01", "WP02")
+
+
+def test_preview_claimable_wp_allows_dep_after_done(tmp_path: Path) -> None:
+    """A dependent planned WP becomes claimable once upstream is ``done``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    feature_dir, _ = _scaffold(
+        repo,
+        {"WP01": Lane.DONE, "WP02": Lane.PLANNED},
+        dependencies={"WP02": ["WP01"]},
+    )
+
+    preview = preview_claimable_wp(feature_dir)
+
+    assert preview.wp_id == "WP02"
+    assert preview.selection_reason is None
+    assert preview.candidates == ("WP01", "WP02")
+
+
+def test_preview_claimable_wp_preserves_independent_fanout(tmp_path: Path) -> None:
+    """An independent planned WP remains claimable while another WP is active."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    feature_dir, _ = _scaffold(repo, {"WP01": Lane.IN_PROGRESS, "WP02": Lane.PLANNED})
+
+    preview = preview_claimable_wp(feature_dir)
+
+    assert preview.wp_id == "WP02"
+    assert preview.selection_reason is None
+    assert preview.candidates == ("WP01", "WP02")
 
 
 def test_next_json_payload_serializes_claimable_wp_id(tmp_path: Path) -> None:

--- a/tests/next/test_next_claimable_payload.py
+++ b/tests/next/test_next_claimable_payload.py
@@ -89,7 +89,7 @@ def _scaffold(
 
 
 def test_preview_claimable_wp_returns_first_planned_wp(tmp_path: Path) -> None:
-    """The discovery helper mirrors ``_find_first_planned_wp`` candidate selection."""
+    """``preview_claimable_wp`` returns the first claimable planned WP in candidate order."""
     repo = tmp_path / "repo"
     repo.mkdir()
     feature_dir, _ = _scaffold(repo, {"WP01": Lane.PLANNED, "WP02": Lane.PLANNED})
@@ -153,7 +153,7 @@ def test_preview_claimable_wp_distinguishes_terminal_from_active(
 def test_preview_claimable_wp_uses_frontmatter_id_not_filename(
     tmp_path: Path,
 ) -> None:
-    """WP id source is YAML ``work_package_id``, matching ``_find_first_planned_wp`` (FR-003)."""
+    """WP id source is YAML ``work_package_id``, the canonical claim source (FR-003)."""
     repo = tmp_path / "repo"
     repo.mkdir()
     feature_dir, _ = _scaffold(repo, {"WP01": Lane.PLANNED})
@@ -175,7 +175,7 @@ def test_preview_claimable_wp_uses_frontmatter_id_not_filename(
 
 
 def test_preview_claimable_wp_skips_dep_blocked_planned_wp(tmp_path: Path) -> None:
-    """Planned WPs are not claimable until every dependency reaches ``done``."""
+    """Planned WPs are not claimable until every dependency is approved or done."""
     repo = tmp_path / "repo"
     repo.mkdir()
     feature_dir, _ = _scaffold(
@@ -198,6 +198,28 @@ def test_preview_claimable_wp_allows_dep_after_done(tmp_path: Path) -> None:
     feature_dir, _ = _scaffold(
         repo,
         {"WP01": Lane.DONE, "WP02": Lane.PLANNED},
+        dependencies={"WP02": ["WP01"]},
+    )
+
+    preview = preview_claimable_wp(feature_dir)
+
+    assert preview.wp_id == "WP02"
+    assert preview.selection_reason is None
+    assert preview.candidates == ("WP01", "WP02")
+
+
+def test_preview_claimable_wp_allows_dep_after_approved(tmp_path: Path) -> None:
+    """A dependent planned WP becomes claimable once upstream is ``approved``.
+
+    ``done`` is only reached at whole-mission merge time, so an ``approved``
+    dependency (review passed, merge pending) must unblock the dependent WP;
+    otherwise every same-mission dependency chain deadlocks.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    feature_dir, _ = _scaffold(
+        repo,
+        {"WP01": Lane.APPROVED, "WP02": Lane.PLANNED},
         dependencies={"WP02": ["WP01"]},
     )
 

--- a/tests/specify_cli/cli/commands/agent/test_workflow.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow.py
@@ -294,7 +294,59 @@ def test_auto_claim_failure_message_preserves_dependency_reason() -> None:
     message = workflow_module._auto_claim_failure_message(preview)
 
     assert "dependencies_not_satisfied" in message
-    assert "all dependencies must be done" in message
+    assert "all dependencies must be approved or done" in message
+
+
+def test_preview_claimable_wp_for_mission_reads_repo_root_not_worktree(tmp_path, monkeypatch):
+    """The auto-claim readiness preview resolves to the repository-root checkout's
+    canonical event log (via get_main_repo_root), never a stale worktree-local copy.
+
+    A dependent WP whose dependency is `approved` in the authoritative log must be
+    surfaced as claimable even when the helper is invoked with a worktree repo root.
+    """
+    import json as _json
+
+    from specify_cli.cli.commands.agent import workflow as workflow_module
+    from specify_cli.status.models import Lane, StatusEvent
+    from specify_cli.status.store import append_event
+
+    mission_slug = "010-feature"
+    main_repo = tmp_path / "main"
+    feature_dir = main_repo / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    for wp_id, deps in (("WP01", []), ("WP02", ["WP01"])):
+        (tasks_dir / f"{wp_id}.md").write_text(
+            f"---\nwork_package_id: {wp_id}\ndependencies: {_json.dumps(deps)}\ntitle: {wp_id}\n---\n# {wp_id}\n",
+            encoding="utf-8",
+        )
+    for wp_id, lane in (("WP01", Lane.APPROVED), ("WP02", Lane.PLANNED)):
+        append_event(
+            feature_dir,
+            StatusEvent(
+                event_id=f"seed-{wp_id}",
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                from_lane=Lane.PLANNED,
+                to_lane=lane,
+                at="2026-05-30T08:30:00+00:00",
+                actor="fixture",
+                force=True,
+                execution_mode="worktree",
+            ),
+        )
+
+    # The helper is handed a *worktree* repo root; it must still resolve to the
+    # main checkout via get_main_repo_root rather than reading the worktree.
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    monkeypatch.setattr(workflow_module, "get_main_repo_root", lambda _path: main_repo)
+
+    preview = workflow_module._preview_claimable_wp_for_mission(worktree_root, mission_slug)
+
+    assert preview is not None
+    assert preview.wp_id == "WP02"
+    assert preview.selection_reason is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
@@ -482,3 +482,91 @@ class TestPlanningArtifactWorkflowPrompt:
         prompt = prompt_path.read_text(encoding="utf-8")
 
         assert "Review commands unavailable: no deterministic implementation claim commit found for this WP." in prompt
+
+
+# ---------------------------------------------------------------------------
+# Dependency gate on the `agent action implement` verb (explicit WP, existing
+# workspace). Mirrors the orchestrator-api start-implementation twin.
+# ---------------------------------------------------------------------------
+
+
+class TestImplementDependencyGate:
+    """workflow.py `implement` dependency gate: block fresh dep-blocked claims,
+    resume already-in_progress WPs without re-gating."""
+
+    def _scaffold_dependent_pair(self, feature_dir: Path, wp02_dep: str = "WP01") -> None:
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        write_single_lane_manifest(feature_dir, wp_ids=("WP01", "WP02"), predicted_surfaces=("workflow",))
+        (feature_dir / "tasks.md").write_text(
+            "## WP01 Test\n\n- [x] T001 Placeholder task\n\n## WP02 Test\n\n- [x] T002 Placeholder task\n",
+            encoding="utf-8",
+        )
+        (tasks_dir / "WP01-test.md").write_text(
+            "---\n"
+            "work_package_id: WP01\n"
+            "subtasks: [T001]\n"
+            "title: WP01 Test\n"
+            "dependencies: []\n"
+            "execution_mode: code_change\n"
+            "owned_files:\n  - src/wp01/**\n"
+            "authoritative_surface: src/wp01/\n"
+            "---\n# WP01 Prompt\n",
+            encoding="utf-8",
+        )
+        (tasks_dir / "WP02-test.md").write_text(
+            "---\n"
+            "work_package_id: WP02\n"
+            "subtasks: [T002]\n"
+            "title: WP02 Test\n"
+            f"dependencies: [{wp02_dep}]\n"
+            "execution_mode: code_change\n"
+            "owned_files:\n  - src/wp02/**\n"
+            "authoritative_surface: src/wp02/\n"
+            "---\n# WP02 Prompt\n",
+            encoding="utf-8",
+        )
+
+    def test_implement_blocks_dep_unsatisfied_planned_wp_with_existing_workspace(
+        self, workflow_repo: Path
+    ) -> None:
+        """Explicit dep-blocked planned WP is rejected at the workflow.py gate even
+        when its workspace already exists (so top_level_implement is not called)."""
+        mission_slug = "060-test-feature"
+        feature_dir = workflow_repo / "kitty-specs" / mission_slug
+        self._scaffold_dependent_pair(feature_dir)
+        # WP01 is only in_progress (not approved/done); WP02 stays planned.
+        _seed_wp_lane(feature_dir, "WP01", "in_progress")
+        # Workspace already resolves so creation is skipped and the gate is reached.
+        lane_worktree_path(workflow_repo, mission_slug).mkdir(parents=True)
+
+        result = CliRunner().invoke(
+            workflow.app,
+            ["implement", "WP02", "--mission", mission_slug, "--agent", "test-agent"],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        assert "dependencies_not_satisfied" in result.stdout
+        assert "all dependencies must be approved or done" in result.stdout
+
+    def test_implement_resumes_in_progress_wp_with_unsatisfied_dependency(
+        self, workflow_repo: Path
+    ) -> None:
+        """An already in_progress WP resumes without re-gating, even if its
+        dependency later regressed out of approved/done."""
+        mission_slug = "060-test-feature"
+        feature_dir = workflow_repo / "kitty-specs" / mission_slug
+        self._scaffold_dependent_pair(feature_dir)
+        # WP01 reverted to in_progress (unsatisfied); WP02 was already started.
+        _seed_wp_lane(feature_dir, "WP01", "in_progress")
+        _seed_wp_lane(feature_dir, "WP02", "in_progress", actor="test-agent")
+        lane_worktree_path(workflow_repo, mission_slug).mkdir(parents=True)
+
+        result = CliRunner().invoke(
+            workflow.app,
+            ["implement", "WP02", "--mission", mission_slug, "--agent", "test-agent"],
+        )
+
+        # Gate skipped (WP02 is in_progress) -> resume succeeds, no dependency error.
+        assert result.exit_code == 0, result.stdout
+        assert "dependencies_not_satisfied" not in result.stdout

--- a/tests/specify_cli/cli/commands/test_doctor_restart_daemon_timing.py
+++ b/tests/specify_cli/cli/commands/test_doctor_restart_daemon_timing.py
@@ -102,22 +102,17 @@ def _fetch_health(url: str, token: str) -> dict[str, object]:
     return payload
 
 
-def _wait_for_runtime_ready(home: Path, expected_pid: int, *, deadline: float) -> dict[str, object]:
+def _wait_for_control_plane_ready(home: Path, expected_pid: int, *, deadline: float) -> dict[str, object]:
     last_payload: dict[str, object] | None = None
     while time.perf_counter() < deadline:
         url, _port, token, pid = _read_daemon_record(home)
         assert pid == expected_pid
         payload = _fetch_health(url, token)
         last_payload = payload
-        sync_payload = payload.get("sync")
-        if (
-            payload.get("status") == "ok"
-            and isinstance(sync_payload, dict)
-            and sync_payload.get("running") is True
-        ):
+        if payload.get("status") == "ok":
             return payload
         time.sleep(0.1)
-    raise AssertionError(f"sync runtime was not ready before NFR deadline: {last_payload}")
+    raise AssertionError(f"sync control plane was not ready before NFR deadline: {last_payload}")
 
 
 def _terminate_known_daemon_pids(pids: list[int]) -> None:
@@ -139,7 +134,7 @@ def _terminate_known_daemon_pids(pids: list[int]) -> None:
 def test_doctor_restart_daemon_completes_under_nfr_002_threshold(
     tmp_path: Path,
 ) -> None:
-    """NFR-002: real stop + respawn + health response finishes under 10s."""
+    """NFR-002: real stop + respawn + control-plane health finishes under 10s."""
     home = tmp_path / "home"
     home.mkdir()
     env = _subprocess_env(home)
@@ -180,7 +175,7 @@ def test_doctor_restart_daemon_completes_under_nfr_002_threshold(
         assert payload["status"] == "restarted"
         assert payload["previous_pid"] != payload["new_pid"]
         created_pids.append(int(payload["new_pid"]))
-        health_payload = _wait_for_runtime_ready(
+        health_payload = _wait_for_control_plane_ready(
             home,
             int(payload["new_pid"]),
             deadline=start + _NFR_002_SECONDS,

--- a/tests/sync/test_daemon_owner_record.py
+++ b/tests/sync/test_daemon_owner_record.py
@@ -559,7 +559,13 @@ def test_build_record_for_current_process_uses_identity(
         "auth_scope": "https://example.test|alice@example.test|team-a",
         "queue_db_path": "/tmp/queue.db",
     }
-    monkeypatch.setattr(owner_mod, "compute_foreground_identity", lambda: fake_identity)
+    observed_allow_network: list[bool] = []
+
+    def fake_compute_identity(*, allow_network: bool = True) -> dict[str, Any]:
+        observed_allow_network.append(allow_network)
+        return fake_identity
+
+    monkeypatch.setattr(owner_mod, "compute_foreground_identity", fake_compute_identity)
 
     record = owner_mod.build_record_for_current_process(pid=4242, port=9410, token="t")
     assert record.pid == 4242
@@ -573,6 +579,39 @@ def test_build_record_for_current_process_uses_identity(
     assert record.auth_team == "team-a"
     assert record.auth_scope == "https://example.test|alice@example.test|team-a"
     assert record.queue_db_path == "/tmp/queue.db"
+    assert observed_allow_network == [True]
+
+
+def test_build_record_for_current_process_can_skip_network_identity(
+    _scoped_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from specify_cli.sync import owner as owner_mod
+
+    observed_allow_network: list[bool] = []
+
+    def fake_compute_identity(*, allow_network: bool = True) -> dict[str, Any]:
+        observed_allow_network.append(allow_network)
+        return {
+            "package_version": "1.2.3",
+            "executable_path": "/usr/bin/python-test",
+            "source_checkout_path": "/some/path",
+            "server_url": "https://example.test",
+            "auth_principal": None,
+            "auth_team": None,
+            "auth_scope": None,
+            "queue_db_path": "/tmp/queue.db",
+        }
+
+    monkeypatch.setattr(owner_mod, "compute_foreground_identity", fake_compute_identity)
+
+    record = owner_mod.build_record_for_current_process(
+        pid=4242,
+        port=9410,
+        token="t",
+        allow_network=False,
+    )
+
+    assert observed_allow_network == [False]
     # Timestamp is ISO-8601 UTC.
     assert record.started_at.endswith("+00:00")
 

--- a/tests/sync/test_team_ingress_resolver.py
+++ b/tests/sync/test_team_ingress_resolver.py
@@ -26,7 +26,7 @@ from specify_cli.auth.secure_storage import SecureStorage
 from specify_cli.auth.session import StoredSession, Team
 from specify_cli.auth.token_manager import TokenManager
 from specify_cli.sync.emitter import EventEmitter
-from specify_cli.sync.queue import read_queue_scope_from_session
+from specify_cli.sync.queue import default_queue_db_path, read_queue_scope_from_session
 
 pytestmark = pytest.mark.fast
 
@@ -167,6 +167,68 @@ def test_queue_ingress_rehydrates_and_sends_private(
     assert scope is not None
     assert "t-private" in scope
     assert me_route.call_count == 1
+
+
+@respx.mock
+def test_queue_scope_local_only_skips_rehydrate(
+    token_manager_with_shared_only_session: TokenManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local-only scope reads must not call TeamSpace membership rehydrate."""
+    me_route = respx.get(f"{_SAAS_BASE_URL}/api/v1/me").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "email": "u@example.com",
+                "teams": [
+                    {
+                        "id": "t-private",
+                        "name": "Private",
+                        "role": "owner",
+                        "is_private_teamspace": True,
+                    }
+                ],
+            },
+        )
+    )
+
+    _patched_token_manager(monkeypatch, token_manager_with_shared_only_session)
+
+    scope = read_queue_scope_from_session(allow_rehydrate=False)
+
+    assert scope is None
+    assert me_route.call_count == 0
+
+
+@respx.mock
+def test_default_queue_db_path_local_only_skips_rehydrate(
+    token_manager_with_shared_only_session: TokenManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local-only queue path resolution must not call TeamSpace membership rehydrate."""
+    me_route = respx.get(f"{_SAAS_BASE_URL}/api/v1/me").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "email": "u@example.com",
+                "teams": [
+                    {
+                        "id": "t-private",
+                        "name": "Private",
+                        "role": "owner",
+                        "is_private_teamspace": True,
+                    }
+                ],
+            },
+        )
+    )
+
+    _patched_token_manager(monkeypatch, token_manager_with_shared_only_session)
+
+    path = default_queue_db_path(allow_rehydrate=False)
+
+    assert path.name == "queue.db"
+    assert me_route.call_count == 0
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

This PR has two parts.

### A) Dependency gating for `next` and `implement` (fixes #715 follow-up)

A planned work package whose declared dependencies are not yet complete must not be
auto-claimed or implemented. A shared helper, `dependency_readiness_for_wp()`
(`core/dependency_graph.py`), is enforced at every claim path:

- `next/discovery.py::preview_claimable_wp()` — skips dependency-blocked planned WPs and
  returns the structured reason `dependencies_not_satisfied` when only blocked candidates remain.
- `agent action implement` and the low-level `implement` command — reject a blocked WP
  before any worktree is created.
- `orchestrator-api list-ready` / `start-implementation` — share the same readiness helper.

**A dependency is "satisfied" when it is `approved` OR `done`** — not strictly `done`.
`done` is emitted only by the whole-mission `spec-kitty merge` (`_mark_wp_merged_done`),
which itself refuses to complete until every WP has reached `done`. Gating strictly on
`done` would deadlock every same-mission dependency chain (the dependent WP could never
start → the mission could never merge → the dependency could never reach `done`). This
matches the pre-existing merge dependency gate (`policy/merge_gates.py`, which already
treats `{approved, done}` as satisfied). Independent WPs still fan out in parallel.

The gate guards only the not-yet-started (`planned`/`claimed`) claim transition — re-invoking
implement on an already `in_progress` WP is a no-op resume and is not re-gated, so a
dependency that later regresses out of `approved`/`done` does not block in-flight work.

The auto-claim readiness preview always reads the repository-root checkout's canonical event
log (via `get_main_repo_root`), never a stale worktree-local copy, so its candidate/reason
agree with the authoritative gate.

New glossary terms (`dependency readiness`, `dependency gate`) and a CLAUDE.md section
document the canonical semantics.

### B) Daemon restart control path nonblocking

Defers the network-dependent owner-record enrichment so the daemon health endpoint comes up
fast: the initial `DaemonOwnerRecord` is written with `allow_network=False`, then a background
re-write enriches it with `allow_network=True`. `allow_network`/`allow_rehydrate` thread
through `sync/owner.py` and `sync/queue.py`; the `doctor restart-daemon` fast-path is moved
ahead of heavy imports in `__init__.py` (`SPEC_KITTY_SYNC_MINIMAL_IMPORT`). Verified to be
internally coherent and **not** a regression/partial-revert of #1394.
`test_doctor_restart_daemon_timing.py` intentionally relaxes the #1382 NFR-002 assertion
(drops `sync.running is True`, keeps `status == "ok"`) because runtime startup now happens in
a background thread after control-plane health is live.

## Tests

Dependency gating:
- `uv run pytest tests/agent/test_dependency_graph.py tests/next/test_next_claimable_payload.py tests/agent/test_implement_command.py tests/agent/test_orchestrator_commands_integration.py tests/specify_cli/cli/commands/agent/test_workflow.py -q`
- Added: `approved`-satisfies + multi-dependency mixed-state readiness; `approved`-dependency claimable in discovery; `list-ready` excludes dep-blocked / includes approved-satisfied; `start-implementation` approved-allowed + in_progress resume not dep-gated; auto-claim preview reads repo-root not worktree.

Daemon:
- `uv run pytest tests/sync/test_daemon_owner_record.py tests/sync/test_team_ingress_resolver.py tests/specify_cli/cli/commands/test_doctor_restart_daemon_timing.py -q`

Full affected sweep: `uv run pytest tests/next tests/agent/test_dependency_graph.py tests/agent/test_implement_command.py tests/agent/test_orchestrator_commands_integration.py tests/specify_cli/cli/commands/agent/ tests/lanes/test_dependent_wp_scheduling.py -q` → 778 passed.

Lint: `uv run ruff check` clean on all touched files.
