### PR TITLE
Fix charter token budget warning headroom

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -26,6 +26,7 @@ from charter._doctrine_paths import resolve_project_root
 from charter.context_renderers import (
     BUDGET_DEFAULT,
     RenderedSection,
+    budget_without_warning_line,
     render_authority_paths,
     render_critical_section_bodies,
 )
@@ -791,7 +792,7 @@ def _enforce_token_budget(
     current_text = text
     swapped_ids: list[str] = []
     for section in candidates:
-        if len(current_text) <= budget:
+        if len(current_text) <= budget_without_warning_line(len(swapped_ids), budget):
             break
         stanza = "\n".join(
             _shared_fetch_stanza_lines(

--- a/src/charter/context_renderers/__init__.py
+++ b/src/charter/context_renderers/__init__.py
@@ -48,6 +48,7 @@ from charter.context_renderers.token_budget import (
     BUDGET_DEFAULT,
     RenderedSection,
     apply_token_budget,
+    budget_without_warning_line,
     warning_line,
 )
 
@@ -61,6 +62,7 @@ __all__ = [
     "DEFAULT_WHEN_CLAUSE",
     "RenderedSection",
     "apply_token_budget",
+    "budget_without_warning_line",
     "critical_section_header",
     "fetch_stanza",
     "fetch_stanza_lines",

--- a/src/charter/context_renderers/token_budget.py
+++ b/src/charter/context_renderers/token_budget.py
@@ -46,6 +46,7 @@ __all__ = [
     "BUDGET_DEFAULT",
     "RenderedSection",
     "apply_token_budget",
+    "budget_without_warning_line",
     "warning_line",
 ]
 
@@ -110,6 +111,14 @@ def warning_line(count: int, budget: int) -> str:
         f"# Governance payload: {count} sections substituted with fetch "
         f"commands (budget={budget})."
     )
+
+
+def budget_without_warning_line(count: int, budget: int) -> int:
+    """Return pre-warning content budget after reserving warning-line space."""
+
+    if count <= 0:
+        return budget
+    return budget - len(f"\n\n{warning_line(count, budget)}")
 
 
 def _join_sections(sections: list[RenderedSection]) -> str:
@@ -199,7 +208,7 @@ def apply_token_budget(
     if len(joined) <= budget:
         return joined, notes
 
-    while len(joined) > budget:
+    while len(joined) > budget_without_warning_line(len(notes), budget):
         # Pick the longest substitutable section with a non-empty selector.
         candidates = [
             (idx, sec)

--- a/tests/charter/test_context_token_budget.py
+++ b/tests/charter/test_context_token_budget.py
@@ -172,6 +172,59 @@ class TestWarningLine:
         assert notes == []
         assert "# Governance payload" not in joined
 
+    def test_warning_line_counts_against_budget_after_substitution(self) -> None:
+        long_body = "L" * 1_000
+        short_body = "S" * 400
+        sections = [
+            _make_section("longest", long_body, selector="directive:DIRECTIVE_010"),
+            _make_section("short", short_body, selector="tactic:TACTIC_010"),
+        ]
+        first_swap_text = "\n\n".join(
+            [
+                fetch_stanza("directive:DIRECTIVE_010", "are about to apply a code change"),
+                short_body,
+            ]
+        )
+        budget = len(first_swap_text) + 30
+
+        joined, notes = apply_token_budget(sections, budget=budget)
+
+        assert len(joined) <= budget
+        assert long_body not in joined
+        assert short_body not in joined
+        assert len(notes) == 2
+        assert joined.rstrip().endswith(warning_line(len(notes), budget))
+
+    def test_production_context_budget_counts_warning_line(self) -> None:
+        from charter.context import _enforce_token_budget
+
+        section_block = "S" * 1_000
+        profile_block = "P" * 400
+        text = f"Charter Context (Bootstrap):\n\n{section_block}\n\n{profile_block}"
+        first_swap_text = text.replace(
+            section_block,
+            fetch_stanza(
+                "section:critical-implement",
+                "need to consult the action-critical charter sections",
+                indent="  ",
+            ),
+            1,
+        )
+        budget = len(first_swap_text) + 30
+
+        result = _enforce_token_budget(
+            text,
+            action="implement",
+            profile_block=profile_block,
+            section_block=section_block,
+            budget=budget,
+        )
+
+        assert len(result) <= budget
+        assert section_block not in result
+        assert profile_block not in result
+        assert result.rstrip().endswith(warning_line(2, budget))
+
 
 # ---------------------------------------------------------------------------
 # Fetch stanza contract


### PR DESCRIPTION
## Summary
- Reserve warning-line headroom inside charter token budget substitution loops.
- Apply same final-artifact budget invariant to the production `charter.context` caller.
- Add regression coverage proving final returned text, including warning/substitution text, stays within budget when another safe substitution is available.

Fixes #1466.

## Tests
- `uv run pytest tests/charter/test_context_token_budget.py::TestWarningLine::test_warning_line_counts_against_budget_after_substitution -q` (failed before fix: 636 chars returned for 586 budget)
- `uv run pytest tests/charter/test_context_token_budget.py::TestWarningLine -q`
- `uv run pytest tests/charter/test_context_token_budget.py -q`
- `uv run pytest tests/charter/test_context.py -q`
- `uv run pytest tests/charter/test_context_selection_render.py -q`
- `uv run ruff check src/charter/context.py src/charter/context_renderers/__init__.py src/charter/context_renderers/token_budget.py tests/charter/test_context_token_budget.py`
- `git diff --check`

## Notes
- Full `uv run ruff check` still fails on pre-existing issues outside this patch (`.kittify/overrides/scripts/tasks/tasks_cli.py`, `scripts/generate_schemas.py`, `scripts/lint_canonical_producers.py`, `scripts/sync_all_contributors.py`, `scripts/tasks/*`, `scripts/verify_occurrences.py`).
- Self-run adversarial review found no merge blockers in the changed surface.