### PR TITLE
Reject WP lane changes in mark-status

### DIFF
--- a/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-program-orchestrate/SKILL.md
@@ -90,7 +90,7 @@ gated on the prior phase producing a clean artifact.
 3. /spec-kitty.tasks                   → tasks.md + tasks/WPxx-*.md + finalize-tasks
 4. Implement-review loop               (dispatch sub-agents per spec-kitty-implement-review)
 5. spec-kitty accept + merge           → readiness nudge, then squash commit on main
-6. Post-merge mark-status done         (handle invariant-check workarounds)
+6. Post-merge move WPs done           (handle invariant-check workarounds)
 7. spec-kitty-mission-review skill     → structured report with verdict
 8. Retrospective workflow              → capture learning while context is fresh
 9. Post-merge remediation branch       (address any HIGH/MEDIUM findings)
@@ -188,14 +188,16 @@ is: `cd .worktrees/<slug>-lane-<letter> && git merge kitty/mission-<slug>`,
 resolve conflicts (usually union-merge on TOML/imports/comments), commit, retry
 the outer merge. See issue #771 for planned auto-rebase support.
 
-### 2g. Phase 6 — Mark WPs Done (workaround for the invariant check)
+### 2g. Phase 6 — Move WPs Done (workaround for the invariant check)
 
 The post-merge bookkeeping often fails on `.worktrees/` being untracked.
 Workaround:
 
 ```bash
 mv .worktrees /tmp/<slug>-worktrees-parked
-spec-kitty agent tasks mark-status WP01 WP02 ... --status done --mission <slug>
+for wp in WP01 WP02 ...; do
+  spec-kitty agent tasks move-task "$wp" --to done --mission <slug>
+done
 mv /tmp/<slug>-worktrees-parked .worktrees
 ```
 
@@ -339,7 +341,7 @@ the workaround ready in your dispatch prompts.
 |---|---|---|---|
 | Test-DB collisions across parallel lanes | Django-backed projects with ≥2 concurrent lane runs | `DJANGO_TEST_DATABASE_NAME=test_<proj>_lane_<letter> <project-test-command> --create-db` | #770 |
 | Stale lane on merge | Missions where multiple WPs touched `pyproject.toml` / `urls.py` / shared `__init__.py` | `cd .worktrees/<slug>-lane-<letter> && git merge kitty/mission-<slug>` per stale lane, resolve, retry outer merge | #771 |
-| Post-merge invariant check on `.worktrees/` | Every successful merge | `mv .worktrees /tmp/park && mark-status done && mv back` | #772 |
+| Post-merge invariant check on `.worktrees/` | Every successful merge | `mv .worktrees /tmp/park && move-task WP## --to done && mv back` | #772 |
 | Silent repo fallback when target isn't initialized | Phase 1 on a repo without `.kittify/` scaffold | Detect via `ls <target>/kitty-specs/` after ceremony; if empty and another repo got the artifacts, relocate + `spec-kitty init --ai <agent>` in the real target | #773 |
 | `spec-kitty decision` not found | Sub-agents referencing the `decision` command group | Use `spec-kitty agent decision ...` | #774 |
 | `review-request` is not a real command | Sub-agents trying to submit a WP for review | Use `spec-kitty agent tasks move-task WP## --to for_review` | #775 |

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -2298,62 +2298,21 @@ def _resolve_wp_id(
     mission_slug: str | None,
     feature_dir: Path,
 ) -> TaskIdResult | None:
-    """Resolve a bare WP ID by appending a canonical status event."""
+    """Reject bare WP IDs; mark-status is scoped to task/subtask updates."""
     if not re.match(r"^WP\d+$", wp_id, re.IGNORECASE):
         return None
 
     normalized_wp_id = wp_id.upper()
-    if not _wp_id_exists(feature_dir, normalized_wp_id):
-        return TaskIdResult(
-            id=normalized_wp_id,
-            outcome=TaskIdResolutionOutcome.NOT_FOUND,
-            format=TaskIdResolutionFormat.WP_ID,
-            message=f"{normalized_wp_id}: no matching work package artifact found.",
-        )
-
-    to_lane = resolve_lane_alias(status)
-
-    try:
-        from specify_cli.status.lane_reader import get_wp_lane
-
-        current_lane = get_wp_lane(feature_dir, normalized_wp_id)
-        current_lane_value = getattr(current_lane, "value", current_lane)
-        if current_lane_value == to_lane:
-            return TaskIdResult(
-                id=normalized_wp_id,
-                outcome=TaskIdResolutionOutcome.ALREADY_SATISFIED,
-                format=TaskIdResolutionFormat.WP_ID,
-                message=f"{normalized_wp_id} is already in lane '{to_lane}'.",
-            )
-    except Exception:
-        current_lane_value = None
-
-    try:
-        emit_status_transition(
-            feature_dir=feature_dir,
-            mission_slug=mission_slug or feature_dir.name,
-            wp_id=normalized_wp_id,
-            to_lane=to_lane,
-            actor="agent",
-            force=True,
-            reason="mark-status WP ID resolution",
-            execution_mode="direct_repo",
-            ensure_sync_daemon=False,
-            sync_dossier=False,
-        )
-        return TaskIdResult(
-            id=normalized_wp_id,
-            outcome=TaskIdResolutionOutcome.UPDATED,
-            format=TaskIdResolutionFormat.WP_ID,
-            message=f"Emitted status transition for {normalized_wp_id} to lane '{to_lane}'.",
-        )
-    except Exception as exc:
-        return TaskIdResult(
-            id=normalized_wp_id,
-            outcome=TaskIdResolutionOutcome.NOT_FOUND,
-            format=TaskIdResolutionFormat.WP_ID,
-            message=f"{normalized_wp_id}: transition failed - {exc}",
-        )
+    del status, mission_slug, feature_dir
+    return TaskIdResult(
+        id=normalized_wp_id,
+        outcome=TaskIdResolutionOutcome.NOT_FOUND,
+        format=TaskIdResolutionFormat.WP_ID,
+        message=(
+            f"{normalized_wp_id}: mark-status does not change work-package lanes. "
+            "Use `spec-kitty agent tasks move-task <WP_ID> --to <lane>`."
+        ),
+    )
 
 
 def _mark_status_json_payload(results: list[TaskIdResult]) -> dict[str, object]:
@@ -2518,7 +2477,11 @@ def mark_status(
                 if json_output:
                     print(json.dumps(_mark_status_json_payload(results)))
                 else:
-                    _output_error(json_output, f"No task IDs found in tasks.md: {', '.join(not_found_tasks)}")
+                    if any(result.format == TaskIdResolutionFormat.WP_ID for result in results):
+                        detail = "; ".join(result.message for result in results if result.message)
+                        _output_error(json_output, detail)
+                    else:
+                        _output_error(json_output, f"No task IDs found in tasks.md: {', '.join(not_found_tasks)}")
                 raise typer.Exit(1)
 
             # Write updated content (single write for all changes)

--- a/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
@@ -15,8 +15,6 @@ from specify_cli.core.wps_manifest import (
     WpsManifest,
     generate_tasks_md_from_manifest,
 )
-from specify_cli.status.models import Lane, StatusEvent
-from specify_cli.status.store import append_event, read_events
 
 import pytest
 
@@ -46,7 +44,7 @@ def _null_lock(repo_root: Path, mission_slug: str):  # type: ignore[no-untyped-d
     yield
 
 
-def _invoke_mark_status(repo: Path, slug: str, *ids: str) -> dict:
+def _invoke_mark_status(repo: Path, slug: str, *ids: str, expected_exit_code: int = 0) -> dict:
     with (
         patch("specify_cli.cli.commands.agent.tasks.locate_project_root", return_value=repo),
         patch("specify_cli.cli.commands.agent.tasks._find_mission_slug", return_value=slug),
@@ -68,30 +66,12 @@ def _invoke_mark_status(repo: Path, slug: str, *ids: str) -> dict:
                 "--no-auto-commit",
             ],
         )
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == expected_exit_code, result.output
     return json.loads(result.stdout)
 
 
 def _result_by_id(payload: dict, task_id: str) -> dict:
     return next(result for result in payload["results"] if result["id"] == task_id)
-
-
-def _seed_done_event(mission_dir: Path, slug: str, wp_id: str) -> None:
-    append_event(
-        mission_dir,
-        StatusEvent(
-            event_id=f"01TEST{wp_id}DONE000000000000",
-            mission_slug=slug,
-            wp_id=wp_id,
-            from_lane=Lane.PLANNED,
-            to_lane=Lane.DONE,
-            at="2026-05-05T00:00:00+00:00",
-            actor="test",
-            force=True,
-            reason="test seed",
-            execution_mode="direct_repo",
-        ),
-    )
 
 
 def test_inline_subtasks_single(tmp_path: Path) -> None:
@@ -146,28 +126,31 @@ def test_generated_bold_inline_subtasks_are_markable(tmp_path: Path) -> None:
     assert "- [x] T014" in (mission_dir / "tasks.md").read_text(encoding="utf-8")
 
 
-def test_wp_id_mark_done(tmp_path: Path) -> None:
+def test_wp_id_rejected_with_move_task_guidance(tmp_path: Path) -> None:
     slug = "003-wp-mark-done"
-    mission_dir = _write_mission(tmp_path, slug, "# Tasks\n\n## WP02\n", wp_ids=("WP02",))
+    _write_mission(tmp_path, slug, "# Tasks\n\n## WP02\n", wp_ids=("WP02",))
 
-    payload = _invoke_mark_status(tmp_path, slug, "WP02")
+    with patch("specify_cli.cli.commands.agent.tasks.emit_status_transition") as emit_mock:
+        payload = _invoke_mark_status(tmp_path, slug, "WP02", expected_exit_code=1)
 
     result = _result_by_id(payload, "WP02")
-    assert result["outcome"] == "updated"
+    assert result["outcome"] == "not_found"
     assert result["format"] == "wp_id"
-    assert any(event.wp_id == "WP02" and event.to_lane == Lane.DONE for event in read_events(mission_dir))
+    assert "mark-status does not change work-package lanes" in result["message"]
+    assert "move-task" in result["message"]
+    emit_mock.assert_not_called()
 
 
-def test_wp_id_already_done(tmp_path: Path) -> None:
+def test_wp_id_rejection_does_not_consult_lane_state(tmp_path: Path) -> None:
     slug = "004-wp-already-done"
-    mission_dir = _write_mission(tmp_path, slug, "# Tasks\n\n## WP02\n", wp_ids=("WP02",))
-    _seed_done_event(mission_dir, slug, "WP02")
+    _write_mission(tmp_path, slug, "# Tasks\n\n## WP02\n", wp_ids=("WP02",))
 
-    payload = _invoke_mark_status(tmp_path, slug, "WP02")
+    payload = _invoke_mark_status(tmp_path, slug, "WP02", expected_exit_code=1)
 
     result = _result_by_id(payload, "WP02")
-    assert result["outcome"] == "already_satisfied"
+    assert result["outcome"] == "not_found"
     assert result["format"] == "wp_id"
+    assert "move-task" in result["message"]
 
 
 def test_unknown_id_not_found(tmp_path: Path) -> None:
@@ -195,10 +178,11 @@ def test_mixed_formats(tmp_path: Path) -> None:
     assert _result_by_id(payload, "T001")["format"] == "checkbox"
     assert _result_by_id(payload, "T002")["format"] == "inline_subtasks"
     assert _result_by_id(payload, "WP03")["format"] == "wp_id"
+    assert _result_by_id(payload, "WP03")["outcome"] == "not_found"
+    assert "move-task" in _result_by_id(payload, "WP03")["message"]
     content = (mission_dir / "tasks.md").read_text(encoding="utf-8")
     assert "- [x] T001" in content
     assert "- [x] T002" in content
-    assert any(event.wp_id == "WP03" and event.to_lane == Lane.DONE for event in read_events(mission_dir))
 
 
 def test_existing_checkbox_unchanged(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- Reject bare WP IDs in `agent tasks mark-status` instead of emitting lane transitions\n- Point WP lane changes to `agent tasks move-task`\n- Update mark-status regression coverage to assert no forced status transition is emitted\n\nCloses #1412.\n\n## Tests\n- `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py tests/git_ops/test_atomic_status_commits_unit.py::TestMarkStatusAtomicCommit -q`\n- `.venv/bin/ruff check src/specify_cli/cli/commands/agent/tasks.py tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py`