### PR TITLE
Fix doctrine new suffixes for agent profiles and step contracts

### DIFF
--- a/src/specify_cli/cli/commands/doctrine.py
+++ b/src/specify_cli/cli/commands/doctrine.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import typer
+from doctrine.artifact_kinds import ArtifactKind
 from rich.console import Console
 
 __all__ = ["app"]
@@ -254,6 +255,14 @@ _CANONICAL_KIND_SINGULAR_TO_PLURAL: dict[str, str] = {
 #: tightens a required field, the next ``doctrine new`` invocation will
 #: surface the mismatch immediately rather than silently scaffolding an
 #: invalid file.
+def _artifact_filename(kind_singular: str, artifact_id: str) -> str:
+    """Return the canonical filename for a doctrine artifact."""
+    glob_pattern = ArtifactKind(kind_singular).glob_pattern
+    if not glob_pattern.startswith("*"):
+        raise ValueError(f"Unsupported artifact kind: {kind_singular}")
+    return f"{artifact_id}{glob_pattern.removeprefix('*')}"
+
+
 def _stub_template(kind_singular: str, artifact_id: str) -> str:
     """Return the canonical YAML stub for ``kind_singular`` populated with ``artifact_id``."""
     if kind_singular == "directive":
@@ -417,7 +426,7 @@ def new(
 
     target_dir = doctrine_root / plural
     target_dir.mkdir(parents=True, exist_ok=True)
-    target_path = target_dir / f"{artifact_id}.{kind_singular}.yaml"
+    target_path = target_dir / _artifact_filename(kind_singular, artifact_id)
 
     if target_path.exists():
         console.print(

--- a/tests/specify_cli/cli/commands/test_doctrine_new.py
+++ b/tests/specify_cli/cli/commands/test_doctrine_new.py
@@ -84,6 +84,49 @@ def test_new_validates_stub_against_schema_so_validate_passes(tmp_path: Path) ->
     assert "OK" in result_validate.stdout
 
 
+@pytest.mark.parametrize(
+    ("kind", "artifact_id", "plural", "filename"),
+    [
+        ("agent_profile", "sample-agent", "agent_profiles", "sample-agent.agent.yaml"),
+        (
+            "mission_step_contract",
+            "sample-step",
+            "mission_step_contracts",
+            "sample-step.step-contract.yaml",
+        ),
+    ],
+)
+def test_new_special_kind_suffixes_validate_on_first_emit(
+    tmp_path: Path,
+    kind: str,
+    artifact_id: str,
+    plural: str,
+    filename: str,
+) -> None:
+    """Special-kind scaffold filenames MUST match ``doctrine validate`` suffixes."""
+    project = _make_project_root(tmp_path)
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(project)
+        result_new = runner.invoke(
+            doctrine_app, ["new", kind, artifact_id], catch_exceptions=False
+        )
+        assert result_new.exit_code == 0, result_new.stdout
+
+        target = project / ".kittify" / "doctrine" / plural / filename
+        assert target.exists()
+
+        result_validate = runner.invoke(
+            doctrine_app, ["validate", str(target)], catch_exceptions=False
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    assert result_validate.exit_code == 0, result_validate.stdout
+    assert "OK" in result_validate.stdout
+
+
 def test_new_refuses_to_overwrite_existing_file(tmp_path: Path) -> None:
     """Re-running ``doctrine new`` on the same id fails with a clear message."""
     project = _make_project_root(tmp_path)

--- a/tests/specify_cli/cli/commands/test_doctrine_validate.py
+++ b/tests/specify_cli/cli/commands/test_doctrine_validate.py
@@ -116,7 +116,8 @@ def test_validate_rejects_unknown_suffix(tmp_path: Path) -> None:
     result = runner.invoke(doctrine_app, ["validate", str(target)], catch_exceptions=False)
 
     assert result.exit_code == 1
-    assert "unrecognised artifact filename suffix" in result.stdout
+    flat = " ".join(result.stdout.split())
+    assert "unrecognised artifact filename suffix" in flat
 
 
 def test_validate_missing_path_returns_2(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes https://github.com/Priivacy-ai/spec-kitty/issues/1450.

`spec-kitty doctrine new` now derives scaffold filenames from the canonical `ArtifactKind.glob_pattern`, so special kinds emit validator-compatible files:

- `agent_profile` -> `*.agent.yaml`
- `mission_step_contract` -> `*.step-contract.yaml`

Also adds regression coverage proving both special-kind scaffolds validate immediately after creation.

## Verification

- Red first: `.venv/bin/python -m pytest tests/specify_cli/cli/commands/test_doctrine_new.py::test_new_special_kind_suffixes_validate_on_first_emit -q` failed before production fix because canonical target files did not exist.
- Focused regression: `.venv/bin/python -m pytest tests/specify_cli/cli/commands/test_doctrine_new.py::test_new_special_kind_suffixes_validate_on_first_emit -q` -> 2 passed.
- Adjacent tests: `.venv/bin/python -m pytest tests/specify_cli/cli/commands/test_doctrine_new.py tests/specify_cli/cli/commands/test_doctrine_validate.py tests/doctrine/test_artifact_kinds.py -q` -> 44 passed.
- Public CLI repro: `spec-kitty doctrine new agent_profile sample-agent` + `doctrine validate .../sample-agent.agent.yaml` -> pass; `spec-kitty doctrine new mission_step_contract sample-step` + `doctrine validate .../sample-step.step-contract.yaml` -> pass.
- Patch-surface lint: `.venv/bin/ruff check src/specify_cli/cli/commands/doctrine.py tests/specify_cli/cli/commands/test_doctrine_new.py tests/specify_cli/cli/commands/test_doctrine_validate.py` -> pass.
- Required full lint attempted: `uv run --extra lint ruff check` -> fails on unrelated existing files under `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/`.
- `git diff --check` -> pass.

## Self-review

Ran adversarial self-review using `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` against the local diff. Verdict: SAFE. No merge-blocking findings; residual risk is the unrelated repository-wide ruff baseline above.
