### PR TITLE
Fail closed on corrupt lane acceptance manifests

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -579,11 +579,19 @@ def _check_lane_gates(
     mutate_matrix: bool = True,
 ) -> None:
     """Enforce lane-based acceptance gates: branch check + acceptance matrix."""
-    try:
-        from specify_cli.lanes.persistence import read_lanes_json
+    from specify_cli.lanes.persistence import CorruptLanesError, read_lanes_json
 
+    try:
         lanes_manifest = read_lanes_json(feature_dir)
-    except Exception:
+    except CorruptLanesError as exc:
+        message = str(exc)
+        activity_issues.append(message)
+        blocked_checks.append(AcceptanceCheckDiagnostic(check="lanes_manifest", detail=message))
+        _append_skipped_lane_checks(
+            skipped_checks,
+            reason="lanes.json is corrupt or malformed",
+            include_matrix_presence=True,
+        )
         return
 
     if lanes_manifest is None:
@@ -773,6 +781,8 @@ def _build_recommended_fix_order(
         recommendations.append("Resolve open NEEDS CLARIFICATION markers.")
     if any(item.check == "acceptance_matrix" for item in blocked_checks):
         recommendations.append("Create or restore kitty-specs/<mission>/acceptance-matrix.json.")
+    if any(item.check == "lanes_manifest" for item in blocked_checks):
+        recommendations.append("Restore or regenerate kitty-specs/<mission>/lanes.json.")
     if any("Evidence:" in issue for issue in activity_issues):
         recommendations.append("Fill missing acceptance matrix evidence fields.")
     if any("Acceptance matrix verdict is" in issue for issue in activity_issues):

--- a/src/specify_cli/lanes/persistence.py
+++ b/src/specify_cli/lanes/persistence.py
@@ -81,7 +81,7 @@ def read_lanes_json(feature_dir: Path) -> LanesManifest | None:
     try:
         data = json.loads(lanes_path.read_text(encoding="utf-8"))
         return LanesManifest.from_dict(data)
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         raise CorruptLanesError(
             f"lanes.json at {lanes_path} is corrupt or malformed: {exc}"
         ) from exc

--- a/tests/cross_cutting/misc/test_acceptance_support.py
+++ b/tests/cross_cutting/misc/test_acceptance_support.py
@@ -265,6 +265,45 @@ def test_accept_diagnose_json_reports_skipped_checks_without_mutation(
     assert status.stdout == ""
 
 
+def test_accept_diagnose_json_blocks_corrupt_lanes_json(
+    feature_repo: Path, mission_slug: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.lane_test_utils import write_single_lane_manifest
+    from tests.utils import run
+
+    _write_acceptance_meta(feature_repo, mission_slug)
+    feature_dir = feature_repo / "kitty-specs" / mission_slug
+    write_single_lane_manifest(feature_dir)
+    (feature_dir / "lanes.json").write_text("{not-json", encoding="utf-8")
+    run(["git", "branch", "-M", "main"], cwd=feature_repo)
+    run(["git", "add", "."], cwd=feature_repo)
+    run(["git", "commit", "-m", "Add corrupt lane metadata"], cwd=feature_repo)
+    run(["git", "checkout", "-b", f"kitty/mission-{mission_slug}"], cwd=feature_repo)
+
+    before_meta = (feature_dir / "meta.json").read_text(encoding="utf-8")
+    monkeypatch.chdir(feature_repo)
+    result = runner.invoke(
+        cli_app,
+        [
+            "accept",
+            "--mission",
+            mission_slug,
+            "--diagnose",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert any(item["check"] == "lanes_manifest" for item in payload["blocked_checks"])
+    assert any(item["check"] == "acceptance_matrix_presence" for item in payload["skipped_checks"])
+    assert any("lanes.json" in item for item in payload["recommended_fix_order"])
+    assert (feature_dir / "meta.json").read_text(encoding="utf-8") == before_meta
+    status = run(["git", "status", "--short"], cwd=feature_repo)
+    assert status.stdout == ""
+
+
 def test_accept_diagnose_does_not_mutate_matrix_metadata_or_events(
     feature_repo: Path, mission_slug: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/lanes/test_persistence.py
+++ b/tests/lanes/test_persistence.py
@@ -63,6 +63,12 @@ def test_read_invalid_schema_raises(tmp_path):
         read_lanes_json(tmp_path)
 
 
+def test_read_unreadable_lanes_path_raises_corrupt(tmp_path):
+    (tmp_path / "lanes.json").mkdir()
+    with pytest.raises(CorruptLanesError, match="corrupt or malformed"):
+        read_lanes_json(tmp_path)
+
+
 def test_atomic_write_leaves_no_temp_on_success(tmp_path):
     manifest = _make_manifest()
     write_lanes_json(tmp_path, manifest)

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -486,6 +486,31 @@ def test_collect_feature_summary_blocks_corrupt_lanes_json(tmp_path: Path, lanes
     assert any("lanes.json" in item for item in summary.recommended_fix_order)
 
 
+def test_collect_feature_summary_blocks_unreadable_lanes_path(tmp_path: Path) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    write_single_lane_manifest(feature_dir)
+    (feature_dir / "lanes.json").unlink()
+    (feature_dir / "lanes.json").mkdir()
+    (feature_dir / "lanes.json" / ".keep").write_text("", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add unreadable lanes manifest"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "checkout", "-b", f"kitty/mission-{_FEATURE_SLUG}"],
+        check=True,
+        capture_output=True,
+    )
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG, mutate_matrix=False)
+
+    assert summary.ok is False
+    assert any("lanes.json" in issue and "corrupt or malformed" in issue for issue in summary.activity_issues)
+    assert any(item.check == "lanes_manifest" for item in summary.blocked_checks)
+
+
 # ---------------------------------------------------------------------------
 # Integration branch guard: merge guidance must not target integration branch
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -447,6 +447,45 @@ def test_collect_feature_summary_blocks_malformed_matrix_verdict_values(tmp_path
     assert summary.ok is False
 
 
+@pytest.mark.parametrize(
+    "lanes_payload",
+    [
+        "{not-json",
+        '{"version": 1}',
+    ],
+)
+def test_collect_feature_summary_blocks_corrupt_lanes_json(tmp_path: Path, lanes_payload: str) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    write_single_lane_manifest(feature_dir)
+    (feature_dir / "lanes.json").write_text(lanes_payload, encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "Add corrupt lanes manifest"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "checkout", "-b", f"kitty/mission-{_FEATURE_SLUG}"],
+        check=True,
+        capture_output=True,
+    )
+
+    summary = collect_feature_summary(repo_root, _FEATURE_SLUG, mutate_matrix=False)
+
+    assert summary.all_done is True
+    assert summary.ok is False
+    assert any("lanes.json" in issue and "corrupt or malformed" in issue for issue in summary.activity_issues)
+    assert any(item.check == "lanes_manifest" for item in summary.blocked_checks)
+    skipped = {item.check for item in summary.skipped_checks}
+    assert {
+        "acceptance_matrix_presence",
+        "acceptance_matrix_evidence",
+        "negative_invariants",
+        "acceptance_matrix_verdict",
+    } <= skipped
+    assert any("lanes.json" in item for item in summary.recommended_fix_order)
+
+
 # ---------------------------------------------------------------------------
 # Integration branch guard: merge guidance must not target integration branch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treat corrupt or malformed `lanes.json` as a blocking lane-gate diagnostic instead of silently skipping acceptance-matrix gates.
- Add summary-level regression coverage for invalid JSON and malformed schema payloads.
- Add CLI `accept --diagnose --json` coverage to preserve machine-readable blocked/skipped checks without mutation.

Fixes #1447

## Verification
- `.venv/bin/ruff check src/specify_cli/acceptance/__init__.py tests/specify_cli/test_acceptance_regressions.py tests/cross_cutting/misc/test_acceptance_support.py`
- `.venv/bin/pytest tests/specify_cli/test_acceptance_regressions.py tests/cross_cutting/misc/test_acceptance_support.py tests/lanes/test_persistence.py tests/lanes/test_acceptance_matrix.py -q`

## Self adversarial review
- Initial review found missing schema-malformed coverage and missing CLI JSON contract coverage; both were added.
- Re-reviewed local diff after fixes; no remaining merge blockers found.
