### PR TITLE
Fail closed on bulk-edit diff git errors

### DIFF
--- a/src/specify_cli/bulk_edit/gate.py
+++ b/src/specify_cli/bulk_edit/gate.py
@@ -36,6 +36,16 @@ class GateResult:
     warnings: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class GitDiffFilesResult:
+    """Outcome of resolving the review-time file diff."""
+
+    ok: bool
+    files: list[str] = field(default_factory=list)
+    stderr: str = ""
+    returncode: int | None = None
+
+
 def ensure_occurrence_classification_ready(feature_dir: Path) -> GateResult:
     """Check if a bulk_edit mission has a valid occurrence map.
 
@@ -106,14 +116,43 @@ def _git_diff_files(
     repo_root: Path,
     base_ref: str,
     head_ref: str,
-) -> list[str]:
+) -> GitDiffFilesResult:
     """Return the list of files changed between *base_ref* and *head_ref*.
 
     Uses ``git diff --name-only <base>..<head>`` and returns one path per
-    line, relative to *repo_root*. Returns an empty list on any git failure;
-    the caller is responsible for deciding whether an empty diff is
-    acceptable.
+    line, relative to *repo_root*. Git failures are returned explicitly so
+    callers can fail closed instead of confusing them with valid empty diffs.
     """
+    for label, ref in (("base_ref", base_ref), ("head_ref", head_ref)):
+        if not ref.strip():
+            return GitDiffFilesResult(
+                ok=False,
+                stderr=f"{label} is empty",
+                returncode=None,
+            )
+        try:
+            verified = subprocess.run(
+                ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+                cwd=str(repo_root),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+        except (subprocess.SubprocessError, OSError) as exc:
+            return GitDiffFilesResult(
+                ok=False,
+                stderr=f"failed to verify {label} {ref!r}: {exc}",
+                returncode=None,
+            )
+        if verified.returncode != 0:
+            stderr = verified.stderr.strip() or f"{label} {ref!r} could not be resolved"
+            return GitDiffFilesResult(
+                ok=False,
+                stderr=stderr,
+                returncode=verified.returncode,
+            )
+
     try:
         completed = subprocess.run(
             ["git", "diff", "--name-only", f"{base_ref}..{head_ref}"],
@@ -123,11 +162,24 @@ def _git_diff_files(
             check=False,
             timeout=30,
         )
-    except (subprocess.SubprocessError, OSError):
-        return []
+    except (subprocess.SubprocessError, OSError) as exc:
+        return GitDiffFilesResult(
+            ok=False,
+            stderr=str(exc),
+            returncode=None,
+        )
     if completed.returncode != 0:
-        return []
-    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+        return GitDiffFilesResult(
+            ok=False,
+            stderr=completed.stderr.strip(),
+            returncode=completed.returncode,
+        )
+    return GitDiffFilesResult(
+        ok=True,
+        files=[line.strip() for line in completed.stdout.splitlines() if line.strip()],
+        stderr=completed.stderr.strip(),
+        returncode=completed.returncode,
+    )
 
 
 def check_review_diff_compliance(
@@ -164,8 +216,19 @@ def check_review_diff_compliance(
             ],
         )
 
-    changed_files = _git_diff_files(repo_root, base_ref, head_ref)
-    return check_diff_compliance(changed_files, omap)
+    diff_files = _git_diff_files(repo_root, base_ref, head_ref)
+    if not diff_files.ok:
+        details = [
+            "Review diff check cannot run: git diff failed.",
+            f"base_ref={base_ref!r}",
+            f"head_ref={head_ref!r}",
+            f"returncode={diff_files.returncode!r}",
+        ]
+        if diff_files.stderr:
+            details.append(f"stderr={diff_files.stderr}")
+        return DiffCheckResult(passed=False, errors=["; ".join(details)])
+
+    return check_diff_compliance(diff_files.files, omap)
 
 
 def render_diff_check_failure(

--- a/tests/specify_cli/bulk_edit/test_gate.py
+++ b/tests/specify_cli/bulk_edit/test_gate.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from specify_cli.bulk_edit.gate import GateResult, ensure_occurrence_classification_ready
+from specify_cli.bulk_edit.gate import (
+    GateResult,
+    check_review_diff_compliance,
+    ensure_occurrence_classification_ready,
+)
 
 
 pytestmark = [pytest.mark.unit]
+
 
 def _write_meta(feature_dir: Path, meta: dict) -> None:
     """Helper to write a meta.json file."""
@@ -143,3 +149,172 @@ class TestGatePassesBulkEditValidMap:
         assert result.passed is True
         assert result.change_mode == "bulk_edit"
         assert result.errors == []
+
+
+REVIEW_DIFF_OCCURRENCE_MAP = """\
+target:
+  term: oldName
+  operation: rename
+categories:
+  code_symbols:
+    action: rename
+  import_paths:
+    action: rename
+  filesystem_paths:
+    action: rename
+  serialized_keys:
+    action: do_not_change
+  cli_commands:
+    action: rename
+  user_facing_strings:
+    action: rename
+  tests_fixtures:
+    action: rename
+  logs_telemetry:
+    action: rename
+"""
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", message)
+    return _run_git(repo, "rev-parse", "HEAD")
+
+
+def _make_review_feature_dir(tmp_path: Path) -> Path:
+    feature_dir = tmp_path / "feature"
+    feature_dir.mkdir()
+    _write_meta(feature_dir, {"change_mode": "bulk_edit"})
+    _write_occurrence_map(feature_dir, REVIEW_DIFF_OCCURRENCE_MAP)
+    return feature_dir
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test User")
+    return repo
+
+
+def test_review_diff_compliance_bad_base_ref_fails_closed(tmp_path: Path) -> None:
+    feature_dir = _make_review_feature_dir(tmp_path)
+    repo = _make_repo(tmp_path)
+    (repo / "config.yaml").write_text("oldName: true\n", encoding="utf-8")
+    _commit(repo, "initial")
+
+    result = check_review_diff_compliance(
+        feature_dir=feature_dir,
+        repo_root=repo,
+        base_ref="does-not-exist",
+        head_ref="HEAD",
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert result.assessments == []
+    assert any("git diff failed" in error for error in result.errors)
+    assert any("base_ref='does-not-exist'" in error for error in result.errors)
+
+
+def test_review_diff_compliance_git_failure_includes_stderr(tmp_path: Path) -> None:
+    feature_dir = _make_review_feature_dir(tmp_path)
+    repo = _make_repo(tmp_path)
+    (repo / "config.yaml").write_text("oldName: true\n", encoding="utf-8")
+    _commit(repo, "initial")
+
+    result = check_review_diff_compliance(
+        feature_dir=feature_dir,
+        repo_root=repo,
+        base_ref="does-not-exist",
+        head_ref="HEAD",
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert any("returncode=128" in error for error in result.errors)
+    assert any("does-not-exist" in error for error in result.errors)
+
+
+@pytest.mark.parametrize(
+    "base_ref,head_ref,missing_ref",
+    [
+        ("", "HEAD", "base_ref"),
+        ("HEAD", "", "head_ref"),
+    ],
+)
+def test_review_diff_compliance_empty_ref_fails_closed(
+    tmp_path: Path,
+    base_ref: str,
+    head_ref: str,
+    missing_ref: str,
+) -> None:
+    feature_dir = _make_review_feature_dir(tmp_path)
+    repo = _make_repo(tmp_path)
+    (repo / "config.yaml").write_text("oldName: true\n", encoding="utf-8")
+    _commit(repo, "initial")
+
+    result = check_review_diff_compliance(
+        feature_dir=feature_dir,
+        repo_root=repo,
+        base_ref=base_ref,
+        head_ref=head_ref,
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert result.assessments == []
+    assert any(f"{missing_ref} is empty" in error for error in result.errors)
+
+
+def test_review_diff_compliance_valid_empty_diff_can_pass(tmp_path: Path) -> None:
+    feature_dir = _make_review_feature_dir(tmp_path)
+    repo = _make_repo(tmp_path)
+    (repo / "config.yaml").write_text("oldName: true\n", encoding="utf-8")
+    head = _commit(repo, "initial")
+
+    result = check_review_diff_compliance(
+        feature_dir=feature_dir,
+        repo_root=repo,
+        base_ref=head,
+        head_ref=head,
+    )
+
+    assert result is not None
+    assert result.passed is True
+    assert result.assessments == []
+    assert result.errors == []
+
+
+def test_review_diff_compliance_valid_violation_still_blocks(tmp_path: Path) -> None:
+    feature_dir = _make_review_feature_dir(tmp_path)
+    repo = _make_repo(tmp_path)
+    config = repo / "config.yaml"
+    config.write_text("oldName: true\n", encoding="utf-8")
+    base = _commit(repo, "initial")
+    config.write_text("oldName: false\n", encoding="utf-8")
+    _commit(repo, "change config")
+
+    result = check_review_diff_compliance(
+        feature_dir=feature_dir,
+        repo_root=repo,
+        base_ref=base,
+        head_ref="HEAD",
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert any(a.path == "config.yaml" and a.violation for a in result.assessments)
+    assert any("do_not_change" in error for error in result.errors)


### PR DESCRIPTION
## Summary
- Return a structured git diff result from the bulk-edit review gate so git failures are distinguishable from valid empty diffs.
- Verify non-empty `base_ref` and `head_ref` with `git rev-parse --verify <ref>^{commit}` before diffing.
- Fail review-time diff compliance closed when ref verification or `git diff` fails, including base/head refs, return code, and stderr in the error.
- Add regression coverage for invalid base refs, empty refs, stderr reporting, valid empty diffs, and valid forbidden-file violations.

Fixes #1421

## Verification
- `.venv/bin/pytest tests/specify_cli/bulk_edit/test_gate.py tests/specify_cli/bulk_edit/test_diff_check.py`
- `.venv/bin/pytest tests/specify_cli/bulk_edit tests/specify_cli/mission_v1/test_guards_bulk_edit.py`
- `.venv/bin/ruff check src/specify_cli/bulk_edit/gate.py tests/specify_cli/bulk_edit/test_gate.py tests/specify_cli/bulk_edit/test_diff_check.py`
- `.venv/bin/mypy src/specify_cli/bulk_edit/gate.py`
- `git diff --check`
- Manual edge repro: invalid, empty base, and empty head refs all return `ok=False`