### PR TITLE
Fix accept commit metadata persistence

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -860,6 +860,15 @@ def _commit_acceptance_meta(
             if _history:
                 _history[-1]["accept_commit"] = accept_commit
             write_meta(summary.feature_dir, _meta)
+            run_git(["add", str(meta_path.relative_to(summary.repo_root))], cwd=summary.repo_root, check=True)
+            commit_status = run_git(["diff", "--cached", "--name-only"], cwd=summary.repo_root, check=True)
+            commit_staged_files = [line.strip() for line in commit_status.stdout.splitlines() if line.strip()]
+            if commit_staged_files:
+                run_git(
+                    ["commit", "-m", f"Record acceptance commit for {summary.feature}"],
+                    cwd=summary.repo_root,
+                    check=True,
+                )
 
     return parent_commit, accept_commit, True
 

--- a/src/specify_cli/scripts/tasks/acceptance_support.py
+++ b/src/specify_cli/scripts/tasks/acceptance_support.py
@@ -44,11 +44,13 @@ _EXPORT_NAMES = (
     "AcceptanceSummary",
     "ArtifactEncodingError",
     "WorkPackageState",
+    "acceptance_lane_derivations",
     "choose_mode",
     "collect_feature_summary",
     "detect_mission_slug",
     "normalize_feature_encoding",
     "perform_acceptance",
+    "resolve_acceptance_actor",
 )
 
 
@@ -70,9 +72,11 @@ __all__ = [
     "AcceptanceSummary",
     "ArtifactEncodingError",
     "WorkPackageState",
+    "acceptance_lane_derivations",
     "choose_mode",
     "collect_feature_summary",
     "detect_mission_slug",
     "normalize_feature_encoding",
     "perform_acceptance",
+    "resolve_acceptance_actor",
 ]

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -338,6 +338,24 @@ def test_perform_acceptance_persists_accept_commit(tmp_path: Path) -> None:
         f"Result.accept_commit mismatch: {result.accept_commit!r} != {accept_commit!r}"
     )
 
+    status = subprocess.run(
+        ["git", "-C", str(repo_root), "status", "--short"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert status.stdout == ""
+
+    committed_meta = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"HEAD:kitty-specs/{_FEATURE_SLUG}/meta.json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    committed = json.loads(committed_meta.stdout)
+    assert committed["accept_commit"] == accept_commit
+    assert committed["acceptance_history"][-1]["accept_commit"] == accept_commit
+
 
 # ---------------------------------------------------------------------------
 # Integration branch guard: merge guidance must not target integration branch


### PR DESCRIPTION
## Summary
- persist the final accept_commit bookkeeping in a scoped follow-up metadata commit so acceptance leaves the worktree clean
- assert git status stays clean after perform_acceptance()
- assert HEAD:kitty-specs/<mission>/meta.json contains accept_commit in both top-level metadata and acceptance_history[-1]
- restore acceptance_support wrapper export parity required by the regression suite

## Tradeoff
A single amend cannot make meta.json contain the amended commit's own hash: changing meta.json changes the commit hash again. This PR keeps accept_commit as the acceptance-state commit and records that value in a second scoped metadata commit, so HEAD contains the recorded accept_commit without leaving meta.json dirty.

## Tests
- uv run pytest tests/specify_cli/test_acceptance_regressions.py::test_perform_acceptance_persists_accept_commit -q
- uv run pytest tests/specify_cli/test_acceptance_regressions.py tests/cross_cutting/misc/test_acceptance_support.py -q

Refs #1149