### PR TITLE
Fix isolated rebase lane merges

### DIFF
--- a/src/specify_cli/lanes/merge.py
+++ b/src/specify_cli/lanes/merge.py
@@ -391,19 +391,18 @@ def _merge_branch_into(
                     f"{result.stderr.strip() or result.stdout.strip()}"
                 )
         elif strategy == MergeStrategy.REBASE:
-            # Rebase source onto target then fast-forward target.
-            # We work in a temporary clone of source branch, rebase onto target.
+            # Rebase source onto target in the isolated worktree, then
+            # fast-forward target to the rebased detached HEAD. Do not check
+            # out or rewrite source_branch in the user's main checkout.
             result = subprocess.run(
-                ["git", "rebase", "HEAD", source_branch],
-                cwd=str(repo_root), capture_output=True, text=True,
-            )
-            # Rebase approach: checkout source in the worktree and rebase onto target.
-            # Simpler: just do a rebase in the tmp worktree.
-            # First checkout source_branch in tmp worktree.
-            result = subprocess.run(
-                ["git", "checkout", source_branch],
+                ["git", "checkout", "--detach", source_branch],
                 cwd=str(tmp_path), capture_output=True, text=True,
             )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to check out {source_branch} in merge worktree: "
+                    f"{result.stderr.strip() or result.stdout.strip()}"
+                )
             # Rebase source on top of target.
             result = subprocess.run(
                 ["git", "rebase", target_branch],

--- a/tests/lanes/test_merge.py
+++ b/tests/lanes/test_merge.py
@@ -7,6 +7,7 @@ import pytest
 from specify_cli.lanes.merge import (
     LaneMergeResult,
     MissionMergeResult,
+    _merge_branch_into,
     merge_lane_to_mission,
     merge_mission_to_target,
 )
@@ -18,6 +19,16 @@ pytestmark = pytest.mark.git_repo
 
 def _run(cmd, cwd):
     subprocess.run(cmd, cwd=str(cwd), capture_output=True, check=True)
+
+
+def _git_stdout(repo, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
 
 
 def _commit(repo, filename, content, message):
@@ -292,3 +303,53 @@ class TestMergeMissionToTarget:
 
         assert result.success is False
         assert "does not exist" in result.errors[0]
+
+    def test_rebase_strategy_does_not_mutate_main_checkout_before_worktree(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        source_branch = "kitty/mission-010-feat"
+
+        _run(["git", "branch", source_branch], repo)
+        _run(["git", "checkout", source_branch], repo)
+        _commit(repo, "src/rebased.py", "mission work\n", "mission work")
+        _run(["git", "checkout", "main"], repo)
+
+        source_before = _git_stdout(repo, "rev-parse", source_branch)
+
+        changed = _merge_branch_into(
+            repo,
+            source_branch,
+            "main",
+            strategy=MergeStrategy.REBASE,
+        )
+
+        assert changed is True
+        assert _git_stdout(repo, "branch", "--show-current") == "main"
+        assert _git_stdout(repo, "rev-parse", source_branch) == source_before
+        assert _git_stdout(repo, "show", "main:src/rebased.py") == "mission work"
+
+    def test_rebase_strategy_conflict_leaves_main_checkout_and_refs_unchanged(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        source_branch = "kitty/mission-010-feat"
+
+        _commit(repo, "src/conflict.py", "base\n", "base conflict file")
+        _run(["git", "branch", source_branch], repo)
+        _run(["git", "checkout", source_branch], repo)
+        _commit(repo, "src/conflict.py", "source\n", "source conflict")
+        _run(["git", "checkout", "main"], repo)
+        _commit(repo, "src/conflict.py", "target\n", "target conflict")
+
+        source_before = _git_stdout(repo, "rev-parse", source_branch)
+        target_before = _git_stdout(repo, "rev-parse", "main")
+
+        with pytest.raises(RuntimeError, match="Rebase of .* failed"):
+            _merge_branch_into(
+                repo,
+                source_branch,
+                "main",
+                strategy=MergeStrategy.REBASE,
+            )
+
+        assert _git_stdout(repo, "branch", "--show-current") == "main"
+        assert _git_stdout(repo, "rev-parse", source_branch) == source_before
+        assert _git_stdout(repo, "rev-parse", "main") == target_before
+        assert not (repo / ".git" / "rebase-merge").exists()


### PR DESCRIPTION
## Summary
- Fixes #1473.
- Remove the repo-root rebase from the rebase merge strategy.
- Rebase source commits on a detached HEAD inside the temporary merge worktree, then fast-forward only the target ref.
- Add success and conflict regressions proving the main checkout and source branch ref are not mutated.

## Verification
- `uv run pytest tests/lanes/test_merge.py -q`
- `uv run pytest tests/cli/commands/test_merge_strategy.py -q`
- `uv run ruff check src/specify_cli/lanes/merge.py tests/lanes/test_merge.py`
- `git diff --check`

## Self-review
Used `$adversarial-pr-review` on the local branch before PR creation. Initial finding: missing failure-path coverage for rebase conflicts. Addressed by adding a conflict regression that asserts checkout/source ref/target ref are unchanged after failure.