### PR TITLE
Fix PR-bound mission create JSON abort

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -733,11 +733,23 @@ def create_mission(
             current_branch=current_branch,
             merge_target_branch=effective_merge_target,
             branch_strategy=branch_strategy,
-            prompt=lambda message: typer.confirm(message, default=False),
+            prompt=None if json_output else lambda message: typer.confirm(message, default=False),
         )
     except BranchStrategyGateError as exc:
         if json_output:
-            _emit_json({"error": str(exc)})
+            _emit_json(
+                {
+                    "error_code": "BRANCH_STRATEGY_CONFIRMATION_REQUIRED",
+                    "error": (
+                        "PR-bound mission creation requires explicit branch-strategy "
+                        "confirmation in --json mode."
+                    ),
+                    "branch_strategy_gate": "confirmation_required",
+                    "current_branch": current_branch,
+                    "merge_target_branch": effective_merge_target,
+                    "remediation": "Pass `--branch-strategy already-confirmed` or run without --json to confirm interactively.",
+                }
+            )
         else:
             console.print(f"[bold red]Error:[/bold red] {exc}")
         raise typer.Exit(1) from exc

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -112,6 +112,19 @@ def _branch_sha(repo: Path, branch: str) -> str:
     return _git(repo, "rev-parse", branch).stdout.strip()
 
 
+def _json_payload_from_output(output: str) -> dict[str, Any]:
+    """Return the first JSON object emitted by the CLI."""
+    for line in output.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    pytest.fail(f"No JSON payload in CLI output: {output!r}")
+
+
 # ---------------------------------------------------------------------------
 # Pure-helper tests (no CLI, no mission scaffold)
 # ---------------------------------------------------------------------------
@@ -325,3 +338,89 @@ def test_create_json_output_contains_coordination_branch(tmp_path: Path) -> None
     assert "coordination_branch" in payload
     assert payload["coordination_branch"].startswith("kitty/mission-cli-json-test-")
     assert payload["coordination_branch_created"] is True
+
+
+def test_pr_bound_create_json_refuses_with_json_instead_of_prompt_abort(tmp_path: Path) -> None:
+    """Issue #1451: ``--pr-bound --json`` must not call the interactive prompt."""
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
+        patch(f"{_CORE_MODULE}.emit_mission_created"),
+        patch(f"{_CORE_MODULE}._commit_feature_file"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main"),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "json-pr-bound",
+                "--pr-bound",
+                "--json",
+                "--target-branch",
+                "main",
+                "--friendly-name",
+                "JSON PR Bound",
+                "--purpose-tldr",
+                "Validate JSON branch-strategy refusal.",
+                "--purpose-context",
+                "Issue #1451 — scripted callers need machine-parseable output.",
+            ],
+            input="",
+        )
+
+    assert result.exit_code == 1
+    assert "Aborted" not in result.output
+    assert "Proceed anyway?" not in result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["error_code"] == "BRANCH_STRATEGY_CONFIRMATION_REQUIRED"
+    assert payload["branch_strategy_gate"] == "confirmation_required"
+    assert "already-confirmed" in payload["remediation"]
+
+
+def test_pr_bound_create_json_already_confirmed_preserves_success_path(tmp_path: Path) -> None:
+    """The non-interactive JSON refusal must not break the explicit automation bypass."""
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
+        patch(f"{_CORE_MODULE}.emit_mission_created"),
+        patch(f"{_CORE_MODULE}._commit_feature_file"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main"),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "json-pr-bound-confirmed",
+                "--pr-bound",
+                "--branch-strategy",
+                "already-confirmed",
+                "--json",
+                "--target-branch",
+                "main",
+                "--friendly-name",
+                "JSON PR Bound Confirmed",
+                "--purpose-tldr",
+                "Validate confirmed PR-bound create.",
+                "--purpose-context",
+                "Automation can bypass the gate explicitly and still receive JSON.",
+            ],
+            input="",
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["result"] == "success"
+    meta = json.loads(Path(str(payload["meta_file"])).read_text(encoding="utf-8"))
+    assert meta["pr_bound"] is True


### PR DESCRIPTION
## Summary
- Fixes https://github.com/Priivacy-ai/spec-kitty/issues/1451
- Keeps `agent mission create --pr-bound --json` from invoking the interactive branch-strategy prompt
- Emits deterministic JSON with `BRANCH_STRATEGY_CONFIRMATION_REQUIRED` when explicit confirmation is missing
- Preserves the `--branch-strategy already-confirmed` JSON success path and `pr_bound` metadata persistence

## Verification
- TDD red: `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_mission_create.py -k 'pr_bound_create_json' -q` failed on prompt/`Aborted.` before fix
- PASS: `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_mission_create.py -k 'pr_bound_create_json' -q`
- PASS: `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_mission_create.py -q`
- PASS: `.venv/bin/pytest tests/integration/test_branch_strategy_gate.py -q`
- PASS: `.venv/bin/ruff check src/specify_cli/cli/commands/agent/mission.py tests/specify_cli/cli/commands/agent/test_mission_create.py`
- PASS: `git diff --check`
- FAIL (unrelated baseline): `.venv/bin/ruff check` reports existing issues in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`; no changed-file ruff errors

## Self-review
- Ran adversarial-pr-review locally against branch diff
- Verdict: SAFE; no merge-blocking findings after focused machine-contract, branch-gate, and positive-path checks
