### PR TITLE
Fix lane workflow tail rough edges (#1353)

### DIFF
--- a/docs/explanation/retrospective-learning-loop.md
+++ b/docs/explanation/retrospective-learning-loop.md
@@ -150,7 +150,7 @@ Their lifecycle:
 
 1. **Generated**: the pure-Python generator produces proposals and writes them to
    `.kittify/missions/<mission_id>/retrospective.yaml`.
-2. **Staged**: proposals are visible in `agent retrospect synthesize --preview`. No changes
+2. **Staged**: proposals are visible in `agent retrospect synthesize` (dry-run by default). No changes
    have been made to governance state yet.
 3. **Applied or rejected**: `agent retrospect synthesize --apply <id>` validates, conflict-checks,
    and applies. Rejected or conflicting proposals are not applied.
@@ -175,7 +175,7 @@ conflicting set.
 You cannot bypass the synthesizer by editing governance files directly — those files are derived
 artifacts and would be overwritten on the next `charter synthesize` run. The correct path:
 
-1. Review proposals (`agent retrospect synthesize --preview`)
+1. Review proposals (`agent retrospect synthesize`, dry-run by default)
 2. Resolve any conflicts (manually, in `charter.md` if needed)
 3. Apply (`agent retrospect synthesize --apply <id>` or `--apply` for full batch)
 4. Re-run `charter synthesize` if `charter.md` was edited

--- a/docs/how-to/accept-and-merge.md
+++ b/docs/how-to/accept-and-merge.md
@@ -119,7 +119,7 @@ operator verb.
 spec-kitty retrospect summary
 
 # Preview proposals in this mission's retrospective.yaml (dry-run by default)
-spec-kitty agent retrospect synthesize --mission <handle> --preview
+spec-kitty agent retrospect synthesize --mission <handle>
 
 # Apply a proposal (requires explicit --apply)
 spec-kitty agent retrospect synthesize --mission <handle> --apply <proposal-id>

--- a/docs/how-to/merge-feature.md
+++ b/docs/how-to/merge-feature.md
@@ -357,7 +357,7 @@ spec-kitty retrospect create --mission <handle>
 
 ```bash
 spec-kitty retrospect summary                              # cross-mission view (read-only)
-spec-kitty agent retrospect synthesize --mission <handle> --preview  # inspect proposals
+spec-kitty agent retrospect synthesize --mission <handle>  # inspect proposals (dry-run by default)
 spec-kitty agent retrospect synthesize --mission <handle> --apply <id>  # apply a proposal
 ```
 

--- a/docs/how-to/run-an-autonomous-mission.md
+++ b/docs/how-to/run-an-autonomous-mission.md
@@ -171,7 +171,7 @@ Verify the retrospective record and inspect synthesis proposals:
 ```bash
 spec-kitty retrospect create --mission <mission-slug>
 spec-kitty retrospect summary
-spec-kitty agent retrospect synthesize --mission <mission-slug> --preview
+spec-kitty agent retrospect synthesize --mission <mission-slug>
 ```
 
 Apply an individual proposal only after review:

--- a/docs/how-to/use-retrospective-learning.md
+++ b/docs/how-to/use-retrospective-learning.md
@@ -149,7 +149,7 @@ doctrine, and so on. Applying them is always human-approved:
 
 ```bash
 # Preview proposals (dry-run — no mutations)
-spec-kitty agent retrospect synthesize --mission my-feature-01J6XW9K --preview
+spec-kitty agent retrospect synthesize --mission my-feature-01J6XW9K
 
 # Apply a specific proposal
 spec-kitty agent retrospect synthesize --mission my-feature-01J6XW9K --apply p-001

--- a/docs/tutorials/your-first-feature.md
+++ b/docs/tutorials/your-first-feature.md
@@ -146,7 +146,7 @@ Before you move on, complete the three post-merge steps:
 3. **Surface findings** — review the record's proposals:
    ```bash
    spec-kitty retrospect summary                              # cross-mission aggregation (read-only)
-   spec-kitty agent retrospect synthesize --mission <slug> --preview  # inspect proposals
+   spec-kitty agent retrospect synthesize --mission <slug>  # inspect proposals (dry-run by default)
    ```
 
 For the full retrospective workflow, see

--- a/spec-kitty-mission-workflow.md
+++ b/spec-kitty-mission-workflow.md
@@ -133,7 +133,7 @@ Verify or create the retrospective, then inspect synthesis proposals:
 
 ```bash
 spec-kitty retrospect create --mission <mission-slug>
-spec-kitty agent retrospect synthesize --mission <mission-slug> --preview
+spec-kitty agent retrospect synthesize --mission <mission-slug>
 ```
 
 Apply only the proposals you intend to preserve:

--- a/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
@@ -792,8 +792,8 @@ spec-kitty retrospect create --mission <mission-slug>
 
 ```bash
 spec-kitty retrospect summary                              # cross-mission aggregation (read-only)
-spec-kitty agent retrospect synthesize --mission <slug> --preview  # inspect proposals
-spec-kitty agent retrospect synthesize --mission <slug> --apply <id>  # apply a proposal
+spec-kitty agent retrospect synthesize --mission <slug>  # inspect proposals (dry-run by default)
+spec-kitty agent retrospect synthesize --mission <slug> --apply  # apply proposals (mutates)
 ```
 
 `summary` aggregates; it does NOT author. `synthesize` previews and applies proposals from an

--- a/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
@@ -43,7 +43,7 @@ After this mission review, remind the operator to follow the canonical post-merg
 while the work is still fresh: **author or verify the retrospective** (`retrospect create`
 if the record is absent, or verify the existing `.kittify/missions/<mission_id>/retrospective.yaml`);
 **surface findings** (`spec-kitty retrospect summary` for cross-mission aggregation;
-`spec-kitty agent retrospect synthesize --mission <slug> --preview` to inspect proposals).
+`spec-kitty agent retrospect synthesize --mission <slug>` to inspect proposals, dry-run by default).
 
 ---
 
@@ -791,8 +791,8 @@ spec-kitty retrospect create --mission <slug>
 Then surface findings:
 
 - `spec-kitty retrospect summary` — cross-mission aggregation (read-only; does NOT author)
-- `spec-kitty agent retrospect synthesize --mission <slug> --preview` — inspect proposals
-- `spec-kitty agent retrospect synthesize --mission <slug> --apply <id>` — apply a proposal
+- `spec-kitty agent retrospect synthesize --mission <slug>` — inspect proposals (dry-run by default)
+- `spec-kitty agent retrospect synthesize --mission <slug> --apply` — apply proposals (mutates)
 
 If the record is absent and `retrospect create` fails, escalate — the terminus facilitator
 either did not run or was skipped without a recorded reason. Check `status.events.jsonl` for

--- a/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
@@ -230,8 +230,8 @@ Then surface findings:
 
 ```bash
 spec-kitty retrospect summary                              # cross-mission aggregation (read-only)
-spec-kitty agent retrospect synthesize --mission <slug> --preview  # inspect proposals
-spec-kitty agent retrospect synthesize --mission <slug> --apply <id>  # apply a proposal
+spec-kitty agent retrospect synthesize --mission <slug>  # inspect proposals (dry-run by default)
+spec-kitty agent retrospect synthesize --mission <slug> --apply  # apply proposals (mutates)
 ```
 
 If `retrospective.yaml` is missing and `retrospect create` fails, escalate — check

--- a/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
@@ -482,7 +482,7 @@ if [ "$KIND" = "terminal" ] || [ "$DONE" -eq "$TOTAL" ]; then
   #      OR verify: cat .kittify/missions/<mission_id>/retrospective.yaml
   #   c. Surface findings:
   #      spec-kitty retrospect summary                                   # read-only aggregation
-  #      spec-kitty agent retrospect synthesize --mission 042-mission --preview
+  #      spec-kitty agent retrospect synthesize --mission 042-mission  # dry-run by default; --apply to mutate
   # Note: summary aggregates; synthesize applies proposals — neither authors records.
 fi
 ```

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -977,14 +977,19 @@ def _commit_acceptance_meta(
     record_acceptance(summary.feature_dir, accepted_by=actor_name, mode=mode, from_commit=parent_commit, accept_commit=None)
 
     meta_path = summary.feature_dir / "meta.json"
-    run_git(["add", str(meta_path.relative_to(summary.repo_root))], cwd=summary.repo_root, check=True)
+    meta_rel = str(meta_path.relative_to(summary.repo_root))
+    run_git(["add", meta_rel], cwd=summary.repo_root, check=True)
 
-    status = run_git(["diff", "--cached", "--name-only"], cwd=summary.repo_root, check=True)
+    # Scope the staged-check and commit to meta.json. A bare ``git commit`` would
+    # sweep in any unrelated files the operator had pre-staged before running
+    # ``accept``; the explicit ``-- <meta>`` pathspec commits only the
+    # acceptance metadata and leaves the operator's staged work untouched.
+    status = run_git(["diff", "--cached", "--name-only", "--", meta_rel], cwd=summary.repo_root, check=True)
     staged_files = [line.strip() for line in status.stdout.splitlines() if line.strip()]
     if not staged_files:
         return parent_commit, None, False
 
-    run_git(["commit", "-m", f"Accept {summary.feature}"], cwd=summary.repo_root, check=True)
+    run_git(["commit", "-m", f"Accept {summary.feature}", "--", meta_rel], cwd=summary.repo_root, check=True)
     try:
         accept_commit: str | None = run_git(["rev-parse", "HEAD"], cwd=summary.repo_root, check=True).stdout.strip()
     except TaskCliError:
@@ -998,12 +1003,12 @@ def _commit_acceptance_meta(
             if _history:
                 _history[-1]["accept_commit"] = accept_commit
             write_meta(summary.feature_dir, _meta)
-            run_git(["add", str(meta_path.relative_to(summary.repo_root))], cwd=summary.repo_root, check=True)
-            commit_status = run_git(["diff", "--cached", "--name-only"], cwd=summary.repo_root, check=True)
+            run_git(["add", meta_rel], cwd=summary.repo_root, check=True)
+            commit_status = run_git(["diff", "--cached", "--name-only", "--", meta_rel], cwd=summary.repo_root, check=True)
             commit_staged_files = [line.strip() for line in commit_status.stdout.splitlines() if line.strip()]
             if commit_staged_files:
                 run_git(
-                    ["commit", "-m", f"Record acceptance commit for {summary.feature}"],
+                    ["commit", "-m", f"Record acceptance commit for {summary.feature}", "--", meta_rel],
                     cwd=summary.repo_root,
                     check=True,
                 )

--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -183,6 +183,75 @@ def read_acceptance_matrix(feature_dir: Path) -> AcceptanceMatrix | None:
     return AcceptanceMatrix.from_dict(data)
 
 
+# Marker dropped into scaffolded criteria so operators (and reviewers) can
+# tell a placeholder row apart from a real, authored acceptance criterion.
+SCAFFOLD_TODO_MARKER = "TODO: replace with a real acceptance criterion"
+
+
+def scaffold_acceptance_matrix(
+    feature_dir: Path,
+    mission_slug: str,
+    requirement_ids: list[str] | None = None,
+) -> Path | None:
+    """Author a minimal, schema-valid ``acceptance-matrix.json`` for a feature.
+
+    Lane-based features require ``acceptance-matrix.json`` to exist before the
+    acceptance gate will run (see ``specify_cli.acceptance``). This helper
+    scaffolds a minimal but schema-valid matrix at task-finalization time so the
+    artifact is never silently missing.
+
+    The scaffold is **idempotent**: an existing ``acceptance-matrix.json`` is
+    never overwritten, so operator-curated criteria survive re-runs.
+
+    When ``requirement_ids`` are supplied (e.g. functional requirement ids from
+    ``spec.md``), one ``pending`` criterion is derived per requirement. When no
+    requirement ids are available, a single placeholder criterion carrying
+    :data:`SCAFFOLD_TODO_MARKER` is written so the file is valid yet obviously
+    awaiting real content.
+
+    Args:
+        feature_dir: The ``kitty-specs/<slug>/`` directory for the mission.
+        mission_slug: Feature slug (e.g. ``010-lane-only-runtime``).
+        requirement_ids: Optional functional requirement ids to seed criteria.
+
+    Returns:
+        Path to the scaffolded (or pre-existing) ``acceptance-matrix.json``.
+    """
+    path = feature_dir / MATRIX_FILENAME
+    if path.exists():
+        # Respect operator-curated content; idempotent re-runs must not clobber.
+        return path
+
+    criteria: list[AcceptanceCriterion] = []
+    for req_id in requirement_ids or []:
+        criteria.append(
+            AcceptanceCriterion(
+                criterion_id=req_id,
+                description=f"Verify {req_id} is satisfied",
+                proof_type="automated_test",
+                pass_fail="pending",  # noqa: S106
+                notes=SCAFFOLD_TODO_MARKER,
+            )
+        )
+
+    if not criteria:
+        # Empty-but-valid scaffold with an explicit TODO marker. A single
+        # placeholder keeps the JSON schema-valid while signalling clearly that
+        # no real criteria have been authored yet.
+        criteria.append(
+            AcceptanceCriterion(
+                criterion_id="AC-001",
+                description=SCAFFOLD_TODO_MARKER,
+                proof_type="automated_test",
+                pass_fail="pending",  # noqa: S106
+                notes=SCAFFOLD_TODO_MARKER,
+            )
+        )
+
+    matrix = AcceptanceMatrix(mission_slug=mission_slug, criteria=criteria)
+    return write_acceptance_matrix(feature_dir, matrix)
+
+
 # ---------------------------------------------------------------------------
 # Evidence validation
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/cli/commands/accept.py
+++ b/src/specify_cli/cli/commands/accept.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import typer
 from rich.table import Table
@@ -21,7 +22,13 @@ from specify_cli.cli import StepTracker
 from specify_cli.cli.selector_resolution import resolve_mission_handle
 from specify_cli.cli.helpers import console, show_banner
 from specify_cli.git.commit_helpers import assert_not_protected_branch
-from specify_cli.task_utils import LANES, TaskCliError, find_repo_root
+from specify_cli.task_utils import (
+    LANES,
+    TaskCliError,
+    find_repo_root,
+    git_status_lines,
+    run_git,
+)
 
 
 def _safe_emit_error_logged(message: str) -> None:
@@ -32,6 +39,73 @@ def _safe_emit_error_logged(message: str) -> None:
     except Exception:
         # Non-blocking: never fail the command on emission errors
         pass
+
+
+def _spec_artifact_dirty_paths(repo_root: Path, feature_slug: str) -> list[str]:
+    """Return tracked-but-uncommitted spec/meta artifacts under the mission dir.
+
+    The acceptance pipeline materializes derived artifacts (e.g.
+    ``acceptance-matrix.json`` and status views) while running readiness checks
+    *before* the acceptance commit is created. Those writes happen after the
+    git-cleanliness snapshot is taken, so the acceptance commit only captures
+    ``meta.json`` and leaves the materialized artifacts modified-unstaged. This
+    helper finds exactly those leftover tracked modifications so the command can
+    fold them into the acceptance state and leave a clean working tree.
+
+    Untracked files (``??``) are deliberately excluded so the cleanup commit
+    never sweeps in unrelated, unmanaged files the operator may have created.
+    """
+    prefix = f"kitty-specs/{feature_slug}/"
+    dirty: list[str] = []
+    for line in git_status_lines(repo_root):
+        # Porcelain format: two status chars, a space, then the path.
+        status_code = line[:2]
+        path = line[3:].strip()
+        # Rename entries look like "old -> new"; keep the destination path.
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        if status_code == "??":
+            continue
+        if path.startswith(prefix):
+            dirty.append(path)
+    return dirty
+
+
+def _commit_residual_acceptance_artifacts(repo_root: Path, feature_slug: str) -> bool:
+    """Stage and commit any leftover acceptance artifacts so the tree is clean.
+
+    Returns True when a follow-up commit was created. This preserves the
+    recorded ``accept_commit`` SHA (it still points at the real acceptance
+    commit) while guaranteeing a successful ``accept`` leaves no
+    staged-but-uncommitted or modified-unstaged spec/meta artifacts behind.
+    """
+    dirty = _spec_artifact_dirty_paths(repo_root, feature_slug)
+    if not dirty:
+        return False
+
+    for path in dirty:
+        run_git(["add", path], cwd=repo_root, check=True)
+
+    # Scope the staged-check and the commit to the mission's dirty artifacts
+    # only. A bare ``git commit`` would sweep in any files the operator had
+    # pre-staged outside the mission dir; the explicit ``-- <paths>`` pathspec
+    # commits exactly these spec/meta artifacts and leaves unrelated staged work
+    # untouched.
+    staged = run_git(
+        ["diff", "--cached", "--name-only", "--", *dirty],
+        cwd=repo_root,
+        check=True,
+    )
+    staged_files = [line.strip() for line in staged.stdout.splitlines() if line.strip()]
+    if not staged_files:
+        return False
+
+    run_git(
+        ["commit", "-m", f"Finalize acceptance artifacts for {feature_slug}", "--", *dirty],
+        cwd=repo_root,
+        check=True,
+    )
+    return True
 
 
 def _print_acceptance_summary(summary: AcceptanceSummary) -> None:
@@ -292,6 +366,14 @@ def accept(
                 tests=acceptance_tests,
                 auto_commit=commit_required,
             )
+        if commit_required:
+            # The acceptance commit (inside perform_acceptance) only captures
+            # meta.json. Derived artifacts materialized during readiness checks
+            # (e.g. acceptance-matrix.json, status views) are written after the
+            # git-cleanliness snapshot and would otherwise be left dirty. Fold
+            # them into a follow-up commit so a successful accept leaves a clean
+            # working tree on every path (including accept_commit == None).
+            _commit_residual_acceptance_artifacts(repo_root, mission_slug)
         if commit_required and not json_output:
             detail = "commit created" if result.commit_created else "no changes"
             tracker.complete("commit", detail)

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -95,6 +95,7 @@ def _collect_finalize_artifacts(
         feature_dir / "status.events.jsonl",
         feature_dir / "status.json",
         feature_dir / TASKS_MD_FILENAME,
+        feature_dir / "acceptance-matrix.json",
         feature_dir / ".kittify" / "dossiers" / mission_slug / "snapshot-latest.json",
     ]
     candidates.extend(sorted(path for path in tasks_dir.iterdir() if path.is_file()))
@@ -2598,6 +2599,43 @@ def finalize_tasks(
                 else:
                     console.print(f"[red]Error:[/red] {error_msg}")
                 raise typer.Exit(1)
+
+        # Finding 6: scaffold a minimal, schema-valid ``acceptance-matrix.json``
+        # for lane-based missions whenever it is absent. The acceptance gate
+        # requires this artifact for lane-based features, so creating it at
+        # finalize-tasks time prevents a silently-missing file from blocking
+        # acceptance later. The helper is idempotent (existing files are never
+        # overwritten) and must never block finalize on failure.
+        if lanes_manifest is not None and not validate_only:
+            try:
+                from specify_cli.acceptance.matrix import scaffold_acceptance_matrix
+
+                acceptance_matrix_path = scaffold_acceptance_matrix(
+                    feature_dir,
+                    mission_slug,
+                    requirement_ids=sorted(functional_spec_requirement_ids),
+                )
+            except Exception as _acc_matrix_exc:  # noqa: BLE001
+                # Never block finalize-tasks on a scaffold failure — this is a
+                # convenience artifact, not a correctness gate. Emit a
+                # copy-pasteable remediation command so operators can recover.
+                if not json_output:
+                    console.print(
+                        "[yellow]Warning:[/yellow] could not scaffold "
+                        f"acceptance-matrix.json: {_acc_matrix_exc}"
+                    )
+                    console.print(
+                        "[yellow]Hint:[/yellow] create it manually before "
+                        "acceptance:\n  spec-kitty agent mission finalize-tasks "
+                        f"--feature {mission_slug}"
+                    )
+            else:
+                if acceptance_matrix_path is not None and not json_output:
+                    try:
+                        rel = acceptance_matrix_path.relative_to(repo_root)
+                    except ValueError:
+                        rel = acceptance_matrix_path
+                    console.print(f"[info] Scaffolded {rel}")
 
         # Run dossier sync before the commit so its deterministic snapshot lands
         # atomically with the rest of the planning artifacts.

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -739,12 +739,33 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
 
     content = tasks_md.read_text(encoding="utf-8")
 
-    # Find subtasks for this WP (looking for - [ ] or - [x] checkboxes under WP section)
+    # Find canonical subtasks for this WP. Only unchecked rows of the form
+    # ``- [ ] T### <desc>`` count as blocking. Validation/procedure/checklist
+    # command rows (e.g. ``- [ ] swift test``, ``- [ ] git status --short``),
+    # prose, and anything inside fenced code blocks are intentionally ignored —
+    # they are not work-package subtasks and must not block a lane transition.
     lines = content.split("\n")
-    unchecked = []
+    unchecked: list[str] = []
     in_wp_section = False
+    in_code_fence = False
+
+    # Canonical subtask row: ``- [ ] T001 ...``. A ``T`` id of at least three
+    # digits is mandatory (``\d{3,}`` so ids past T999 still block).
+    canonical_unchecked = re.compile(r"^-\s*\[\s*\]\s*(T\d{3,})\b")
 
     for line in lines:
+        stripped = line.strip()
+
+        # Toggle fenced-code-block state on ``` or ~~~ markers. Task-like lines
+        # inside fenced code blocks (examples in implementation notes) must not
+        # be treated as real subtasks.
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code_fence = not in_code_fence
+            continue
+
+        if in_code_fence:
+            continue
+
         # Check if we entered this WP's section
         if re.search(rf"^#{{2,4}}[^#].*{wp_id}\b", line):
             in_wp_section = True
@@ -754,13 +775,11 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
         if in_wp_section and re.search(r"^#{2,4}[^#].*WP\d{2}\b", line):
             break  # Left this WP's section
 
-        # Look for unchecked tasks in this WP's section
+        # Look for unchecked canonical task rows in this WP's section
         if in_wp_section:
-            # Match patterns like: - [ ] T001 or - [ ] Task description
-            unchecked_match = re.match(r"-\s*\[\s*\]\s*(T\d{3}|.*)", line.strip())
+            unchecked_match = canonical_unchecked.match(stripped)
             if unchecked_match:
-                task_id = unchecked_match.group(1).split()[0] if unchecked_match.group(1) else line.strip()
-                unchecked.append(task_id)
+                unchecked.append(unchecked_match.group(1))
 
     return unchecked
 
@@ -1610,13 +1629,14 @@ def move_task(
         if target_lane in (Lane.FOR_REVIEW, Lane.APPROVED, Lane.DONE) and not force:
             unchecked = _check_unchecked_subtasks(repo_root, mission_slug, task_id, force)
             if unchecked:
+                # ``unchecked`` only ever contains canonical T### ids, so the
+                # remediation commands below are always valid mark-status calls.
                 error_msg = f"Cannot move {task_id} to {target_lane} - unchecked subtasks:\n"
                 for task in unchecked:
                     error_msg += f"  - [ ] {task}\n"
                 error_msg += "\nMark these complete first:\n"
                 for task in unchecked[:3]:  # Show first 3 examples
-                    task_clean = task.split()[0] if " " in task else task
-                    error_msg += f"  spec-kitty agent tasks mark-status {task_clean} --status done\n"
+                    error_msg += f"  spec-kitty agent tasks mark-status {task} --status done\n"
                 error_msg += "\nOr use --force to override (not recommended)"
                 _output_error(json_output, error_msg)
                 raise typer.Exit(1)

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -92,6 +92,19 @@ LINEAR_HISTORY_REJECTION_TOKENS: tuple[str, ...] = (
 MissionBranchBlocker = dict[str, str | bool]
 
 
+class BaselineMergeCommitError(RuntimeError):
+    """Raised when the post-merge review baseline cannot be recorded or verified.
+
+    Modern lane missions (those whose ``meta.json`` carries a canonical
+    ``mission_id``) MUST land ``baseline_merge_commit`` on the target branch.
+    When the baseline is missing, the working meta is absent/corrupt, or the
+    committed target meta lacks the expected value, downstream
+    ``spec-kitty review`` raises ``MISSION_REVIEW_MODE_MISMATCH``. We surface
+    that failure loudly at merge time instead of letting an apparently
+    successful merge ship a mission that cannot be reviewed post-merge.
+    """
+
+
 def _classify_porcelain_lines(
     lines: list[str],
     expected_paths: set[str],
@@ -903,18 +916,43 @@ def _emit_merge_diff_summary(
 def _record_baseline_merge_commit(
     feature_dir: Path,
     baseline_commit: str | None,
+    *,
+    mission_id: str | None = None,
 ) -> Path | None:
     """Persist the post-merge review baseline in mission meta.json.
 
     ``baseline_merge_commit`` anchors post-merge review diffs. It should point
     at the target-branch baseline before the mission lands, not at the final
     housekeeping commit produced by merge.
+
+    For **modern lane missions** (``mission_id`` is set — the canonical ULID
+    introduced by mission 083), an empty baseline, a missing ``meta.json``, or
+    corrupt JSON is a HARD failure: we raise :class:`BaselineMergeCommitError`
+    so the merge stops loudly instead of shipping a mission that
+    ``spec-kitty review --mode post-merge`` cannot anchor
+    (``MISSION_REVIEW_MODE_MISMATCH``).
+
+    For **legacy missions** (no ``mission_id``) the historical soft behavior is
+    preserved: the function logs a warning and returns ``None`` so the merge
+    proceeds without a baseline.
     """
+    is_modern = bool(mission_id and str(mission_id).strip())
+
     if not baseline_commit or not baseline_commit.strip():
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: no target baseline SHA was captured."
+            )
         return None
 
     meta_path = feature_dir / "meta.json"
     if not meta_path.exists():
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: meta.json is missing."
+            )
         logger.warning(
             "Cannot record baseline_merge_commit for %s: meta.json is missing",
             feature_dir.name,
@@ -924,6 +962,11 @@ def _record_baseline_merge_commit(
     try:
         meta = load_meta(feature_dir)
     except ValueError as exc:
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: meta.json is invalid ({exc})."
+            ) from exc
         logger.warning(
             "Cannot record baseline_merge_commit for %s: %s",
             feature_dir.name,
@@ -932,6 +975,11 @@ def _record_baseline_merge_commit(
         return None
 
     if meta is None:
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: meta.json could not be loaded."
+            )
         return None
 
     existing = meta.get("baseline_merge_commit")
@@ -941,6 +989,104 @@ def _record_baseline_merge_commit(
     meta["baseline_merge_commit"] = baseline_commit.strip()
     write_meta(feature_dir, meta, validate=False)
     return meta_path
+
+
+def _assert_baseline_merge_commit_on_target(
+    main_repo: Path,
+    mission_slug: str,
+    target_branch: str,
+    expected_baseline: str | None,
+    *,
+    feature_dir: Path | None = None,
+    mission_id: str | None = None,
+) -> None:
+    """Fail the merge if ``baseline_merge_commit`` did not land on *target_branch*.
+
+    Mirrors :func:`_assert_merged_wps_reached_done`: it reads the target
+    branch's COMMITTED ``kitty-specs/<slug>/meta.json`` via
+    ``git show <target>:<path>`` and asserts ``baseline_merge_commit`` is both
+    present and equal to the baseline that was actually RECORDED for this
+    mission. This is the post-commit invariant that closes the gap behind
+    ``MISSION_REVIEW_MODE_MISMATCH``: it proves the baseline is durable in git
+    history (not just in the working tree) before any worktree removal or
+    branch cleanup runs.
+
+    The expected baseline is read from the recorded mission ``meta.json`` in
+    *feature_dir* (the idempotent value written by
+    :func:`_record_baseline_merge_commit`) and only falls back to
+    *expected_baseline* when that is unavailable. This is deliberate:
+    ``target_baseline_sha`` is re-derived from the live target HEAD on every
+    invocation, so on ``spec-kitty merge --resume`` — after a prior run already
+    landed the mission/bookkeeping commits — the live HEAD has advanced past the
+    original baseline. Comparing the committed value against a re-derived HEAD
+    would spuriously fail an otherwise-correct resume; comparing it against the
+    recorded value does not.
+
+    Only enforced for **modern missions** (``mission_id`` set). Legacy missions
+    never carry a baseline and are skipped.
+    """
+    if not (mission_id and str(mission_id).strip()):
+        return
+
+    recorded = ""
+    if feature_dir is not None:
+        try:
+            working_meta = load_meta(feature_dir)
+        except ValueError:
+            working_meta = None
+        if isinstance(working_meta, dict):
+            recorded = str(working_meta.get("baseline_merge_commit") or "").strip()
+
+    expected = recorded or (expected_baseline or "").strip()
+    if not expected:
+        raise BaselineMergeCommitError(
+            f"Cannot verify baseline_merge_commit for modern mission "
+            f"{mission_slug}: no recorded baseline SHA was found."
+        )
+
+    meta_rel = f"kitty-specs/{mission_slug}/meta.json"
+    ret, out, err = run_command(
+        ["git", "show", f"{target_branch}:{meta_rel}"],
+        capture=True,
+        check_return=False,
+        cwd=main_repo,
+    )
+    if ret != 0:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"could not read {meta_rel} from {target_branch} "
+            f"({(err or '').strip() or 'git show failed'})."
+        )
+
+    try:
+        committed_meta = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"committed {meta_rel} on {target_branch} is not valid JSON ({exc})."
+        ) from exc
+
+    if not isinstance(committed_meta, dict):
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"committed {meta_rel} on {target_branch} is not a JSON object."
+        )
+
+    committed_baseline = str(committed_meta.get("baseline_merge_commit") or "").strip()
+    if not committed_baseline:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"baseline_merge_commit is missing from committed {meta_rel} on "
+            f"{target_branch}. Downstream `spec-kitty review --mode post-merge` "
+            f"would fail with MISSION_REVIEW_MODE_MISMATCH."
+        )
+
+    if committed_baseline != expected:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"committed baseline_merge_commit ({committed_baseline}) on "
+            f"{target_branch} does not match the captured baseline ({expected})."
+        )
 
 
 def _validate_target_branch(
@@ -1388,6 +1534,16 @@ def _run_lane_based_merge_locked(
     )
     target_baseline_sha = target_baseline_sha.strip() if _ret == 0 else "HEAD~1"
 
+    # -- Resolve the canonical mission_id (ULID) to gate modern-mission invariants --
+    # ``canonical_id`` falls back to the slug for legacy missions, so it cannot
+    # distinguish modern (083+) from pre-083 missions. Re-resolve the raw
+    # mission_id from meta.json: a non-empty value means this is a MODERN lane
+    # mission and the baseline_merge_commit invariants below are HARD failures.
+    try:
+        _baseline_mission_id = resolve_mission_identity(feature_dir).mission_id
+    except Exception:  # noqa: BLE001 — meta.json may be missing/corrupt for legacy missions
+        _baseline_mission_id = None
+
     # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
     # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
     # which serializes ALL merge operations — same-mission and cross-mission.
@@ -1435,10 +1591,18 @@ def _run_lane_based_merge_locked(
     # repos; the helper uses a tracked-file hard refresh instead.
     _refresh_primary_checkout_after_merge(main_repo)
 
-    baseline_meta_path = _record_baseline_merge_commit(
-        feature_dir,
-        target_baseline_sha,
-    )
+    try:
+        baseline_meta_path = _record_baseline_merge_commit(
+            feature_dir,
+            target_baseline_sha,
+            mission_id=_baseline_mission_id,
+        )
+    except BaselineMergeCommitError as exc:
+        # Modern lane mission could not record its post-merge review baseline.
+        # Fail loudly — an apparently successful merge that drops the baseline
+        # produces MISSION_REVIEW_MODE_MISMATCH downstream.
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
 
     # If the final bookkeeping commit fails after done events are emitted,
     # restore the canonical status artifacts to their pre-emit bytes. This
@@ -1562,6 +1726,27 @@ def _run_lane_based_merge_locked(
             raise
     else:
         console.print("  [dim]No post-merge bookkeeping changes to commit; continuing cleanup.[/dim]")
+
+    # -- Post-merge baseline invariant (mirrors _assert_merged_wps_reached_done) --
+    # Now that the bookkeeping commit (which carries meta.json's
+    # baseline_merge_commit) has landed on the target branch, verify the
+    # baseline is durable in committed git history BEFORE any worktree removal
+    # or branch cleanup. Together with _assert_merged_wps_reached_done this
+    # guarantees BOTH the done-state AND the baseline gate merge success: a
+    # merge cannot appear successful while the baseline is absent, which would
+    # otherwise surface downstream as MISSION_REVIEW_MODE_MISMATCH.
+    try:
+        _assert_baseline_merge_commit_on_target(
+            main_repo,
+            mission_slug,
+            lanes_manifest.target_branch,
+            target_baseline_sha,
+            feature_dir=feature_dir,
+            mission_id=_baseline_mission_id,
+        )
+    except BaselineMergeCommitError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
 
     console.print("  [dim]Syncing dossier state for the merged mission...[/dim]")
     trigger_feature_dossier_sync_if_enabled(
@@ -2047,6 +2232,9 @@ def merge(
 __all__ = [
     "_has_transition_to",
     "_assert_merged_wps_reached_done",
+    "_assert_baseline_merge_commit_on_target",
+    "_record_baseline_merge_commit",
+    "BaselineMergeCommitError",
     "_mark_wp_merged_done",
     "_run_lane_based_merge",
     "_is_linear_history_rejection",

--- a/src/specify_cli/cli/commands/retrospect.py
+++ b/src/specify_cli/cli/commands/retrospect.py
@@ -389,8 +389,8 @@ def create_cmd(
         "evidence_refs": len(record.evidence_refs),
     }
     next_step = (
-        f"Run `spec-kitty agent retrospect synthesize --mission {resolved.mission_slug} --preview` "
-        "to review proposals."
+        f"Run `spec-kitty agent retrospect synthesize --mission {resolved.mission_slug}` "
+        "to review proposals (dry-run by default; add --apply to mutate)."
     )
 
     if json_output:
@@ -798,8 +798,8 @@ def backfill_cmd(  # noqa: C901
     next_actions: list[str] = []
     if created and not dry_run:
         next_actions.append(
-            "Run `spec-kitty agent retrospect synthesize --mission <handle> --preview` "
-            "on newly authored records."
+            "Run `spec-kitty agent retrospect synthesize --mission <handle>` "
+            "on newly authored records (dry-run by default; add --apply to mutate)."
         )
     if failed:
         next_actions.append(f"Inspect the {len(failed)} failed mission(s) listed above.")

--- a/src/specify_cli/missions/software-dev/command-templates/accept.md
+++ b/src/specify_cli/missions/software-dev/command-templates/accept.md
@@ -1,0 +1,88 @@
+---
+description: Validate an approved mission before merge
+---
+# /spec-kitty.accept - Validate Mission Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved` or `done`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/cli/commands/test_merge_status_commit.py
+++ b/tests/cli/commands/test_merge_status_commit.py
@@ -111,6 +111,33 @@ def _write_meta(feature_dir: Path, mission_slug: str, **overrides: object) -> No
     )
 
 
+def _baseline_run_command_side_effect(feature_dir: Path, baseline_sha: str):
+    """run_command side_effect that simulates a target carrying the baseline.
+
+    Every git command returns ``(0, baseline_sha, "")`` EXCEPT ``git show
+    <target>:kitty-specs/<slug>/meta.json``, which returns the committed
+    target meta.json with ``baseline_merge_commit`` populated. This lets the
+    full merge flow exercise ``_assert_baseline_merge_commit_on_target``
+    without a real git history.
+    """
+    meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+    meta["baseline_merge_commit"] = baseline_sha
+    committed_meta_json = json.dumps(meta, sort_keys=True)
+
+    def _side_effect(cmd, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if (
+            isinstance(cmd, (list, tuple))
+            and len(cmd) >= 3
+            and cmd[0] == "git"
+            and cmd[1] == "show"
+            and str(cmd[2]).endswith("meta.json")
+        ):
+            return (0, committed_meta_json, "")
+        return (0, baseline_sha, "")
+
+    return _side_effect
+
+
 class TestBaselineMergeCommitMetadata:
     def test_record_baseline_merge_commit_fills_blank_field(self, tmp_path: Path) -> None:
         mission_slug = "068-baseline-meta"
@@ -321,7 +348,10 @@ class TestSafeCommitCalledAfterMarkDoneLoop:
             patch("specify_cli.post_merge.stale_assertions.run_check") as mock_run_check,
             patch("specify_cli.policy.merge_gates.evaluate_merge_gates") as mock_gates,
             patch("specify_cli.policy.config.load_policy_config") as mock_policy,
-            patch("specify_cli.cli.commands.merge.run_command", return_value=(0, "base123", "")),
+            patch(
+                "specify_cli.cli.commands.merge.run_command",
+                side_effect=_baseline_run_command_side_effect(feature_dir, "base123"),
+            ),
             patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
             patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
             patch("specify_cli.cli.commands.merge.clear_state"),
@@ -641,7 +671,10 @@ class TestDoneEventsCommittedToGit:
             patch("specify_cli.post_merge.stale_assertions.run_check") as mock_run_check,
             patch("specify_cli.policy.merge_gates.evaluate_merge_gates") as mock_gates,
             patch("specify_cli.policy.config.load_policy_config") as mock_policy,
-            patch("specify_cli.cli.commands.merge.run_command", return_value=(0, "abc123", "")),
+            patch(
+                "specify_cli.cli.commands.merge.run_command",
+                side_effect=_baseline_run_command_side_effect(feature_dir, "abc123"),
+            ),
             patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
             patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
             patch("specify_cli.cli.commands.merge.clear_state"),

--- a/tests/docs/test_no_retrospect_preview.py
+++ b/tests/docs/test_no_retrospect_preview.py
@@ -1,0 +1,102 @@
+"""Guard test: ``retrospect synthesize`` must never be paired with ``--preview``.
+
+The ``spec-kitty agent retrospect synthesize`` command is dry-run by default and
+takes ``--apply`` to mutate; it does NOT accept a ``--preview`` flag (see
+``src/specify_cli/cli/commands/agent_retrospect.py::synthesize_cmd``).
+
+Stale guidance that tells operators to run ``... synthesize ... --preview`` is a
+documentation bug because the flag does not exist. This test scans the owned
+source tree (``src/`` and ``docs/``) plus the repo-root mission-workflow file and
+fails if any ``retrospect synthesize`` reference still pairs with ``--preview``.
+
+Excluded from the scan:
+- ``kitty-specs/`` (historical mission artifacts, intentionally frozen)
+- generated agent copies under dot-directories (``.claude/``, ``.agents/``,
+  ``.amazonq/``, etc.) which are produced from the source templates
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories whose markdown/source files we own and want to keep correct.
+SCAN_ROOTS = (
+    REPO_ROOT / "src",
+    REPO_ROOT / "docs",
+)
+
+# Repo-root standalone files that document the workflow.
+SCAN_FILES = (REPO_ROOT / "spec-kitty-mission-workflow.md",)
+
+# File extensions worth scanning for command guidance.
+SCAN_SUFFIXES = {".md", ".py", ".txt", ".rst"}
+
+# Matches a ``retrospect synthesize`` invocation that also carries ``--preview``
+# on the same logical command line (we scan line by line, which is how these
+# guidance strings are authored).
+_PATTERN = re.compile(r"retrospect\s+synthesize\b.*--preview\b")
+
+
+def _is_excluded(path: Path) -> bool:
+    """Return True for paths that must NOT be scanned.
+
+    Skips ``kitty-specs/`` (historical) and any generated agent copy living
+    under a dot-directory (``.claude``, ``.agents``, ``.amazonq``, ...).
+    """
+    try:
+        rel_parts = path.relative_to(REPO_ROOT).parts
+    except ValueError:
+        rel_parts = path.parts
+    for part in rel_parts:
+        if part == "kitty-specs":
+            return True
+        # Generated agent copies live under dot-directories.
+        if part.startswith(".") and part not in {".", ".."}:
+            return True
+    return False
+
+
+def _iter_candidate_files() -> list[Path]:
+    candidates: list[Path] = []
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in SCAN_SUFFIXES:
+                continue
+            if _is_excluded(path):
+                continue
+            candidates.append(path)
+    for path in SCAN_FILES:
+        if path.is_file() and not _is_excluded(path):
+            candidates.append(path)
+    return candidates
+
+
+def test_no_retrospect_synthesize_preview_pairing() -> None:
+    """No owned source/doc file may pair ``retrospect synthesize`` with ``--preview``."""
+    offenders: list[str] = []
+    for path in _iter_candidate_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _PATTERN.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "`retrospect synthesize` is dry-run by default and uses --apply to mutate; "
+        "it does not accept --preview. Remove the stale --preview reference(s):\n"
+        + "\n".join(offenders)
+    )

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -361,3 +361,69 @@ class TestNegativeInvariants:
         restored = json.loads((feature_dir / MATRIX_FILENAME).read_text(encoding="utf-8"))
         assert restored["negative_invariants"][0]["result"] == "confirmed_absent"
         assert restored["negative_invariants"][0]["verification_pattern"] == "operator-authored extension"
+
+
+class TestScaffoldAcceptanceMatrix:
+    """Finding 6: ``scaffold_acceptance_matrix`` writes a schema-valid file."""
+
+    def test_scaffold_empty_but_valid_when_no_requirements(self, tmp_path):
+        from specify_cli.acceptance.matrix import (
+            SCAFFOLD_TODO_MARKER,
+            scaffold_acceptance_matrix,
+        )
+
+        feature_dir = tmp_path / "kitty-specs" / "010-feat"
+        feature_dir.mkdir(parents=True)
+
+        out_path = scaffold_acceptance_matrix(feature_dir, "010-feat", requirement_ids=[])
+
+        assert out_path == feature_dir / MATRIX_FILENAME
+        assert out_path.exists()
+
+        # Schema-valid: round-trips through read_acceptance_matrix.
+        matrix = read_acceptance_matrix(feature_dir)
+        assert matrix is not None
+        assert matrix.mission_slug == "010-feat"
+        # Empty-but-valid scaffold has a clear TODO marker.
+        assert len(matrix.criteria) == 1
+        assert SCAFFOLD_TODO_MARKER in (matrix.criteria[0].notes or "")
+        # Verdict stays pending until evidence is supplied.
+        assert matrix.overall_verdict == "pending"
+
+    def test_scaffold_derives_criteria_from_requirements(self, tmp_path):
+        from specify_cli.acceptance.matrix import scaffold_acceptance_matrix
+
+        feature_dir = tmp_path / "kitty-specs" / "010-feat"
+        feature_dir.mkdir(parents=True)
+
+        scaffold_acceptance_matrix(feature_dir, "010-feat", requirement_ids=["FR-001", "FR-002"])
+
+        matrix = read_acceptance_matrix(feature_dir)
+        assert matrix is not None
+        assert [c.criterion_id for c in matrix.criteria] == ["FR-001", "FR-002"]
+        assert all(c.pass_fail == "pending" for c in matrix.criteria)
+
+    def test_scaffold_is_idempotent(self, tmp_path):
+        from specify_cli.acceptance.matrix import scaffold_acceptance_matrix
+
+        feature_dir = tmp_path / "kitty-specs" / "010-feat"
+        feature_dir.mkdir(parents=True)
+
+        # Operator-curated content must survive a re-scaffold.
+        curated = AcceptanceMatrix(
+            mission_slug="010-feat",
+            criteria=[
+                AcceptanceCriterion(
+                    criterion_id="AC-CUSTOM",
+                    description="Operator authored",
+                    proof_type="manual_qa",
+                ),
+            ],
+        )
+        write_acceptance_matrix(feature_dir, curated)
+
+        scaffold_acceptance_matrix(feature_dir, "010-feat", requirement_ids=["FR-001"])
+
+        matrix = read_acceptance_matrix(feature_dir)
+        assert matrix is not None
+        assert [c.criterion_id for c in matrix.criteria] == ["AC-CUSTOM"]

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import typer
 
 from specify_cli.cli.commands.merge import (
+    BaselineMergeCommitError,
+    _assert_baseline_merge_commit_on_target,
     _assert_merged_wps_reached_done,
     _mark_wp_merged_done,
+    _record_baseline_merge_commit,
 )
 
 pytestmark = pytest.mark.fast
@@ -224,3 +228,254 @@ def test_assert_merged_wps_reached_done_fails_when_wp_not_done(
 
     with pytest.raises(typer.Exit):
         _assert_merged_wps_reached_done(tmp_path, "021-test", ["WP01", "WP02"])
+
+
+# ---------------------------------------------------------------------------
+# baseline_merge_commit invariants (Finding 5): modern lane missions must
+# land baseline_merge_commit on the target branch or the merge fails loudly.
+# ---------------------------------------------------------------------------
+
+
+_MODERN_MISSION_ID = "01KTESTMISSIONID00000000000"
+
+
+def _write_meta(feature_dir: Path, mission_slug: str, **overrides: object) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict[str, object] = {
+        "created_at": "2026-04-07T00:00:00+00:00",
+        "friendly_name": mission_slug.replace("-", " "),
+        "mission_id": _MODERN_MISSION_ID,
+        "mission_number": None,
+        "mission_slug": mission_slug,
+        "mission_type": "software-dev",
+        "slug": mission_slug,
+        "target_branch": "main",
+    }
+    meta.update(overrides)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_record_baseline_merge_commit_modern_mission_missing_meta_raises(tmp_path: Path) -> None:
+    """A modern lane mission with no meta.json is a HARD failure (Finding 5 (b))."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    feature_dir.mkdir(parents=True)
+    # No meta.json on disk.
+
+    with pytest.raises(BaselineMergeCommitError):
+        _record_baseline_merge_commit(
+            feature_dir,
+            "base123",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_record_baseline_merge_commit_modern_mission_empty_baseline_raises(tmp_path: Path) -> None:
+    """A modern lane mission with an empty captured baseline is a HARD failure."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test", baseline_merge_commit=None)
+
+    with pytest.raises(BaselineMergeCommitError):
+        _record_baseline_merge_commit(
+            feature_dir,
+            "   ",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_record_baseline_merge_commit_modern_mission_invalid_meta_raises(tmp_path: Path) -> None:
+    """A modern lane mission with corrupt meta.json is a HARD failure."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(BaselineMergeCommitError):
+        _record_baseline_merge_commit(
+            feature_dir,
+            "base123",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_record_baseline_merge_commit_legacy_missing_meta_soft_returns_none(tmp_path: Path) -> None:
+    """A legacy mission (no mission_id) preserves the soft skip behavior."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    feature_dir.mkdir(parents=True)
+    # No meta.json, no mission_id → legacy soft path returns None, no raise.
+
+    result = _record_baseline_merge_commit(feature_dir, "base123", mission_id=None)
+
+    assert result is None
+
+
+def test_record_baseline_merge_commit_modern_mission_fills_field(tmp_path: Path) -> None:
+    """A modern lane mission with valid meta records baseline and returns the path."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test", baseline_merge_commit=None)
+
+    result = _record_baseline_merge_commit(
+        feature_dir,
+        "base123",
+        mission_id=_MODERN_MISSION_ID,
+    )
+
+    assert result == feature_dir / "meta.json"
+    data = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+    assert data["baseline_merge_commit"] == "base123"
+
+
+def test_assert_baseline_on_target_passes_when_committed_meta_matches(tmp_path: Path) -> None:
+    """Finding 5 (a)/(c): target meta.json carrying the matching baseline passes."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test")
+    committed_meta = json.dumps({"baseline_merge_commit": "base123"})
+
+    with patch(
+        "specify_cli.cli.commands.merge.run_command",
+        return_value=(0, committed_meta, ""),
+    ):
+        # Must not raise.
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "base123",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_assert_baseline_on_target_raises_when_baseline_absent(tmp_path: Path) -> None:
+    """Finding 5 (c): target meta.json lacking baseline_merge_commit fails loudly."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test")
+    committed_meta = json.dumps({"mission_slug": "021-test"})  # no baseline_merge_commit
+
+    with patch(
+        "specify_cli.cli.commands.merge.run_command",
+        return_value=(0, committed_meta, ""),
+    ), pytest.raises(BaselineMergeCommitError):
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "base123",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_assert_baseline_on_target_raises_when_baseline_mismatches(tmp_path: Path) -> None:
+    """Target meta.json carrying a DIFFERENT baseline fails loudly."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test")
+    committed_meta = json.dumps({"baseline_merge_commit": "other999"})
+
+    with patch(
+        "specify_cli.cli.commands.merge.run_command",
+        return_value=(0, committed_meta, ""),
+    ), pytest.raises(BaselineMergeCommitError):
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "base123",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_assert_baseline_on_target_raises_when_git_show_fails(tmp_path: Path) -> None:
+    """A failed `git show <target>:meta.json` (e.g. path absent) fails loudly."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test")
+
+    with patch(
+        "specify_cli.cli.commands.merge.run_command",
+        return_value=(128, "", "fatal: path does not exist"),
+    ), pytest.raises(BaselineMergeCommitError):
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "base123",
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_assert_baseline_on_target_skips_legacy_mission(tmp_path: Path) -> None:
+    """Legacy missions (no mission_id) skip the target baseline assertion entirely."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    feature_dir.mkdir(parents=True)
+
+    # run_command would raise if called — assert it is never invoked for legacy.
+    def _boom(*_a: Any, **_kw: Any):
+        raise AssertionError("run_command must not be called for legacy missions")
+
+    with patch("specify_cli.cli.commands.merge.run_command", side_effect=_boom):
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "base123",
+            mission_id=None,
+        )
+
+
+def test_assert_baseline_on_target_resume_uses_recorded_baseline_not_live_head(
+    tmp_path: Path,
+) -> None:
+    """Resume safety (Finding 5): the invariant compares the COMMITTED target
+    baseline against the RECORDED working-meta value, not a freshly re-derived
+    target HEAD.
+
+    On ``spec-kitty merge --resume`` a prior run already landed the
+    mission/bookkeeping commits, so the live target HEAD (the value
+    ``expected_baseline`` is captured from on each invocation) has advanced past
+    the original baseline. Comparing the committed value against that advanced
+    HEAD would spuriously fail an otherwise-correct resume. Passing
+    ``feature_dir`` makes the assertion read the originally-recorded baseline,
+    which is stable across resume.
+    """
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    # Run 1 recorded the original pre-merge baseline into the working meta and
+    # committed the same value to the target branch.
+    _write_meta(feature_dir, "021-test", baseline_merge_commit="original_sha_a")
+    committed_meta = json.dumps({"baseline_merge_commit": "original_sha_a"})
+
+    with patch(
+        "specify_cli.cli.commands.merge.run_command",
+        return_value=(0, committed_meta, ""),
+    ):
+        # expected_baseline is the RE-DERIVED, now-advanced target HEAD on
+        # resume; it must be ignored in favor of the recorded value.
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "advanced_sha_b_from_live_head",
+            feature_dir=feature_dir,
+            mission_id=_MODERN_MISSION_ID,
+        )
+
+
+def test_assert_baseline_on_target_raises_when_committed_differs_from_recorded(
+    tmp_path: Path,
+) -> None:
+    """A genuine drift (committed target baseline != recorded value) still fails
+    loudly even when ``feature_dir`` supplies the recorded baseline."""
+    feature_dir = tmp_path / "kitty-specs" / "021-test"
+    _write_meta(feature_dir, "021-test", baseline_merge_commit="recorded_sha_a")
+    committed_meta = json.dumps({"baseline_merge_commit": "drifted_sha_c"})
+
+    with patch(
+        "specify_cli.cli.commands.merge.run_command",
+        return_value=(0, committed_meta, ""),
+    ), pytest.raises(BaselineMergeCommitError):
+        _assert_baseline_merge_commit_on_target(
+            tmp_path,
+            "021-test",
+            "main",
+            "recorded_sha_a",
+            feature_dir=feature_dir,
+            mission_id=_MODERN_MISSION_ID,
+        )

--- a/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
+++ b/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
@@ -438,6 +438,118 @@ class TestWP01Regressions:
                 continue
         pytest.fail("No JSON output with 'result': 'validation_passed' found")
 
+
+# ---------------------------------------------------------------------------
+# Finding 6: finalize-tasks scaffolds acceptance-matrix.json for lane-based
+# missions (those that produce lanes.json).
+# ---------------------------------------------------------------------------
+
+
+def _setup_lane_based_feature(tmp_path: Path, mission_slug: str = "061-lane-feature") -> Path:
+    """Create a feature whose WPs have disjoint owned_files so lanes compute."""
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+
+    (feature_dir / "spec.md").write_text(
+        "---\ntitle: Lane Feature\n---\n\n## Requirements\n\n"
+        "- FR-001: First requirement\n- FR-002: Second requirement\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks.md").write_text(
+        "# Tasks\n\n## WP01\n\nNo dependencies.\n\n## WP02\n\nNo dependencies.\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "meta.json").write_text(
+        json.dumps({"mission_slug": mission_slug}), encoding="utf-8"
+    )
+
+    # Two independent WPs owning disjoint files → compute_lanes yields lanes.
+    for wp_id, owned, refs in [
+        ("WP01", ["src/alpha.py"], ["FR-001"]),
+        ("WP02", ["src/beta.py"], ["FR-002"]),
+    ]:
+        owned_yaml = "\n".join(f"  - {o}" for o in owned)
+        refs_yaml = "\n".join(f"  - {r}" for r in refs)
+        (tasks_dir / f"{wp_id}-test.md").write_text(
+            f'---\nwork_package_id: "{wp_id}"\ntitle: "Test {wp_id}"\n'
+            f"requirement_refs:\n{refs_yaml}\n"
+            f"owned_files:\n{owned_yaml}\n"
+            f"dependencies: []\n---\n\n# {wp_id}\n",
+            encoding="utf-8",
+        )
+
+    return feature_dir
+
+
+class TestFinalizeScaffoldsAcceptanceMatrix:
+    """Finding 6: lane-based finalize-tasks creates acceptance-matrix.json."""
+
+    def test_lane_based_finalize_creates_valid_matrix(self, tmp_path: Path) -> None:
+        mission_slug = "061-lane-feature"
+        feature_dir = _setup_lane_based_feature(tmp_path, mission_slug)
+
+        patches = _common_patches(tmp_path, mission_slug)
+        patches[f"{MODULE}._find_feature_directory"] = MagicMock(return_value=feature_dir)
+        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
+            return_value=_make_bootstrap_result()
+        )
+
+        from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+        ctx_patches = {k: patch(k, v) for k, v in patches.items()}
+        for p in ctx_patches.values():
+            p.start()
+        try:
+            finalize_tasks(feature=mission_slug, json_output=True, validate_only=False)
+        except (typer.Exit, SystemExit):
+            pass
+        finally:
+            for p in ctx_patches.values():
+                p.stop()
+
+        # Lane-based: lanes.json was written, so the matrix must exist.
+        assert (feature_dir / "lanes.json").exists(), "test setup must produce a lane-based feature"
+
+        from specify_cli.acceptance.matrix import read_acceptance_matrix
+
+        matrix_path = feature_dir / "acceptance-matrix.json"
+        assert matrix_path.exists(), "lane-based finalize must scaffold acceptance-matrix.json"
+
+        # Schema-valid + derived from functional requirements.
+        matrix = read_acceptance_matrix(feature_dir)
+        assert matrix is not None
+        assert matrix.mission_slug == mission_slug
+        criterion_ids = {c.criterion_id for c in matrix.criteria}
+        assert {"FR-001", "FR-002"} <= criterion_ids
+
+    def test_validate_only_does_not_scaffold_matrix(self, tmp_path: Path) -> None:
+        mission_slug = "061-lane-feature"
+        feature_dir = _setup_lane_based_feature(tmp_path, mission_slug)
+
+        patches = _common_patches(tmp_path, mission_slug)
+        patches[f"{MODULE}._find_feature_directory"] = MagicMock(return_value=feature_dir)
+        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
+            return_value=_make_bootstrap_result()
+        )
+
+        from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+        ctx_patches = {k: patch(k, v) for k, v in patches.items()}
+        for p in ctx_patches.values():
+            p.start()
+        try:
+            finalize_tasks(feature=mission_slug, json_output=True, validate_only=True)
+        except (typer.Exit, SystemExit):
+            pass
+        finally:
+            for p in ctx_patches.values():
+                p.stop()
+
+        assert not (feature_dir / "acceptance-matrix.json").exists(), (
+            "validate-only must not write the acceptance-matrix scaffold"
+        )
+
     def test_explicit_frontmatter_dependencies_beat_tasks_md_parser(
         self,
         tmp_path: Path,

--- a/tests/specify_cli/cli/commands/agent/test_wp_header_regex_depth.py
+++ b/tests/specify_cli/cli/commands/agent/test_wp_header_regex_depth.py
@@ -215,3 +215,106 @@ class TestCheckUncheckedSubtasksHeaderDepth:
 
         result = _check_unchecked_subtasks(repo_root, "060-test", "WP01", _force=False)
         assert len(result) == 0, "WP01 section should end at #### WP02 boundary"
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: only canonical ``- [ ] T###`` rows block a lane transition.
+# Validation/command rows, prose, and fenced code blocks must NOT count.
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUncheckedSubtasksCanonicalOnly:
+    """_check_unchecked_subtasks must only block on canonical T### subtasks."""
+
+    def _setup_feature(
+        self,
+        tmp_path: Path,
+        tasks_content: str,
+        feature_slug: str = "060-test",
+    ) -> Path:
+        feature_dir = tmp_path / "kitty-specs" / feature_slug
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "tasks.md").write_text(tasks_content, encoding="utf-8")
+        return tmp_path  # repo_root
+
+    @patch("specify_cli.cli.commands.agent.tasks.get_main_repo_root")
+    def test_real_unchecked_tasks_still_block(self, mock_main_root: MagicMock, tmp_path: Path) -> None:
+        """Genuine ``- [ ] T###`` rows must still block movement (regression guard)."""
+        from specify_cli.cli.commands.agent.tasks import _check_unchecked_subtasks
+
+        content = (
+            "## WP01: Setup\n\n"
+            "### Included Subtasks\n"
+            "- [ ] T001 Create the module\n"
+            "- [x] T002 Already done\n"
+            "- [ ] T003 Wire it up\n"
+        )
+        repo_root = self._setup_feature(tmp_path, content)
+        mock_main_root.return_value = repo_root
+
+        result = _check_unchecked_subtasks(repo_root, "060-test", "WP01", _force=False)
+        assert result == ["T001", "T003"], "Only unchecked canonical T### rows should be reported"
+
+    @patch("specify_cli.cli.commands.agent.tasks.get_main_repo_root")
+    def test_validation_command_rows_do_not_block(self, mock_main_root: MagicMock, tmp_path: Path) -> None:
+        """Validation/checklist command rows like ``- [ ] swift test`` must NOT block."""
+        from specify_cli.cli.commands.agent.tasks import _check_unchecked_subtasks
+
+        content = (
+            "## WP01: Setup\n\n"
+            "### Included Subtasks\n"
+            "- [x] T001 Implement feature\n\n"
+            "### Validation\n"
+            "- [ ] swift test\n"
+            "- [ ] git status --short\n"
+            "- [ ] npm run lint\n"
+            "- [ ] Review the diff before merging\n"
+        )
+        repo_root = self._setup_feature(tmp_path, content)
+        mock_main_root.return_value = repo_root
+
+        result = _check_unchecked_subtasks(repo_root, "060-test", "WP01", _force=False)
+        assert result == [], "Validation/command/prose rows must not be treated as blocking subtasks"
+
+    @patch("specify_cli.cli.commands.agent.tasks.get_main_repo_root")
+    def test_fenced_code_task_like_lines_do_not_block(self, mock_main_root: MagicMock, tmp_path: Path) -> None:
+        """Task-like lines inside fenced code blocks must NOT block."""
+        from specify_cli.cli.commands.agent.tasks import _check_unchecked_subtasks
+
+        content = (
+            "## WP01: Setup\n\n"
+            "### Included Subtasks\n"
+            "- [x] T001 Implement feature\n\n"
+            "### Implementation Notes\n"
+            "Example task list to mimic in the README:\n"
+            "```markdown\n"
+            "- [ ] T999 This is documentation, not a real subtask\n"
+            "- [ ] T998 Neither is this\n"
+            "```\n"
+        )
+        repo_root = self._setup_feature(tmp_path, content)
+        mock_main_root.return_value = repo_root
+
+        result = _check_unchecked_subtasks(repo_root, "060-test", "WP01", _force=False)
+        assert result == [], "T### rows inside fenced code blocks must not block"
+
+    @patch("specify_cli.cli.commands.agent.tasks.get_main_repo_root")
+    def test_mixed_real_and_noise(self, mock_main_root: MagicMock, tmp_path: Path) -> None:
+        """Real unchecked T### blocks even when surrounded by command/code noise."""
+        from specify_cli.cli.commands.agent.tasks import _check_unchecked_subtasks
+
+        content = (
+            "## WP01: Setup\n\n"
+            "### Included Subtasks\n"
+            "- [ ] T001 Real unchecked subtask\n"
+            "- [ ] swift test\n"
+            "```sh\n"
+            "- [ ] T500 fenced noise\n"
+            "```\n"
+            "- [ ] git status --short\n"
+        )
+        repo_root = self._setup_feature(tmp_path, content)
+        mock_main_root.return_value = repo_root
+
+        result = _check_unchecked_subtasks(repo_root, "060-test", "WP01", _force=False)
+        assert result == ["T001"], "Only the canonical unchecked T### should be reported"

--- a/tests/specify_cli/cli/commands/test_accept_clean_tree.py
+++ b/tests/specify_cli/cli/commands/test_accept_clean_tree.py
@@ -1,0 +1,326 @@
+"""Regression: a successful ``accept`` must leave a clean working tree.
+
+Bug: the acceptance pipeline materializes derived artifacts (e.g.
+``acceptance-matrix.json`` and status views) while running readiness checks,
+*after* the git-cleanliness snapshot is taken. The acceptance commit created
+inside ``perform_acceptance`` only stages ``meta.json``, so those materialized
+artifacts were left modified-unstaged. After a successful accept the working
+tree was dirty (``git status --porcelain`` non-empty for tracked spec/meta
+artifacts), which then blocked the downstream merge preflight.
+
+These tests drive the real top-level ``accept`` command against a lane-based
+fixture whose acceptance matrix carries a negative invariant (so the matrix is
+rewritten during readiness checks) and assert the tree is clean afterwards.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from specify_cli.acceptance.matrix import (
+    AcceptanceCriterion,
+    AcceptanceMatrix,
+    NegativeInvariant,
+    write_acceptance_matrix,
+)
+from specify_cli.cli.commands.accept import accept
+from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.lanes.persistence import write_lanes_json
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.reducer import materialize
+from specify_cli.status.store import append_event
+
+# Marked for mutmut sandbox skip — subprocess CLI/git invocation.
+pytestmark = [pytest.mark.non_sandbox, pytest.mark.git_repo]
+
+_SLUG = "099-test-feature"
+_MISSION_ID = "01JZZZZZZZZZZZZZZZZZZZZZZZ"
+_MISSION_BRANCH = f"kitty/mission-{_SLUG}"
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _porcelain(repo_root: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _create_lane_feature(
+    repo_root: Path,
+    *,
+    with_negative_invariant: bool,
+) -> Path:
+    """Create a clean, accept-ready lane-based feature on its mission branch.
+
+    Returns the feature directory.
+    """
+    _git(repo_root, "init", ".")
+    _git(repo_root, "config", "user.email", "test@test.com")
+    _git(repo_root, "config", "user.name", "Test")
+    _git(repo_root, "branch", "-M", "main")
+
+    # .kittify marker anchors find_repo_root() to this repo (paired with the
+    # SPECIFY_REPO_ROOT env var set by the test) so mission resolution works
+    # regardless of where pytest happens to run.
+    (repo_root / ".kittify").mkdir()
+
+    feature_dir = repo_root / "kitty-specs" / _SLUG
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+
+    meta = {
+        "mission_number": "099",
+        "slug": _SLUG,
+        "mission_slug": _SLUG,
+        "mission_id": _MISSION_ID,
+        "mid8": _MISSION_ID[:8],
+        "friendly_name": "Test Feature",
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    (feature_dir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n")
+
+    for fname in ("spec.md", "plan.md", "tasks.md"):
+        (feature_dir / fname).write_text(f"# {fname}\nDone.\n")
+
+    (tasks_dir / "WP01-test.md").write_text(
+        "---\n"
+        'work_package_id: "WP01"\n'
+        'title: "Test WP"\n'
+        'lane: "done"\n'
+        'assignee: "test-agent"\n'
+        'agent: "test-agent"\n'
+        'shell_pid: "12345"\n'
+        "---\n"
+        "# WP01\nDone.\n"
+    )
+
+    append_event(
+        feature_dir,
+        StatusEvent(
+            event_id="01TESTACCEPTCLEANTREE000001",
+            mission_slug=_SLUG,
+            wp_id="WP01",
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.DONE,
+            at=datetime.now(UTC).isoformat(),
+            actor="test-agent",
+            force=True,
+            execution_mode="direct_repo",
+            reason="Test setup: skip to done",
+        ),
+    )
+    materialize(feature_dir)
+
+    write_lanes_json(
+        feature_dir,
+        LanesManifest(
+            version=1,
+            mission_slug=_SLUG,
+            mission_id=_SLUG,
+            mission_branch=_MISSION_BRANCH,
+            target_branch="main",
+            lanes=[
+                ExecutionLane(
+                    lane_id="lane-a",
+                    wp_ids=("WP01",),
+                    write_scope=("src/**",),
+                    predicted_surfaces=("test",),
+                    depends_on_lanes=(),
+                    parallel_group=0,
+                )
+            ],
+            computed_at="2026-04-05T12:00:00Z",
+            computed_from="test",
+        ),
+    )
+
+    # A passing automated-test criterion gives the matrix a 'pass' verdict so
+    # acceptance is allowed to proceed to the commit step.
+    criteria = [
+        AcceptanceCriterion(
+            criterion_id="AC1",
+            description="feature behaves as specified",
+            proof_type="automated_test",
+            pass_fail="pass",
+        )
+    ]
+    invariants = []
+    if with_negative_invariant:
+        # A grep_absence invariant whose pattern matches nothing -> the matrix
+        # gets rewritten with the resolved result during readiness checks.
+        invariants = [
+            NegativeInvariant(
+                invariant_id="NI1",
+                description="legacy symbol must be absent",
+                verification_method="grep_absence",
+                verification_command="ZZZ_PATTERN_THAT_NEVER_MATCHES_ZZZ",
+            )
+        ]
+    write_acceptance_matrix(
+        feature_dir,
+        AcceptanceMatrix(
+            mission_slug=_SLUG,
+            criteria=criteria,
+            negative_invariants=invariants,
+        ),
+    )
+
+    # Commit a clean baseline, then move onto the mission branch where accept runs.
+    _git(repo_root, "add", "-A")
+    _git(repo_root, "commit", "-m", "init")
+    _git(repo_root, "checkout", "-b", _MISSION_BRANCH)
+    return feature_dir
+
+
+def test_accept_leaves_clean_tree_with_materialized_matrix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The acceptance matrix is rewritten during checks -- accept must clean up.
+
+    Before the fix the acceptance commit only captured meta.json, leaving
+    ``acceptance-matrix.json`` modified-unstaged after a successful accept.
+    """
+    repo_root = (tmp_path / "repo").resolve()
+    repo_root.mkdir()
+    _create_lane_feature(repo_root, with_negative_invariant=True)
+    monkeypatch.setenv("SPECIFY_REPO_ROOT", str(repo_root))
+    monkeypatch.chdir(repo_root)
+
+    # Successful (non-json) accept returns normally; no Exit is raised.
+    accept(
+        mission=_SLUG,
+        feature=None,
+        mode="auto",
+        actor="tester",
+        test=[],
+        json_output=False,
+        lenient=False,
+        no_commit=False,
+        diagnose=False,
+        allow_fail=False,
+    )
+
+    porcelain = _porcelain(repo_root)
+    assert porcelain == "", (
+        f"accept left a dirty working tree:\n{porcelain}"
+    )
+
+    # The materialized matrix must be tracked in HEAD, not floating in the tree.
+    show = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"HEAD:kitty-specs/{_SLUG}/acceptance-matrix.json"],
+        capture_output=True,
+        text=True,
+    )
+    assert show.returncode == 0, "acceptance-matrix.json is not committed in HEAD"
+    matrix = json.loads(show.stdout)
+    # Negative invariant was executed during readiness checks; its result must
+    # be the committed value (no longer 'pending').
+    assert matrix["negative_invariants"][0]["result"] == "confirmed_absent"
+
+
+def test_accept_clean_tree_without_negative_invariant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even with no matrix rewrite, accept must leave a clean tree."""
+    repo_root = (tmp_path / "repo").resolve()
+    repo_root.mkdir()
+    _create_lane_feature(repo_root, with_negative_invariant=False)
+    monkeypatch.setenv("SPECIFY_REPO_ROOT", str(repo_root))
+    monkeypatch.chdir(repo_root)
+
+    accept(
+        mission=_SLUG,
+        feature=None,
+        mode="auto",
+        actor="tester",
+        test=[],
+        json_output=False,
+        lenient=False,
+        no_commit=False,
+        diagnose=False,
+        allow_fail=False,
+    )
+
+    porcelain = _porcelain(repo_root)
+    assert porcelain == "", f"accept left a dirty working tree:\n{porcelain}"
+
+
+def test_residual_acceptance_commit_is_scoped_to_mission_paths(
+    tmp_path: Path,
+) -> None:
+    """The residual finalize commit is scoped to the mission's dirty spec
+    artifacts only.
+
+    ``_commit_residual_acceptance_artifacts`` stages and commits the mission's
+    leftover spec/meta files. The commit uses an explicit pathspec so an
+    unrelated file the operator pre-staged is never swept into mission history;
+    the operator's staged work must survive uncommitted. (The top-level
+    ``accept`` command normally blocks on a dirty tree, but ``--allow-fail`` /
+    ``--lenient`` paths can reach the commit step with other changes present, so
+    the commit itself must be scoped.)
+    """
+    from specify_cli.cli.commands.accept import _commit_residual_acceptance_artifacts
+
+    repo_root = (tmp_path / "repo").resolve()
+    repo_root.mkdir()
+    _git(repo_root, "init", ".")
+    _git(repo_root, "config", "user.email", "test@test.com")
+    _git(repo_root, "config", "user.name", "Test")
+    _git(repo_root, "branch", "-M", "main")
+
+    feature_dir = repo_root / "kitty-specs" / _SLUG
+    feature_dir.mkdir(parents=True)
+    matrix_path = feature_dir / "acceptance-matrix.json"
+    matrix_path.write_text('{"version": 1}\n')
+    _git(repo_root, "add", "-A")
+    _git(repo_root, "commit", "-m", "baseline")
+
+    # Mission artifact becomes dirty (tracked, modified) — the residual target.
+    matrix_path.write_text('{"version": 2}\n')
+    # Operator has unrelated work staged before the residual commit runs.
+    unrelated = repo_root / "unrelated.txt"
+    unrelated.write_text("operator work in progress\n")
+    _git(repo_root, "add", "unrelated.txt")
+
+    created = _commit_residual_acceptance_artifacts(repo_root, _SLUG)
+    assert created is True
+
+    # The mission artifact WAS committed at HEAD.
+    matrix_show = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"HEAD:kitty-specs/{_SLUG}/acceptance-matrix.json"],
+        capture_output=True,
+        text=True,
+    )
+    assert matrix_show.returncode == 0
+    assert json.loads(matrix_show.stdout)["version"] == 2
+
+    # The unrelated file must NOT have been swept into that commit.
+    unrelated_show = subprocess.run(
+        ["git", "-C", str(repo_root), "show", "HEAD:unrelated.txt"],
+        capture_output=True,
+        text=True,
+    )
+    assert unrelated_show.returncode != 0, (
+        "residual commit swept an unrelated pre-staged file into mission history"
+    )
+
+    # The operator's staged work is preserved (still staged, uncommitted).
+    assert "unrelated.txt" in _porcelain(repo_root)

--- a/tests/specify_cli/missions/test_mission_template_consistency.py
+++ b/tests/specify_cli/missions/test_mission_template_consistency.py
@@ -1,0 +1,192 @@
+"""Global consistency guard for packaged mission prompt templates.
+
+Every step in a packaged ``mission-runtime.yaml`` declares a ``prompt_template``
+(or ``None``). At runtime, ``spec-kitty next`` resolves that template one of two
+ways:
+
+1. **Composition-driven** -- the step's action is dispatched through
+   ``StepContractExecutor`` composition (see
+   ``runtime_bridge._COMPOSED_ACTIONS_BY_MISSION``). These steps never read a
+   file from ``command-templates/``; the built-in step contracts under
+   ``src/doctrine/mission_step_contracts/built-in/`` are authoritative.
+2. **Command-template-driven** -- the step's action falls through to
+   ``prompt_builder._build_template_prompt`` which calls
+   ``resolve_command(f"{action}.md", ..., mission=<mission>)``. The packaged
+   tier (Tier 5) of that resolver is
+   ``specify_cli/missions/<mission>/command-templates/<name>``, so the file MUST
+   exist in the mission's packaged ``command-templates/`` directory or a fresh
+   install raises ``FileNotFoundError`` and ``spec-kitty next`` blocks.
+
+This test asserts that every command-template-driven step has its
+``prompt_template`` materialized in the packaged ``command-templates/`` for its
+mission. It is the regression guard for the missing ``software-dev/accept.md``
+bug: before that file existed, the ``accept`` step (which is NOT a composed
+action) had no packaged template and ``spec-kitty next`` failed resolving the
+accept prompt.
+
+Genuinely CLI-driven steps that intentionally do not ship a packaged template
+must be added to ``KNOWN_CLI_DRIVEN`` with a documented reason so the gap is
+explicit rather than silent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.next._internal_runtime.schema import load_mission_template_file
+from specify_cli.next.runtime_bridge import _COMPOSED_ACTIONS_BY_MISSION
+
+pytestmark = pytest.mark.fast
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MISSIONS_ROOT = _REPO_ROOT / "src" / "specify_cli" / "missions"
+
+
+# (mission_key, prompt_template) pairs that are intentionally CLI-driven and do
+# NOT ship a packaged command-template. Each entry must carry a reason. Entries
+# here are KNOWN GAPS: the runtime currently has no packaged template for them,
+# so adding one (or routing them through composition) is tracked separately.
+#
+# NOTE: ``software-dev`` -> ``accept.md`` is deliberately NOT listed here. The
+# software-dev accept step resolves a packaged command-template and must ship
+# ``command-templates/accept.md``; allow-listing it would mask the very
+# regression this test exists to catch.
+KNOWN_CLI_DRIVEN: dict[tuple[str, str], str] = {
+    # research/documentation declare an ``accept`` step but ship no
+    # ``command-templates/`` directory. The runtime currently raises
+    # FileNotFoundError when resolving these accept prompts (latent bug tracked
+    # separately; see risks). They are allow-listed here ONLY so this guard can
+    # still assert the software-dev contract without conflating the two gaps.
+    ("research", "accept.md"): (
+        "research mission ships no packaged command-templates/; accept prompt "
+        "resolution is a known latent gap tracked separately"
+    ),
+    ("documentation", "accept.md"): (
+        "documentation mission ships no packaged command-templates/; accept "
+        "prompt resolution is a known latent gap tracked separately"
+    ),
+}
+
+
+def _packaged_missions() -> list[Path]:
+    """Return every packaged mission directory that ships a runtime YAML."""
+    missions: list[Path] = []
+    for child in sorted(_MISSIONS_ROOT.iterdir()):
+        if not child.is_dir():
+            continue
+        if (child / "mission-runtime.yaml").is_file():
+            missions.append(child)
+    return missions
+
+
+def _mission_keys() -> list[str]:
+    return [m.name for m in _packaged_missions()]
+
+
+def test_packaged_missions_discovered() -> None:
+    """Sanity: the loader sees the shipped missions, including software-dev."""
+    keys = _mission_keys()
+    assert keys, "no packaged missions with mission-runtime.yaml were discovered"
+    assert "software-dev" in keys
+
+
+@pytest.mark.parametrize("mission_dir", _packaged_missions(), ids=_mission_keys())
+def test_every_prompt_template_is_resolvable(mission_dir: Path) -> None:
+    """Each step's ``prompt_template`` is composed, packaged, or allow-listed.
+
+    A non-composed step whose ``prompt_template`` is neither present in the
+    mission's packaged ``command-templates/`` nor explicitly allow-listed as
+    CLI-driven would cause ``spec-kitty next`` to fail resolving that prompt on
+    a fresh install. That is exactly the ``software-dev/accept.md`` regression.
+    """
+    runtime_path = mission_dir / "mission-runtime.yaml"
+    template = load_mission_template_file(runtime_path)
+    mission_key = template.mission.key
+
+    command_templates_dir = mission_dir / "command-templates"
+    composed_actions = _COMPOSED_ACTIONS_BY_MISSION.get(mission_key, frozenset())
+
+    problems: list[str] = []
+    for step in template.steps:
+        prompt_template = step.prompt_template
+        if not prompt_template:
+            # Steps without a prompt_template carry no template contract.
+            continue
+
+        # Composition-driven steps never read command-templates/.
+        if step.id in composed_actions:
+            continue
+
+        # Explicitly allow-listed CLI-driven steps.
+        if (mission_key, prompt_template) in KNOWN_CLI_DRIVEN:
+            continue
+
+        # Otherwise the template MUST exist in the packaged command-templates/.
+        candidate = command_templates_dir / prompt_template
+        if not candidate.is_file():
+            problems.append(
+                f"mission '{mission_key}' step '{step.id}' references "
+                f"prompt_template '{prompt_template}' but no packaged template "
+                f"exists at {candidate} (and the step is neither a composed "
+                f"action nor allow-listed in KNOWN_CLI_DRIVEN). "
+                f"spec-kitty next will fail resolving this prompt."
+            )
+
+    assert not problems, "\n".join(problems)
+
+
+def test_software_dev_accept_template_exists() -> None:
+    """Regression: the software-dev accept step ships a packaged template.
+
+    The ``accept`` step is not a composed action, so the runtime resolves it via
+    ``resolve_command('accept.md', ..., mission='software-dev')`` whose packaged
+    tier is ``missions/software-dev/command-templates/accept.md``. This file was
+    missing, so a fresh install blocked at the accept step.
+    """
+    accept_template = (
+        _MISSIONS_ROOT / "software-dev" / "command-templates" / "accept.md"
+    )
+    assert accept_template.is_file(), (
+        f"software-dev accept template missing at {accept_template}; "
+        "spec-kitty next cannot resolve the accept prompt without it."
+    )
+    # Must not be empty and should target the acceptance command.
+    body = accept_template.read_text(encoding="utf-8")
+    assert body.strip(), "accept.md is empty"
+    assert "spec-kitty accept" in body, (
+        "accept.md should instruct the operator to run 'spec-kitty accept'"
+    )
+
+
+def test_software_dev_accept_resolves_from_clean_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``resolve_command`` finds software-dev/accept.md at the packaged tier.
+
+    With no project-local overrides, resolution must fall through to the
+    packaged ``command-templates/accept.md``. Before the fix this raised
+    ``FileNotFoundError``.
+
+    The global runtime tier (``GLOBAL_MISSION`` --
+    ``<kittify-home>/missions/software-dev/command-templates/accept.md``) is
+    consulted *before* ``PACKAGE_DEFAULT``. ``get_kittify_home()`` lets
+    ``SPEC_KITTY_HOME`` win unconditionally, so we pin it at an empty temp dir;
+    otherwise a developer/CI machine with a populated ``~/.kittify`` would
+    resolve at ``GLOBAL_MISSION`` and this assertion would be environment-coupled.
+    """
+    from specify_cli.runtime.resolver import ResolutionTier, resolve_command
+
+    empty_home = tmp_path / "kittify-home"
+    empty_home.mkdir()
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(empty_home))
+
+    project_dir = tmp_path / "clean-project"
+    project_dir.mkdir()
+
+    result = resolve_command("accept.md", project_dir, mission="software-dev")
+    assert result.tier == ResolutionTier.PACKAGE_DEFAULT
+    assert result.path.name == "accept.md"
+    assert result.path.is_file()


### PR DESCRIPTION
## Summary

Fixes the post-implementation / accept / merge **tail rough edges** reported in #1353 (lane-based `software-dev` missions). All six findings were validated against `main` before implementation (see the [validation comment](https://github.com/Priivacy-ai/spec-kitty/issues/1353#issuecomment-4582598951)).

| # | Finding | Fix |
|---|---------|-----|
| 1 | `spec-kitty next` couldn't resolve `accept.md` (packaged template missing) | Added packaged `missions/software-dev/command-templates/accept.md` + a global mission-template consistency guard |
| 2 | `move-task` blocked on validation command rows (`- [ ] swift test`) | `_check_unchecked_subtasks` now only blocks on canonical `- [ ] T###` rows (3+ digits), skipping validation rows & fenced code; error output only suggests valid task ids |
| 3 | Docs/skills still told operators to pass `--preview` | Replaced with the dry-run-default / `--apply` contract across docs, doctrine skills, and CLI guidance strings + a guard test |
| 4 | `accept` left metadata dirty after committing | Acceptance commits scoped to mission spec/meta paths; residual materialized artifacts folded into a scoped commit → clean tree, no sweeping of unrelated staged work |
| 5 + baseline | Squash merge left `baseline_merge_commit` (and per the report, done-state) off the target branch → `MISSION_REVIEW_MODE_MISMATCH` | Hard-fail baseline recording for modern lane missions + a post-merge invariant asserting both done-state and `baseline_merge_commit` landed on target **before** worktree cleanup |
| 6 | `acceptance-matrix.json` surfaced late | Scaffold a valid matrix during task finalization for lane missions (mirrors `issue-matrix` autoscaffold) |

## Notes on Finding 5

Done-transition recording already runs unconditionally on `main` and commits to the target branch — the rc25 done-drift the reporter saw looks release-specific. The durable gap was `baseline_merge_commit`, which soft-failed and had no post-merge invariant. The new `_assert_baseline_merge_commit_on_target` reads the **recorded** baseline (resume-safe) rather than re-deriving from the live target HEAD, so `merge --resume` is not broken after a partial run has advanced the target tip.

## Adversarial review hardening

The implementation was adversarially reviewed; the following review findings were fixed before this PR:
- **Resume regression** in the new baseline invariant (re-derived HEAD vs recorded value) — fixed + 2 regression tests.
- **Environment-coupled test** (`test_software_dev_accept_resolves_from_clean_project`) that didn't isolate the global `~/.kittify` tier — now pins `SPEC_KITTY_HOME` to an empty dir.
- **Regex** `T\d{3}` → `T\d{3,}` to keep blocking on ids past `T999`.
- **Commit scoping**: acceptance commits now use explicit pathspecs so an operator's unrelated pre-staged work is never swept into mission history.

Two known latent gaps are documented (not silently masked): the `research` and `documentation` missions also declare an `accept` step but ship no `command-templates/` — allow-listed in the consistency guard with reasons and tracked separately.

## Testing

- `ruff check` clean on the entire changeset.
- New/updated targeted suites all pass: `test_mission_template_consistency`, `test_wp_header_regex_depth`, `test_no_retrospect_preview`, `test_acceptance_matrix`, `test_feature_finalize_bootstrap`, `test_merge_done_recording`, `test_accept_clean_tree`, `test_merge`, `test_merge_status_commit`, `test_merge_resume`.
- Pre-existing failures in `test_acceptance_support.py` (teamspace-auth fixture) and `sparse_checkout/` are unrelated and confirmed failing on pristine `HEAD`.

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
