### PR TITLE
Fix agent profile context-sources guide retention

### DIFF
--- a/src/doctrine/agent_profiles/profile.py
+++ b/src/doctrine/agent_profiles/profile.py
@@ -139,10 +139,13 @@ class SpecializationContext(BaseModel):
 class ContextSources(BaseModel):
     """Doctrine context sources this agent loads."""
 
-    model_config = ConfigDict(frozen=True, populate_by_name=True)
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
 
     doctrine_layers: list[str] = Field(default_factory=list, alias="doctrine-layers")
     directives: list[str] = Field(default_factory=list)
+    tactics: list[str] = Field(default_factory=list)
+    toolguides: list[str] = Field(default_factory=list)
+    styleguides: list[str] = Field(default_factory=list)
     additional: list[str] = Field(default_factory=list)
 
 

--- a/tests/doctrine/test_profile_model.py
+++ b/tests/doctrine/test_profile_model.py
@@ -266,6 +266,48 @@ class TestAgentProfileInterface:
         assert profile.routing_priority == 75
         assert profile.max_concurrent_tasks == 3
 
+    def test_context_sources_preserve_schema_declared_artifact_lists(self):
+        """Runtime model preserves all schema-approved context-sources lists."""
+        data = {
+            "profile-id": "context-source-artifacts",
+            "name": "Context Source Artifacts",
+            "purpose": "Prove context-sources artifact lists survive validation",
+            "roles": ["reviewer"],
+            "specialization": {"primary-focus": "testing"},
+            "context-sources": {
+                "doctrine-layers": ["directives", "tactics", "toolguides"],
+                "directives": ["001"],
+                "tactics": ["code-review-incremental"],
+                "toolguides": ["python-review-checks"],
+                "styleguides": ["python-conventions"],
+                "additional": ["review-checklist"],
+            },
+        }
+
+        profile = AgentProfile.model_validate(data)
+
+        assert profile.context_sources.tactics == ["code-review-incremental"]
+        assert profile.context_sources.toolguides == ["python-review-checks"]
+        assert profile.context_sources.styleguides == ["python-conventions"]
+
+    def test_context_sources_reject_unknown_keys(self):
+        """Runtime context-sources must not silently drop unsupported fields."""
+        data = {
+            "profile-id": "context-source-unknown",
+            "name": "Context Source Unknown",
+            "purpose": "Prove unsupported context-sources fields are explicit errors",
+            "roles": ["reviewer"],
+            "specialization": {"primary-focus": "testing"},
+            "context-sources": {
+                "doctrine-layers": ["directives"],
+                "directives": ["001"],
+                "unknown-guide-kind": ["silent-drop"],
+            },
+        }
+
+        with pytest.raises(ValidationError, match="unknown-guide-kind"):
+            AgentProfile.model_validate(data)
+
 
 class TestAgentProfileExceptions:
     """Exceptions: Missing required fields."""

--- a/tests/doctrine/test_shipped_profiles.py
+++ b/tests/doctrine/test_shipped_profiles.py
@@ -326,6 +326,38 @@ class TestShippedProfilesContextSources:
         assert profile is not None
         assert len(profile.directive_references) > 0, f"Profile '{profile_id}' has no directive references"
 
+    @pytest.mark.parametrize(
+        "profile_id,expected_tactics",
+        [
+            (
+                "debugger-debbie",
+                [
+                    "five-paradigm-parallel-debugging",
+                    "code-review-incremental",
+                    "review-intent-and-risk-first",
+                ],
+            ),
+            (
+                "reviewer-renata",
+                [
+                    "code-review-incremental",
+                    "language-driven-design",
+                    "reverse-speccing",
+                ],
+            ),
+        ],
+    )
+    def test_context_sources_preserve_shipped_tactic_lists(
+        self,
+        repo: AgentProfileRepository,
+        profile_id: str,
+        expected_tactics: list[str],
+    ):
+        """Shipped context-sources.tactics survive repository validation/loading."""
+        profile = repo.get(profile_id)
+        assert profile is not None
+        assert profile.context_sources.tactics == expected_tactics
+
 
 class TestShippedProfilesPerformance:
     """Performance gate: loading all shipped profiles must complete quickly."""


### PR DESCRIPTION
Closes #1455

## Summary
- Adds runtime `ContextSources` fields for schema-declared `tactics`, `toolguides`, and `styleguides` so agent profile YAML values are preserved instead of silently dropped.
- Aligns `ContextSources` with the schema twin by forbidding unknown nested context-source keys.
- Adds regression coverage for synthetic schema-declared artifact lists and shipped `debugger-debbie` / `reviewer-renata` `context-sources.tactics`.

## TDD / Regression
- First added failing tests proving `ContextSources` had no `tactics` attribute and shipped profile tactic lists were dropped.
- Then fixed the owning domain model boundary in `src/doctrine/agent_profiles/profile.py`.

## Self-review
- Ran requested adversarial self-review against the local diff. Verdict: SAFE. No merge-blocking finding survived.
- Checked bounded-context ownership, schema/runtime parity, repository load behavior, prompt-adjacent consumers, and unknown-field silent-drop risk.

## Verification
- PASS: `.venv/bin/pytest tests/doctrine/test_profile_model.py::TestAgentProfileInterface::test_context_sources_preserve_schema_declared_artifact_lists tests/doctrine/test_profile_model.py::TestAgentProfileInterface::test_context_sources_reject_unknown_keys -q`
- PASS: `.venv/bin/pytest tests/doctrine/test_shipped_profiles.py::TestShippedProfilesContextSources::test_context_sources_preserve_shipped_tactic_lists -q`
- PASS: `.venv/bin/pytest tests/doctrine/test_profile_model.py tests/doctrine/test_shipped_profiles.py tests/doctrine/test_profile_repository.py tests/doctrine/test_debugger_debbie_artifacts.py -q` (328 passed)
- PASS: `.venv/bin/pytest tests/charter/test_context_profile.py tests/specify_cli/next/test_wp_prompt_governance_contract.py -q` (37 passed)
- PASS: `.venv/bin/ruff check src/doctrine/agent_profiles/profile.py tests/doctrine/test_profile_model.py tests/doctrine/test_shipped_profiles.py`
- PASS: `git diff --check`
- NOTE: full `.venv/bin/ruff check` was run and fails on pre-existing unrelated lint in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/.../baseline/capture.py`, and `scripts/*`; touched-file ruff is clean.