### PR TITLE
Remove retired runtime install from CI

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -218,11 +218,6 @@ jobs:
       - name: "[ENFORCED] Install Python dependencies"
         run: |
           uv sync --frozen --all-extras
-          # spec-kitty-runtime is required by next/runtime tests and patch-target
-          # validation, but its published wheel pins an older spec-kitty-events.
-          # Install it without deps so this repo's spec-kitty-events==4.0.0 pin
-          # remains authoritative.
-          uv pip install spec-kitty-runtime==0.4.5 --no-deps
 
       - name: "[ENFORCED] Prepare report directories"
         run: |
@@ -951,7 +946,6 @@ jobs:
           python-version: '3.12'
       - run: |
           uv sync --frozen --all-extras
-          uv pip install spec-kitty-runtime==0.4.5 --no-deps
       - run: mkdir -p out/reports/coverage
       - name: "Run fast tests — next"
         run: |
@@ -1570,7 +1564,6 @@ jobs:
           python-version: '3.12'
       - run: |
           uv sync --frozen --all-extras
-          uv pip install spec-kitty-runtime==0.4.5 --no-deps
       - run: mkdir -p out/reports/coverage
       - name: "Run integration tests — next"
         run: |

--- a/tests/architectural/test_no_runtime_pypi_dep.py
+++ b/tests/architectural/test_no_runtime_pypi_dep.py
@@ -37,6 +37,7 @@ pytestmark = [pytest.mark.architectural]
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_CI_QUALITY_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci-quality.yml"
 _SRC = _REPO_ROOT / "src"
 
 # Optional-dependency groups that are dev-only and may legitimately mention
@@ -162,4 +163,16 @@ def test_cli_next_decision_imports_without_spec_kitty_runtime() -> None:
     )
     assert "OK" in result.stdout, (
         f"Sub-process did not print OK marker; stdout={result.stdout!r}"
+    )
+
+
+def test_ci_quality_does_not_install_retired_runtime_package() -> None:
+    """CI must not reinstall the retired runtime package after cutover."""
+    content = _CI_QUALITY_WORKFLOW.read_text(encoding="utf-8")
+    forbidden = "uv pip install spec-kitty-runtime"
+    assert forbidden not in content, (
+        ".github/workflows/ci-quality.yml installs spec-kitty-runtime even "
+        "though the standalone runtime package is retired. Remove the install; "
+        "the clean-install-verification job is the authoritative guard that "
+        "spec-kitty next works without spec-kitty-runtime."
     )


### PR DESCRIPTION
## Summary
- remove retired spec-kitty-runtime installs from CI quality jobs
- add architectural guard preventing ci-quality.yml from reinstalling the retired runtime package

Fixes #1400

## Verification
- .venv/bin/python -m pytest tests/architectural/test_no_runtime_pypi_dep.py -q