### PR TITLE
fix: address SonarCloud transaction and coverage regressions

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -122,8 +122,10 @@ jobs:
               - '.github/workflows/check-spec-kitty-events-alignment.yml'
             status:
               - 'src/specify_cli/status/**'
+              - 'src/specify_cli/coordination/**'
               - 'tests/status/**'
               - 'tests/specify_cli/status/**'
+              - 'tests/specify_cli/coordination/**'
             review:
               - 'src/specify_cli/review/**'
               - 'tests/review/**'
@@ -1512,9 +1514,10 @@ jobs:
         run: |
           uv run python -m pytest \
             -v \
-            tests/status/ tests/specify_cli/status/ \
+            tests/status/ tests/specify_cli/status/ tests/specify_cli/coordination/ \
             -m "not windows_ci and (git_repo or integration)" \
             --cov=src/specify_cli/status \
+            --cov=src/specify_cli/coordination \
             --cov-report=xml:out/reports/coverage/coverage-integration-status.xml \
             --junitxml=out/reports/xunit-reports/xunit-result-integration-status-${{ github.run_id }}.xml
 

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -133,18 +133,6 @@ _EVENTS_FILENAME = "status.events.jsonl"
 _SNAPSHOT_FILENAME = "status.json"
 
 
-def _confine_transaction_artifact_path(path: Path, worktree_root: Path) -> Path:
-    """Return a resolved artifact path confined to the coordination worktree."""
-    candidate = path.resolve()
-    try:
-        candidate.relative_to(worktree_root.resolve())
-    except ValueError as exc:
-        raise ValueError(
-            f"Refusing to write artifact outside coordination worktree: {candidate}"
-        ) from exc
-    return candidate
-
-
 def _kitty_specs_dir_name(mission_slug: str, mid8: str) -> str:
     """Return the kitty-specs sub-directory name for this mission.
 
@@ -684,21 +672,35 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         previously exist). C-009: no ``git checkout --`` in the
         rollback path.
         """
-        path = _confine_path_to_worktree(self.worktree_root, path)
+        try:
+            candidate = _confine_path_to_worktree(self.worktree_root, path)
+        except ValueError as exc:
+            raise ValueError(
+                "Refusing to write artifact outside coordination worktree "
+                "(outside worktree): "
+                f"{path}"
+            ) from exc
+        resolved_worktree = self.worktree_root.resolve()
         # Capture snapshot ONLY if we have not seen this path yet.
         # Re-writing the same path repeatedly in one transaction still
         # rolls back to the *original* pre-transaction state.
-        path = _confine_transaction_artifact_path(path, self.worktree_root)
-        if path not in self._snapshots:
-            self._snapshots[path] = (
-                path.read_bytes() if path.exists() else None
+        resolved_path = candidate.resolve(strict=False)
+        if not resolved_path.is_relative_to(resolved_worktree):
+            raise ValueError(
+                "Refusing to write artifact outside coordination worktree "
+                "(outside worktree): "
+                f"{resolved_path}"
+            )
+        if resolved_path not in self._snapshots:
+            self._snapshots[resolved_path] = (
+                resolved_path.read_bytes() if resolved_path.exists() else None
             )
 
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(content)
+        resolved_path.parent.mkdir(parents=True, exist_ok=True)
+        resolved_path.write_bytes(content)
 
-        if path not in self._staged_paths:
-            self._staged_paths.append(path)
+        if resolved_path not in self._staged_paths:
+            self._staged_paths.append(resolved_path)
 
     def stage_path(self, path: Path) -> None:
         """Add ``path`` to the commit changeset without snapshot tracking.

--- a/tests/agent/test_init_command.py
+++ b/tests/agent/test_init_command.py
@@ -222,6 +222,41 @@ def test_init_writes_event_log_merge_attributes(
     assert ".kittify/migrations/** -diff" in attributes
 
 
+def test_ensure_event_log_merge_attributes_preserves_existing_file(tmp_path: Path) -> None:
+    attributes_path = tmp_path / ".gitattributes"
+    original_line = "*.png binary"
+    attributes_path.write_text(
+        "\n".join(
+            [
+                original_line,
+                "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    changed = init_module._ensure_event_log_merge_attributes(tmp_path)
+
+    lines = attributes_path.read_text(encoding="utf-8").splitlines()
+    assert changed is True
+    assert lines[0] == original_line
+    assert lines.count("kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log") == 1
+    assert "kitty-specs/**/status.json linguist-generated=true" in lines
+    assert ".kittify/migrations/** -diff" in lines
+
+
+def test_ensure_event_log_merge_attributes_is_idempotent(tmp_path: Path) -> None:
+    init_module._ensure_event_log_merge_attributes(tmp_path)
+
+    changed = init_module._ensure_event_log_merge_attributes(tmp_path)
+
+    lines = (tmp_path / ".gitattributes").read_text(encoding="utf-8").splitlines()
+    assert changed is False
+    assert lines.count("kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log") == 1
+    assert lines.count(".kittify/workspaces/** -diff") == 1
+
+
 # test_init_amends_initial_commit_after_cleanup deleted in feature 076:
 # the initial git commit block was removed from init.py.
 

--- a/tests/specify_cli/coordination/test_transaction.py
+++ b/tests/specify_cli/coordination/test_transaction.py
@@ -525,6 +525,27 @@ def test_write_artifact_refuses_paths_outside_coordination_worktree(repo: Path) 
             txn.write_artifact(outside_path, b"bad")
 
 
+def test_write_artifact_refuses_symlink_escape(repo: Path, tmp_path: Path) -> None:
+    """Artifact writes must reject symlinks that resolve outside the worktree."""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+
+    with BookkeepingTransaction.acquire(
+        repo_root=repo,
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        destination_ref=COORD_BRANCH,
+        operation="artifact_symlink_escape",
+    ) as txn:
+        link_path = txn.worktree_root / "kitty-specs" / FEATURE_DIRNAME / "escape-link"
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(outside_dir, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="outside worktree"):
+            txn.write_artifact(link_path / "artifact.txt", b"bad")
+
+
 # ---------------------------------------------------------------------------
 # Nested-lock
 # ---------------------------------------------------------------------------

--- a/tests/upgrade/migrations/test_m_3_2_0rc28_github_diff_attributes.py
+++ b/tests/upgrade/migrations/test_m_3_2_0rc28_github_diff_attributes.py
@@ -58,6 +58,26 @@ def test_apply_preserves_existing_attributes_and_is_idempotent(tmp_path: Path) -
     assert attributes[0] == "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log"
 
 
+def test_can_apply_rejects_missing_project_path(tmp_path: Path) -> None:
+    migration = GitHubDiffAttributesMigration()
+
+    ok, reason = migration.can_apply(tmp_path / "missing")
+
+    assert ok is False
+    assert "Project path does not exist" in reason
+
+
+def test_apply_dry_run_reports_missing_entries_without_writing(tmp_path: Path) -> None:
+    migration = GitHubDiffAttributesMigration()
+
+    result = migration.apply(tmp_path, dry_run=True)
+
+    assert result.success is True
+    assert result.changes_made
+    assert result.changes_made[0].startswith("Would add .gitattributes entry:")
+    assert not (tmp_path / ".gitattributes").exists()
+
+
 def test_attributes_match_nested_generated_artifacts(tmp_path: Path) -> None:
     _git(["init", "-b", "main"], tmp_path)
     migration = GitHubDiffAttributesMigration()


### PR DESCRIPTION
## Summary
- harden `BookkeepingTransaction.write_artifact()` with inline resolved-path confinement so Sonar no longer treats the file write as path-injection-prone
- add focused init/migration tests for the recent `.gitattributes` helper paths that drove the nightly new-code coverage drop
- keep the localhost daemon HTTP hotspot out of this patch because it is an intentional loopback control plane, not an external transport path

## Validation
- `ruff check src/specify_cli/coordination/transaction.py tests/specify_cli/coordination/test_transaction.py tests/agent/test_init_command.py tests/upgrade/migrations/test_m_3_2_0rc28_github_diff_attributes.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/coordination/test_transaction.py tests/agent/test_init_command.py tests/upgrade/migrations/test_m_3_2_0rc28_github_diff_attributes.py -q`

## Sonar / security context
- fixes the open Sonar-backed code-scanning alert on `src/specify_cli/coordination/transaction.py`
- adds regression coverage for the `.gitattributes` init/migration code added on `main`
- intentionally does **not** suppress the localhost HTTP hotspot in `sync/daemon.py`; that item should be reviewed as loopback-only rather than masked in code
