### PR TITLE
Fix stale coordination worktree registration recovery

### DIFF
--- a/src/specify_cli/coordination/workspace.py
+++ b/src/specify_cli/coordination/workspace.py
@@ -77,6 +77,39 @@ def _compose_mission_dir(mission_slug: str, mid8: str) -> str:
     return f"{mission_slug}-{mid8}"
 
 
+def _has_stale_worktree_registration(repo_root: Path, path: Path) -> bool:
+    """Return whether git records ``path`` as prunable/missing."""
+    output = subprocess.check_output(
+        ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+        text=True,
+    )
+    expected = path.resolve(strict=False)
+    current_path: Path | None = None
+    current_prunable = False
+
+    for line in output.splitlines() + [""]:
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree ")).resolve(strict=False)
+            current_prunable = False
+            continue
+        if line.startswith("prunable"):
+            current_prunable = True
+            continue
+        if line == "" and current_path is not None:
+            if current_path == expected and current_prunable:
+                return True
+            current_path = None
+            current_prunable = False
+    return False
+
+
+def _remove_worktree_registration(repo_root: Path, path: Path) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(path)],
+        check=True,
+    )
+
+
 class CoordinationWorkspace:
     """Resolve / create / teardown a per-mission coordination worktree.
 
@@ -137,6 +170,8 @@ class CoordinationWorkspace:
         # The caller is responsible for ensuring the branch already
         # exists (WP03's mission create does this).
         path.parent.mkdir(parents=True, exist_ok=True)
+        if _has_stale_worktree_registration(repo_root, path):
+            _remove_worktree_registration(repo_root, path)
         subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "add", str(path), branch],
             check=True,
@@ -155,6 +190,8 @@ class CoordinationWorkspace:
         """
         path = cls.worktree_path(repo_root, mission_slug, mid8)
         if not path.exists():
+            if _has_stale_worktree_registration(repo_root, path):
+                _remove_worktree_registration(repo_root, path)
             return
         subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "remove",

--- a/tests/specify_cli/coordination/test_workspace.py
+++ b/tests/specify_cli/coordination/test_workspace.py
@@ -14,6 +14,7 @@ These cover the FR-024 / FR-018 lifecycle contract:
 from __future__ import annotations
 
 import subprocess
+import shutil
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,13 @@ COORD_BRANCH = f"kitty/mission-{MISSION_SLUG}-{MID8}"
 
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _worktree_list(repo: Path) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(repo), "worktree", "list", "--porcelain"],
+        text=True,
+    )
 
 
 @pytest.fixture
@@ -104,6 +112,25 @@ def test_resolve_reuses_existing(repo_with_coord_branch: Path) -> None:
     assert marker.read_text() == "preserved\n"
 
 
+def test_resolve_recovers_stale_prunable_registration(
+    repo_with_coord_branch: Path,
+) -> None:
+    path = CoordinationWorkspace.resolve(
+        repo_with_coord_branch, MISSION_SLUG, MID8,
+    )
+    shutil.rmtree(path)
+    assert not path.exists()
+    assert "prunable" in _worktree_list(repo_with_coord_branch)
+
+    recovered = CoordinationWorkspace.resolve(
+        repo_with_coord_branch, MISSION_SLUG, MID8,
+    )
+
+    assert recovered == path
+    assert recovered.exists()
+    assert "prunable" not in _worktree_list(repo_with_coord_branch)
+
+
 def test_resolve_branch_mismatch_raises(repo_with_coord_branch: Path) -> None:
     path = CoordinationWorkspace.resolve(
         repo_with_coord_branch, MISSION_SLUG, MID8,
@@ -139,6 +166,25 @@ def test_teardown_idempotent(repo_with_coord_branch: Path) -> None:
         repo_with_coord_branch, MISSION_SLUG, MID8,
     )
     assert not path.exists()
+
+
+def test_teardown_prunes_stale_missing_registration(
+    repo_with_coord_branch: Path,
+) -> None:
+    path = CoordinationWorkspace.resolve(
+        repo_with_coord_branch, MISSION_SLUG, MID8,
+    )
+    shutil.rmtree(path)
+    assert not path.exists()
+    assert "prunable" in _worktree_list(repo_with_coord_branch)
+
+    CoordinationWorkspace.teardown(
+        repo_with_coord_branch, MISSION_SLUG, MID8,
+    )
+
+    worktree_list = _worktree_list(repo_with_coord_branch)
+    assert str(path) not in worktree_list
+    assert "prunable" not in worktree_list
 
 
 def test_teardown_does_not_delete_branch(


### PR DESCRIPTION
## Summary

- Closes #1463.
- Add regression coverage for `CoordinationWorkspace.resolve()` after a bare `rm -rf` leaves Git's canonical coordination worktree registration prunable.
- Add adjacent teardown coverage for the same stale missing registration state.
- Fix the owning coordination-workspace boundary by detecting the exact stale registration with `git worktree list --porcelain`, removing only that registration with `git worktree remove --force <path>`, then proceeding with normal resolve/teardown behavior.

## Regression Test

The new tests reproduce the current failure mode in an isolated real git repo fixture:

- `test_resolve_recovers_stale_prunable_registration`
- `test_teardown_prunes_stale_missing_registration`

TDD red state confirmed before fix: `resolve()` failed with Git exit 128: missing but already registered worktree; `teardown()` left the prunable registration behind.

## Verification

- `uv run pytest tests/specify_cli/coordination/test_workspace.py -q` -> 10 passed
- `uv run pytest tests/specify_cli/coordination/test_transaction.py tests/specify_cli/coordination/test_sparse_checkout.py tests/specify_cli/cli/commands/test_doctor_coordination.py tests/integration/test_mission_close.py -q` -> 42 passed
- `uv run ruff check src/specify_cli/coordination/workspace.py tests/specify_cli/coordination/test_workspace.py` -> passed
- `git diff --check` -> passed
- `uv run ruff check` -> failed on pre-existing unrelated lint in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`; touched files were clean.

## Self-Review

Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` locally before PR handoff.

Finding fixed before PR: initial implementation used `git worktree prune`, which could clear unrelated stale registrations. Replaced it with exact-path `git worktree remove --force <path>` after proving Git accepts that command for a missing-but-registered worktree.

No merge-blocking self-review findings remain.
