### PR TITLE
Fix status emit feature lock race

### DIFF
--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -51,6 +51,7 @@ from .transitions import resolve_lane_alias, validate_transition
 from . import store as _store
 from . import reducer as _reducer
 from .adapters import fire_dossier_sync, fire_saas_fanout
+from .locking import feature_status_lock
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +349,15 @@ def _legacy_alias_collapses_to_current_lane(
     return normalized != resolved_lane and resolved_lane == from_lane
 
 
+def _feature_status_lock_root(feature_dir: Path, repo_root: Path | None) -> Path:
+    """Resolve the repo root used for per-feature status locking."""
+    if repo_root is not None:
+        return repo_root
+    if feature_dir.parent.name == "kitty-specs":
+        return feature_dir.parent.parent
+    return feature_dir
+
+
 def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 params are optional with stable defaults; refactor tracked separately
     feature_dir: TransitionRequest | Path | None = None,
     _legacy_mission_slug: str | None = None,
@@ -466,36 +476,83 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
     # never lands in a stale worktree-local copy.
     feature_dir = canonicalize_feature_dir(feature_dir)
 
-    # T023: Load mission_id (ULID) from meta.json to use as the canonical
-    # machine-facing identity for new events.  None for legacy/pre-3.1.1 missions.
-    mission_id = _load_mission_id(feature_dir)
+    lock_root = _feature_status_lock_root(feature_dir, repo_root)
+    with feature_status_lock(lock_root, mission_slug):
+        # T023: Load mission_id (ULID) from meta.json to use as the canonical
+        # machine-facing identity for new events.  None for legacy/pre-3.1.1 missions.
+        mission_id = _load_mission_id(feature_dir)
 
-    raw_to_lane = to_lane.strip().lower()
+        raw_to_lane = to_lane.strip().lower()
 
-    # Step 1: Resolve alias
-    resolved_lane = resolve_lane_alias(to_lane)
+        # Step 1: Resolve alias
+        resolved_lane = resolve_lane_alias(to_lane)
 
-    # Step 2: Derive from_lane from last event for this WP
-    from_lane = _derive_from_lane(feature_dir, wp_id)
+        # Step 2: Derive from_lane from last event for this WP
+        from_lane = _derive_from_lane(feature_dir, wp_id)
 
-    if workspace_context is None:
-        context_root = repo_root if repo_root is not None else feature_dir
-        workspace_context = f"{execution_mode}:{context_root}"
-    if subtasks_complete is None and from_lane == "in_progress" and resolved_lane == "for_review":
-        subtasks_complete = _infer_subtasks_complete(feature_dir, wp_id)
-    if implementation_evidence_present is None and from_lane == "in_progress" and resolved_lane == "for_review":
-        implementation_evidence_present = _infer_implementation_evidence(feature_dir, wp_id)
+        if workspace_context is None:
+            context_root = repo_root if repo_root is not None else feature_dir
+            workspace_context = f"{execution_mode}:{context_root}"
+        if subtasks_complete is None and from_lane == "in_progress" and resolved_lane == "for_review":
+            subtasks_complete = _infer_subtasks_complete(feature_dir, wp_id)
+        if implementation_evidence_present is None and from_lane == "in_progress" and resolved_lane == "for_review":
+            implementation_evidence_present = _infer_implementation_evidence(feature_dir, wp_id)
 
-    if _legacy_alias_collapses_to_current_lane(raw_to_lane, resolved_lane, from_lane):
-        logger.info(
-            "Collapsing legacy alias %s to existing lane %s for %s/%s",
-            to_lane,
+        if _legacy_alias_collapses_to_current_lane(raw_to_lane, resolved_lane, from_lane):
+            logger.info(
+                "Collapsing legacy alias %s to existing lane %s for %s/%s",
+                to_lane,
+                resolved_lane,
+                mission_slug,
+                wp_id,
+            )
+            _mirror_phase1_frontmatter_lane(feature_dir, wp_id, resolved_lane)
+            return StatusEvent(
+                event_id=_generate_ulid(),
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                from_lane=Lane(from_lane),
+                to_lane=Lane(resolved_lane),
+                at=_now_utc(),
+                actor=actor,
+                force=force,
+                execution_mode=execution_mode,
+                reason=reason,
+                review_ref=review_ref,
+                evidence=None,
+                policy_metadata=policy_metadata,
+                mission_id=mission_id,
+            )
+
+        # Step 3: Validate the transition
+        # Build DoneEvidence early so we can pass it to validate_transition
+        done_evidence: DoneEvidence | None = None
+        if evidence is not None:
+            done_evidence = _build_done_evidence(evidence)
+
+        ok, error_msg = validate_transition(
+            from_lane,
             resolved_lane,
-            mission_slug,
-            wp_id,
+            GuardContext(
+                force=force,
+                actor=actor,
+                workspace_context=workspace_context,
+                subtasks_complete=subtasks_complete,
+                implementation_evidence_present=implementation_evidence_present,
+                reason=reason,
+                review_ref=review_ref,
+                evidence=done_evidence,
+                review_result=review_result,
+                current_actor=current_actor,
+            ),
         )
-        _mirror_phase1_frontmatter_lane(feature_dir, wp_id, resolved_lane)
-        return StatusEvent(
+        if not ok:
+            raise TransitionError(error_msg)
+
+        # Step 4: Create StatusEvent with ULID event_id.
+        # mission_id is the canonical machine-facing identity (ULID from meta.json).
+        # T023: New events carry mission_id alongside mission_slug.
+        event = StatusEvent(
             event_id=_generate_ulid(),
             mission_slug=mission_slug,
             wp_id=wp_id,
@@ -507,69 +564,24 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
             execution_mode=execution_mode,
             reason=reason,
             review_ref=review_ref,
-            evidence=None,
+            evidence=done_evidence,
             policy_metadata=policy_metadata,
             mission_id=mission_id,
         )
 
-    # Step 3: Validate the transition
-    # Build DoneEvidence early so we can pass it to validate_transition
-    done_evidence: DoneEvidence | None = None
-    if evidence is not None:
-        done_evidence = _build_done_evidence(evidence)
+        # Step 5: Persist event to JSONL log and require readback before success.
+        _store.append_event_verified(feature_dir, event)
 
-    ok, error_msg = validate_transition(
-        from_lane,
-        resolved_lane,
-        GuardContext(
-            force=force,
-            actor=actor,
-            workspace_context=workspace_context,
-            subtasks_complete=subtasks_complete,
-            implementation_evidence_present=implementation_evidence_present,
-            reason=reason,
-            review_ref=review_ref,
-            evidence=done_evidence,
-            review_result=review_result,
-            current_actor=current_actor,
-        ),
-    )
-    if not ok:
-        raise TransitionError(error_msg)
+        # Step 6: Materialize snapshot from event log
+        try:
+            _reducer.materialize(feature_dir)
+        except Exception:
+            logger.warning(
+                "Materialization failed after event %s was persisted; run 'status materialize' to recover",
+                event.event_id,
+            )
 
-    # Step 4: Create StatusEvent with ULID event_id.
-    # mission_id is the canonical machine-facing identity (ULID from meta.json).
-    # T023: New events carry mission_id alongside mission_slug.
-    event = StatusEvent(
-        event_id=_generate_ulid(),
-        mission_slug=mission_slug,
-        wp_id=wp_id,
-        from_lane=Lane(from_lane),
-        to_lane=Lane(resolved_lane),
-        at=_now_utc(),
-        actor=actor,
-        force=force,
-        execution_mode=execution_mode,
-        reason=reason,
-        review_ref=review_ref,
-        evidence=done_evidence,
-        policy_metadata=policy_metadata,
-        mission_id=mission_id,
-    )
-
-    # Step 5: Persist event to JSONL log and require readback before success.
-    _store.append_event_verified(feature_dir, event)
-
-    # Step 6: Materialize snapshot from event log
-    try:
-        _reducer.materialize(feature_dir)
-    except Exception:
-        logger.warning(
-            "Materialization failed after event %s was persisted; run 'status materialize' to recover",
-            event.event_id,
-        )
-
-    _mirror_phase1_frontmatter_lane(feature_dir, wp_id, resolved_lane)
+        _mirror_phase1_frontmatter_lane(feature_dir, wp_id, resolved_lane)
 
     # Step 7: SaaS fan-out (never blocks canonical persistence)
     _saas_fan_out(

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -294,6 +294,12 @@ class TestLoadMissionId:
 class TestEmitStatusTransition:
     """Tests for the main emit orchestration function."""
 
+    def test_feature_status_lock_root_falls_back_to_feature_dir(self, tmp_path: Path) -> None:
+        """Non-standard feature dirs still get a deterministic local lock root."""
+        feature_dir = tmp_path / "standalone-feature"
+
+        assert emit_module._feature_status_lock_root(feature_dir, repo_root=None) == feature_dir
+
     def test_transition_request_rejects_mixed_legacy_args(self, feature_dir: Path):
         """TransitionRequest calls must not also pass legacy arguments."""
         request = TransitionRequest(
@@ -462,6 +468,37 @@ class TestEmitStatusTransition:
             actor="agent-1",
         ))
         assert event.to_lane == Lane.IN_PROGRESS
+
+    def test_alias_collapse_noop_returns_without_new_event(self, feature_dir: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Legacy alias to the current lane is a locked no-op, not a duplicate event."""
+        emit_status_transition(TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug="034-test-feature",
+            wp_id="WP01",
+            to_lane="claimed",
+            actor="agent-1",
+        ))
+        emit_status_transition(TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug="034-test-feature",
+            wp_id="WP01",
+            to_lane="doing",
+            actor="agent-1",
+        ))
+
+        with caplog.at_level("INFO"):
+            event = emit_status_transition(TransitionRequest(
+                feature_dir=feature_dir,
+                mission_slug="034-test-feature",
+                wp_id="WP01",
+                to_lane="doing",
+                actor="agent-1",
+            ))
+
+        assert event.from_lane == Lane.IN_PROGRESS
+        assert event.to_lane == Lane.IN_PROGRESS
+        assert len(read_events(feature_dir)) == 2
+        assert "Collapsing legacy alias doing to existing lane in_progress" in caplog.text
 
     def test_invalid_transition_rejected_no_persistence(self, feature_dir: Path):
         """Invalid transition raises TransitionError and persists nothing."""

--- a/tests/status/test_emit.py
+++ b/tests/status/test_emit.py
@@ -8,6 +8,7 @@ alias resolution, and pipeline ordering guarantees.
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -345,6 +346,66 @@ class TestEmitStatusTransition:
         assert snapshot_path.exists()
         data = json.loads(snapshot_path.read_text(encoding="utf-8"))
         assert data["work_packages"]["WP01"]["lane"] == "claimed"
+
+    def test_transition_holds_feature_lock_through_canonical_mutation(
+        self,
+        feature_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Derive, append, and materialize must share the feature status lock."""
+        lock_root = feature_dir.parent.parent
+        lock_state = {"held": False}
+        observed: list[str] = []
+
+        @contextmanager
+        def tracking_lock(repo_root: Path, mission_slug: str):  # type: ignore[no-untyped-def]
+            assert repo_root == lock_root
+            assert mission_slug == "034-test-feature"
+            lock_state["held"] = True
+            try:
+                yield lock_root / ".git" / "spec-kitty-locks" / f"{mission_slug}.status.lock"
+            finally:
+                lock_state["held"] = False
+
+        real_derive = emit_module._derive_from_lane
+        real_append = emit_module._store.append_event_verified
+        real_materialize = emit_module._reducer.materialize
+
+        def tracking_derive(*args: object, **kwargs: object):
+            assert lock_state["held"] is True
+            observed.append("derive")
+            return real_derive(*args, **kwargs)
+
+        def tracking_append(*args: object, **kwargs: object):
+            assert lock_state["held"] is True
+            observed.append("append")
+            return real_append(*args, **kwargs)
+
+        def tracking_materialize(*args: object, **kwargs: object):
+            assert lock_state["held"] is True
+            observed.append("materialize")
+            return real_materialize(*args, **kwargs)
+
+        monkeypatch.setattr(emit_module, "feature_status_lock", tracking_lock, raising=False)
+        monkeypatch.setattr(emit_module, "_derive_from_lane", tracking_derive)
+        monkeypatch.setattr(emit_module._store, "append_event_verified", tracking_append)
+        monkeypatch.setattr(emit_module._reducer, "materialize", tracking_materialize)
+
+        event = emit_status_transition(
+            TransitionRequest(
+                feature_dir=feature_dir,
+                mission_slug="034-test-feature",
+                wp_id="WP01",
+                to_lane="claimed",
+                actor="claude-opus",
+                repo_root=lock_root,
+            ),
+            ensure_sync_daemon=False,
+            sync_dossier=False,
+        )
+
+        assert event.to_lane == Lane.CLAIMED
+        assert observed == ["derive", "append", "materialize"]
 
     def test_chained_transitions(self, feature_dir: Path):
         """Multiple transitions chain correctly, deriving from_lane."""


### PR DESCRIPTION
## Summary
- fixes #1444 by acquiring feature_status_lock inside emit_status_transition before deriving, validating, appending, materializing, and mirroring canonical status state
- keeps SaaS/dossier fanout outside the lock
- adds regression coverage proving derive/append/materialize share the feature lock

## Verification
- .venv/bin/pytest tests/status/test_emit.py::TestEmitStatusTransition::test_transition_holds_feature_lock_through_canonical_mutation -q
- .venv/bin/pytest tests/status/test_emit.py tests/status/test_agent_status_emit_cli.py -q
- .venv/bin/pytest tests/contract/test_canonical_root_when_in_worktree.py tests/git_ops/test_atomic_status_commits_unit.py::TestFeatureStatusLock -q
- .venv/bin/pytest tests/status/test_work_package_lifecycle.py tests/status/test_emit_backward_transition.py tests/sync/test_dual_write_integration.py -q
- .venv/bin/ruff check src/specify_cli/status/emit.py tests/status/test_emit.py
- git diff --check

## Self Review
Used adversarial-pr-review stance before PR. Checked lock granularity, fanout placement, reentrant lock callers, worktree canonical-root behavior, and batch callers. No merge blockers found.