### PR TITLE
Fix charter synthesis interview key aliases

### DIFF
--- a/src/charter/synthesizer/interview_mapping.py
+++ b/src/charter/synthesizer/interview_mapping.py
@@ -21,13 +21,21 @@ Each ``InterviewSectionMapping`` entry describes one interview section and the
 artifact kinds it drives. The ``requires_nonempty`` flag gates target emission
 on a non-empty, non-whitespace answer for that section.
 
+Producer key aliases
+--------------------
+The synthesis labels in ``INTERVIEW_MAPPINGS`` are legacy artifact-topic names.
+The real ``CharterInterview.answers`` producer uses newer question keys. The
+``_INTERVIEW_SECTION_ALIASES`` table is the explicit compatibility contract:
+when a synthesis label is absent, resolver reads the producer alias before
+deciding a required section is blank.
+
 Special-case sections
 ---------------------
 - ``selected_directives``: each selected directive URN drives a distinct tactic
   artifact (``how-we-apply-<directive-id>``) for each item in the selection
   list. Handled by ``resolve_sections()`` using a per-item expansion.
-- ``language_scope``: each selected language drives a distinct styleguide
-  artifact (``<lang>-style-guide``). Handled by per-item expansion.
+- ``language_scope``: each selected or declared language drives a distinct
+  styleguide artifact (``<lang>-style-guide``). Handled by per-item expansion.
 
 These expansions are intentionally kept inside ``resolve_sections()`` rather
 than inside the table so the table remains declarative and inspectable.
@@ -37,6 +45,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Literal
+
+from charter.language_scope import extract_declared_languages
 
 __all__ = [
     "resolve_sections",
@@ -123,6 +133,23 @@ INTERVIEW_MAPPINGS: tuple[InterviewSectionMapping, ...] = (
     ),
 )
 
+# Real interview producer keys that feed legacy synthesis section labels.
+_INTERVIEW_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
+    "testing_philosophy": ("testing_requirements",),
+    "risk_appetite": ("risk_boundaries",),
+    "language_scope": ("languages_frameworks",),
+}
+
+# Gated sections without a direct producer key. These remain accepted for
+# legacy/synthetic synthesis snapshots and are documented so contract tests do
+# not silently bless missing real interview data.
+_SYNTHETIC_SECTIONS: dict[str, str] = {
+    "neutrality_posture": (
+        "Legacy synthesis topic with no current CharterInterview producer key; "
+        "accepted only when callers provide it explicitly."
+    ),
+}
+
 # Interview sections that receive special per-item expansion in resolve_sections().
 # These are NOT rows in INTERVIEW_MAPPINGS because each item in the list drives
 # a distinct artifact, not a single fixed artifact per section.
@@ -139,15 +166,28 @@ _EXPANDED_SECTIONS: frozenset[str] = frozenset(
 # ---------------------------------------------------------------------------
 
 
-def _section_answer(snapshot: dict[str, Any], section_label: str) -> str:
-    """Extract a scalar answer string from the interview snapshot.
+def _section_answer_with_source(
+    snapshot: dict[str, Any],
+    section_label: str,
+) -> tuple[str, str]:
+    """Extract a scalar answer string and the key it came from.
 
-    Returns an empty string when the section is absent or not a string.
+    Returns ("", section_label) when the section and aliases are absent or not
+    strings. The canonical section takes precedence over aliases.
     """
-    value = snapshot.get(section_label, "")
-    if isinstance(value, str):
-        return value.strip()
-    return ""
+    for key in (section_label, *_INTERVIEW_SECTION_ALIASES.get(section_label, ())):
+        value = snapshot.get(key, "")
+        if isinstance(value, str):
+            answer = value.strip()
+            if answer:
+                return answer, key
+    return "", section_label
+
+
+def _section_answer(snapshot: dict[str, Any], section_label: str) -> str:
+    """Extract a scalar answer string from the interview snapshot."""
+    answer, _source_key = _section_answer_with_source(snapshot, section_label)
+    return answer
 
 
 def _section_is_nonempty(snapshot: dict[str, Any], section_label: str) -> bool:
@@ -162,7 +202,7 @@ def _append_table_driven_results(
     """Append the standard fixed-cardinality section mappings."""
     for mapping in INTERVIEW_MAPPINGS:
         label = mapping.section_label
-        answer = _section_answer(interview_snapshot, label)
+        answer, source_key = _section_answer_with_source(interview_snapshot, label)
 
         if mapping.requires_nonempty and not answer:
             continue
@@ -174,6 +214,7 @@ def _append_table_driven_results(
                     "answer": answer,
                     "kinds": list(mapping.kinds),
                     "source_section": label,
+                    "answer_source": source_key,
                 },
             )
         )
@@ -220,7 +261,18 @@ def _append_language_scope_results(
     interview_snapshot: dict[str, Any],
 ) -> None:
     """Append one styleguide entry per declared language."""
-    for language in _iter_clean_strings(interview_snapshot.get("language_scope", [])):
+    source_key = "language_scope"
+    languages = _iter_clean_strings(interview_snapshot.get("language_scope", []))
+    if not languages:
+        raw_alias = interview_snapshot.get("languages_frameworks", "")
+        source_key = "languages_frameworks"
+        languages = (
+            tuple(extract_declared_languages(raw_alias))
+            if isinstance(raw_alias, str)
+            else _iter_clean_strings(raw_alias)
+        )
+
+    for language in languages:
         normalized_language = language.lower()
         results.append(
             (
@@ -229,6 +281,7 @@ def _append_language_scope_results(
                     "answer": normalized_language,
                     "kinds": ["styleguide"],
                     "source_section": "language_scope",
+                    "answer_source": source_key,
                     "language": normalized_language,
                 },
             )

--- a/src/charter/synthesizer/interview_mapping.py
+++ b/src/charter/synthesizer/interview_mapping.py
@@ -143,6 +143,16 @@ _INTERVIEW_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "language_scope": ("languages_frameworks",),
 }
 
+_MISSION_IDENTIFIER_ANSWERS: frozenset[str] = frozenset(
+    {
+        "documentation",
+        "plan",
+        "research",
+        "software_dev",
+        "software-dev",
+    }
+)
+
 # Gated sections without a direct producer key. These remain accepted for
 # legacy/synthetic synthesis snapshots and are documented so contract tests do
 # not silently bless missing real interview data.
@@ -229,7 +239,15 @@ def _section_answer_with_source(
     Returns ("", section_label) when the section and aliases are absent or not
     strings. The canonical section takes precedence over aliases.
     """
-    for key in (section_label, *_INTERVIEW_SECTION_ALIASES.get(section_label, ())):
+    keys = (section_label, *_INTERVIEW_SECTION_ALIASES.get(section_label, ()))
+    if section_label == "mission_type":
+        canonical = snapshot.get(section_label, "")
+        if isinstance(canonical, str):
+            normalized_canonical = _normalize_section_selector(canonical)
+            if normalized_canonical in _MISSION_IDENTIFIER_ANSWERS:
+                keys = (*_INTERVIEW_SECTION_ALIASES.get(section_label, ()), section_label)
+
+    for key in keys:
         value = snapshot.get(key, "")
         if isinstance(value, str):
             answer = value.strip()

--- a/src/charter/synthesizer/interview_mapping.py
+++ b/src/charter/synthesizer/interview_mapping.py
@@ -49,6 +49,8 @@ from typing import Any, Literal
 from charter.language_scope import extract_declared_languages
 
 __all__ = [
+    "canonicalize_interview_section_label",
+    "normalize_interview_snapshot",
     "resolve_sections",
 ]
 
@@ -135,6 +137,7 @@ INTERVIEW_MAPPINGS: tuple[InterviewSectionMapping, ...] = (
 
 # Real interview producer keys that feed legacy synthesis section labels.
 _INTERVIEW_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
+    "mission_type": ("project_intent",),
     "testing_philosophy": ("testing_requirements",),
     "risk_appetite": ("risk_boundaries",),
     "language_scope": ("languages_frameworks",),
@@ -148,6 +151,12 @@ _SYNTHETIC_SECTIONS: dict[str, str] = {
         "Legacy synthesis topic with no current CharterInterview producer key; "
         "accepted only when callers provide it explicitly."
     ),
+}
+
+_ALIAS_TO_SECTION: dict[str, str] = {
+    alias: section
+    for section, aliases in _INTERVIEW_SECTION_ALIASES.items()
+    for alias in aliases
 }
 
 # Interview sections that receive special per-item expansion in resolve_sections().
@@ -164,6 +173,51 @@ _EXPANDED_SECTIONS: frozenset[str] = frozenset(
 # ---------------------------------------------------------------------------
 # Resolution helpers
 # ---------------------------------------------------------------------------
+
+
+def _normalize_section_selector(label: str) -> str:
+    return label.strip().replace("-", "_").replace(" ", "_")
+
+
+def canonicalize_interview_section_label(label: str) -> str:
+    """Return the legacy synthesis section label for a producer/alias key."""
+    normalized = _normalize_section_selector(label)
+    return _ALIAS_TO_SECTION.get(normalized, normalized)
+
+
+def normalize_interview_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Return a synthesis-canonical interview snapshot.
+
+    Real ``CharterInterview.answers`` producer keys are copied into the legacy
+    synthesis section labels before target resolution, adapter dispatch, and
+    provenance hashing. Non-alias keys remain untouched.
+    """
+    normalized = dict(snapshot)
+
+    for section_label, aliases in _INTERVIEW_SECTION_ALIASES.items():
+        if section_label == "language_scope":
+            continue
+        answer, source_key = _section_answer_with_source(normalized, section_label)
+        if answer and source_key != section_label:
+            normalized[section_label] = answer
+        if answer:
+            for alias in aliases:
+                normalized.pop(alias, None)
+
+    languages = _iter_clean_strings(normalized.get("language_scope", []))
+    if not languages and "languages_frameworks" in normalized:
+        raw_alias = normalized["languages_frameworks"]
+        languages = (
+            tuple(extract_declared_languages(raw_alias))
+            if isinstance(raw_alias, str)
+            else _iter_clean_strings(raw_alias)
+        )
+        if languages:
+            normalized["language_scope"] = list(languages)
+    if languages:
+        normalized.pop("languages_frameworks", None)
+
+    return normalized
 
 
 def _section_answer_with_source(

--- a/src/charter/synthesizer/orchestrator.py
+++ b/src/charter/synthesizer/orchestrator.py
@@ -130,6 +130,7 @@ def synthesize(
         from doctrine.drg.models import DRGGraph as _DRGGraph  # noqa: PLC0415
         from importlib.metadata import version as _pkg_version  # noqa: PLC0415
         _SPEC_KITTY_VERSION = _pkg_version("spec-kitty-cli")
+        from .interview_mapping import normalize_interview_snapshot as _normalize_interview_snapshot  # noqa: PLC0415
         from .interview_mapping import resolve_sections as _resolve_sections  # noqa: PLC0415
         from .project_drg import apply_post_condition as _apply_post_condition  # noqa: PLC0415
         from .project_drg import emit_project_layer as _emit_project_layer  # noqa: PLC0415
@@ -151,9 +152,10 @@ def synthesize(
     results = _run_all(request, adapter=adapter)
 
     built_in_drg = _DRGGraph.model_validate(_built_in_drg_from_snapshot(request.drg_snapshot))
-    sections = _resolve_sections(dict(request.interview_snapshot))
+    interview_snapshot = _normalize_interview_snapshot(dict(request.interview_snapshot))
+    sections = _resolve_sections(interview_snapshot)
     targets = _build_targets(
-        interview_snapshot=dict(request.interview_snapshot),
+        interview_snapshot=interview_snapshot,
         mappings=sections,
         drg_snapshot=dict(request.drg_snapshot),
     )

--- a/src/charter/synthesizer/synthesize_pipeline.py
+++ b/src/charter/synthesizer/synthesize_pipeline.py
@@ -45,7 +45,7 @@ from ruamel.yaml import YAML
 
 from .adapter import AdapterOutput, SynthesisAdapter
 from .errors import SynthesisSchemaError
-from .interview_mapping import resolve_sections
+from .interview_mapping import normalize_interview_snapshot, resolve_sections
 from .orchestrator import SynthesisResult
 from .request import SynthesisRequest, SynthesisTarget, compute_inputs_hash, _evidence_to_jsonable
 from .targets import build_targets, detect_duplicates, order_targets
@@ -365,12 +365,13 @@ def run(
             "Pass a FixtureAdapter instance explicitly."
         )
 
-    # Stage 1: resolve sections from the interview snapshot
-    sections = resolve_sections(dict(request.interview_snapshot))
+    # Stage 1: resolve sections from the synthesis-canonical interview snapshot
+    interview_snapshot = normalize_interview_snapshot(dict(request.interview_snapshot))
+    sections = resolve_sections(interview_snapshot)
 
     # Stage 2: build targets (validates source URNs against drg_snapshot)
     all_targets = build_targets(
-        interview_snapshot=dict(request.interview_snapshot),
+        interview_snapshot=interview_snapshot,
         mappings=sections,
         drg_snapshot=dict(request.drg_snapshot),
     )
@@ -391,7 +392,7 @@ def run(
         per_target_requests.append(
             SynthesisRequest(
                 target=target,
-                interview_snapshot=request.interview_snapshot,
+                interview_snapshot=interview_snapshot,
                 doctrine_snapshot=request.doctrine_snapshot,
                 drg_snapshot=request.drg_snapshot,
                 run_id=request.run_id,
@@ -514,9 +515,10 @@ def run_all(
             "Production adapter wiring is not yet implemented (WP05)."
         )
 
-    sections = resolve_sections(dict(request.interview_snapshot))
+    interview_snapshot = normalize_interview_snapshot(dict(request.interview_snapshot))
+    sections = resolve_sections(interview_snapshot)
     all_targets = build_targets(
-        interview_snapshot=dict(request.interview_snapshot),
+        interview_snapshot=interview_snapshot,
         mappings=sections,
         drg_snapshot=dict(request.drg_snapshot),
     )
@@ -529,7 +531,7 @@ def run_all(
     per_target_requests: list[SynthesisRequest] = [
         SynthesisRequest(
             target=t,
-            interview_snapshot=request.interview_snapshot,
+            interview_snapshot=interview_snapshot,
             doctrine_snapshot=request.doctrine_snapshot,
             drg_snapshot=request.drg_snapshot,
             run_id=request.run_id,

--- a/src/charter/synthesizer/topic_resolver.py
+++ b/src/charter/synthesizer/topic_resolver.py
@@ -24,6 +24,7 @@ from typing import Any, Literal
 from collections.abc import Mapping, Sequence
 
 from .errors import TopicSelectorUnresolvedError
+from .interview_mapping import canonicalize_interview_section_label
 from .request import SynthesisTarget
 
 # ---------------------------------------------------------------------------
@@ -171,10 +172,11 @@ def _normalize_interview_section_label(label: str) -> str:
 
     The stored section labels are underscore-delimited (`testing_philosophy`),
     but operators naturally type hyphenated forms (`testing-philosophy`).
-    Normalize both to the canonical underscore form for matching and error
-    suggestions without changing the persisted provenance keys.
+    Normalize both to the canonical underscore form and map real interview
+    producer keys (for example ``testing_requirements``) back to the legacy
+    synthesis section labels stored in provenance.
     """
-    return label.strip().replace("-", "_").replace(" ", "_")
+    return canonicalize_interview_section_label(label)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +268,8 @@ def _resolve_interview_section(
     known interview section set.
     """
     normalized_sections = {
-        _normalize_interview_section_label(section): section for section in interview_sections
+        _normalize_interview_section_label(section): _normalize_interview_section_label(section)
+        for section in interview_sections
     }
     normalized_raw = _normalize_interview_section_label(raw)
     canonical_section = normalized_sections.get(normalized_raw)
@@ -371,7 +374,8 @@ def resolve(
         section_results = _resolve_interview_section(raw, project_artifacts, interview_sections)
         if section_results is not None:
             normalized_sections = {
-                _normalize_interview_section_label(section): section for section in interview_sections
+                _normalize_interview_section_label(section): _normalize_interview_section_label(section)
+                for section in interview_sections
             }
             matched_value = normalized_sections[_normalize_interview_section_label(raw)]
             return ResolvedTopic(

--- a/src/specify_cli/cli/commands/charter/_synthesis.py
+++ b/src/specify_cli/cli/commands/charter/_synthesis.py
@@ -47,7 +47,7 @@ def _build_synthesis_request(
 
     # Build a minimal interview snapshot from the interview data
     interview_snapshot: dict[str, Any] = {
-        "mission_type": interview_data.mission,
+        "mission_id": interview_data.mission,
         "selected_directives": interview_data.selected_directives,
         "selected_paradigms": interview_data.selected_paradigms,
     }

--- a/src/specify_cli/cli/commands/charter/_synthesis.py
+++ b/src/specify_cli/cli/commands/charter/_synthesis.py
@@ -147,7 +147,7 @@ def _build_synthesis_validation_callback(request: Any) -> Any:
     from doctrine.drg.models import DRGGraph
     from importlib.metadata import version as pkg_version
 
-    from charter.synthesizer.interview_mapping import resolve_sections
+    from charter.synthesizer.interview_mapping import normalize_interview_snapshot, resolve_sections
     from charter.synthesizer.orchestrator import _built_in_drg_from_snapshot
     from charter.synthesizer.project_drg import emit_project_layer, persist as persist_project_graph
     from charter.synthesizer.targets import build_targets, detect_duplicates, order_targets
@@ -155,9 +155,10 @@ def _build_synthesis_validation_callback(request: Any) -> Any:
 
     spec_kitty_version = pkg_version("spec-kitty-cli")
     built_in_drg = DRGGraph.model_validate(_built_in_drg_from_snapshot(request.drg_snapshot))
-    sections = resolve_sections(dict(request.interview_snapshot))
+    interview_snapshot = normalize_interview_snapshot(dict(request.interview_snapshot))
+    sections = resolve_sections(interview_snapshot)
     targets = build_targets(
-        interview_snapshot=dict(request.interview_snapshot),
+        interview_snapshot=interview_snapshot,
         mappings=sections,
         drg_snapshot=dict(request.drg_snapshot),
     )

--- a/tests/charter/synthesizer/test_interview_mapping.py
+++ b/tests/charter/synthesizer/test_interview_mapping.py
@@ -445,3 +445,22 @@ class TestNormalizeInterviewSnapshot:
         assert "testing_requirements" not in normalized
         assert "risk_boundaries" not in normalized
         assert "languages_frameworks" not in normalized
+
+    def test_project_intent_wins_over_legacy_mission_identifier_collision(self) -> None:
+        """Production snapshots must not treat workflow mission ids as intent text."""
+        snapshot = {
+            "mission_type": "software-dev",
+            "project_intent": "Build a patient safety workflow assistant",
+            "testing_requirements": "pytest coverage and browser tests",
+            "risk_boundaries": "no credential leaks",
+        }
+
+        normalized = normalize_interview_snapshot(snapshot)
+        contexts = dict(resolve_sections(normalized))
+
+        assert normalized["mission_type"] == "Build a patient safety workflow assistant"
+        assert "project_intent" not in normalized
+        assert contexts["mission_type"]["answer"] == (
+            "Build a patient safety workflow assistant"
+        )
+        assert contexts["mission_type"]["answer_source"] == "mission_type"

--- a/tests/charter/synthesizer/test_interview_mapping.py
+++ b/tests/charter/synthesizer/test_interview_mapping.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import pytest
 
+from charter.interview import QUESTION_ORDER
 from charter.synthesizer.interview_mapping import (
     INTERVIEW_MAPPINGS,
     InterviewSectionMapping,
     _EXPANDED_SECTIONS,
+    _INTERVIEW_SECTION_ALIASES,
+    _SYNTHETIC_SECTIONS,
     resolve_sections,
 )
 
@@ -82,6 +85,24 @@ class TestInterviewMappingsTable:
         for section in expected:
             assert section in present, (
                 f"Expected section '{section}' not in INTERVIEW_MAPPINGS"
+            )
+
+    def test_mapping_rows_have_producer_alias_or_synthetic_reason(self) -> None:
+        """Every gated mapping has a real producer, alias, or documented exception."""
+        producer_keys = set(QUESTION_ORDER)
+        alias_targets = set(_INTERVIEW_SECTION_ALIASES)
+        synthetic_targets = set(_SYNTHETIC_SECTIONS)
+
+        for mapping in INTERVIEW_MAPPINGS:
+            if not mapping.requires_nonempty:
+                continue
+
+            assert (
+                mapping.section_label in producer_keys
+                or mapping.section_label in alias_targets
+                or mapping.section_label in synthetic_targets
+            ), (
+                f"{mapping.section_label} has no interview producer contract"
             )
 
     def test_expanded_sections_not_in_mappings_table(self) -> None:
@@ -303,6 +324,33 @@ class TestResolveSectionsLanguageScope:
         lang_results = [label for label, _ in results if label == "language_scope"]
         assert len(lang_results) == 0
 
+    def test_language_frameworks_emits_language_styleguide_targets(self) -> None:
+        """Real producer key languages_frameworks feeds language_scope expansion."""
+        snapshot = {"languages_frameworks": "Python 3.11, TypeScript, pytest"}
+        results = resolve_sections(snapshot)
+        langs = [
+            ctx["language"]
+            for label, ctx in results
+            if label == "language_scope"
+        ]
+
+        assert langs == ["python", "typescript"]
+
+    def test_language_scope_takes_precedence_over_alias(self) -> None:
+        """Explicit legacy language_scope remains stable if both keys are present."""
+        snapshot = {
+            "language_scope": ["rust"],
+            "languages_frameworks": "Python 3.11",
+        }
+        results = resolve_sections(snapshot)
+        langs = [
+            ctx["language"]
+            for label, ctx in results
+            if label == "language_scope"
+        ]
+
+        assert langs == ["rust"]
+
 
 # ---------------------------------------------------------------------------
 # T009f: Full snapshot round-trip
@@ -337,6 +385,27 @@ class TestResolveFullSnapshot:
         # Expanded sections
         assert "selected_directives" in labels
         assert "language_scope" in labels
+
+    def test_real_interview_answer_keys_emit_intended_sections(self) -> None:
+        """Production-shaped CharterInterview.answers keys are accepted."""
+        snapshot = {
+            "languages_frameworks": "Python 3.11 and TypeScript",
+            "testing_requirements": "pytest coverage and browser tests",
+            "quality_gates": "coverage >= 90%",
+            "review_policy": "two reviewers required",
+            "documentation_policy": "public APIs documented",
+            "risk_boundaries": "no credential leaks",
+        }
+
+        results = resolve_sections(snapshot)
+        labels = [label for label, _ in results]
+
+        assert "testing_philosophy" in labels
+        assert "risk_appetite" in labels
+        assert "quality_gates" in labels
+        assert "review_policy" in labels
+        assert "documentation_policy" in labels
+        assert labels.count("language_scope") == 2
 
     def test_return_type_is_list_of_tuples(self) -> None:
         """resolve_sections() always returns a list of 2-tuples."""

--- a/tests/charter/synthesizer/test_interview_mapping.py
+++ b/tests/charter/synthesizer/test_interview_mapping.py
@@ -20,6 +20,7 @@ from charter.synthesizer.interview_mapping import (
     _EXPANDED_SECTIONS,
     _INTERVIEW_SECTION_ALIASES,
     _SYNTHETIC_SECTIONS,
+    normalize_interview_snapshot,
     resolve_sections,
 )
 
@@ -88,15 +89,12 @@ class TestInterviewMappingsTable:
             )
 
     def test_mapping_rows_have_producer_alias_or_synthetic_reason(self) -> None:
-        """Every gated mapping has a real producer, alias, or documented exception."""
+        """Every mapping has a real producer, alias, or documented exception."""
         producer_keys = set(QUESTION_ORDER)
         alias_targets = set(_INTERVIEW_SECTION_ALIASES)
         synthetic_targets = set(_SYNTHETIC_SECTIONS)
 
         for mapping in INTERVIEW_MAPPINGS:
-            if not mapping.requires_nonempty:
-                continue
-
             assert (
                 mapping.section_label in producer_keys
                 or mapping.section_label in alias_targets
@@ -389,6 +387,7 @@ class TestResolveFullSnapshot:
     def test_real_interview_answer_keys_emit_intended_sections(self) -> None:
         """Production-shaped CharterInterview.answers keys are accepted."""
         snapshot = {
+            "project_intent": "Ship trustworthy agent workflows",
             "languages_frameworks": "Python 3.11 and TypeScript",
             "testing_requirements": "pytest coverage and browser tests",
             "quality_gates": "coverage >= 90%",
@@ -399,7 +398,10 @@ class TestResolveFullSnapshot:
 
         results = resolve_sections(snapshot)
         labels = [label for label, _ in results]
+        contexts = dict(results)
 
+        assert contexts["mission_type"]["answer"] == "Ship trustworthy agent workflows"
+        assert contexts["mission_type"]["answer_source"] == "project_intent"
         assert "testing_philosophy" in labels
         assert "risk_appetite" in labels
         assert "quality_gates" in labels
@@ -420,3 +422,26 @@ class TestResolveFullSnapshot:
         result = resolve_sections({"testing_philosophy": "tdd"})
         for _, ctx in result:
             assert isinstance(ctx, dict)
+
+
+class TestNormalizeInterviewSnapshot:
+    def test_producer_keys_are_canonicalized_for_synthesis_requests(self) -> None:
+        """Pipeline-facing snapshots use legacy synthesis labels, not aliases."""
+        snapshot = {
+            "project_intent": "Ship trustworthy agent workflows",
+            "languages_frameworks": "Python 3.11 and TypeScript",
+            "testing_requirements": "pytest coverage and browser tests",
+            "risk_boundaries": "no credential leaks",
+            "quality_gates": "coverage >= 90%",
+        }
+
+        normalized = normalize_interview_snapshot(snapshot)
+
+        assert normalized["mission_type"] == "Ship trustworthy agent workflows"
+        assert normalized["testing_philosophy"] == "pytest coverage and browser tests"
+        assert normalized["risk_appetite"] == "no credential leaks"
+        assert normalized["language_scope"] == ["python", "typescript"]
+        assert "project_intent" not in normalized
+        assert "testing_requirements" not in normalized
+        assert "risk_boundaries" not in normalized
+        assert "languages_frameworks" not in normalized

--- a/tests/charter/synthesizer/test_request.py
+++ b/tests/charter/synthesizer/test_request.py
@@ -20,6 +20,7 @@ from charter.synthesizer.evidence import (
     CorpusSnapshot,
     EvidenceBundle,
 )
+from charter.synthesizer.interview_mapping import normalize_interview_snapshot
 from charter.synthesizer.request import (
     SynthesisRequest,
     SynthesisTarget,
@@ -258,6 +259,33 @@ def test_run_id_excluded_from_hash() -> None:
     h_b = compute_inputs_hash(request_b, _ADAPTER_ID, _ADAPTER_VERSION)
 
     assert h_a == h_b
+
+
+def test_alias_equivalent_interview_snapshots_hash_identically_after_normalization() -> None:
+    """Producer-key snapshots canonicalize before fixture/provenance hashing."""
+    canonical = {
+        "mission_type": "Ship trustworthy agent workflows",
+        "language_scope": ["python", "typescript"],
+        "testing_philosophy": "pytest coverage and browser tests",
+        "risk_appetite": "no credential leaks",
+    }
+    producer = {
+        "project_intent": "Ship trustworthy agent workflows",
+        "languages_frameworks": "Python 3.11 and TypeScript",
+        "testing_requirements": "pytest coverage and browser tests",
+        "risk_boundaries": "no credential leaks",
+    }
+
+    request_a = _make_base_request(
+        interview_snapshot=normalize_interview_snapshot(canonical)
+    )
+    request_b = _make_base_request(
+        interview_snapshot=normalize_interview_snapshot(producer)
+    )
+
+    assert compute_inputs_hash(request_a, _ADAPTER_ID, _ADAPTER_VERSION) == compute_inputs_hash(
+        request_b, _ADAPTER_ID, _ADAPTER_VERSION
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/charter/synthesizer/test_topic_resolver.py
+++ b/tests/charter/synthesizer/test_topic_resolver.py
@@ -278,6 +278,60 @@ class TestTier3InterviewSection:
         assert "how-we-apply-directive-003" in slugs
         assert "python-testing-style" in slugs
 
+    def test_producer_key_resolves_to_legacy_source_section(
+        self, all_artifacts, merged_drg, tactic_artifact, styleguide_artifact
+    ) -> None:
+        """testing_requirements selects artifacts stored as testing_philosophy."""
+        result = resolve(
+            "testing_requirements",
+            all_artifacts,
+            merged_drg,
+            ["testing_requirements"],
+        )
+
+        assert result.matched_form == "interview_section"
+        assert result.matched_value == "testing_philosophy"
+        assert result.targets == [tactic_artifact, styleguide_artifact]
+
+    def test_legacy_section_resolves_when_interview_sections_are_producer_keys(
+        self, all_artifacts, merged_drg
+    ) -> None:
+        """testing_philosophy remains accepted for production-shaped snapshots."""
+        result = resolve(
+            "testing_philosophy",
+            all_artifacts,
+            merged_drg,
+            ["testing_requirements"],
+        )
+
+        assert result.matched_form == "interview_section"
+        assert result.matched_value == "testing_philosophy"
+        slugs = {target.slug for target in result.targets}
+        assert slugs == {"how-we-apply-directive-003", "python-testing-style"}
+
+    def test_language_frameworks_resolves_to_language_scope_artifacts(
+        self, all_artifacts, merged_drg
+    ) -> None:
+        """languages_frameworks selects artifacts stored as language_scope."""
+        language_artifact = SynthesisTarget(
+            kind="styleguide",
+            slug="python-style-guide",
+            title="Python Style Guide",
+            artifact_id="python-style-guide",
+            source_section="language_scope",
+        )
+
+        result = resolve(
+            "languages_frameworks",
+            [*all_artifacts, language_artifact],
+            merged_drg,
+            ["languages_frameworks"],
+        )
+
+        assert result.matched_form == "interview_section"
+        assert result.matched_value == "language_scope"
+        assert result.targets == [language_artifact]
+
     def test_section_hit_with_no_artifacts(
         self, all_artifacts, merged_drg, interview_sections
     ) -> None:

--- a/tests/doctrine/drg/migration/test_extractor.py
+++ b/tests/doctrine/drg/migration/test_extractor.py
@@ -24,6 +24,7 @@ from doctrine.drg.migration.extractor import (
     generate_graph,
 )
 from doctrine.drg.models import NodeKind, Relation
+from doctrine.drg.query import resolve_context
 from doctrine.drg.validator import validate_graph
 
 # Path to the shipped doctrine root inside the repo.
@@ -444,6 +445,37 @@ class TestGenerateGraph:
         assert tasks < implement, f"|tasks| ({tasks}) should be < |implement| ({implement})"
         assert review >= 0.80 * implement, (
             f"|review| ({review}) should be >= 80% of |implement| ({implement})"
+        )
+
+    def test_resolved_surface_inequalities(self, tmp_path: Path) -> None:
+        """Generated graph must satisfy shipped resolved-context calibration."""
+        output = tmp_path / "graph.yaml"
+        graph = generate_graph(DOCTRINE_ROOT, output)
+
+        def _resolved(action: str) -> int:
+            return len(
+                resolve_context(
+                    graph,
+                    f"action:software-dev/{action}",
+                    depth=2,
+                ).artifact_urns
+            )
+
+        specify = _resolved("specify")
+        plan = _resolved("plan")
+        tasks = _resolved("tasks")
+        implement = _resolved("implement")
+        review = _resolved("review")
+
+        assert specify < plan, f"resolved specify ({specify}) should be < plan ({plan})"
+        assert plan < implement, (
+            f"resolved plan ({plan}) should be < implement ({implement})"
+        )
+        assert tasks < implement, (
+            f"resolved tasks ({tasks}) should be < implement ({implement})"
+        )
+        assert review >= 0.80 * implement, (
+            f"resolved review ({review}) should be >= 80% of implement ({implement})"
         )
 
     def test_discovers_styleguide_nodes(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add explicit alias mapping from real CharterInterview answer keys to legacy synthesis section labels
- route languages_frameworks through language extraction for language_scope target expansion
- document neutrality_posture as legacy/synthetic-only and add contract coverage

Fixes #1416

## Tests
- .venv/bin/ruff check src/charter/synthesizer/interview_mapping.py tests/charter/synthesizer/test_interview_mapping.py
- .venv/bin/pytest tests/charter/synthesizer -q
- .venv/bin/pytest tests/charter/test_language_scope.py tests/charter/test_phase3_integration.py tests/agent/cli/commands/test_charter_synthesize_cli.py tests/agent/cli/commands/test_charter_resynthesize_cli.py -q