### PR TITLE
Ensure current v2 manifest repairs are detected

### DIFF
--- a/src/specify_cli/upgrade/migrations/m_3_2_6_charter_bundle_v2.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_charter_bundle_v2.py
@@ -45,7 +45,12 @@ class CharterBundleV2Migration(BaseMigration):
         if not charter_dir.exists():
             return False
         bundle_version = get_bundle_schema_version(charter_dir)
-        return bundle_version is None or bundle_version < CURRENT_BUNDLE_SCHEMA_VERSION
+        if bundle_version is None or bundle_version < CURRENT_BUNDLE_SCHEMA_VERSION:
+            return True
+        if bundle_version == CURRENT_BUNDLE_SCHEMA_VERSION:
+            repair = repair_v2_synthesis_manifest_defaults(charter_dir, dry_run=True)
+            return bool(repair.changes_made or repair.errors)
+        return False
 
     def can_apply(self, project_path: Path) -> tuple[bool, str]:
         """Return (True, '') when the charter directory is present."""

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_charter_manifest_defaults_repair.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_charter_manifest_defaults_repair.py
@@ -1,0 +1,68 @@
+"""Repair current v2 charter manifests missing verifier-visible defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+from charter.versioning import (
+    CURRENT_BUNDLE_SCHEMA_VERSION,
+    BundleCompatibilityStatus,
+    check_bundle_compatibility,
+    get_bundle_schema_version,
+    repair_v2_synthesis_manifest_defaults,
+)
+
+
+@MigrationRegistry.register
+class CharterManifestDefaultsRepair(BaseMigration):
+    """Repairs current v2 synthesis manifests from before built_in_only was serialized."""
+
+    migration_id = "3.2.6_charter_manifest_defaults_repair"
+    target_version = "3.2.6"
+    description = (
+        "Repair current v2 charter synthesis manifests that predate verifier-visible "
+        "manifest defaults."
+    )
+
+    def detect(self, project_path: Path) -> bool:
+        charter_dir = project_path / ".kittify" / "charter"
+        if not charter_dir.exists():
+            return False
+        if get_bundle_schema_version(charter_dir) != CURRENT_BUNDLE_SCHEMA_VERSION:
+            return False
+
+        repair = repair_v2_synthesis_manifest_defaults(charter_dir, dry_run=True)
+        return bool(repair.changes_made or repair.errors)
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        charter_dir = project_path / ".kittify" / "charter"
+        if not charter_dir.exists():
+            return False, "No charter directory found at .kittify/charter"
+
+        bundle_version = get_bundle_schema_version(charter_dir)
+        compatibility = check_bundle_compatibility(bundle_version)
+        if compatibility.status in (
+            BundleCompatibilityStatus.INCOMPATIBLE_OLD,
+            BundleCompatibilityStatus.INCOMPATIBLE_NEW,
+        ):
+            return False, compatibility.message
+        if bundle_version != CURRENT_BUNDLE_SCHEMA_VERSION:
+            return False, "Charter bundle is not at current v2 schema."
+        return True, ""
+
+    def apply(
+        self,
+        project_path: Path,
+        dry_run: bool = False,
+    ) -> MigrationResult:
+        repair = repair_v2_synthesis_manifest_defaults(
+            project_path / ".kittify" / "charter",
+            dry_run=dry_run,
+        )
+        return MigrationResult(
+            success=len(repair.errors) == 0,
+            changes_made=repair.changes_made,
+            errors=repair.errors,
+        )

--- a/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
+++ b/tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py
@@ -13,6 +13,9 @@ from ruamel.yaml import YAML
 from specify_cli.upgrade.migrations.m_3_2_6_charter_bundle_v2 import (
     CharterBundleV2Migration,
 )
+from specify_cli.upgrade.migrations.m_3_2_6_charter_manifest_defaults_repair import (
+    CharterManifestDefaultsRepair,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +205,71 @@ def test_detect_v2_bundle_returns_false(tmp_path: Path) -> None:
     _create_v2_bundle(tmp_path)
     migration = CharterBundleV2Migration()
     assert migration.detect(tmp_path) is False
+
+
+def test_detect_current_v2_manifest_repair_returns_true(tmp_path: Path) -> None:
+    """Current-version bundles still detect when the manifest repair is pending."""
+    _create_legacy_v2_bundle_without_built_in_only(tmp_path)
+
+    assert CharterBundleV2Migration().detect(tmp_path) is True
+
+
+def test_registry_includes_current_version_manifest_repair(tmp_path: Path) -> None:
+    """Same-version upgrade runs must include the repair migration."""
+    from specify_cli.upgrade.registry import MigrationRegistry
+
+    _create_legacy_v2_bundle_without_built_in_only(tmp_path)
+
+    migrations = MigrationRegistry.get_applicable(
+        "3.2.6",
+        "3.2.6",
+        project_path=tmp_path,
+    )
+
+    assert any(
+        migration.migration_id == CharterManifestDefaultsRepair.migration_id
+        for migration in migrations
+    )
+
+
+def test_runner_repairs_current_v2_after_original_migration_was_recorded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Already-recorded original migration must not suppress same-version repair."""
+    from datetime import datetime
+
+    from charter.synthesizer.manifest import load_yaml, verify_manifest_hash
+    from specify_cli.upgrade.metadata import ProjectMetadata
+    from specify_cli.upgrade.runner import MigrationRunner
+
+    _create_legacy_v2_bundle_without_built_in_only(tmp_path)
+    metadata = ProjectMetadata(version="3.2.6", initialized_at=datetime.now())
+    metadata.record_migration(
+        CharterBundleV2Migration.migration_id,
+        "success",
+        "already applied by previous release",
+    )
+    metadata.save(tmp_path / ".kittify")
+
+    runner = MigrationRunner(tmp_path)
+    monkeypatch.setattr(runner.detector, "detect_version", lambda: "3.2.6")
+    monkeypatch.setattr(
+        "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+        lambda _from, _to, project_path=None: [  # noqa: ARG005
+            CharterBundleV2Migration(),
+            CharterManifestDefaultsRepair(),
+        ],
+    )
+
+    result = runner.upgrade("3.2.6", include_worktrees=False)
+
+    assert result.success is True
+    assert result.migrations_skipped == [CharterBundleV2Migration.migration_id]
+    assert result.migrations_applied == [CharterManifestDefaultsRepair.migration_id]
+    manifest_path = tmp_path / ".kittify" / "charter" / "synthesis-manifest.yaml"
+    assert _load_yaml(manifest_path)["built_in_only"] is False
+    verify_manifest_hash(load_yaml(manifest_path))
 
 
 def test_detect_no_charter_returns_false(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make the charter v2 migration detect pending current-version manifest repairs
- add a dedicated same-version repair migration so projects that already recorded the original 3.2.6 migration still repair legacy manifests
- add registry and runner regressions for current v2 manifests missing built_in_only

Follow-up to #1417 adversarial review.

## Tests
- uv run ruff check src/specify_cli/upgrade/migrations/m_3_2_6_charter_bundle_v2.py src/specify_cli/upgrade/migrations/m_3_2_6_charter_manifest_defaults_repair.py tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py tests/upgrade/test_auto_discovery.py tests/upgrade/test_runner_status_classification.py
- uv run python -m pytest tests/specify_cli/upgrade/test_charter_bundle_v2_migration.py tests/upgrade/test_auto_discovery.py tests/upgrade/test_runner_status_classification.py -q --tb=short