### PR TITLE
Fix synthesis manifest self-hash drift

### DIFF
--- a/kitty-specs/charter-p7-schema-versioning-provenance-01KQEG13/contracts/synthesis-manifest-v2.schema.yaml
+++ b/kitty-specs/charter-p7-schema-versioning-provenance-01KQEG13/contracts/synthesis-manifest-v2.schema.yaml
@@ -65,6 +65,14 @@ properties:
       $ref: "#/$defs/ManifestArtifactEntry"
     description: "One entry per committed artifact, in deterministic order."
 
+  built_in_only:
+    type: boolean
+    default: false
+    description: |
+      True when synthesis legitimately produced no project DRG. Readers treat
+      this as authoritative built-in-only state and ignore stale project graph
+      files.
+
 $defs:
   ManifestArtifactEntry:
     type: object

--- a/src/charter/synthesizer/manifest.py
+++ b/src/charter/synthesizer/manifest.py
@@ -191,7 +191,7 @@ def compute_manifest_hash(manifest_or_data: SynthesisManifest | Mapping[str, Any
         ).model_dump(mode="python")
 
     data_without_hash = {k: v for k, v in data.items() if k != "manifest_hash"}
-    return hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()
+    return hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def verify_manifest_hash(manifest: SynthesisManifest) -> None:
@@ -212,7 +212,7 @@ def verify_manifest_hash(manifest: SynthesisManifest) -> None:
             legacy_data = manifest.model_dump(mode="python")
             legacy_data.pop("manifest_hash", None)
             legacy_data.pop("built_in_only", None)
-            legacy_computed = hashlib.sha256(canonical_yaml(legacy_data)).hexdigest()
+            legacy_computed = hashlib.sha256(canonical_yaml(legacy_data)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
             if legacy_computed == manifest.manifest_hash:
                 return
 

--- a/src/charter/synthesizer/manifest.py
+++ b/src/charter/synthesizer/manifest.py
@@ -23,7 +23,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from ruamel.yaml import YAML
 
 from .errors import ManifestIntegrityError
@@ -74,6 +74,7 @@ class SynthesisManifest(BaseModel):
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
+    _raw_field_names: frozenset[str] | None = PrivateAttr(default=None)
 
     schema_version: Literal["2"] = "2"
     mission_id: str | None = None
@@ -168,7 +169,10 @@ def load_yaml(path: Path) -> SynthesisManifest:
     """
     y = _yaml_instance()
     raw = y.load(path.read_text(encoding="utf-8"))
-    return SynthesisManifest.model_validate(raw)
+    manifest = SynthesisManifest.model_validate(raw)
+    if isinstance(raw, Mapping):
+        manifest._raw_field_names = frozenset(str(key) for key in raw)
+    return manifest
 
 
 def compute_manifest_hash(manifest_or_data: SynthesisManifest | Mapping[str, Any]) -> str:
@@ -203,6 +207,15 @@ def verify_manifest_hash(manifest: SynthesisManifest) -> None:
     """
     computed = compute_manifest_hash(manifest)
     if computed != manifest.manifest_hash:
+        raw_field_names = manifest._raw_field_names
+        if raw_field_names is not None and "built_in_only" not in raw_field_names:
+            legacy_data = manifest.model_dump(mode="python")
+            legacy_data.pop("manifest_hash", None)
+            legacy_data.pop("built_in_only", None)
+            legacy_computed = hashlib.sha256(canonical_yaml(legacy_data)).hexdigest()
+            if legacy_computed == manifest.manifest_hash:
+                return
+
         raise ValueError(
             f"manifest_hash mismatch (stored {manifest.manifest_hash[:12]}..., "
             f"computed {computed[:12]}...)"

--- a/src/charter/synthesizer/manifest.py
+++ b/src/charter/synthesizer/manifest.py
@@ -19,8 +19,9 @@ All filesystem writes go through ``PathGuard`` (FR-016).
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from ruamel.yaml import YAML
@@ -45,7 +46,7 @@ _PROVENANCE_PATH_PREFIX = Path(".kittify/charter/provenance")
 class ManifestArtifactEntry(BaseModel):
     """One synthesized artifact listed in the synthesis manifest (data-model §E-6a)."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     kind: Literal["directive", "tactic", "styleguide"]
     slug: str
@@ -72,7 +73,7 @@ class SynthesisManifest(BaseModel):
     except manifest_hash)`` — allows readers to verify manifest self-integrity.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     schema_version: Literal["2"] = "2"
     mission_id: str | None = None
@@ -170,6 +171,25 @@ def load_yaml(path: Path) -> SynthesisManifest:
     return SynthesisManifest.model_validate(raw)
 
 
+def compute_manifest_hash(manifest_or_data: SynthesisManifest | Mapping[str, Any]) -> str:
+    """Compute the canonical manifest self-hash.
+
+    The contract is intentionally identical to ``verify_manifest_hash``:
+    SHA-256 of ``canonical_yaml(all manifest fields except manifest_hash)``.
+    Mapping inputs are validated through ``SynthesisManifest`` first so model
+    defaults, including future fields, participate in the hash consistently.
+    """
+    if isinstance(manifest_or_data, SynthesisManifest):
+        data = manifest_or_data.model_dump(mode="python")
+    else:
+        data = SynthesisManifest.model_validate(
+            {**manifest_or_data, "manifest_hash": "0" * 64}
+        ).model_dump(mode="python")
+
+    data_without_hash = {k: v for k, v in data.items() if k != "manifest_hash"}
+    return hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()
+
+
 def verify_manifest_hash(manifest: SynthesisManifest) -> None:
     """Verify the manifest self-hash field.
 
@@ -181,9 +201,7 @@ def verify_manifest_hash(manifest: SynthesisManifest) -> None:
     ValueError
         If the computed hash does not match ``manifest.manifest_hash``.
     """
-    data = manifest.model_dump(mode="python")
-    data_without_hash = {k: v for k, v in data.items() if k != "manifest_hash"}
-    computed = hashlib.sha256(canonical_yaml(data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
+    computed = compute_manifest_hash(manifest)
     if computed != manifest.manifest_hash:
         raise ValueError(
             f"manifest_hash mismatch (stored {manifest.manifest_hash[:12]}..., "
@@ -277,6 +295,7 @@ __all__ = [
     "MANIFEST_PATH",
     "dump_yaml",
     "load_yaml",
+    "compute_manifest_hash",
     "verify",
     "verify_manifest_hash",
 ]

--- a/src/charter/synthesizer/project_drg.py
+++ b/src/charter/synthesizer/project_drg.py
@@ -262,7 +262,13 @@ def apply_post_condition(
     import os  # noqa: PLC0415
     import tempfile  # noqa: PLC0415
 
-    from .manifest import MANIFEST_PATH, SynthesisManifest, dump_yaml, load_yaml  # noqa: PLC0415
+    from .manifest import (  # noqa: PLC0415
+        MANIFEST_PATH,
+        SynthesisManifest,
+        compute_manifest_hash,
+        dump_yaml,
+        load_yaml,
+    )
     from .path_guard import PathGuard  # noqa: PLC0415
 
     manifest_path = repo_root / MANIFEST_PATH
@@ -283,6 +289,14 @@ def apply_post_condition(
         return
 
     # Build the post-condition manifest (immutable Pydantic model -> copy).
+    manifest_hash = compute_manifest_hash(
+        manifest.model_copy(
+            update={
+                "built_in_only": desired_built_in_only,
+                "manifest_hash": "0" * 64,
+            }
+        )
+    )
     new_manifest = SynthesisManifest(
         schema_version=manifest.schema_version,
         mission_id=manifest.mission_id,
@@ -291,7 +305,7 @@ def apply_post_condition(
         adapter_id=manifest.adapter_id,
         adapter_version=manifest.adapter_version,
         synthesizer_version=manifest.synthesizer_version,
-        manifest_hash=manifest.manifest_hash,
+        manifest_hash=manifest_hash,
         artifacts=list(manifest.artifacts),
         built_in_only=desired_built_in_only,
     )

--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -44,6 +44,7 @@ from .manifest import (
     MANIFEST_PATH,
     ManifestArtifactEntry,
     SynthesisManifest,
+    compute_manifest_hash,
     load_yaml as load_manifest,
 )
 from .request import SynthesisRequest, SynthesisTarget
@@ -183,7 +184,6 @@ def _rewrite_manifest(
     created_at = datetime.now(tz=UTC).isoformat()
 
     # Compute manifest_hash over all fields except manifest_hash itself.
-    # canonical_yaml() returns bytes — do NOT call .encode() on its result.
     manifest_data_without_hash: dict[str, Any] = {
         "schema_version": "2",
         "mission_id": existing.mission_id,
@@ -194,7 +194,7 @@ def _rewrite_manifest(
         "synthesizer_version": synthesizer_ver,
         "artifacts": [e.model_dump(mode="python") for e in sorted_merged],
     }
-    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
+    manifest_hash = compute_manifest_hash(manifest_data_without_hash)
 
     return SynthesisManifest(
         mission_id=existing.mission_id,

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -43,6 +43,7 @@ from .manifest import (
     MANIFEST_PATH,
     ManifestArtifactEntry,
     SynthesisManifest,
+    compute_manifest_hash,
     dump_yaml as dump_manifest,
 )
 from .provenance import dump_yaml as dump_provenance, provenance_path_for
@@ -541,7 +542,6 @@ def promote(
     sorted_artifacts = sorted(manifest_entries, key=lambda e: (e.kind, e.slug))
 
     # Build the manifest data dict without manifest_hash first, then hash it.
-    # canonical_yaml() returns bytes — do NOT call .encode() on its result.
     manifest_data_without_hash: dict[str, Any] = {
         "schema_version": "2",
         "mission_id": mission_id,
@@ -552,7 +552,7 @@ def promote(
         "synthesizer_version": synthesizer_ver,
         "artifacts": [e.model_dump(mode="python") for e in sorted_artifacts],
     }
-    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data_without_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
+    manifest_hash = compute_manifest_hash(manifest_data_without_hash)
 
     manifest = SynthesisManifest(
         mission_id=mission_id,

--- a/src/charter/versioning.py
+++ b/src/charter/versioning.py
@@ -16,6 +16,7 @@ from doctrine.versioning import (
     BundleCompatibilityStatus,
     check_bundle_compatibility,
     get_bundle_schema_version,
+    repair_v2_synthesis_manifest_defaults,
     run_migration,
 )
 
@@ -24,5 +25,6 @@ __all__ = [
     "CURRENT_BUNDLE_SCHEMA_VERSION",
     "check_bundle_compatibility",
     "get_bundle_schema_version",
+    "repair_v2_synthesis_manifest_defaults",
     "run_migration",
 ]

--- a/src/doctrine/versioning.py
+++ b/src/doctrine/versioning.py
@@ -201,7 +201,7 @@ def _compute_v2_synthesis_manifest_hash(manifest_data: dict[str, object]) -> str
     fields_for_hash["schema_version"] = "2"
     fields_for_hash.setdefault("mission_id", None)
     fields_for_hash.setdefault("built_in_only", False)
-    return hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()
+    return hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
 
 def repair_v2_synthesis_manifest_defaults(
@@ -244,7 +244,7 @@ def repair_v2_synthesis_manifest_defaults(
     legacy_fields_for_hash = {
         k: v for k, v in manifest_data.items() if k != "manifest_hash"
     }
-    legacy_hash = hashlib.sha256(canonical_yaml(legacy_fields_for_hash)).hexdigest()
+    legacy_hash = hashlib.sha256(canonical_yaml(legacy_fields_for_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
     if legacy_hash != stored_hash:
         return MigrationResult(
             changes_made=[],

--- a/src/doctrine/versioning.py
+++ b/src/doctrine/versioning.py
@@ -204,6 +204,85 @@ def _compute_v2_synthesis_manifest_hash(manifest_data: dict[str, object]) -> str
     return hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()
 
 
+def repair_v2_synthesis_manifest_defaults(
+    bundle_root: Path,
+    dry_run: bool = False,
+) -> MigrationResult:
+    """Repair current v2 manifests that predate verifier-visible defaults."""
+    _yaml = YAML()
+    _yaml.default_flow_style = False
+    _yaml.explicit_start = False
+
+    manifest_path = bundle_root / "synthesis-manifest.yaml"
+    if not manifest_path.exists():
+        return MigrationResult(changes_made=[], errors=[], from_version=2, to_version=2)
+
+    try:
+        manifest_data = _yaml.load(manifest_path)
+    except Exception as exc:  # noqa: BLE001
+        return MigrationResult(
+            changes_made=[],
+            errors=[f"Failed to load synthesis-manifest.yaml: {exc}"],
+            from_version=2,
+            to_version=2,
+        )
+
+    if not isinstance(manifest_data, dict) or manifest_data.get("schema_version") != "2":
+        return MigrationResult(changes_made=[], errors=[], from_version=2, to_version=2)
+    if "built_in_only" in manifest_data:
+        return MigrationResult(changes_made=[], errors=[], from_version=2, to_version=2)
+
+    stored_hash = manifest_data.get("manifest_hash")
+    if not isinstance(stored_hash, str):
+        return MigrationResult(
+            changes_made=[],
+            errors=["Cannot repair synthesis-manifest.yaml: manifest_hash is missing or invalid."],
+            from_version=2,
+            to_version=2,
+        )
+
+    legacy_fields_for_hash = {
+        k: v for k, v in manifest_data.items() if k != "manifest_hash"
+    }
+    legacy_hash = hashlib.sha256(canonical_yaml(legacy_fields_for_hash)).hexdigest()
+    if legacy_hash != stored_hash:
+        return MigrationResult(
+            changes_made=[],
+            errors=[
+                "Cannot repair synthesis-manifest.yaml: existing manifest_hash does not "
+                "match the pre-built_in_only v2 payload."
+            ],
+            from_version=2,
+            to_version=2,
+        )
+
+    manifest_data["built_in_only"] = False
+    manifest_data["manifest_hash"] = _compute_v2_synthesis_manifest_hash(manifest_data)
+    changes_made = [str(manifest_path)]
+
+    if not dry_run:
+        try:
+            import io as _io
+
+            buf = _io.BytesIO()
+            _yaml.dump(manifest_data, buf)
+            manifest_path.write_bytes(buf.getvalue())
+        except Exception as exc:  # noqa: BLE001
+            return MigrationResult(
+                changes_made=[],
+                errors=[f"Failed to write synthesis-manifest.yaml: {exc}"],
+                from_version=2,
+                to_version=2,
+            )
+
+    return MigrationResult(
+        changes_made=changes_made,
+        errors=[],
+        from_version=2,
+        to_version=2,
+    )
+
+
 def _register_migration(
     from_version: int,
     fn: Callable[[Path, bool], MigrationResult],
@@ -402,5 +481,6 @@ __all__ = [
     "check_bundle_compatibility",
     "get_bundle_schema_version",
     "migrate_v1_to_v2",
+    "repair_v2_synthesis_manifest_defaults",
     "run_migration",
 ]

--- a/src/doctrine/versioning.py
+++ b/src/doctrine/versioning.py
@@ -193,6 +193,17 @@ _MIGRATIONS: dict[int, Callable[[Path, bool], MigrationResult]] = {}
 PRE_PHASE7_MIGRATION_SENTINEL = "(pre-phase7-migration)"
 
 
+def _compute_v2_synthesis_manifest_hash(manifest_data: dict[str, object]) -> str:
+    """Hash a migrated v2 synthesis manifest using verifier-visible defaults."""
+    fields_for_hash = {
+        k: v for k, v in manifest_data.items() if k != "manifest_hash"
+    }
+    fields_for_hash["schema_version"] = "2"
+    fields_for_hash.setdefault("mission_id", None)
+    fields_for_hash.setdefault("built_in_only", False)
+    return hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()
+
+
 def _register_migration(
     from_version: int,
     fn: Callable[[Path, bool], MigrationResult],
@@ -304,20 +315,11 @@ def migrate_v1_to_v2(bundle_root: Path, dry_run: bool = False) -> MigrationResul
 
         if isinstance(manifest_data, dict) and manifest_data.get("schema_version") != "2":
             manifest_data.setdefault("synthesizer_version", PRE_PHASE7_MIGRATION_SENTINEL)
-
-            # Compute manifest_hash over all fields except manifest_hash itself.
-            fields_for_hash = {
-                k: v for k, v in manifest_data.items() if k != "manifest_hash"
-            }
-            # Set schema_version to "2" in the hash-input fields too, so the
-            # hash covers the post-migration state.
-            fields_for_hash["schema_version"] = "2"
-            fields_for_hash.setdefault("mission_id", None)
-            fields_for_hash.setdefault("built_in_only", False)
-            manifest_hash = hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
+            manifest_data.setdefault("mission_id", None)
+            manifest_data.setdefault("built_in_only", False)
+            manifest_hash = _compute_v2_synthesis_manifest_hash(manifest_data)
 
             manifest_data["schema_version"] = "2"
-            manifest_data.setdefault("mission_id", None)
             manifest_data["manifest_hash"] = manifest_hash
             manifest_data.setdefault("built_in_only", False)
 

--- a/src/doctrine/versioning.py
+++ b/src/doctrine/versioning.py
@@ -312,10 +312,14 @@ def migrate_v1_to_v2(bundle_root: Path, dry_run: bool = False) -> MigrationResul
             # Set schema_version to "2" in the hash-input fields too, so the
             # hash covers the post-migration state.
             fields_for_hash["schema_version"] = "2"
+            fields_for_hash.setdefault("mission_id", None)
+            fields_for_hash.setdefault("built_in_only", False)
             manifest_hash = hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()  # noqa: TID251 - production raw SHA-256 owner
 
             manifest_data["schema_version"] = "2"
+            manifest_data.setdefault("mission_id", None)
             manifest_data["manifest_hash"] = manifest_hash
+            manifest_data.setdefault("built_in_only", False)
 
             changes_made.append(str(manifest_path))
             if not dry_run:

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_charter_bundle_v2.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_charter_bundle_v2.py
@@ -22,6 +22,7 @@ from charter.versioning import (
     BundleCompatibilityStatus,
     check_bundle_compatibility,
     get_bundle_schema_version,
+    repair_v2_synthesis_manifest_defaults,
     run_migration,
 )
 
@@ -81,11 +82,11 @@ class CharterBundleV2Migration(BaseMigration):
         current = bundle_version if bundle_version is not None else 1
 
         if current >= CURRENT_BUNDLE_SCHEMA_VERSION:
-            # Bundle is already current — nothing to do.
+            repair = repair_v2_synthesis_manifest_defaults(charter_dir, dry_run=dry_run)
             return BaseMigrationResult(
-                success=True,
-                changes_made=[],
-                errors=[],
+                success=len(repair.errors) == 0,
+                changes_made=repair.changes_made,
+                errors=repair.errors,
             )
 
         all_changes: list[str] = []
@@ -96,6 +97,11 @@ class CharterBundleV2Migration(BaseMigration):
             all_changes.extend(result.changes_made)
             all_errors.extend(result.errors)
             current += 1
+
+        if not all_errors:
+            repair = repair_v2_synthesis_manifest_defaults(charter_dir, dry_run=dry_run)
+            all_changes.extend(repair.changes_made)
+            all_errors.extend(repair.errors)
 
         return BaseMigrationResult(
             success=len(all_errors) == 0,

--- a/tests/charter/synthesizer/test_manifest.py
+++ b/tests/charter/synthesizer/test_manifest.py
@@ -28,6 +28,7 @@ from charter.synthesizer.manifest import (
     dump_yaml,
     load_yaml,
     verify,
+    verify_manifest_hash,
 )
 from charter.synthesizer.path_guard import PathGuard
 from charter.synthesizer.synthesize_pipeline import canonical_yaml
@@ -527,6 +528,33 @@ def test_manifest_hash_validates(tmp_path: Path, guard: PathGuard) -> None:
     # canonical_yaml() returns bytes — hash directly, no .encode()
     computed = hashlib.sha256(canonical_yaml(fields_without_hash)).hexdigest()  # noqa: TID251 — charter synthesizer's own manifest/content-hash scheme, not the charter.hasher.hash_content() freshness algorithm
     assert computed == manifest.manifest_hash
+
+
+def test_legacy_v2_manifest_hash_without_built_in_only_verifies(tmp_path: Path) -> None:
+    """Pre-built_in_only v2 manifests remain readable and self-hash-valid."""
+    manifest_data = {
+        "schema_version": "2",
+        "mission_id": None,
+        "created_at": "2026-04-17T12:00:00+00:00",
+        "run_id": "01KPE222TESTRUNID0000000001",
+        "adapter_id": "fixture",
+        "adapter_version": "1.0.0",
+        "synthesizer_version": "3.2.0a5",
+        "artifacts": [],
+    }
+    manifest_data["manifest_hash"] = hashlib.sha256(  # noqa: TID251 — legacy manifest self-hash compatibility
+        canonical_yaml(manifest_data)
+    ).hexdigest()
+    path = tmp_path / "synthesis-manifest.yaml"
+    yaml = YAML()
+    yaml.default_flow_style = False
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.dump(manifest_data, fh)
+
+    loaded = load_yaml(path)
+
+    assert loaded.built_in_only is False
+    verify_manifest_hash(loaded)
 
 
 def test_manifest_synthesizer_version_empty_raises() -> None:

--- a/tests/charter/synthesizer/test_manifest.py
+++ b/tests/charter/synthesizer/test_manifest.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
+import jsonschema
 import pytest
 from pydantic import ValidationError
+from ruamel.yaml import YAML
 
 from charter.synthesizer.errors import ManifestIntegrityError
 from charter.synthesizer.manifest import (
@@ -172,6 +174,34 @@ def test_manifest_round_trip(tmp_path: Path, guard: PathGuard) -> None:
     assert loaded.artifacts[0].kind == "tactic"
     assert loaded.artifacts[0].slug == "my-tactic"
     assert loaded.artifacts[0].content_hash == "a" * 64
+
+
+def test_manifest_rejects_unknown_top_level_fields(tmp_path: Path) -> None:
+    """Unknown manifest fields must not be silently dropped before hashing."""
+    manifest = _make_manifest()
+    data = manifest.model_dump(mode="python")
+    data["tamper_marker"] = "unexpected"
+    manifest_path = tmp_path / "synthesis-manifest.yaml"
+    manifest_path.write_text(canonical_yaml(data).decode("utf-8"), encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        load_yaml(manifest_path)
+
+
+def test_manifest_v2_schema_accepts_runtime_model_dump() -> None:
+    """Runtime SynthesisManifest output must remain compatible with v2 schema."""
+    schema_path = (
+        Path(__file__).parents[3]
+        / "kitty-specs"
+        / "charter-p7-schema-versioning-provenance-01KQEG13"
+        / "contracts"
+        / "synthesis-manifest-v2.schema.yaml"
+    )
+    schema = YAML(typ="safe").load(schema_path.read_text(encoding="utf-8"))
+
+    jsonschema.Draft202012Validator(schema).validate(
+        _make_manifest().model_dump(mode="python")
+    )
 
 
 def test_manifest_with_mission_id(tmp_path: Path, guard: PathGuard) -> None:

--- a/tests/charter/synthesizer/test_orchestrator_resynthesize.py
+++ b/tests/charter/synthesizer/test_orchestrator_resynthesize.py
@@ -30,6 +30,7 @@ from charter.synthesizer.manifest import (
     MANIFEST_PATH,
     SynthesisManifest,
     load_yaml as load_manifest,
+    verify_manifest_hash,
 )
 from charter.synthesizer.resynthesize_pipeline import run as resynthesize_run
 
@@ -232,6 +233,7 @@ class TestUs3KindSlug:
 
         # New run_id
         assert result.manifest.run_id != prior_run_id
+        verify_manifest_hash(load_manifest(repo / MANIFEST_PATH))
 
     def test_resynthesize_kind_slug_preserves_unrelated_hashes(
         self,

--- a/tests/charter/synthesizer/test_write_pipeline.py
+++ b/tests/charter/synthesizer/test_write_pipeline.py
@@ -344,3 +344,57 @@ def test_gate_preserves_staging_on_violation(tmp_path: Path) -> None:
 
     # Staging root must still exist — gate must NOT wipe it
     assert staging_root.exists(), "Gate must not wipe staging dir on violation"
+
+
+def test_promote_writes_manifest_with_valid_self_hash(tmp_path: Path) -> None:
+    """promote() writes a manifest whose self-hash verifies after reload."""
+    from charter.synthesizer.manifest import MANIFEST_PATH, load_yaml, verify_manifest_hash
+    from charter.synthesizer.request import SynthesisRequest, SynthesisTarget
+    from charter.synthesizer.staging import StagingDir
+    from charter.synthesizer.synthesize_pipeline import ProvenanceEntry
+    from charter.synthesizer.write_pipeline import promote
+
+    target = SynthesisTarget(
+        kind="tactic",
+        slug="testing-philosophy",
+        title="Testing Philosophy",
+        artifact_id="testing-philosophy",
+        source_urns=("directive:DIRECTIVE_003",),
+    )
+    request = SynthesisRequest(
+        target=target,
+        interview_snapshot={"testing_philosophy": "layered tests"},
+        doctrine_snapshot={},
+        drg_snapshot={"nodes": [], "edges": [], "schema_version": "1"},
+        run_id="01KMANIFESTHASH000000000001",
+    )
+    provenance = ProvenanceEntry(
+        schema_version="2",
+        artifact_urn="tactic:testing-philosophy",
+        artifact_kind="tactic",
+        artifact_slug="testing-philosophy",
+        artifact_content_hash="a" * 64,
+        inputs_hash="b" * 64,
+        adapter_id="fixture",
+        adapter_version="1.0.0",
+        synthesizer_version="3.2.0a5",
+        source_section="testing_philosophy",
+        source_urns=["directive:DIRECTIVE_003"],
+        source_input_ids=["directive:DIRECTIVE_003"],
+        generated_at="2026-04-19T00:00:00+00:00",
+        produced_at="2026-04-19T00:00:00+00:00",
+        corpus_snapshot_id="(none)",
+        synthesis_run_id="01KMANIFESTHASH000000000001",
+    )
+    stage = StagingDir.create(tmp_path, "01KMANIFESTHASH000000000001")
+
+    promote(
+        request=request,
+        staging_dir=stage,
+        results=[({"title": "Testing Philosophy", "body": "Use layered tests."}, provenance)],
+        validation_callback=lambda _stage: None,
+        repo_root=tmp_path,
+    )
+
+    loaded = load_yaml(tmp_path / MANIFEST_PATH)
+    verify_manifest_hash(loaded)

--- a/tests/doctrine/drg/migration/test_extractor.py
+++ b/tests/doctrine/drg/migration/test_extractor.py
@@ -24,6 +24,7 @@ from doctrine.drg.migration.extractor import (
     generate_graph,
 )
 from doctrine.drg.models import NodeKind, Relation
+from doctrine.drg.query import resolve_context
 from doctrine.drg.validator import validate_graph
 
 # Path to the shipped doctrine root inside the repo.
@@ -444,6 +445,37 @@ class TestGenerateGraph:
         assert tasks < implement, f"|tasks| ({tasks}) should be < |implement| ({implement})"
         assert review >= 0.80 * implement, (
             f"|review| ({review}) should be >= 80% of |implement| ({implement})"
+        )
+
+    def test_resolved_surface_inequalities(self, tmp_path: Path) -> None:
+        """Generated graph must satisfy shipped resolved-context calibration."""
+        output = tmp_path / "graph.yaml"
+        graph = generate_graph(DOCTRINE_ROOT, output)
+
+        def _resolved(action: str) -> int:
+            return len(
+                resolve_context(
+                    graph,
+                    f"action:software-dev/{action}",
+                    depth=2,
+                ).artifact_urns
+            )
+
+        specify = _resolved("specify")
+        plan = _resolved("plan")
+        tasks = _resolved("tasks")
+        implement = _resolved("implement")
+        review = _resolved("review")
+
+        assert specify < plan, f"resolved specify ({specify}) should be < plan ({plan})"
+        assert plan < implement, (
+            f"resolved plan ({plan}) should be < implement ({implement})"
+        )
+        assert tasks < implement, (
+            f"resolved tasks ({tasks}) should be < implement ({implement})"
+        )
+        assert review >= 0.80 * implement, (
+            f"resolved review ({review}) should be >= 80% of implement ({implement})"
         )
 
     def test_discovers_styleguide_nodes(self, tmp_path: Path) -> None:

--- a/tests/doctrine/test_versioning.py
+++ b/tests/doctrine/test_versioning.py
@@ -15,6 +15,7 @@ from doctrine.versioning import (
     MigrationResult,
     check_bundle_compatibility,
     get_bundle_schema_version,
+    repair_v2_synthesis_manifest_defaults,
     run_migration,
 )
 
@@ -359,6 +360,149 @@ def test_run_migration_v1_uses_sentinel_when_sidecar_stat_fails(
         encoding="utf-8"
     )
     assert "produced_at: (pre-phase7-migration)" in sidecar
+
+
+def _write_legacy_v2_manifest(
+    bundle_root: Path,
+    *,
+    stored_hash: str | None = None,
+) -> Path:
+    import hashlib
+
+    from doctrine.yaml_utils import canonical_yaml
+    from ruamel.yaml import YAML
+
+    manifest_data = {
+        "schema_version": "2",
+        "mission_id": None,
+        "created_at": "2026-01-01T00:00:00Z",
+        "run_id": "01TEST000000000000000000001",
+        "adapter_id": "fixture",
+        "adapter_version": "1.0.0",
+        "synthesizer_version": "3.2.6",
+        "artifacts": [],
+    }
+    manifest_data["manifest_hash"] = stored_hash or hashlib.sha256(  # noqa: TID251 — legacy v2 manifest self-hash fixture
+        canonical_yaml(manifest_data)
+    ).hexdigest()
+
+    manifest_path = bundle_root / "synthesis-manifest.yaml"
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.explicit_start = False
+    yaml.dump(manifest_data, manifest_path)
+    return manifest_path
+
+
+def test_repair_v2_manifest_no_manifest_is_noop(tmp_path: Path) -> None:
+    result = repair_v2_synthesis_manifest_defaults(tmp_path)
+
+    assert result.changes_made == []
+    assert result.errors == []
+
+
+def test_repair_v2_manifest_load_error_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import doctrine.versioning as versioning
+
+    (tmp_path / "synthesis-manifest.yaml").write_text("schema_version: '2'\n")
+
+    class BrokenYaml:
+        default_flow_style = False
+        explicit_start = False
+
+        def load(self, _text: str) -> dict:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(versioning, "YAML", BrokenYaml)
+
+    result = repair_v2_synthesis_manifest_defaults(tmp_path)
+
+    assert result.changes_made == []
+    assert result.errors == ["Failed to load synthesis-manifest.yaml: boom"]
+
+
+def test_repair_v2_manifest_ignores_non_v2_and_already_current(tmp_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    manifest_path = tmp_path / "synthesis-manifest.yaml"
+    yaml = YAML()
+    yaml.dump({"schema_version": "1"}, manifest_path)
+    assert repair_v2_synthesis_manifest_defaults(tmp_path).changes_made == []
+
+    yaml.dump({"schema_version": "2", "built_in_only": False}, manifest_path)
+    assert repair_v2_synthesis_manifest_defaults(tmp_path).changes_made == []
+
+
+def test_repair_v2_manifest_missing_hash_is_error(tmp_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    YAML().dump({"schema_version": "2"}, tmp_path / "synthesis-manifest.yaml")
+
+    result = repair_v2_synthesis_manifest_defaults(tmp_path)
+
+    assert result.changes_made == []
+    assert result.errors == [
+        "Cannot repair synthesis-manifest.yaml: manifest_hash is missing or invalid."
+    ]
+
+
+def test_repair_v2_manifest_hash_mismatch_is_error(tmp_path: Path) -> None:
+    _write_legacy_v2_manifest(tmp_path, stored_hash="0" * 64)
+
+    result = repair_v2_synthesis_manifest_defaults(tmp_path)
+
+    assert result.changes_made == []
+    assert result.errors == [
+        "Cannot repair synthesis-manifest.yaml: existing manifest_hash does not "
+        "match the pre-built_in_only v2 payload."
+    ]
+
+
+def test_repair_v2_manifest_writes_canonical_default(tmp_path: Path) -> None:
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+    from ruamel.yaml import YAML
+
+    manifest_path = _write_legacy_v2_manifest(tmp_path)
+
+    result = repair_v2_synthesis_manifest_defaults(tmp_path)
+
+    assert result.changes_made == [str(manifest_path)]
+    assert result.errors == []
+    assert YAML().load(manifest_path)["built_in_only"] is False
+    verify_manifest_hash(load_yaml(manifest_path))
+
+
+def test_repair_v2_manifest_dry_run_reports_without_write(tmp_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    manifest_path = _write_legacy_v2_manifest(tmp_path)
+
+    result = repair_v2_synthesis_manifest_defaults(tmp_path, dry_run=True)
+
+    assert result.changes_made == [str(manifest_path)]
+    assert result.errors == []
+    assert "built_in_only" not in YAML().load(manifest_path)
+
+
+def test_repair_v2_manifest_write_error_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _write_legacy_v2_manifest(tmp_path)
+    original_write_bytes = Path.write_bytes
+
+    def patched_write_bytes(path: Path, data: bytes) -> int:
+        if path == manifest_path:
+            raise OSError("disk full")
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", patched_write_bytes)
+
+    result = repair_v2_synthesis_manifest_defaults(tmp_path)
+
+    assert result.changes_made == []
+    assert result.errors == ["Failed to write synthesis-manifest.yaml: disk full"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/doctrine/test_versioning.py
+++ b/tests/doctrine/test_versioning.py
@@ -318,16 +318,22 @@ def test_run_migration_v1_returns_migration_result(tmp_path: Path) -> None:
 
 
 def test_run_migration_v1_backfills_manifest_and_sidecar_fields(tmp_path: Path) -> None:
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+
     _write_v1_bundle(tmp_path)
 
     result = run_migration(1, tmp_path)
 
     assert result.errors == []
-    manifest = (tmp_path / "synthesis-manifest.yaml").read_text(encoding="utf-8")
+    manifest_path = tmp_path / "synthesis-manifest.yaml"
+    manifest = manifest_path.read_text(encoding="utf-8")
     sidecar = (tmp_path / "provenance" / "directive-use-prs.yaml").read_text(
         encoding="utf-8"
     )
     assert "synthesizer_version: (pre-phase7-migration)" in manifest
+    assert "mission_id:" in manifest
+    assert "built_in_only: false" in manifest
+    verify_manifest_hash(load_yaml(manifest_path))
     assert "synthesizer_version: (pre-phase7-migration)" in sidecar
     assert "synthesis_run_id: (pre-phase7-migration)" in sidecar
     assert "source_input_ids:" in sidecar

--- a/tests/integration/test_charter_synthesize_built_in_only.py
+++ b/tests/integration/test_charter_synthesize_built_in_only.py
@@ -14,11 +14,14 @@ must NEVER be reachable from the synthesizer.  Exercises the dedicated
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
 
 import pytest
+
+from charter.synthesizer.synthesize_pipeline import canonical_yaml
 
 pytestmark = [pytest.mark.integration]
 
@@ -31,6 +34,18 @@ pytestmark = [pytest.mark.integration]
 def _seed_manifest(repo: Path, *, built_in_only: bool) -> Path:
     manifest_path = repo / ".kittify" / "charter" / "synthesis-manifest.yaml"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_data = {
+        "schema_version": "2",
+        "mission_id": None,
+        "created_at": "2099-01-01T00:00:00+00:00",
+        "run_id": "01JTESTRUNIDXXXXXXXXXXXXXX",
+        "adapter_id": "test",
+        "adapter_version": "0.0.0",
+        "synthesizer_version": "0.0.0",
+        "artifacts": [],
+        "built_in_only": built_in_only,
+    }
+    manifest_hash = hashlib.sha256(canonical_yaml(manifest_data)).hexdigest()  # noqa: TID251 — charter synthesizer manifest self-hash, not charter.hasher.hash_content() freshness
     manifest_path.write_text(
         dedent(
             f"""\
@@ -41,7 +56,7 @@ def _seed_manifest(repo: Path, *, built_in_only: bool) -> Path:
             adapter_id: test
             adapter_version: '0.0.0'
             synthesizer_version: '0.0.0'
-            manifest_hash: {"a" * 64}
+            manifest_hash: {manifest_hash}
             artifacts: []
             built_in_only: {str(built_in_only).lower()}
             """
@@ -89,9 +104,24 @@ def test_post_condition_sets_built_in_only_and_removes_graph(tmp_path: Path) -> 
     assert _read_built_in_only(manifest_path) is True
 
 
+def test_post_condition_recomputes_hash_when_built_in_only_changes(tmp_path: Path) -> None:
+    """Changing built_in_only must also refresh manifest_hash."""
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+    from charter.synthesizer.project_drg import apply_post_condition
+
+    _seed_manifest(tmp_path, built_in_only=False)
+    _seed_graph(tmp_path)
+
+    apply_post_condition(tmp_path, has_project_graph=False)
+
+    manifest_path = tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    verify_manifest_hash(load_yaml(manifest_path))
+
+
 def test_post_condition_preserves_graph_and_clears_built_in_only(tmp_path: Path) -> None:
     """When synthesis emitted a project graph, the helper must leave the
     graph in place and ensure ``built_in_only=false`` in the manifest."""
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
     from charter.synthesizer.project_drg import apply_post_condition
 
     _seed_manifest(tmp_path, built_in_only=True)
@@ -103,6 +133,7 @@ def test_post_condition_preserves_graph_and_clears_built_in_only(tmp_path: Path)
     assert manifest_path.exists()
     assert graph_path.exists(), "graph.yaml must be retained"
     assert _read_built_in_only(manifest_path) is False
+    verify_manifest_hash(load_yaml(manifest_path))
 
 
 def test_post_condition_no_op_when_manifest_already_consistent(tmp_path: Path) -> None:

--- a/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
+++ b/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
@@ -259,6 +259,19 @@ def test_apply_manifest_gets_v2_fields(tmp_path: Path) -> None:
     )
 
 
+def test_apply_manifest_hash_verifies_after_v2_migration(tmp_path: Path) -> None:
+    """Migrated manifests must satisfy the v2 self-hash contract."""
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+
+    _create_v1_bundle(tmp_path)
+    CharterBundleV2Migration().apply(tmp_path)
+
+    manifest = load_yaml(
+        tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    )
+    verify_manifest_hash(manifest)
+
+
 def test_apply_dry_run_makes_no_changes(tmp_path: Path) -> None:
     """apply(dry_run=True) reports what would change but does not mutate files."""
     _create_v1_bundle(tmp_path)

--- a/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
+++ b/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
@@ -153,6 +153,26 @@ def _create_v2_bundle(project_path: Path) -> None:
     )
 
 
+def _create_legacy_v2_bundle_without_built_in_only(project_path: Path) -> None:
+    """Create a v2 bundle from before manifest built_in_only was introduced."""
+    _create_v2_bundle(project_path)
+
+    import hashlib
+
+    from doctrine.yaml_utils import canonical_yaml
+
+    manifest_path = (
+        project_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    )
+    manifest = _load_yaml(manifest_path)
+    manifest.pop("built_in_only")
+    manifest.pop("manifest_hash")
+    manifest["manifest_hash"] = hashlib.sha256(  # noqa: TID251 — legacy v2 manifest self-hash fixture
+        canonical_yaml(manifest)
+    ).hexdigest()
+    _write_yaml(manifest_path, manifest)
+
+
 def _create_bundle_with_metadata_version(project_path: Path, version: int) -> None:
     """Create a charter bundle whose metadata advertises a specific version."""
     charter_dir = project_path / ".kittify" / "charter"
@@ -278,6 +298,37 @@ def test_apply_manifest_hash_verifies_after_v2_migration(tmp_path: Path) -> None
         tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
     )
     verify_manifest_hash(manifest)
+
+
+def test_apply_repairs_current_v2_manifest_missing_built_in_only(tmp_path: Path) -> None:
+    """Current v2 bundles with legacy self-hashes get a canonical manifest repair."""
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+
+    _create_legacy_v2_bundle_without_built_in_only(tmp_path)
+
+    result = CharterBundleV2Migration().apply(tmp_path)
+
+    assert result.success is True
+    assert result.errors == []
+    assert result.changes_made == [
+        str(tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml")
+    ]
+    manifest_path = tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    manifest_data = _load_yaml(manifest_path)
+    assert manifest_data["built_in_only"] is False
+    verify_manifest_hash(load_yaml(manifest_path))
+
+
+def test_apply_current_v2_manifest_repair_is_dry_run_safe(tmp_path: Path) -> None:
+    """Dry-run reports the legacy v2 manifest repair without mutating the file."""
+    _create_legacy_v2_bundle_without_built_in_only(tmp_path)
+    manifest_path = tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+
+    result = CharterBundleV2Migration().apply(tmp_path, dry_run=True)
+
+    assert result.success is True
+    assert result.changes_made == [str(manifest_path)]
+    assert "built_in_only" not in _load_yaml(manifest_path)
 
 
 def test_apply_dry_run_makes_no_changes(tmp_path: Path) -> None:

--- a/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
+++ b/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
@@ -125,12 +125,14 @@ def _create_v2_bundle(project_path: Path) -> None:
 
     fields_for_hash = {
         "schema_version": "2",
+        "mission_id": None,
         "created_at": "2026-01-01T00:00:00Z",
         "run_id": "01TEST000000000000000000001",
         "adapter_id": "fixture",
         "adapter_version": "1.0.0",
         "synthesizer_version": "3.2.6",
         "artifacts": [],
+        "built_in_only": False,
     }
     manifest_hash = hashlib.sha256(canonical_yaml(fields_for_hash)).hexdigest()  # noqa: TID251 — migration preserves existing manifest hash verbatim, not charter.hasher.hash_content() freshness
 
@@ -138,6 +140,7 @@ def _create_v2_bundle(project_path: Path) -> None:
         charter_dir / "synthesis-manifest.yaml",
         {
             "schema_version": "2",
+            "mission_id": None,
             "created_at": "2026-01-01T00:00:00Z",
             "run_id": "01TEST000000000000000000001",
             "adapter_id": "fixture",
@@ -145,6 +148,7 @@ def _create_v2_bundle(project_path: Path) -> None:
             "synthesizer_version": "3.2.6",
             "manifest_hash": manifest_hash,
             "artifacts": [],
+            "built_in_only": False,
         },
     )
 
@@ -246,17 +250,21 @@ def test_apply_updates_metadata_yaml(tmp_path: Path) -> None:
 
 def test_apply_manifest_gets_v2_fields(tmp_path: Path) -> None:
     """apply() upgrades synthesis-manifest.yaml to v2 with schema_version and manifest_hash."""
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+
     _create_v1_bundle(tmp_path)
     CharterBundleV2Migration().apply(tmp_path)
 
-    manifest = _load_yaml(
-        tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
-    )
+    manifest_path = tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    manifest = _load_yaml(manifest_path)
     assert manifest["schema_version"] == "2"
     assert "synthesizer_version" in manifest
+    assert manifest["mission_id"] is None
+    assert manifest["built_in_only"] is False
     assert len(manifest["manifest_hash"]) == 64, (
         f"manifest_hash should be a 64-char hex digest, got: {manifest['manifest_hash']!r}"
     )
+    verify_manifest_hash(load_yaml(manifest_path))
 
 
 def test_apply_manifest_hash_verifies_after_v2_migration(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- centralize synthesis manifest self-hash calculation next to verification
- update promote, resynthesize rewrite, DRG post-condition, and v1→v2 migration paths to hash all manifest fields except manifest_hash
- reject unknown manifest fields before hashing and align the v2 schema with runtime built_in_only manifests
- add regressions for promote, resynthesize, post-condition rewrites, migration, unknown-field tamper rejection, and schema compatibility

Fixes #1415.

## Tests
- uv run ruff check src/charter/synthesizer/manifest.py src/charter/synthesizer/write_pipeline.py src/charter/synthesizer/resynthesize_pipeline.py src/charter/synthesizer/project_drg.py src/doctrine/versioning.py tests/charter/synthesizer/test_manifest.py tests/charter/synthesizer/test_write_pipeline.py tests/charter/synthesizer/test_orchestrator_resynthesize.py tests/integration/test_charter_synthesize_built_in_only.py tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
- uv run pytest tests/charter/synthesizer/test_manifest.py tests/charter/synthesizer/test_write_pipeline.py tests/charter/synthesizer/test_orchestrator_resynthesize.py tests/integration/test_charter_synthesize_built_in_only.py tests/charter/synthesizer/test_bundle_validate_extension.py::test_manifest_hash_mismatch_is_error tests/charter/synthesizer/test_bundle_validate_extension.py::test_manifest_hash_is_deterministic tests/charter/synthesizer/test_bundle_validate_extension.py::test_manifest_hash_is_stable_regardless_of_artifact_insertion_order tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py