### PR TITLE
Fix stale file lock adoption

### DIFF
--- a/src/specify_cli/core/file_lock.py
+++ b/src/specify_cli/core/file_lock.py
@@ -228,6 +228,25 @@ def _record_from_payload(payload: object) -> LockRecord | None:
     )
 
 
+def _record_from_bytes(raw: bytes) -> LockRecord | None:
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return _record_from_payload(payload)
+
+
+def _read_lock_record_from_fd(fd: int) -> LockRecord | None:
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        raw = os.read(fd, 65536)
+    except OSError:
+        return None
+    return _record_from_bytes(raw)
+
+
 def read_lock_record(path: Path) -> LockRecord | None:
     """Return the lock record at ``path`` without acquiring the OS lock.
 
@@ -246,23 +265,18 @@ def read_lock_record(path: Path) -> LockRecord | None:
         return None
     except OSError:
         return None
-    if not raw:
-        return None
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return None
-    return _record_from_payload(payload)
+    return _record_from_bytes(raw)
 
 
 def force_release(path: Path, *, only_if_age_s: float = STALE_AFTER_S_DEFAULT) -> bool:
-    """Remove the lock file at ``path`` iff the record is older than ``only_if_age_s``.
+    """Clear the lock record at ``path`` iff it is older than ``only_if_age_s``.
 
-    Returns ``True`` when the file was removed (it existed and was stuck);
-    ``False`` when the file is missing, unreadable, or still considered fresh.
+    Returns ``True`` when the record was cleared (it existed and was stuck);
+    ``False`` when the file is missing, unreadable, held, or still considered fresh.
 
-    A fresh lock cannot be ripped out from under a running process — the age
-    check is performed before any filesystem mutation.
+    A lock cannot be ripped out from under a running process: force release
+    first proves the OS lock is available, then truncates the existing inode
+    under that lock instead of unlinking the path.
     """
     record = read_lock_record(path)
     if record is None:
@@ -270,10 +284,28 @@ def force_release(path: Path, *, only_if_age_s: float = STALE_AFTER_S_DEFAULT) -
     if record.age_s <= only_if_age_s:
         return False
     try:
-        path.unlink(missing_ok=True)
+        fd = os.open(str(path), os.O_RDWR)
     except OSError:
         return False
-    return True
+    try:
+        try:
+            _os_lock(fd)
+        except OSError as exc:
+            if _is_contention_error(exc):
+                return False
+            return False
+        locked_record = _read_lock_record_from_fd(fd)
+        if locked_record is None or locked_record.age_s <= only_if_age_s:
+            return False
+        try:
+            _atomic_write_under_lock(fd, b"")
+        except OSError:
+            return False
+        return True
+    finally:
+        _os_unlock(fd)
+        with contextlib.suppress(OSError):
+            os.close(fd)
 
 
 class MachineFileLock:
@@ -295,10 +327,9 @@ class MachineFileLock:
     ``_RETRY_SLEEP_S`` seconds for at most ``acquire_timeout_s`` seconds. If
     contention persists past the timeout :class:`LockAcquireTimeout` is raised.
 
-    Stale-lock adoption: when the existing record is older than
-    ``stale_after_s`` the helper deletes the file and retries the OS lock once
-    to reclaim ownership. Concurrent adopters are tolerated — the loop simply
-    re-enters bounded wait if the second attempt also contends.
+    Stale-lock adoption: age is diagnostic only while another process holds
+    the OS lock. A stale record without a live OS holder is adopted by taking
+    the lock on the existing inode and rewriting the record.
 
     The protected block is the caller's responsibility; ``max_hold_s`` is
     advisory and callers SHOULD wrap the work in :func:`asyncio.wait_for` to
@@ -337,7 +368,6 @@ class MachineFileLock:
     async def __aenter__(self) -> LockRecord:
         _ensure_dir(self.path)
         deadline = asyncio.get_event_loop().time() + self.acquire_timeout_s
-        adopted_once = False
         while True:
             fd = self._open_fd()
             try:
@@ -346,19 +376,6 @@ class MachineFileLock:
                 os.close(fd)
                 if not _is_contention_error(exc):
                     raise
-                # Contention path — consider staleness adoption then sleep.
-                existing = read_lock_record(self.path)
-                if (
-                    not adopted_once
-                    and existing is not None
-                    and existing.age_s > self.stale_after_s
-                ):
-                    adopted_once = True
-                    # Another process may have already adopted; fall through.
-                    with contextlib.suppress(OSError):
-                        self.path.unlink(missing_ok=True)
-                    # Immediate retry of the OS lock without sleep.
-                    continue
                 if asyncio.get_event_loop().time() >= deadline:
                     raise LockAcquireTimeout(path=str(self.path)) from None
                 await asyncio.sleep(_RETRY_SLEEP_S)

--- a/tests/auth/test_auth_doctor_repair.py
+++ b/tests/auth/test_auth_doctor_repair.py
@@ -20,7 +20,7 @@ import pytest
 from specify_cli.auth.session import StoredSession, Team
 from specify_cli.cli.commands import _auth_doctor
 from specify_cli.cli.commands._auth_doctor import doctor_impl
-from specify_cli.core.file_lock import LockRecord
+from specify_cli.core.file_lock import LockRecord, read_lock_record
 from specify_cli.sync.daemon import SyncDaemonStatus
 from specify_cli.sync.orphan_sweep import OrphanDaemon, SweepReport
 
@@ -232,7 +232,7 @@ def test_reset_repairs_recorded_unhealthy_daemon(
 def test_unstick_drops_old_lock(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """120-second-old lock + ``--unstick-lock`` ⇒ lock file removed."""
+    """120-second-old lock + ``--unstick-lock`` ⇒ lock record cleared."""
     session = _make_session()
     lock_path = tmp_path / "auth" / "refresh.lock"
     _write_lock_record(lock_path, age_s=120.0)
@@ -248,7 +248,7 @@ def test_unstick_drops_old_lock(
         json_output=True, reset=False, unstick_lock=True, stuck_threshold=60.0
     )
 
-    assert not lock_path.exists()
+    assert read_lock_record(lock_path) is None
     # F-003 was the only critical finding; after the unstick repair the
     # second pass finds nothing critical so exit 0.
     assert exit_code == 0
@@ -307,6 +307,6 @@ def test_combined_flags_run_both(
     )
 
     assert sweep_calls == [[orphan]]
-    assert not lock_path.exists()
+    assert read_lock_record(lock_path) is None
     # After both repairs nothing critical remains.
     assert exit_code == 0

--- a/tests/core/test_file_lock.py
+++ b/tests/core/test_file_lock.py
@@ -128,6 +128,25 @@ async def test_stale_lock_adopted(lock_path: Path) -> None:
         assert on_disk.pid == os.getpid()
 
 
+async def test_stale_record_with_live_holder_does_not_admit_second_lock(
+    lock_path: Path,
+) -> None:
+    holder = MachineFileLock(lock_path, acquire_timeout_s=1.0)
+    await holder.__aenter__()
+    contender = MachineFileLock(lock_path, acquire_timeout_s=0.15, stale_after_s=0.0)
+    try:
+        # Advisory locks do not stop diagnostics from observing an old record.
+        # Age alone must not authorize unlinking the path while a live holder
+        # still owns the locked inode.
+        _write_record(lock_path, age_s=120.0, pid=999_999)
+
+        with pytest.raises(LockAcquireTimeout):
+            await contender.__aenter__()
+    finally:
+        await contender.__aexit__(None, None, None)
+        await holder.__aexit__(None, None, None)
+
+
 # ---------------------------------------------------------------------------
 # 5. test_force_release_only_when_stuck
 # ---------------------------------------------------------------------------
@@ -144,7 +163,21 @@ def test_force_release_only_when_stuck(lock_path: Path) -> None:
 
     _write_record(lock_path, age_s=120.0)
     assert force_release(lock_path, only_if_age_s=60.0) is True
-    assert not lock_path.exists()
+    assert read_lock_record(lock_path) is None
+
+
+async def test_force_release_does_not_unlink_when_stale_lock_is_held(
+    lock_path: Path,
+) -> None:
+    holder = MachineFileLock(lock_path, acquire_timeout_s=1.0)
+    await holder.__aenter__()
+    try:
+        _write_record(lock_path, age_s=120.0, pid=999_999)
+
+        assert force_release(lock_path, only_if_age_s=60.0) is False
+        assert read_lock_record(lock_path) is not None
+    finally:
+        await holder.__aexit__(None, None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -283,15 +316,15 @@ def test_read_lock_record_non_string_fields_returns_none(lock_path: Path) -> Non
     assert read_lock_record(lock_path) is None
 
 
-def test_force_release_unlink_failure(
+def test_force_release_clear_failure(
     lock_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _write_record(lock_path, age_s=120.0)
 
-    def _boom(self: Path, *args: Any, **kwargs: Any) -> None:
+    def _boom(_fd: int, _payload: bytes) -> None:
         raise OSError("permission denied")
 
-    monkeypatch.setattr(Path, "unlink", _boom)
+    monkeypatch.setattr(fl, "_atomic_write_under_lock", _boom)
     assert force_release(lock_path, only_if_age_s=60.0) is False
 
 

--- a/tests/core/test_file_lock_behavior.py
+++ b/tests/core/test_file_lock_behavior.py
@@ -182,16 +182,16 @@ def test_read_lock_record_returns_none_for_non_mapping_json(tmp_path: Path) -> N
     assert result is None
 
 
-def test_force_release_removes_stale_lock(tmp_path: Path) -> None:
+def test_force_release_clears_stale_lock(tmp_path: Path) -> None:
     """Arrange: lock file with 2-minute-old record;
     Act: force_release with 60s threshold;
-    Assert: file removed, True returned."""
+    Assert: stale record cleared, True returned."""
     lock_path = tmp_path / "stale.lock"
     _write_synthetic_record(lock_path, age_s=120.0)
 
     result = force_release(lock_path, only_if_age_s=60.0)
     assert result is True
-    assert not lock_path.exists()
+    assert read_lock_record(lock_path) is None
 
 
 def test_force_release_does_not_remove_fresh_lock(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1471.

## Summary
- stop stale-record contention handling from unlinking the live lock path during `MachineFileLock.__aenter__`
- make `force_release` prove the OS lock is available, then clear the record under that lock instead of deleting the lock inode
- update auth-doctor repair expectations to assert the machine-visible lock record is cleared

## TDD / Regression
- first added failing tests for a stale-looking record with a live holder admitting a second lock, and for force-release touching a held stale lock
- confirmed failures before implementation

## Self adversarial review
- initial fix still allowed inode rotation through `force_release`; addressed by truncating under the acquired OS lock
- no remaining merge blockers found in local review

## Verification
- `uv run pytest tests/core/test_file_lock.py tests/core/test_file_lock_behavior.py tests/auth/concurrency/test_machine_refresh_lock.py tests/auth/test_auth_doctor_offline.py tests/auth/test_auth_doctor_repair.py tests/auth/test_auth_doctor_report.py -q`
- `uv run ruff check src/specify_cli/core/file_lock.py tests/core/test_file_lock.py tests/core/test_file_lock_behavior.py tests/auth/test_auth_doctor_repair.py`
- `git diff --check`