### PR TITLE
Fix workflow typer.Exit error wrapping

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1421,6 +1421,10 @@ def implement(
         print(f'  3. spec-kitty agent tasks move-task {normalized_wp_id} --to for_review --mission {mission_slug} --note "Ready for review"')
         print("     (Pre-flight check will verify no uncommitted changes)")
 
+    except typer.Exit:
+        with contextlib.suppress(Exception):
+            _print_commit_summary(command_name="implement")
+        raise
     except Exception as e:
         # WP06 T029: surface any partial commit summary before exiting,
         # so operators see what got recorded vs. refused.
@@ -2294,6 +2298,10 @@ def review(
         print(f'  ✅ spec-kitty agent tasks move-task {normalized_wp_id} --to approved --mission {mission_slug} --note "Review passed"')
         print(f"  ❌ spec-kitty agent tasks move-task {normalized_wp_id} --to planned --review-feedback-file {review_feedback_path} --mission {mission_slug}")
 
+    except typer.Exit:
+        with contextlib.suppress(Exception):
+            _print_commit_summary(command_name="review")
+        raise
     except Exception as e:
         with contextlib.suppress(Exception):
             _print_commit_summary(command_name="review")

--- a/tests/agent/test_workflow_review_lane_gate.py
+++ b/tests/agent/test_workflow_review_lane_gate.py
@@ -116,6 +116,23 @@ def test_workflow_review_rejects_planned_lane(workflow_repo: Path) -> None:
     assert extract_scalar(frontmatter, "lane") == "planned"
 
 
+@pytest.mark.parametrize("command", ["implement", "review"])
+def test_workflow_commands_do_not_print_spurious_error_for_handled_exit(
+    command: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("specify_cli.cli.commands.agent.workflow.locate_project_root", lambda: None)
+
+    result = CliRunner().invoke(
+        workflow.app,
+        [command, "WP01", "--mission", "001-test-feature", "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: Could not locate project root" in result.stdout
+    assert "Error: 1" not in result.stdout
+
+
 def test_workflow_review_accepts_for_review_lane(workflow_repo: Path) -> None:
     mission_slug = "001-test-feature"
     feature_dir = workflow_repo / "kitty-specs" / mission_slug


### PR DESCRIPTION
Fixes #1460.

## Summary
- Add regression coverage for `agent action implement` and `agent action review` handled exits so they keep the real error and do not append phantom `Error: 1`.
- Add `except typer.Exit` before the broad workflow exception handlers, preserving the existing commit-summary output before re-raising.

## Self-review
- Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` locally against the branch diff.
- Initial self-review finding: bare `except typer.Exit: raise` would suppress existing partial commit summaries on handled exits. Fixed by printing the accumulated commit summary before re-raising.
- Final self-review verdict: SAFE; no remaining merge blockers found.

## Verification
- Red TDD check before fix: `.venv/bin/pytest tests/agent/test_workflow_review_lane_gate.py::test_workflow_commands_do_not_print_spurious_error_for_handled_exit -q` failed on both implement/review with `Error: 1`.
- `.venv/bin/pytest tests/agent/test_workflow_review_lane_gate.py::test_workflow_commands_do_not_print_spurious_error_for_handled_exit -q` passed.
- `.venv/bin/pytest tests/agent/test_workflow_review_lane_gate.py -q` passed: 13 passed, 1 warning.
- `.venv/bin/pytest tests/agent/test_workflow_feedback_pointer_2x_unit.py tests/agent/test_workflow_charter_context.py tests/agent/test_workflow_mixed_dependency_review_context.py tests/agent/test_workflow_review_cycle_pointer.py tests/agent/test_workflow_review_lane_gate.py -q` passed: 37 passed, 9 skipped, 1 warning.
- `.venv/bin/ruff check src/specify_cli/cli/commands/agent/workflow.py tests/agent/test_workflow_review_lane_gate.py` passed.
- `git diff --check` passed.
- `ruff check` was run and failed on pre-existing unrelated lint in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`; this PR does not touch those files.