### PR TITLE
Add Paula Patterns architecture scout skill

### DIFF
--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -279,6 +279,9 @@ nodes:
 - urn: tactic:five-paradigm-parallel-debugging
   kind: tactic
   label: Five-Paradigm Parallel Debugging
+- urn: tactic:paula-patterns-architecture-scout-review
+  kind: tactic
+  label: Paula Patterns Architecture Scout Review
 - urn: tactic:focused-function-complexity-check
   kind: tactic
   label: Focused Function Complexity Check
@@ -846,6 +849,9 @@ edges:
   relation: requires
 - source: directive:DIRECTIVE_001
   target: tactic:language-driven-design
+  relation: requires
+- source: directive:DIRECTIVE_001
+  target: tactic:paula-patterns-architecture-scout-review
   relation: requires
 - source: directive:DIRECTIVE_001
   target: tactic:premortem-risk-identification
@@ -1580,6 +1586,26 @@ edges:
   target: tactic:review-intent-and-risk-first
   relation: suggests
   when: Evaluate whether the structural fix plan closes the class and what blast radius it carries.
+- source: tactic:paula-patterns-architecture-scout-review
+  target: directive:DIRECTIVE_001
+  relation: suggests
+  when: Use when scout findings point to missing or violated architecture boundaries.
+- source: tactic:paula-patterns-architecture-scout-review
+  target: directive:DIRECTIVE_032
+  relation: suggests
+  when: Use when scout findings point to language drift or confused ownership concepts.
+- source: tactic:paula-patterns-architecture-scout-review
+  target: tactic:anti-corruption-layer
+  relation: suggests
+  when: Use when external system details leak into core domain or application decisions.
+- source: tactic:paula-patterns-architecture-scout-review
+  target: tactic:domain-event-capture
+  relation: suggests
+  when: Use when durable state transitions, replay, or provenance are missing.
+- source: tactic:paula-patterns-architecture-scout-review
+  target: tactic:review-intent-and-risk-first
+  relation: suggests
+  when: Use when separating release-safe fixes from long-term architecture work.
 - source: directive:DIRECTIVE_035
   target: tactic:occurrence-classification-workflow
   relation: requires

--- a/src/doctrine/skills/README.md
+++ b/src/doctrine/skills/README.md
@@ -55,6 +55,7 @@ Skills should teach agents to load doctrine **iteratively**:
 | `spec-kitty-orchestrator-api-operator` | External automation via orchestrator-api |
 | `spec-kitty-bulk-edit-classification` | Detect bulk-edit intent and drive occurrence-map guardrail (DIRECTIVE_035) |
 | `debugger-debbie` | Dispatch five independent debugging paradigms for recurring bug classes that need structural intervention |
+| `paula-patterns` | Dispatch five architecture scouts and synthesize release-safe vs long-term architecture recommendations |
 
 ## Source Location
 

--- a/src/doctrine/skills/paula-patterns/SKILL.md
+++ b/src/doctrine/skills/paula-patterns/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: paula-patterns
+description: >-
+  Architecture-scout review for recurring boundary leaks, ownership confusion,
+  whack-a-field fixes, and regressions where point patches keep exposing the
+  same missing architecture decision. Dispatches five architecture scouts with
+  different philosophies, then synthesizes a matrix that separates the smallest
+  release-safe fix from deferred architecture work. Use when asked for "Paula
+  Patterns", "architecture scouts", "why does this keep recurring", "boundary
+  leakage", "ownership confusion", or "not another point fix". Do not use for
+  cheap local defects, purely mechanical refactors, or first-occurrence issues
+  without evidence of architectural recurrence.
+---
+
+# Paula Patterns
+
+Paula Patterns is a heavyweight architecture-review skill. It dispatches
+five independent architecture scouts over the same review surface, then the
+parent LLM synthesizes their findings into one pragmatic decision.
+
+Use it when a change feels like whack-a-field fixes, repeated regressions,
+ownership confusion, or boundary leakage. The skill should answer:
+
+- Why does this problem keep recurring?
+- Which architectural boundary is missing or violated?
+- Which short-term release fix is appropriate now?
+- Which long-term architecture issue should be filed separately?
+
+This skill is the agent-facing entry point. The reusable doctrine procedure is
+the `paula-patterns-architecture-scout-review` tactic. Load that tactic when
+you need the durable doctrine artifact; use this skill when operating an agent
+session.
+
+---
+
+## When to Use This Skill
+
+Use Paula Patterns when any of these are true:
+
+- A review keeps finding new variants of the same missing field, state, or
+  boundary rule.
+- Multiple fixes have patched symptoms but not ownership.
+- Logic crosses presentation, application, domain, and infrastructure layers.
+- External system details leak into core domain decisions.
+- Observed state, generated diagnostics, or machine-output contracts are being
+  treated inconsistently.
+- The team needs to decide what must ship now vs what belongs in a follow-up
+  architecture issue.
+
+Do not use Paula Patterns when:
+
+- The defect is a one-line typo or localized stack-trace fix.
+- The desired output is a full rewrite plan before a release.
+- There is no recurrence, boundary, or ownership question.
+- Five subagents would cost more than simply reviewing the change directly.
+
+---
+
+## Step 1: Frame the Review Surface
+
+Load the reusable doctrine tactic
+`paula-patterns-architecture-scout-review`, then write one shared review
+statement for all five scouts. Include:
+
+- The observed recurrence or review smell.
+- The files, PR, issue, or diff range under review.
+- Prior reactive fixes and what each changed.
+- The boundary or ownership question the team keeps circling.
+- Any release deadline or compatibility constraint.
+
+Do not include your own preferred architecture answer in the shared statement.
+The scouts must inspect independently.
+
+---
+
+## Step 2: Dispatch Five Architecture Scouts
+
+Read `references/scout-prompts.md` and dispatch all five scouts in parallel
+where tool support allows:
+
+- Layered Architecture Scout.
+- Bounded Context / DDD Scout.
+- Event-Driven Architecture Scout.
+- Hexagonal / Ports-and-Adapters Scout.
+- Consumer Compatibility / Contract Scout.
+
+Each scout gets the same review statement and its role-specific prompt from
+`references/scout-prompts.md`. Do not inline-modify those prompts in the skill
+body; keep the copyable prompts in the reference file and the reusable
+procedure in the tactic.
+
+---
+
+## Step 3: Synthesize Through the Tactic
+
+Follow `paula-patterns-architecture-scout-review` for the synthesis rules.
+The parent LLM owns the architecture decision and must not paste the five
+reports back-to-back. Use the matrix template in
+`references/synthesis-matrix.md`:
+
+| Finding | Layered | DDD | EDA | Hexagonal | Contract | Evidence | Release action | Long-term action |
+|---|---|---|---|---|---|---|---|---|
+
+For each recurring issue, identify:
+
+- Shared root cause across lenses.
+- Concrete release blocker, if any.
+- Smallest safe release fix.
+- Deferred architecture issue.
+- Tests required before merge.
+
+The parent decision must separate:
+
+- **Release fix:** smallest change that safely closes the currently observed
+  failure without destabilizing the release.
+- **Long-term architecture fix:** boundary, ownership, contract, or state model
+  work that deserves a separate issue or mission.
+
+Do not let a scout force a large refactor into the release path. Also do not
+hide a true release blocker by calling it architecture debt.
+
+---
+
+## Step 4: Produce the Decision
+
+Return these sections:
+
+1. `Verdict`
+   - Whether Paula Patterns was warranted.
+   - Release blocker yes/no.
+   - Recommended release action.
+   - Recommended long-term architecture action.
+
+2. `Scout Matrix`
+   - The synthesis matrix above.
+
+3. `Release Fix`
+   - Files or modules likely touched.
+   - Tests required before merge.
+   - Compatibility constraints.
+
+4. `Long-Term Issue`
+   - Issue title.
+   - Problem statement.
+   - Architecture boundary to restore.
+   - Non-goals.
+
+5. `Scout Notes`
+   - Unique findings from each scout.
+   - Divergence that the parent accepted or rejected, with reason.
+
+---
+
+## Reference Pattern: #1343 / #1359 uv-tool Remediation
+
+Problem: `spec-kitty review` needed uv-tool remediation for a missing test
+runner, but fixes kept missing Git/source installs, version specifier quoting,
+spoofed uv paths, custom `UV_TOOL_DIR`, Windows shell syntax, and editable extra
+deps.
+
+Scout synthesis:
+
+- Layered: review command was parsing uv receipts and rendering installer
+  commands.
+- DDD: `InstallMethod.UV_TOOL` was too thin; the real domain was installed CLI
+  runtime/provenance.
+- EDA: heuristic detection became mutation authority without verified runtime
+  state.
+- Hexagonal: shell strings were used instead of structured
+  `argv/env/platform/provenance` command data.
+- Contract: JSON diagnostic exposed one shell string, creating POSIX/Windows
+  and machine-output risk.
+
+Release action:
+
+- Patch known uv-tool receipt/provenance cases in #1359.
+- Keep JSON diagnostic stable.
+- Avoid a full runtime/provenance refactor before release.
+
+Long-term action:
+
+- File #1358 for shared `InstalledCliRuntime` and structured remediation
+  planning.
+
+---
+
+## References
+
+- `references/scout-prompts.md` - copyable scout prompts and output contracts.
+- `references/synthesis-matrix.md` - parent synthesis template and example.
+- Doctrine tactic: `paula-patterns-architecture-scout-review`.

--- a/src/doctrine/skills/paula-patterns/references/scout-prompts.md
+++ b/src/doctrine/skills/paula-patterns/references/scout-prompts.md
@@ -1,0 +1,85 @@
+# Paula Patterns Scout Prompts
+
+Use one shared review statement for every scout. Do not include the parent
+LLM's preferred architecture answer in that statement.
+
+## Layered Architecture Scout
+
+You are the Layered Architecture Scout. Review the surface for presentation vs
+application vs domain vs infrastructure boundary violations. Look for business
+logic inside CLI/UI handlers, data access or external-system parsing leaking
+upward, and duplicate policy across layers. Return only high-signal findings
+with concrete file/line evidence. For each finding, name the layer that
+currently owns the behavior, the layer that should own it, the release risk,
+and the smallest release-safe fix.
+
+Required output:
+
+- Layer violations.
+- Correct owning layer.
+- Concrete file/line evidence.
+- Release action vs deferred architecture action.
+
+## Bounded Context / DDD Scout
+
+You are the Bounded Context / DDD Scout. Review the surface for aggregate
+ownership failures, ubiquitous-language drift, anemic domain concepts,
+responsibilities crossing context boundaries, and missing anti-corruption
+layers around external systems. Build a context map of the relevant domains.
+Return only high-signal findings with concrete file/line evidence. Propose
+domain concept, value object, aggregate, or service names only when they clarify
+ownership.
+
+Required output:
+
+- Context map of the relevant domains.
+- Ownership violations.
+- Proposed domain concept/value object/service names.
+- Release action vs deferred architecture action.
+
+## Event-Driven Architecture Scout
+
+You are the Event-Driven Architecture Scout. Review the surface for missing
+state transitions/events, observations being treated as authoritative state,
+replay/idempotency gaps, failure/retry/attempt-history loss, and audit or
+provenance loss. Return only high-signal findings with concrete file/line
+evidence. Identify where durable state, events, or projections are needed and
+what can safely remain heuristic for this release.
+
+Required output:
+
+- Missing events or projections.
+- Places where durable state is needed.
+- Idempotency/retry/provenance risks.
+- Release action vs deferred architecture action.
+
+## Hexagonal / Ports-and-Adapters Scout
+
+You are the Hexagonal / Ports-and-Adapters Scout. Review the surface for
+external dependency leakage, shell/OS/API/database/package-manager details in
+core flows, missing ports, and adapter-specific strings becoming the domain
+model. Return only high-signal findings with concrete file/line evidence.
+Suggest structured boundary contracts such as argv/env/platform/provenance
+objects when they reduce leakage.
+
+Required output:
+
+- Missing ports/adapters.
+- Adapter leakage evidence.
+- Suggested structured boundary contracts.
+- Release action vs deferred architecture action.
+
+## Consumer Compatibility / Contract Scout
+
+You are the Consumer Compatibility / Contract Scout. Review the surface for
+machine-output contract risks, downstream consumers, backward compatibility,
+cross-platform compatibility, and docs/tests that encode stale assumptions.
+Return only high-signal findings with concrete file/line evidence. Name the
+minimum release-safe test coverage required before merge.
+
+Required output:
+
+- Contract risks.
+- Compatibility matrix.
+- Downstream consumers and stale assumptions.
+- Minimum release-safe tests.

--- a/src/doctrine/skills/paula-patterns/references/synthesis-matrix.md
+++ b/src/doctrine/skills/paula-patterns/references/synthesis-matrix.md
@@ -1,0 +1,38 @@
+# Paula Patterns Synthesis Matrix
+
+The parent LLM synthesizes scout findings. Do not concatenate scout reports.
+
+| Finding | Layered | DDD | EDA | Hexagonal | Contract | Evidence | Release action | Long-term action |
+|---|---|---|---|---|---|---|---|---|
+|  |  |  |  |  |  |  |  |  |
+
+For each row, decide:
+
+- Shared root cause across lenses.
+- Concrete release blocker, if any.
+- Smallest safe release fix.
+- Deferred architecture issue.
+- Tests required before merge.
+
+## Decision Split
+
+Release fix:
+
+- Minimal change that closes the currently observed failure.
+- Compatible with existing machine-output contracts unless a breaking change is
+  explicitly approved.
+- Covered by the smallest release-safe tests.
+
+Long-term architecture fix:
+
+- Boundary, ownership, contract, or state-model repair that deserves its own
+  issue or mission.
+- Includes non-goals so the follow-up does not absorb the release fix.
+- Names the doctrine tactic, directive, or pattern that should govern the work
+  when one applies.
+
+## Example: #1343 / #1359 uv-tool Remediation
+
+| Finding | Layered | DDD | EDA | Hexagonal | Contract | Evidence | Release action | Long-term action |
+|---|---|---|---|---|---|---|---|---|
+| uv-tool remediation kept missing install variants | Review command parsed uv receipts and rendered installer commands | `InstallMethod.UV_TOOL` hid runtime/provenance distinctions | Heuristic detection became mutation authority without verified state | Shell strings stood in for structured argv/env/platform/provenance | One JSON shell string created POSIX/Windows and machine-output risk | #1343 / #1359 review findings | Patch known uv-tool receipt/provenance cases; keep JSON stable | File #1358 for shared `InstalledCliRuntime` and structured remediation planning |

--- a/src/doctrine/tactics/built-in/architecture/paula-patterns-architecture-scout-review.tactic.yaml
+++ b/src/doctrine/tactics/built-in/architecture/paula-patterns-architecture-scout-review.tactic.yaml
@@ -1,0 +1,83 @@
+schema_version: "1.0"
+id: paula-patterns-architecture-scout-review
+name: Paula Patterns Architecture Scout Review
+purpose: >
+  Review recurring boundary leaks, whack-a-field fixes, ownership confusion,
+  and compatibility regressions by dispatching five architecture scouts with
+  different lenses, then synthesizing one pragmatic matrix that separates the
+  smallest release-safe fix from deferred architecture repair.
+steps:
+  - title: Verify architecture-scout mode is warranted
+    description: >
+      Use this tactic only when recurrence, ownership confusion, boundary
+      leakage, or repeated reactive fixes make a single-lens review too weak.
+      If the issue is localized and first-occurrence, run ordinary review or
+      investigation instead.
+  - title: Frame one shared review statement
+    description: >
+      Write one paragraph covering the observable recurrence, review surface,
+      prior reactive fixes, contested ownership boundary, and any release or
+      compatibility constraint. Do not include a preferred architecture answer;
+      the scouts must inspect independently.
+  - title: Dispatch the five architecture scouts
+    description: >
+      Run five scouts in parallel where possible: Layered Architecture,
+      Bounded Context / DDD, Event-Driven Architecture, Hexagonal /
+      Ports-and-Adapters, and Consumer Compatibility / Contract. Each scout
+      receives the same review statement and returns merge-blocking or
+      high-signal findings only, with concrete file/line evidence and a
+      release-vs-long-term recommendation.
+    examples:
+      - "Layered returns layer violations and the correct owning layer. DDD returns a context map and ownership violations. EDA returns missing events/projections and durable-state risks. Hexagonal returns missing ports/adapters and leakage evidence. Contract returns compatibility risks and minimum release-safe tests."
+  - title: Synthesize findings into the Paula matrix
+    description: >
+      The parent LLM builds a matrix with columns: Finding, Layered, DDD, EDA,
+      Hexagonal, Contract, Evidence, Release action, Long-term action. Do not
+      concatenate scout reports. For every recurring issue, identify the shared
+      root cause, release blocker, smallest safe release fix, deferred
+      architecture issue, and tests required before merge.
+  - title: Choose the pragmatic release path
+    description: >
+      Keep release fixes small and contract-conscious. Do not smuggle a large
+      refactor into the release path. Also do not label a true release blocker
+      as architecture debt. The output must state release blocker yes/no,
+      release action, long-term architecture action, and required tests.
+  - title: File or draft the long-term architecture issue
+    description: >
+      When the scouts identify a missing boundary, domain concept, durable
+      state model, port, or contract, draft the follow-up issue separately from
+      the release fix. Include non-goals so deferred work does not blur back
+      into the current release patch.
+failure_modes:
+  - "Using Paula Patterns for cheap local defects where five scouts cost more than direct review."
+  - "Concatenating scout findings instead of synthesizing a matrix and decision."
+  - "Letting one scout force a large refactor into a release fix without compatibility justification."
+  - "Calling a release blocker long-term architecture debt to avoid hard decisions."
+  - "Omitting concrete file/line evidence, which turns architecture review into taste."
+  - "Losing downstream machine-output or cross-platform compatibility while fixing ownership."
+references:
+  - name: Architectural Integrity Standard
+    type: directive
+    id: DIRECTIVE_001
+    when: Paula Patterns is triggered by missing or violated architecture boundaries.
+  - name: Conceptual Alignment
+    type: directive
+    id: DIRECTIVE_032
+    when: Scout findings reveal language drift or confused ownership concepts.
+  - name: Anti-Corruption Layer
+    type: tactic
+    id: anti-corruption-layer
+    when: External system details leak into domain or application decisions.
+  - name: Domain Event Capture
+    type: tactic
+    id: domain-event-capture
+    when: Durable state transitions, replay, or provenance are missing.
+  - name: Review Intent and Risk First
+    type: tactic
+    id: review-intent-and-risk-first
+    when: Evaluate whether the release fix closes the observed issue and what blast radius it carries.
+notes: >
+  Reference pattern: #1343 / #1359 uv-tool remediation. Release action patched
+  known uv-tool receipt/provenance cases and kept JSON diagnostics stable.
+  Long-term action filed #1358 for shared InstalledCliRuntime and structured
+  remediation planning.

--- a/tests/doctrine/test_paula_patterns_artifacts.py
+++ b/tests/doctrine/test_paula_patterns_artifacts.py
@@ -1,0 +1,106 @@
+"""Smoke tests for the Paula Patterns doctrine artifacts."""
+
+from __future__ import annotations
+
+import pytest
+
+from doctrine.drg.loader import load_graph
+from doctrine.service import DoctrineService
+from specify_cli.skills.registry import SkillRegistry
+
+from tests.doctrine.conftest import DOCTRINE_SOURCE_ROOT
+
+pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
+
+
+BUILT_IN_ROOT = DOCTRINE_SOURCE_ROOT
+
+
+@pytest.fixture(scope="module")
+def service() -> DoctrineService:
+    return DoctrineService(built_in_root=BUILT_IN_ROOT)
+
+
+def test_paula_patterns_tactic_loads(service: DoctrineService) -> None:
+    tactic = service.tactics.get("paula-patterns-architecture-scout-review")
+
+    assert tactic is not None
+    assert tactic.schema_version == "1.0"
+    assert tactic.name == "Paula Patterns Architecture Scout Review"
+    assert len(tactic.steps) == 6
+    assert any(ref.id == "DIRECTIVE_001" for ref in tactic.references)
+    assert "InstalledCliRuntime" in (tactic.notes or "")
+
+
+def test_paula_patterns_skill_references_exist() -> None:
+    skill_root = BUILT_IN_ROOT / "skills" / "paula-patterns"
+    skill_path = skill_root / "SKILL.md"
+
+    assert skill_path.is_file()
+    body = skill_path.read_text(encoding="utf-8")
+    for scout in [
+        "Layered Architecture Scout",
+        "Bounded Context / DDD Scout",
+        "Event-Driven Architecture Scout",
+        "Hexagonal / Ports-and-Adapters Scout",
+        "Consumer Compatibility / Contract Scout",
+    ]:
+        assert scout in body
+    assert "Release fix" in body
+    assert "Long-term architecture fix" in body
+    assert "#1343 / #1359" in body
+    assert "Do not inline-modify those prompts" in body
+    for reference in [
+        "references/scout-prompts.md",
+        "references/synthesis-matrix.md",
+    ]:
+        assert reference in body
+        assert (skill_root / reference).is_file()
+
+    prompts = (skill_root / "references" / "scout-prompts.md").read_text(
+        encoding="utf-8"
+    )
+    for scout in [
+        "You are the Layered Architecture Scout",
+        "You are the Bounded Context / DDD Scout",
+        "You are the Event-Driven Architecture Scout",
+        "You are the Hexagonal / Ports-and-Adapters Scout",
+        "You are the Consumer Compatibility / Contract Scout",
+    ]:
+        assert scout in prompts
+
+
+def test_paula_patterns_skill_is_discoverable() -> None:
+    registry = SkillRegistry(BUILT_IN_ROOT / "skills")
+    skill = registry.get_skill("paula-patterns")
+
+    assert skill is not None
+    assert skill.skill_md.is_file()
+    assert {path.name for path in skill.references} == {
+        "scout-prompts.md",
+        "synthesis-matrix.md",
+    }
+
+
+def test_paula_patterns_graph_node_and_edges_exist() -> None:
+    graph = load_graph(BUILT_IN_ROOT / "graph.yaml")
+    nodes = graph.node_urns()
+
+    assert "tactic:paula-patterns-architecture-scout-review" in nodes
+
+    edges = {(edge.source, edge.target, str(edge.relation)) for edge in graph.edges}
+    assert (
+        "directive:DIRECTIVE_001",
+        "tactic:paula-patterns-architecture-scout-review",
+        "requires",
+    ) in edges
+    assert (
+        "tactic:paula-patterns-architecture-scout-review",
+        "directive:DIRECTIVE_001",
+        "suggests",
+    ) in edges
+    assert (
+        "tactic:paula-patterns-architecture-scout-review",
+        "tactic:review-intent-and-risk-first",
+        "suggests",
+    ) in edges


### PR DESCRIPTION
## Summary

- Add `paula-patterns` doctrine skill as the agent-facing entry point for architecture-scout review.
- Add reusable `paula-patterns-architecture-scout-review` tactic so the durable workflow lives in doctrine, not only in skill prose.
- Add scout prompt and synthesis matrix references, DRG graph links, skills README inventory, and smoke tests.

Closes #1362.

## Validation

- `.venv/bin/pytest tests/doctrine/test_paula_patterns_artifacts.py tests/doctrine/test_debugger_debbie_artifacts.py`
- `.venv/bin/pytest tests/doctrine/tactics/test_validation.py tests/doctrine/test_schema_validation.py tests/doctrine/drg/test_shipped_graph_valid.py`
- `.venv/bin/pytest tests/specify_cli/skills/test_registry.py`
- `.venv/bin/ruff check src/doctrine/skills src/doctrine/tactics tests/doctrine/test_paula_patterns_artifacts.py`
- `git diff --check`
