### PR TITLE
Fix current review rollback precedence

### DIFF
--- a/src/specify_cli/status/reducer.py
+++ b/src/specify_cli/status/reducer.py
@@ -33,10 +33,15 @@ def _now_utc() -> str:
 def _is_rollback_event(event: StatusEvent) -> bool:
     """Check if an event represents a reviewer rollback.
 
-    A rollback is a transition from for_review back to in_progress
-    with a review reference (indicating a reviewer requested changes).
+    Current review rejection rolls back from in_review to in_progress.
+    Legacy logs represented the same outcome as for_review to in_progress
+    with a review reference.
     """
-    return event.from_lane == Lane.FOR_REVIEW and event.to_lane == Lane.IN_PROGRESS and event.review_ref is not None
+    if event.to_lane != Lane.IN_PROGRESS:
+        return False
+    if event.from_lane == Lane.IN_REVIEW:
+        return True
+    return event.from_lane == Lane.FOR_REVIEW and event.review_ref is not None
 
 
 def _wp_state_from_event(

--- a/tests/status/test_reducer.py
+++ b/tests/status/test_reducer.py
@@ -262,6 +262,71 @@ class TestReduceForceCount:
         assert snapshot.work_packages["WP01"]["force_count"] == 2
 
 
+class TestReduceConcurrentRollbackPrecedence:
+    """Tests for rollback-aware conflict resolution."""
+
+    def test_in_review_to_in_progress_rollback_beats_concurrent_approval(self) -> None:
+        """Current reviewer rollback transition wins over same-timestamp approval."""
+        at = "2026-02-08T15:00:00Z"
+        events = [
+            _make_event(
+                event_id="01HXYZ0000000000000000000A",
+                wp_id="WP01",
+                from_lane=Lane.IN_REVIEW,
+                to_lane=Lane.IN_PROGRESS,
+                at=at,
+                actor="reviewer-a",
+            ),
+            _make_event(
+                event_id="01HXYZ0000000000000000000B",
+                wp_id="WP01",
+                from_lane=Lane.IN_REVIEW,
+                to_lane=Lane.APPROVED,
+                at=at,
+                actor="reviewer-b",
+                review_ref="review://WP01/approved",
+            ),
+        ]
+
+        snapshot = reduce(events)
+
+        assert snapshot.work_packages["WP01"]["lane"] == "in_progress"
+        assert snapshot.work_packages["WP01"]["last_event_id"] == "01HXYZ0000000000000000000A"
+        assert snapshot.summary["in_progress"] == 1
+        assert snapshot.summary["approved"] == 0
+
+    def test_legacy_for_review_to_in_progress_rollback_still_beats_concurrent_forward_event(self) -> None:
+        """Legacy reviewer rollback shape keeps rollback precedence."""
+        at = "2026-02-08T15:00:00Z"
+        events = [
+            _make_event(
+                event_id="01HXYZ0000000000000000000A",
+                wp_id="WP01",
+                from_lane=Lane.FOR_REVIEW,
+                to_lane=Lane.IN_PROGRESS,
+                at=at,
+                actor="reviewer-a",
+                review_ref="review://WP01/changes-requested",
+            ),
+            _make_event(
+                event_id="01HXYZ0000000000000000000B",
+                wp_id="WP01",
+                from_lane=Lane.FOR_REVIEW,
+                to_lane=Lane.APPROVED,
+                at=at,
+                actor="reviewer-b",
+                review_ref="review://WP01/approved",
+            ),
+        ]
+
+        snapshot = reduce(events)
+
+        assert snapshot.work_packages["WP01"]["lane"] == "in_progress"
+        assert snapshot.work_packages["WP01"]["last_event_id"] == "01HXYZ0000000000000000000A"
+        assert snapshot.summary["in_progress"] == 1
+        assert snapshot.summary["approved"] == 0
+
+
 class TestSummaryCounts:
     """Tests that summary counts match WP states."""
 


### PR DESCRIPTION
## Summary
- Treat current `in_review -> in_progress` review rejection events as rollback precedence winners in the status reducer.
- Preserve legacy `for_review -> in_progress` rollback precedence when a review reference is present.
- Add reducer regressions for current and legacy same-timestamp rollback-vs-forward conflicts.

Closes #1475

## Tests
- FAILS before fix: `.venv/bin/pytest tests/status/test_reducer.py::TestReduceConcurrentRollbackPrecedence::test_in_review_to_in_progress_rollback_beats_concurrent_approval -q` (`approved` vs `in_progress`)
- PASS: `.venv/bin/pytest tests/status/test_reducer.py::TestReduceConcurrentRollbackPrecedence -q`
- PASS: `.venv/bin/pytest tests/status/test_reducer.py -q`
- PASS: `.venv/bin/pytest tests/status/test_transitions.py tests/status/test_validate.py tests/status/test_emit.py -q`
- PASS: `.venv/bin/ruff check src/specify_cli/status/reducer.py tests/status/test_reducer.py`
- PASS: `git diff --check`
- FAILS unrelated baseline: `.venv/bin/ruff check` reports pre-existing lint in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, `scripts/generate_schemas.py`, `scripts/lint_canonical_producers.py`, `scripts/sync_all_contributors.py`, `scripts/tasks/task_helpers.py`, `scripts/tasks/tasks_cli.py`, and `scripts/verify_occurrences.py`.

## Self-review
- Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` locally against the branch diff.
- No merge-blocking findings survived. Residual risk is limited to unrelated repo-wide ruff baseline failures.