### PR TITLE
Fix post-merge issue-matrix violations failing review

### DIFF
--- a/src/specify_cli/cli/commands/review/_report.py
+++ b/src/specify_cli/cli/commands/review/_report.py
@@ -16,6 +16,16 @@ from rich.console import Console
 
 from specify_cli.cli.commands.review._ble001_audit import _BLE001_REMEDIATION
 
+_HARD_FAILURE_FINDING_TYPES = frozenset(
+    {
+        "wp_not_done",
+        "rejected_review_artifact",
+        "ble001_suppression",
+        "issue_matrix_violation",
+        "dead_code_baseline_missing",
+    }
+)
+
 
 @dataclass(frozen=True)
 class GateRecord:
@@ -26,6 +36,50 @@ class GateRecord:
     command: str
     exit_code: int
     result: Literal["pass", "fail", "skip"]
+
+
+def _format_finding_line(finding: dict[str, str]) -> str | None:
+    finding_type = finding["type"]
+    if finding_type == "wp_not_done":
+        return (
+            f"- **wp_not_done** `{finding['wp_id']}`: "
+            f"lane is `{finding.get('lane', 'unknown')}`"
+        )
+    if finding_type == "dead_code":
+        return (
+            f"- **dead_code** `{finding['file']}` — `{finding['symbol']}`: "
+            "no non-test callers found"
+        )
+    if finding_type == "dead_code_baseline_missing":
+        return (
+            f"- **dead_code_baseline_missing** "
+            f"`{finding.get('diagnostic_code', 'unknown')}`: "
+            f"{finding.get('remediation', 'unknown')}"
+        )
+    if finding_type == "ble001_suppression":
+        return (
+            f"- **ble001_suppression** `{finding['file']}:{finding['line']}`: "
+            f"`{finding.get('content', 'unknown')}`; "
+            f"remediation=`{finding.get('remediation', _BLE001_REMEDIATION)}`"
+        )
+    if finding_type == "rejected_review_artifact":
+        return (
+            f"- **rejected_review_artifact** `{finding['wp_id']}`: lane is "
+            f"`{finding.get('lane', 'unknown')}`, latest artifact is "
+            f"`{finding.get('artifact_path', 'unknown')}`; "
+            f"diagnostic_code=`{finding.get('diagnostic_code', 'unknown')}`, "
+            "branch_or_work_package="
+            f"`{finding.get('branch_or_work_package', 'unknown')}`, "
+            f"violated_invariant=`{finding.get('violated_invariant', 'unknown')}`, "
+            f"remediation=`{finding.get('remediation', 'unknown')}`"
+        )
+    if finding_type == "issue_matrix_violation":
+        return (
+            f"- **issue_matrix_violation** "
+            f"`{finding.get('diagnostic_code', 'unknown')}`: "
+            f"{finding.get('message', 'unknown')}"
+        )
+    return None
 
 
 def write_review_report(
@@ -53,10 +107,7 @@ def write_review_report(
     import typer
 
     hard_failure_count = sum(
-        1
-        for f in findings
-        if f["type"]
-        in {"wp_not_done", "rejected_review_artifact", "ble001_suppression"}
+        1 for f in findings if f["type"] in _HARD_FAILURE_FINDING_TYPES
     )
     if hard_failure_count > 0:
         verdict = "fail"
@@ -96,30 +147,9 @@ def write_review_report(
         report_lines.append("## Findings")
         report_lines.append("")
         for f in findings:
-            if f["type"] == "wp_not_done":
-                report_lines.append(
-                    f"- **wp_not_done** `{f['wp_id']}`: lane is `{f.get('lane', 'unknown')}`"
-                )
-            elif f["type"] == "dead_code":
-                report_lines.append(
-                    f"- **dead_code** `{f['file']}` — `{f['symbol']}`: no non-test callers found"
-                )
-            elif f["type"] == "ble001_suppression":
-                report_lines.append(
-                    f"- **ble001_suppression** `{f['file']}:{f['line']}`: "
-                    f"`{f.get('content', 'unknown')}`; "
-                    f"remediation=`{f.get('remediation', _BLE001_REMEDIATION)}`"
-                )
-            elif f["type"] == "rejected_review_artifact":
-                report_lines.append(
-                    f"- **rejected_review_artifact** `{f['wp_id']}`: lane is "
-                    f"`{f.get('lane', 'unknown')}`, latest artifact is "
-                    f"`{f.get('artifact_path', 'unknown')}`; "
-                    f"diagnostic_code=`{f.get('diagnostic_code', 'unknown')}`, "
-                    f"branch_or_work_package=`{f.get('branch_or_work_package', 'unknown')}`, "
-                    f"violated_invariant=`{f.get('violated_invariant', 'unknown')}`, "
-                    f"remediation=`{f.get('remediation', 'unknown')}`"
-                )
+            finding_line = _format_finding_line(f)
+            if finding_line is not None:
+                report_lines.append(finding_line)
     else:
         report_lines.append("No findings.")
 

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -185,6 +185,7 @@ def test_review_report_frontmatter_structure(tmp_path: Path, monkeypatch: pytest
     repo_root, feature_dir = _setup_fixture(
         tmp_path,
         {"WP01": "done"},
+        baseline_merge_commit="0000000000000000000000000000000000000000",
     )
 
     monkeypatch.chdir(repo_root)
@@ -200,7 +201,7 @@ def test_review_report_frontmatter_structure(tmp_path: Path, monkeypatch: pytest
 
     app = _build_cli_app()
     runner = CliRunner()
-    result = runner.invoke(app, ["--mission", _MISSION_SLUG])
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "lightweight"])
 
     assert result.exit_code == 0, result.output
 
@@ -280,12 +281,175 @@ def test_review_post_merge_requires_issue_matrix(
     runner = CliRunner()
     result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "post-merge"])
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
 
     report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
-    assert "verdict: pass_with_notes" in report_text
+    assert "verdict: fail" in report_text
     assert "ISSUE_MATRIX_MISSING" in result.output
     assert "issue_matrix_present: false" in report_text
+
+
+def test_review_post_merge_invalid_issue_matrix_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-merge mode must fail when issue-matrix.md validator diagnostics fire."""
+    repo_root, feature_dir = _setup_fixture(
+        tmp_path,
+        {"WP01": "done"},
+        baseline_merge_commit="0000000000000000000000000000000000000000",
+    )
+    (feature_dir / "issue-matrix.md").write_text(
+        "\n".join(
+            [
+                "# Issue Matrix",
+                "",
+                "| issue | verdict | evidence_ref |",
+                "|-------|---------|--------------|",
+                "| #123 | deferred | commit abc123 |",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.assert_pytest_available",
+        lambda _: None,
+    )
+    _mock_resolved = _make_mock_resolved(feature_dir)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.resolve_mission_handle",
+        lambda handle, repo_root: _mock_resolved,
+    )
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "post-merge"])
+
+    assert result.exit_code == 1, result.output
+
+    report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
+    assert "verdict: fail" in report_text
+    assert "ISSUE_MATRIX_VERDICT_UNKNOWN" in result.output
+    assert "ISSUE_MATRIX_VERDICT_UNKNOWN" in report_text
+    assert "issue_matrix_present: true" in report_text
+
+
+def test_issue_matrix_violation_is_hard_failure(tmp_path: Path) -> None:
+    """Report writer must fail-hard on issue-matrix violations."""
+    import io
+
+    import typer
+    from rich.console import Console
+
+    from specify_cli.cli.commands.review._report import write_review_report
+
+    repo_root = tmp_path / "repo"
+    feature_dir = repo_root / "kitty-specs" / _MISSION_SLUG
+    feature_dir.mkdir(parents=True)
+
+    findings = [
+        {
+            "type": "issue_matrix_violation",
+            "diagnostic_code": "MISSION_REVIEW_ISSUE_MATRIX_MISSING",
+            "message": "issue-matrix.md is required in post-merge mode",
+        }
+    ]
+
+    with pytest.raises(typer.Exit) as exc_info:
+        write_review_report(
+            feature_dir,
+            repo_root,
+            findings,
+            Console(file=io.StringIO()),
+            mode="post-merge",
+            issue_matrix_present=False,
+        )
+
+    assert exc_info.value.exit_code == 1
+    report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
+    assert "verdict: fail" in report_text
+    assert "MISSION_REVIEW_ISSUE_MATRIX_MISSING" in report_text
+
+
+def test_review_lightweight_modern_missing_baseline_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Modern lightweight review must fail when baseline_merge_commit is missing."""
+    repo_root, feature_dir = _setup_fixture(
+        tmp_path,
+        {"WP01": "done"},
+    )
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.assert_pytest_available",
+        lambda _: None,
+    )
+    _mock_resolved = _make_mock_resolved(feature_dir)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.resolve_mission_handle",
+        lambda handle, repo_root: _mock_resolved,
+    )
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "lightweight"])
+
+    assert result.exit_code == 1, result.output
+
+    report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
+    assert "verdict: fail" in report_text
+    assert "LIGHTWEIGHT_REVIEW_MISSING_BASELINE" in result.output
+    assert "LIGHTWEIGHT_REVIEW_MISSING_BASELINE" in report_text
+    assert "issue_matrix_present: not_applicable" in report_text
+
+
+def test_dead_code_baseline_missing_is_hard_failure(tmp_path: Path) -> None:
+    """Report writer must fail-hard on missing dead-code baselines."""
+    import io
+
+    import typer
+    from rich.console import Console
+
+    from specify_cli.cli.commands.review._report import write_review_report
+
+    repo_root = tmp_path / "repo"
+    feature_dir = repo_root / "kitty-specs" / _MISSION_SLUG
+    feature_dir.mkdir(parents=True)
+
+    findings = [
+        {
+            "type": "dead_code_baseline_missing",
+            "diagnostic_code": "LIGHTWEIGHT_REVIEW_MISSING_BASELINE",
+            "remediation": "Run `spec-kitty merge` to bake baseline_merge_commit into meta.json.",
+        }
+    ]
+
+    with pytest.raises(typer.Exit) as exc_info:
+        write_review_report(
+            feature_dir,
+            repo_root,
+            findings,
+            Console(file=io.StringIO()),
+            mode="lightweight",
+        )
+
+    assert exc_info.value.exit_code == 1
+    report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
+    assert "verdict: fail" in report_text
+    assert "LIGHTWEIGHT_REVIEW_MISSING_BASELINE" in report_text
 
 
 def test_review_emits_json_diagnostic_when_pytest_missing(
@@ -918,7 +1082,7 @@ def test_review_passes_with_notes_when_dead_code_scan_finds_symbol(
 
     app = _build_cli_app()
     runner = CliRunner()
-    result = runner.invoke(app, ["--mission", _MISSION_SLUG])
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "lightweight"])
 
     assert result.exit_code == 0, result.output
     report_path = feature_dir / "mission-review-report.md"


### PR DESCRIPTION
## Summary

- classify `issue_matrix_violation` findings as hard review failures
- classify the existing `dead_code_baseline_missing` fail-hard finding as a hard review failure too
- render both issue-matrix and missing-baseline diagnostics in `mission-review-report.md`
- update/add regressions for missing and invalid post-merge `issue-matrix.md` cases
- add command-level/report-writer coverage for modern lightweight review missing `baseline_merge_commit`
- keep dead-code-only `pass_with_notes` coverage explicit to lightweight mode

Closes #1423.

## Adversarial review follow-up

A delegated adversarial review found the first PR head still contained an unrelated `kitty-specs/test-feature-01KSYS4Q/meta.json` commit. The branch has been rebuilt from `origin/main` and force-with-lease pushed. Current PR head: `23d9028c4f802b6a7bc5f2bdc17d2478386831a7`.

Current PR file list is now only:

- `src/specify_cli/cli/commands/review/_report.py`
- `tests/specify_cli/cli/commands/test_review.py`

## Verification

- `uv run pytest tests/specify_cli/cli/commands/review tests/specify_cli/cli/commands/test_review.py -q` -> 112 passed
- `uv run ruff check src/specify_cli/cli/commands/review tests/specify_cli/cli/commands/review tests/specify_cli/cli/commands/test_review.py` -> passed
- `uv run mypy src/specify_cli/cli/commands/review/_report.py` -> passed
- `git diff --check` -> passed

Additional notes:

- Confirmed the original issue-matrix regression tests fail before the production fix.
- Previous full `uv run ruff check .` failed on pre-existing unrelated lint outside this patch.
- Previous full `uv run pytest -q` was stopped around 13% after unrelated architectural/audit/calibration/charter failures had already appeared; scoped review tests above pass.
