### PR TITLE
Prevent duplicate invocation completion after correlation links

### DIFF
--- a/src/specify_cli/cli/commands/invocations_cmd.py
+++ b/src/specify_cli/cli/commands/invocations_cmd.py
@@ -94,6 +94,29 @@ def _read_last_line(path: Path) -> dict | None:  # type: ignore[type-arg]
         return None
 
 
+def _read_completed_record(path: Path, invocation_id: str) -> dict | None:  # type: ignore[type-arg]
+    """Return the first completed event for *invocation_id*, wherever it appears."""
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    isinstance(data, dict)
+                    and data.get("event") == "completed"
+                    and data.get("invocation_id") == invocation_id
+                ):
+                    return data
+    except OSError:
+        return None
+    return None
+
+
 def append_to_index(repo_root: Path, record: dict) -> None:  # type: ignore[type-arg]
     """Append a lightweight index entry for one invocation.
 
@@ -200,16 +223,12 @@ def _iter_records_from_index(
             continue
         # Determine open / closed by checking the per-invocation file.
         inv_file = events_dir / f"{inv_id}.jsonl"
-        last = _read_last_line(inv_file)
         record: dict = dict(entry)  # type: ignore[type-arg]
-        if (
-            last is not None
-            and last.get("event") == "completed"
-            and last.get("invocation_id") == inv_id
-        ):
-            record["completed_at"] = last.get("completed_at")
-            record["outcome"] = last.get("outcome")
-            record["evidence_ref"] = last.get("evidence_ref")
+        completed = _read_completed_record(inv_file, inv_id)
+        if completed is not None:
+            record["completed_at"] = completed.get("completed_at")
+            record["outcome"] = completed.get("outcome")
+            record["evidence_ref"] = completed.get("evidence_ref")
             record["status"] = "closed"
         else:
             record["status"] = "open"
@@ -249,17 +268,13 @@ def _iter_records_from_dir(
             continue
         if profile_filter and started.get("profile_id") != profile_filter:
             continue
-        last = _read_last_line(path)
         record: dict = dict(started)  # type: ignore[type-arg]
         inv_id = record.get("invocation_id")
-        if (
-            last is not None
-            and last.get("event") == "completed"
-            and last.get("invocation_id") == inv_id
-        ):
-            record["completed_at"] = last.get("completed_at")
-            record["outcome"] = last.get("outcome")
-            record["evidence_ref"] = last.get("evidence_ref")
+        completed = _read_completed_record(path, inv_id) if isinstance(inv_id, str) else None
+        if completed is not None:
+            record["completed_at"] = completed.get("completed_at")
+            record["outcome"] = completed.get("outcome")
+            record["evidence_ref"] = completed.get("evidence_ref")
             record["status"] = "closed"
         else:
             record["status"] = "open"

--- a/src/specify_cli/invocation/writer.py
+++ b/src/specify_cli/invocation/writer.py
@@ -139,15 +139,14 @@ class InvocationWriter:
         if not path.exists():
             raise InvocationError(f"Invocation record not found: {invocation_id}")
 
-        # Already-closed check: read last line to see if a completed event exists.
         raw = path.read_text(encoding="utf-8")
         lines = [line.strip() for line in raw.splitlines() if line.strip()]
-        last = json.loads(lines[-1]) if lines else {}
-        if last.get("event") == "completed":
+        records = [json.loads(line) for line in lines]
+        if any(record.get("event") == "completed" for record in records):
             raise AlreadyClosedError(invocation_id)
 
         # Read profile_id from the started event (first line) for the completed record.
-        first = json.loads(lines[0]) if lines else {}
+        first = records[0] if records else {}
         profile_id = first.get("profile_id", "")
 
         completed = InvocationRecord(

--- a/tests/specify_cli/invocation/cli/test_invocations.py
+++ b/tests/specify_cli/invocation/cli/test_invocations.py
@@ -280,6 +280,39 @@ class TestInvocationsListJSON:
         assert statuses[open_id] == "open"
         assert statuses[closed_id] == "closed"
 
+    def test_status_closed_when_correlation_links_follow_completion(self, tmp_path: Path) -> None:
+        """Closed status must not depend on completed being the final JSONL line."""
+        events_dir = _make_events_dir(tmp_path)
+        invocation_id = _new_ulid()
+        path = _write_started(events_dir, invocation_id=invocation_id)
+        _write_completed(path, invocation_id=invocation_id, outcome="done")
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({"event": "artifact_link", "invocation_id": invocation_id, "ref": "spec.md"}) + "\n")
+            f.write(json.dumps({"event": "commit_link", "invocation_id": invocation_id, "sha": "abc123"}) + "\n")
+
+        records = list(_iter_records(events_dir, None, 10, repo_root=tmp_path))
+        record = next(r for r in records if r["invocation_id"] == invocation_id)
+        assert record["status"] == "closed"
+        assert record["outcome"] == "done"
+
+    def test_indexed_status_closed_when_correlation_links_follow_completion(
+        self, tmp_path: Path
+    ) -> None:
+        """Index path must also scan for completed before post-terminal links."""
+        events_dir = _make_events_dir(tmp_path)
+        invocation_id = _new_ulid()
+        path = _write_started(events_dir, invocation_id=invocation_id)
+        started = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        append_to_index(tmp_path, started)
+        _write_completed(path, invocation_id=invocation_id, outcome="done")
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({"event": "artifact_link", "invocation_id": invocation_id, "ref": "spec.md"}) + "\n")
+
+        records = list(_iter_records(events_dir, None, 10, repo_root=tmp_path))
+        record = next(r for r in records if r["invocation_id"] == invocation_id)
+        assert record["status"] == "closed"
+        assert record["outcome"] == "done"
+
     def test_no_events_dir_returns_empty(self, tmp_path: Path) -> None:
         """When .kittify/events/profile-invocations does not exist, return []."""
         with pytest.MonkeyPatch().context() as mp:

--- a/tests/specify_cli/invocation/test_writer.py
+++ b/tests/specify_cli/invocation/test_writer.py
@@ -129,6 +129,32 @@ class TestAlreadyClosed:
         with pytest.raises(AlreadyClosedError):
             writer.write_completed(_INVOCATION_ID, tmp_path, outcome="done")
 
+    @pytest.mark.parametrize(
+        ("link_kwargs", "link_event"),
+        [
+            ({"ref": "spec.md"}, "artifact_link"),
+            ({"sha": "abc123"}, "commit_link"),
+        ],
+    )
+    def test_complete_after_correlation_link_raises_already_closed_error(
+        self, tmp_path: Path, link_kwargs: dict[str, str], link_event: str
+    ) -> None:
+        writer = InvocationWriter(tmp_path)
+        writer.write_started(_make_record())
+        writer.write_completed(_INVOCATION_ID, tmp_path, outcome="done")
+        writer.append_correlation_link(_INVOCATION_ID, **link_kwargs)
+
+        with pytest.raises(AlreadyClosedError):
+            writer.write_completed(_INVOCATION_ID, tmp_path, outcome="failed")
+
+        file_path = writer.invocation_path(_INVOCATION_ID)
+        events = [
+            json.loads(line)["event"]
+            for line in file_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert events == ["started", "completed", link_event]
+
     def test_complete_nonexistent_invocation_raises_invocation_error(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- fix invocation writer closed guard to reject any prior completed event, not only a trailing completed event
- add regression coverage for second completion attempts after artifact and commit correlation links
- preserve valid correlation link writes after terminal records

Fixes #1472

## Verification
- RED: .venv/bin/pytest tests/specify_cli/invocation/test_writer.py::TestAlreadyClosed::test_complete_after_correlation_link_raises_already_closed_error failed before fix with DID NOT RAISE AlreadyClosedError
- .venv/bin/pytest tests/specify_cli/invocation/test_writer.py tests/specify_cli/invocation/test_correlation.py
- .venv/bin/pytest tests/specify_cli/invocation/test_invocation_e2e.py
- .venv/bin/ruff check src/specify_cli/invocation/writer.py tests/specify_cli/invocation/test_writer.py
- git diff --check

Note: full-repo .venv/bin/ruff check currently reports pre-existing unrelated lint failures in .kittify/overrides, scripts, and kitty-specs paths.