### PR TITLE
Fix neutrality banned term case sensitivity

### DIFF
--- a/src/charter/neutrality/lint.py
+++ b/src/charter/neutrality/lint.py
@@ -78,7 +78,8 @@ class _CompiledTerm:
     term_id: str
     kind: str  # "literal" | "regex"
     pattern: str
-    compiled: re.Pattern[str] | None  # None for literal
+    case_sensitive: bool
+    compiled: re.Pattern[str] | None  # regex terms, plus case-insensitive literals
 
 
 def _is_glob_pattern(path_spec: str) -> bool:
@@ -94,13 +95,25 @@ def _load_banned_terms(path: Path) -> list[_CompiledTerm]:
         term_id: str = entry["id"]
         kind: str = entry["kind"]
         pattern: str = entry["pattern"]
+        case_sensitive: bool = entry.get("case_sensitive", True)
         compiled: re.Pattern[str] | None = None
+        flags = re.MULTILINE if case_sensitive else re.MULTILINE | re.IGNORECASE
         if kind == "regex":
             try:
-                compiled = re.compile(pattern, re.MULTILINE)
+                compiled = re.compile(pattern, flags)
             except re.error as exc:
                 raise ValueError(f"Banned term {term_id!r} has invalid regex pattern {pattern!r}: {exc}") from exc
-        terms.append(_CompiledTerm(term_id=term_id, kind=kind, pattern=pattern, compiled=compiled))
+        elif not case_sensitive:
+            compiled = re.compile(re.escape(pattern), flags)
+        terms.append(
+            _CompiledTerm(
+                term_id=term_id,
+                kind=kind,
+                pattern=pattern,
+                case_sensitive=case_sensitive,
+                compiled=compiled,
+            )
+        )
     return terms
 
 
@@ -219,6 +232,13 @@ def _scan_literal_matches(
 ) -> list[BannedTermHit]:
     """Return all literal matches for one term on one line."""
     hits: list[BannedTermHit] = []
+    if not term.case_sensitive:
+        assert term.compiled is not None
+        return [
+            _make_hit(repo_relative, lineno, match.start() + 1, term, match.group(0))
+            for match in term.compiled.finditer(line_text)
+        ]
+
     idx = 0
     while True:
         pos = line_text.find(term.pattern, idx)

--- a/tests/charter/test_neutrality_lint.py
+++ b/tests/charter/test_neutrality_lint.py
@@ -328,6 +328,78 @@ def test_regex_term_reports_accurate_column(tmp_path: Path) -> None:
     assert hit.match == "pip install"
 
 
+def test_case_sensitive_false_matches_literal_and_regex_terms(tmp_path: Path) -> None:
+    """Per-term ``case_sensitive: false`` must make literal and regex terms ignore case."""
+    scan_root = tmp_path / "src" / "doctrine"
+    scan_root.mkdir(parents=True)
+    target = scan_root / "mixed-case.md"
+    target.write_text("Run PyTest, then use PIP INSTALL foo.\n", encoding="utf-8")
+
+    banned_terms = tmp_path / "banned.yaml"
+    banned_terms.write_text(
+        "schema_version: '1'\n"
+        "terms:\n"
+        "  - id: PY-900\n"
+        "    kind: literal\n"
+        "    pattern: pytest\n"
+        "    rationale: Case-insensitive literal regression fixture.\n"
+        "    case_sensitive: false\n"
+        "  - id: PY-901\n"
+        "    kind: regex\n"
+        "    pattern: \"\\\\bpip install\\\\b\"\n"
+        "    rationale: Case-insensitive regex regression fixture.\n"
+        "    case_sensitive: false\n",
+        encoding="utf-8",
+    )
+    empty_allowlist = tmp_path / "allow.yaml"
+    empty_allowlist.write_text("schema_version: '1'\npaths: []\n", encoding="utf-8")
+
+    result = run_neutrality_lint(
+        repo_root=tmp_path,
+        scan_roots=[scan_root],
+        banned_terms_path=banned_terms,
+        allowlist_path=empty_allowlist,
+    )
+
+    hits_by_id = {hit.term_id: hit for hit in result.hits}
+    assert hits_by_id["PY-900"].match == "PyTest"
+    assert hits_by_id["PY-901"].match == "PIP INSTALL"
+
+
+def test_banned_terms_remain_case_sensitive_by_default(tmp_path: Path) -> None:
+    """Omitted ``case_sensitive`` keeps the schema default: exact-case matching."""
+    scan_root = tmp_path / "src" / "doctrine"
+    scan_root.mkdir(parents=True)
+    target = scan_root / "mixed-case-default.md"
+    target.write_text("Run PyTest, then use PIP INSTALL foo.\n", encoding="utf-8")
+
+    banned_terms = tmp_path / "banned.yaml"
+    banned_terms.write_text(
+        "schema_version: '1'\n"
+        "terms:\n"
+        "  - id: PY-900\n"
+        "    kind: literal\n"
+        "    pattern: pytest\n"
+        "    rationale: Default-sensitive literal regression fixture.\n"
+        "  - id: PY-901\n"
+        "    kind: regex\n"
+        "    pattern: \"\\\\bpip install\\\\b\"\n"
+        "    rationale: Default-sensitive regex regression fixture.\n",
+        encoding="utf-8",
+    )
+    empty_allowlist = tmp_path / "allow.yaml"
+    empty_allowlist.write_text("schema_version: '1'\npaths: []\n", encoding="utf-8")
+
+    result = run_neutrality_lint(
+        repo_root=tmp_path,
+        scan_roots=[scan_root],
+        banned_terms_path=banned_terms,
+        allowlist_path=empty_allowlist,
+    )
+
+    assert result.passed, f"Expected no case-mismatched hits by default; got hits={result.hits}"
+
+
 # ---------------------------------------------------------------------------
 # T012 — Runtime budget (NFR-001)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- honor `case_sensitive` from `src/charter/neutrality/banned_terms.yaml` entries
- compile case-insensitive regex terms with `re.IGNORECASE`
- support case-insensitive literal terms while preserving actual matched text
- add regression coverage for `case_sensitive: false` and default true behavior

Fixes #1454

## Verification
- TDD pre-fix: `.venv/bin/pytest tests/charter/test_neutrality_lint.py -k case_sensitive` failed before production change (`KeyError: 'PY-900'`)
- `.venv/bin/pytest tests/charter/test_neutrality_lint.py -k case_sensitive` -> 2 passed
- `.venv/bin/pytest tests/charter/test_neutrality_lint.py` -> 12 passed
- `.venv/bin/pytest tests/charter/synthesizer/test_write_pipeline.py` -> 16 passed
- `.venv/bin/ruff check src/charter/neutrality/lint.py tests/charter/test_neutrality_lint.py` -> passed
- `git diff --check` -> passed
- `.venv/bin/ruff check` -> fails on 22 pre-existing unrelated findings outside this diff (`.kittify/`, `scripts/`, `kitty-specs/`)

## Self-review
- Ran adversarial self-review against local diff before PR handoff: verdict SAFE, no merge-blocking findings.
