### PR TITLE
fix: reconcile restart daemon state without owner

### DIFF
--- a/src/specify_cli/sync/restart.py
+++ b/src/specify_cli/sync/restart.py
@@ -84,15 +84,15 @@ class RestartResult:
 
 
 def _read_previous_pid() -> int | None:
-    """Return the PID recorded in the owner record, or ``None`` if absent."""
+    """Return the PID recorded in owner/state metadata, or ``None`` if absent."""
     # Local import keeps module import cheap and avoids cycles with
     # ``specify_cli.sync.owner`` at module load time.
     from specify_cli.sync.owner import read_owner_record
 
     record = read_owner_record()
-    if record is None:
-        return None
-    return int(record.pid)
+    if record is not None:
+        return int(record.pid)
+    return _read_daemon_state_pid()
 
 
 def _owner_record_present() -> bool:
@@ -109,6 +109,16 @@ def _daemon_state_metadata_present() -> bool:
     return bool(DAEMON_STATE_FILE.exists())
 
 
+def _read_daemon_state_pid() -> int | None:
+    """Return the PID from daemon state metadata, or ``None`` if absent/invalid."""
+    from specify_cli.sync.daemon import DAEMON_STATE_FILE, _parse_daemon_file
+
+    if not DAEMON_STATE_FILE.exists():
+        return None
+    _url, _port, _token, pid = _parse_daemon_file(DAEMON_STATE_FILE)
+    return pid
+
+
 def _owner_record_present_after_grace() -> bool:
     """Allow a short grace window for owner registration after daemon start."""
     if _owner_record_present():
@@ -122,6 +132,19 @@ def _owner_record_present_after_grace() -> bool:
         if _owner_record_present():
             return True
     return _owner_record_present()
+
+
+def _registered_daemon_metadata_present_after_grace() -> bool:
+    """Return True when any restartable daemon metadata is present.
+
+    The owner record is richer, but the daemon state file is sufficient for
+    stop/respawn. macOS can observe a started daemon with state metadata before
+    or without owner registration; restart-daemon should reconcile that state,
+    not refuse with ``no_owner``.
+    """
+    if _owner_record_present_after_grace():
+        return True
+    return _daemon_state_metadata_present()
 
 
 def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserved for future repo-scoped state
@@ -158,8 +181,8 @@ def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserv
     # through stop, because the on-disk path exists. The contract treats
     # "no owner record on disk at all" as the only ``no_owner`` case
     # (FR-007 / FR-009: actionable refusal points operator at ``sync now``).
-    owner_present = _owner_record_present_after_grace()
-    if not owner_present:
+    metadata_present = _registered_daemon_metadata_present_after_grace()
+    if not metadata_present:
         return RestartResult(
             status="no_owner",
             exit_code=1,
@@ -171,7 +194,7 @@ def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserv
             ),
         )
 
-    previous_pid = _read_previous_pid() if owner_present else None
+    previous_pid = _read_previous_pid()
 
     # Local imports — keeps cycles tight and lets test monkeypatches target
     # the canonical symbol on the ``specify_cli.sync.daemon`` module.

--- a/src/specify_cli/sync/restart.py
+++ b/src/specify_cli/sync/restart.py
@@ -7,7 +7,8 @@ re-implement any daemon lifecycle logic: it reads the on-disk
 previous PID, then composes:
 
 - :func:`specify_cli.sync.daemon.stop_sync_daemon` to terminate the
-  currently-registered daemon (used by the existing operator workflow).
+  daemon recorded in owner/state metadata (used by the existing operator
+  workflow).
 - :func:`specify_cli.sync.daemon.ensure_sync_daemon_running` with
   ``intent=REMOTE_REQUIRED`` to respawn the daemon at the foreground
   executable/source (used by ``sync now`` and the event emitter).
@@ -67,8 +68,8 @@ class RestartResult:
     Attributes:
         status: One of the literal :data:`RestartStatus` values.
         exit_code: Process exit code per the contract's exit-code matrix.
-        previous_pid: PID recorded in the owner record before the restart,
-            or ``None`` when no owner record was present.
+        previous_pid: PID recorded in owner/state metadata before the restart,
+            or ``None`` when no PID metadata was present.
         new_pid: PID of the freshly-launched daemon, or ``None`` if launch
             did not run (no_owner / stop_failed) or did not return a PID
             (respawn_failed, including ``skipped_reason`` paths).
@@ -109,6 +110,16 @@ def _daemon_state_metadata_present() -> bool:
     return bool(DAEMON_STATE_FILE.exists())
 
 
+def _restartable_daemon_state_metadata_present() -> bool:
+    """Return True iff daemon state metadata is parseable enough to stop."""
+    from specify_cli.sync.daemon import DAEMON_STATE_FILE, _parse_daemon_file
+
+    if not DAEMON_STATE_FILE.exists():
+        return False
+    _url, port, _token, _pid = _parse_daemon_file(DAEMON_STATE_FILE)
+    return port is not None
+
+
 def _read_daemon_state_pid() -> int | None:
     """Return the PID from daemon state metadata, or ``None`` if absent/invalid."""
     from specify_cli.sync.daemon import DAEMON_STATE_FILE, _parse_daemon_file
@@ -135,7 +146,7 @@ def _owner_record_present_after_grace() -> bool:
 
 
 def _registered_daemon_metadata_present_after_grace() -> bool:
-    """Return True when any restartable daemon metadata is present.
+    """Return True when restartable daemon metadata is present.
 
     The owner record is richer, but the daemon state file is sufficient for
     stop/respawn. macOS can observe a started daemon with state metadata before
@@ -144,7 +155,7 @@ def _registered_daemon_metadata_present_after_grace() -> bool:
     """
     if _owner_record_present_after_grace():
         return True
-    return _daemon_state_metadata_present()
+    return _restartable_daemon_state_metadata_present()
 
 
 def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserved for future repo-scoped state
@@ -152,12 +163,12 @@ def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserv
 
     Composition pipeline:
 
-    1. Read the on-disk daemon owner record. If absent, return a
+    1. Read restartable on-disk daemon metadata. If absent, return a
        ``no_owner`` result (exit 1) directing the operator to
        ``spec-kitty sync now``.
-    2. Capture the previous PID from the record (best-effort: a
+    2. Capture the previous PID from owner/state metadata (best-effort: a
        malformed record yields ``previous_pid=None`` but still proceeds
-       through the stop step because the on-disk path exists).
+       through the stop step when restartable daemon state metadata exists).
     3. Call :func:`stop_sync_daemon`. Two normal outcomes:
 
        - ``(True, _)`` — process stopped or unhealthy metadata cleared.
@@ -176,11 +187,12 @@ def restart_daemon(repo_root: Path) -> RestartResult:  # noqa: ARG001 — reserv
     owner record itself; both sides of the pipeline are owned by the
     existing primitives.
     """
-    # Step 1 + 2 — read existing owner record. We tolerate a malformed
-    # record by treating ``previous_pid`` as unknown but still proceeding
-    # through stop, because the on-disk path exists. The contract treats
-    # "no owner record on disk at all" as the only ``no_owner`` case
-    # (FR-007 / FR-009: actionable refusal points operator at ``sync now``).
+    # Step 1 + 2 — read existing owner/state metadata. We tolerate a malformed
+    # owner record by treating ``previous_pid`` as unknown but still proceeding
+    # through stop when restartable daemon state metadata exists. Corrupt
+    # state-only metadata is not restartable, so it stays on the ``no_owner``
+    # boundary instead of laundering a local metadata parse failure as
+    # ``stop_failed``.
     metadata_present = _registered_daemon_metadata_present_after_grace()
     if not metadata_present:
         return RestartResult(

--- a/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
+++ b/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
@@ -83,6 +83,7 @@ def _install_daemon_state_file_fake(
     monkeypatch: pytest.MonkeyPatch,
     *,
     exists: bool,
+    port: int | None = 9400,
     pid: int | None = None,
 ) -> None:
     """Wire up a fake ``DAEMON_STATE_FILE.exists()`` response."""
@@ -98,7 +99,7 @@ def _install_daemon_state_file_fake(
     )
     monkeypatch.setattr(
         "specify_cli.sync.daemon._parse_daemon_file",
-        lambda _path: ("http://127.0.0.1:9400", 9400, "token", pid),
+        lambda _path: ("http://127.0.0.1:9400", port, "token", pid),
         raising=True,
     )
 
@@ -341,6 +342,51 @@ def test_daemon_state_without_owner_is_restartable(
     assert payload["status"] == "restarted"
     assert payload["previous_pid"] == 12345
     assert payload["new_pid"] == 67890
+
+
+def test_invalid_daemon_state_without_owner_is_not_restartable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Corrupt state-only metadata stays on the no-owner boundary."""
+
+    class _MissingPath:
+        def exists(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "specify_cli.sync.owner.owner_record_path",
+        lambda: _MissingPath(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.owner.read_owner_record",
+        lambda: None,
+        raising=True,
+    )
+    _install_daemon_state_file_fake(monkeypatch, exists=True, port=None, pid=None)
+
+    ticks = iter([0.0, 0.1, 0.2, 0.3, 2.1])
+    sleeps: list[float] = []
+    monkeypatch.setattr("specify_cli.sync.restart.time.monotonic", lambda: next(ticks))
+    monkeypatch.setattr("specify_cli.sync.restart.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    stop_calls = _install_stop_fake(monkeypatch, result=(False, "invalid metadata"))
+    launch_calls = _install_launch_fake(
+        monkeypatch,
+        outcome=DaemonStartOutcome(started=True, skipped_reason=None, pid=67890),
+    )
+
+    result = _runner().invoke(doctor_module.app, ["restart-daemon", "--json"])
+
+    assert result.exit_code == 1
+    assert sleeps, "restart should wait briefly for owner before checking state"
+    assert stop_calls == []
+    assert launch_calls == []
+    payload = json.loads(result.stdout.strip())
+    assert payload["status"] == "no_owner"
+    assert payload["previous_pid"] is None
+    assert payload["new_pid"] is None
+    assert "spec-kitty sync now" in (payload["error"] or "")
 
 
 def test_stop_failure_exits_three_and_skips_launch(

--- a/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
+++ b/tests/specify_cli/cli/commands/test_doctor_restart_daemon.py
@@ -83,6 +83,7 @@ def _install_daemon_state_file_fake(
     monkeypatch: pytest.MonkeyPatch,
     *,
     exists: bool,
+    pid: int | None = None,
 ) -> None:
     """Wire up a fake ``DAEMON_STATE_FILE.exists()`` response."""
 
@@ -93,6 +94,11 @@ def _install_daemon_state_file_fake(
     monkeypatch.setattr(
         "specify_cli.sync.daemon.DAEMON_STATE_FILE",
         _FakePath(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.daemon._parse_daemon_file",
+        lambda _path: ("http://127.0.0.1:9400", 9400, "token", pid),
         raising=True,
     )
 
@@ -293,10 +299,10 @@ def test_owner_grace_wait_allows_registered_daemon_to_restart(
     assert len(launch_calls) == 1
 
 
-def test_owner_grace_wait_still_fails_closed_when_owner_never_appears(
+def test_daemon_state_without_owner_is_restartable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Daemon metadata alone is insufficient; absent owner still returns no_owner."""
+    """Daemon state metadata is enough to stop and respawn when owner is absent."""
 
     class _MissingPath:
         def exists(self) -> bool:
@@ -312,25 +318,29 @@ def test_owner_grace_wait_still_fails_closed_when_owner_never_appears(
         lambda: None,
         raising=True,
     )
-    _install_daemon_state_file_fake(monkeypatch, exists=True)
+    _install_daemon_state_file_fake(monkeypatch, exists=True, pid=12345)
 
     ticks = iter([0.0, 0.1, 0.2, 0.3, 2.1])
     sleeps: list[float] = []
     monkeypatch.setattr("specify_cli.sync.restart.time.monotonic", lambda: next(ticks))
     monkeypatch.setattr("specify_cli.sync.restart.time.sleep", lambda seconds: sleeps.append(seconds))
 
-    stop_calls = _install_stop_fake(monkeypatch, result=(False, "should-not-call"))
+    stop_calls = _install_stop_fake(monkeypatch, result=(True, "Sync daemon stopped."))
     launch_calls = _install_launch_fake(
         monkeypatch,
-        outcome=DaemonStartOutcome(started=False, skipped_reason="x", pid=None),
+        outcome=DaemonStartOutcome(started=True, skipped_reason=None, pid=67890),
     )
 
     result = _runner().invoke(doctor_module.app, ["restart-daemon", "--json"])
 
-    assert result.exit_code == 1
-    assert sleeps, "restart should wait briefly before failing closed"
-    assert stop_calls == []
-    assert launch_calls == []
+    assert result.exit_code == 0
+    assert sleeps, "restart should wait briefly for owner before falling back to state"
+    assert stop_calls == [1.0]
+    assert len(launch_calls) == 1
+    payload = json.loads(result.stdout.strip())
+    assert payload["status"] == "restarted"
+    assert payload["previous_pid"] == 12345
+    assert payload["new_pid"] == 67890
 
 
 def test_stop_failure_exits_three_and_skips_launch(


### PR DESCRIPTION
## Summary

Fixes the macOS `doctor restart-daemon NFR-002 timing` failure where setup reports a daemon started but `doctor restart-daemon --json` exits `status="no_owner"`.

Root cause: daemon startup and restart used different readiness authorities. `ensure_sync_daemon_running()` can leave restartable daemon state metadata while `restart-daemon` required owner.json. On macOS CI that owner record can be absent/late, so restart refused instead of reconciling.

This PR keeps the scope narrow:
- Treat daemon state metadata as restartable when owner.json is absent.
- Read previous PID from owner first, then daemon state.
- Add regression coverage for state-without-owner restart.

## Verification

- `uv run ruff check src/specify_cli/sync/restart.py tests/specify_cli/cli/commands/test_doctor_restart_daemon.py`
- `uv run pytest tests/specify_cli/cli/commands/test_doctor_restart_daemon.py tests/specify_cli/cli/commands/test_doctor_restart_daemon_timing.py -m "fast or timing" -q --tb=short`
- Python 3.12 local timing gate: `python3.12 -m pytest tests/specify_cli/cli/commands/test_doctor_restart_daemon_timing.py -m timing -q --tb=short`

## Context

Debugger Debbie/adversarial review found this is upstream macOS timing drift, not dependency-gate logic from #1391. This PR intentionally isolates only the restart-daemon mac timing issue.