### PR TITLE
Add accept diagnostic cascade reporting

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -85,6 +85,15 @@ class WorkPackageState:
 
 
 @dataclass
+class AcceptanceCheckDiagnostic:
+    check: str
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"check": self.check, "detail": self.detail}
+
+
+@dataclass
 class AcceptanceSummary:
     feature: str
     repo_root: Path
@@ -104,6 +113,9 @@ class AcceptanceSummary:
     git_dirty: list[str]
     path_violations: list[str]
     warnings: list[str]
+    skipped_checks: list[AcceptanceCheckDiagnostic] = field(default_factory=list)
+    blocked_checks: list[AcceptanceCheckDiagnostic] = field(default_factory=list)
+    recommended_fix_order: list[str] = field(default_factory=list)
 
     @property
     def all_done(self) -> bool:
@@ -143,6 +155,13 @@ class AcceptanceSummary:
         }
         return {key: value for key, value in buckets.items() if value}
 
+    def failed_checks(self) -> list[AcceptanceCheckDiagnostic]:
+        return [
+            AcceptanceCheckDiagnostic(check=check, detail=detail)
+            for check, details in self.outstanding().items()
+            for detail in details
+        ]
+
     def to_dict(self) -> dict[str, object]:
         identity = resolve_mission_identity(self.feature_dir)
         return {
@@ -177,6 +196,10 @@ class AcceptanceSummary:
             "git_dirty": self.git_dirty,
             "path_violations": self.path_violations,
             "warnings": self.warnings,
+            "failed_checks": [item.to_dict() for item in self.failed_checks()],
+            "skipped_checks": [item.to_dict() for item in self.skipped_checks],
+            "blocked_checks": [item.to_dict() for item in self.blocked_checks],
+            "recommended_fix_order": self.recommended_fix_order,
             "all_done": self.all_done,
             "ok": self.ok,
         }
@@ -524,11 +547,36 @@ def _validate_wp_readiness(
             activity_issues.append(f"{wp_id}: canonical lane is '{wp_snapshot.get('lane')}', expected 'approved' or 'done'")
 
 
+def _append_skipped_lane_checks(
+    skipped_checks: list[AcceptanceCheckDiagnostic],
+    *,
+    reason: str,
+    include_matrix_presence: bool = False,
+) -> None:
+    checks = [
+        ("acceptance_matrix_presence", "Acceptance matrix presence check"),
+        ("acceptance_matrix_evidence", "Acceptance matrix evidence validation"),
+        ("negative_invariants", "Negative invariant execution"),
+        ("acceptance_matrix_verdict", "Acceptance matrix verdict evaluation"),
+    ]
+    for check, label in checks[0 if include_matrix_presence else 1:]:
+        skipped_checks.append(
+            AcceptanceCheckDiagnostic(
+                check=check,
+                detail=f"{label} skipped: {reason}",
+            )
+        )
+
+
 def _check_lane_gates(
     repo_root: Path,
     feature_dir: Path,
     branch: str | None,
     activity_issues: list[str],
+    skipped_checks: list[AcceptanceCheckDiagnostic],
+    blocked_checks: list[AcceptanceCheckDiagnostic],
+    *,
+    mutate_matrix: bool = True,
 ) -> None:
     """Enforce lane-based acceptance gates: branch check + acceptance matrix."""
     try:
@@ -542,7 +590,15 @@ def _check_lane_gates(
         return
 
     if branch and branch != lanes_manifest.mission_branch:
-        activity_issues.append(f"Acceptance must run on mission branch {lanes_manifest.mission_branch}, not {branch}")
+        message = f"Acceptance must run on mission branch {lanes_manifest.mission_branch}, not {branch}"
+        activity_issues.append(message)
+        blocked_checks.append(AcceptanceCheckDiagnostic(check="mission_branch", detail=message))
+        _append_skipped_lane_checks(
+            skipped_checks,
+            reason="current branch does not match the mission branch",
+            include_matrix_presence=True,
+        )
+        return
 
     from specify_cli.acceptance.matrix import (
         enforce_negative_invariants,
@@ -553,12 +609,25 @@ def _check_lane_gates(
 
     acc_matrix = read_acceptance_matrix(feature_dir)
     if acc_matrix is None:
-        activity_issues.append("Acceptance matrix (acceptance-matrix.json) is required for lane-based features but was not found")
+        message = "Acceptance matrix (acceptance-matrix.json) is required for lane-based features but was not found"
+        activity_issues.append(message)
+        blocked_checks.append(AcceptanceCheckDiagnostic(check="acceptance_matrix", detail=message))
+        _append_skipped_lane_checks(
+            skipped_checks,
+            reason="acceptance-matrix.json is missing",
+        )
         return
 
-    if acc_matrix.negative_invariants:
+    if acc_matrix.negative_invariants and mutate_matrix:
         acc_matrix.negative_invariants = enforce_negative_invariants(repo_root, acc_matrix.negative_invariants)
         write_acceptance_matrix(feature_dir, acc_matrix)
+    elif acc_matrix.negative_invariants:
+        skipped_checks.append(
+            AcceptanceCheckDiagnostic(
+                check="negative_invariants",
+                detail="Negative invariant execution skipped: diagnose mode is read-only",
+            )
+        )
 
     for err in validate_matrix_evidence(acc_matrix):
         activity_issues.append(f"Evidence: {err}")
@@ -674,11 +743,54 @@ def _check_workflow_run_evidence(
         )
 
 
+def _build_recommended_fix_order(
+    *,
+    lanes: dict[str, list[str]],
+    metadata_issues: list[str],
+    activity_issues: list[str],
+    unchecked_tasks: list[str],
+    needs_clarification: list[str],
+    missing_artifacts: list[str],
+    git_dirty: list[str],
+    path_violations: list[str],
+    blocked_checks: list[AcceptanceCheckDiagnostic],
+) -> list[str]:
+    recommendations: list[str] = []
+
+    if git_dirty:
+        recommendations.append("Commit, stash, or discard working tree changes before acceptance.")
+    if any(item.check == "mission_branch" for item in blocked_checks):
+        recommendations.append("Switch to the mission branch named in the branch failure.")
+    if missing_artifacts:
+        recommendations.append("Restore required mission artifacts before acceptance.")
+    if metadata_issues:
+        recommendations.append("Fix work-package metadata issues.")
+    if any(wp_ids for lane, wp_ids in lanes.items() if lane not in {"approved", "done"}):
+        recommendations.append("Move all work packages to approved or done.")
+    if unchecked_tasks:
+        recommendations.append("Complete unchecked items in tasks.md.")
+    if needs_clarification:
+        recommendations.append("Resolve open NEEDS CLARIFICATION markers.")
+    if any(item.check == "acceptance_matrix" for item in blocked_checks):
+        recommendations.append("Create or restore kitty-specs/<mission>/acceptance-matrix.json.")
+    if any("Evidence:" in issue for issue in activity_issues):
+        recommendations.append("Fill missing acceptance matrix evidence fields.")
+    if any("Acceptance matrix verdict is" in issue for issue in activity_issues):
+        recommendations.append("Resolve pending or failing acceptance matrix criteria and negative invariants.")
+    if any("Workflow run evidence required" in issue for issue in activity_issues):
+        recommendations.append("Add successful GitHub Actions run evidence for workflow changes.")
+    if path_violations:
+        recommendations.append("Fix mission path convention violations.")
+
+    return recommendations
+
+
 def collect_feature_summary(
     repo_root: Path,
     feature: str,
     *,
     strict_metadata: bool = True,
+    mutate_matrix: bool = True,
 ) -> AcceptanceSummary:
     feature_dir = repo_root / "kitty-specs" / feature
     tasks_dir = feature_dir / "tasks"
@@ -691,6 +803,8 @@ def collect_feature_summary(
     work_packages: list[WorkPackageState] = []
     metadata_issues: list[str] = []
     activity_issues: list[str] = []
+    skipped_checks: list[AcceptanceCheckDiagnostic] = []
+    blocked_checks: list[AcceptanceCheckDiagnostic] = []
 
     snapshot_wps = _collect_snapshot_wps(feature, feature_dir, activity_issues)
 
@@ -768,8 +882,29 @@ def collect_feature_summary(
     if path_violations:
         warnings.append("Path conventions not satisfied.")
 
-    _check_lane_gates(repo_root, feature_dir, branch, activity_issues)
+    _check_lane_gates(
+        repo_root,
+        feature_dir,
+        branch,
+        activity_issues,
+        skipped_checks,
+        blocked_checks,
+        mutate_matrix=mutate_matrix,
+    )
     _check_workflow_run_evidence(repo_root, feature_dir, branch, activity_issues)
+
+    normalized_unchecked_tasks = unchecked_tasks if unchecked_tasks != [f"{TASKS_FILE} missing"] else []
+    recommended_fix_order = _build_recommended_fix_order(
+        lanes=lanes,
+        metadata_issues=metadata_issues,
+        activity_issues=activity_issues,
+        unchecked_tasks=normalized_unchecked_tasks,
+        needs_clarification=needs_clarification,
+        missing_artifacts=missing_required,
+        git_dirty=git_dirty,
+        path_violations=path_violations,
+        blocked_checks=blocked_checks,
+    )
 
     return AcceptanceSummary(
         feature=feature,
@@ -783,13 +918,16 @@ def collect_feature_summary(
         work_packages=work_packages,
         metadata_issues=metadata_issues,
         activity_issues=activity_issues,
-        unchecked_tasks=unchecked_tasks if unchecked_tasks != [f"{TASKS_FILE} missing"] else [],
+        unchecked_tasks=normalized_unchecked_tasks,
         needs_clarification=needs_clarification,
         missing_artifacts=missing_required,
         optional_missing=missing_optional,
         git_dirty=git_dirty,
         path_violations=path_violations,
         warnings=warnings,
+        skipped_checks=skipped_checks,
+        blocked_checks=blocked_checks,
+        recommended_fix_order=recommended_fix_order,
     )
 
 

--- a/src/specify_cli/cli/commands/accept.py
+++ b/src/specify_cli/cli/commands/accept.py
@@ -99,6 +99,31 @@ def _print_acceptance_result(result: AcceptanceResult) -> None:
             console.print(f"  - {note}")
 
 
+def _print_acceptance_diagnosis(summary: AcceptanceSummary) -> None:
+    failed_checks = summary.failed_checks()
+    if failed_checks:
+        console.print("\n[bold red]Failed checks[/bold red]")
+        for item in failed_checks:
+            console.print(f"[red]- {item.check}[/red]: {item.detail}")
+    else:
+        console.print("\n[green]No failed acceptance checks detected.[/green]")
+
+    if summary.skipped_checks:
+        console.print("\n[bold yellow]Skipped checks[/bold yellow]")
+        for item in summary.skipped_checks:
+            console.print(f"[yellow]- {item.check}[/yellow]: {item.detail}")
+
+    if summary.blocked_checks:
+        console.print("\n[bold yellow]Blocked checks[/bold yellow]")
+        for item in summary.blocked_checks:
+            console.print(f"[yellow]- {item.check}[/yellow]: {item.detail}")
+
+    if summary.recommended_fix_order:
+        console.print("\n[bold]Recommended fix order[/bold]")
+        for idx, item in enumerate(summary.recommended_fix_order, start=1):
+            console.print(f"  {idx}. {item}")
+
+
 def _summary_payload(summary: AcceptanceSummary) -> dict[str, object]:
     payload = summary.to_dict()
     payload.update(acceptance_lane_derivations(summary))
@@ -123,6 +148,7 @@ def accept(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of formatted text"),
     lenient: bool = typer.Option(False, "--lenient", help="Skip strict metadata validation"),
     no_commit: bool = typer.Option(False, "--no-commit", help="Report acceptance readiness without writing metadata or status changes"),
+    diagnose: bool = typer.Option(False, "--diagnose", help="Diagnose acceptance blockers without writing metadata or matrix artifacts"),
     allow_fail: bool = typer.Option(False, "--allow-fail", help="Return checklist even when issues remain"),
 ) -> None:
     """Validate mission readiness before merging to main."""
@@ -168,11 +194,11 @@ def accept(
 
     requested_mode = (mode or "auto").lower()
     actual_mode = choose_mode(requested_mode, repo_root)
-    commit_required = actual_mode != "checklist" and not no_commit
+    commit_required = actual_mode != "checklist" and not no_commit and not diagnose
     if commit_required and not json_output:
         tracker.add("commit", "Record acceptance metadata")
     if not json_output:
-        tracker.add("guide", "Share next steps")
+        tracker.add("guide", "Share next steps" if not diagnose else "Report diagnostics")
 
     if not json_output:
         tracker.start("verify")
@@ -181,6 +207,7 @@ def accept(
             repo_root,
             mission_slug,
             strict_metadata=not lenient,
+            mutate_matrix=not diagnose,
         )
     except AcceptanceError as exc:
         _safe_emit_error_logged(str(exc))
@@ -193,6 +220,18 @@ def accept(
         raise typer.Exit(1)
     if not json_output:
         tracker.complete("verify", "ready" if summary.ok else "issues found")
+
+    if diagnose:
+        if json_output:
+            payload = _summary_payload(summary)
+            payload["diagnose"] = True
+            print(json.dumps(payload, indent=2))
+        else:
+            tracker.start("guide")
+            tracker.complete("guide", "diagnostics ready")
+            console.print(tracker.render())
+            _print_acceptance_diagnosis(summary)
+        raise typer.Exit(0)
 
     if actual_mode == "checklist":
         if json_output:

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -1529,6 +1529,7 @@ def accept_feature(
     json_output: Annotated[bool, typer.Option("--json", help="Output results as JSON for agent parsing")] = False,
     lenient: Annotated[bool, typer.Option("--lenient", help="Skip strict metadata validation")] = False,
     no_commit: Annotated[bool, typer.Option("--no-commit", help="Skip auto-commit (report only)")] = False,
+    diagnose: Annotated[bool, typer.Option("--diagnose", help="Diagnose acceptance blockers without mutation")] = False,
 ) -> None:
     """Perform mission acceptance workflow.
 
@@ -1562,6 +1563,7 @@ def accept_feature(
             json_output=json_output,
             lenient=lenient,
             no_commit=no_commit,
+            diagnose=diagnose,
             allow_fail=False,  # Agent commands use strict validation
         )
     except typer.Exit:

--- a/tests/cross_cutting/misc/test_acceptance_support.py
+++ b/tests/cross_cutting/misc/test_acceptance_support.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -222,6 +224,167 @@ def test_accept_no_commit_reports_merge_pending_without_mutation(
     assert len(read_events(feature_dir)) == before_events
     summary = acc.collect_feature_summary(feature_repo, mission_slug, strict_metadata=True)
     assert summary.lanes["approved"] == ["WP01"]
+
+
+def test_accept_diagnose_json_reports_skipped_checks_without_mutation(
+    feature_repo: Path, mission_slug: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.lane_test_utils import write_single_lane_manifest
+    from tests.utils import run
+
+    _write_acceptance_meta(feature_repo, mission_slug)
+    feature_dir = feature_repo / "kitty-specs" / mission_slug
+    write_single_lane_manifest(feature_dir)
+    run(["git", "branch", "-M", "main"], cwd=feature_repo)
+    run(["git", "add", "."], cwd=feature_repo)
+    run(["git", "commit", "-m", "Add lane metadata"], cwd=feature_repo)
+    run(["git", "checkout", "-b", f"kitty/mission-{mission_slug}"], cwd=feature_repo)
+
+    before_meta = (feature_dir / "meta.json").read_text(encoding="utf-8")
+    monkeypatch.chdir(feature_repo)
+    result = runner.invoke(
+        cli_app,
+        [
+            "accept",
+            "--mission",
+            mission_slug,
+            "--diagnose",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["diagnose"] is True
+    assert any(item["check"] == "acceptance_matrix" for item in payload["blocked_checks"])
+    assert any(item["check"] == "negative_invariants" for item in payload["skipped_checks"])
+    assert any("acceptance-matrix.json" in item for item in payload["recommended_fix_order"])
+    assert (feature_dir / "meta.json").read_text(encoding="utf-8") == before_meta
+    assert "acceptance-matrix.json" not in {path.name for path in feature_dir.iterdir()}
+    status = run(["git", "status", "--short"], cwd=feature_repo)
+    assert status.stdout == ""
+
+
+def test_accept_diagnose_does_not_mutate_matrix_metadata_or_events(
+    feature_repo: Path, mission_slug: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import specify_cli.status.emit as status_emit
+    from specify_cli.acceptance.matrix import AcceptanceMatrix, NegativeInvariant, write_acceptance_matrix
+    from specify_cli.status.store import read_events
+    from tests.lane_test_utils import write_single_lane_manifest
+    from tests.utils import run
+
+    monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
+    _write_acceptance_meta(feature_repo, mission_slug)
+    feature_dir = feature_repo / "kitty-specs" / mission_slug
+    write_single_lane_manifest(feature_dir)
+    write_acceptance_matrix(
+        feature_dir,
+        AcceptanceMatrix(
+            mission_slug=mission_slug,
+            negative_invariants=[
+                NegativeInvariant(
+                    "NI-01",
+                    "Legacy route stays absent",
+                    "grep_absence",
+                    verification_command="legacy_route_that_does_not_exist",
+                )
+            ],
+        ),
+    )
+    _approve_wp(feature_repo, mission_slug, "WP01")
+    run(["git", "branch", "-M", "main"], cwd=feature_repo)
+    run(["git", "add", "."], cwd=feature_repo)
+    run(["git", "commit", "-m", "Prepare accepted lane mission"], cwd=feature_repo)
+    run(["git", "checkout", "-b", f"kitty/mission-{mission_slug}"], cwd=feature_repo)
+
+    matrix_path = feature_dir / "acceptance-matrix.json"
+    before_matrix = matrix_path.read_text(encoding="utf-8")
+    before_meta = (feature_dir / "meta.json").read_text(encoding="utf-8")
+    before_events = len(read_events(feature_dir))
+
+    monkeypatch.chdir(feature_repo)
+    result = runner.invoke(
+        cli_app,
+        [
+            "accept",
+            "--mission",
+            mission_slug,
+            "--diagnose",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["diagnose"] is True
+    assert payload["ok"] is False
+    assert any(item["check"] == "negative_invariants" for item in payload["skipped_checks"])
+    assert any("Acceptance matrix verdict is 'pending'" in item["detail"] for item in payload["failed_checks"])
+    assert matrix_path.read_text(encoding="utf-8") == before_matrix
+    assert (feature_dir / "meta.json").read_text(encoding="utf-8") == before_meta
+    assert len(read_events(feature_dir)) == before_events
+    status = run(["git", "status", "--short"], cwd=feature_repo)
+    assert status.stdout == ""
+
+
+def test_accept_diagnose_does_not_execute_custom_negative_invariants(
+    feature_repo: Path, mission_slug: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import specify_cli.status.emit as status_emit
+    from specify_cli.acceptance.matrix import AcceptanceMatrix, NegativeInvariant, write_acceptance_matrix
+    from tests.lane_test_utils import write_single_lane_manifest
+    from tests.utils import run
+
+    monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
+    _write_acceptance_meta(feature_repo, mission_slug)
+    feature_dir = feature_repo / "kitty-specs" / mission_slug
+    side_effect_path = feature_repo / "diagnose-side-effect.txt"
+    write_single_lane_manifest(feature_dir)
+    command = (
+        f"{shlex.quote(sys.executable)} -c "
+        "\"from pathlib import Path; Path('diagnose-side-effect.txt').write_text('mutated')\""
+    )
+    write_acceptance_matrix(
+        feature_dir,
+        AcceptanceMatrix(
+            mission_slug=mission_slug,
+            negative_invariants=[
+                NegativeInvariant(
+                    "NI-01",
+                    "Diagnostic command must not run",
+                    "custom_command",
+                    verification_command=command,
+                )
+            ],
+        ),
+    )
+    _approve_wp(feature_repo, mission_slug, "WP01")
+    run(["git", "branch", "-M", "main"], cwd=feature_repo)
+    run(["git", "add", "."], cwd=feature_repo)
+    run(["git", "commit", "-m", "Prepare custom invariant mission"], cwd=feature_repo)
+    run(["git", "checkout", "-b", f"kitty/mission-{mission_slug}"], cwd=feature_repo)
+
+    before_matrix = (feature_dir / "acceptance-matrix.json").read_text(encoding="utf-8")
+    monkeypatch.chdir(feature_repo)
+    result = runner.invoke(
+        cli_app,
+        [
+            "accept",
+            "--mission",
+            mission_slug,
+            "--diagnose",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert any(item["check"] == "negative_invariants" for item in payload["skipped_checks"])
+    assert not side_effect_path.exists()
+    assert (feature_dir / "acceptance-matrix.json").read_text(encoding="utf-8") == before_matrix
+    status = run(["git", "status", "--short"], cwd=feature_repo)
+    assert status.stdout == ""
 
 
 def test_accept_does_not_require_done_evidence_for_approved_wp(

--- a/tests/missions/test_feature_lifecycle_unit.py
+++ b/tests/missions/test_feature_lifecycle_unit.py
@@ -128,6 +128,7 @@ def test_accept_command_delegates_to_toplevel(mock_locate: MagicMock, mock_accep
         json_output=True,
         lenient=False,
         no_commit=False,
+        diagnose=False,
         allow_fail=False,
     )
 
@@ -161,6 +162,7 @@ def test_accept_command_passes_flags(mock_locate: MagicMock, mock_accept: MagicM
         json_output=True,
         lenient=True,
         no_commit=True,
+        diagnose=False,
         allow_fail=False,
     )
 
@@ -491,5 +493,6 @@ def test_accept_command_with_all_flags_console_output(mock_locate: MagicMock, mo
         json_output=False,
         lenient=True,
         no_commit=True,
+        diagnose=False,
         allow_fail=False,
     )

--- a/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
+++ b/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
@@ -52,6 +52,31 @@ def test_agent_mission_accept_passes_explicit_feature_none(
         json_output=True,
         lenient=False,
         no_commit=False,
+        diagnose=False,
+        allow_fail=False,
+    )
+
+
+@patch("specify_cli.cli.commands.agent.mission.top_level_accept")
+def test_agent_mission_accept_passes_diagnose_flag(
+    mock_top_level_accept: MagicMock,
+) -> None:
+    result = runner.invoke(
+        app,
+        ["accept", "--mission", "077-mission-terminology-cleanup", "--diagnose", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_top_level_accept.assert_called_once_with(
+        mission="077-mission-terminology-cleanup",
+        feature=None,
+        mode="auto",
+        actor=None,
+        test=[],
+        json_output=True,
+        lenient=False,
+        no_commit=False,
+        diagnose=True,
         allow_fail=False,
     )
 

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -358,6 +358,55 @@ def test_perform_acceptance_persists_accept_commit(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# T017: accept diagnostics expose skipped cascade checks
+# ---------------------------------------------------------------------------
+
+
+def test_collect_feature_summary_reports_branch_mismatch_skipped_checks(tmp_path: Path) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    write_single_lane_manifest(feature_dir)
+    subprocess.run(["git", "-C", str(repo_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add lanes manifest"], check=True, capture_output=True)
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG, mutate_matrix=False)
+
+    assert any("Acceptance must run on mission branch" in issue for issue in summary.activity_issues)
+    assert any(item.check == "mission_branch" for item in summary.blocked_checks)
+    skipped = {item.check for item in summary.skipped_checks}
+    assert "acceptance_matrix_presence" in skipped
+    assert "acceptance_matrix_verdict" in skipped
+    assert any("Switch to the mission branch" in item for item in summary.recommended_fix_order)
+
+
+def test_collect_feature_summary_reports_missing_matrix_skipped_checks(tmp_path: Path) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    write_single_lane_manifest(feature_dir)
+    subprocess.run(["git", "-C", str(repo_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add lanes manifest"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "checkout", "-b", f"kitty/mission-{_FEATURE_SLUG}"],
+        check=True,
+        capture_output=True,
+    )
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG, mutate_matrix=False)
+
+    assert any("Acceptance matrix" in issue and "required" in issue for issue in summary.activity_issues)
+    assert any(item.check == "acceptance_matrix" for item in summary.blocked_checks)
+    skipped = {item.check for item in summary.skipped_checks}
+    assert {"acceptance_matrix_evidence", "negative_invariants", "acceptance_matrix_verdict"} <= skipped
+    assert any("acceptance-matrix.json" in item for item in summary.recommended_fix_order)
+
+
+# ---------------------------------------------------------------------------
 # Integration branch guard: merge guidance must not target integration branch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add structured failed_checks, skipped_checks, blocked_checks, and recommended_fix_order to acceptance summaries
- report skipped hidden lane checks when branch mismatch or missing acceptance-matrix.json prevents meaningful evaluation
- add read-only `spec-kitty accept --diagnose` JSON/human output
- wire `spec-kitty agent mission accept --diagnose` through the agent wrapper
- keep negative-invariant method behavior unchanged: unknown methods still remain pending instead of being reinterpreted

## Read-only behavior
`--diagnose` does not call `perform_acceptance()`, does not write acceptance metadata, does not emit status changes, and calls `collect_feature_summary(..., mutate_matrix=False)` so negative-invariant results are not persisted back to acceptance-matrix.json.

## Stacking
This PR is stacked on #1392 because the full requested acceptance regression suite depends on the wrapper parity fix in PR 1. After #1392 lands, this branch can be retargeted to `main`.

## Tests
- uv run pytest tests/specify_cli/test_acceptance_regressions.py::test_collect_feature_summary_reports_branch_mismatch_skipped_checks tests/specify_cli/test_acceptance_regressions.py::test_collect_feature_summary_reports_missing_matrix_skipped_checks -q
- uv run pytest tests/cross_cutting/misc/test_acceptance_support.py::test_accept_diagnose_json_reports_skipped_checks_without_mutation tests/cross_cutting/misc/test_acceptance_support.py::test_accept_diagnose_does_not_mutate_matrix_metadata_or_events tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py::test_agent_mission_accept_passes_diagnose_flag -q
- uv run pytest tests/specify_cli/test_acceptance_regressions.py tests/cross_cutting/misc/test_acceptance_support.py tests/lanes/test_acceptance_matrix.py tests/missions/test_feature_lifecycle_unit.py tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py -q
- uv run pytest tests/agent/test_commands.py tests/contract/test_machine_facing_canonical_fields.py -q
- uv run ruff check src/specify_cli/acceptance/__init__.py src/specify_cli/scripts/tasks/acceptance_support.py src/specify_cli/cli/commands/accept.py src/specify_cli/cli/commands/agent/mission.py tests/cross_cutting/misc/test_acceptance_support.py tests/missions/test_feature_lifecycle_unit.py tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py tests/specify_cli/test_acceptance_regressions.py

Refs #1149