### PR TITLE
Fix static analysis backlog and CI guard drift

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -105,8 +105,11 @@ jobs:
             missions:
               - 'src/specify_cli/mission.py'
               - 'src/specify_cli/mission_metadata.py'
+              - 'src/specify_cli/missions/**'
               - 'src/doctrine/missions/**'
+              - 'tests/fixtures/missions/**'
               - 'tests/missions/**'
+              - 'tests/specify_cli/missions/**'
             post_merge:
               - 'src/specify_cli/post_merge/**'
               - 'tests/post_merge/**'

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -139,6 +139,7 @@ jobs:
             lanes:
               - 'src/specify_cli/lanes/**'
               - 'tests/lanes/**'
+              - 'tests/specify_cli/lanes/**'
             dashboard:
               - 'src/specify_cli/dashboard/**'
               - 'tests/test_dashboard/**'
@@ -1019,7 +1020,7 @@ jobs:
       - run: mkdir -p out/reports/coverage
       - name: "Run fast tests — lanes"
         run: |
-          uv run python -m pytest tests/lanes/ -m "fast and not windows_ci" -q --tb=short \
+          uv run python -m pytest tests/lanes/ tests/specify_cli/lanes/ -m "fast and not windows_ci" -q --tb=short \
             --cov=src/specify_cli/lanes \
             --cov-report=xml:out/reports/coverage/coverage-fast-lanes.xml
       - name: "Upload fast-lanes coverage"
@@ -1601,7 +1602,7 @@ jobs:
       - run: mkdir -p out/reports/coverage
       - name: "Run integration tests — lanes"
         run: |
-          uv run python -m pytest tests/lanes/ \
+          uv run python -m pytest tests/lanes/ tests/specify_cli/lanes/ \
             -m 'not windows_ci and (git_repo or integration)' \
             -q --tb=short \
             --cov=src/specify_cli/lanes \

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -216,11 +216,6 @@ jobs:
       - name: "[ENFORCED] Install Python dependencies"
         run: |
           uv sync --frozen --all-extras
-          # spec-kitty-runtime is required by next/runtime tests and patch-target
-          # validation, but its published wheel pins an older spec-kitty-events.
-          # Install it without deps so this repo's spec-kitty-events==4.0.0 pin
-          # remains authoritative.
-          uv pip install spec-kitty-runtime==0.4.5 --no-deps
 
       - name: "[ENFORCED] Prepare report directories"
         run: |
@@ -465,6 +460,12 @@ jobs:
           # '# noqa: TID251 — <justification>'. This realises the ADR Decision Outcome:
           # "automated enforcement rather than convention".
           uv run python -m ruff check src tests --select TID251
+
+      - name: "[ENFORCED] Typer 0.26 JSON error surface"
+        id: typer026
+        if: always()
+        run: |
+          uv run --with 'typer>=0.26' python -m pytest tests/agent/test_json_group_typer_surface.py -q
 
       - name: "[INFO] Run mypy report (advisory)"
         id: mypy
@@ -949,7 +950,6 @@ jobs:
           python-version: '3.12'
       - run: |
           uv sync --frozen --all-extras
-          uv pip install spec-kitty-runtime==0.4.5 --no-deps
       - run: mkdir -p out/reports/coverage
       - name: "Run fast tests — next"
         run: |
@@ -1567,7 +1567,6 @@ jobs:
           python-version: '3.12'
       - run: |
           uv sync --frozen --all-extras
-          uv pip install spec-kitty-runtime==0.4.5 --no-deps
       - run: mkdir -p out/reports/coverage
       - name: "Run integration tests — next"
         run: |

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -803,7 +803,7 @@ jobs:
       - run: mkdir -p out/reports/coverage
       - name: "Run fast tests — missions"
         run: |
-          uv run python -m pytest tests/missions/ -m "fast and not windows_ci" -q --tb=short \
+          uv run python -m pytest tests/missions/ tests/specify_cli/missions/ -m "fast and not windows_ci" -q --tb=short \
             --cov=src/specify_cli/mission \
             --cov=src/specify_cli/mission_metadata \
             --cov=src/doctrine/missions \
@@ -1416,7 +1416,7 @@ jobs:
       - run: mkdir -p out/reports/coverage
       - name: "Run integration tests — missions"
         run: |
-          uv run python -m pytest tests/missions/ \
+          uv run python -m pytest tests/missions/ tests/specify_cli/missions/ \
             -m 'not windows_ci and (git_repo or integration)' \
             -q --tb=short \
             --cov=src/specify_cli/mission \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,42 +246,10 @@ ignore = [
 # manifest scheme, fingerprint-definition tests, migration sentinel checks, …), OR call
 # ``charter.hasher.hash_content()`` when it genuinely mirrors the charter freshness hash.
 #
-# Production code has legitimate raw SHA-256 owners, but the old blanket
-# src/** ignore also disarmed the Gap-5 click.exceptions ban. Keep the hash
-# carve-out exact so new production click.exceptions.* uses are linted.
-"src/charter/hasher.py" = ["TID251"]
-"src/charter/synthesizer/manifest.py" = ["TID251"]
-"src/charter/synthesizer/request.py" = ["TID251"]
-"src/charter/synthesizer/resynthesize_pipeline.py" = ["TID251"]
-"src/charter/synthesizer/synthesize_pipeline.py" = ["TID251"]
-"src/charter/synthesizer/write_pipeline.py" = ["TID251"]
-"src/doctrine/versioning.py" = ["TID251"]
-"src/specify_cli/auth/loopback/pkce.py" = ["TID251"]
-"src/specify_cli/charter_runtime/lint/checks/contradiction.py" = ["TID251"]
-"src/specify_cli/cli/commands/charter/_fresh_doctrine.py" = ["TID251"]
-"src/specify_cli/doctrine_synthesizer/provenance.py" = ["TID251"]
-"src/specify_cli/dossier/drift_detector.py" = ["TID251"]
-"src/specify_cli/dossier/hasher.py" = ["TID251"]
-"src/specify_cli/dossier/snapshot.py" = ["TID251"]
-"src/specify_cli/glossary/checkpoint.py" = ["TID251"]
-"src/specify_cli/glossary/drg_builder.py" = ["TID251"]
-"src/specify_cli/identity/project.py" = ["TID251"]
-"src/specify_cli/invocation/executor.py" = ["TID251"]
-"src/specify_cli/migration/mission_state.py" = ["TID251"]
-"src/specify_cli/migration/rebuild_state.py" = ["TID251"]
-"src/specify_cli/mission_brief.py" = ["TID251"]
-"src/specify_cli/next/_internal_runtime/engine.py" = ["TID251"]
-"src/specify_cli/next/_internal_runtime/planner.py" = ["TID251"]
-"src/specify_cli/review/prompt_metadata.py" = ["TID251"]
-"src/specify_cli/skills/command_renderer.py" = ["TID251"]
-"src/specify_cli/skills/manifest.py" = ["TID251"]
-"src/specify_cli/skills/manifest_store.py" = ["TID251"]
-"src/specify_cli/skills/verifier.py" = ["TID251"]
-"src/specify_cli/sync/body_upload.py" = ["TID251"]
-"src/specify_cli/sync/clock.py" = ["TID251"]
-"src/specify_cli/sync/queue.py" = ["TID251"]
-"src/specify_cli/tracker/store.py" = ["TID251"]
-"src/specify_cli/upgrade/migrations/m_3_2_0_codex_to_skills.py" = ["TID251"]
+# Production code has legitimate raw SHA-256 owners, but file-level TID251
+# ignores also disarm the Gap-5 click.exceptions ban for those files. Keep
+# production raw-SHA exceptions inline at each call site so click.exceptions.*
+# remains enforced across all src files.
 "scripts/**" = ["TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,10 +246,42 @@ ignore = [
 # manifest scheme, fingerprint-definition tests, migration sentinel checks, …), OR call
 # ``charter.hasher.hash_content()`` when it genuinely mirrors the charter freshness hash.
 #
-# Only production (src/**) and tooling (scripts/**) stay dir-exempt: src/ legitimately uses
-# hashlib directly (charter/hasher.py) and click via the typer compatibility shim, and
-# scripts/ are tooling helpers — neither is test code the Gap-3/Gap-5 contract governs.
-"src/**" = ["TID251"]
+# Production code has legitimate raw SHA-256 owners, but the old blanket
+# src/** ignore also disarmed the Gap-5 click.exceptions ban. Keep the hash
+# carve-out exact so new production click.exceptions.* uses are linted.
+"src/charter/hasher.py" = ["TID251"]
+"src/charter/synthesizer/manifest.py" = ["TID251"]
+"src/charter/synthesizer/request.py" = ["TID251"]
+"src/charter/synthesizer/resynthesize_pipeline.py" = ["TID251"]
+"src/charter/synthesizer/synthesize_pipeline.py" = ["TID251"]
+"src/charter/synthesizer/write_pipeline.py" = ["TID251"]
+"src/doctrine/versioning.py" = ["TID251"]
+"src/specify_cli/auth/loopback/pkce.py" = ["TID251"]
+"src/specify_cli/charter_runtime/lint/checks/contradiction.py" = ["TID251"]
+"src/specify_cli/cli/commands/charter/_fresh_doctrine.py" = ["TID251"]
+"src/specify_cli/doctrine_synthesizer/provenance.py" = ["TID251"]
+"src/specify_cli/dossier/drift_detector.py" = ["TID251"]
+"src/specify_cli/dossier/hasher.py" = ["TID251"]
+"src/specify_cli/dossier/snapshot.py" = ["TID251"]
+"src/specify_cli/glossary/checkpoint.py" = ["TID251"]
+"src/specify_cli/glossary/drg_builder.py" = ["TID251"]
+"src/specify_cli/identity/project.py" = ["TID251"]
+"src/specify_cli/invocation/executor.py" = ["TID251"]
+"src/specify_cli/migration/mission_state.py" = ["TID251"]
+"src/specify_cli/migration/rebuild_state.py" = ["TID251"]
+"src/specify_cli/mission_brief.py" = ["TID251"]
+"src/specify_cli/next/_internal_runtime/engine.py" = ["TID251"]
+"src/specify_cli/next/_internal_runtime/planner.py" = ["TID251"]
+"src/specify_cli/review/prompt_metadata.py" = ["TID251"]
+"src/specify_cli/skills/command_renderer.py" = ["TID251"]
+"src/specify_cli/skills/manifest.py" = ["TID251"]
+"src/specify_cli/skills/manifest_store.py" = ["TID251"]
+"src/specify_cli/skills/verifier.py" = ["TID251"]
+"src/specify_cli/sync/body_upload.py" = ["TID251"]
+"src/specify_cli/sync/clock.py" = ["TID251"]
+"src/specify_cli/sync/queue.py" = ["TID251"]
+"src/specify_cli/tracker/store.py" = ["TID251"]
+"src/specify_cli/upgrade/migrations/m_3_2_0_codex_to_skills.py" = ["TID251"]
 "scripts/**" = ["TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports]

--- a/src/charter/hasher.py
+++ b/src/charter/hasher.py
@@ -23,7 +23,7 @@ def hash_content(content: str) -> str:
     """
     # Normalize whitespace (strip trailing newlines)
     normalized = content.strip()
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     return f"sha256:{digest}"
 
 

--- a/src/charter/synthesizer/manifest.py
+++ b/src/charter/synthesizer/manifest.py
@@ -183,7 +183,7 @@ def verify_manifest_hash(manifest: SynthesisManifest) -> None:
     """
     data = manifest.model_dump(mode="python")
     data_without_hash = {k: v for k, v in data.items() if k != "manifest_hash"}
-    computed = hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()
+    computed = hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     if computed != manifest.manifest_hash:
         raise ValueError(
             f"manifest_hash mismatch (stored {manifest.manifest_hash[:12]}..., "
@@ -263,7 +263,7 @@ def verify(manifest: SynthesisManifest, repo_root: Path) -> None:
                 offending_artifact=entry.path,
             )
         on_disk_bytes = artifact_path.read_bytes()
-        on_disk_hash = hashlib.sha256(on_disk_bytes).hexdigest()
+        on_disk_hash = hashlib.sha256(on_disk_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
         if on_disk_hash != entry.content_hash:
             raise ManifestIntegrityError(
                 manifest_path=manifest_path,

--- a/src/charter/synthesizer/request.py
+++ b/src/charter/synthesizer/request.py
@@ -289,7 +289,7 @@ def compute_inputs_hash(
     stability guarantees with zero new dependencies.
     """
     raw = normalize_request_for_hash(request, adapter_id, adapter_version)
-    return hashlib.sha256(raw).hexdigest()
+    return hashlib.sha256(raw).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def short_hash(full_hex: str, length: int = 12) -> str:

--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -136,7 +136,7 @@ def _rewrite_manifest(
 
         filename = artifact_filename(kind, slug, artifact_id)
         yaml_bytes = canonical_yaml(body)
-        content_hash = hashlib.sha256(yaml_bytes).hexdigest()
+        content_hash = hashlib.sha256(yaml_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
         rel_content = (
             f"{_KITTIFY_DIRNAME}/doctrine/{doctrine_kind_subdir(kind)}/{filename}"
@@ -194,7 +194,7 @@ def _rewrite_manifest(
         "synthesizer_version": synthesizer_ver,
         "artifacts": [e.model_dump(mode="python") for e in sorted_merged],
     }
-    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data_without_hash)).hexdigest()
+    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
     return SynthesisManifest(
         mission_id=existing.mission_id,

--- a/src/charter/synthesizer/synthesize_pipeline.py
+++ b/src/charter/synthesizer/synthesize_pipeline.py
@@ -247,7 +247,7 @@ def _content_hash(yaml_bytes: bytes) -> str:
     ``compute_inputs_hash``. The full 64-char hex digest is stored in
     ``ProvenanceEntry.artifact_content_hash``.
     """
-    return hashlib.sha256(yaml_bytes).hexdigest()
+    return hashlib.sha256(yaml_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +266,7 @@ def _compute_evidence_hashes(request: SynthesisRequest) -> tuple[str | None, str
     evidence_bytes = json.dumps(
         _evidence_to_jsonable(request.evidence), sort_keys=True, ensure_ascii=True
     ).encode("utf-8")
-    evidence_hash = hashlib.sha256(evidence_bytes).hexdigest()
+    evidence_hash = hashlib.sha256(evidence_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     corpus_id = (
         request.evidence.corpus_snapshot.snapshot_id
         if request.evidence.corpus_snapshot is not None

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -204,7 +204,7 @@ def _doctrine_kind_subdir(kind: str) -> str:
 
 def _compute_content_hash(yaml_bytes: bytes) -> str:
     """SHA-256 hex digest of artifact YAML bytes (matches synthesize_pipeline)."""
-    return hashlib.sha256(yaml_bytes).hexdigest()
+    return hashlib.sha256(yaml_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +552,7 @@ def promote(
         "synthesizer_version": synthesizer_ver,
         "artifacts": [e.model_dump(mode="python") for e in sorted_artifacts],
     }
-    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data_without_hash)).hexdigest()
+    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
     manifest = SynthesisManifest(
         mission_id=mission_id,

--- a/src/doctrine/drg/migration/extractor.py
+++ b/src/doctrine/drg/migration/extractor.py
@@ -71,6 +71,11 @@ _CURATED_ARTIFACT_EDGES: tuple[tuple[str, str, Relation], ...] = (
         "tactic:paula-patterns-architecture-scout-review",
         Relation.REQUIRES,
     ),
+    (
+        "directive:DIRECTIVE_003",
+        "tactic:traceable-decisions",
+        Relation.REQUIRES,
+    ),
 )
 
 

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -797,6 +797,15 @@ edges:
   target: tactic:requirements-validation-workflow
   relation: scope
 - source: action:software-dev/implement
+  target: directive:DIRECTIVE_001
+  relation: scope
+- source: action:software-dev/implement
+  target: directive:DIRECTIVE_003
+  relation: scope
+- source: action:software-dev/implement
+  target: directive:DIRECTIVE_010
+  relation: scope
+- source: action:software-dev/implement
   target: directive:DIRECTIVE_024
   relation: scope
 - source: action:software-dev/implement
@@ -815,22 +824,70 @@ edges:
   target: directive:DIRECTIVE_034
   relation: scope
 - source: action:software-dev/implement
+  target: directive:DIRECTIVE_036
+  relation: scope
+- source: action:software-dev/implement
+  target: directive:DIRECTIVE_037
+  relation: scope
+- source: action:software-dev/implement
+  target: procedure:disciplined-defect-diagnosis
+  relation: scope
+- source: action:software-dev/implement
+  target: procedure:legacy-codebase-triage
+  relation: scope
+- source: action:software-dev/implement
+  target: procedure:refactoring
+  relation: scope
+- source: action:software-dev/implement
+  target: procedure:test-first-bug-fixing
+  relation: scope
+- source: action:software-dev/implement
   target: tactic:acceptance-test-first
   relation: scope
 - source: action:software-dev/implement
   target: tactic:autonomous-operation-protocol
   relation: scope
 - source: action:software-dev/implement
+  target: tactic:black-box-integration-testing
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:boring-code-review
+  relation: scope
+- source: action:software-dev/implement
   target: tactic:change-apply-smallest-viable-diff
   relation: scope
 - source: action:software-dev/implement
+  target: tactic:dependency-hygiene
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:focused-function-complexity-check
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:function-over-form-testing
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:generated-code-stewardship
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:input-validation-fail-fast
+  relation: scope
+- source: action:software-dev/implement
   target: tactic:quality-gate-verification
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:secure-design-checklist
   relation: scope
 - source: action:software-dev/implement
   target: tactic:stopping-conditions
   relation: scope
 - source: action:software-dev/implement
   target: tactic:tdd-red-green-refactor
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:test-boundaries-by-responsibility
+  relation: scope
+- source: action:software-dev/implement
+  target: tactic:testing-select-appropriate-level
   relation: scope
 - source: action:software-dev/implement
   target: toolguide:efficient-local-tooling
@@ -884,6 +941,12 @@ edges:
   target: tactic:stopping-conditions
   relation: scope
 - source: action:software-dev/review
+  target: directive:DIRECTIVE_001
+  relation: scope
+- source: action:software-dev/review
+  target: directive:DIRECTIVE_003
+  relation: scope
+- source: action:software-dev/review
   target: directive:DIRECTIVE_010
   relation: scope
 - source: action:software-dev/review
@@ -902,7 +965,46 @@ edges:
   target: directive:DIRECTIVE_030
   relation: scope
 - source: action:software-dev/review
+  target: directive:DIRECTIVE_034
+  relation: scope
+- source: action:software-dev/review
+  target: directive:DIRECTIVE_036
+  relation: scope
+- source: action:software-dev/review
   target: directive:DIRECTIVE_037
+  relation: scope
+- source: action:software-dev/review
+  target: procedure:disciplined-defect-diagnosis
+  relation: scope
+- source: action:software-dev/review
+  target: procedure:legacy-codebase-triage
+  relation: scope
+- source: action:software-dev/review
+  target: procedure:refactoring
+  relation: scope
+- source: action:software-dev/review
+  target: procedure:test-first-bug-fixing
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:acceptance-test-first
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:autonomous-operation-protocol
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:black-box-integration-testing
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:boring-code-review
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:change-apply-smallest-viable-diff
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:dependency-hygiene
+  relation: scope
+- source: action:software-dev/review
+  target: tactic:focused-function-complexity-check
   relation: scope
 - source: action:software-dev/review
   target: tactic:quality-gate-verification
@@ -1136,6 +1238,9 @@ edges:
   reason: 'Apply the dual-perspective reconstruction check during review: read only the test suite and attempt to reconstruct system behavior, then compare against the specification. Tests that fail reconstruction are documentation gaps.'
 - source: directive:DIRECTIVE_001
   target: tactic:paula-patterns-architecture-scout-review
+  relation: requires
+- source: directive:DIRECTIVE_003
+  target: tactic:traceable-decisions
   relation: requires
 - source: directive:DIRECTIVE_024
   target: directive:DIRECTIVE_025

--- a/src/doctrine/missions/software-dev/actions/implement/index.yaml
+++ b/src/doctrine/missions/software-dev/actions/implement/index.yaml
@@ -1,19 +1,38 @@
 action: implement
 directives:
+  - 001-architectural-integrity-standard
+  - 003-decision-documentation-requirement
+  - 010-specification-fidelity-requirement
   - 024-locality-of-change
   - 025-boy-scout-rule
   - 028-search-tool-discipline
   - 029-agent-commit-signing-policy
   - 030-test-and-typecheck-quality-gate
   - 034-test-first-development
+  - 036-black-box-integration-testing
+  - 037-living-documentation-sync
 tactics:
   - acceptance-test-first
   - tdd-red-green-refactor
+  - black-box-integration-testing
+  - boring-code-review
   - change-apply-smallest-viable-diff
+  - dependency-hygiene
+  - focused-function-complexity-check
+  - function-over-form-testing
+  - generated-code-stewardship
+  - input-validation-fail-fast
   - autonomous-operation-protocol
   - quality-gate-verification
+  - secure-design-checklist
   - stopping-conditions
+  - test-boundaries-by-responsibility
+  - testing-select-appropriate-level
 styleguides: []
 toolguides:
   - efficient-local-tooling
-procedures: []
+procedures:
+  - disciplined-defect-diagnosis
+  - legacy-codebase-triage
+  - refactoring
+  - test-first-bug-fixing

--- a/src/doctrine/paradigms/built-in/__init__.py
+++ b/src/doctrine/paradigms/built-in/__init__.py
@@ -1,2 +1,0 @@
-"""Shipped paradigm artifacts."""
-

--- a/src/doctrine/procedures/built-in/__init__.py
+++ b/src/doctrine/procedures/built-in/__init__.py
@@ -1,1 +1,0 @@
-"""Shipped procedure artifacts."""

--- a/src/doctrine/toolguides/built-in/__init__.py
+++ b/src/doctrine/toolguides/built-in/__init__.py
@@ -1,2 +1,0 @@
-"""Shipped toolguide artifacts."""
-

--- a/src/doctrine/versioning.py
+++ b/src/doctrine/versioning.py
@@ -312,7 +312,7 @@ def migrate_v1_to_v2(bundle_root: Path, dry_run: bool = False) -> MigrationResul
             # Set schema_version to "2" in the hash-input fields too, so the
             # hash covers the post-migration state.
             fields_for_hash["schema_version"] = "2"
-            manifest_hash = hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()
+            manifest_hash = hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
             manifest_data["schema_version"] = "2"
             manifest_data["manifest_hash"] = manifest_hash

--- a/src/specify_cli/auth/loopback/pkce.py
+++ b/src/specify_cli/auth/loopback/pkce.py
@@ -43,7 +43,7 @@ def generate_code_challenge(verifier: str) -> str:
     Returns:
         A base64url-encoded SHA256 digest with no trailing ``=`` characters.
     """
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()  # noqa: TID251 - production raw SHA-256 owner
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 

--- a/src/specify_cli/charter_runtime/lint/checks/contradiction.py
+++ b/src/specify_cli/charter_runtime/lint/checks/contradiction.py
@@ -27,7 +27,7 @@ def _content_hash(text: str | None) -> str:
     """Return a short SHA-256 hex digest for *text*, or '' when None."""
     if text is None:
         return ""
-    return hashlib.sha256(text.encode()).hexdigest()[:16]
+    return hashlib.sha256(text.encode()).hexdigest()[:16]  # noqa: TID251 - production raw SHA-256 owner
 
 
 class ContradictionChecker:

--- a/src/specify_cli/cli/commands/charter/_fresh_doctrine.py
+++ b/src/specify_cli/cli/commands/charter/_fresh_doctrine.py
@@ -75,7 +75,7 @@ def _fresh_seed_manifest_text() -> str:
         "artifacts": [],
         "built_in_only": True,
     }
-    manifest_hash = hashlib.sha256(canonical_yaml(without_hash)).hexdigest()
+    manifest_hash = hashlib.sha256(canonical_yaml(without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     manifest = SynthesisManifest.model_validate(
         {**without_hash, "manifest_hash": manifest_hash}
     )

--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -537,112 +537,146 @@ def close_cmd(
         console.print(f"[red]Mission not found:[/red] {mission_slug}")
         raise typer.Exit(1)
 
-    # Load meta to get mid8 (required for coordination worktree teardown).
     meta_path = feature_dir / "meta.json"
-    mid8_value: str = ""
-    if meta_path.exists():
-        try:
-            meta = json.loads(meta_path.read_text(encoding="utf-8"))
-            if isinstance(meta, dict):
-                mid8_value = str(meta.get("mid8") or "").strip()
-                if not mid8_value:
-                    mission_id_meta = str(meta.get("mission_id") or "").strip()
-                    if len(mission_id_meta) >= 8:
-                        mid8_value = mission_id_meta[:8]
-        except (OSError, json.JSONDecodeError):
-            pass
+    mid8_value = _read_mission_mid8(meta_path)
 
     if discard:
-        # Confirm unless --force.
-        if not force:
-            confirm = typer.confirm(
-                f"Discard mission {mission_slug}? This deletes the coordination "
-                f"branch, every lane branch, and all worktrees. Unmerged work "
-                f"on those branches WILL BE LOST.",
-                default=False,
-            )
-            if not confirm:
-                console.print("[yellow]Aborted.[/yellow]")
-                raise typer.Exit(1)
-
-        # Load lanes.json (if present) so we know which branches to delete.
-        lanes_manifest = None
-        try:
-            from specify_cli.lanes.persistence import (
-                CorruptLanesError,
-                MissingLanesError,
-                require_lanes_json,
-            )
-
-            lanes_manifest = require_lanes_json(feature_dir)
-        except (MissingLanesError, CorruptLanesError):
-            lanes_manifest = None
-
-        # Delete every lane branch + the coordination/mission branch.
-        if lanes_manifest is not None:
-            from specify_cli.lanes.branch_naming import lane_branch_name
-            try:
-                from specify_cli.lanes.merge import PLANNING_LANE_ID
-            except ImportError:
-                PLANNING_LANE_ID = "lane-planning"  # historical fallback
-
-            for lane in lanes_manifest.lanes:
-                if lane.lane_id == PLANNING_LANE_ID:
-                    continue
-                branch_name = lane_branch_name(mission_slug, lane.lane_id)
-                _force_delete_branch_if_exists(repo_root, branch_name)
-
-            _force_delete_branch_if_exists(repo_root, lanes_manifest.mission_branch)
-            console.print(
-                f"  Deleted {len(lanes_manifest.lanes)} lane branch(es) + "
-                f"mission/coordination branch"
-            )
-        else:
-            # No lanes.json -- legacy mission. Best-effort: try the canonical
-            # coordination_branch from meta if present.
-            if meta_path.exists():
-                try:
-                    meta = json.loads(meta_path.read_text(encoding="utf-8"))
-                    coord_branch = (
-                        meta.get("coordination_branch") if isinstance(meta, dict) else None
-                    )
-                except (OSError, json.JSONDecodeError):
-                    coord_branch = None
-                if coord_branch:
-                    _force_delete_branch_if_exists(repo_root, str(coord_branch))
-                    console.print(f"  Deleted coordination branch {coord_branch}")
-
-        # Remove operator-visible lane worktrees.
-        if lanes_manifest is not None:
-            _remove_lane_worktrees(repo_root, mission_slug, mid8_value, lanes_manifest)
+        _discard_mission(
+            repo_root=repo_root,
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            mid8_value=mid8_value,
+            meta_path=meta_path,
+            force=force,
+        )
 
     # Teardown the coordination worktree. Same path as merge.py:1568.
     # Idempotent: no-ops on legacy missions / when already torn down.
-    if mid8_value:
-        try:
-            from specify_cli.coordination import CoordinationWorkspace
-
-            CoordinationWorkspace.teardown(repo_root, mission_slug, mid8_value)
-            if CoordinationWorkspace.is_present(repo_root, mission_slug, mid8_value):
-                console.print(
-                    "[yellow]Warning:[/yellow] coordination worktree still "
-                    "present after teardown; manual cleanup may be required."
-                )
-            else:
-                console.print(
-                    f"[green]✓[/green] Coordination worktree torn down for "
-                    f"{mission_slug}-{mid8_value}"
-                )
-        except Exception as exc:  # noqa: BLE001 — teardown is best-effort
-            console.print(
-                f"[yellow]Warning:[/yellow] coordination worktree teardown "
-                f"failed (non-fatal): {exc}"
-            )
+    _teardown_coordination_worktree(repo_root, mission_slug, mid8_value)
 
     if discard:
         console.print(f"[green]✓[/green] Mission {mission_slug} discarded.")
     else:
         console.print(f"[green]✓[/green] Mission {mission_slug} closed.")
+
+
+def _read_mission_mid8(meta_path: Path) -> str:
+    if not meta_path.exists():
+        return ""
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(meta, dict):
+        return ""
+    mid8_value = str(meta.get("mid8") or "").strip()
+    if mid8_value:
+        return mid8_value
+    mission_id_meta = str(meta.get("mission_id") or "").strip()
+    return mission_id_meta[:8] if len(mission_id_meta) >= 8 else ""
+
+
+def _discard_mission(
+    *,
+    repo_root: Path,
+    feature_dir: Path,
+    mission_slug: str,
+    mid8_value: str,
+    meta_path: Path,
+    force: bool,
+) -> None:
+    _confirm_discard(mission_slug, force=force)
+    lanes_manifest = _load_lanes_manifest(feature_dir)
+    if lanes_manifest is not None:
+        _delete_lane_branches(repo_root, mission_slug, lanes_manifest)
+        _remove_lane_worktrees(repo_root, mission_slug, mid8_value, lanes_manifest)
+        return
+    _delete_legacy_coordination_branch(repo_root, meta_path)
+
+
+def _confirm_discard(mission_slug: str, *, force: bool) -> None:
+    if force:
+        return
+    confirm = typer.confirm(
+        f"Discard mission {mission_slug}? This deletes the coordination "
+        f"branch, every lane branch, and all worktrees. Unmerged work "
+        f"on those branches WILL BE LOST.",
+        default=False,
+    )
+    if not confirm:
+        console.print("[yellow]Aborted.[/yellow]")
+        raise typer.Exit(1)
+
+
+def _load_lanes_manifest(feature_dir: Path) -> Any | None:
+    try:
+        from specify_cli.lanes.persistence import (
+            CorruptLanesError,
+            MissingLanesError,
+            require_lanes_json,
+        )
+
+        return require_lanes_json(feature_dir)
+    except (MissingLanesError, CorruptLanesError):
+        return None
+
+
+def _delete_lane_branches(repo_root: Path, mission_slug: str, lanes_manifest: Any) -> None:
+    from specify_cli.lanes.branch_naming import lane_branch_name
+
+    try:
+        from specify_cli.lanes.merge import PLANNING_LANE_ID
+    except ImportError:
+        PLANNING_LANE_ID = "lane-planning"  # historical fallback
+
+    for lane in lanes_manifest.lanes:
+        if lane.lane_id == PLANNING_LANE_ID:
+            continue
+        branch_name = lane_branch_name(mission_slug, lane.lane_id)
+        _force_delete_branch_if_exists(repo_root, branch_name)
+
+    _force_delete_branch_if_exists(repo_root, lanes_manifest.mission_branch)
+    console.print(
+        f"  Deleted {len(lanes_manifest.lanes)} lane branch(es) + "
+        f"mission/coordination branch"
+    )
+
+
+def _delete_legacy_coordination_branch(repo_root: Path, meta_path: Path) -> None:
+    if not meta_path.exists():
+        return
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    coord_branch = meta.get("coordination_branch") if isinstance(meta, dict) else None
+    if coord_branch:
+        _force_delete_branch_if_exists(repo_root, str(coord_branch))
+        console.print(f"  Deleted coordination branch {coord_branch}")
+
+
+def _teardown_coordination_worktree(repo_root: Path, mission_slug: str, mid8_value: str) -> None:
+    if not mid8_value:
+        return
+    try:
+        from specify_cli.coordination import CoordinationWorkspace
+
+        CoordinationWorkspace.teardown(repo_root, mission_slug, mid8_value)
+        if CoordinationWorkspace.is_present(repo_root, mission_slug, mid8_value):
+            console.print(
+                "[yellow]Warning:[/yellow] coordination worktree still "
+                "present after teardown; manual cleanup may be required."
+            )
+        else:
+            console.print(
+                f"[green]✓[/green] Coordination worktree torn down for "
+                f"{mission_slug}-{mid8_value}"
+            )
+    except Exception as exc:  # noqa: BLE001 — teardown is best-effort
+        console.print(
+            f"[yellow]Warning:[/yellow] coordination worktree teardown "
+            f"failed (non-fatal): {exc}"
+        )
 
 
 def _force_delete_branch_if_exists(repo_root: Path, branch_name: str) -> None:

--- a/src/specify_cli/doctrine_synthesizer/provenance.py
+++ b/src/specify_cli/doctrine_synthesizer/provenance.py
@@ -47,7 +47,7 @@ def _safe_path_component(value: str) -> str:
     if not cleaned:
         cleaned = "artifact"
     if cleaned != value or len(cleaned) > 128:
-        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]  # noqa: TID251 - production raw SHA-256 owner
         cleaned = f"{cleaned[:115]}-{digest}"
     return cleaned
 

--- a/src/specify_cli/dossier/drift_detector.py
+++ b/src/specify_cli/dossier/drift_detector.py
@@ -81,7 +81,7 @@ class BaselineKey:
             64-character SHA256 hash in hex format.
         """
         data = json.dumps(self.to_dict(), sort_keys=True)
-        return hashlib.sha256(data.encode()).hexdigest()
+        return hashlib.sha256(data.encode()).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
     def __eq__(self, other: object) -> bool:
         """Check equality with another BaselineKey.

--- a/src/specify_cli/dossier/hasher.py
+++ b/src/specify_cli/dossier/hasher.py
@@ -41,7 +41,7 @@ def hash_file(file_path: Path) -> str:
         >>> len(hash1)
         64
     """
-    hasher = hashlib.sha256()
+    hasher = hashlib.sha256()  # noqa: TID251 - production raw SHA-256 owner
     try:
         with open(file_path, "rb") as f:
             # Read in 8KB chunks to avoid memory issues with large files
@@ -112,7 +112,7 @@ def hash_file_with_validation(file_path: Path) -> tuple[str | None, str | None]:
             return None, "invalid_utf8"
 
         # Hash the bytes directly
-        hasher = hashlib.sha256()
+        hasher = hashlib.sha256()  # noqa: TID251 - production raw SHA-256 owner
         hasher.update(content_bytes)
         return hasher.hexdigest(), None
 
@@ -203,7 +203,7 @@ class Hasher:
         combined = "".join(sorted_hashes)
 
         # Compute SHA256 of concatenated string
-        parity_hasher = hashlib.sha256()
+        parity_hasher = hashlib.sha256()  # noqa: TID251 - production raw SHA-256 owner
         parity_hasher.update(combined.encode("utf-8"))
 
         return parity_hasher.hexdigest()

--- a/src/specify_cli/dossier/snapshot.py
+++ b/src/specify_cli/dossier/snapshot.py
@@ -47,7 +47,7 @@ def compute_parity_hash_from_dossier(dossier: MissionDossier) -> str:
     combined = "".join(sorted_hashes)
 
     # 4. Hash
-    parity_hash = hashlib.sha256(combined.encode()).hexdigest()
+    parity_hash = hashlib.sha256(combined.encode()).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
     return parity_hash
 

--- a/src/specify_cli/glossary/checkpoint.py
+++ b/src/specify_cli/glossary/checkpoint.py
@@ -90,7 +90,7 @@ def compute_input_hash(inputs: dict[str, Any]) -> str:
         64-character lowercase hex string (SHA256 hash)
     """
     canonical = json.dumps(inputs, sort_keys=True, ensure_ascii=False)
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def create_checkpoint(

--- a/src/specify_cli/glossary/drg_builder.py
+++ b/src/specify_cli/glossary/drg_builder.py
@@ -44,7 +44,7 @@ def glossary_urn(surface_text: str) -> str:
         >>> glossary_urn("lane")
         'glossary:d93244e7'
     """
-    hex_id = hashlib.sha256(surface_text.encode()).hexdigest()[:8]
+    hex_id = hashlib.sha256(surface_text.encode()).hexdigest()[:8]  # noqa: TID251 - production raw SHA-256 owner
     return f"glossary:{hex_id}"
 
 

--- a/src/specify_cli/identity/project.py
+++ b/src/specify_cli/identity/project.py
@@ -200,7 +200,7 @@ def generate_node_id() -> str:
     hostname = socket.gethostname()
     username = getpass.getuser()
     raw = f"{hostname}:{username}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:12]
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]  # noqa: TID251 - production raw SHA-256 owner
 
 
 def is_writable(path: Path) -> bool:

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -183,7 +183,7 @@ class ProfileInvocationExecutor:
             action=action,
             mark_loaded=False,
         )
-        ctx_hash = hashlib.sha256(ctx_result.text.encode()).hexdigest()[:16]
+        ctx_hash = hashlib.sha256(ctx_result.text.encode()).hexdigest()[:16]  # noqa: TID251 - production raw SHA-256 owner
         ctx_available = ctx_result.mode != "missing"
 
         # 2a. Run glossary chokepoint scan (T016/T017)

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -466,7 +466,7 @@ class _CanonicalRowResult:
 def deterministic_ulid(seed: bytes | str) -> str:
     """Return a deterministic 26-char Crockford identifier from *seed*."""
     raw = seed.encode("utf-8") if isinstance(seed, str) else seed
-    value = int.from_bytes(hashlib.sha256(raw).digest()[:16], "big")
+    value = int.from_bytes(hashlib.sha256(raw).digest()[:16], "big")  # noqa: TID251 - production raw SHA-256 owner
     chars: list[str] = []
     for _ in range(26):
         chars.append(_CROCKFORD[value & 31])
@@ -607,11 +607,11 @@ def teamspace_dry_run(
                     synthesized_event_type=envelope["event_type"],
                     aggregate_id=envelope["aggregate_id"],
                     row_sha256=(
-                        hashlib.sha256(row_location.text.encode("utf-8")).hexdigest()
+                        hashlib.sha256(row_location.text.encode("utf-8")).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
                         if row_location is not None
                         else None
                     ),
-                    envelope_sha256=hashlib.sha256(
+                    envelope_sha256=hashlib.sha256(  # noqa: TID251 - production raw SHA-256 owner
                         json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
                     ).hexdigest(),
                 )
@@ -1592,7 +1592,7 @@ def _valid_event_id(value: object) -> bool:
 
 
 def _compute_run_id(repo_root: Path, mission_dirs: Sequence[Path]) -> str:
-    digest = hashlib.sha256()
+    digest = hashlib.sha256()  # noqa: TID251 - production raw SHA-256 owner
     digest.update(b"spec-kitty:mission-state:v1\n")
     for mission_dir in mission_dirs:
         for name in (META_FILENAME, EVENTS_FILENAME, STATUS_FILENAME):
@@ -1611,7 +1611,7 @@ def _file_fingerprint(path: Path) -> tuple[str | None, int | None]:
     if not path.exists():
         return None, None
     data = path.read_bytes()
-    return hashlib.sha256(data).hexdigest(), len(data)
+    return hashlib.sha256(data).hexdigest(), len(data)  # noqa: TID251 - production raw SHA-256 owner
 
 
 def _file_change(
@@ -1630,7 +1630,7 @@ def _file_change(
 
 
 def _sha256_text(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def _repo_relpath(repo_root: Path, path: Path) -> str:

--- a/src/specify_cli/migration/rebuild_state.py
+++ b/src/specify_cli/migration/rebuild_state.py
@@ -82,7 +82,7 @@ def _deterministic_id(*parts: str) -> str:
     minted by this module are reproducible across runs.
     """
     seed = "|".join(parts).encode("utf-8")
-    value = int.from_bytes(hashlib.sha256(seed).digest()[:16], "big")
+    value = int.from_bytes(hashlib.sha256(seed).digest()[:16], "big")  # noqa: TID251 - production raw SHA-256 owner
     chars: list[str] = []
     for _ in range(26):
         chars.append(_CROCKFORD[value & 31])

--- a/src/specify_cli/mission_brief.py
+++ b/src/specify_cli/mission_brief.py
@@ -73,7 +73,7 @@ def write_mission_brief(
         brief_path.unlink(missing_ok=True)
         source_path.unlink(missing_ok=True)
 
-    brief_hash = hashlib.sha256(content.encode()).hexdigest()
+    brief_hash = hashlib.sha256(content.encode()).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     ingested_at = datetime.now(tz=UTC).isoformat()
 
     # WP02 T007: provenance strings come from operator-controlled file

--- a/src/specify_cli/missions/_create.py
+++ b/src/specify_cli/missions/_create.py
@@ -152,12 +152,7 @@ def coordination_branch_name(mission_slug: str, mission_id: str) -> str:
     """
     mid8_token = _mid8(mission_id)
     suffix = f"-{mid8_token}"
-    if mission_slug.endswith(suffix):
-        # Formatted slug already carries the mid8 — use as-is.
-        human_part = mission_slug
-    else:
-        # Bare slug (with or without numeric prefix) — derive the formatted form.
-        human_part = f"{strip_numeric_prefix(mission_slug)}{suffix}"
+    human_part = mission_slug if mission_slug.endswith(suffix) else f"{strip_numeric_prefix(mission_slug)}{suffix}"
     return f"kitty/mission-{human_part}"
 
 

--- a/src/specify_cli/missions/_resolve_planning_branch.py
+++ b/src/specify_cli/missions/_resolve_planning_branch.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Mapping
+from collections.abc import Mapping
 
 __all__ = [
     "PlanningBranchResolutionFailed",

--- a/src/specify_cli/next/_internal_runtime/engine.py
+++ b/src/specify_cli/next/_internal_runtime/engine.py
@@ -143,7 +143,7 @@ def _freeze_template(run_dir: Path, template: MissionTemplate, template_path: st
     frozen_path = run_dir / "mission_template_frozen.yaml"
     frozen_path.write_bytes(yaml_bytes)
 
-    return hashlib.sha256(yaml_bytes).hexdigest()
+    return hashlib.sha256(yaml_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def _load_frozen_template(run_dir: Path) -> MissionTemplate:

--- a/src/specify_cli/next/_internal_runtime/planner.py
+++ b/src/specify_cli/next/_internal_runtime/planner.py
@@ -224,7 +224,7 @@ def _check_template_drift(
     if not live_template_path.exists():
         return None
     live_bytes = live_template_path.read_bytes()
-    live_hash = hashlib.sha256(live_bytes).hexdigest()
+    live_hash = hashlib.sha256(live_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     if live_hash != snapshot.template_hash:
         return "Template changed during active run. Migration required."
     return None

--- a/src/specify_cli/review/prompt_metadata.py
+++ b/src/specify_cli/review/prompt_metadata.py
@@ -93,7 +93,7 @@ def utc_now_for_review_prompt() -> str:
 def safe_repo_identifier(repo_root: Path) -> str:
     """Return a filesystem-safe repo identity component with a path hash."""
     resolved = str(repo_root.expanduser().resolve())
-    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:12]
+    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:12]  # noqa: TID251 - production raw SHA-256 owner
     safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", repo_root.name).strip("-") or "repo"
     return f"{safe_name}-{digest}"
 

--- a/src/specify_cli/skills/command_renderer.py
+++ b/src/specify_cli/skills/command_renderer.py
@@ -432,7 +432,7 @@ def render(
         raise SkillRenderError("template_not_found", path=str(template_path))
 
     raw_bytes = template_path.read_bytes()
-    source_hash = hashlib.sha256(raw_bytes).hexdigest()
+    source_hash = hashlib.sha256(raw_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     raw_text = raw_bytes.decode("utf-8")
 
     # Apply the SPDD/REASONS conditional prompt fragment renderer before any

--- a/src/specify_cli/skills/manifest.py
+++ b/src/specify_cli/skills/manifest.py
@@ -119,5 +119,5 @@ def clear_manifest(project_path: Path) -> None:
 def compute_content_hash(file_path: Path) -> str:
     """Compute sha256 hash of file content."""
     content = file_path.read_bytes()
-    digest = hashlib.sha256(content).hexdigest()
+    digest = hashlib.sha256(content).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     return f"sha256:{digest}"

--- a/src/specify_cli/skills/manifest_store.py
+++ b/src/specify_cli/skills/manifest_store.py
@@ -345,7 +345,7 @@ def fingerprint(content: bytes) -> str:
     snapshot tests, and migration to ensure all components agree on the
     content-hash format stored in ``ManifestEntry.content_hash``.
     """
-    return hashlib.sha256(content).hexdigest()
+    return hashlib.sha256(content).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def fingerprint_file(path: Path) -> str:

--- a/src/specify_cli/skills/verifier.py
+++ b/src/specify_cli/skills/verifier.py
@@ -274,4 +274,4 @@ def _expected_content_hash(source: Path, skill_name: str, source_file: str) -> s
         return compute_content_hash(source)
     content = source.read_text(encoding="utf-8")
     normalized = ensure_skill_frontmatter(content, skill_name).encode("utf-8")
-    return "sha256:" + hashlib.sha256(normalized).hexdigest()
+    return "sha256:" + hashlib.sha256(normalized).hexdigest()  # noqa: TID251 - production raw SHA-256 owner

--- a/src/specify_cli/sync/body_upload.py
+++ b/src/specify_cli/sync/body_upload.py
@@ -111,7 +111,7 @@ def _read_and_rehash(
         )
 
     # Hash raw bytes to match dossier/hasher.py hash_file() convention
-    actual_hash = hashlib.sha256(raw_bytes).hexdigest()
+    actual_hash = hashlib.sha256(raw_bytes).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     if actual_hash != expected_hash:
         return UploadOutcome(
             artifact_path=relative_path,

--- a/src/specify_cli/sync/clock.py
+++ b/src/specify_cli/sync/clock.py
@@ -22,7 +22,7 @@ def generate_node_id() -> str:
     hostname = socket.gethostname()
     username = getpass.getuser()
     raw = f"{hostname}:{username}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:12]
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]  # noqa: TID251 - production raw SHA-256 owner
 
 
 @dataclass

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -490,7 +490,7 @@ def read_queue_scope_from_session(*, allow_rehydrate: bool = True) -> str | None
 
 def scope_db_path(scope: str) -> Path:
     """Resolve a deterministic queue DB path for a given scope."""
-    digest = hashlib.sha256(scope.encode("utf-8")).hexdigest()[:16]
+    digest = hashlib.sha256(scope.encode("utf-8")).hexdigest()[:16]  # noqa: TID251 - production raw SHA-256 owner
     return _scoped_queue_dir() / f"queue-{digest}.db"
 
 

--- a/src/specify_cli/tracker/store.py
+++ b/src/specify_cli/tracker/store.py
@@ -91,7 +91,7 @@ def build_tracker_scope(
     user = (username or "anonymous").strip().lower()
     team = (team_slug or "no-team").strip().lower()
     identity = f"{provider.strip().lower()}|{workspace.strip().lower()}|{server}|{user}|{team}"
-    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]  # noqa: TID251 - production raw SHA-256 owner
 
 
 def default_tracker_db_path(

--- a/src/specify_cli/upgrade/migrations/m_3_2_0_codex_to_skills.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0_codex_to_skills.py
@@ -93,7 +93,7 @@ def _compute_hash(path: Path) -> str:
     import hashlib  # noqa: PLC0415
 
     try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
+        return hashlib.sha256(path.read_bytes()).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     except OSError:
         return ""
 

--- a/tests/architectural/test_ci_quality_path_filters.py
+++ b/tests/architectural/test_ci_quality_path_filters.py
@@ -1,0 +1,29 @@
+"""Architectural guards for CI path-filter ownership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.architectural
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci-quality.yml"
+
+
+def _path_filters() -> dict[str, list[str]]:
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    filter_step = next(
+        step for step in data["jobs"]["changes"]["steps"] if step.get("id") == "filter"
+    )
+    return yaml.safe_load(filter_step["with"]["filters"])
+
+
+def test_missions_filter_includes_missions_package_and_tests() -> None:
+    """Mission package edits must run the mission test slice."""
+    missions_filter = set(_path_filters()["missions"])
+    assert "src/specify_cli/missions/**" in missions_filter
+    assert "tests/fixtures/missions/**" in missions_filter
+    assert "tests/specify_cli/missions/**" in missions_filter

--- a/tests/architectural/test_ci_quality_path_filters.py
+++ b/tests/architectural/test_ci_quality_path_filters.py
@@ -32,11 +32,19 @@ def _job_run_script(job_name: str, step_name: str) -> str:
 
 
 def test_missions_filter_includes_missions_package_and_tests() -> None:
-    """Mission package edits must run the mission test slice."""
+    """Mission package tests must both trigger and run the mission test slice."""
     missions_filter = set(_path_filters()["missions"])
     assert "src/specify_cli/missions/**" in missions_filter
     assert "tests/fixtures/missions/**" in missions_filter
     assert "tests/specify_cli/missions/**" in missions_filter
+
+    fast_run = _job_run_script("fast-tests-missions", "Run fast tests — missions")
+    integration_run = _job_run_script(
+        "integration-tests-missions",
+        "Run integration tests — missions",
+    )
+    assert "tests/specify_cli/missions/" in fast_run
+    assert "tests/specify_cli/missions/" in integration_run
 
 
 def test_lanes_filter_and_jobs_include_lanes_package_tests() -> None:

--- a/tests/architectural/test_ci_quality_path_filters.py
+++ b/tests/architectural/test_ci_quality_path_filters.py
@@ -21,9 +21,33 @@ def _path_filters() -> dict[str, list[str]]:
     return yaml.safe_load(filter_step["with"]["filters"])
 
 
+def _job_run_script(job_name: str, step_name: str) -> str:
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    step = next(
+        step
+        for step in data["jobs"][job_name]["steps"]
+        if step.get("name") == step_name
+    )
+    return str(step["run"])
+
+
 def test_missions_filter_includes_missions_package_and_tests() -> None:
     """Mission package edits must run the mission test slice."""
     missions_filter = set(_path_filters()["missions"])
     assert "src/specify_cli/missions/**" in missions_filter
     assert "tests/fixtures/missions/**" in missions_filter
     assert "tests/specify_cli/missions/**" in missions_filter
+
+
+def test_lanes_filter_and_jobs_include_lanes_package_tests() -> None:
+    """Lane package tests must both trigger and run the lane test slice."""
+    lanes_filter = set(_path_filters()["lanes"])
+    assert "tests/specify_cli/lanes/**" in lanes_filter
+
+    fast_run = _job_run_script("fast-tests-lanes", "Run fast tests — lanes")
+    integration_run = _job_run_script(
+        "integration-tests-lanes",
+        "Run integration tests — lanes",
+    )
+    assert "tests/specify_cli/lanes/" in fast_run
+    assert "tests/specify_cli/lanes/" in integration_run

--- a/tests/architectural/test_no_runtime_pypi_dep.py
+++ b/tests/architectural/test_no_runtime_pypi_dep.py
@@ -37,6 +37,7 @@ pytestmark = [pytest.mark.architectural]
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_CI_QUALITY = _REPO_ROOT / ".github" / "workflows" / "ci-quality.yml"
 _SRC = _REPO_ROOT / "src"
 
 # Optional-dependency groups that are dev-only and may legitimately mention
@@ -90,6 +91,13 @@ def test_pyproject_optional_dep_groups_do_not_smuggle_runtime_into_production() 
         f"({sorted(_DEV_OPTIONAL_GROUPS)}) are permitted. Offenders:\n  "
         + "\n  ".join(offenders)
     )
+
+
+def test_ci_quality_does_not_install_retired_runtime() -> None:
+    """CI must not manually install the retired runtime into test jobs."""
+    workflow = _CI_QUALITY.read_text(encoding="utf-8")
+    assert "uv pip install spec-kitty-runtime" not in workflow
+    assert "pip install spec-kitty-runtime" not in workflow
 
 
 def test_cli_next_decision_imports_without_spec_kitty_runtime() -> None:

--- a/tests/architectural/test_tid251_enforcement.py
+++ b/tests/architectural/test_tid251_enforcement.py
@@ -23,8 +23,8 @@ This guard pins the enforcement so neither regression can recur:
 3. Functionally, with the repository's real ruff config, an unannotated raw
    ``hashlib.sha256`` in a *formerly-exempt* directory (``tests/charter/``) is flagged,
    while the same call carrying ``# noqa: TID251`` is allowed.
-4. The production ``src/**`` tree is not blanket-exempt, so Gap-5
-   ``click.exceptions.*`` usage is enforced outside exact raw-SHA owners.
+4. The production ``src/**`` tree has no file-level TID251 exemptions, so Gap-5
+   ``click.exceptions.*`` usage is enforced even in raw-SHA owner files.
 """
 
 from __future__ import annotations
@@ -112,6 +112,21 @@ def test_no_blanket_src_tid251_exemption() -> None:
     )
 
 
+def test_no_src_file_level_tid251_exemptions() -> None:
+    """Production raw-SHA exceptions must be inline, not file-level."""
+    config = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    per_file = config["tool"]["ruff"]["lint"]["per-file-ignores"]
+    offenders = {
+        pattern: codes
+        for pattern, codes in per_file.items()
+        if pattern.startswith("src/") and "TID251" in codes
+    }
+    assert not offenders, (
+        "File-level src TID251 ignores also disable the click.exceptions ban "
+        f"inside raw-SHA owner files: {offenders}. Keep raw-SHA exceptions inline."
+    )
+
+
 def _ruff_probe(snippet: str, stdin_filename: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -170,5 +185,18 @@ def test_click_exceptions_probe_in_src_is_flagged() -> None:
     assert proc.returncode != 0, (
         "Bare click.exceptions.UsageError under src/ was NOT flagged — "
         f"Gap-5 enforcement is dead for production code.\nstdout:\n{proc.stdout}"
+    )
+    assert "TID251" in proc.stdout
+
+
+def test_click_exceptions_probe_in_raw_sha_owner_file_is_flagged() -> None:
+    """Gap-5 must stay live in files that also own legitimate raw SHA calls."""
+    proc = _ruff_probe(
+        "import click\nraise click.exceptions.UsageError('bad')\n",
+        "src/specify_cli/sync/body_upload.py",
+    )
+    assert proc.returncode != 0, (
+        "Bare click.exceptions.UsageError inside a raw-SHA owner file was NOT "
+        f"flagged.\nstdout:\n{proc.stdout}"
     )
     assert "TID251" in proc.stdout

--- a/tests/architectural/test_tid251_enforcement.py
+++ b/tests/architectural/test_tid251_enforcement.py
@@ -23,6 +23,8 @@ This guard pins the enforcement so neither regression can recur:
 3. Functionally, with the repository's real ruff config, an unannotated raw
    ``hashlib.sha256`` in a *formerly-exempt* directory (``tests/charter/``) is flagged,
    while the same call carrying ``# noqa: TID251`` is allowed.
+4. The production ``src/**`` tree is not blanket-exempt, so Gap-5
+   ``click.exceptions.*`` usage is enforced outside exact raw-SHA owners.
 """
 
 from __future__ import annotations
@@ -94,6 +96,22 @@ def test_no_whole_dir_tid251_exemption_for_tests() -> None:
     )
 
 
+def test_no_blanket_src_tid251_exemption() -> None:
+    """No ``src/**`` per-file-ignore may disable Gap-5 for all production code."""
+    config = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    per_file = config["tool"]["ruff"]["lint"]["per-file-ignores"]
+    offenders = {
+        pattern: codes
+        for pattern, codes in per_file.items()
+        if pattern.rstrip("/") in {"src", "src/**"} and "TID251" in codes
+    }
+    assert not offenders, (
+        "Whole-tree src TID251 ignores make the click.exceptions ban dead config "
+        f"for production code: {offenders}. Keep exceptions scoped to exact "
+        "raw-SHA owner files."
+    )
+
+
 def _ruff_probe(snippet: str, stdin_filename: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -141,3 +159,16 @@ def test_annotated_sha256_is_allowed() -> None:
         f"`# noqa: TID251` did not suppress the ban.\nstdout:\n{proc.stdout}\n"
         f"stderr:\n{proc.stderr}"
     )
+
+
+def test_click_exceptions_probe_in_src_is_flagged() -> None:
+    """Gap-5 must be live for production files, not just tests."""
+    proc = _ruff_probe(
+        "import click\nraise click.exceptions.UsageError('bad')\n",
+        "src/specify_cli/orchestrator_api/_tid251_probe.py",
+    )
+    assert proc.returncode != 0, (
+        "Bare click.exceptions.UsageError under src/ was NOT flagged — "
+        f"Gap-5 enforcement is dead for production code.\nstdout:\n{proc.stdout}"
+    )
+    assert "TID251" in proc.stdout

--- a/tests/architectural/test_typer_compat_ci.py
+++ b/tests/architectural/test_typer_compat_ci.py
@@ -1,0 +1,27 @@
+"""Architectural guard for the Typer 0.26 compatibility smoke test."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.architectural
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci-quality.yml"
+
+
+def test_ci_exercises_typer_026_json_error_surface() -> None:
+    """CI must install Typer 0.26+ for the JSON error-surface smoke test."""
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    lint_steps = data["jobs"]["lint"]["steps"]
+    runs = [str(step.get("run", "")) for step in lint_steps]
+    assert any(
+        "typer>=0.26" in run and "tests/agent/test_json_group_typer_surface.py" in run
+        for run in runs
+    ), (
+        "ci-quality.yml must exercise tests/agent/test_json_group_typer_surface.py "
+        "under Typer >=0.26 so the vendored-click compatibility path is live."
+    )

--- a/tests/integration/test_cli_status_mediation.py
+++ b/tests/integration/test_cli_status_mediation.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 

--- a/tests/integration/test_legacy_mission_fallback.py
+++ b/tests/integration/test_legacy_mission_fallback.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -280,17 +279,16 @@ def test_legacy_mission_forced_commit_failure_rolls_back(
         actor="claude",
     )
 
-    with pytest.raises(BookkeepingCommitFailed):
-        with BookkeepingTransaction.acquire(
-            repo_root=repo_root,
-            mission_id=legacy_mission["mission_id"],
-            mission_slug=legacy_mission["mission_slug"],
-            mid8=legacy_mission["mid8"],
-            destination_ref="kitty/x",
-            operation="legacy_forced_failure",
-        ) as txn:
-            txn.append_event(event)
-            txn.commit("chore: legacy rollback regression test")
+    with pytest.raises(BookkeepingCommitFailed), BookkeepingTransaction.acquire(
+        repo_root=repo_root,
+        mission_id=legacy_mission["mission_id"],
+        mission_slug=legacy_mission["mission_slug"],
+        mid8=legacy_mission["mid8"],
+        destination_ref="kitty/x",
+        operation="legacy_forced_failure",
+    ) as txn:
+        txn.append_event(event)
+        txn.commit("chore: legacy rollback regression test")
 
     # SHA-256 must match pre-emit: rollback is byte-identical.
     post_digest = _sha256(events_path)

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -145,12 +145,12 @@ def test_ensure_creates_branch_when_missing(tmp_path: Path) -> None:
 def test_ensure_is_idempotent_when_branch_at_target(tmp_path: Path) -> None:
     """Re-running against an existing branch that is at the target is a silent no-op."""
     _init_repo(tmp_path)
-    args = dict(
-        repo_root=tmp_path,
-        mission_slug="my-feature-01KSPTVW",
-        mission_id="01KSPTVWZ9ABCDEFGHJKMNPQRS",
-        target_branch="main",
-    )
+    args = {
+        "repo_root": tmp_path,
+        "mission_slug": "my-feature-01KSPTVW",
+        "mission_id": "01KSPTVWZ9ABCDEFGHJKMNPQRS",
+        "target_branch": "main",
+    }
 
     first = ensure_coordination_branch(**args)
     sha_after_first = _branch_sha(tmp_path, first.branch_name)
@@ -165,12 +165,12 @@ def test_ensure_is_idempotent_when_branch_at_target(tmp_path: Path) -> None:
 def test_ensure_raises_when_branch_diverged(tmp_path: Path) -> None:
     """A branch advanced past the target raises CoordinationBranchDiverged with structured fields."""
     _init_repo(tmp_path)
-    args = dict(
-        repo_root=tmp_path,
-        mission_slug="my-feature-01KSPTVW",
-        mission_id="01KSPTVWZ9ABCDEFGHJKMNPQRS",
-        target_branch="main",
-    )
+    args = {
+        "repo_root": tmp_path,
+        "mission_slug": "my-feature-01KSPTVW",
+        "mission_id": "01KSPTVWZ9ABCDEFGHJKMNPQRS",
+        "target_branch": "main",
+    }
     first = ensure_coordination_branch(**args)
     branch = first.branch_name
 
@@ -197,12 +197,12 @@ def test_ensure_raises_when_branch_diverged(tmp_path: Path) -> None:
 
 def test_force_recreate_resets_diverged_branch_to_target(tmp_path: Path) -> None:
     _init_repo(tmp_path)
-    args = dict(
-        repo_root=tmp_path,
-        mission_slug="my-feature-01KSPTVW",
-        mission_id="01KSPTVWZ9ABCDEFGHJKMNPQRS",
-        target_branch="main",
-    )
+    args = {
+        "repo_root": tmp_path,
+        "mission_slug": "my-feature-01KSPTVW",
+        "mission_id": "01KSPTVWZ9ABCDEFGHJKMNPQRS",
+        "target_branch": "main",
+    }
     first = ensure_coordination_branch(**args)
     branch = first.branch_name
 

--- a/tests/specify_cli/lanes/test_worktree_allocator_coord.py
+++ b/tests/specify_cli/lanes/test_worktree_allocator_coord.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from pathlib import Path
 
 import pytest
@@ -64,7 +64,7 @@ def _make_manifest(
             depends_on_lanes=(),
             parallel_group=0,
         )],
-        computed_at=datetime.now(timezone.utc).isoformat(),
+        computed_at=datetime.now(UTC).isoformat(),
         computed_from="test",
     )
 


### PR DESCRIPTION
## Summary
- clears the current ruff advisory backlog by applying mechanical fixes and extracting mission close helpers
- removes invalid `built-in/__init__.py` doctrine asset packages so `mypy --strict src/doctrine` can discover cleanly
- removes retired `spec-kitty-runtime` CI installs, adds a Typer >=0.26 JSON error-surface smoke test, and keeps TID251 enforced across `src`/`tests`
- moves production raw SHA-256 TID251 exceptions from file-level ignores to inline call-site `noqa`, so Gap-5 `click.exceptions.*` stays live even in raw-SHA owner files
- expands the missions path filter so `src/specify_cli/missions/**`, mission fixtures, and `tests/specify_cli/missions/**` edits run the mission-suite slice
- expands mission CI jobs so `tests/specify_cli/missions/` is actually executed by both fast and integration mission jobs
- expands lane CI so `tests/specify_cli/lanes/**` edits trigger lane jobs and the lane jobs execute that test tree

Closes #1398
Closes #1399
Closes #1400
Closes #1401
Closes #1402

## Verification
- `.venv/bin/ruff check src tests --select TID251`
- `.venv/bin/ruff check tests/architectural/test_ci_quality_path_filters.py`
- `.venv/bin/mypy --strict src/doctrine`
- `uv run --with 'typer>=0.26' python -m pytest tests/agent/test_json_group_typer_surface.py -q`
- `.venv/bin/pytest tests/architectural/test_tid251_enforcement.py tests/architectural/test_no_runtime_pypi_dep.py tests/architectural/test_typer_compat_ci.py tests/architectural/test_ci_quality_path_filters.py -q`
- `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_mission_create.py tests/integration/test_legacy_mission_fallback.py tests/specify_cli/lanes/test_worktree_allocator_coord.py tests/integration/test_cli_status_mediation.py -q`
- `.venv/bin/pytest tests/missions tests/specify_cli/missions -q`
- `.venv/bin/pytest tests/missions/ tests/specify_cli/missions/ -m "fast and not windows_ci" -q --tb=short`
- `.venv/bin/pytest tests/missions/ tests/specify_cli/missions/ -m 'not windows_ci and (git_repo or integration)' -q --tb=short`
- `.venv/bin/pytest tests/lanes tests/specify_cli/lanes -m "fast and not windows_ci" -q --tb=short`
- `.venv/bin/pytest tests/lanes tests/specify_cli/lanes -m 'not windows_ci and (git_repo or integration)' -q --tb=short`
- `python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/ci-quality.yml').read_text()); print('yaml ok')"`
- `.venv/bin/pytest tests/architectural -q` *(known unrelated failures: dead module/symbol and marker taxonomy gates on existing files)*
