### PR TITLE
Fix null preflight enabled default

### DIFF
--- a/src/specify_cli/charter_runtime/preflight/config.py
+++ b/src/specify_cli/charter_runtime/preflight/config.py
@@ -16,8 +16,10 @@ Behaviour:
 * Missing ``preflight`` section → default config.
 * Corrupt YAML / unreadable file → default config (best-effort; we never
   break unrelated commands because the config is malformed).
-* Non-bool values for ``preflight.enabled`` / ``preflight.auto_refresh`` → coerced via ``bool()``,
-  matching the lenient policy of the merge-config loader.
+* Null / value-less ``preflight.enabled`` → default ``True``. A missing value
+  is a reset-to-default, not a safety-gate opt-out.
+* Other non-bool values for ``preflight.enabled`` / ``preflight.auto_refresh`` → coerced via
+  ``bool()``, matching the lenient policy of the merge-config loader.
 """
 
 from __future__ import annotations
@@ -75,6 +77,6 @@ def load_preflight_config(repo_root: Path) -> PreflightConfig:
     raw_enabled = section.get("enabled", True)
     raw_auto_refresh = section.get("auto_refresh", False)
     return PreflightConfig(
-        enabled=bool(raw_enabled),
+        enabled=True if raw_enabled is None else bool(raw_enabled),
         auto_refresh=bool(raw_auto_refresh),
     )

--- a/tests/agent/cli/commands/test_next_preflight.py
+++ b/tests/agent/cli/commands/test_next_preflight.py
@@ -77,6 +77,30 @@ def test_hook_disabled_by_project_config_does_not_load_runner(
     assert result.passed is True
 
 
+def test_null_project_config_enabled_still_runs_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Null enabled resets to the default; it must not silently skip the gate."""
+    from specify_cli.charter_preflight import hook as hook_mod
+
+    config_path = tmp_path / ".kittify" / "config.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text("preflight:\n  enabled: null\n", encoding="utf-8")
+    runner_calls: list[dict] = []
+
+    def _run_charter_preflight(**kwargs):
+        runner_calls.append(kwargs)
+        return _pass_result()
+
+    monkeypatch.setattr(hook_mod, "run_charter_preflight", _run_charter_preflight)
+
+    result = hook_mod.run_preflight_or_abort(tmp_path, consumer="next")
+
+    assert result.passed is True
+    assert runner_calls == [{"repo_root": tmp_path, "auto_refresh": False, "strict": False}]
+
+
 def test_hook_aborts_with_exit_1_when_preflight_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/specify_cli/charter_preflight/test_config.py
+++ b/tests/specify_cli/charter_preflight/test_config.py
@@ -11,6 +11,7 @@ from specify_cli.charter_preflight.config import load_preflight_config
 
 pytestmark = [pytest.mark.fast]
 
+
 def test_missing_config_defaults_to_enabled_without_auto_refresh(tmp_path: Path) -> None:
     cfg = load_preflight_config(tmp_path)
 
@@ -30,3 +31,23 @@ def test_config_can_disable_preflight(tmp_path: Path) -> None:
 
     assert cfg.enabled is False
     assert cfg.auto_refresh is True
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        "preflight:\n  enabled: null\n",
+        "preflight:\n  enabled:\n",
+    ],
+)
+def test_null_or_value_less_preflight_enabled_defaults_to_enabled(
+    tmp_path: Path,
+    config_text: str,
+) -> None:
+    config_path = tmp_path / ".kittify" / "config.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text(config_text, encoding="utf-8")
+
+    cfg = load_preflight_config(tmp_path)
+
+    assert cfg.enabled is True

--- a/tests/test_dashboard/test_dashboard_preflight.py
+++ b/tests/test_dashboard/test_dashboard_preflight.py
@@ -131,6 +131,30 @@ def test_dashboard_hook_clears_warning_on_success(
     assert read_preflight_warning(tmp_path) is None
 
 
+def test_null_project_config_enabled_still_runs_dashboard_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Null enabled must not silently skip the dashboard warning gate."""
+    from specify_cli.charter_preflight import hook as hook_mod
+
+    config_path = tmp_path / ".kittify" / "config.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text("preflight:\n  enabled: null\n", encoding="utf-8")
+    runner_calls: list[dict] = []
+
+    def _run_charter_preflight(**kwargs):
+        runner_calls.append(kwargs)
+        return _pass_result()
+
+    monkeypatch.setattr(hook_mod, "run_charter_preflight", _run_charter_preflight)
+
+    result = hook_mod.run_preflight_for_dashboard(tmp_path)
+
+    assert result.passed is True
+    assert runner_calls == [{"repo_root": tmp_path, "auto_refresh": False, "strict": False}]
+
+
 # ---------------------------------------------------------------------------
 # API surface — /api/health response shape
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #1470.
- Treats null / value-less `preflight.enabled` as the documented default `true` instead of disabling charter preflight.
- Adds config, `next`/`implement` shared hook, and dashboard hook regressions proving null cannot skip the runner.

## Verification
- `uv run pytest tests/specify_cli/charter_preflight/test_config.py tests/agent/cli/commands/test_next_preflight.py tests/test_dashboard/test_dashboard_preflight.py -q`
- `uv run ruff check src/specify_cli/charter_runtime/preflight/config.py tests/specify_cli/charter_preflight/test_config.py tests/agent/cli/commands/test_next_preflight.py tests/test_dashboard/test_dashboard_preflight.py`
- `git diff --check`

## Self adversarial review
- Checked explicit `preflight.enabled: false` remains the only tested opt-out path.
- Checked null/value-less config reaches runner for aborting hook and dashboard hook.
- No merge blockers found before opening PR.
