### PR TITLE
Fix widen pending review crash retention

### DIFF
--- a/src/specify_cli/cli/commands/charter/_widen.py
+++ b/src/specify_cli/cli/commands/charter/_widen.py
@@ -384,7 +384,7 @@ def _dispatch_widen_input(  # noqa: C901
     if result.action == WidenAction.CONTINUE:
         # Write WidenPendingEntry (T024 pattern — caller does persistence)
         if widen_store is not None:
-            with contextlib.suppress(Exception):
+            try:
                 widen_store.add_pending(WidenPendingEntry(
                     decision_id=result.decision_id or current_decision_id,
                     mission_slug=mission_slug,
@@ -393,6 +393,12 @@ def _dispatch_widen_input(  # noqa: C901
                     entered_pending_at=datetime.now(tz=UTC),
                     widen_endpoint_response={},
                 ))
+            except Exception as exc:  # noqa: BLE001
+                console.print(
+                    "[red]Could not save pending widen marker: "
+                    f"{exc}. Question was NOT parked.[/red]"
+                )
+                return None, False
         answers_override[question_id] = ""
         return "", True  # advance to next question
 

--- a/src/specify_cli/cli/commands/charter/_widen.py
+++ b/src/specify_cli/cli/commands/charter/_widen.py
@@ -118,9 +118,9 @@ def _resolve_locally(
     final_answer: str,
     actor: str,
     console: Console,
-) -> None:
+) -> bool:
     """FR-018: resolve with source=manual at the blocked widen prompt."""
-    with contextlib.suppress(_DecisionError):
+    try:
         _dm_service.resolve_decision(
             repo_root=repo_root,
             mission_slug=mission_slug,
@@ -128,7 +128,13 @@ def _resolve_locally(
             final_answer=final_answer,
             actor=actor,
         )
+    except _DecisionError as exc:
+        console.print(
+            f"[red]Write-back failed: {exc}. Your answer was NOT saved.[/red]"
+        )
+        return False
     console.print("[green]Resolved locally.[/green] SaaS will close the Slack thread shortly.")
+    return True
 
 
 def _defer_from_blocked_prompt(
@@ -137,14 +143,14 @@ def _defer_from_blocked_prompt(
     repo_root: Path,
     actor: str,
     console: Console,
-) -> None:
+) -> bool:
     """T032: defer the widened decision from the blocked prompt."""
     try:
         rationale = console.input("Rationale for deferral (press Enter to skip): ").strip()
     except (KeyboardInterrupt, EOFError):
         rationale = ""
 
-    with contextlib.suppress(_DecisionError):
+    try:
         _dm_service.defer_decision(
             repo_root=repo_root,
             mission_slug=mission_slug,
@@ -152,7 +158,13 @@ def _defer_from_blocked_prompt(
             rationale=rationale or "deferred from blocked widen prompt",
             actor=actor,
         )
+    except _DecisionError as exc:
+        console.print(
+            f"[red]Write-back failed: {exc}. Your deferral was NOT saved.[/red]"
+        )
+        return False
     console.print("[yellow]Decision deferred.[/yellow]")
+    return True
 
 
 def _fetch_and_review_from_blocked(
@@ -444,14 +456,16 @@ def _run_blocked_prompt_loop(
             _inactivity_timer = _schedule_inactivity_reminder(console)
         elif cmd.lower() == "d":
             _inactivity_timer.cancel()
-            _defer_from_blocked_prompt(
+            deferred = _defer_from_blocked_prompt(
                 decision_id=decision_id,
                 mission_slug=mission_slug,
                 repo_root=repo_root,
                 actor=actor,
                 console=console,
             )
-            break
+            if deferred:
+                break
+            _inactivity_timer = _schedule_inactivity_reminder(console)
         elif cmd.lower() == "!cancel":
             _inactivity_timer.cancel()
             console.print("[dim]Interview canceled.[/dim]")
@@ -459,7 +473,7 @@ def _run_blocked_prompt_loop(
         else:
             # Plain text → local answer (FR-018)
             _inactivity_timer.cancel()
-            _resolve_locally(
+            resolved = _resolve_locally(
                 decision_id=decision_id,
                 mission_slug=mission_slug,
                 repo_root=repo_root,
@@ -467,4 +481,6 @@ def _run_blocked_prompt_loop(
                 actor=actor,
                 console=console,
             )
-            break
+            if resolved:
+                break
+            _inactivity_timer = _schedule_inactivity_reminder(console)

--- a/src/specify_cli/missions/plan/plan_interview.py
+++ b/src/specify_cli/missions/plan/plan_interview.py
@@ -244,7 +244,7 @@ def run_plan_interview(  # noqa: C901
 
                 if result.action == WidenAction.CONTINUE:
                     if widen_store is not None:
-                        with contextlib.suppress(Exception):
+                        try:
                             widen_store.add_pending(
                                 WidenPendingEntry(
                                     decision_id=result.decision_id or current_decision_id,
@@ -255,6 +255,12 @@ def run_plan_interview(  # noqa: C901
                                     widen_endpoint_response={},
                                 )
                             )
+                        except Exception as exc:  # noqa: BLE001
+                            console.print(
+                                "[red]Could not save pending widen marker: "
+                                f"{exc}. Question was NOT parked.[/red]"
+                            )
+                            continue
                     user_answer = ""
                     break
 

--- a/src/specify_cli/missions/plan/specify_interview.py
+++ b/src/specify_cli/missions/plan/specify_interview.py
@@ -245,7 +245,7 @@ def run_specify_interview(  # noqa: C901
 
                 if result.action == WidenAction.CONTINUE:
                     if widen_store is not None:
-                        with contextlib.suppress(Exception):
+                        try:
                             widen_store.add_pending(
                                 WidenPendingEntry(
                                     decision_id=result.decision_id or current_decision_id,
@@ -256,6 +256,12 @@ def run_specify_interview(  # noqa: C901
                                     widen_endpoint_response={},
                                 )
                             )
+                        except Exception as exc:  # noqa: BLE001
+                            console.print(
+                                "[red]Could not save pending widen marker: "
+                                f"{exc}. Question was NOT parked.[/red]"
+                            )
+                            continue
                     user_answer = ""
                     break
 

--- a/src/specify_cli/widen/interview_helpers.py
+++ b/src/specify_cli/widen/interview_helpers.py
@@ -73,8 +73,8 @@ def _resolve_pending_entry(
 ) -> None:
     """Fetch discussion + run candidate review for one pending widen entry.
 
-    Removes the entry from the store after any terminal action (accept, edit,
-    defer) or on unexpected exception (T042 — always-progress rule).
+    Removes the entry from the store after a terminal candidate-review action.
+    Review/write-back crashes or review cancellation leave the marker intact.
 
     Args:
         entry:        A WidenPendingEntry.
@@ -94,9 +94,8 @@ def _resolve_pending_entry(
         f"      Widened at: {entry.entered_pending_at.strftime('%Y-%m-%d %H:%M UTC')}"
     )
 
-    # T042 — always remove from store even on unexpected failure.
-    # Wrap the entire body so any exception (fetch failure, validation error,
-    # run_candidate_review error) is suppressed and the interview always progresses.
+    # Fetch failures can fall back to an empty discussion, but review/write-back
+    # crashes must not erase the pending marker.
     try:
         # Fetch discussion from SaaS
         console.print("      Fetching discussion...")
@@ -128,7 +127,7 @@ def _resolve_pending_entry(
                 truncated=False,
             )
 
-        run_candidate_review(
+        review = run_candidate_review(
             discussion_data=discussion,
             decision_id=entry.decision_id,
             question_text=entry.question_text,
@@ -138,11 +137,11 @@ def _resolve_pending_entry(
             dm_service=dm_service,
             actor=actor,
         )
+        if review is not None:
+            with contextlib.suppress(Exception):
+                store.remove_pending(entry.decision_id)
     except Exception:  # noqa: BLE001
         pass  # never block the interview
-    finally:
-        with contextlib.suppress(Exception):
-            store.remove_pending(entry.decision_id)
 
 
 # ---------------------------------------------------------------------------
@@ -287,18 +286,17 @@ def render_already_widened_prompt(
                     messages=[],
                     truncated=False,
                 )
-            try:
-                run_candidate_review(
-                    discussion_data=discussion,
-                    decision_id=decision_id,
-                    question_text=question_text,
-                    mission_slug=mission_slug,
-                    repo_root=repo_root,
-                    console=console,
-                    dm_service=dm_service,
-                    actor=actor,
-                )
-            finally:
+            review = run_candidate_review(
+                discussion_data=discussion,
+                decision_id=decision_id,
+                question_text=question_text,
+                mission_slug=mission_slug,
+                repo_root=repo_root,
+                console=console,
+                dm_service=dm_service,
+                actor=actor,
+            )
+            if review is not None:
                 with contextlib.suppress(Exception):
                     widen_store.remove_pending(decision_id)
             return

--- a/src/specify_cli/widen/interview_helpers.py
+++ b/src/specify_cli/widen/interview_helpers.py
@@ -299,7 +299,11 @@ def render_already_widened_prompt(
             if review is not None:
                 with contextlib.suppress(Exception):
                     widen_store.remove_pending(decision_id)
-            return
+                return
+            console.print(
+                "[yellow]Decision is still pending. Choose another action or !cancel.[/yellow]"
+            )
+            continue
 
         elif raw.lower() in ("d", "defer", "[d]efer"):
             # Defer path — remove from store only after write-back succeeds.
@@ -324,7 +328,7 @@ def render_already_widened_prompt(
                 console.print(
                     f"[red]Write-back failed: {exc}. Your deferral was NOT saved.[/red]"
                 )
-                return
+                continue
             console.print("[yellow]Decision deferred.[/yellow]")
             with contextlib.suppress(Exception):
                 widen_store.remove_pending(decision_id)
@@ -347,7 +351,7 @@ def render_already_widened_prompt(
                 console.print(
                     f"[red]Write-back failed: {exc}. Your answer was NOT saved.[/red]"
                 )
-                return
+                continue
             console.print(
                 "[green]Resolved locally.[/green] "
                 "SaaS will close the Slack thread shortly."

--- a/src/specify_cli/widen/interview_helpers.py
+++ b/src/specify_cli/widen/interview_helpers.py
@@ -302,7 +302,7 @@ def render_already_widened_prompt(
             return
 
         elif raw.lower() in ("d", "defer", "[d]efer"):
-            # Defer path — also removes from store
+            # Defer path — remove from store only after write-back succeeds.
             try:
                 rationale = (
                     console.input(
@@ -312,7 +312,7 @@ def render_already_widened_prompt(
             except (KeyboardInterrupt, EOFError):
                 rationale = ""
 
-            with contextlib.suppress(Exception):
+            try:
                 dm_service.defer_decision(
                     repo_root=repo_root,
                     mission_slug=mission_slug,
@@ -320,6 +320,11 @@ def render_already_widened_prompt(
                     rationale=rationale or "deferred from already-widened prompt",
                     actor=actor,
                 )
+            except Exception as exc:  # noqa: BLE001
+                console.print(
+                    f"[red]Write-back failed: {exc}. Your deferral was NOT saved.[/red]"
+                )
+                return
             console.print("[yellow]Decision deferred.[/yellow]")
             with contextlib.suppress(Exception):
                 widen_store.remove_pending(decision_id)
@@ -330,7 +335,7 @@ def render_already_widened_prompt(
 
         elif raw:
             # Plain text → local resolve
-            with contextlib.suppress(Exception):
+            try:
                 dm_service.resolve_decision(
                     repo_root=repo_root,
                     mission_slug=mission_slug,
@@ -338,6 +343,11 @@ def render_already_widened_prompt(
                     final_answer=raw,
                     actor=actor,
                 )
+            except Exception as exc:  # noqa: BLE001
+                console.print(
+                    f"[red]Write-back failed: {exc}. Your answer was NOT saved.[/red]"
+                )
+                return
             console.print(
                 "[green]Resolved locally.[/green] "
                 "SaaS will close the Slack thread shortly."

--- a/src/specify_cli/widen/review.py
+++ b/src/specify_cli/widen/review.py
@@ -16,7 +16,6 @@ Prompt-contract model (R-7):
 
 from __future__ import annotations
 
-import contextlib
 import difflib
 import json
 import os
@@ -366,8 +365,13 @@ def _handle_defer(
     dm_service: Any,
     actor: str,
     console: Console,
-) -> None:
-    """Defer the decision with a required rationale (§6.3)."""
+) -> bool:
+    """Defer the decision with a required rationale (§6.3).
+
+    Returns:
+        ``True`` on successful persistence; ``False`` when a
+        ``DecisionError`` prevents the write-back (user is notified).
+    """
     from specify_cli.decisions.service import DecisionError  # local import
 
     try:
@@ -375,7 +379,7 @@ def _handle_defer(
     except (KeyboardInterrupt, EOFError):
         rationale = ""
 
-    with contextlib.suppress(DecisionError):
+    try:
         dm_service.defer_decision(
             repo_root=repo_root,
             mission_slug=mission_slug,
@@ -383,7 +387,13 @@ def _handle_defer(
             rationale=rationale or "deferred during candidate review",
             actor=actor,
         )
+    except DecisionError as exc:
+        console.print(
+            f"[red]Write-back failed: {exc}. Your deferral was NOT saved.[/red]"
+        )
+        return False
     console.print("[yellow]Decision deferred.[/yellow]")
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -409,13 +419,12 @@ def run_candidate_review(
     3. Parse into ``CandidateReview``; fall back on timeout / parse failure.
     4. Render §6 Candidate Review Panel.
     5. Prompt owner for ``[a]ccept`` / ``[e]dit`` / ``[d]efer``.
-    6. Dispatch to the appropriate handler and return the ``CandidateReview``.
+    6. Dispatch to the appropriate handler and return the ``CandidateReview``
+       only after the terminal action is persisted.
 
     Returns:
-        The ``CandidateReview`` on accept or edit (decision resolved).
-        The ``CandidateReview`` on defer (decision deferred, still pending).
-        ``None`` only if the user cancels (KeyboardInterrupt / EOFError at the
-        prompt before choosing an action).
+        The ``CandidateReview`` on persisted accept/edit/defer.
+        ``None`` if the user cancels or the terminal write-back fails.
     """
     # ------------------------------------------------------------------
     # Step 1 — emit instruction block
@@ -472,16 +481,19 @@ def run_candidate_review(
             return None
 
         if choice in ("a", "accept"):
-            _handle_accept(candidate, mission_slug, repo_root, dm_service, actor, console)
-            return candidate
+            if _handle_accept(candidate, mission_slug, repo_root, dm_service, actor, console):
+                return candidate
+            return None
 
         if choice in ("e", "edit"):
-            _handle_edit(candidate, mission_slug, repo_root, dm_service, actor, console)
-            return candidate
+            if _handle_edit(candidate, mission_slug, repo_root, dm_service, actor, console):
+                return candidate
+            return None
 
         if choice in ("d", "defer"):
-            _handle_defer(candidate, mission_slug, repo_root, dm_service, actor, console)
-            return candidate
+            if _handle_defer(candidate, mission_slug, repo_root, dm_service, actor, console):
+                return candidate
+            return None
 
         console.print(
             "[yellow]Invalid choice. Please enter 'a' (accept), 'e' (edit), or 'd' (defer).[/yellow]"

--- a/tests/specify_cli/cli/commands/test_charter_widen.py
+++ b/tests/specify_cli/cli/commands/test_charter_widen.py
@@ -15,11 +15,13 @@ from __future__ import annotations
 import json
 import os
 import time
+from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from charter.interview import MINIMAL_QUESTION_ORDER
+from rich.console import Console
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.charter import app as charter_app
@@ -87,9 +89,86 @@ def _invoke_interview(
         os.chdir(old_cwd)
 
 
+def _make_decision_error() -> Exception:
+    from specify_cli.decisions.models import DecisionErrorCode
+    from specify_cli.decisions.service import DecisionError
+
+    return DecisionError(code=DecisionErrorCode.TERMINAL_CONFLICT)
+
+
 # ---------------------------------------------------------------------------
 # [w]iden affordance visibility
 # ---------------------------------------------------------------------------
+
+
+class TestBlockedPromptWriteBackFailures:
+    """Blocked prompt write-back failures must not fake terminal progress."""
+
+    def test_local_answer_failure_reprompts_before_advancing(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.charter import _run_blocked_prompt_loop
+
+        console = Console(file=StringIO(), highlight=False, markup=False)
+        timer = MagicMock()
+
+        with (
+            patch.object(console, "input", side_effect=["first answer", "second answer"]),
+            patch(
+                "specify_cli.cli.commands.charter._widen._schedule_inactivity_reminder",
+                return_value=timer,
+            ),
+            patch(
+                "specify_cli.cli.commands.charter._widen._dm_service.resolve_decision",
+                side_effect=[_make_decision_error(), MagicMock()],
+            ) as mock_resolve,
+        ):
+            _run_blocked_prompt_loop(
+                decision_id="dec-001",
+                question_text="Which DB?",
+                invited=["Alice"],
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                console=console,
+                saas_client=MagicMock(),
+                actor="tester",
+            )
+
+        assert mock_resolve.call_count == 2
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "not saved" in output.lower()
+        assert "Resolved locally" in output
+
+    def test_defer_failure_reprompts_before_advancing(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.charter import _run_blocked_prompt_loop
+
+        console = Console(file=StringIO(), highlight=False, markup=False)
+        timer = MagicMock()
+
+        with (
+            patch.object(console, "input", side_effect=["d", "not ready", "d", "ready"]),
+            patch(
+                "specify_cli.cli.commands.charter._widen._schedule_inactivity_reminder",
+                return_value=timer,
+            ),
+            patch(
+                "specify_cli.cli.commands.charter._widen._dm_service.defer_decision",
+                side_effect=[_make_decision_error(), MagicMock()],
+            ) as mock_defer,
+        ):
+            _run_blocked_prompt_loop(
+                decision_id="dec-001",
+                question_text="Which DB?",
+                invited=["Alice"],
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                console=console,
+                saas_client=MagicMock(),
+                actor="tester",
+            )
+
+        assert mock_defer.call_count == 2
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "not saved" in output.lower()
+        assert "Decision deferred" in output
 
 
 class TestWidenAffordanceVisibility:
@@ -197,6 +276,10 @@ class TestWidenHappyPathBlock:
                 ),
                 patch("specify_cli.widen.check_prereqs", return_value=prereq_ok),
                 patch("specify_cli.widen.flow.WidenFlow", return_value=mock_flow),
+                patch(
+                    "specify_cli.cli.commands.charter._widen._dm_service.resolve_decision",
+                    return_value=MagicMock(),
+                ),
                 patch("specify_cli.widen.state.WidenPendingStore") as mock_store_cls,
             ):
                 mock_store = MagicMock()
@@ -245,6 +328,10 @@ class TestWidenHappyPathBlock:
                 ),
                 patch("specify_cli.widen.check_prereqs", return_value=prereq_ok),
                 patch("specify_cli.widen.flow.WidenFlow", return_value=mock_flow),
+                patch(
+                    "specify_cli.cli.commands.charter._widen._dm_service.resolve_decision",
+                    return_value=MagicMock(),
+                ),
                 patch("specify_cli.widen.state.WidenPendingStore") as mock_store_cls,
             ):
                 mock_store = MagicMock()

--- a/tests/specify_cli/cli/commands/test_charter_widen.py
+++ b/tests/specify_cli/cli/commands/test_charter_widen.py
@@ -360,6 +360,48 @@ class TestWidenHappyPathBlock:
 class TestWidenHappyPathContinue:
     """Secondary scenario: w → CONTINUE → question parked in pending store."""
 
+    def test_continue_marker_failure_does_not_advance_question(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Pending marker write failure must re-prompt instead of parking blank."""
+        from specify_cli.cli.commands.charter import _dispatch_widen_input
+
+        decision_id = "01KWP10CONTINUEFAIL01"
+        mock_flow = MagicMock()
+        mock_flow.run_widen_mode.return_value = WidenFlowResult(
+            action=WidenAction.CONTINUE,
+            decision_id=decision_id,
+            invited=["Alice Johnson"],
+        )
+        bad_store = MagicMock()
+        bad_store.add_pending.side_effect = OSError("disk full")
+        console = Console(file=StringIO(), highlight=False, markup=False)
+        answers_override: dict[str, str] = {}
+
+        answer, should_break = _dispatch_widen_input(
+            widen_flow=mock_flow,
+            current_decision_id=decision_id,
+            mission_id=MISSION_ID,
+            mission_slug=MISSION_SLUG,
+            question_id="database",
+            prompt_text="Which DB?",
+            hint_line="[enter]=accept default | [w]iden",
+            widen_store=bad_store,
+            answers_override=answers_override,
+            repo_root=tmp_path,
+            console=console,
+            saas_client=MagicMock(),
+            actor="tester",
+        )
+
+        assert answer is None
+        assert should_break is False
+        assert answers_override == {}
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "Question was NOT" in output
+        assert "parked" in output
+
     def test_w_then_continue_parks_question(self, tmp_path: Path) -> None:
         """w input → CONTINUE → WidenPendingEntry written to store (FR-009)."""
         _setup_repo(tmp_path)

--- a/tests/specify_cli/cli/commands/test_charter_widen_integration.py
+++ b/tests/specify_cli/cli/commands/test_charter_widen_integration.py
@@ -401,6 +401,10 @@ class TestWidenBlockPath:
                 patch("specify_cli.saas_client.client.SaasClient.from_env", return_value=MagicMock(_token="tok")),
                 patch("specify_cli.widen.check_prereqs", return_value=prereq_ok),
                 patch("specify_cli.widen.flow.WidenFlow", return_value=mock_flow),
+                patch(
+                    "specify_cli.cli.commands.charter._widen._dm_service.resolve_decision",
+                    return_value=MagicMock(),
+                ),
                 patch("specify_cli.widen.state.WidenPendingStore") as mock_store_cls,
             ):
                 mock_store_inst = MagicMock()
@@ -447,6 +451,10 @@ class TestWidenBlockPath:
                 patch("specify_cli.saas_client.client.SaasClient.from_env", return_value=MagicMock(_token="tok")),
                 patch("specify_cli.widen.check_prereqs", return_value=prereq_ok),
                 patch("specify_cli.widen.flow.WidenFlow", return_value=mock_flow),
+                patch(
+                    "specify_cli.cli.commands.charter._widen._dm_service.defer_decision",
+                    return_value=MagicMock(),
+                ),
                 patch("specify_cli.widen.state.WidenPendingStore") as mock_store_cls,
             ):
                 mock_store_inst = MagicMock()

--- a/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
+++ b/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
@@ -67,6 +67,13 @@ def _console_output(console: Console) -> str:
     return console.file.getvalue()  # type: ignore[union-attr]
 
 
+def _make_decision_error() -> Exception:
+    from specify_cli.decisions.models import DecisionErrorCode
+    from specify_cli.decisions.service import DecisionError
+
+    return DecisionError(code=DecisionErrorCode.TERMINAL_CONFLICT)
+
+
 # ---------------------------------------------------------------------------
 # T040 — run_end_of_interview_pending_pass
 # ---------------------------------------------------------------------------
@@ -486,6 +493,33 @@ class TestRenderAlreadyWidenedPrompt:
         mock_dm.resolve_decision.assert_called_once()
         assert store.list_pending() == []
 
+    def test_local_answer_write_back_failure_keeps_pending(self, tmp_path: Path) -> None:
+        """Regression G0085: failed already-widened local resolve leaves pending."""
+        store, entry = self._make_store_with_entry(tmp_path)
+        console = _capture_console()
+        mock_dm = MagicMock()
+        mock_dm.resolve_decision.side_effect = _make_decision_error()
+
+        with patch.object(console, "input", return_value="PostgreSQL"):
+            render_already_widened_prompt(
+                question_text="Which database?",
+                decision_id="dec-001",
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                saas_client=MagicMock(),
+                widen_store=store,
+                dm_service=mock_dm,
+                actor="test",
+                console=console,
+            )
+
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
+        output = _console_output(console).lower()
+        assert "not saved" in output
+        assert "resolved locally" not in output
+
     def test_defer_path(self, tmp_path: Path) -> None:
         """d input → defer_decision called, entry removed."""
         store, entry = self._make_store_with_entry(tmp_path)
@@ -511,6 +545,34 @@ class TestRenderAlreadyWidenedPrompt:
 
         mock_dm.defer_decision.assert_called_once()
         assert store.list_pending() == []
+
+    def test_defer_write_back_failure_keeps_pending(self, tmp_path: Path) -> None:
+        """Regression G0085: failed already-widened direct defer leaves pending."""
+        store, entry = self._make_store_with_entry(tmp_path)
+        console = _capture_console()
+        mock_dm = MagicMock()
+        mock_dm.defer_decision.side_effect = _make_decision_error()
+        inputs_iter = iter(["d", "not ready"])
+
+        with patch.object(console, "input", side_effect=inputs_iter):
+            render_already_widened_prompt(
+                question_text="Tech stack?",
+                decision_id="dec-001",
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                saas_client=MagicMock(),
+                widen_store=store,
+                dm_service=mock_dm,
+                actor="test",
+                console=console,
+            )
+
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
+        output = _console_output(console).lower()
+        assert "not saved" in output
+        assert "decision deferred" not in output
 
     def test_fetch_path(self, tmp_path: Path) -> None:
         """f input → fetch + run_candidate_review, entry removed."""

--- a/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
+++ b/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
@@ -406,6 +406,47 @@ class TestResolvePendingEntry:
         assert len(pending) == 1
         assert pending[0].decision_id == entry.decision_id
 
+    def test_keeps_entry_when_review_write_back_fails(self, tmp_path: Path) -> None:
+        """Regression G0085: failed terminal write-back leaves pending entry retryable."""
+        from specify_cli.decisions.models import DecisionErrorCode
+        from specify_cli.decisions.service import DecisionError
+        from specify_cli.widen.models import DiscussionFetch
+
+        entry = _make_entry()
+        store = _make_store(tmp_path, [entry])
+        console = _capture_console()
+        mock_saas = MagicMock()
+        mock_saas.fetch_discussion.return_value = DiscussionFetch(
+            participants=[], message_count=0, thread_url=None, messages=[], truncated=False,
+        )
+        mock_dm = MagicMock()
+        mock_dm.resolve_decision.side_effect = DecisionError(
+            code=DecisionErrorCode.TERMINAL_CONFLICT
+        )
+        llm_payload = {
+            "candidate_summary": "Team chose Postgres",
+            "candidate_answer": "PostgreSQL",
+            "source_hint": "slack_extraction",
+        }
+
+        with patch.object(console, "input", return_value="a"), patch(
+            "specify_cli.widen.review._read_llm_response", return_value=llm_payload
+        ):
+            _resolve_pending_entry(
+                entry=entry,
+                store=store,
+                saas_client=mock_saas,
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                console=console,
+                dm_service=mock_dm,
+                actor="test",
+            )
+
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
+
 
 # ---------------------------------------------------------------------------
 # T045 — render_already_widened_prompt

--- a/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
+++ b/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
@@ -493,14 +493,20 @@ class TestRenderAlreadyWidenedPrompt:
         mock_dm.resolve_decision.assert_called_once()
         assert store.list_pending() == []
 
-    def test_local_answer_write_back_failure_keeps_pending(self, tmp_path: Path) -> None:
+    def test_local_answer_write_back_failure_keeps_pending_and_reprompts(self, tmp_path: Path) -> None:
         """Regression G0085: failed already-widened local resolve leaves pending."""
+        import typer
+
         store, entry = self._make_store_with_entry(tmp_path)
         console = _capture_console()
         mock_dm = MagicMock()
         mock_dm.resolve_decision.side_effect = _make_decision_error()
+        inputs = iter(["PostgreSQL", "!cancel"])
 
-        with patch.object(console, "input", return_value="PostgreSQL"):
+        with (
+            patch.object(console, "input", side_effect=lambda _prompt="": next(inputs)),
+            pytest.raises(typer.Exit),
+        ):
             render_already_widened_prompt(
                 question_text="Which database?",
                 decision_id="dec-001",
@@ -546,15 +552,20 @@ class TestRenderAlreadyWidenedPrompt:
         mock_dm.defer_decision.assert_called_once()
         assert store.list_pending() == []
 
-    def test_defer_write_back_failure_keeps_pending(self, tmp_path: Path) -> None:
+    def test_defer_write_back_failure_keeps_pending_and_reprompts(self, tmp_path: Path) -> None:
         """Regression G0085: failed already-widened direct defer leaves pending."""
+        import typer
+
         store, entry = self._make_store_with_entry(tmp_path)
         console = _capture_console()
         mock_dm = MagicMock()
         mock_dm.defer_decision.side_effect = _make_decision_error()
-        inputs_iter = iter(["d", "not ready"])
+        inputs_iter = iter(["d", "not ready", "!cancel"])
 
-        with patch.object(console, "input", side_effect=inputs_iter):
+        with (
+            patch.object(console, "input", side_effect=inputs_iter),
+            pytest.raises(typer.Exit),
+        ):
             render_already_widened_prompt(
                 question_text="Tech stack?",
                 decision_id="dec-001",
@@ -646,6 +657,8 @@ class TestRenderAlreadyWidenedPrompt:
 
     def test_fetch_path_keeps_pending_when_review_is_cancelled(self, tmp_path: Path) -> None:
         """A non-terminal already-widened review cancellation leaves pending state retryable."""
+        import typer
+
         store, entry = self._make_store_with_entry(tmp_path)
         console = Console(highlight=False, markup=False)
         mock_dm = MagicMock()
@@ -658,9 +671,15 @@ class TestRenderAlreadyWidenedPrompt:
             thread_url="https://slack.com/abc", messages=["Use PG"], truncated=False,
         )
 
-        with patch.object(console, "input", return_value="f"), \
+        inputs_iter = iter(["f", "!cancel"])
+
+        with patch.object(console, "input", side_effect=inputs_iter), \
              patch.object(console, "print"), \
-             patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+             patch(
+                 "specify_cli.widen.review.run_candidate_review",
+                 MagicMock(return_value=None),
+             ), \
+             pytest.raises(typer.Exit):
             render_already_widened_prompt(
                 question_text="DB choice?",
                 decision_id="dec-001",

--- a/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
+++ b/tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py
@@ -4,7 +4,7 @@ Tests cover:
 - Empty pending list → no panel rendered (silent no-op).
 - Non-empty pending list → §7 Panel rendered + entries resolved.
 - Failed fetch → fallback DiscussionFetch used; entry still removed from store.
-- T042: unexpected exception in run_candidate_review → entry still removed (always-progress).
+- Unexpected exception in run_candidate_review → entry stays pending for retry.
 - T045: already-widened question prompt for [f]etch, [d]efer, local answer, !cancel paths.
 - Charter interview end-of-interview pass integration.
 """
@@ -133,7 +133,7 @@ class TestRunEndOfInterviewPendingPassWithEntries:
         mock_saas.fetch_discussion.return_value = DiscussionFetch(
             participants=[], message_count=0, thread_url=None, messages=[], truncated=False,
         )
-        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=object())):
             run_end_of_interview_pending_pass(
                 widen_store=store,
                 saas_client=mock_saas,
@@ -159,7 +159,7 @@ class TestRunEndOfInterviewPendingPassWithEntries:
             participants=[], message_count=0, thread_url=None,
             messages=[], truncated=False,
         ))
-        mock_review = MagicMock(return_value=None)
+        mock_review = MagicMock(return_value=object())
 
         with patch("specify_cli.widen.review.run_candidate_review", mock_review), \
              patch.object(
@@ -189,8 +189,8 @@ class TestRunEndOfInterviewPendingPassWithEntries:
 
         assert store.list_pending() == [], "All entries should be removed from store after pending pass"
 
-    def test_entry_removed_even_on_review_exception(self, tmp_path: Path) -> None:
-        """T042: unexpected exception in run_candidate_review → entry still removed."""
+    def test_entry_stays_pending_on_review_exception(self, tmp_path: Path) -> None:
+        """Regression G0085: candidate-review crashes must not clear pending state."""
         entry = _make_entry()
         store = _make_store(tmp_path, [entry])
         console = _capture_console()
@@ -216,7 +216,9 @@ class TestRunEndOfInterviewPendingPassWithEntries:
                 actor="test",
             )
 
-        assert store.list_pending() == [], "Entry must be removed from store even on unexpected exception (T042)"
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
 
     def test_fetch_failure_uses_fallback_discussion(self, tmp_path: Path) -> None:
         """Fetch failure → fallback DiscussionFetch; run_candidate_review still called."""
@@ -229,7 +231,7 @@ class TestRunEndOfInterviewPendingPassWithEntries:
         mock_saas = MagicMock()
         mock_saas.fetch_discussion.side_effect = SaasClientError("network error")
 
-        mock_review = MagicMock(return_value=None)
+        mock_review = MagicMock(return_value=object())
         with patch("specify_cli.widen.review.run_candidate_review", mock_review):
             run_end_of_interview_pending_pass(
                 widen_store=store,
@@ -266,7 +268,7 @@ class TestRunEndOfInterviewPendingPassWithEntries:
             participants=[], message_count=0, thread_url=None, messages=[], truncated=False,
         )
 
-        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=object())):
             run_end_of_interview_pending_pass(
                 widen_store=store,
                 saas_client=mock_saas,
@@ -294,7 +296,7 @@ class TestRunEndOfInterviewPendingPassWithEntries:
             participants=[], message_count=0, thread_url=None, messages=[], truncated=False,
         )
 
-        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=object())):
             run_end_of_interview_pending_pass(
                 widen_store=store,
                 saas_client=mock_saas,
@@ -329,7 +331,7 @@ class TestResolvePendingEntry:
             participants=["Alice"], message_count=3, thread_url=None, messages=["Hi"], truncated=False,
         )
 
-        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=object())):
             _resolve_pending_entry(
                 entry=entry,
                 store=store,
@@ -343,8 +345,8 @@ class TestResolvePendingEntry:
 
         assert store.list_pending() == []
 
-    def test_removes_entry_on_exception(self, tmp_path: Path) -> None:
-        """T042 always-progress: entry removed even if run_candidate_review raises."""
+    def test_keeps_entry_on_review_exception(self, tmp_path: Path) -> None:
+        """Regression G0085: review/write-back crash leaves pending entry retryable."""
         entry = _make_entry()
         store = _make_store(tmp_path, [entry])
         console = _capture_console()
@@ -371,7 +373,38 @@ class TestResolvePendingEntry:
                 actor="test",
             )
 
-        assert store.list_pending() == [], "T042: entry must be removed even after exception"
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
+
+    def test_keeps_entry_when_review_is_cancelled(self, tmp_path: Path) -> None:
+        """A non-terminal candidate-review cancellation leaves pending state retryable."""
+        entry = _make_entry()
+        store = _make_store(tmp_path, [entry])
+        console = _capture_console()
+
+        from specify_cli.widen.models import DiscussionFetch
+
+        mock_saas = MagicMock()
+        mock_saas.fetch_discussion.return_value = DiscussionFetch(
+            participants=[], message_count=0, thread_url=None, messages=[], truncated=False,
+        )
+
+        with patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+            _resolve_pending_entry(
+                entry=entry,
+                store=store,
+                saas_client=mock_saas,
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                console=console,
+                dm_service=MagicMock(),
+                actor="test",
+            )
+
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
 
 
 # ---------------------------------------------------------------------------
@@ -452,7 +485,7 @@ class TestRenderAlreadyWidenedPrompt:
             thread_url="https://slack.com/abc", messages=["Use PG"], truncated=False,
         )
 
-        mock_review = MagicMock(return_value=None)
+        mock_review = MagicMock(return_value=object())
         with patch.object(console, "input", return_value="f"), \
              patch.object(console, "print"), \
              patch("specify_cli.widen.review.run_candidate_review", mock_review):
@@ -470,6 +503,76 @@ class TestRenderAlreadyWidenedPrompt:
 
         mock_review.assert_called_once()
         assert store.list_pending() == []
+
+    def test_fetch_path_keeps_pending_on_review_exception(self, tmp_path: Path) -> None:
+        """Regression G0085: already-widened fetch crash leaves pending entry retryable."""
+        store, entry = self._make_store_with_entry(tmp_path)
+        console = Console(highlight=False, markup=False)
+        mock_dm = MagicMock()
+
+        from specify_cli.widen.models import DiscussionFetch
+
+        mock_saas = MagicMock()
+        mock_saas.fetch_discussion.return_value = DiscussionFetch(
+            participants=["Alice"], message_count=1,
+            thread_url="https://slack.com/abc", messages=["Use PG"], truncated=False,
+        )
+
+        with patch.object(console, "input", return_value="f"), \
+             patch.object(console, "print"), \
+             patch(
+                 "specify_cli.widen.review.run_candidate_review",
+                 side_effect=RuntimeError("review crash"),
+             ), \
+             pytest.raises(RuntimeError, match="review crash"):
+            render_already_widened_prompt(
+                question_text="DB choice?",
+                decision_id="dec-001",
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                saas_client=mock_saas,
+                widen_store=store,
+                dm_service=mock_dm,
+                actor="test",
+                console=console,
+            )
+
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
+
+    def test_fetch_path_keeps_pending_when_review_is_cancelled(self, tmp_path: Path) -> None:
+        """A non-terminal already-widened review cancellation leaves pending state retryable."""
+        store, entry = self._make_store_with_entry(tmp_path)
+        console = Console(highlight=False, markup=False)
+        mock_dm = MagicMock()
+
+        from specify_cli.widen.models import DiscussionFetch
+
+        mock_saas = MagicMock()
+        mock_saas.fetch_discussion.return_value = DiscussionFetch(
+            participants=["Alice"], message_count=1,
+            thread_url="https://slack.com/abc", messages=["Use PG"], truncated=False,
+        )
+
+        with patch.object(console, "input", return_value="f"), \
+             patch.object(console, "print"), \
+             patch("specify_cli.widen.review.run_candidate_review", MagicMock(return_value=None)):
+            render_already_widened_prompt(
+                question_text="DB choice?",
+                decision_id="dec-001",
+                mission_slug=MISSION_SLUG,
+                repo_root=tmp_path,
+                saas_client=mock_saas,
+                widen_store=store,
+                dm_service=mock_dm,
+                actor="test",
+                console=console,
+            )
+
+        pending = store.list_pending()
+        assert len(pending) == 1
+        assert pending[0].decision_id == entry.decision_id
 
     def test_cancel_raises_exit(self, tmp_path: Path) -> None:
         """!cancel → typer.Exit raised."""
@@ -531,7 +634,7 @@ class TestRenderAlreadyWidenedPrompt:
         mock_saas = MagicMock()
         mock_saas.fetch_discussion.side_effect = SaasClientError("net error")
 
-        mock_review = MagicMock(return_value=None)
+        mock_review = MagicMock(return_value=object())
         with patch.object(console, "input", return_value="f"), \
              patch.object(console, "print"), \
              patch("specify_cli.widen.review.run_candidate_review", mock_review):

--- a/tests/specify_cli/cli/commands/test_plan_widen.py
+++ b/tests/specify_cli/cli/commands/test_plan_widen.py
@@ -335,6 +335,10 @@ class TestPlanWidenBlockPath:
                     return_value=mock_flow,
                 ),
                 patch(
+                    "specify_cli.cli.commands.charter._widen._dm_service.resolve_decision",
+                    return_value=MagicMock(),
+                ),
+                patch(
                     "specify_cli.widen.state.WidenPendingStore",
                 ) as mock_store_cls,
             ):

--- a/tests/specify_cli/cli/commands/test_plan_widen.py
+++ b/tests/specify_cli/cli/commands/test_plan_widen.py
@@ -210,6 +210,63 @@ class TestPlanWidenCancelPath:
 class TestPlanWidenContinuePath:
     """CONTINUE: typing w → CONTINUE → WidenPendingEntry written; question skipped."""
 
+    def test_continue_marker_failure_reprompts_without_parking_blank(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _setup_repo(tmp_path)
+
+        decision_id = "01KPLANWIDENMARKERFAIL01"
+        continue_result = WidenFlowResult(
+            action=WidenAction.CONTINUE,
+            decision_id=decision_id,
+            invited=["Carol Lee"],
+        )
+        mock_flow = MagicMock()
+        mock_flow.run_widen_mode.return_value = continue_result
+        bad_store = MagicMock()
+        bad_store.list_pending.return_value = []
+        bad_store.add_pending.side_effect = OSError("disk full")
+
+        prereq_ok = PrereqState(teamspace_ok=True, slack_ok=True, saas_reachable=True)
+        q1_inputs = ["w", "Manual plan answer"]
+        remaining_q = [""] * (_N_QUESTIONS - 1)
+        inputs = _make_inputs(q1_inputs + remaining_q)
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            with (
+                patch(
+                    "specify_cli.cli.commands.lifecycle.agent_feature.setup_plan",
+                    return_value=None,
+                ),
+                patch(
+                    "specify_cli.cli.commands.lifecycle.locate_project_root",
+                    return_value=tmp_path,
+                ),
+                patch(
+                    "specify_cli.saas_client.client.SaasClient.from_env",
+                    return_value=MagicMock(has_token=True),
+                ),
+                patch("specify_cli.widen.check_prereqs", return_value=prereq_ok),
+                patch("specify_cli.widen.flow.WidenFlow", return_value=mock_flow),
+                patch("specify_cli.widen.state.WidenPendingStore", return_value=bad_store),
+            ):
+                result = runner.invoke(
+                    _app,
+                    ["--mission", MISSION_SLUG],
+                    input=inputs,
+                    catch_exceptions=False,
+                )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0, result.output
+        bad_store.add_pending.assert_called_once()
+        assert "Question was NOT parked" in result.output
+        assert mock_flow.run_widen_mode.call_count == 1
+
     def test_continue_path_writes_pending_entry(self, tmp_path: Path) -> None:
         _setup_repo(tmp_path)
 

--- a/tests/specify_cli/cli/commands/test_specify_widen.py
+++ b/tests/specify_cli/cli/commands/test_specify_widen.py
@@ -196,6 +196,63 @@ class TestSpecifyWidenCancelPath:
 class TestSpecifyWidenContinuePath:
     """CONTINUE: typing w → CONTINUE → WidenPendingEntry written; question skipped."""
 
+    def test_continue_marker_failure_reprompts_without_parking_blank(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _setup_repo(tmp_path)
+
+        decision_id = "01KSPECWIDENMARKERFAIL1"
+        continue_result = WidenFlowResult(
+            action=WidenAction.CONTINUE,
+            decision_id=decision_id,
+            invited=["Alice Johnson"],
+        )
+        mock_flow = MagicMock()
+        mock_flow.run_widen_mode.return_value = continue_result
+        bad_store = MagicMock()
+        bad_store.list_pending.return_value = []
+        bad_store.add_pending.side_effect = OSError("disk full")
+
+        prereq_ok = PrereqState(teamspace_ok=True, slack_ok=True, saas_reachable=True)
+        q1_inputs = ["w", "Manual specify answer"]
+        remaining_q = [""] * (_N_QUESTIONS - 1)
+        inputs = _make_inputs(q1_inputs + remaining_q)
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            with (
+                patch(
+                    "specify_cli.cli.commands.lifecycle.agent_feature.create_mission",
+                    return_value=None,
+                ),
+                patch(
+                    "specify_cli.cli.commands.lifecycle.locate_project_root",
+                    return_value=tmp_path,
+                ),
+                patch(
+                    "specify_cli.saas_client.client.SaasClient.from_env",
+                    return_value=MagicMock(has_token=True),
+                ),
+                patch("specify_cli.widen.check_prereqs", return_value=prereq_ok),
+                patch("specify_cli.widen.flow.WidenFlow", return_value=mock_flow),
+                patch("specify_cli.widen.state.WidenPendingStore", return_value=bad_store),
+            ):
+                result = runner.invoke(
+                    _app,
+                    [MISSION_SLUG],
+                    input=inputs,
+                    catch_exceptions=False,
+                )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0, result.output
+        bad_store.add_pending.assert_called_once()
+        assert "Question was NOT parked" in result.output
+        assert mock_flow.run_widen_mode.call_count == 1
+
     def test_continue_path_writes_pending_entry(self, tmp_path: Path) -> None:
         _setup_repo(tmp_path)
 

--- a/tests/specify_cli/cli/commands/test_specify_widen.py
+++ b/tests/specify_cli/cli/commands/test_specify_widen.py
@@ -321,6 +321,10 @@ class TestSpecifyWidenBlockPath:
                     return_value=mock_flow,
                 ),
                 patch(
+                    "specify_cli.cli.commands.charter._widen._dm_service.resolve_decision",
+                    return_value=MagicMock(),
+                ),
+                patch(
                     "specify_cli.widen.state.WidenPendingStore",
                 ) as mock_store_cls,
             ):

--- a/tests/specify_cli/widen/test_review.py
+++ b/tests/specify_cli/widen/test_review.py
@@ -11,6 +11,7 @@ Coverage:
 - _handle_edit: editor used, minor edit → SLACK_EXTRACTION, major → OVERRIDE
 - _handle_edit: None from click.edit falls back to original text
 - _handle_defer: calls dm_service.defer_decision, prints deferred, default rationale
+- run_candidate_review: write-back failures return None
 - run_candidate_review: accept path returns CandidateReview
 - run_candidate_review: edit path returns CandidateReview
 - run_candidate_review: defer path returns CandidateReview
@@ -81,6 +82,13 @@ def make_dm_service() -> MagicMock:
     svc.resolve_decision.return_value = MagicMock()
     svc.defer_decision.return_value = MagicMock()
     return svc
+
+
+def make_decision_error() -> Exception:
+    from specify_cli.decisions.models import DecisionErrorCode
+    from specify_cli.decisions.service import DecisionError
+
+    return DecisionError(code=DecisionErrorCode.TERMINAL_CONFLICT)
 
 
 # ---------------------------------------------------------------------------
@@ -625,6 +633,40 @@ class TestHandleDefer:
             _handle_defer(candidate, "m", Path("/r"), svc, "actor", console)
         assert "deferred" in buf.getvalue().lower()
 
+    def test_decision_error_surfaces_clear_message_and_returns_false(self) -> None:
+        """DecisionError on defer must print a visible error and return False."""
+        console, buf = _console_with_capture()
+        svc = make_dm_service()
+        svc.defer_decision.side_effect = make_decision_error()
+        discussion = make_discussion()
+        candidate = CandidateReview(
+            decision_id="D01",
+            discussion_fetch=discussion,
+            candidate_summary="",
+            candidate_answer="",
+            source_hint=SummarySource.MANUAL,
+        )
+        with patch.object(console, "input", return_value="will decide later"):
+            result = _handle_defer(candidate, "m", Path("/r"), svc, "actor", console)
+        assert result is False
+        assert "deferred" not in buf.getvalue().lower()
+
+    def test_defer_returns_true_on_success(self) -> None:
+        """_handle_defer returns True when defer_decision succeeds."""
+        console, buf = _console_with_capture()
+        svc = make_dm_service()
+        discussion = make_discussion()
+        candidate = CandidateReview(
+            decision_id="D01",
+            discussion_fetch=discussion,
+            candidate_summary="",
+            candidate_answer="",
+            source_hint=SummarySource.MANUAL,
+        )
+        with patch.object(console, "input", return_value="will decide later"):
+            result = _handle_defer(candidate, "m", Path("/r"), svc, "actor", console)
+        assert result is True
+
 
 # ---------------------------------------------------------------------------
 # run_candidate_review (T035 integration)
@@ -688,6 +730,35 @@ class TestRunCandidateReview:
         result, output = _run_review_with_responses(llm_payload, "d", extra_inputs=["need more info"])
         assert isinstance(result, CandidateReview)
 
+    def test_accept_write_back_failure_returns_none(self) -> None:
+        llm_payload = {
+            "candidate_summary": "Team chose Postgres",
+            "candidate_answer": "PostgreSQL",
+            "source_hint": "slack_extraction",
+        }
+        console, buf = _console_with_capture()
+        svc = make_dm_service()
+        svc.resolve_decision.side_effect = make_decision_error()
+        discussion = make_discussion()
+
+        with (
+            patch.object(console, "input", return_value="a"),
+            patch("specify_cli.widen.review._read_llm_response", return_value=llm_payload),
+        ):
+            result = run_candidate_review(
+                discussion_data=discussion,
+                decision_id="D01",
+                question_text="Which database?",
+                mission_slug="m",
+                repo_root=Path("/r"),
+                console=console,
+                dm_service=svc,
+                actor="actor",
+            )
+
+        assert result is None
+        assert "not saved" in buf.getvalue().lower()
+
     def test_edit_path_returns_candidate_review(self) -> None:
         llm_payload = {
             "candidate_summary": "S",
@@ -714,6 +785,69 @@ class TestRunCandidateReview:
                 actor="actor",
             )
         assert isinstance(result, CandidateReview)
+
+    def test_edit_write_back_failure_returns_none(self) -> None:
+        llm_payload = {
+            "candidate_summary": "S",
+            "candidate_answer": "A",
+            "source_hint": "slack_extraction",
+        }
+        console, buf = _console_with_capture()
+        svc = make_dm_service()
+        svc.resolve_decision.side_effect = make_decision_error()
+        discussion = make_discussion()
+
+        with (
+            patch.object(console, "input", return_value="e"),
+            patch("specify_cli.widen.review._read_llm_response", return_value=llm_payload),
+            patch("specify_cli.widen.review.click.edit", return_value="A edited"),
+        ):
+            result = run_candidate_review(
+                discussion_data=discussion,
+                decision_id="D01",
+                question_text="Q?",
+                mission_slug="m",
+                repo_root=Path("/r"),
+                console=console,
+                dm_service=svc,
+                actor="actor",
+            )
+
+        assert result is None
+        assert "not saved" in buf.getvalue().lower()
+
+    def test_defer_write_back_failure_returns_none(self) -> None:
+        llm_payload = {
+            "candidate_summary": "S",
+            "candidate_answer": "A",
+            "source_hint": "slack_extraction",
+        }
+        console, buf = _console_with_capture()
+        svc = make_dm_service()
+        svc.defer_decision.side_effect = make_decision_error()
+        discussion = make_discussion()
+        inputs = iter(["d", "need more info"])
+
+        def fake_input(_prompt: str = "") -> str:
+            return next(inputs)
+
+        with (
+            patch.object(console, "input", side_effect=fake_input),
+            patch("specify_cli.widen.review._read_llm_response", return_value=llm_payload),
+        ):
+            result = run_candidate_review(
+                discussion_data=discussion,
+                decision_id="D01",
+                question_text="Q?",
+                mission_slug="m",
+                repo_root=Path("/r"),
+                console=console,
+                dm_service=svc,
+                actor="actor",
+            )
+
+        assert result is None
+        assert "not saved" in buf.getvalue().lower()
 
     def test_keyboard_interrupt_at_prompt_returns_none(self) -> None:
         console, buf = _console_with_capture()


### PR DESCRIPTION
## Summary
- keep widen pending entries when candidate review crashes instead of deleting the retry marker
- keep pending entries when candidate review is cancelled before a terminal action
- preserve terminal success behavior: accept/edit/defer still removes the pending entry

Closes #1477

## Tests
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py -q` -> 22 passed
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_charter_widen.py tests/specify_cli/cli/commands/test_specify_widen.py tests/specify_cli/cli/commands/test_plan_widen.py -q` -> 19 passed, 1 existing DeprecationWarning
- `.venv/bin/ruff check src/specify_cli/widen/interview_helpers.py tests/specify_cli/cli/commands/test_end_of_interview_pending_pass.py` -> passed
- `git diff --check` -> passed

## Notes
- Global `.venv/bin/ruff check` currently fails on unrelated pre-existing files under `.kittify/overrides/scripts/tasks/tasks_cli.py`, `scripts/generate_schemas.py`, `scripts/lint_canonical_producers.py`, `scripts/tasks/*`, `scripts/sync_all_contributors.py`, and `scripts/verify_occurrences.py`.