### PR TITLE
fix(upgrade): stamp worktree schema metadata

### DIFF
--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -531,6 +531,7 @@ def upgrade(  # noqa: C901
         auto_committed = False
         auto_commit_paths: list[str] = []
         auto_commit_warning: str | None = None
+        worktree_warnings: list[str] = []
 
         # Still stamp the version even when no migrations are needed
         from specify_cli.upgrade.metadata import ProjectMetadata
@@ -546,6 +547,17 @@ def upgrade(  # noqa: C901
 
             if REQUIRED_SCHEMA_VERSION is not None:
                 MigrationRunner._stamp_schema_version(kittify_dir, REQUIRED_SCHEMA_VERSION)
+
+        if not no_worktrees and current_version == target_version:
+            worktrees_result = MigrationRunner(project_path, console)._upgrade_worktrees(
+                target_version,
+                [],
+                dry_run,
+            )
+            worktree_warnings.extend(worktrees_result.get("warnings", []))
+            if worktrees_result.get("errors"):
+                worktree_warnings.extend(worktrees_result["errors"])
+                worktree_warnings.append("Some worktrees had issues - check errors above")
 
         if not dry_run:
             auto_committed, auto_commit_paths, auto_commit_warning = _auto_commit_upgrade_changes(
@@ -564,7 +576,9 @@ def upgrade(  # noqa: C901
             )
 
         if json_output:
-            warnings = [auto_commit_warning] if auto_commit_warning else []
+            warnings = list(worktree_warnings)
+            if auto_commit_warning:
+                warnings.append(auto_commit_warning)
             print(
                 json.dumps(
                     {
@@ -579,6 +593,8 @@ def upgrade(  # noqa: C901
             )
         else:
             console.print("[green]Project is already up to date![/green]")
+            for warning in worktree_warnings:
+                console.print(f"[yellow]Warning:[/yellow] {warning}")
             if auto_committed:
                 console.print(f"[cyan]→ Auto-committed upgrade changes ({len(auto_commit_paths)} files)[/cyan]")
             if auto_commit_warning:

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -352,6 +352,10 @@ class MigrationRunner:
                 wt_metadata.version = target_version
                 wt_metadata.last_upgraded_at = datetime.now()
                 wt_metadata.save(wt_kittify)
+                # ProjectMetadata.save() rewrites metadata.yaml from its fixed
+                # model, so stamp after save just like the main project path.
+                if REQUIRED_SCHEMA_VERSION is not None:
+                    self._stamp_schema_version(wt_kittify, REQUIRED_SCHEMA_VERSION)
 
         return result
 

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -128,7 +128,7 @@ class MigrationRunner:
             if not dry_run and REQUIRED_SCHEMA_VERSION is not None:
                 self._stamp_schema_version(self.kittify_dir, REQUIRED_SCHEMA_VERSION)
 
-            if include_worktrees:
+            if include_worktrees and from_version == target_version:
                 worktrees_result = self._upgrade_worktrees(target_version, migrations, dry_run)
                 result.warnings.extend(worktrees_result.get("warnings", []))
                 if worktrees_result.get("errors"):
@@ -282,6 +282,9 @@ class MigrationRunner:
         """
         result: dict[str, Any] = {"warnings": [], "errors": []}
         worktree_migrations = [migration for migration in migrations if migration.runs_on_worktrees]
+
+        if migrations and not worktree_migrations:
+            return result
 
         worktrees_dir = self.project_path / WORKTREES_DIR
         if not worktrees_dir.exists():

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -128,6 +128,13 @@ class MigrationRunner:
             if not dry_run and REQUIRED_SCHEMA_VERSION is not None:
                 self._stamp_schema_version(self.kittify_dir, REQUIRED_SCHEMA_VERSION)
 
+            if include_worktrees:
+                worktrees_result = self._upgrade_worktrees(target_version, migrations, dry_run)
+                result.warnings.extend(worktrees_result.get("warnings", []))
+                if worktrees_result.get("errors"):
+                    result.errors.extend(worktrees_result["errors"])
+                    result.warnings.append("Some worktrees had issues - check errors above")
+
             result.warnings.append(f"No migrations needed from {from_version} to {target_version}")
             return result
 
@@ -276,9 +283,6 @@ class MigrationRunner:
         result: dict[str, Any] = {"warnings": [], "errors": []}
         worktree_migrations = [migration for migration in migrations if migration.runs_on_worktrees]
 
-        if not worktree_migrations:
-            return result
-
         worktrees_dir = self.project_path / WORKTREES_DIR
         if not worktrees_dir.exists():
             return result
@@ -289,7 +293,10 @@ class MigrationRunner:
                 continue
 
             wt_kittify = worktree / KITTIFY_DIR
-            has_upgradeable_state = wt_kittify.exists() or (worktree / "kitty-specs").exists() or (worktree / ".specify").exists()
+            has_upgradeable_state = wt_kittify.exists() or (
+                bool(worktree_migrations)
+                and ((worktree / "kitty-specs").exists() or (worktree / ".specify").exists())
+            )
             if not has_upgradeable_state:
                 continue
 

--- a/tests/upgrade/test_runner_status_classification.py
+++ b/tests/upgrade/test_runner_status_classification.py
@@ -179,6 +179,43 @@ def test_worktree_upgrade_stamps_schema_version_after_metadata_save(
     assert worktree_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
 
 
+def test_no_migrations_stamps_existing_worktree_schema_version(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    project_path = _setup_project(tmp_path)
+    ProjectMetadata(
+        version="1.0.0",
+        initialized_at=datetime.now(),
+    ).save(project_path / ".kittify")
+    worktree = project_path / ".worktrees" / "001-feature-lane-a"
+    (worktree / ".kittify").mkdir(parents=True)
+    ProjectMetadata(
+        version="1.0.0",
+        initialized_at=datetime.now(),
+    ).save(worktree / ".kittify")
+
+    runner = MigrationRunner(project_path)
+
+    monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+    monkeypatch.setattr(
+        "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+        lambda _from, _to, project_path=None: [],  # noqa: ARG005
+    )
+
+    result = runner.upgrade("1.0.0", include_worktrees=True)
+
+    assert result.success is True
+    main_metadata = yaml.safe_load(
+        (project_path / ".kittify" / "metadata.yaml").read_text(encoding="utf-8")
+    )
+    worktree_metadata = yaml.safe_load(
+        (worktree / ".kittify" / "metadata.yaml").read_text(encoding="utf-8")
+    )
+    assert main_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
+    assert worktree_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
+
+
 def test_upgrade_rejects_downgrade_target(monkeypatch, tmp_path: Path) -> None:
     project_path = _setup_project(tmp_path)
     runner = MigrationRunner(project_path)

--- a/tests/upgrade/test_runner_status_classification.py
+++ b/tests/upgrade/test_runner_status_classification.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import pytest
+import yaml
 from datetime import datetime
 from pathlib import Path
 
+from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
 from specify_cli.upgrade.metadata import ProjectMetadata
 from specify_cli.upgrade.migrations.base import BaseMigration, MigrationResult
 from specify_cli.upgrade.runner import MigrationRunner
@@ -137,7 +139,44 @@ def test_upgrade_creates_worktree_metadata_when_only_kitty_specs_exists(
     result = runner.upgrade("9.9.9", include_worktrees=True)
 
     assert result.success is True
-    assert (worktree / ".kittify" / "metadata.yaml").exists()
+    worktree_metadata_path = worktree / ".kittify" / "metadata.yaml"
+    assert worktree_metadata_path.exists()
+    worktree_metadata = yaml.safe_load(worktree_metadata_path.read_text(encoding="utf-8"))
+    assert worktree_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
+
+
+def test_worktree_upgrade_stamps_schema_version_after_metadata_save(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    project_path = _setup_project(tmp_path)
+    worktree = project_path / ".worktrees" / "001-feature-lane-a"
+    (worktree / ".kittify").mkdir(parents=True)
+    ProjectMetadata(
+        version="1.0.0",
+        initialized_at=datetime.now(),
+    ).save(worktree / ".kittify")
+
+    runner = MigrationRunner(project_path)
+    migration = _AppliedMigration()
+
+    monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+    monkeypatch.setattr(
+        "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+        lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+    )
+
+    result = runner.upgrade("9.9.9", include_worktrees=True)
+
+    assert result.success is True
+    main_metadata = yaml.safe_load(
+        (project_path / ".kittify" / "metadata.yaml").read_text(encoding="utf-8")
+    )
+    worktree_metadata = yaml.safe_load(
+        (worktree / ".kittify" / "metadata.yaml").read_text(encoding="utf-8")
+    )
+    assert main_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
+    assert worktree_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
 
 
 def test_upgrade_rejects_downgrade_target(monkeypatch, tmp_path: Path) -> None:

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -566,6 +566,125 @@ def test_upgrade_no_migrations_stamps_missing_schema_version(
     assert safe_commit_calls == [[".kittify/metadata.yaml"]]
 
 
+def test_upgrade_no_migrations_stamps_existing_worktree_schema_version(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """CLI no-migrations path must repair existing worktree schema metadata."""
+    import yaml
+
+    from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
+
+    project_path = _setup_upgrade_project(tmp_path)
+    worktree_kittify = project_path / ".worktrees" / "001-feature-lane-a" / ".kittify"
+    worktree_kittify.mkdir(parents=True)
+    (worktree_kittify / "metadata.yaml").write_text(
+        "spec_kitty:\n"
+        "  version: '1.0.0a1'\n"
+        "  initialized_at: '2026-01-01T00:00:00'\n"
+        "environment:\n"
+        "  python_version: '3.12'\n"
+        "  platform: linux\n"
+        "  platform_version: ''\n"
+        "migrations:\n"
+        "  applied: []\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+
+    status_calls = {"count": 0}
+
+    def _fake_status(_repo_path: Path) -> set[str]:
+        status_calls["count"] += 1
+        if status_calls["count"] == 1:
+            return set()
+        return {
+            ".kittify/metadata.yaml",
+            ".worktrees/001-feature-lane-a/.kittify/metadata.yaml",
+        }
+
+    safe_commit_calls: list[list[str]] = []
+
+    def _fake_safe_commit(**kwargs: object) -> object:
+        safe_commit_calls.append([str(path) for path in kwargs["paths"]])
+        return object()
+
+    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
+
+    upgrade_cmd.upgrade(
+        dry_run=False,
+        force=True,
+        target="1.0.0a1",
+        json_output=True,
+        verbose=False,
+        no_worktrees=False,
+        cli=False,
+        project=False,
+    )
+
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["status"] == "up_to_date"
+    assert data["auto_commit_paths"] == [
+        ".kittify/metadata.yaml",
+        ".worktrees/001-feature-lane-a/.kittify/metadata.yaml",
+    ]
+    worktree_metadata = yaml.safe_load((worktree_kittify / "metadata.yaml").read_text(encoding="utf-8"))
+    assert worktree_metadata["spec_kitty"]["schema_version"] == REQUIRED_SCHEMA_VERSION
+    assert safe_commit_calls == [
+        [
+            ".kittify/metadata.yaml",
+            ".worktrees/001-feature-lane-a/.kittify/metadata.yaml",
+        ]
+    ]
+
+
+def test_upgrade_no_migrations_respects_no_worktrees_for_schema_stamp(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """--no-worktrees must keep the same-version repair scoped to the root project."""
+    import yaml
+
+    project_path = _setup_upgrade_project(tmp_path)
+    worktree_kittify = project_path / ".worktrees" / "001-feature-lane-a" / ".kittify"
+    worktree_kittify.mkdir(parents=True)
+    (worktree_kittify / "metadata.yaml").write_text(
+        "spec_kitty:\n"
+        "  version: '1.0.0a1'\n"
+        "  initialized_at: '2026-01-01T00:00:00'\n"
+        "environment:\n"
+        "  python_version: '3.12'\n"
+        "  platform: linux\n"
+        "  platform_version: ''\n"
+        "migrations:\n"
+        "  applied: []\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _repo_path: {".kittify/metadata.yaml"})
+    monkeypatch.setattr(upgrade_cmd, "safe_commit", lambda **_kw: object())
+
+    upgrade_cmd.upgrade(
+        dry_run=False,
+        force=True,
+        target="1.0.0a1",
+        json_output=True,
+        verbose=False,
+        no_worktrees=True,
+        cli=False,
+        project=False,
+    )
+
+    assert json.loads(capsys.readouterr().out.strip())["status"] == "up_to_date"
+    worktree_metadata = yaml.safe_load((worktree_kittify / "metadata.yaml").read_text(encoding="utf-8"))
+    assert "schema_version" not in worktree_metadata["spec_kitty"]
+
+
 def test_upgrade_no_migrations_surfaces_teamspace_mission_state_prompt(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- stamp `spec_kitty.schema_version` after worktree metadata saves in the upgrade runner
- add regression coverage for newly-created and existing worktree metadata

Closes #1476

## Tests
- `.venv/bin/pytest tests/upgrade/test_runner_status_classification.py::test_worktree_upgrade_stamps_schema_version_after_metadata_save -q`
- `.venv/bin/pytest tests/upgrade/test_runner_status_classification.py -q`
- `.venv/bin/pytest tests/specify_cli/migration/test_schema_version.py tests/specify_cli/migration/test_schema_version_range.py -q`
- `.venv/bin/pytest tests/upgrade/test_upgrade_auto_commit_unit.py -q`
- `.venv/bin/pytest tests/upgrade/test_unified_bundle_migration.py::test_runner_include_worktrees_does_not_mutate_worktree_metadata tests/upgrade/test_unified_bundle_migration.py::test_detect_returns_false_inside_linked_worktree -q`
- `.venv/bin/ruff check src tests`
- `git diff --check`

## Notes
- Full `.venv/bin/ruff check` currently fails on unrelated pre-existing `.kittify/` and `scripts/` violations; CI uses `ruff check src tests`, which passes locally.