### PR TITLE
Fix org-required doctrine selection rendering

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -295,14 +295,21 @@ def _classify_artifact_urns(
     artifact_urns: frozenset[str] | set[str],
     merged: object,
     project_directives: set[str],
+    selected_tactics: set[str] | None = None,
+    selected_paradigms: set[str] | None = None,
 ) -> tuple[list[str], list[str], list[str], list[str]]:
     """Partition resolved artifact URNs into doctrine-type buckets."""
     from doctrine.drg.models import NodeKind, Relation
     from doctrine.drg.query import resolve_transitive_refs
 
+    selected_tactics = selected_tactics or set()
+    selected_paradigms = selected_paradigms or set()
+    start_urns = {f"directive:{directive_id}" for directive_id in project_directives}
+    start_urns.update(f"tactic:{tactic_id}" for tactic_id in selected_tactics)
+    start_urns.update(f"paradigm:{paradigm_id}" for paradigm_id in selected_paradigms)
     selected_closure = resolve_transitive_refs(
         merged,
-        start_urns={f"directive:{directive_id}" for directive_id in project_directives},
+        start_urns=start_urns,
         relations={Relation.REQUIRES, Relation.SUGGESTS},
     )
     artifact_urns = set(artifact_urns)
@@ -494,13 +501,14 @@ def _load_action_doctrine_bundle(
 ) -> _ActionDoctrineBundle:
     """Load DRG-backed action doctrine artifacts for bootstrap rendering."""
     from charter._drg_helpers import load_validated_graph
-    from charter.sync import load_governance_config
     from doctrine.drg.loader import DRGLoadError
     from doctrine.drg.query import resolve_context
 
-    governance = load_governance_config(repo_root)
-    mission = (governance.doctrine.template_set or "software-dev-default").removesuffix("-default")
-    project_directives = {_normalize_directive_id(d) for d in governance.doctrine.selected_directives}
+    doctrine_selection = _load_doctrine_selection(repo_root)
+    mission = (doctrine_selection.template_set or "software-dev-default").removesuffix("-default")
+    project_directives = {_normalize_directive_id(d) for d in doctrine_selection.selected_directives}
+    selected_tactics = {t for t in doctrine_selection.selected_tactics if t}
+    selected_paradigms = {p for p in doctrine_selection.selected_paradigms if p}
 
     # WP07 T034: route the DRG load through the shared helper so the built-in +
     # org + project three-layer overlay is honoured.  Callers in ``specify_cli``
@@ -524,7 +532,11 @@ def _load_action_doctrine_bundle(
         action_urn = f"action:{mission}/{action}"
         resolved = resolve_context(merged, action_urn, depth=effective_depth)
         directive_ids, tactic_ids, styleguide_ids, toolguide_ids = _classify_artifact_urns(
-            resolved.artifact_urns, merged, project_directives
+            resolved.artifact_urns,
+            merged,
+            project_directives,
+            selected_tactics,
+            selected_paradigms,
         )
     except DRGLoadError as exc:
         _LOGGER.warning(
@@ -1033,15 +1045,14 @@ def _append_action_doctrine_lines(
     """Append action doctrine content to lines list. Degrades gracefully on error."""
     from doctrine.missions import MissionTemplateRepository
     from doctrine.missions.action_index import load_action_index
-    from charter.sync import load_governance_config
 
     try:
         repo = MissionTemplateRepository.default()
-        governance = load_governance_config(repo_root)
-        template_set = governance.doctrine.template_set or "software-dev-default"
+        doctrine_selection = _load_doctrine_selection(repo_root)
+        template_set = doctrine_selection.template_set or "software-dev-default"
         mission = template_set.removesuffix("-default")
         action_index = load_action_index(repo._missions_root, mission, action)
-        project_directives: set[str] = {_normalize_directive_id(d) for d in governance.doctrine.selected_directives}
+        project_directives: set[str] = {_normalize_directive_id(d) for d in doctrine_selection.selected_directives}
         doctrine_service = _build_doctrine_service(repo_root)
 
         lines.append(f"Action Doctrine ({action}):")
@@ -1459,6 +1470,9 @@ def _render_profile_tactics(
 # ---------------------------------------------------------------------------
 
 
+_SELECTED_PARADIGMS_HEADER = "Selected paradigms:"
+_SELECTED_DIRECTIVES_HEADER = "Selected directives:"
+_SELECTED_TACTICS_HEADER = "Selected tactics:"
 _SELECTED_STYLEGUIDES_HEADER = "Selected styleguides:"
 _SELECTED_TOOLGUIDES_HEADER = "Selected toolguides:"
 _SELECTED_PROCEDURES_HEADER = "Selected procedures:"
@@ -1507,6 +1521,36 @@ def _format_inline_styleguide_body(styleguide: object) -> list[str]:
         body_lines.append("    Principles:")
         for principle in principles:
             body_lines.append(f"      - {principle}")
+    return body_lines
+
+
+def _format_inline_paradigm_body(paradigm: object) -> list[str]:
+    """Render the verbatim body of a paradigm as indented lines."""
+    body_lines: list[str] = []
+    name = getattr(paradigm, "name", None)
+    if isinstance(name, str) and name.strip():
+        body_lines.append(f"    Name: {name.strip()}")
+    summary = getattr(paradigm, "summary", None)
+    if isinstance(summary, str) and summary.strip():
+        body_lines.append(f"    Summary: {summary.strip()}")
+    return body_lines
+
+
+def _format_inline_tactic_body(tactic: object) -> list[str]:
+    """Render the verbatim body of a tactic as indented lines."""
+    body_lines: list[str] = []
+    name = getattr(tactic, "name", None)
+    if isinstance(name, str) and name.strip():
+        body_lines.append(f"    Name: {name.strip()}")
+    purpose = getattr(tactic, "purpose", None)
+    if isinstance(purpose, str) and purpose.strip():
+        body_lines.append(f"    Purpose: {purpose.strip()}")
+    steps = getattr(tactic, "steps", None)
+    if isinstance(steps, list) and steps:
+        body_lines.append("    Steps:")
+        for step in steps:
+            step_title = getattr(step, "title", str(step))
+            body_lines.append(f"      - {step_title}")
     return body_lines
 
 
@@ -1629,7 +1673,7 @@ def _available_catalog_ids(repository: object | None) -> list[str]:
 
 def _render_selected_artifacts(
     selected_ids: list[str],
-    repository: object,
+    repository: object | None,
     *,
     header: str,
     selector_kind: str,
@@ -1637,7 +1681,7 @@ def _render_selected_artifacts(
     body_formatter,  # noqa: ANN001 — callable[(object), list[str]]
     org_source_map: dict[str, str] | None = None,
 ) -> list[str]:
-    """Shared implementation for the 5 ``_render_selected_<kind>`` helpers.
+    """Shared implementation for the 8 ``_render_selected_<kind>`` helpers.
 
     Each helper is a thin wrapper that picks the right repository
     (``service.styleguides`` / ``service.toolguides`` / ...) and inline
@@ -1714,6 +1758,63 @@ def _render_selected_artifacts(
             )
 
     return lines
+
+
+def _render_selected_paradigms(
+    selected_ids: list[str],
+    service: object,
+    *,
+    org_source_map: dict[str, str] | None = None,
+) -> list[str]:
+    """Render globally-selected paradigms into prompt lines."""
+    repo = getattr(service, "paradigms", None)
+    return _render_selected_artifacts(
+        selected_ids,
+        repo,
+        header=_SELECTED_PARADIGMS_HEADER,
+        selector_kind="paradigm",
+        when_clause="are about to choose a reasoning frame",
+        body_formatter=_format_inline_paradigm_body,
+        org_source_map=org_source_map,
+    )
+
+
+def _render_selected_directives(
+    selected_ids: list[str],
+    service: object,
+    *,
+    org_source_map: dict[str, str] | None = None,
+) -> list[str]:
+    """Render globally-selected directives into prompt lines."""
+    repo = getattr(service, "directives", None)
+    return _render_selected_artifacts(
+        selected_ids,
+        repo,
+        header=_SELECTED_DIRECTIVES_HEADER,
+        selector_kind="directive",
+        when_clause="are about to apply a code change",
+        body_formatter=_format_inline_directive_body,
+        org_source_map=org_source_map,
+    )
+
+
+def _render_selected_tactics(
+    selected_ids: list[str],
+    service: object,
+    *,
+    org_source_map: dict[str, str] | None = None,
+) -> list[str]:
+    """Render globally-selected tactics into prompt lines."""
+    repo = getattr(service, "tactics", None)
+    return _render_selected_artifacts(
+        selected_ids,
+        repo,
+        header=_SELECTED_TACTICS_HEADER,
+        selector_kind="tactic",
+        when_clause="are about to apply a code change",
+        body_formatter=_format_inline_tactic_body,
+        org_source_map=org_source_map,
+    )
 
 
 def _render_selected_styleguides(
@@ -1853,9 +1954,9 @@ def _render_selection_block(
     *,
     repo_root: Path | None = None,
 ) -> str:
-    """Render the combined 5-kind selection section block.
+    """Render the combined 8-kind selection section block.
 
-    Concatenates the 5 ``_render_selected_<kind>`` outputs with blank
+    Concatenates the 8 ``_render_selected_<kind>`` outputs with blank
     lines between non-empty blocks so the prompt body remains readable.
     Returns ``""`` when no selections exist on the charter — the caller
     can then skip the leading blank line without emitting a stray
@@ -1895,6 +1996,27 @@ def _render_selection_block(
                 merged[sid] = ""
         return merged
 
+    paradigm_org = _merge(
+        _collect_org_source_map(
+            getattr(service, "paradigms", None), doctrine_selection.selected_paradigms
+        ),
+        "paradigms",
+        doctrine_selection.selected_paradigms,
+    )
+    directive_org = _merge(
+        _collect_org_source_map(
+            getattr(service, "directives", None), doctrine_selection.selected_directives
+        ),
+        "directives",
+        doctrine_selection.selected_directives,
+    )
+    tactic_org = _merge(
+        _collect_org_source_map(
+            getattr(service, "tactics", None), doctrine_selection.selected_tactics
+        ),
+        "tactics",
+        doctrine_selection.selected_tactics,
+    )
     styleguide_org = _merge(
         _collect_org_source_map(
             getattr(service, "styleguides", None), doctrine_selection.selected_styleguides
@@ -1935,6 +2057,15 @@ def _render_selection_block(
 
     blocks: list[str] = []
     sections = (
+        _render_selected_paradigms(
+            doctrine_selection.selected_paradigms, service, org_source_map=paradigm_org
+        ),
+        _render_selected_directives(
+            doctrine_selection.selected_directives, service, org_source_map=directive_org
+        ),
+        _render_selected_tactics(
+            doctrine_selection.selected_tactics, service, org_source_map=tactic_org
+        ),
         _render_selected_styleguides(
             doctrine_selection.selected_styleguides, service, org_source_map=styleguide_org
         ),

--- a/tests/charter/test_context.py
+++ b/tests/charter/test_context.py
@@ -284,6 +284,93 @@ class TestBuildContextV2:
         assert "DIRECTIVE_039" in result.text
         assert "boring-code-review" in result.text
 
+    def test_org_required_primary_kinds_contribute_to_prompt(self, tmp_path: Path) -> None:
+        """Org-required directives, tactics, and paradigms render without project mirroring."""
+        _setup_fixture_repo(tmp_path)
+        org_pack = tmp_path / "org-pack"
+        org_pack.mkdir()
+        (org_pack / "org-charter.yaml").write_text(
+            textwrap.dedent("""\
+                required_directives:
+                  - DIRECTIVE_039
+                required_tactics:
+                  - threat-model-first
+                required_paradigms:
+                  - structured-prompt-driven-development
+            """),
+            encoding="utf-8",
+        )
+        (tmp_path / ".kittify" / "config.yaml").write_text(
+            textwrap.dedent(f"""\
+                doctrine:
+                  org:
+                    packs:
+                      - name: security
+                        local_path: {org_pack.as_posix()}
+            """),
+            encoding="utf-8",
+        )
+
+        graph_yaml = textwrap.dedent("""\
+            schema_version: "1.0"
+            generated_at: "2026-04-13T10:00:00+00:00"
+            generated_by: "test"
+            nodes:
+              - urn: "action:software-dev/implement"
+                kind: action
+                label: implement
+              - urn: "directive:DIRECTIVE_039"
+                kind: directive
+                label: Lynn Cole Engineering Culture
+              - urn: "tactic:boring-code-review"
+                kind: tactic
+                label: Boring Code Review
+              - urn: "tactic:threat-model-first"
+                kind: tactic
+                label: Threat Model First
+              - urn: "tactic:reasons-canvas-fill"
+                kind: tactic
+                label: Reasons Canvas Fill
+              - urn: "paradigm:structured-prompt-driven-development"
+                kind: paradigm
+                label: Structured Prompt-Driven Development
+            edges:
+              - source: "directive:DIRECTIVE_039"
+                target: "tactic:boring-code-review"
+                relation: requires
+              - source: "paradigm:structured-prompt-driven-development"
+                target: "tactic:reasons-canvas-fill"
+                relation: requires
+        """)
+
+        from io import StringIO
+
+        from doctrine.drg.models import DRGGraph
+        from ruamel.yaml import YAML
+
+        yaml = YAML(typ="safe")
+        mock_graph = DRGGraph.model_validate(yaml.load(StringIO(graph_yaml)))
+
+        with (
+            patch("charter._drg_helpers.load_validated_graph", return_value=mock_graph),
+            patch("charter.catalog.resolve_doctrine_root", return_value=tmp_path),
+            patch("doctrine.drg.validator.assert_valid"),
+            patch("charter.sync.ensure_charter_bundle_fresh", return_value=None),
+        ):
+            result = build_charter_context(tmp_path, action="implement", depth=2, mark_loaded=False)
+
+        action_block = result.text.split("Action Doctrine (implement):", 1)[1]
+        assert "DIRECTIVE_039" in action_block
+        assert "boring-code-review" in action_block
+        assert "threat-model-first" in action_block
+        assert "reasons-canvas-fill" in action_block
+        assert "Selected paradigms:" in result.text
+        assert "structured-prompt-driven-development" in result.text
+        assert "Selected directives:" in result.text
+        assert "DIRECTIVE_039" in result.text
+        assert "Selected tactics:" in result.text
+        assert "threat-model-first" in result.text
+
     def test_text_contains_reference_docs(self, tmp_path: Path) -> None:
         """Output text includes Reference Docs section."""
         result = self._call(tmp_path)

--- a/tests/charter/test_context_selection_render.py
+++ b/tests/charter/test_context_selection_render.py
@@ -1,6 +1,6 @@
 """WP04 unit tests — charter-level global selection renderers.
 
-This module pins the behaviour of the 5 ``_render_selected_<kind>``
+This module pins the behaviour of the ``_render_selected_<kind>``
 helpers introduced by WP04 of mission
 ``charter-mediated-doctrine-selection-01KRTZCA``.
 
@@ -79,12 +79,18 @@ class _StubService:
     def __init__(
         self,
         *,
+        paradigms: _StubRepo | None = None,
+        directives: _StubRepo | None = None,
+        tactics: _StubRepo | None = None,
         styleguides: _StubRepo | None = None,
         toolguides: _StubRepo | None = None,
         procedures: _StubRepo | None = None,
         agent_profiles: _StubRepo | None = None,
         mission_step_contracts: _StubRepo | None = None,
     ) -> None:
+        self.paradigms = paradigms or _StubRepo()
+        self.directives = directives or _StubRepo()
+        self.tactics = tactics or _StubRepo()
         self.styleguides = styleguides or _StubRepo()
         self.toolguides = toolguides or _StubRepo()
         self.procedures = procedures or _StubRepo()
@@ -97,6 +103,25 @@ class _DummyStyleguide:
         self.title = title
         self.scope = scope
         self.principles = principles
+
+
+class _DummyParadigm:
+    def __init__(self, *, name: str, summary: str) -> None:
+        self.name = name
+        self.summary = summary
+
+
+class _DummyDirective:
+    def __init__(self, *, title: str, intent: str) -> None:
+        self.title = title
+        self.intent = intent
+
+
+class _DummyTactic:
+    def __init__(self, *, name: str, purpose: str, steps: list[Any]) -> None:
+        self.name = name
+        self.purpose = purpose
+        self.steps = steps
 
 
 class _DummyToolguide:
@@ -387,12 +412,43 @@ class TestDeduplication:
 
 
 # ---------------------------------------------------------------------------
-# Combined block — all 5 sections compose correctly
+# Combined block — selected sections compose correctly
 # ---------------------------------------------------------------------------
 
 
 class TestCombinedSelectionBlock:
-    """``_render_selection_block`` composes all 5 sections in fixed order."""
+    """``_render_selection_block`` composes selected sections in fixed order."""
+
+    def test_directives_tactics_and_paradigms_render_from_global_selection(self) -> None:
+        paradigm = _DummyParadigm(name="SPDD", summary="Use structured prompts.")
+        directive = _DummyDirective(title="Security Baseline", intent="Never leak secrets.")
+        tactic = _DummyTactic(
+            name="Threat Model First",
+            purpose="Find attacker paths before coding.",
+            steps=[_DummyStep(title="Map trust boundaries")],
+        )
+        service = _StubService(
+            paradigms=_StubRepo(items={"structured-prompt-driven-development": paradigm}),
+            directives=_StubRepo(items={"DIRECTIVE_999": directive}),
+            tactics=_StubRepo(items={"threat-model-first": tactic}),
+        )
+        selection = DoctrineSelectionConfig(
+            selected_paradigms=["structured-prompt-driven-development"],
+            selected_directives=["DIRECTIVE_999"],
+            selected_tactics=["threat-model-first"],
+        )
+
+        block = _render_selection_block(selection, service)
+
+        assert "Selected paradigms:" in block
+        assert "structured-prompt-driven-development" in block
+        assert "Use structured prompts." in block
+        assert "Selected directives:" in block
+        assert "DIRECTIVE_999" in block
+        assert "Never leak secrets." in block
+        assert "Selected tactics:" in block
+        assert "threat-model-first" in block
+        assert "Find attacker paths before coding." in block
 
     def test_all_five_kinds_appear_in_order(self) -> None:
         sg = _DummyStyleguide(title="SG", principles=["a"])


### PR DESCRIPTION
## Summary
- render selected paradigms, directives, and tactics in the charter global selection block
- feed unioned org-required doctrine selections into Action Doctrine resolution
- add regressions for org-required directives/tactics/paradigms reaching prompts without project mirroring

Closes #1465

## Verification
- .venv/bin/pytest tests/charter/test_context_selection_render.py tests/charter/test_context.py tests/architectural/test_artifact_selection_completeness.py tests/integration/test_org_pack_artifact_lifecycle.py tests/specify_cli/doctrine/test_org_charter.py tests/specify_cli/doctrine/test_org_charter_union.py
- .venv/bin/ruff check src/charter/context.py tests/charter/test_context_selection_render.py tests/charter/test_context.py

## Self-review
Ran adversarial-pr-review locally before opening. Finding: initial tests missed selected tactic/paradigm action-context behavior. Addressed by expanding the org-required regression to cover directive closure, direct tactic inclusion, and paradigm closure.