### PR TITLE
Fail closed on malformed acceptance verdict values

### DIFF
--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -20,6 +20,13 @@ from typing import Any
 from specify_cli.configured_command import ConfiguredCommandUnsupported, run_configured_command
 from specify_cli.mission_metadata import mission_identity_fields, resolve_mission_identity
 
+CRITERION_VERDICTS = frozenset({"pass", "fail", "pending"})
+NEGATIVE_INVARIANT_RESULTS = frozenset({"confirmed_absent", "still_present", "pending"})
+
+
+def _is_allowed_value(value: Any, allowed: frozenset[str]) -> bool:
+    return isinstance(value, str) and value in allowed
+
 
 def _split_known_fields(
     cls: type[Any],
@@ -103,12 +110,19 @@ class AcceptanceMatrix:
     @property
     def overall_verdict(self) -> str:
         """Compute verdict from individual results."""
-        all_items = [c.pass_fail for c in self.criteria] + [ni.result for ni in self.negative_invariants]
-        if not all_items:
+        criterion_results = [c.pass_fail for c in self.criteria]
+        invariant_results = [ni.result for ni in self.negative_invariants]
+        if not criterion_results and not invariant_results:
             return "pending"
-        if any(v == "fail" or v == "still_present" for v in all_items):
+        if any(not _is_allowed_value(v, CRITERION_VERDICTS) for v in criterion_results):
             return "fail"
-        if any(v == "pending" for v in all_items):
+        if any(not _is_allowed_value(v, NEGATIVE_INVARIANT_RESULTS) for v in invariant_results):
+            return "fail"
+        if any(v == "fail" for v in criterion_results):
+            return "fail"
+        if any(v == "still_present" for v in invariant_results):
+            return "fail"
+        if any(v == "pending" for v in criterion_results + invariant_results):
             return "pending"
         return "pass"
 
@@ -284,7 +298,14 @@ def validate_matrix_evidence(matrix: AcceptanceMatrix) -> list[str]:
     """Validate all evidence in the matrix. Returns list of errors."""
     errors: list[str] = []
     for criterion in matrix.criteria:
+        if not _is_allowed_value(criterion.pass_fail, CRITERION_VERDICTS):
+            allowed = ", ".join(sorted(CRITERION_VERDICTS))
+            errors.append(f"{criterion.criterion_id}: pass_fail must be one of {allowed}; got {criterion.pass_fail!r}")
         errors.extend(validate_manual_evidence(criterion))
+    for invariant in matrix.negative_invariants:
+        if not _is_allowed_value(invariant.result, NEGATIVE_INVARIANT_RESULTS):
+            allowed = ", ".join(sorted(NEGATIVE_INVARIANT_RESULTS))
+            errors.append(f"{invariant.invariant_id}: result must be one of {allowed}; got {invariant.result!r}")
     return errors
 
 

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -76,6 +76,28 @@ class TestAcceptanceMatrix:
         m = AcceptanceMatrix(mission_slug="test")
         assert m.overall_verdict == "pending"
 
+    @pytest.mark.parametrize("pass_fail", ["failed", "FAIL", "Pending", None, ["fail"]])
+    def test_verdict_invalid_criterion_result_fails_closed(self, pass_fail):
+        m = AcceptanceMatrix(
+            mission_slug="test",
+            criteria=[
+                AcceptanceCriterion("AC-01", "Test", "automated_test", pass_fail=pass_fail),
+            ],
+        )
+
+        assert m.overall_verdict == "fail"
+
+    @pytest.mark.parametrize("result", ["absent", "STILL_PRESENT", "Pending", None, ["still_present"]])
+    def test_verdict_invalid_negative_invariant_result_fails_closed(self, result):
+        m = AcceptanceMatrix(
+            mission_slug="test",
+            negative_invariants=[
+                NegativeInvariant("NI-01", "Old route gone", "grep_absence", result=result),
+            ],
+        )
+
+        assert m.overall_verdict == "fail"
+
 
 class TestPersistence:
     def test_round_trip(self, tmp_path):
@@ -201,6 +223,22 @@ class TestManualEvidence:
         )
         errors = validate_matrix_evidence(m)
         assert len(errors) == 3  # evidence, verified_at, verified_by
+
+    def test_matrix_level_validation_rejects_invalid_verdict_values(self):
+        m = AcceptanceMatrix(
+            mission_slug="test",
+            criteria=[
+                AcceptanceCriterion("AC-01", "Auto", "automated_test", pass_fail="failed"),
+            ],
+            negative_invariants=[
+                NegativeInvariant("NI-01", "Legacy route gone", "grep_absence", result="absent"),
+            ],
+        )
+
+        errors = validate_matrix_evidence(m)
+
+        assert "AC-01: pass_fail must be one of fail, pass, pending; got 'failed'" in errors
+        assert "NI-01: result must be one of confirmed_absent, pending, still_present; got 'absent'" in errors
 
 
 class TestNegativeInvariants:

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -406,6 +406,47 @@ def test_collect_feature_summary_reports_missing_matrix_skipped_checks(tmp_path:
     assert any("acceptance-matrix.json" in item for item in summary.recommended_fix_order)
 
 
+def test_collect_feature_summary_blocks_malformed_matrix_verdict_values(tmp_path: Path) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    write_single_lane_manifest(feature_dir)
+    (feature_dir / "acceptance-matrix.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": _FEATURE_SLUG,
+                "criteria": [
+                    {
+                        "criterion_id": "AC-01",
+                        "description": "Automated acceptance proof",
+                        "proof_type": "automated_test",
+                        "pass_fail": "failed",
+                    }
+                ],
+                "negative_invariants": [],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "-C", str(repo_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add malformed acceptance matrix"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "checkout", "-b", f"kitty/mission-{_FEATURE_SLUG}"],
+        check=True,
+        capture_output=True,
+    )
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG, mutate_matrix=False)
+
+    assert "Evidence: AC-01: pass_fail must be one of fail, pass, pending; got 'failed'" in summary.activity_issues
+    assert "Acceptance matrix verdict is 'fail' — negative invariants or criteria not satisfied" in summary.activity_issues
+    assert summary.ok is False
+
+
 # ---------------------------------------------------------------------------
 # Integration branch guard: merge guidance must not target integration branch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fail closed when acceptance matrix criterion `pass_fail` has malformed/non-string values
- fail closed when negative invariant `result` has malformed/non-string values
- report explicit evidence validation errors and cover lane-gate summary behavior

Closes #1424

## Verification
- `uv run pytest tests/specify_cli/test_acceptance_regressions.py tests/lanes/test_acceptance_matrix.py -q`
- `uv run ruff check src/specify_cli/acceptance/matrix.py tests/lanes/test_acceptance_matrix.py tests/specify_cli/test_acceptance_regressions.py`
- `git diff --check`

## Self-review
- Ran adversarial-pr-review against local diff before opening PR. Initial finding: non-string/unhashable persisted JSON verdict values could still crash instead of fail closed. Fixed with `_is_allowed_value` and regression cases for `None`/list values. No remaining merge blockers found locally.