### PR TITLE
Add project-authored workflow sequencing

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -3434,4 +3434,77 @@ _Tracker synchronization commands_
 ```
 
 ```
+
+## spec-kitty workflow
+
+_Manage mission workflow definitions_
+
+```
+ Usage: spec-kitty workflow [OPTIONS] COMMAND [ARGS]...
+
+ Manage mission workflow definitions
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list    List workflow ids available to a project.                            │
+│ export  Export a resolvable workflow YAML file.                              │
+│ import  Import a workflow YAML into `.kittify/overrides/workflows`.          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## spec-kitty workflow export
+
+```
+ Usage: spec-kitty workflow export [OPTIONS] WORKFLOW_ID OUTPUT
+
+ Export a resolvable workflow YAML file.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    workflow_id      TEXT  Workflow id to export. [required]                │
+│ *    output           PATH  Destination file or directory. [required]        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --project-root        PATH  Project root used for .kittify workflow          │
+│                             discovery.                                       │
+│                             [default: .]                                     │
+│ --force                     Overwrite an existing destination file.           │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## spec-kitty workflow import
+
+```
+ Usage: spec-kitty workflow import [OPTIONS] SOURCE
+
+ Import a workflow YAML into `.kittify/overrides/workflows`.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    source      PATH  Workflow YAML file to import. [required]              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --project-root        PATH  Project root that receives the workflow          │
+│                             override.                                        │
+│                             [default: .]                                     │
+│ --force                     Overwrite an existing workflow file.              │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## spec-kitty workflow list
+
+```
+ Usage: spec-kitty workflow list [OPTIONS]
+
+ List workflow ids available to a project.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --project-root        PATH  Project root used for .kittify workflow          │
+│                             discovery.                                       │
+│                             [default: .]                                     │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
 <!-- END GENERATED -->

--- a/docs/reference/missions.md
+++ b/docs/reference/missions.md
@@ -376,6 +376,11 @@ Each `actions[]` entry supports:
 
 Validation rejects duplicate action names, unresolved `next` references, unreachable actions, cycles, terminal actions with successors, and branching `next` lists. Unknown workflow ids fail closed and list available workflow ids; they do not silently fall back to `software-dev-default`.
 
+When a workflow introduces a new software-dev action, make sure a matching command
+template such as `.kittify/overrides/command-templates/<action-name>.md` is
+available. Actions that reuse shipped names such as `specify`, `plan`, `tasks`,
+`implement`, `review`, `accept`, or `design-review` resolve to bundled templates.
+
 ### Workflow portability commands
 
 Use `spec-kitty workflow list` to see the workflow ids visible from the current project. Use `spec-kitty workflow export <workflow-id> <path>` to copy the resolved workflow YAML to a portable file, preserving project override precedence. Use `spec-kitty workflow import <path>` to validate a workflow file and copy it into `.kittify/overrides/workflows/<workflow-id>.yaml`. Both import and export refuse to overwrite existing files unless `--force` is supplied.

--- a/docs/reference/missions.md
+++ b/docs/reference/missions.md
@@ -322,6 +322,64 @@ The loader queries seven tiers in priority order; the highest-precedence tier wi
 6. **Project config (mission packs)** — `.kittify/config.yaml mission_packs: [...]` referencing `mission-pack.yaml` manifests.
 7. **Built-in** — `software-dev`, `research`, `documentation`, `plan`.
 
+## Authoring Custom Workflows
+
+Workflows are the project-authored execution sequence for a mission. A mission's `meta.json` may set `workflow_id`; when absent, Spec Kitty uses the shipped `software-dev-default` workflow. Project workflow files are discovered before shipped workflows, so teams can opt into a named local sequence without forking the runtime.
+
+Workflow files live in `.kittify/overrides/workflows/` and may use either `<workflow-id>.workflow.yaml` or `<workflow-id>.yaml`. The file's top-level `workflow_id` MUST match the requested slug. Slugs are lowercase URL-style identifiers matching `[a-z0-9][a-z0-9-]*`; path traversal, spaces, uppercase letters, and special characters are rejected before filesystem lookup.
+
+Minimal valid example:
+
+```yaml
+workflow_id: solo-fast
+description: Solo workflow that skips review.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    next: [plan]
+  - action_name: plan
+    description: Create an implementation plan
+    next: [implement]
+  - action_name: implement
+    description: Implement directly
+    next: [accept]
+  - action_name: accept
+    description: Accept without review
+    terminal: true
+```
+
+### Workflow fields
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `workflow_id` | yes | str | Must match the filename slug requested by `meta.json::workflow_id`. |
+| `description` | yes | str | Human-readable summary. |
+| `version` | yes | int | Schema version, currently `1`. |
+| `initial` | yes | str | First action in the workflow. Must name an action in `actions[]`. |
+| `integrations` | no | object | Declarative provider bindings, such as `vcs.provider` or `issue_tracker.provider`. Runtime support is provider-specific. |
+| `actions` | yes | list | Ordered action graph. v1 workflows are linear: each action can name at most one successor in `next`. |
+
+Each `actions[]` entry supports:
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `action_name` | yes | str | Unique action identifier. |
+| `description` | yes | str | Human-readable step summary. |
+| `next` | no | list[str] | Empty or omitted for terminal actions; otherwise one successor action. |
+| `terminal` | no | bool | Terminal actions must not declare `next`. |
+| `agent_profile` | no | str | Optional profile binding for workflow-aware callers. |
+| `human_in_the_loop` | no | str | Optional checkpoint marker for non-agent actions. |
+| `integration` | no | str | Optional reference such as `vcs.open_pr`. |
+| `outputs` | no | object | Optional output names/templates declared by the action. |
+
+Validation rejects duplicate action names, unresolved `next` references, unreachable actions, cycles, terminal actions with successors, and branching `next` lists. Unknown workflow ids fail closed and list available workflow ids; they do not silently fall back to `software-dev-default`.
+
+### Workflow portability commands
+
+Use `spec-kitty workflow list` to see the workflow ids visible from the current project. Use `spec-kitty workflow export <workflow-id> <path>` to copy the resolved workflow YAML to a portable file, preserving project override precedence. Use `spec-kitty workflow import <path>` to validate a workflow file and copy it into `.kittify/overrides/workflows/<workflow-id>.yaml`. Both import and export refuse to overwrite existing files unless `--force` is supplied.
+
 ### Validation error codes
 
 The loader emits a closed enumeration of error and warning codes. Wire spellings are stable: removal or rename is a breaking change requiring a deprecation cycle. Additions are non-breaking. Tooling MAY rely on string equality on `error_code` / warning `code` and MUST NOT fail on unknown `details` keys.

--- a/src/specify_cli/cli/commands/__init__.py
+++ b/src/specify_cli/cli/commands/__init__.py
@@ -80,6 +80,7 @@ def register_commands(app: typer.Typer) -> None:
     from . import validate_encoding as validate_encoding_module
     from . import validate_tasks as validate_tasks_module
     from . import verify as verify_module
+    from . import workflow as workflow_module
     from specify_cli import orchestrator_api as orchestrator_api_module
     from specify_cli.saas.rollout import is_saas_sync_enabled
 
@@ -125,6 +126,7 @@ def register_commands(app: typer.Typer) -> None:
     app.command(name="validate-encoding")(validate_encoding_module.validate_encoding)
     app.command(name="validate-tasks")(validate_tasks_module.validate_tasks)
     app.command()(verify_module.verify_setup)
+    app.add_typer(workflow_module.app, name="workflow", help="Manage mission workflow definitions")
     app.add_typer(profiles_cmd_module.app, name="profiles")
     app.command(name="advise", help="Get governance context for a request (opens an invocation record).")(advise_module.advise)
     app.command(name="ask", help="Invoke a named profile directly.")(advise_module.ask)

--- a/src/specify_cli/cli/commands/workflow.py
+++ b/src/specify_cli/cli/commands/workflow.py
@@ -1,0 +1,86 @@
+"""Workflow portability commands."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import typer
+
+from specify_cli.next._internal_runtime.workflow_registry import (
+    list_available_workflows,
+    load_workflow_file,
+    resolve_workflow_path,
+)
+
+app = typer.Typer(name="workflow", help="Manage mission workflow definitions")
+
+
+@app.command(name="list")
+def list_workflows(
+    project_root: Path = typer.Option(
+        Path("."),
+        "--project-root",
+        help="Project root used for .kittify workflow discovery.",
+    ),
+) -> None:
+    """List workflow ids available to a project."""
+    for workflow_id in list_available_workflows(project_root=project_root.resolve()):
+        typer.echo(workflow_id)
+
+
+@app.command(name="export")
+def export_workflow(
+    workflow_id: str = typer.Argument(..., help="Workflow id to export."),
+    output: Path = typer.Argument(..., help="Destination file or directory."),
+    project_root: Path = typer.Option(
+        Path("."),
+        "--project-root",
+        help="Project root used for .kittify workflow discovery.",
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite an existing destination file."),
+) -> None:
+    """Export a resolvable workflow YAML file."""
+    source = resolve_workflow_path(workflow_id, project_root=project_root.resolve())
+    load_workflow_file(source, requested_workflow_id=workflow_id)
+    destination = _destination_path(output, workflow_id=workflow_id)
+    _copy_workflow(source, destination, force=force)
+    typer.echo(str(destination))
+
+
+@app.command(name="import")
+def import_workflow(
+    source: Path = typer.Argument(..., help="Workflow YAML file to import."),
+    project_root: Path = typer.Option(
+        Path("."),
+        "--project-root",
+        help="Project root that receives the workflow override.",
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite an existing workflow file."),
+) -> None:
+    """Import a workflow YAML into `.kittify/overrides/workflows`."""
+    workflow = load_workflow_file(source)
+    destination = (
+        project_root.resolve()
+        / ".kittify"
+        / "overrides"
+        / "workflows"
+        / f"{workflow.workflow_id}.yaml"
+    )
+    _copy_workflow(source, destination, force=force)
+    typer.echo(str(destination))
+
+
+def _destination_path(output: Path, *, workflow_id: str) -> Path:
+    if output.exists() and output.is_dir():
+        return output / f"{workflow_id}.yaml"
+    if str(output).endswith(("/", "\\")):
+        return output / f"{workflow_id}.yaml"
+    return output
+
+
+def _copy_workflow(source: Path, destination: Path, *, force: bool) -> None:
+    if destination.exists() and not force:
+        raise typer.BadParameter(f"Destination exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)

--- a/src/specify_cli/cli/commands/workflow.py
+++ b/src/specify_cli/cli/commands/workflow.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 import typer
 
+from specify_cli.core.atomic import atomic_write
 from specify_cli.next._internal_runtime.workflow_registry import (
     list_available_workflows,
     load_workflow_file,
@@ -82,5 +82,4 @@ def _destination_path(output: Path, *, workflow_id: str) -> Path:
 def _copy_workflow(source: Path, destination: Path, *, force: bool) -> None:
     if destination.exists() and not force:
         raise typer.BadParameter(f"Destination exists: {destination}")
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(source, destination)
+    atomic_write(destination, source.read_bytes(), mkdir=True)

--- a/src/specify_cli/missions/software-dev/command-templates/design-review.md
+++ b/src/specify_cli/missions/software-dev/command-templates/design-review.md
@@ -1,0 +1,52 @@
+---
+description: Review design direction before task decomposition
+---
+# /spec-kitty.design-review - Review Design Direction
+
+**Version**: 3.2.0+
+
+## Purpose
+
+Review the planned product, interface, architecture, or workflow design before
+the mission is decomposed into work packages. This step is intended for custom
+software-dev workflows that insert `design-review` between `plan` and `tasks`.
+
+## Working Directory
+
+Run from the repository root checkout. Do not create or switch to a work-package
+worktree during this step.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Consider the user input before proceeding when it is not empty.
+
+## Inputs
+
+Read the mission artifacts under `kitty-specs/<mission>/`:
+
+- `spec.md`
+- `plan.md`
+- `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` when present
+
+## Review Focus
+
+Check the design for:
+
+- clear user workflow and acceptance boundaries
+- consistency with the charter and mission scope
+- implementation risks that should be split or sequenced before task generation
+- missing constraints, edge cases, or migration/rollback considerations
+- ambiguous ownership between frontend, backend, runtime, docs, and tests
+
+## Output
+
+Update `plan.md` or add a short design-review note under the mission directory
+with any required corrections. If no corrections are needed, record that the
+design is ready for task decomposition.
+
+After the review is complete, run `spec-kitty next --agent <name>` to continue
+to the next workflow action.

--- a/src/specify_cli/next/_internal_runtime/engine.py
+++ b/src/specify_cli/next/_internal_runtime/engine.py
@@ -185,10 +185,12 @@ def start_mission_run(
     context: DiscoveryContext | None = None,
     run_store: Path | None = None,
     emitter: RuntimeEventEmitter | None = None,
+    template_override: MissionTemplate | None = None,
+    template_path_override: str | None = None,
 ) -> MissionRunRef:
     """Start and persist a new mission run with template freezing."""
     emitter = emitter or NullEmitter()
-    template = load_mission_template(template_key, context=context)
+    template = template_override or load_mission_template(template_key, context=context)
 
     runs_dir = _runtime_runs_dir(run_store)
     run_id = uuid4().hex
@@ -196,7 +198,7 @@ def start_mission_run(
     run_dir.mkdir(parents=True, exist_ok=False)
 
     # Always resolve to a real filesystem path for drift detection.
-    template_path = _resolve_template_path(template_key, context)
+    template_path = template_path_override or _resolve_template_path(template_key, context)
 
     # Freeze template and compute hash.
     template_hash = _freeze_template(run_dir, template, template_path)

--- a/src/specify_cli/next/_internal_runtime/planner.py
+++ b/src/specify_cli/next/_internal_runtime/planner.py
@@ -9,9 +9,9 @@ internal ``plan_next`` (DAG engine, used by ``engine.py`` and
 
 * ``_resolve_workflow_for_mission(mission_dir)`` — reads ``meta.json``,
   extracts ``workflow_id``, and returns the validated ``WorkflowSequence``
-  (defaulting to ``software-dev-default`` when ``workflow_id`` is absent).
-  Unknown ids propagate ``UnknownWorkflowError`` — no silent fallback
-  (FR-015 binding).
+  from project overrides or shipped defaults (defaulting to
+  ``software-dev-default`` when ``workflow_id`` is absent). Unknown ids
+  propagate ``UnknownWorkflowError`` — no silent fallback (FR-015 binding).
 * ``PlanResult`` — lightweight dataclass returned by
   ``resolve_next_workflow_action``.
 * ``resolve_next_workflow_action(mission_dir, current_action)`` — looks up the
@@ -57,7 +57,7 @@ from specify_cli.next._internal_runtime.workflow_schema import ActionStep, Workf
 # _resolve_workflow_for_mission, resolve_next_workflow_action) are intentionally
 # kept as non-exported symbols so the symbol-level dead-code gate does not
 # require them to have callers in other src/ files.  They are exercised by
-# integration tests and by prompt_builder._cached_workflow_for (which calls
+# integration tests and by prompt_builder._workflow_for (which calls
 # _resolve_workflow_for_mission directly).
 
 
@@ -102,14 +102,26 @@ def _resolve_workflow_for_mission(mission_dir: Path) -> WorkflowSequence:
         resolved by the registry.  FR-015 binding: no silent fallback.
     """
     meta_path = mission_dir / "meta.json"
+    project_root = _infer_project_root(mission_dir)
     if not meta_path.exists():
-        return get_workflow("software-dev-default")
+        return get_workflow("software-dev-default", project_root=project_root)
     meta: dict[str, Any] = json.loads(meta_path.read_text(encoding="utf-8"))
     workflow_id: str | None = meta.get("workflow_id")
     if workflow_id is None:
-        return get_workflow("software-dev-default")
+        return get_workflow("software-dev-default", project_root=project_root)
     # Unknown ids propagate UnknownWorkflowError — no silent fallback (FR-015).
-    return get_workflow(workflow_id)
+    return get_workflow(workflow_id, project_root=project_root)
+
+
+def _infer_project_root(mission_dir: Path) -> Path | None:
+    """Infer the project root that owns *mission_dir* for `.kittify` lookup."""
+    current = mission_dir.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".kittify").exists():
+            return candidate
+        if candidate.name == "kitty-specs":
+            return candidate.parent
+    return None
 
 
 def resolve_next_workflow_action(
@@ -141,7 +153,7 @@ def resolve_next_workflow_action(
     by_name: dict[str, ActionStep] = {a.action_name: a for a in workflow.actions}
     action: ActionStep | None = by_name.get(current_action)
     if action is None:
-        available_workflows = list_available_workflows()
+        available_workflows = list_available_workflows(project_root=_infer_project_root(mission_dir))
         raise ValueError(
             f"action {current_action!r} not in workflow {workflow.workflow_id!r}. "
             f"Available actions: {sorted(by_name)}. "

--- a/src/specify_cli/next/_internal_runtime/planner.py
+++ b/src/specify_cli/next/_internal_runtime/planner.py
@@ -87,6 +87,81 @@ class PlanResult:
     workflow_id: str
 
 
+def compose_template_with_workflow(
+    template: MissionTemplate,
+    workflow: WorkflowSequence,
+) -> MissionTemplate:
+    """Return a runtime template whose steps follow *workflow*.
+
+    The workflow artifact owns public action ordering; the runtime still needs
+    a ``MissionTemplate`` DAG. This adapter keeps the live ``spec-kitty next``
+    path on the same planner while preserving existing step metadata when an
+    action matches a shipped/custom mission step.
+    """
+    by_id = {step.id: step for step in template.steps}
+    composed: list[PromptStep] = []
+    previous_id: str | None = None
+
+    if workflow.initial == "specify" and "discovery" in by_id and "discovery" not in {
+        action.action_name for action in workflow.actions
+    }:
+        discovery = by_id["discovery"]
+        composed.append(
+            PromptStep(
+                id=discovery.id,
+                title=discovery.title,
+                description=discovery.description,
+                prompt=discovery.prompt,
+                prompt_template=discovery.prompt_template,
+                expected_output=discovery.expected_output,
+                requires_inputs=discovery.requires_inputs,
+                depends_on=[],
+                raci=discovery.raci,
+                raci_override_reason=discovery.raci_override_reason,
+                agent_profile=discovery.agent_profile,
+                contract_ref=discovery.contract_ref,
+            )
+        )
+        previous_id = "discovery"
+
+    for action in workflow.actions:
+        source = by_id.get(action.action_name)
+        depends_on = [previous_id] if previous_id is not None else []
+        if source is not None:
+            step = PromptStep(
+                id=source.id,
+                title=source.title,
+                description=action.description or source.description,
+                prompt=source.prompt,
+                prompt_template=source.prompt_template,
+                expected_output=source.expected_output,
+                requires_inputs=source.requires_inputs,
+                depends_on=depends_on,
+                raci=source.raci,
+                raci_override_reason=source.raci_override_reason,
+                agent_profile=action.agent_profile or source.agent_profile,
+                contract_ref=source.contract_ref,
+            )
+        else:
+            step = PromptStep(
+                id=action.action_name,
+                title=action.action_name.replace("-", " ").title(),
+                description=action.description,
+                prompt_template=f"{action.action_name}.md",
+                requires_inputs=[action.human_in_the_loop] if action.human_in_the_loop else [],
+                depends_on=depends_on,
+                agent_profile=action.agent_profile,
+            )
+        composed.append(step)
+        previous_id = action.action_name
+
+    return MissionTemplate(
+        mission=template.mission,
+        steps=composed,
+        audit_steps=template.audit_steps,
+    )
+
+
 def _resolve_workflow_for_mission(mission_dir: Path) -> WorkflowSequence:
     """Return the ``WorkflowSequence`` for the mission rooted at *mission_dir*.
 

--- a/src/specify_cli/next/_internal_runtime/workflow_registry.py
+++ b/src/specify_cli/next/_internal_runtime/workflow_registry.py
@@ -1,15 +1,14 @@
 """Workflow registry (FR-012, FR-015).
 
-Loads ``.workflow.yaml`` files from ``src/doctrine/workflows/`` and returns
-validated ``WorkflowSequence`` instances.
+Loads project-authored and shipped workflow YAML files and returns validated
+``WorkflowSequence`` instances.
 
 Search precedence
 -----------------
-1. ``src/doctrine/workflows/<workflow_id>.workflow.yaml`` (built-in defaults)
-2. ``src/doctrine/workflows/_fixtures/<workflow_id>.workflow.yaml`` (test fixtures)
-
-Operator override at ``.kittify/workflows/<workflow_id>.workflow.yaml`` is
-reserved for a future extension (not load-bearing this mission).
+1. ``<project_root>/.kittify/overrides/workflows/<workflow_id>.workflow.yaml``
+2. ``<project_root>/.kittify/overrides/workflows/<workflow_id>.yaml``
+3. ``src/doctrine/workflows/<workflow_id>.workflow.yaml`` (built-in defaults)
+4. ``src/doctrine/workflows/_fixtures/<workflow_id>.workflow.yaml`` (test fixtures)
 
 Layer rule (C-001 / NFR-003)
 -----------------------------
@@ -28,15 +27,21 @@ caller (currently WP11's ``planner.plan_next``).
 """
 from __future__ import annotations
 
-import functools
 import re
 from pathlib import Path
 
+from pydantic import ValidationError
 import yaml
 
 from .workflow_schema import WorkflowSequence
 
-__all__ = ["get_workflow", "list_available_workflows"]
+__all__ = [
+    "get_workflow",
+    "list_available_workflows",
+    "load_workflow_file",
+    "resolve_workflow_path",
+    "validate_workflow_id",
+]
 
 
 class UnknownWorkflowError(Exception):
@@ -87,12 +92,12 @@ _SEARCH_ROOTS: tuple[Path, ...] = (
 )
 
 
-@functools.cache
-def get_workflow(workflow_id: str) -> WorkflowSequence:
+def get_workflow(workflow_id: str, project_root: Path | None = None) -> WorkflowSequence:
     """Return the validated ``WorkflowSequence`` for *workflow_id*.
 
-    Search order: built-in defaults first, then test fixtures (see module
-    docstring for the full precedence list).
+    Search order: project overrides first when *project_root* is provided,
+    then built-in defaults, then test fixtures (see module docstring for the
+    full precedence list).
 
     Raises
     ------
@@ -104,8 +109,43 @@ def get_workflow(workflow_id: str) -> WorkflowSequence:
     pydantic.ValidationError
         If the resolved YAML file fails ``WorkflowSequence`` validation.
     """
-    # MEDIUM-4: slug validator (defense-in-depth against path traversal).
-    # Reject before any filesystem interaction.
+    candidate = resolve_workflow_path(workflow_id, project_root=project_root)
+    return load_workflow_file(candidate, requested_workflow_id=workflow_id)
+
+
+def resolve_workflow_path(workflow_id: str, project_root: Path | None = None) -> Path:
+    """Return the source YAML path for *workflow_id* using registry precedence."""
+    validate_workflow_id(workflow_id)
+    for candidate in _candidate_paths(workflow_id, project_root):
+        if candidate.exists():
+            return candidate
+
+    available = list_available_workflows(project_root=project_root)
+    raise UnknownWorkflowError(
+        f"Unknown workflow_id={workflow_id!r}. "
+        f"Available: {available}. "
+        f"Searched: {[str(p) for p in _candidate_paths(workflow_id, project_root)]}."
+    )
+
+
+def load_workflow_file(
+    path: Path,
+    requested_workflow_id: str | None = None,
+) -> WorkflowSequence:
+    """Load and validate a workflow YAML file."""
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    workflow = WorkflowSequence.model_validate(raw)
+    validate_workflow_id(workflow.workflow_id)
+    if requested_workflow_id is not None and workflow.workflow_id != requested_workflow_id:
+        raise UnknownWorkflowError(
+            f"Workflow file {path} declares workflow_id={workflow.workflow_id!r} "
+            f"but was requested as {requested_workflow_id!r}."
+        )
+    return workflow
+
+
+def validate_workflow_id(workflow_id: str) -> None:
+    """Reject workflow ids that cannot be safely interpolated into paths."""
     if not _WORKFLOW_ID_PATTERN.fullmatch(workflow_id):
         raise UnknownWorkflowError(
             f"Invalid workflow_id {workflow_id!r}: must match [a-z0-9][a-z0-9-]*. "
@@ -113,27 +153,51 @@ def get_workflow(workflow_id: str) -> WorkflowSequence:
             f"characters are not permitted in workflow identifiers."
         )
 
-    for root in _SEARCH_ROOTS:
-        candidate = root / f"{workflow_id}.workflow.yaml"
-        if candidate.exists():
-            raw = yaml.safe_load(candidate.read_text(encoding="utf-8"))
-            return WorkflowSequence.model_validate(raw)
 
-    available = list_available_workflows()
-    raise UnknownWorkflowError(
-        f"Unknown workflow_id={workflow_id!r}. "
-        f"Available: {available}. "
-        f"Searched: {[str(r) for r in _SEARCH_ROOTS]}."
-    )
-
-
-def list_available_workflows() -> list[str]:
-    """Return a sorted list of workflow ids resolvable from the search roots."""
+def list_available_workflows(project_root: Path | None = None) -> list[str]:
+    """Return a sorted list of validated workflow ids resolvable from the search roots."""
     available: list[str] = []
-    for root in _SEARCH_ROOTS:
+    for root in _search_roots(project_root):
         if root.exists():
-            for p in sorted(root.glob("*.workflow.yaml")):
-                # p.stem is e.g. "software-dev-default.workflow"
-                workflow_id = p.stem.replace(".workflow", "")
+            for p in sorted(root.glob("*.yaml")):
+                workflow_id = _workflow_id_from_path(p)
+                try:
+                    validate_workflow_id(workflow_id)
+                    load_workflow_file(p, requested_workflow_id=workflow_id)
+                except (OSError, UnknownWorkflowError, ValidationError, yaml.YAMLError):
+                    continue
                 available.append(workflow_id)
     return sorted(set(available))
+
+
+def _search_roots(project_root: Path | None) -> tuple[Path, ...]:
+    project_roots: tuple[Path, ...] = ()
+    if project_root is not None:
+        project_roots = (Path(project_root) / ".kittify" / "overrides" / "workflows",)
+    return project_roots + _SEARCH_ROOTS
+
+
+def _candidate_paths(workflow_id: str, project_root: Path | None) -> tuple[Path, ...]:
+    project_paths: tuple[Path, ...] = ()
+    if project_root is not None:
+        override_root = Path(project_root) / ".kittify" / "overrides" / "workflows"
+        project_paths = (
+            override_root / f"{workflow_id}.workflow.yaml",
+            override_root / f"{workflow_id}.yaml",
+        )
+    shipped_paths = tuple(root / f"{workflow_id}.workflow.yaml" for root in _SEARCH_ROOTS)
+    return project_paths + shipped_paths
+
+
+def _workflow_id_from_path(path: Path) -> str:
+    name = path.name
+    if name.endswith(".workflow.yaml"):
+        return name[: -len(".workflow.yaml")]
+    return path.stem
+
+
+def _clear_noop_cache() -> None:
+    """Compatibility no-op for tests and callers that cleared the old cache."""
+
+
+get_workflow.cache_clear = _clear_noop_cache  # type: ignore[attr-defined]

--- a/src/specify_cli/next/_internal_runtime/workflow_schema.py
+++ b/src/specify_cli/next/_internal_runtime/workflow_schema.py
@@ -10,6 +10,8 @@ as data by ``workflow_registry``; they are not imported as Python modules.
 """
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = ["WorkflowSequence", "ActionStep"]
@@ -24,12 +26,21 @@ class ActionStep(BaseModel):
     next: list[str] = Field(default_factory=list)
     description: str
     terminal: bool = False
+    agent_profile: str | None = None
+    human_in_the_loop: str | None = None
+    integration: str | None = None
+    outputs: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def _validate_terminal_has_no_next(self) -> ActionStep:
+    def _validate_step_shape(self) -> ActionStep:
         if self.terminal and self.next:
             raise ValueError(
                 f"action {self.action_name!r}: terminal=True forbids non-empty `next`"
+            )
+        if len(self.next) > 1:
+            raise ValueError(
+                f"action {self.action_name!r}: workflows are linear in v1; "
+                "`next` may name at most one action"
             )
         return self
 
@@ -52,6 +63,7 @@ class WorkflowSequence(BaseModel):
     actions: list[ActionStep]
     initial: str
     version: int = Field(ge=1)
+    integrations: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> WorkflowSequence:

--- a/src/specify_cli/next/prompt_builder.py
+++ b/src/specify_cli/next/prompt_builder.py
@@ -3,19 +3,16 @@
 Independent from ``workflow.py``.  Generates prompt text for each action type,
 writes it to a temp file, and returns ``(prompt_text, prompt_file_path)``.
 
-WP11 addition: ``_cached_workflow_for``
+WP11 addition: ``_workflow_for``
 -----------------------------------------
-Slice F WP11 adds a per-process cached workflow lookup so the workflow YAML
-is loaded at most once per mission directory per process.  This satisfies the
-NFR-001 byte-stability contract: missions without ``workflow_id`` in
+Slice F WP11 adds a workflow lookup helper. This satisfies the NFR-001
+byte-stability contract: missions without ``workflow_id`` in
 ``meta.json`` always get the ``software-dev-default`` workflow (permanent
-default per NEW-2 resolution).  The cache is keyed by the stringified mission
-directory path; ``functools.lru_cache`` provides the implicit storage.
+default per NEW-2 resolution).
 """
 
 from __future__ import annotations
 
-import functools
 import subprocess
 import tempfile
 from pathlib import Path
@@ -35,22 +32,17 @@ from specify_cli.workspace.context import resolve_workspace_for_wp
 
 
 # ---------------------------------------------------------------------------
-# Workflow lookup cache (Slice F WP11, FR-013 / NFR-001)
+# Workflow lookup (Slice F WP11, FR-013 / NFR-001)
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=128)
-def _cached_workflow_for(mission_dir_str: str):
-    """Return the ``WorkflowSequence`` for *mission_dir_str* (cached per process).
-
-    The cache is keyed by the stringified mission directory path.  For
-    long-lived processes, the cache is invalidated by restarting the CLI;
-    operators who swap ``workflow_id`` mid-session should restart.  This is
-    documented and acceptable for the NEW-2 permanent-default use case where
-    workflow ids are stable across a mission's lifetime.
+def _workflow_for(mission_dir_str: str):
+    """Return the ``WorkflowSequence`` for *mission_dir_str*.
 
     Uses ``_resolve_workflow_for_mission`` from ``planner`` so the resolver
     logic is co-located with the DAG-based runtime engine and not duplicated.
+    Project-authored workflow files are mutable, so this helper intentionally
+    performs a fresh load.
     """
     from specify_cli.next._internal_runtime.planner import _resolve_workflow_for_mission
 

--- a/src/specify_cli/next/runtime_bridge.py
+++ b/src/specify_cli/next/runtime_bridge.py
@@ -1738,6 +1738,36 @@ def _runtime_template_key(mission_type: str, repo_root: Path) -> str:
     return mission_type
 
 
+def _workflow_runtime_template(
+    mission_slug: str,
+    mission_type: str,
+    repo_root: Path,
+    template_key: str,
+):
+    """Compose a runtime template when mission meta selects a workflow."""
+    del mission_type
+    mission_dir = repo_root / "kitty-specs" / mission_slug
+    meta_path = mission_dir / "meta.json"
+    if not meta_path.exists():
+        return None, None
+
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    workflow_id = meta.get("workflow_id")
+    if workflow_id is None:
+        return None, None
+
+    from specify_cli.next._internal_runtime.discovery import load_mission_template
+    from specify_cli.next._internal_runtime.planner import compose_template_with_workflow
+    from specify_cli.next._internal_runtime.workflow_registry import get_workflow
+
+    context = _build_discovery_context(repo_root)
+    base_template = load_mission_template(template_key, context=context)
+    workflow = get_workflow(str(workflow_id), project_root=repo_root)
+    template = compose_template_with_workflow(base_template, workflow)
+    template_path = f"{template_key}#workflow:{workflow.workflow_id}"
+    return template, template_path
+
+
 def _existing_run_ref(
     mission_slug: str,
     repo_root: Path,
@@ -1777,6 +1807,9 @@ def _start_ephemeral_query_run(
     run_store = Path(tempfile.mkdtemp(prefix="spec-kitty-query-run-"))
     try:
         template_key = _runtime_template_key(mission_type, repo_root)
+        template_override, template_path_override = _workflow_runtime_template(
+            mission_slug, mission_type, repo_root, template_key
+        )
         context = _build_discovery_context(repo_root)
 
         run_ref = start_mission_run(
@@ -1786,6 +1819,8 @@ def _start_ephemeral_query_run(
             context=context,
             run_store=run_store,
             emitter=NullEmitter(),
+            template_override=template_override,
+            template_path_override=template_path_override,
         )
     except Exception:
         shutil.rmtree(run_store, ignore_errors=True)
@@ -1821,6 +1856,9 @@ def get_or_start_run(
     # Start a new run
     run_store = repo_root / ".kittify" / "runtime" / "runs"
     template_key = _runtime_template_key(mission_type, repo_root)
+    template_override, template_path_override = _workflow_runtime_template(
+        mission_slug, mission_type, repo_root, template_key
+    )
     context = _build_discovery_context(repo_root)
 
     run_ref = start_mission_run(
@@ -1830,6 +1868,8 @@ def get_or_start_run(
         context=context,
         run_store=run_store,
         emitter=emitter or NullEmitter(),
+        template_override=template_override,
+        template_path_override=template_path_override,
     )
 
     # Persist to index

--- a/tests/integration/test_workflow_sequence_runtime.py
+++ b/tests/integration/test_workflow_sequence_runtime.py
@@ -94,3 +94,48 @@ def test_unknown_workflow_id_in_meta_json_hard_fails(tmp_path: Path) -> None:
 
     with pytest.raises(UnknownWorkflowError):
         resolve_next_workflow_action(mission_dir=mission_dir, current_action="plan")
+
+
+def test_project_override_workflow_id_drives_next_action(tmp_path: Path) -> None:
+    """Issue #682: project-authored `.kittify` workflow sequences are runtime-owned."""
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "solo-fast.yaml").write_text(
+        """
+workflow_id: solo-fast
+description: Project override that skips review.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    next: [plan]
+  - action_name: plan
+    description: Create an implementation plan
+    next: [implement]
+  - action_name: implement
+    description: Implement directly
+    next: [accept]
+  - action_name: accept
+    description: Accept without review
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    mission_dir = tmp_path / "kitty-specs" / "solo-fast-mission-01YYY"
+    mission_dir.mkdir(parents=True)
+    (mission_dir / "meta.json").write_text(json.dumps({
+        "mission_id": "01YYY000000000000000000000",
+        "mission_slug": "solo-fast-mission",
+        "mission_number": None,
+        "workflow_id": "solo-fast",
+    }))
+
+    from specify_cli.next._internal_runtime.planner import resolve_next_workflow_action
+    from specify_cli.next._internal_runtime.workflow_registry import get_workflow
+
+    get_workflow.cache_clear()
+    result = resolve_next_workflow_action(mission_dir=mission_dir, current_action="implement")
+
+    assert result.workflow_id == "solo-fast"
+    assert result.next_action == "accept"

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -176,6 +176,42 @@ class TestRuntimeTemplateKey:
         result = runtime_bridge._runtime_template_key("software-dev", repo_root)
         assert "src/specify_cli/missions/software-dev/mission-runtime.yaml" in result
 
+
+class TestWorkflowRuntimeTemplate:
+    pytestmark = pytest.mark.git_repo
+
+    def test_workflow_id_composes_frozen_runtime_template(self, tmp_path: Path) -> None:
+        """meta.json::workflow_id affects the canonical run template used by `next`."""
+        repo_root = _scaffold_project(tmp_path)
+        mission_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (mission_dir / "meta.json").write_text(
+            json.dumps(
+                {
+                    "mission_type": "software-dev",
+                    "workflow_id": "our-team-design-first",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        from specify_cli.next._internal_runtime.engine import _load_frozen_template
+        from specify_cli.next.runtime_bridge import get_or_start_run
+
+        run_ref = get_or_start_run("042-test-feature", repo_root, "software-dev")
+        template = _load_frozen_template(Path(run_ref.run_dir))
+        step_ids = [step.id for step in template.steps]
+
+        assert step_ids == [
+            "discovery",
+            "specify",
+            "plan",
+            "design-review",
+            "tasks",
+            "implement",
+            "review",
+            "merge",
+        ]
+
     def test_software_dev_builtin_outranks_stale_user_global(
         self,
         tmp_path: Path,

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -212,6 +212,70 @@ class TestWorkflowRuntimeTemplate:
             "merge",
         ]
 
+    def test_workflow_inserted_step_resolves_prompt_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A workflow-inserted step must not block on missing prompt resolution."""
+        repo_root = _scaffold_project(tmp_path)
+        mission_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (mission_dir / "meta.json").write_text(
+            json.dumps(
+                {
+                    "mission_type": "software-dev",
+                    "workflow_id": "our-team-design-first",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        from specify_cli.next import runtime_bridge
+        from specify_cli.next.decision import DecisionKind
+
+        monkeypatch.setattr(
+            runtime_bridge.SyncRuntimeEventEmitter,
+            "for_feature",
+            staticmethod(lambda **_: runtime_bridge._BufferingRuntimeEmitter()),
+        )
+
+        runtime_bridge.decide_next_via_runtime(
+            "agent",
+            "042-test-feature",
+            "success",
+            repo_root,
+        )
+        specify = runtime_bridge.decide_next_via_runtime(
+            "agent",
+            "042-test-feature",
+            "success",
+            repo_root,
+        )
+        assert specify.step_id == "specify"
+        (mission_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+
+        plan = runtime_bridge.decide_next_via_runtime(
+            "agent",
+            "042-test-feature",
+            "success",
+            repo_root,
+        )
+        assert plan.step_id == "plan"
+        (mission_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+
+        design_review = runtime_bridge.decide_next_via_runtime(
+            "agent",
+            "042-test-feature",
+            "success",
+            repo_root,
+        )
+
+        assert design_review.kind == DecisionKind.step
+        assert design_review.step_id == "design-review"
+        assert design_review.action == "design-review"
+        assert design_review.prompt_file is not None
+        assert Path(design_review.prompt_file).is_file()
+
     def test_software_dev_builtin_outranks_stale_user_global(
         self,
         tmp_path: Path,

--- a/tests/specify_cli/next/test_workflow_command.py
+++ b/tests/specify_cli/next/test_workflow_command.py
@@ -1,0 +1,136 @@
+"""CLI coverage for workflow portability commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.workflow import app
+
+runner = CliRunner()
+
+
+def test_workflow_import_validates_and_copies_to_project_overrides(tmp_path: Path) -> None:
+    source = tmp_path / "solo-fast.yaml"
+    source.write_text(
+        """
+workflow_id: solo-fast
+description: Portable workflow.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    project_root = tmp_path / "project"
+
+    result = runner.invoke(app, ["import", str(source), "--project-root", str(project_root)])
+
+    assert result.exit_code == 0, result.output
+    destination = project_root / ".kittify" / "overrides" / "workflows" / "solo-fast.yaml"
+    assert destination.exists()
+    assert destination.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+    assert str(destination) in result.output
+
+
+def test_workflow_export_uses_project_override_precedence(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    workflow_dir = project_root / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    source = workflow_dir / "software-dev-default.yaml"
+    source.write_text(
+        """
+workflow_id: software-dev-default
+description: Project default workflow.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    exported = tmp_path / "exported.yaml"
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "software-dev-default",
+            str(exported),
+            "--project-root",
+            str(project_root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exported.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+    assert str(exported) in result.output
+
+
+def test_workflow_import_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    source = tmp_path / "solo-fast.yaml"
+    source.write_text(
+        """
+workflow_id: solo-fast
+description: Portable workflow.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    project_root = tmp_path / "project"
+    destination = project_root / ".kittify" / "overrides" / "workflows" / "solo-fast.yaml"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("existing", encoding="utf-8")
+
+    result = runner.invoke(app, ["import", str(source), "--project-root", str(project_root)])
+
+    assert result.exit_code != 0
+    assert destination.read_text(encoding="utf-8") == "existing"
+
+
+def test_workflow_list_omits_invalid_project_files(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "bad name.yaml").write_text(
+        """
+workflow_id: bad name
+description: Invalid slug.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "valid.yaml").write_text(
+        """
+workflow_id: valid
+description: Valid project workflow.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["list", "--project-root", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output
+    assert "bad name" not in result.output

--- a/tests/specify_cli/next/test_workflow_registry.py
+++ b/tests/specify_cli/next/test_workflow_registry.py
@@ -7,6 +7,8 @@ ATDD anchors
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 
@@ -42,6 +44,198 @@ def test_get_workflow_loads_fixture_workflow():
     wf = get_workflow("our-team-design-first")
     action_names = [a.action_name for a in wf.actions]
     assert "design-review" in action_names
+
+
+def test_get_workflow_loads_project_override_yaml(tmp_path: Path):
+    from specify_cli.next._internal_runtime.workflow_registry import get_workflow
+
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "github-pr.yaml").write_text(
+        """
+workflow_id: github-pr
+description: Project-authored GitHub PR workflow.
+version: 1
+initial: specify
+integrations:
+  vcs:
+    provider: github_pr
+    target_branch: main
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    next: [submit]
+  - action_name: submit
+    description: Open a pull request
+    integration: vcs.open_pr
+    next: [accept]
+  - action_name: accept
+    description: Accept the merged mission
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    get_workflow.cache_clear()
+    wf = get_workflow("github-pr", project_root=tmp_path)
+
+    assert wf.workflow_id == "github-pr"
+    assert wf.integrations["vcs"]["provider"] == "github_pr"
+    assert [a.action_name for a in wf.actions] == ["specify", "submit", "accept"]
+    assert wf.actions[1].integration == "vcs.open_pr"
+
+
+def test_project_override_precedes_builtin_workflow(tmp_path: Path):
+    from specify_cli.next._internal_runtime.workflow_registry import get_workflow
+
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "software-dev-default.workflow.yaml").write_text(
+        """
+workflow_id: software-dev-default
+description: Project-specific default override.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    next: [accept]
+  - action_name: accept
+    description: Accept directly
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    get_workflow.cache_clear()
+    wf = get_workflow("software-dev-default", project_root=tmp_path)
+
+    assert [a.action_name for a in wf.actions] == ["specify", "accept"]
+
+
+def test_workflow_file_id_must_match_requested_slug(tmp_path: Path):
+    from specify_cli.next._internal_runtime.workflow_registry import (
+        UnknownWorkflowError,
+        get_workflow,
+    )
+
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "github-pr.yaml").write_text(
+        """
+workflow_id: different-id
+description: Mismatched workflow identity.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    get_workflow.cache_clear()
+    with pytest.raises(UnknownWorkflowError, match="declares workflow_id"):
+        get_workflow("github-pr", project_root=tmp_path)
+
+
+def test_project_workflow_reload_reflects_file_changes(tmp_path: Path):
+    from specify_cli.next._internal_runtime.workflow_registry import get_workflow
+
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow_path = workflow_dir / "solo-fast.yaml"
+    workflow_path.write_text(
+        """
+workflow_id: solo-fast
+description: Mutable project workflow.
+version: 1
+initial: plan
+actions:
+  - action_name: plan
+    description: Plan next
+    next: [implement]
+  - action_name: implement
+    description: Implement
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    first = get_workflow("solo-fast", project_root=tmp_path)
+    workflow_path.write_text(
+        """
+workflow_id: solo-fast
+description: Mutable project workflow.
+version: 1
+initial: plan
+actions:
+  - action_name: plan
+    description: Plan next
+    next: [accept]
+  - action_name: accept
+    description: Accept
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    second = get_workflow("solo-fast", project_root=tmp_path)
+
+    assert first.actions[0].next == ["implement"]
+    assert second.actions[0].next == ["accept"]
+
+
+def test_list_available_workflows_omits_invalid_project_files(tmp_path: Path):
+    from specify_cli.next._internal_runtime.workflow_registry import list_available_workflows
+
+    workflow_dir = tmp_path / ".kittify" / "overrides" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "bad name.yaml").write_text(
+        """
+workflow_id: bad name
+description: Invalid slug.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "mismatch.yaml").write_text(
+        """
+workflow_id: different
+description: Mismatched file slug.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (workflow_dir / "valid.yaml").write_text(
+        """
+workflow_id: valid
+description: Valid project workflow.
+version: 1
+initial: specify
+actions:
+  - action_name: specify
+    description: Create a mission specification
+    terminal: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    available = list_available_workflows(project_root=tmp_path)
+
+    assert "valid" in available
+    assert "bad name" not in available
+    assert "mismatch" not in available
 
 
 def test_workflow_sequence_actions_form_dag():
@@ -187,6 +381,40 @@ def test_workflow_sequence_rejects_unreachable_action():
                     },
                     {
                         "action_name": "orphan",
+                        "description": "x",
+                        "terminal": True,
+                    },
+                ],
+            }
+        )
+
+
+def test_workflow_sequence_rejects_branching_next_actions():
+    """Issue #682 v1 workflows stay linear: one current action has one successor."""
+    import pydantic
+
+    from specify_cli.next._internal_runtime.workflow_schema import WorkflowSequence
+
+    with pytest.raises(pydantic.ValidationError, match="linear"):
+        WorkflowSequence.model_validate(
+            {
+                "workflow_id": "test",
+                "description": "x",
+                "version": 1,
+                "initial": "start",
+                "actions": [
+                    {
+                        "action_name": "start",
+                        "description": "x",
+                        "next": ["a", "b"],
+                    },
+                    {
+                        "action_name": "a",
+                        "description": "x",
+                        "terminal": True,
+                    },
+                    {
+                        "action_name": "b",
                         "description": "x",
                         "terminal": True,
                     },


### PR DESCRIPTION
## Summary

- load project-authored workflow definitions from `.kittify/overrides/workflows` before shipped workflows
- extend workflow schema with linear v1 integration/profile/HITL metadata and validation
- compose selected workflows into the frozen `spec-kitty next` runtime template so `meta.json::workflow_id` affects the live path
- add `spec-kitty workflow list/export/import` for portable workflow files
- document custom workflow authoring and generated CLI reference entries

Closes #682.

## Adversarial review follow-up

Ran adversarial reviews before and after opening the PR. Addressed blockers found there:

- removed stale caching for mutable project workflow files
- made `workflow list` show only workflow files that are slug-valid, schema-valid, and identity-matched
- wired `meta.json::workflow_id` into canonical `spec-kitty next` runtime run creation instead of only helper resolution
- updated `docs/reference/cli-commands.md` so docs-freshness recognizes the new visible CLI surface

## Tests

- `.venv/bin/ruff check src/specify_cli/next/_internal_runtime/engine.py src/specify_cli/next/_internal_runtime/planner.py src/specify_cli/next/runtime_bridge.py tests/next/test_runtime_bridge_unit.py tests/specify_cli/next/test_workflow_registry.py tests/specify_cli/next/test_workflow_command.py tests/integration/test_workflow_sequence_runtime.py`
- `.venv/bin/pytest tests/next/test_runtime_bridge_unit.py::TestWorkflowRuntimeTemplate::test_workflow_id_composes_frozen_runtime_template tests/specify_cli/next/test_workflow_registry.py tests/specify_cli/next/test_workflow_command.py tests/integration/test_workflow_sequence_runtime.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 PYTHONPATH=. .venv/bin/python scripts/docs/check_docs_freshness.py --ci --report /tmp/spec-kitty-docs-freshness-1481.json --link-check none`
- `.venv/bin/pytest tests/specify_cli/next/test_workflow_registry.py tests/specify_cli/next/test_workflow_command.py tests/integration/test_workflow_sequence_runtime.py tests/specify_cli/next/test_workflow_software_dev_default_is_byte_stable.py tests/integration/test_slice_f_cross_axis.py tests/next/test_prompt_builder_unit.py tests/next/test_runtime_bridge_unit.py::TestWorkflowRuntimeTemplate::test_workflow_id_composes_frozen_runtime_template`
