### PR TITLE
Fix orchestrator policy secret scanning for dangerous flags

### DIFF
--- a/src/specify_cli/orchestrator_api/envelope.py
+++ b/src/specify_cli/orchestrator_api/envelope.py
@@ -41,6 +41,15 @@ _REQUIRED_POLICY_FIELDS = (
     "dangerous_flags",
 )
 
+_STRING_POLICY_FIELDS = (
+    "orchestrator_id",
+    "orchestrator_version",
+    "agent_family",
+    "approval_mode",
+    "sandbox_mode",
+    "network_mode",
+)
+
 
 def _new_correlation_id() -> str:
     return "corr-" + uuid.uuid4().hex
@@ -88,6 +97,24 @@ class PolicyMetadata:
     tool_restrictions: str | None = None
 
 
+def _reject_secret_like_policy_value(field_path: str, value: Any) -> None:
+    if isinstance(value, str):
+        if SECRET_PATTERN.search(value):
+            raise ValueError(
+                f"--policy field '{field_path}' appears to contain a secret "
+                f"(matched pattern: token|secret|key|password|credential). "
+                f"Do not pass secrets via --policy."
+            )
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_secret_like_policy_value(f"{field_path}[{index}]", item)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _reject_secret_like_policy_value(f"{field_path}.{key}", item)
+
+
 def parse_and_validate_policy(raw_json: str) -> PolicyMetadata:
     """Parse --policy JSON, validate structure, reject secret-like values.
 
@@ -116,28 +143,35 @@ def parse_and_validate_policy(raw_json: str) -> PolicyMetadata:
         if field_name not in data:
             raise ValueError(f"--policy missing required field: '{field_name}'")
 
+    for field_name in _STRING_POLICY_FIELDS:
+        if not isinstance(data[field_name], str):
+            raise ValueError(f"--policy.{field_name} must be a string")
+
     # Validate dangerous_flags is a list
     if not isinstance(data["dangerous_flags"], list):
         raise ValueError("--policy.dangerous_flags must be a JSON array")
 
-    # Validate all values: reject secret-like strings
+    for flag in data["dangerous_flags"]:
+        if not isinstance(flag, str):
+            raise ValueError("--policy.dangerous_flags entries must be strings")
+
+    tool_restrictions = data.get("tool_restrictions")
+    if tool_restrictions is not None and not isinstance(tool_restrictions, str):
+        raise ValueError("--policy.tool_restrictions must be a string or null")
+
+    # Validate all policy values: reject secret-like strings at every depth.
     for field_name, value in data.items():
-        if isinstance(value, str) and SECRET_PATTERN.search(value):
-            raise ValueError(
-                f"--policy field '{field_name}' appears to contain a secret "
-                f"(matched pattern: token|secret|key|password|credential). "
-                f"Do not pass secrets via --policy."
-            )
+        _reject_secret_like_policy_value(field_name, value)
 
     return PolicyMetadata(
-        orchestrator_id=str(data["orchestrator_id"]),
-        orchestrator_version=str(data["orchestrator_version"]),
-        agent_family=str(data["agent_family"]),
-        approval_mode=str(data["approval_mode"]),
-        sandbox_mode=str(data["sandbox_mode"]),
-        network_mode=str(data["network_mode"]),
+        orchestrator_id=data["orchestrator_id"],
+        orchestrator_version=data["orchestrator_version"],
+        agent_family=data["agent_family"],
+        approval_mode=data["approval_mode"],
+        sandbox_mode=data["sandbox_mode"],
+        network_mode=data["network_mode"],
         dangerous_flags=list(data["dangerous_flags"]),
-        tool_restrictions=data.get("tool_restrictions"),
+        tool_restrictions=tool_restrictions,
     )
 
 

--- a/tests/agent/test_envelope_unit.py
+++ b/tests/agent/test_envelope_unit.py
@@ -96,11 +96,48 @@ class TestParsePolicyValid:
         with pytest.raises(ValueError, match="appears to contain a secret"):
             parse_and_validate_policy(raw)
 
+    def test_parse_policy_required_fields_must_be_strings(self):
+        """Structured required fields cannot bypass policy metadata scanning."""
+        policy_dict = self._valid_policy(orchestrator_id=["API_KEY=abc123"])
+        raw = json.dumps(policy_dict)
+        with pytest.raises(ValueError, match="orchestrator_id must be a string"):
+            parse_and_validate_policy(raw)
+
     def test_parse_policy_dangerous_flags_must_be_list(self):
         """dangerous_flags as string raises ValueError."""
         policy_dict = self._valid_policy(dangerous_flags="--full-auto")
         raw = json.dumps(policy_dict)
         with pytest.raises(ValueError, match="must be a JSON array"):
+            parse_and_validate_policy(raw)
+
+    def test_parse_policy_rejects_secret_in_dangerous_flags_entry(self):
+        """Secret-like dangerous_flags entries are rejected before persistence."""
+        policy_dict = self._valid_policy(
+            dangerous_flags=["AWS_SECRET_ACCESS_KEY=abc123"]
+        )
+        raw = json.dumps(policy_dict)
+        with pytest.raises(ValueError, match="appears to contain a secret"):
+            parse_and_validate_policy(raw)
+
+    def test_parse_policy_dangerous_flags_entries_must_be_strings(self):
+        """Structured dangerous_flags entries cannot bypass string scanning."""
+        policy_dict = self._valid_policy(dangerous_flags=[{"name": "--full-auto"}])
+        raw = json.dumps(policy_dict)
+        with pytest.raises(ValueError, match="entries must be strings"):
+            parse_and_validate_policy(raw)
+
+    def test_parse_policy_preserves_valid_dangerous_flags_entries(self):
+        """Non-secret dangerous_flags entries survive validation unchanged."""
+        policy_dict = self._valid_policy(dangerous_flags=["--full-auto"])
+        raw = json.dumps(policy_dict)
+        policy = parse_and_validate_policy(raw)
+        assert policy.dangerous_flags == ["--full-auto"]
+
+    def test_parse_policy_tool_restrictions_must_be_string_or_null(self):
+        """Structured tool_restrictions cannot bypass policy metadata scanning."""
+        policy_dict = self._valid_policy(tool_restrictions=["API_KEY=abc123"])
+        raw = json.dumps(policy_dict)
+        with pytest.raises(ValueError, match="tool_restrictions must be a string or null"):
             parse_and_validate_policy(raw)
 
     def test_parse_policy_invalid_json(self):

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -367,6 +367,33 @@ class TestStartImplementation:
         data = json.loads(result.output)
         assert data["error_code"] == "POLICY_METADATA_REQUIRED"
 
+    def test_dangerous_flags_secret_returns_json_error_without_leak(self, tmp_path):
+        policy = json.loads(_valid_policy_json())
+        policy["dangerous_flags"] = ["AWS_SECRET_ACCESS_KEY=abc123"]
+
+        result = runner.invoke(
+            app,
+            [
+                "start-implementation",
+                "--mission",
+                "099-test-mission",
+                "--wp",
+                "WP01",
+                "--actor",
+                "claude",
+                "--policy",
+                json.dumps(policy),
+            ],
+        )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error_code"] == "POLICY_VALIDATION_FAILED"
+        assert "dangerous_flags[0]" in data["data"]["message"]
+        assert "AWS_SECRET_ACCESS_KEY" not in result.output
+        assert "abc123" not in result.output
+
     def test_planned_wp_composite_transition(self, tmp_path):
         repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
         mission_slug = "099-test-mission"


### PR DESCRIPTION
## Summary
- Closes #1474.
- Reject secret-like strings inside `dangerous_flags` entries instead of only scanning top-level strings.
- Enforce documented policy metadata types for required string fields, `dangerous_flags`, and optional `tool_restrictions` so structured values cannot bypass scanning.
- Add CLI contract coverage for JSON `POLICY_VALIDATION_FAILED` without leaking the secret-bearing flag content.

## Verification
- `uv run pytest tests/agent/test_envelope_unit.py tests/agent/test_orchestrator_commands_integration.py -q`
- `uv run pytest tests/contract/test_machine_facing_canonical_fields.py tests/agent/test_envelope_unit.py tests/agent/test_orchestrator_commands_integration.py -q`
- `uv run ruff check src/specify_cli/orchestrator_api/envelope.py tests/agent/test_envelope_unit.py tests/agent/test_orchestrator_commands_integration.py`
- `git diff --check`

## Self Review
- Ran `$adversarial-pr-review` locally against the branch diff before opening. Finding: same policy boundary allowed structured required fields / `tool_restrictions` to bypass scanning; fixed before PR. No remaining blockers found.