### PR TITLE
Fix fenced heading truncation in charter section extraction

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -28,6 +28,7 @@ from charter.context_renderers import (
     RenderedSection,
     render_authority_paths,
     render_critical_section_bodies,
+    render_critical_section_include,
 )
 from charter.context_renderers.fetch_stanza import (
     fetch_stanza_lines as _shared_fetch_stanza_lines,
@@ -42,6 +43,7 @@ __all__ = [
     "BOOTSTRAP_ACTIONS",
     "CharterContextResult",
     "build_charter_context",
+    "build_charter_context_include",
     "build_charter_context_json",
 ]
 
@@ -265,6 +267,57 @@ def build_charter_context(
         references_count=len(references),
         depth=state_bundle.effective_depth,
     )
+
+
+def build_charter_context_include(
+    repo_root: Path,
+    selector: str,
+    *,
+    action: str | None = None,
+    org_root: Path | None = None,
+) -> str:
+    """Render one fetch-deferred governance selector."""
+
+    kind, separator, identifier = selector.partition(":")
+    kind = kind.strip().lower()
+    identifier = identifier.strip()
+    if not separator or not kind or not identifier:
+        raise ValueError("Expected --include selector in '<kind>:<id>' form.")
+
+    if kind == "section":
+        canonical_root = _bundle_root_for_json(repo_root)
+        charter_path = canonical_root / KITTIFY_DIRNAME / "charter" / "charter.md"
+        if not charter_path.exists():
+            raise ValueError("No charter.md found for section selector.")
+        charter_content = charter_path.read_text(encoding="utf-8")
+        section = render_critical_section_include(
+            charter_content,
+            identifier,
+            action=action.strip().lower() if action else None,
+        )
+        if section is None:
+            raise ValueError(f"No charter section found for selector '{selector}'.")
+        return section
+
+    org_roots = [org_root] if org_root is not None else None
+    service = _build_doctrine_service(repo_root, org_roots=org_roots)
+    if kind == "directive":
+        directive_id = _format_profile_directive_code(identifier)
+        directive = service.directives.get(directive_id)  # type: ignore[attr-defined]
+        if directive is None:
+            raise ValueError(f"No directive found for selector '{selector}'.")
+        title = getattr(directive, "title", directive_id)
+        return "\n".join(
+            [f"Directive {directive_id}: {title}", *_format_inline_directive_body(directive)]
+        )
+    if kind == "tactic":
+        tactic = service.tactics.get(identifier)  # type: ignore[attr-defined]
+        if tactic is None:
+            raise ValueError(f"No tactic found for selector '{selector}'.")
+        name = getattr(tactic, "name", identifier)
+        return "\n".join([f"Tactic {identifier}: {name}", *_format_inline_tactic_body(tactic)])
+
+    raise ValueError(f"Unsupported --include selector kind '{kind}'.")
 
 
 def _prepare_context_state(

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -308,14 +308,24 @@ def build_charter_context_include(
             raise ValueError(f"No directive found for selector '{selector}'.")
         title = getattr(directive, "title", directive_id)
         return "\n".join(
-            [f"Directive {directive_id}: {title}", *_format_inline_directive_body(directive)]
+            [
+                f"Directive {directive_id}: {title}",
+                *_format_inline_directive_body(directive),
+                *_format_full_artifact_payload_body(directive),
+            ]
         )
     if kind == "tactic":
         tactic = service.tactics.get(identifier)  # type: ignore[attr-defined]
         if tactic is None:
             raise ValueError(f"No tactic found for selector '{selector}'.")
         name = getattr(tactic, "name", identifier)
-        return "\n".join([f"Tactic {identifier}: {name}", *_format_inline_tactic_body(tactic)])
+        return "\n".join(
+            [
+                f"Tactic {identifier}: {name}",
+                *_format_inline_tactic_body(tactic),
+                *_format_full_artifact_payload_body(tactic),
+            ]
+        )
     artifact = _render_doctrine_artifact_include(service, kind, identifier)
     if artifact is not None:
         return artifact
@@ -378,7 +388,13 @@ def _render_doctrine_artifact_include(
     if artifact is None:
         raise ValueError(f"No {kind} found for selector '{kind}:{identifier}'.")
     title = getattr(artifact, title_attr, identifier)
-    return "\n".join([f"{label} {identifier}: {title}", *body_formatter(artifact)])
+    return "\n".join(
+        [
+            f"{label} {identifier}: {title}",
+            *body_formatter(artifact),
+            *_format_full_artifact_payload_body(artifact),
+        ]
+    )
 
 
 def _prepare_context_state(
@@ -1379,6 +1395,56 @@ def _format_profile_directive_code(raw: object) -> str:
     if match:
         return f"DIRECTIVE_{match.group(1).zfill(3)}"
     return text
+
+
+def _jsonable_artifact_value(value: object) -> object:
+    """Return a deterministic JSON-safe representation of a doctrine object."""
+
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump(by_alias=True, mode="json", exclude_none=True)
+        except TypeError:
+            dumped = model_dump()
+        return _jsonable_artifact_value(dumped)
+
+    enum_value = getattr(value, "value", None)
+    if isinstance(enum_value, str | int | float | bool):
+        return enum_value
+
+    if isinstance(value, dict):
+        return {
+            str(key): _jsonable_artifact_value(item)
+            for key, item in value.items()
+            if item is not None
+        }
+
+    if isinstance(value, list | tuple | set):
+        return [_jsonable_artifact_value(item) for item in value]
+
+    attrs = getattr(value, "__dict__", None)
+    if isinstance(attrs, dict):
+        return {
+            key: _jsonable_artifact_value(item)
+            for key, item in attrs.items()
+            if not key.startswith("_") and item is not None
+        }
+
+    return str(value)
+
+
+def _format_full_artifact_payload_body(artifact: object) -> list[str]:
+    """Render the full doctrine payload for fetch-selector recovery."""
+
+    payload = _jsonable_artifact_value(artifact)
+    if not isinstance(payload, dict) or not payload:
+        return []
+
+    json_lines = json.dumps(payload, indent=2, sort_keys=True).splitlines()
+    return ["    Full artifact:", *(f"      {line}" for line in json_lines)]
 
 
 def _format_inline_directive_body(directive: object) -> list[str]:

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -302,35 +302,88 @@ def build_charter_context_include(
     org_roots = [org_root] if org_root is not None else None
     service = _build_doctrine_service(repo_root, org_roots=org_roots)
     if kind == "directive":
-        directive_id = _format_profile_directive_code(identifier)
-        directive = service.directives.get(directive_id)  # type: ignore[attr-defined]
-        if directive is None:
-            raise ValueError(f"No directive found for selector '{selector}'.")
-        title = getattr(directive, "title", directive_id)
-        return "\n".join(
-            [
-                f"Directive {directive_id}: {title}",
-                *_format_inline_directive_body(directive),
-                *_format_full_artifact_payload_body(directive),
-            ]
-        )
+        return _render_directive_include(service, identifier, selector)
     if kind == "tactic":
-        tactic = service.tactics.get(identifier)  # type: ignore[attr-defined]
-        if tactic is None:
-            raise ValueError(f"No tactic found for selector '{selector}'.")
-        name = getattr(tactic, "name", identifier)
-        return "\n".join(
-            [
-                f"Tactic {identifier}: {name}",
-                *_format_inline_tactic_body(tactic),
-                *_format_full_artifact_payload_body(tactic),
-            ]
-        )
+        return _render_tactic_include(service, identifier, selector)
+    if kind == "artifact":
+        return _render_generic_artifact_include(service, identifier)
     artifact = _render_doctrine_artifact_include(service, kind, identifier)
     if artifact is not None:
         return artifact
 
     raise ValueError(f"Unsupported --include selector kind '{kind}'.")
+
+
+def _render_directive_include(service: object, identifier: str, selector: str) -> str:
+    """Render a directive selector for ``--include``."""
+
+    directive_id = _format_profile_directive_code(identifier)
+    directive = service.directives.get(directive_id)  # type: ignore[attr-defined]
+    if directive is None:
+        raise ValueError(f"No directive found for selector '{selector}'.")
+    title = getattr(directive, "title", directive_id)
+    return "\n".join(
+        [
+            f"Directive {directive_id}: {title}",
+            *_format_inline_directive_body(directive),
+            *_format_full_artifact_payload_body(directive),
+        ]
+    )
+
+
+def _render_tactic_include(service: object, identifier: str, selector: str) -> str:
+    """Render a tactic selector for ``--include``."""
+
+    tactic = service.tactics.get(identifier)  # type: ignore[attr-defined]
+    if tactic is None:
+        raise ValueError(f"No tactic found for selector '{selector}'.")
+    name = getattr(tactic, "name", identifier)
+    return "\n".join(
+        [
+            f"Tactic {identifier}: {name}",
+            *_format_inline_tactic_body(tactic),
+            *_format_full_artifact_payload_body(tactic),
+        ]
+    )
+
+
+def _render_generic_artifact_include(service: object, identifier: str) -> str:
+    """Resolve a best-effort ``artifact:<id>`` selector emitted by activations."""
+
+    matches: list[tuple[str, str]] = []
+    for candidate_kind in (
+        "directive",
+        "tactic",
+        "paradigm",
+        "styleguide",
+        "toolguide",
+        "procedure",
+        "agent_profile",
+        "mission_step_contract",
+    ):
+        selector = f"{candidate_kind}:{identifier}"
+        try:
+            if candidate_kind == "directive":
+                rendered = _render_directive_include(service, identifier, selector)
+            elif candidate_kind == "tactic":
+                rendered = _render_tactic_include(service, identifier, selector)
+            else:
+                rendered = _render_doctrine_artifact_include(
+                    service, candidate_kind, identifier
+                )
+        except ValueError:
+            continue
+        if rendered is not None:
+            matches.append((candidate_kind, rendered))
+
+    if not matches:
+        raise ValueError(f"No artifact found for selector 'artifact:{identifier}'.")
+    if len(matches) > 1:
+        kinds = ", ".join(kind for kind, _text in matches)
+        raise ValueError(
+            f"Ambiguous artifact selector 'artifact:{identifier}' matched kinds: {kinds}."
+        )
+    return matches[0][1]
 
 
 def _render_doctrine_artifact_include(
@@ -1422,7 +1475,14 @@ def _jsonable_artifact_value(value: object) -> object:
             if item is not None
         }
 
-    if isinstance(value, list | tuple | set):
+    if isinstance(value, set):
+        normalized = [_jsonable_artifact_value(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+
+    if isinstance(value, list | tuple):
         return [_jsonable_artifact_value(item) for item in value]
 
     attrs = getattr(value, "__dict__", None)

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -316,8 +316,69 @@ def build_charter_context_include(
             raise ValueError(f"No tactic found for selector '{selector}'.")
         name = getattr(tactic, "name", identifier)
         return "\n".join([f"Tactic {identifier}: {name}", *_format_inline_tactic_body(tactic)])
+    artifact = _render_doctrine_artifact_include(service, kind, identifier)
+    if artifact is not None:
+        return artifact
 
     raise ValueError(f"Unsupported --include selector kind '{kind}'.")
+
+
+def _render_doctrine_artifact_include(
+    service: object,
+    kind: str,
+    identifier: str,
+) -> str | None:
+    """Render non-directive/tactic doctrine artifacts addressed by ``--include``."""
+
+    renderers = {
+        "paradigm": (
+            "paradigms",
+            "Paradigm",
+            "name",
+            _format_inline_paradigm_body,
+        ),
+        "styleguide": (
+            "styleguides",
+            "Styleguide",
+            "title",
+            _format_inline_styleguide_body,
+        ),
+        "toolguide": (
+            "toolguides",
+            "Toolguide",
+            "title",
+            _format_inline_toolguide_body,
+        ),
+        "procedure": (
+            "procedures",
+            "Procedure",
+            "name",
+            _format_inline_procedure_body,
+        ),
+        "agent_profile": (
+            "agent_profiles",
+            "Agent profile",
+            "name",
+            _format_inline_agent_profile_body,
+        ),
+        "mission_step_contract": (
+            "mission_step_contracts",
+            "Mission step contract",
+            "action",
+            _format_inline_step_contract_body,
+        ),
+    }
+    renderer = renderers.get(kind)
+    if renderer is None:
+        return None
+
+    repo_attr, label, title_attr, body_formatter = renderer
+    repo = getattr(service, repo_attr, None)
+    artifact = repo.get(identifier) if repo is not None else None  # type: ignore[attr-defined]
+    if artifact is None:
+        raise ValueError(f"No {kind} found for selector '{kind}:{identifier}'.")
+    title = getattr(artifact, title_attr, identifier)
+    return "\n".join([f"{label} {identifier}: {title}", *body_formatter(artifact)])
 
 
 def _prepare_context_state(

--- a/src/charter/context_renderers/__init__.py
+++ b/src/charter/context_renderers/__init__.py
@@ -43,6 +43,7 @@ from charter.context_renderers.section_bodies import (
     CRITICAL_SECTION_WHEN_CLAUSES,
     critical_section_header,
     render_critical_section_bodies,
+    render_critical_section_include,
 )
 from charter.context_renderers.token_budget import (
     BUDGET_DEFAULT,
@@ -67,5 +68,6 @@ __all__ = [
     "format_selector",
     "render_authority_paths",
     "render_critical_section_bodies",
+    "render_critical_section_include",
     "warning_line",
 ]

--- a/src/charter/context_renderers/fetch_stanza.py
+++ b/src/charter/context_renderers/fetch_stanza.py
@@ -43,7 +43,19 @@ to``) so it always satisfies the prompt-governance contract — see
 """
 
 
-_VALID_SELECTOR_KINDS: frozenset[str] = frozenset({"directive", "tactic", "section"})
+_VALID_SELECTOR_KINDS: frozenset[str] = frozenset(
+    {
+        "agent_profile",
+        "directive",
+        "mission_step_contract",
+        "paradigm",
+        "procedure",
+        "section",
+        "styleguide",
+        "tactic",
+        "toolguide",
+    }
+)
 
 
 def format_selector(kind: str, identifier: str) -> str:
@@ -51,10 +63,10 @@ def format_selector(kind: str, identifier: str) -> str:
 
     ``kind`` is normalised to lowercase and validated against the set of
     selector kinds the ``spec-kitty charter context --include`` surface
-    accepts (``directive``, ``tactic``, ``section``).  An unknown kind
-    is permitted (returned as-is) so callers can extend the vocabulary
-    without code changes here, but the canonical kinds are guaranteed
-    to round-trip through the validator unchanged.
+    accepts (for example, ``directive``, ``tactic``, ``styleguide``, and
+    ``section``).  An unknown kind is permitted (returned as-is) so callers can
+    extend the vocabulary without code changes here, but the canonical kinds
+    are guaranteed to round-trip through the validator unchanged.
     """
 
     cleaned_kind = (kind or "").strip().lower()

--- a/src/charter/context_renderers/section_bodies.py
+++ b/src/charter/context_renderers/section_bodies.py
@@ -106,6 +106,15 @@ def _is_fence_close(line: str, fence_marker: str, fence_length: int) -> bool:
     return re.match(close_pattern, line) is not None
 
 
+def _has_fence_close(lines: list[str], start_index: int, fence_marker: str, fence_length: int) -> bool:
+    """Return whether the active Markdown fence closes after ``start_index``."""
+
+    return any(
+        _is_fence_close(line, fence_marker, fence_length)
+        for line in lines[start_index:]
+    )
+
+
 def _find_next_section_start(body: str) -> int | None:
     """Return the offset of the next level-two heading outside code fences."""
 
@@ -113,7 +122,8 @@ def _find_next_section_start(body: str) -> int | None:
     fence_length = 0
     offset = 0
 
-    for line in body.splitlines(keepends=True):
+    lines = body.splitlines(keepends=True)
+    for index, line in enumerate(lines):
         if fence_marker is not None:
             if _is_fence_close(line, fence_marker, fence_length):
                 fence_marker = None
@@ -126,6 +136,8 @@ def _find_next_section_start(body: str) -> int | None:
             if fence_match is not None:
                 fence_marker = fence_match.group(1)[0]
                 fence_length = len(fence_match.group(1))
+                if not _has_fence_close(lines, index + 1, fence_marker, fence_length):
+                    return offset
 
         offset += len(line)
 

--- a/src/charter/context_renderers/section_bodies.py
+++ b/src/charter/context_renderers/section_bodies.py
@@ -132,6 +132,34 @@ def _find_next_section_start(body: str) -> int | None:
     return None
 
 
+def _find_heading_end(charter_content: str, heading: str) -> int | None:
+    """Return the end offset for ``## <heading>`` outside code fences."""
+
+    pattern = _heading_pattern(heading)
+    fence_marker: str | None = None
+    fence_length = 0
+    offset = 0
+
+    for line in charter_content.splitlines(keepends=True):
+        if fence_marker is not None:
+            if _is_fence_close(line, fence_marker, fence_length):
+                fence_marker = None
+                fence_length = 0
+        else:
+            match = pattern.match(line)
+            if match is not None:
+                return offset + match.end()
+
+            fence_match = _FENCE_OPEN_RE.match(line)
+            if fence_match is not None:
+                fence_marker = fence_match.group(1)[0]
+                fence_length = len(fence_match.group(1))
+
+        offset += len(line)
+
+    return None
+
+
 def _extract_section_body(charter_content: str, heading: str) -> str | None:
     """Return the body of ``## <heading>`` from *charter_content*, or ``None``.
 
@@ -142,12 +170,10 @@ def _extract_section_body(charter_content: str, heading: str) -> str | None:
     losing structure.
     """
 
-    pattern = _heading_pattern(heading)
-    match = pattern.search(charter_content)
-    if match is None:
+    body_start = _find_heading_end(charter_content, heading)
+    if body_start is None:
         return None
 
-    body_start = match.end()
     remainder = charter_content[body_start:]
     next_section_start = _find_next_section_start(remainder)
     body = (

--- a/src/charter/context_renderers/section_bodies.py
+++ b/src/charter/context_renderers/section_bodies.py
@@ -27,6 +27,7 @@ __all__ = [
     "CRITICAL_SECTION_WHEN_CLAUSES",
     "critical_section_header",
     "render_critical_section_bodies",
+    "render_critical_section_include",
 ]
 
 
@@ -267,3 +268,37 @@ def render_critical_section_bodies(
         blocks.extend(_render_fetch_stanza(heading))
 
     return "\n".join(blocks)
+
+
+def render_critical_section_include(
+    charter_content: str,
+    selector_id: str,
+    *,
+    action: str | None = None,
+) -> str | None:
+    """Render the body addressed by a ``section:<selector_id>`` fetch selector."""
+
+    cleaned = selector_id.strip()
+    if not cleaned:
+        return None
+
+    if cleaned.startswith("critical-"):
+        action_name = cleaned.removeprefix("critical-").strip()
+        if action is not None and action.strip() and action.strip().lower() != action_name:
+            return None
+        return render_critical_section_bodies(charter_content, action_name) or None
+
+    headings = {
+        heading
+        for section_headings in ACTION_CRITICAL_SECTIONS.values()
+        for heading in section_headings
+    }
+    for heading in sorted(headings):
+        if _slugify_heading(heading) != cleaned:
+            continue
+        body = _extract_section_body(charter_content, heading)
+        if body is None:
+            return None
+        return f"### {heading}\n{body}" if body else f"### {heading}"
+
+    return None

--- a/src/charter/context_renderers/section_bodies.py
+++ b/src/charter/context_renderers/section_bodies.py
@@ -96,13 +96,50 @@ def _heading_pattern(heading: str) -> re.Pattern[str]:
     return re.compile(rf"^##\s+{escaped}\b.*$", re.MULTILINE)
 
 
+_FENCE_OPEN_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+
+
+def _is_fence_close(line: str, fence_marker: str, fence_length: int) -> bool:
+    """Return whether *line* closes the active Markdown fence."""
+
+    close_pattern = rf"^[ \t]{{0,3}}{re.escape(fence_marker)}{{{fence_length},}}[ \t]*\r?\n?$"
+    return re.match(close_pattern, line) is not None
+
+
+def _find_next_section_start(body: str) -> int | None:
+    """Return the offset of the next level-two heading outside code fences."""
+
+    fence_marker: str | None = None
+    fence_length = 0
+    offset = 0
+
+    for line in body.splitlines(keepends=True):
+        if fence_marker is not None:
+            if _is_fence_close(line, fence_marker, fence_length):
+                fence_marker = None
+                fence_length = 0
+        else:
+            if re.match(r"^##\s+", line):
+                return offset
+
+            fence_match = _FENCE_OPEN_RE.match(line)
+            if fence_match is not None:
+                fence_marker = fence_match.group(1)[0]
+                fence_length = len(fence_match.group(1))
+
+        offset += len(line)
+
+    return None
+
+
 def _extract_section_body(charter_content: str, heading: str) -> str | None:
     """Return the body of ``## <heading>`` from *charter_content*, or ``None``.
 
     The body is everything from the line **after** the heading up to (but
     not including) the next line that begins with ``## `` at the same
-    level.  Nested ``###`` headings are preserved verbatim so callers can
-    embed multi-paragraph governance text without losing structure.
+    level outside fenced code blocks.  Nested ``###`` headings are preserved
+    verbatim so callers can embed multi-paragraph governance text without
+    losing structure.
     """
 
     pattern = _heading_pattern(heading)
@@ -111,11 +148,12 @@ def _extract_section_body(charter_content: str, heading: str) -> str | None:
         return None
 
     body_start = match.end()
-    next_section = re.search(r"^##\s+", charter_content[body_start:], re.MULTILINE)
+    remainder = charter_content[body_start:]
+    next_section_start = _find_next_section_start(remainder)
     body = (
-        charter_content[body_start:]
-        if next_section is None
-        else charter_content[body_start : body_start + next_section.start()]
+        remainder
+        if next_section_start is None
+        else charter_content[body_start : body_start + next_section_start]
     )
 
     return body.strip("\n").rstrip()

--- a/src/charter/context_renderers/section_bodies.py
+++ b/src/charter/context_renderers/section_bodies.py
@@ -85,7 +85,7 @@ def _slugify_heading(heading: str) -> str:
 
 
 def _heading_pattern(heading: str) -> re.Pattern[str]:
-    """Compile the regex matching ``## <heading>`` (with optional date suffix).
+    """Compile the regex matching an ATX ``<heading>`` (with optional date suffix).
 
     The charter convention permits a parenthetical suffix after the
     heading text (``## Regression Vigilance (2026-04-06)``) — the ATDD
@@ -94,7 +94,7 @@ def _heading_pattern(heading: str) -> re.Pattern[str]:
     """
 
     escaped = re.escape(heading.strip())
-    return re.compile(rf"^##\s+{escaped}\b.*$", re.MULTILINE)
+    return re.compile(rf"^(#{{2,6}})\s+{escaped}\b.*$", re.MULTILINE)
 
 
 _FENCE_OPEN_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
@@ -107,7 +107,9 @@ def _is_fence_close(line: str, fence_marker: str, fence_length: int) -> bool:
     return re.match(close_pattern, line) is not None
 
 
-def _has_fence_close(lines: list[str], start_index: int, fence_marker: str, fence_length: int) -> bool:
+def _has_fence_close(
+    lines: list[str], start_index: int, fence_marker: str, fence_length: int
+) -> bool:
     """Return whether the active Markdown fence closes after ``start_index``."""
 
     return any(
@@ -116,8 +118,8 @@ def _has_fence_close(lines: list[str], start_index: int, fence_marker: str, fenc
     )
 
 
-def _find_next_section_start(body: str) -> int | None:
-    """Return the offset of the next level-two heading outside code fences."""
+def _find_next_section_start(body: str, heading_level: int) -> int | None:
+    """Return the next same-or-higher heading offset outside code fences."""
 
     fence_marker: str | None = None
     fence_length = 0
@@ -130,7 +132,11 @@ def _find_next_section_start(body: str) -> int | None:
                 fence_marker = None
                 fence_length = 0
         else:
-            if re.match(r"^##\s+", line):
+            heading_match = re.match(r"^(#{1,6})\s+", line)
+            if (
+                heading_match is not None
+                and len(heading_match.group(1)) <= heading_level
+            ):
                 return offset
 
             fence_match = _FENCE_OPEN_RE.match(line)
@@ -145,8 +151,8 @@ def _find_next_section_start(body: str) -> int | None:
     return None
 
 
-def _find_heading_end(charter_content: str, heading: str) -> int | None:
-    """Return the end offset for ``## <heading>`` outside code fences."""
+def _find_heading_end(charter_content: str, heading: str) -> tuple[int, int] | None:
+    """Return ``(end offset, level)`` for ``heading`` outside code fences."""
 
     pattern = _heading_pattern(heading)
     fence_marker: str | None = None
@@ -161,7 +167,7 @@ def _find_heading_end(charter_content: str, heading: str) -> int | None:
         else:
             match = pattern.match(line)
             if match is not None:
-                return offset + match.end()
+                return offset + match.end(), len(match.group(1))
 
             fence_match = _FENCE_OPEN_RE.match(line)
             if fence_match is not None:
@@ -183,12 +189,13 @@ def _extract_section_body(charter_content: str, heading: str) -> str | None:
     losing structure.
     """
 
-    body_start = _find_heading_end(charter_content, heading)
-    if body_start is None:
+    heading_match = _find_heading_end(charter_content, heading)
+    if heading_match is None:
         return None
 
+    body_start, heading_level = heading_match
     remainder = charter_content[body_start:]
-    next_section_start = _find_next_section_start(remainder)
+    next_section_start = _find_next_section_start(remainder, heading_level)
     body = (
         remainder
         if next_section_start is None

--- a/src/specify_cli/cli/commands/charter/context.py
+++ b/src/specify_cli/cli/commands/charter/context.py
@@ -26,7 +26,7 @@ def context(
     include: str | None = typer.Option(
         None,
         "--include",
-        help="Fetch one governance selector (directive:<id>|tactic:<id>|section:<slug>)",
+        help="Fetch one governance selector (<kind>:<id>, e.g. directive:<id>|styleguide:<id>|section:<slug>)",
     ),
     mark_loaded: bool = typer.Option(True, "--mark-loaded/--no-mark-loaded", help="Persist first-load state"),
     json_output: bool = typer.Option(

--- a/src/specify_cli/cli/commands/charter/context.py
+++ b/src/specify_cli/cli/commands/charter/context.py
@@ -18,7 +18,16 @@ __all__ = ["context"]
 
 @charter_app.command()
 def context(
-    action: str = typer.Option(..., "--action", help="Workflow action (specify|plan|implement|review)"),
+    action: str | None = typer.Option(
+        None,
+        "--action",
+        help="Workflow action (specify|plan|implement|review)",
+    ),
+    include: str | None = typer.Option(
+        None,
+        "--include",
+        help="Fetch one governance selector (directive:<id>|tactic:<id>|section:<slug>)",
+    ),
     mark_loaded: bool = typer.Option(True, "--mark-loaded/--no-mark-loaded", help="Persist first-load state"),
     json_output: bool = typer.Option(
         False,
@@ -34,6 +43,7 @@ def context(
     from charter.context import (
         BOOTSTRAP_ACTIONS,
         build_charter_context,
+        build_charter_context_include,
         build_charter_context_json,
     )
 
@@ -47,6 +57,33 @@ def context(
         # ``charter`` must not import ``specify_cli`` (ADR 2026-03-27-1).
         org_roots = [p for p in resolve_org_roots(repo_root) if p.exists()]
         org_root = org_roots[0] if org_roots else None
+        if include:
+            included_text = build_charter_context_include(
+                repo_root,
+                include,
+                action=action,
+                org_root=org_root,
+            )
+            if json_output:
+                print(
+                    json.dumps(
+                        {
+                            "result": "success",
+                            "success": True,
+                            "include": include,
+                            "context": included_text,
+                            "text": included_text,
+                        },
+                        indent=2,
+                    )
+                )
+                return
+            console.print(included_text)
+            return
+
+        if action is None:
+            raise TaskCliError("--action is required unless --include is provided.")
+
         result = build_charter_context(
             repo_root,
             action=action,
@@ -105,6 +142,9 @@ def context(
         console.print(result.text)
 
     except TaskCliError as e:
+        _emit_error(console, json_output=json_output, message=str(e))
+        raise typer.Exit(code=1) from e
+    except ValueError as e:
         _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:

--- a/tests/charter/test_context_section_bodies.py
+++ b/tests/charter/test_context_section_bodies.py
@@ -95,6 +95,34 @@ _CHARTER_WITH_FENCED_MARKDOWN_HEADINGS = textwrap.dedent(
 )
 
 
+_CHARTER_WITH_FENCED_SECTION_HEADING_EXAMPLE = textwrap.dedent(
+    """\
+    # Project Charter
+
+    ## Purpose
+
+    A documentation example can mention a critical section heading:
+
+    ```markdown
+    ## Regression Vigilance
+    This is example text, not the charter rule.
+    ```
+
+    ## Terminology Canon
+
+    - canonical term is **Mission**.
+
+    ## Regression Vigilance
+
+    The real rule requires the reviewer to consult glossary/contexts/.
+
+    ## Code Review Checklist
+
+    - check terminology alignment.
+    """
+)
+
+
 def _rendered_section_body(rendered: str, heading: str) -> str:
     section_start = rendered.index(f"### {heading}")
     body_start = rendered.index("\n", section_start) + 1
@@ -128,6 +156,18 @@ class TestVerbatimBodies:
         assert "## STEP 2" in body
         assert "After cleanup, rerun the mission review." in body
         assert "This is the next section" not in body
+
+    def test_fenced_section_heading_example_does_not_spoof_section_start(self) -> None:
+        result = render_critical_section_bodies(
+            _CHARTER_WITH_FENCED_SECTION_HEADING_EXAMPLE, action="implement"
+        )
+
+        body = _rendered_section_body(result, "Regression Vigilance")
+
+        assert "consult glossary/contexts/" in body
+        assert "This is example text" not in body
+        assert "canonical term is **Mission**" not in body
+        assert "check terminology alignment" not in body
 
 
 class TestMissingSectionFetchStanza:

--- a/tests/charter/test_context_section_bodies.py
+++ b/tests/charter/test_context_section_bodies.py
@@ -124,6 +124,36 @@ _CHARTER_WITH_FENCED_SECTION_HEADING_EXAMPLE = textwrap.dedent(
 )
 
 
+_CHARTER_WITH_NESTED_CRITICAL_SECTIONS = textwrap.dedent(
+    """\
+    # Project Charter
+
+    ## Code Quality
+
+    ### Code Review Checklist
+
+    - Tests added for new functionality.
+    - Type annotations present.
+
+    ### Quality Gates
+
+    - Required pytest surface passes.
+
+    ## Terminology Canon (Mission vs Feature)
+
+    - canonical term is **Mission**.
+
+    ### Regression Vigilance (2026-04-06)
+
+    Reviewers MUST grep the diff for the old term before approving.
+
+    ## Charter Resolution Hints
+
+    Not part of the critical section.
+    """
+)
+
+
 _CHARTER_WITH_UNBALANCED_FENCE = textwrap.dedent(
     """\
     # Project Charter
@@ -215,6 +245,28 @@ class TestVerbatimBodies:
         assert result is not None
         assert "consult glossary/contexts/" in result
         assert "This is example text" not in result
+
+    def test_nested_critical_headings_are_recoverable(self) -> None:
+        result = render_critical_section_bodies(
+            _CHARTER_WITH_NESTED_CRITICAL_SECTIONS,
+            action="implement",
+        )
+
+        assert "Tests added for new functionality." in result
+        assert "Reviewers MUST grep the diff" in result
+        assert "Required pytest surface passes." not in result
+        assert "Not part of the critical section." not in result
+
+    def test_section_include_recovers_nested_critical_heading(self) -> None:
+        result = render_critical_section_include(
+            _CHARTER_WITH_NESTED_CRITICAL_SECTIONS,
+            "regression-vigilance",
+        )
+
+        assert result is not None
+        assert result.startswith("### Regression Vigilance")
+        assert "Reviewers MUST grep the diff" in result
+        assert "Not part of the critical section." not in result
 
     def test_section_include_fail_closed_on_unbalanced_fence(self) -> None:
         result = render_critical_section_include(

--- a/tests/charter/test_context_section_bodies.py
+++ b/tests/charter/test_context_section_bodies.py
@@ -123,6 +123,29 @@ _CHARTER_WITH_FENCED_SECTION_HEADING_EXAMPLE = textwrap.dedent(
 )
 
 
+_CHARTER_WITH_UNBALANCED_FENCE = textwrap.dedent(
+    """\
+    # Project Charter
+
+    ## Terminology Canon
+
+    - canonical term is **Mission**.
+
+    ## Regression Vigilance
+
+    Preserve cleanup instructions around command examples:
+
+    ```bash
+    ## STEP 1
+    spec-kitty glossary scan
+
+    ## Code Review Checklist
+
+    - This is the next section and must not be swallowed by Regression Vigilance.
+    """
+)
+
+
 def _rendered_section_body(rendered: str, heading: str) -> str:
     section_start = rendered.index(f"### {heading}")
     body_start = rendered.index("\n", section_start) + 1
@@ -168,6 +191,19 @@ class TestVerbatimBodies:
         assert "This is example text" not in body
         assert "canonical term is **Mission**" not in body
         assert "check terminology alignment" not in body
+
+    def test_unbalanced_fence_does_not_swallow_following_sections(self) -> None:
+        result = render_critical_section_bodies(
+            _CHARTER_WITH_UNBALANCED_FENCE, action="implement"
+        )
+
+        body = _rendered_section_body(result, "Regression Vigilance")
+
+        assert "Preserve cleanup instructions" in body
+        assert "```bash" not in body
+        assert "## STEP 1" not in body
+        assert "This is the next section" not in body
+        assert result.count("  Run: spec-kitty charter context --include") == 3
 
 
 class TestMissingSectionFetchStanza:

--- a/tests/charter/test_context_section_bodies.py
+++ b/tests/charter/test_context_section_bodies.py
@@ -20,6 +20,7 @@ from charter.context_renderers import (
     CRITICAL_SECTION_WHEN_CLAUSES,
     critical_section_header,
     render_critical_section_bodies,
+    render_critical_section_include,
 )
 
 pytestmark = pytest.mark.fast
@@ -204,6 +205,24 @@ class TestVerbatimBodies:
         assert "## STEP 1" not in body
         assert "This is the next section" not in body
         assert result.count("  Run: spec-kitty charter context --include") == 3
+
+    def test_section_include_ignores_fenced_heading_examples(self) -> None:
+        result = render_critical_section_include(
+            _CHARTER_WITH_FENCED_SECTION_HEADING_EXAMPLE,
+            "regression-vigilance",
+        )
+
+        assert result is not None
+        assert "consult glossary/contexts/" in result
+        assert "This is example text" not in result
+
+    def test_section_include_fail_closed_on_unbalanced_fence(self) -> None:
+        result = render_critical_section_include(
+            _CHARTER_WITH_UNBALANCED_FENCE,
+            "code-review-checklist",
+        )
+
+        assert result is None
 
 
 class TestMissingSectionFetchStanza:

--- a/tests/charter/test_context_section_bodies.py
+++ b/tests/charter/test_context_section_bodies.py
@@ -66,6 +66,42 @@ _CHARTER_WITHOUT_REGRESSION_VIGILANCE = textwrap.dedent(
 )
 
 
+_CHARTER_WITH_FENCED_MARKDOWN_HEADINGS = textwrap.dedent(
+    """\
+    # Project Charter
+
+    ## Terminology Canon
+
+    - canonical term is **Mission**.
+
+    ## Regression Vigilance
+
+    Preserve cleanup instructions around command examples:
+
+    ```bash
+    ## STEP 1
+    spec-kitty glossary scan
+        ```
+    ## STEP 2
+    spec-kitty glossary validate
+    ```
+
+    After cleanup, rerun the mission review.
+
+    ## Code Review Checklist
+
+    - This is the next section and not part of Regression Vigilance.
+    """
+)
+
+
+def _rendered_section_body(rendered: str, heading: str) -> str:
+    section_start = rendered.index(f"### {heading}")
+    body_start = rendered.index("\n", section_start) + 1
+    fetch_start = rendered.index("  Run: spec-kitty charter context --include", body_start)
+    return rendered[body_start:fetch_start].rstrip()
+
+
 class TestVerbatimBodies:
     """Existing headings render their body verbatim under a ``### <heading>`` line."""
 
@@ -80,6 +116,18 @@ class TestVerbatimBodies:
             "The canonical term for a unit of governed work is **Mission**"
             in result
         )
+
+    def test_fenced_markdown_headings_do_not_truncate_section_body(self) -> None:
+        result = render_critical_section_bodies(
+            _CHARTER_WITH_FENCED_MARKDOWN_HEADINGS, action="implement"
+        )
+
+        body = _rendered_section_body(result, "Regression Vigilance")
+
+        assert "## STEP 1" in body
+        assert "## STEP 2" in body
+        assert "After cleanup, rerun the mission review." in body
+        assert "This is the next section" not in body
 
 
 class TestMissingSectionFetchStanza:

--- a/tests/charter/test_context_selection_render.py
+++ b/tests/charter/test_context_selection_render.py
@@ -24,10 +24,12 @@ shipped tree so failures isolate to the renderer logic.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+import charter.context as context_module
 from charter.context import (
     _PROFILE_INLINE_BODY_LIMIT_CHARS,
     _SELECTED_AGENT_PROFILES_HEADER,
@@ -37,6 +39,7 @@ from charter.context import (
     _SELECTED_TOOLGUIDES_HEADER,
     _collect_org_source_map,
     _provenance_suffix,
+    _render_doctrine_artifact_include,
     _render_selected_agent_profiles,
     _render_selected_mission_step_contracts,
     _render_selected_procedures,
@@ -316,6 +319,64 @@ class TestTokenBudgetOverflow:
         lines = _render_selected_procedures(["bloated-proc"], service)
         joined = "\n".join(lines)
         assert "spec-kitty charter context --include procedure:bloated-proc" in joined
+
+
+# ---------------------------------------------------------------------------
+# Fetch-selector recovery — emitted selectors must round-trip through --include
+# ---------------------------------------------------------------------------
+
+
+class TestFetchSelectorRecovery:
+    """Every selection kind that can emit a fetch stanza is recoverable."""
+
+    def test_selected_styleguide_include_recovers_body(self) -> None:
+        sg = _DummyStyleguide(title="Caveman", principles=["Prefer concrete names."])
+        service = _StubService(styleguides=_StubRepo(items={"caveman-comments": sg}))
+
+        text = _render_doctrine_artifact_include(service, "styleguide", "caveman-comments")
+
+        assert text is not None
+        assert "Styleguide caveman-comments: Caveman" in text
+        assert "Prefer concrete names." in text
+
+    def test_selected_procedure_include_recovers_body(self) -> None:
+        procedure = _DummyProcedure(
+            name="Review",
+            purpose="keep merge checks honest",
+            entry="diff ready",
+            exit_="review complete",
+            steps=[_DummyStep(title="Run focused tests")],
+        )
+        service = _StubService(procedures=_StubRepo(items={"review-before-merge": procedure}))
+
+        text = _render_doctrine_artifact_include(
+            service, "procedure", "review-before-merge"
+        )
+
+        assert text is not None
+        assert "Procedure review-before-merge: Review" in text
+        assert "Run focused tests" in text
+
+    def test_styleguide_selector_round_trips_through_context_include(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        sg = _DummyStyleguide(title="Caveman", principles=["Prefer concrete names."])
+        service = _StubService(styleguides=_StubRepo(items={"caveman-comments": sg}))
+        monkeypatch.setattr(
+            context_module,
+            "_build_doctrine_service",
+            lambda repo_root, org_roots=None: service,
+        )
+
+        text = context_module.build_charter_context_include(
+            tmp_path,
+            "styleguide:caveman-comments",
+        )
+
+        assert "Styleguide caveman-comments: Caveman" in text
+        assert "Prefer concrete names." in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/charter/test_context_selection_render.py
+++ b/tests/charter/test_context_selection_render.py
@@ -24,6 +24,7 @@ shipped tree so failures isolate to the renderer logic.
 
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -38,7 +39,14 @@ from charter.context import (
     _SELECTED_STYLEGUIDES_HEADER,
     _SELECTED_TOOLGUIDES_HEADER,
     _collect_org_source_map,
+    _default_agent_profile_repository,
+    _format_full_artifact_payload_body,
+    _format_inline_directive_body,
+    _format_profile_directive_code,
+    _jsonable_artifact_value,
+    _load_agent_profile,
     _provenance_suffix,
+    _reset_agent_profile_cache,
     _render_doctrine_artifact_include,
     _render_selected_agent_profiles,
     _render_selected_mission_step_contracts,
@@ -329,6 +337,58 @@ class TestTokenBudgetOverflow:
 class TestFetchSelectorRecovery:
     """Every selection kind that can emit a fetch stanza is recoverable."""
 
+    def test_malformed_include_selector_fails_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Expected --include selector"):
+            context_module.build_charter_context_include(tmp_path, "not-a-selector")
+
+    def test_section_selector_round_trips_through_context_include(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text(
+            "# Project Charter\n\n"
+            "## Regression Vigilance\n\n"
+            "Consult glossary/contexts before approving a terminology cutover.\n",
+            encoding="utf-8",
+        )
+
+        text = context_module.build_charter_context_include(
+            tmp_path,
+            "section:regression-vigilance",
+        )
+
+        assert "### Regression Vigilance" in text
+        assert "Consult glossary/contexts" in text
+
+    def test_section_selector_fails_closed_without_charter(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        with pytest.raises(ValueError, match="No charter.md found"):
+            context_module.build_charter_context_include(
+                tmp_path,
+                "section:regression-vigilance",
+            )
+
+    def test_section_selector_fails_closed_on_missing_heading(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        charter_dir = tmp_path / ".kittify" / "charter"
+        charter_dir.mkdir(parents=True)
+        (charter_dir / "charter.md").write_text(
+            "# Project Charter\n\n## Purpose\n\nNo critical sections.\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="No charter section found"):
+            context_module.build_charter_context_include(
+                tmp_path,
+                "section:regression-vigilance",
+            )
+
     def test_selected_styleguide_include_recovers_body(self) -> None:
         sg = _DummyStyleguide(title="Caveman", principles=["Prefer concrete names."])
         service = _StubService(styleguides=_StubRepo(items={"caveman-comments": sg}))
@@ -338,6 +398,14 @@ class TestFetchSelectorRecovery:
         assert text is not None
         assert "Styleguide caveman-comments: Caveman" in text
         assert "Prefer concrete names." in text
+
+    def test_unknown_doctrine_artifact_include_fails_closed(self) -> None:
+        with pytest.raises(ValueError, match="No styleguide found"):
+            _render_doctrine_artifact_include(
+                _StubService(),
+                "styleguide",
+                "does-not-exist",
+            )
 
     def test_selected_procedure_include_recovers_body(self) -> None:
         procedure = _DummyProcedure(
@@ -457,6 +525,92 @@ class TestFetchSelectorRecovery:
         assert "Full artifact:" in tactic_text
         assert "Run a concrete abuse-path check." in tactic_text
 
+    def test_generic_artifact_selector_recovers_activation_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        sg = _DummyStyleguide(title="Caveman", principles=["Prefer concrete names."])
+        service = _StubService(styleguides=_StubRepo(items={"caveman-comments": sg}))
+        monkeypatch.setattr(
+            context_module,
+            "_build_doctrine_service",
+            lambda repo_root, org_roots=None: service,
+        )
+
+        text = context_module.build_charter_context_include(
+            tmp_path,
+            "artifact:caveman-comments",
+        )
+
+        assert "Styleguide caveman-comments: Caveman" in text
+        assert "Prefer concrete names." in text
+
+    def test_generic_artifact_selector_fails_closed_on_ambiguous_match(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        service = _StubService(
+            styleguides=_StubRepo(
+                items={"shared-id": _DummyStyleguide(title="Style", principles=["One"])}
+            ),
+            toolguides=_StubRepo(
+                items={
+                    "shared-id": _DummyToolguide(
+                        title="Tool",
+                        tool="pytest",
+                        summary="Run tests.",
+                    )
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            context_module,
+            "_build_doctrine_service",
+            lambda repo_root, org_roots=None: service,
+        )
+
+        with pytest.raises(ValueError, match="Ambiguous artifact selector"):
+            context_module.build_charter_context_include(
+                tmp_path,
+                "artifact:shared-id",
+            )
+
+    def test_generic_artifact_selector_fails_closed_on_missing_match(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            context_module,
+            "_build_doctrine_service",
+            lambda repo_root, org_roots=None: _StubService(),
+        )
+
+        with pytest.raises(ValueError, match="No artifact found"):
+            context_module.build_charter_context_include(
+                tmp_path,
+                "artifact:missing-id",
+            )
+
+    def test_unknown_include_kind_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(
+            context_module,
+            "_build_doctrine_service",
+            lambda repo_root, org_roots=None: _StubService(),
+        )
+
+        with pytest.raises(ValueError, match="Unsupported --include selector kind"):
+            context_module.build_charter_context_include(
+                tmp_path,
+                "template:mission",
+            )
+
     def test_styleguide_selector_round_trips_through_context_include(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -477,6 +631,89 @@ class TestFetchSelectorRecovery:
 
         assert "Styleguide caveman-comments: Caveman" in text
         assert "Prefer concrete names." in text
+
+    def test_full_payload_json_conversion_covers_nested_values(self) -> None:
+        class _Mode(Enum):
+            STRICT = "strict"
+
+        class _Dumpable:
+            def model_dump(self, **kwargs: object) -> dict[str, object]:
+                return {"kind": "modern", "kwargs": sorted(kwargs)}
+
+        class _LegacyDumpable:
+            def model_dump(self) -> dict[str, object]:
+                return {"kind": "legacy"}
+
+        payload = {
+            "mode": _Mode.STRICT,
+            "items": [{"name": "rule", "skip": None}],
+            "none": None,
+        }
+
+        assert _jsonable_artifact_value(payload) == {
+            "mode": "strict",
+            "items": [{"name": "rule"}],
+        }
+        assert _jsonable_artifact_value({"tags": {"beta", "alpha"}}) == {
+            "tags": ["alpha", "beta"]
+        }
+        assert _jsonable_artifact_value(_Dumpable()) == {
+            "kind": "modern",
+            "kwargs": ["by_alias", "exclude_none", "mode"],
+        }
+        assert _jsonable_artifact_value(_LegacyDumpable()) == {"kind": "legacy"}
+        assert isinstance(_jsonable_artifact_value(object()), str)
+
+    def test_full_payload_empty_scalar_emits_no_payload(self) -> None:
+        assert _format_full_artifact_payload_body("scalar") == []
+
+    def test_directive_include_renders_list_fields(self) -> None:
+        directive = _DummyDirective(
+            title="Security Baseline",
+            intent="Never leak secrets.",
+        )
+        directive.scope = "security-sensitive code"
+        directive.procedures = ["Map trust boundaries."]
+        directive.integrity_rules = ["Do not hide failures."]
+        directive.validation_criteria = ["Focused repro exists."]
+
+        lines = _format_inline_directive_body(directive)
+
+        joined = "\n".join(lines)
+        assert "Scope: security-sensitive code" in joined
+        assert "Procedures:" in joined
+        assert "Map trust boundaries." in joined
+        assert "Integrity rules:" in joined
+        assert "Validation criteria:" in joined
+
+    def test_profile_lookup_helpers_fail_softly(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _BoomRepo:
+            def get(self, profile_id: str) -> object:
+                raise RuntimeError(profile_id)
+
+        class _EmptyRepo:
+            def get(self, profile_id: str) -> None:
+                return None
+
+        _reset_agent_profile_cache()
+        assert _default_agent_profile_repository() is not None
+        _reset_agent_profile_cache()
+        monkeypatch.setattr(
+            context_module,
+            "_default_agent_profile_repository",
+            lambda: _BoomRepo(),
+        )
+        assert _load_agent_profile("missing-profile") is None
+        monkeypatch.setattr(
+            context_module,
+            "_default_agent_profile_repository",
+            lambda: _EmptyRepo(),
+        )
+        assert _load_agent_profile("missing-profile") is None
+        assert _format_profile_directive_code("7") == "DIRECTIVE_007"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/charter/test_context_selection_render.py
+++ b/tests/charter/test_context_selection_render.py
@@ -357,6 +357,106 @@ class TestFetchSelectorRecovery:
         assert "Procedure review-before-merge: Review" in text
         assert "Run focused tests" in text
 
+    def test_doctrine_artifact_include_recovers_fields_outside_inline_summary(self) -> None:
+        sg = _DummyStyleguide(title="Caveman", principles=["Prefer concrete names."])
+        sg.anti_patterns = [
+            {"name": "soft recovery", "description": "Do not drop governance."}
+        ]
+        toolguide = _DummyToolguide(title="Pytest", tool="pytest", summary="Run tests.")
+        toolguide.commands = ["pytest tests/charter"]
+        procedure = _DummyProcedure(
+            name="Review",
+            purpose="keep merge checks honest",
+            entry="diff ready",
+            exit_="review complete",
+            steps=[_DummyStep(title="Run focused tests")],
+        )
+        procedure.anti_patterns = [{"name": "skip repro", "description": "No repro."}]
+        profile = _DummyAgentProfile(
+            name="Python Pedro",
+            purpose="Implement Python work with TDD discipline.",
+            roles=["implementer"],
+        )
+        profile.initialization_declaration = "Acknowledge governance before coding."
+        contract_step = _DummyStep(
+            title="t",
+            id_="s1",
+            description="First step",
+        )
+        contract_step.guidance = "Recover contract guidance."
+        contract = _DummyContract(
+            action="implement",
+            mission="software-dev",
+            steps=[contract_step],
+        )
+        paradigm = _DummyParadigm(name="SPDD", summary="Use structured prompts.")
+        paradigm.directive_refs = ["DIRECTIVE_039"]
+        service = _StubService(
+            paradigms=_StubRepo(items={"structured-prompt-driven-development": paradigm}),
+            styleguides=_StubRepo(items={"caveman-comments": sg}),
+            toolguides=_StubRepo(items={"pytest-runner": toolguide}),
+            procedures=_StubRepo(items={"review-before-merge": procedure}),
+            agent_profiles=_StubRepo(items={"python-pedro": profile}),
+            mission_step_contracts=_StubRepo(items={"implement-contract": contract}),
+        )
+
+        cases = (
+            ("paradigm", "structured-prompt-driven-development", "DIRECTIVE_039"),
+            ("styleguide", "caveman-comments", "Do not drop governance."),
+            ("toolguide", "pytest-runner", "pytest tests/charter"),
+            ("procedure", "review-before-merge", "No repro."),
+            ("agent_profile", "python-pedro", "Acknowledge governance before coding."),
+            ("mission_step_contract", "implement-contract", "Recover contract guidance."),
+        )
+        for kind, artifact_id, marker in cases:
+            text = _render_doctrine_artifact_include(service, kind, artifact_id)
+            assert text is not None
+            assert "Full artifact:" in text
+            assert marker in text
+
+    def test_directive_and_tactic_include_recovers_fields_outside_inline_summary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        directive = _DummyDirective(
+            title="Security Baseline",
+            intent="Never leak secrets.",
+        )
+        directive.enforcement = "lenient-adherence"
+        directive.explicit_allowances = ["Documented exception marker."]
+        step = _DummyStep(title="Map trust boundaries")
+        step.description = "Full tactic step marker."
+        step.examples = ["Run a concrete abuse-path check."]
+        tactic = _DummyTactic(
+            name="Threat Model First",
+            purpose="Find attacker paths before coding.",
+            steps=[step],
+        )
+        service = _StubService(
+            directives=_StubRepo(items={"DIRECTIVE_999": directive}),
+            tactics=_StubRepo(items={"threat-model-first": tactic}),
+        )
+        monkeypatch.setattr(
+            context_module,
+            "_build_doctrine_service",
+            lambda repo_root, org_roots=None: service,
+        )
+
+        directive_text = context_module.build_charter_context_include(
+            tmp_path,
+            "directive:DIRECTIVE_999",
+        )
+        tactic_text = context_module.build_charter_context_include(
+            tmp_path,
+            "tactic:threat-model-first",
+        )
+
+        assert "Full artifact:" in directive_text
+        assert "Documented exception marker." in directive_text
+        assert "Full artifact:" in tactic_text
+        assert "Run a concrete abuse-path check." in tactic_text
+
     def test_styleguide_selector_round_trips_through_context_include(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/commands/test_charter_rendering.py
+++ b/tests/cli/commands/test_charter_rendering.py
@@ -342,6 +342,50 @@ def test_context_include_renders_selector_without_action(tmp_path: Path) -> None
     )
 
 
+def test_context_include_json_renders_machine_envelope(tmp_path: Path) -> None:
+    """Arrange: include selector + JSON; Act: context --include --json; Assert: envelope emits."""
+
+    project = _project(tmp_path)
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=project),
+        patch("specify_cli.doctrine.config.resolve_org_roots", return_value=[]),
+        patch(
+            "charter.context.build_charter_context_include",
+            return_value="### Regression Vigilance\nRule body.",
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["context", "--include", "section:regression-vigilance", "--json"],
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["success"] is True
+    assert payload["include"] == "section:regression-vigilance"
+    assert payload["text"] == "### Regression Vigilance\nRule body."
+
+
+def test_context_include_renders_value_error(tmp_path: Path) -> None:
+    """Arrange: include builder rejects selector; Act: context --include; Assert: exit 1."""
+
+    project = _project(tmp_path)
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=project),
+        patch("specify_cli.doctrine.config.resolve_org_roots", return_value=[]),
+        patch(
+            "charter.context.build_charter_context_include",
+            side_effect=ValueError("bad selector"),
+        ),
+    ):
+        result = runner.invoke(app, ["context", "--include", "bad"])
+
+    assert result.exit_code == 1
+    assert "bad selector" in result.output
+
+
 def test_context_requires_action_without_include(tmp_path: Path) -> None:
     """Arrange: no action/include; Act: context; Assert: command fails closed."""
 

--- a/tests/cli/commands/test_charter_rendering.py
+++ b/tests/cli/commands/test_charter_rendering.py
@@ -315,3 +315,43 @@ def test_context_renders_error_on_task_cli_error(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "Error" in result.output
+
+
+def test_context_include_renders_selector_without_action(tmp_path: Path) -> None:
+    """Arrange: include selector; Act: context --include; Assert: selector text emits."""
+
+    project = _project(tmp_path)
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=project),
+        patch("specify_cli.doctrine.config.resolve_org_roots", return_value=[]),
+        patch(
+            "charter.context.build_charter_context_include",
+            return_value="### Regression Vigilance\nRule body.",
+        ) as include_builder,
+    ):
+        result = runner.invoke(app, ["context", "--include", "section:regression-vigilance"])
+
+    assert result.exit_code == 0
+    assert "Rule body." in result.output
+    include_builder.assert_called_once_with(
+        project,
+        "section:regression-vigilance",
+        action=None,
+        org_root=None,
+    )
+
+
+def test_context_requires_action_without_include(tmp_path: Path) -> None:
+    """Arrange: no action/include; Act: context; Assert: command fails closed."""
+
+    project = _project(tmp_path)
+
+    with (
+        patch("specify_cli.cli.commands.charter.find_repo_root", return_value=project),
+        patch("specify_cli.doctrine.config.resolve_org_roots", return_value=[]),
+    ):
+        result = runner.invoke(app, ["context"])
+
+    assert result.exit_code == 1
+    assert "--action is required unless --include is provided" in result.output


### PR DESCRIPTION
## Summary
- make charter section body extraction ignore level-two markdown headings while inside fenced code blocks
- preserve normal next-section detection outside fences
- add regression coverage for fenced governance examples containing \ lines

Fixes #1467

## Tests
- FAILING first: \============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /private/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/spec-kitty-20260531-144709-mCt0I2/spec-kitty
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, playwright-0.7.2, html-4.1.1, xdist-3.8.0, timeout-2.4.0, metadata-3.1.1, Faker-33.1.0, cov-4.1.0, asyncio-1.3.0, mock-3.12.0, hypothesis-6.151.2, base-url-2.1.0, typeguard-4.4.4, respx-0.23.1, baml-0.19.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 6 items

tests/charter/test_context_section_bodies.py ......                      [100%]

============================== 6 passed in 1.36s =============================== failed on new regression before production fix (body stopped at fence opener)
- PASS: \============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /private/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/spec-kitty-20260531-144709-mCt0I2/spec-kitty
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, playwright-0.7.2, html-4.1.1, xdist-3.8.0, timeout-2.4.0, metadata-3.1.1, Faker-33.1.0, cov-4.1.0, asyncio-1.3.0, mock-3.12.0, hypothesis-6.151.2, base-url-2.1.0, typeguard-4.4.4, respx-0.23.1, baml-0.19.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 6 items

tests/charter/test_context_section_bodies.py ......                      [100%]

============================== 6 passed in 2.06s =============================== (6 passed)
- PASS: \============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /private/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/spec-kitty-20260531-144709-mCt0I2/spec-kitty
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, playwright-0.7.2, html-4.1.1, xdist-3.8.0, timeout-2.4.0, metadata-3.1.1, Faker-33.1.0, cov-4.1.0, asyncio-1.3.0, mock-3.12.0, hypothesis-6.151.2, base-url-2.1.0, typeguard-4.4.4, respx-0.23.1, baml-0.19.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 33 items

tests/specify_cli/next/test_wp_prompt_governance_contract.py ........... [ 33%]
..............                                                           [ 75%]
tests/architectural/test_template_governance_payload_contract.py ....... [ 96%]
.                                                                        [100%]

=============================== warnings summary ===============================
tests/specify_cli/next/test_wp_prompt_governance_contract.py::TestProfileDirectivesSurfacedInWpPrompt::test_reviewer_renata_directive_032_conceptual_alignment_in_review_prompt
tests/specify_cli/next/test_wp_prompt_governance_contract.py::TestProfileDirectivesSurfacedInWpPrompt::test_reviewer_renata_tactic_language_driven_design_in_review_prompt
tests/architectural/test_template_governance_payload_contract.py::TestReviewTemplateGovernancePayloadContract::test_guaranteed_bodies_listed_in_template_appear_in_resolver
tests/architectural/test_template_governance_payload_contract.py::TestReviewTemplateGovernancePayloadContract::test_guaranteed_authority_pointers_appear_in_resolver
  /private/var/folders/gj/bxx0438j003b20kn5b6s7bsh0000gn/T/spec-kitty-20260531-144709-mCt0I2/spec-kitty/src/charter/context.py:2172: CharterCatalogMissWarning: Charter catalog miss for tactic:bdd-scenario-lifecycle; cause=missing_artifact; context='profile:reviewer-renata'
    tactic_lines = _render_profile_tactics(profile, service)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 33 passed, 4 warnings in 10.21s ======================== (33 passed, 4 existing CharterCatalogMissWarning warnings)
- PASS: \All checks passed!
- PASS: \
- FAIL unrelated existing repo lint: \ARG001 Unused function argument: `repo_root`
   --> .kittify/overrides/scripts/tasks/tasks_cli.py:438:22
    |
438 | def _resolve_mission(repo_root: Path, requested: str | None) -> str:
    |                      ^^^^^^^^^
439 |     if requested:
440 |         return requested
    |

C901 `accept_command` is too complex (16 > 15)
   --> .kittify/overrides/scripts/tasks/tasks_cli.py:515:5
    |
515 | def accept_command(args: argparse.Namespace) -> None:
    |     ^^^^^^^^^^^^^^
516 |     repo_root = find_repo_root()
517 |     mission_slug = _resolve_mission(repo_root, args.mission)
    |

C901 `merge_command` is too complex (32 > 15)
   --> .kittify/overrides/scripts/tasks/tasks_cli.py:629:5
    |
629 | def merge_command(args: argparse.Namespace) -> None:
    |     ^^^^^^^^^^^^^
630 |     # merge_command needs the LOCAL git root (may be a worktree), not the main
631 |     # repo root that find_repo_root() returns.  git rev-parse --show-toplevel
    |

SIM113 Use `enumerate()` for index variable `counter` in `for` loop
   --> kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py:205:9
    |
203 |             ),
204 |         )
205 |         counter += 1
    |         ^^^^^^^^^^^^
206 |     materialize(feature_dir)
    |

C901 `_agent_profile_fixups` is too complex (22 > 15)
   --> scripts/generate_schemas.py:309:5
    |
308 | # --- Agent Profile ---
309 | def _agent_profile_fixups(schema: dict) -> dict:
    |     ^^^^^^^^^^^^^^^^^^^^^
310 |     """Add descriptions matching the hand-written schema."""
311 |     props = schema.get("properties", {})
    |

SIM102 Use a single `if` statement instead of nested `if` statements
   --> scripts/generate_schemas.py:768:9
    |
766 |           if not isinstance(prop_def, dict):
767 |               continue
768 | /         if prop_def.get("type") == "string" and field_name in required:
769 | |             # Don't add minLength if there's already a pattern or minLength
770 | |             if "pattern" not in prop_def and "minLength" not in prop_def:
    | |_________________________________________________________________________^
771 |                   prop_def["minLength"] = 1
    |
help: Combine `if` statements using `and`

B007 Loop control variable `def_name` not used within loop body
   --> scripts/generate_schemas.py:774:9
    |
773 |     # Recurse into definitions
774 |     for def_name, def_body in obj.get("definitions", {}).items():
    |         ^^^^^^^^
775 |         if isinstance(def_body, dict) and "properties" in def_body:
776 |             _add_minlength_to_string_fields(def_body)
    |
help: Rename unused `def_name` to `_def_name`

SIM108 Use ternary operator `schema = _inline_all_enum_refs(raw, defs) if enum_defs - {"ArtifactKind"} else _inline_artifact_kind_refs(raw, defs)` instead of `if`-`else`-block
   --> scripts/generate_schemas.py:951:5
    |
949 |       # For others, only inline ArtifactKind.
950 |       enum_defs = {k for k, v in defs.items() if _is_enum_def(v)}
951 | /     if enum_defs - {"ArtifactKind"}:
952 | |         schema = _inline_all_enum_refs(raw, defs)
953 | |     else:
954 | |         schema = _inline_artifact_kind_refs(raw, defs)
    | |______________________________________________________^
955 |
956 |       # Phase 2: rename $defs → definitions, rewrite $ref paths
    |
help: Replace `if`-`else`-block with `schema = _inline_all_enum_refs(raw, defs) if enum_defs - {"ArtifactKind"} else _inline_artifact_kind_refs(raw, defs)`

UP035 [*] Import from `collections.abc` instead: `Iterable`
   --> scripts/lint_canonical_producers.py:98:1
    |
 96 | from dataclasses import dataclass
 97 | from pathlib import Path
 98 | from typing import Iterable
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 99 |
100 | # --------------------------------------------------------------------------- #
    |
help: Import from `collections.abc`

SIM102 Use a single `if` statement instead of nested `if` statements
   --> scripts/lint_canonical_producers.py:266:9
    |
264 |       """True if a dict literal has `event_type` or `payload` as a string key."""
265 |       for key in node.keys:
266 | /         if isinstance(key, ast.Constant) and isinstance(key.value, str):
267 | |             if key.value in _EVENT_KEYS_REQUIRED:
    | |_________________________________________________^
268 |                   return True
269 |       return False
    |
help: Combine `if` statements using `and`

SIM103 Return the condition directly
   --> scripts/lint_canonical_producers.py:293:5
    |
291 |       if isinstance(second, ast.Name) and second.id in {"Any", "object"}:
292 |           return True
293 | /     if isinstance(second, ast.Attribute) and second.attr == "Any":
294 | |         return True
295 | |     return False
    | |________________^
    |
help: Inline condition

B010 [*] Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
   --> scripts/lint_canonical_producers.py:309:13
    |
307 |     def visit(self, node: ast.AST) -> ast.AST:  # type: ignore[override]
308 |         for child in ast.iter_child_nodes(node):
309 |             setattr(child, "_cp_parent", node)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
310 |             self.visit(child)
311 |         return node
    |
help: Replace `setattr` with assignment

SIM102 Use a single `if` statement instead of nested `if` statements
   --> scripts/lint_canonical_producers.py:370:13
    |
368 |           # dict literal -- is the documented hand-rolled case from rc14->rc22.
369 |           for child in ast.walk(node):
370 | /             if isinstance(child, ast.Return) and isinstance(child.value, ast.Dict):
371 | |                 if _dict_has_any_event_key(child.value):
    | |________________________________________________________^
372 |                       self._maybe_report(
373 |                           line=child.value.lineno,
    |
help: Combine `if` statements using `and`

UP022 Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`
  --> scripts/sync_all_contributors.py:81:17
   |
80 |   def run_json(cmd: list[str]) -> object:
81 |       completed = subprocess.run(
   |  _________________^
82 | |         cmd,
83 | |         check=True,
84 | |         stdout=subprocess.PIPE,
85 | |         stderr=subprocess.PIPE,
86 | |         text=True,
87 | |     )
   | |_____^
88 |       return json.loads(completed.stdout)
   |
help: Replace with `capture_output` keyword argument

UP022 Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`
  --> scripts/sync_all_contributors.py:92:17
   |
91 |   def run_text(cmd: list[str]) -> str:
92 |       completed = subprocess.run(
   |  _________________^
93 | |         cmd,
94 | |         check=True,
95 | |         stdout=subprocess.PIPE,
96 | |         stderr=subprocess.PIPE,
97 | |         text=True,
98 | |     )
   | |_____^
99 |       return completed.stdout
   |
help: Replace with `capture_output` keyword argument

B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
   --> scripts/tasks/task_helpers.py:125:13
    |
123 |         if check:
124 |             message = exc.stderr.strip() or exc.stdout.strip() or "Unknown git error"
125 |             raise TaskCliError(message)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
126 |         return exc
    |

SIM108 Use ternary operator `previous_lane_canonical = str(wp_events[0].from_lane) if len(wp_events) == 1 else str(wp_events[-2].to_lane)` instead of `if`-`else`-block
   --> scripts/tasks/tasks_cli.py:431:5
    |
429 |           raise TaskCliError(f"No canonical status events for {wp_id}. Cannot determine the previous lane.")
430 |
431 | /     if len(wp_events) == 1:
432 | |         # Only one event: previous lane is the from_lane of that event
433 | |         previous_lane_canonical = str(wp_events[0].from_lane)
434 | |     else:
435 | |         # Two or more events: previous lane is the to_lane of the second-to-last
436 | |         previous_lane_canonical = str(wp_events[-2].to_lane)
    | |____________________________________________________________^
437 |       # Map canonical lane back to standalone alias for ensure_lane
438 |       # (e.g. "in_progress" is valid in canonical but standalone uses "doing")
    |
help: Replace `if`-`else`-block with `previous_lane_canonical = str(wp_events[0].from_lane) if len(wp_events) == 1 else str(wp_events[-2].to_lane)`

C901 `accept_command` is too complex (16 > 15)
   --> scripts/tasks/tasks_cli.py:534:5
    |
534 | def accept_command(args: argparse.Namespace) -> None:
    |     ^^^^^^^^^^^^^^
535 |     repo_root = find_repo_root()
536 |     feature = _resolve_feature(repo_root, args.feature)
    |

SIM105 Use `contextlib.suppress(ValueError, FileNotFoundError)` instead of `try`-`except`-`pass`
   --> scripts/tasks/tasks_cli.py:642:5
    |
641 |       feature_dir = meta_path.parent
642 | /     try:
643 | |         finalize_merge(feature_dir, merged_commit=merge_commit)
644 | |     except (ValueError, FileNotFoundError):
645 | |         pass
    | |____________^
    |
help: Replace `try`-`except`-`pass` with `with contextlib.suppress(ValueError, FileNotFoundError): ...`

C901 `merge_command` is too complex (33 > 15)
   --> scripts/tasks/tasks_cli.py:648:5
    |
648 | def merge_command(args: argparse.Namespace) -> None:
    |     ^^^^^^^^^^^^^
649 |     # merge_command needs the LOCAL git root (may be a worktree), not the main
650 |     # repo root that find_repo_root() returns.  git rev-parse --show-toplevel
    |

SIM102 Use a single `if` statement instead of nested `if` statements
   --> scripts/tasks/tasks_cli.py:772:5
    |
770 |           print("[spec-kitty] Skipping push: no remote configured.", file=sys.stderr)
771 |
772 | /     if in_worktree and args.remove_worktree:
773 | |         if repo_root.exists():
    | |______________________________^
774 |               git(["worktree", "remove", str(repo_root), "--force"])
    |
help: Combine `if` statements using `and`

SIM108 Use ternary operator `failures = _verify_index(artifact) if is_index else _verify_per_wp(artifact)` instead of `if`-`else`-block
   --> scripts/verify_occurrences.py:188:5
    |
187 |       is_index = "wps" in artifact and "must_be_zero" in artifact
188 | /     if is_index:
189 | |         failures = _verify_index(artifact)
190 | |     else:
191 | |         failures = _verify_per_wp(artifact)
    | |___________________________________________^
192 |
193 |       rel = os.path.relpath(artifact_path, REPO_ROOT)
    |
help: Replace `if`-`else`-block with `failures = _verify_index(artifact) if is_index else _verify_per_wp(artifact)`

Found 22 errors.
[*] 2 fixable with the `--fix` option (10 hidden fixes can be enabled with the `--unsafe-fixes` option). reports 22 pre-existing errors in .kittify/overrides/scripts/tasks/tasks_cli.py, kitty-specs/.../baseline/capture.py, scripts/generate_schemas.py, scripts/lint_canonical_producers.py, scripts/sync_all_contributors.py, scripts/tasks/*.py, scripts/verify_occurrences.py; no failures in touched files

## Self-review
- Ran /Users/robert/.codex/skills/adversarial-pr-review/SKILL.md against local diff
- Finding fixed before PR: fence close detection originally allowed over-indented closing markers via strip(); tightened to Markdown 0-3 leading-space close rule and covered with fixture