### PR TITLE
Fix audit OSError path leaks

### DIFF
--- a/src/specify_cli/audit/classifiers/_details.py
+++ b/src/specify_cli/audit/classifiers/_details.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+import re
+
+_POSIX_ABSOLUTE_PATH_RE = re.compile(r"(?<!\w)/(?:[^\s'\"<>:]+/)*[^\s'\"<>:]+")
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(
+    r"(?i)\b[A-Z]:\\(?:[^\\\s'\"<>:]+\\)*[^\\\s'\"<>:]+"
+)
+_WINDOWS_UNC_PATH_RE = re.compile(
+    r"\\\\[^\\\s'\"<>:]+\\[^\\\s'\"<>:]+(?:\\[^\\\s'\"<>:]+)*"
+)
+
 
 def format_exception_detail(exc: Exception) -> str:
     """Return exception detail with OSError filename data removed."""
@@ -14,6 +24,8 @@ def _format_os_error_detail(exc: OSError) -> str:
     exc_type = type(exc).__name__
     errno = getattr(exc, "errno", None)
     strerror = getattr(exc, "strerror", None)
+    if strerror:
+        strerror = _sanitize_run_varying_paths(strerror)
 
     if errno is not None and strerror:
         return f"{exc_type}: [Errno {errno}] {strerror}"
@@ -21,3 +33,9 @@ def _format_os_error_detail(exc: OSError) -> str:
         return f"{exc_type}: {strerror}"
 
     return exc_type
+
+
+def _sanitize_run_varying_paths(text: str) -> str:
+    text = _WINDOWS_UNC_PATH_RE.sub("<path>", text)
+    text = _WINDOWS_ABSOLUTE_PATH_RE.sub("<path>", text)
+    return _POSIX_ABSOLUTE_PATH_RE.sub("<path>", text)

--- a/src/specify_cli/audit/classifiers/_details.py
+++ b/src/specify_cli/audit/classifiers/_details.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import re
 
-_POSIX_ABSOLUTE_PATH_RE = re.compile(r"(?<!\w)/(?:[^\s'\"<>:]+/)*[^\s'\"<>:]+")
+_POSIX_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![\w:/])/(?:[^/:\r\n'\"<>]+/)[^:\r\n'\"<>]*"
+)
 _WINDOWS_ABSOLUTE_PATH_RE = re.compile(
-    r"(?i)\b[A-Z]:\\(?:[^\\\s'\"<>:]+\\)*[^\\\s'\"<>:]+"
+    r"(?i)\b[A-Z]:\\[^\r\n'\"<>|]*"
 )
 _WINDOWS_UNC_PATH_RE = re.compile(
-    r"\\\\[^\\\s'\"<>:]+\\[^\\\s'\"<>:]+(?:\\[^\\\s'\"<>:]+)*"
+    r"\\\\[^\\\r\n'\"<>|]+\\[^\r\n'\"<>|]*"
 )
 
 
@@ -31,6 +33,8 @@ def _format_os_error_detail(exc: OSError) -> str:
         return f"{exc_type}: [Errno {errno}] {strerror}"
     if strerror:
         return f"{exc_type}: {strerror}"
+    if len(exc.args) == 1 and isinstance(exc.args[0], str) and exc.args[0]:
+        return f"{exc_type}: {_sanitize_run_varying_paths(exc.args[0])}"
 
     return exc_type
 

--- a/src/specify_cli/audit/classifiers/_details.py
+++ b/src/specify_cli/audit/classifiers/_details.py
@@ -1,0 +1,23 @@
+"""Deterministic audit finding detail helpers."""
+
+from __future__ import annotations
+
+
+def format_exception_detail(exc: Exception) -> str:
+    """Return exception detail with OSError filename data removed."""
+    if isinstance(exc, OSError):
+        return _format_os_error_detail(exc)
+    return str(exc)
+
+
+def _format_os_error_detail(exc: OSError) -> str:
+    exc_type = type(exc).__name__
+    errno = getattr(exc, "errno", None)
+    strerror = getattr(exc, "strerror", None)
+
+    if errno is not None and strerror:
+        return f"{exc_type}: [Errno {errno}] {strerror}"
+    if strerror:
+        return f"{exc_type}: {strerror}"
+
+    return exc_type

--- a/src/specify_cli/audit/classifiers/_details.py
+++ b/src/specify_cli/audit/classifiers/_details.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import re
 
 _POSIX_ABSOLUTE_PATH_RE = re.compile(
-    r"(?<![\w:/])/(?:[^/:\r\n'\"<>]+/)[^:\r\n'\"<>]*"
+    r"(?<![\w:/])/(?:[^/:\r\n'\"<>]+/)[^\r\n'\"<>]*"
+)
+_POSIX_SINGLE_COMPONENT_PATH_RE = re.compile(
+    r"(?<![\w:/])/(?:"
+    r"tmp|var|private|Users|home|etc|opt|usr|bin|sbin|dev|Volumes|"
+    r"System|Library|Applications|[^/\s:\r\n'\"<>]*\.[^/\s:\r\n'\"<>]+"
+    r")(?![\w/.-])"
 )
 _WINDOWS_ABSOLUTE_PATH_RE = re.compile(
     r"(?i)\b[A-Z]:\\[^\r\n'\"<>|]*"
@@ -42,4 +48,5 @@ def _format_os_error_detail(exc: OSError) -> str:
 def _sanitize_run_varying_paths(text: str) -> str:
     text = _WINDOWS_UNC_PATH_RE.sub("<path>", text)
     text = _WINDOWS_ABSOLUTE_PATH_RE.sub("<path>", text)
-    return _POSIX_ABSOLUTE_PATH_RE.sub("<path>", text)
+    text = _POSIX_ABSOLUTE_PATH_RE.sub("<path>", text)
+    return _POSIX_SINGLE_COMPONENT_PATH_RE.sub("<path>", text)

--- a/src/specify_cli/audit/classifiers/mission_events.py
+++ b/src/specify_cli/audit/classifiers/mission_events.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from ..detectors import detect_legacy_keys
 from ..models import MissionFinding, Severity
 from ..shape_registry import check_unknown_keys
+from ._details import format_exception_detail
 
 
 def _classify_jsonl_file(
@@ -43,7 +44,7 @@ def _classify_jsonl_file(
                 code="CORRUPT_JSONL",
                 severity=Severity.ERROR,
                 artifact_path=artifact_path,
-                detail=f"could not read file: {exc}",
+                detail=f"could not read file: {format_exception_detail(exc)}",
             )
         ]
 

--- a/src/specify_cli/audit/classifiers/status_events.py
+++ b/src/specify_cli/audit/classifiers/status_events.py
@@ -13,6 +13,7 @@ from ..detectors import (
 )
 from ..models import MissionFinding, Severity
 from ..shape_registry import check_unknown_keys
+from ._details import format_exception_detail
 
 # Actor format research (from real event logs and tests):
 #
@@ -68,7 +69,7 @@ def classify_status_events_jsonl(
                 code="CORRUPT_JSONL",
                 severity=Severity.ERROR,
                 artifact_path="status.events.jsonl",
-                detail=f"could not read file: {exc}",
+                detail=f"could not read file: {format_exception_detail(exc)}",
             )
         ], True
 

--- a/src/specify_cli/audit/classifiers/status_json.py
+++ b/src/specify_cli/audit/classifiers/status_json.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from ..detectors import detect_legacy_keys
 from ..models import MissionFinding, Severity
 from ..shape_registry import check_unknown_keys
+from ._details import format_exception_detail
 
 
 def classify_status_json(
@@ -41,6 +42,15 @@ def classify_status_json(
     try:
         raw_text = path.read_text(encoding="utf-8")
         obj: dict[str, object] = json.loads(raw_text)
+    except OSError as exc:
+        return [
+            MissionFinding(
+                code="CORRUPT_JSON",
+                severity=Severity.ERROR,
+                artifact_path="status.json",
+                detail=f"could not read file: {format_exception_detail(exc)}",
+            )
+        ]
     except json.JSONDecodeError as exc:
         return [
             MissionFinding(
@@ -74,7 +84,10 @@ def classify_status_json(
                 code="SNAPSHOT_DRIFT",
                 severity=Severity.ERROR,
                 artifact_path="status.json",
-                detail=f"reducer raised during drift check: {exc}",
+                detail=(
+                    "reducer raised during drift check: "
+                    f"{format_exception_detail(exc)}"
+                ),
             )
         )
         return findings

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 
 
+from specify_cli.audit.classifiers._details import format_exception_detail
 from specify_cli.audit.classifiers.decisions_events import classify_decisions_events_jsonl
 from specify_cli.audit.classifiers.handoff_events import classify_handoff_events_jsonl
 from specify_cli.audit.classifiers.meta import classify_meta_json
@@ -55,6 +56,40 @@ def _write_corrupt_jsonl(path: Path, corrupt_line: str = "NOT JSON {{") -> None:
 
 def _codes(findings: list) -> list[str]:
     return [f.code for f in findings]
+
+
+def test_oserror_detail_preserves_non_path_message() -> None:
+    """Message-only OSError details without paths should not be erased."""
+    assert (
+        format_exception_detail(OSError("network share unavailable"))
+        == "OSError: network share unavailable"
+    )
+
+
+def test_oserror_detail_redacts_absolute_paths_with_spaces() -> None:
+    """OSError messages may carry POSIX, Windows, or UNC paths with spaces."""
+    cases = [
+        OSError("failed reading /tmp/My Project/secret.txt"),
+        OSError(5, "failed reading /tmp/My Project/secret.txt"),
+        OSError(5, r"failed reading C:\Users\Rob Douglass\secret.txt"),
+        OSError(5, r"failed reading \\server\My Share\secret.txt"),
+    ]
+
+    for exc in cases:
+        detail = format_exception_detail(exc)
+        assert detail.endswith("failed reading <path>")
+        assert "secret.txt" not in detail
+        assert "My Project" not in detail
+        assert "Rob Douglass" not in detail
+        assert "My Share" not in detail
+
+
+def test_oserror_detail_does_not_redact_non_path_slashes_or_urls() -> None:
+    """Slash commands and URLs are stable messages, not local path evidence."""
+    assert (
+        format_exception_detail(OSError("open /help or https://example.com/path/file"))
+        == "OSError: open /help or https://example.com/path/file"
+    )
 
 
 # Minimal valid ULID
@@ -221,7 +256,7 @@ def test_status_events_read_oserror_without_errno_does_not_echo_message_path(
     findings, flag = classify_status_events_jsonl(tmp_path)
 
     assert flag is True
-    assert findings[0].detail == "could not read file: OSError"
+    assert findings[0].detail == "could not read file: OSError: failed reading <path>"
     _assert_no_absolute_path_leak(findings[0].detail, path)
 
 

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -6,6 +6,7 @@ Total: ≥ 25 test cases.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import json
 from pathlib import Path
 
@@ -82,6 +83,22 @@ def test_oserror_detail_redacts_absolute_paths_with_spaces() -> None:
         assert "My Project" not in detail
         assert "Rob Douglass" not in detail
         assert "My Share" not in detail
+
+
+def test_oserror_detail_redacts_posix_edge_paths() -> None:
+    """POSIX absolute paths may be single-segment or contain colons."""
+    cases = [
+        OSError("failed reading /tmp"),
+        OSError("failed reading /secret.txt"),
+        OSError("failed reading /tmp/project:secret.txt"),
+    ]
+
+    for exc in cases:
+        detail = format_exception_detail(exc)
+        assert detail == "OSError: failed reading <path>"
+        assert "/tmp" not in detail
+        assert "/secret.txt" not in detail
+        assert "project:secret.txt" not in detail
 
 
 def test_oserror_detail_does_not_redact_non_path_slashes_or_urls() -> None:
@@ -538,6 +555,42 @@ def test_mission_events_read_oserror_detail_is_deterministic(
     monkeypatch.setattr(Path, "read_text", raise_for_mission_events)
 
     findings = classify_mission_events_jsonl(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSONL"
+    assert findings[0].detail == (
+        "could not read file: PermissionError: [Errno 13] Permission denied"
+    )
+    _assert_no_absolute_path_leak(findings[0].detail, path)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "classifier"),
+    [
+        (Path("decisions/events.jsonl"), classify_decisions_events_jsonl),
+        (Path("handoff/events.jsonl"), classify_handoff_events_jsonl),
+    ],
+)
+def test_shared_jsonl_classifiers_read_oserror_detail_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: Path,
+    classifier: Callable[[Path], list],
+) -> None:
+    """Shared JSONL classifiers must sanitize OSError details."""
+    path = tmp_path / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def raise_for_shared_jsonl(self: Path, *args: object, **kwargs: object) -> str:
+        if self == path:
+            raise PermissionError(13, "Permission denied", str(path))
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", raise_for_shared_jsonl)
+
+    findings = classifier(tmp_path)
 
     assert len(findings) == 1
     assert findings[0].code == "CORRUPT_JSONL"

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -225,6 +225,31 @@ def test_status_events_read_oserror_without_errno_does_not_echo_message_path(
     _assert_no_absolute_path_leak(findings[0].detail, path)
 
 
+def test_status_events_read_oserror_strerror_path_is_redacted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError.strerror may be caller supplied and must not leak paths."""
+    path = tmp_path / "status.events.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def raise_for_status_events(self: Path, *args: object, **kwargs: object) -> str:
+        if self == path:
+            raise OSError(5, f"failed reading {path}")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", raise_for_status_events)
+
+    findings, flag = classify_status_events_jsonl(tmp_path)
+
+    assert flag is True
+    assert findings[0].detail == (
+        "could not read file: OSError: [Errno 5] failed reading <path>"
+    )
+    _assert_no_absolute_path_leak(findings[0].detail, path)
+
+
 def test_status_events_legacy_key(tmp_path: Path) -> None:
     """Event row with work_package_id → LEGACY_KEY finding."""
     row = {**_MODERN_EVENT, "work_package_id": "WP01"}
@@ -367,6 +392,32 @@ def test_status_json_reducer_oserror_detail_is_deterministic(
     assert drift[0].detail == (
         "reducer raised during drift check: FileNotFoundError: "
         "[Errno 2] No such file or directory"
+    )
+    _assert_no_absolute_path_leak(drift[0].detail, path)
+
+
+def test_status_json_reducer_oserror_strerror_path_is_redacted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reducer OSError.strerror paths must be redacted from drift findings."""
+    path = tmp_path / "status.events.jsonl"
+    (tmp_path / "status.json").write_text("{}", encoding="utf-8")
+
+    from specify_cli.status import reducer
+
+    def raise_reducer_oserror(mission_dir: Path) -> object:
+        assert mission_dir == tmp_path
+        raise OSError(None, f"failed reading {path}")
+
+    monkeypatch.setattr(reducer, "materialize_snapshot", raise_reducer_oserror)
+
+    findings = classify_status_json(tmp_path)
+
+    drift = [f for f in findings if f.code == "SNAPSHOT_DRIFT"]
+    assert len(drift) == 1
+    assert drift[0].detail == (
+        "reducer raised during drift check: OSError: failed reading <path>"
     )
     _assert_no_absolute_path_leak(drift[0].detail, path)
 

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -29,6 +29,12 @@ import pytest
 
 pytestmark = [pytest.mark.integration]
 
+
+def _assert_no_absolute_path_leak(detail: str | None, leaked_path: Path) -> None:
+    assert detail is not None
+    assert str(leaked_path) not in detail
+    assert leaked_path.name not in detail
+
 def _write_json(path: Path, data: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, sort_keys=True, indent=2) + "\n", encoding="utf-8")
@@ -169,6 +175,56 @@ def test_status_events_corrupt_line(tmp_path: Path) -> None:
     assert flag is True
 
 
+def test_status_events_read_oserror_detail_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unreadable status.events.jsonl must not leak absolute paths."""
+    path = tmp_path / "status.events.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def raise_for_status_events(self: Path, *args: object, **kwargs: object) -> str:
+        if self == path:
+            raise PermissionError(13, "Permission denied", str(path))
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", raise_for_status_events)
+
+    findings, flag = classify_status_events_jsonl(tmp_path)
+
+    assert flag is True
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSONL"
+    assert findings[0].detail == (
+        "could not read file: PermissionError: [Errno 13] Permission denied"
+    )
+    _assert_no_absolute_path_leak(findings[0].detail, path)
+
+
+def test_status_events_read_oserror_without_errno_does_not_echo_message_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError args without errno may include paths and must not be copied."""
+    path = tmp_path / "status.events.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def raise_for_status_events(self: Path, *args: object, **kwargs: object) -> str:
+        if self == path:
+            raise OSError(f"failed reading {path}")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", raise_for_status_events)
+
+    findings, flag = classify_status_events_jsonl(tmp_path)
+
+    assert flag is True
+    assert findings[0].detail == "could not read file: OSError"
+    _assert_no_absolute_path_leak(findings[0].detail, path)
+
+
 def test_status_events_legacy_key(tmp_path: Path) -> None:
     """Event row with work_package_id → LEGACY_KEY finding."""
     row = {**_MODERN_EVENT, "work_package_id": "WP01"}
@@ -234,6 +290,32 @@ def test_status_json_corrupt_json(tmp_path: Path) -> None:
     assert "CORRUPT_JSON" in _codes(findings)
 
 
+def test_status_json_read_oserror_detail_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unreadable status.json must not raise or leak absolute paths."""
+    path = tmp_path / "status.json"
+    path.write_text("{}", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def raise_for_status_json(self: Path, *args: object, **kwargs: object) -> str:
+        if self == path:
+            raise PermissionError(13, "Permission denied", str(path))
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", raise_for_status_json)
+
+    findings = classify_status_json(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSON"
+    assert findings[0].detail == (
+        "could not read file: PermissionError: [Errno 13] Permission denied"
+    )
+    _assert_no_absolute_path_leak(findings[0].detail, path)
+
+
 def test_status_json_skip_drift_true(tmp_path: Path) -> None:
     """skip_drift=True → no SNAPSHOT_DRIFT even with mismatched content."""
     # Write a status.json with content that would normally cause drift
@@ -260,6 +342,33 @@ def test_snapshot_drift_detected(tmp_path: Path) -> None:
     drift = [f for f in findings if f.code == "SNAPSHOT_DRIFT"]
     assert len(drift) >= 1
     assert drift[0].severity == Severity.ERROR
+
+
+def test_status_json_reducer_oserror_detail_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reducer OSError details must not leak absolute paths into findings."""
+    path = tmp_path / "status.events.jsonl"
+    (tmp_path / "status.json").write_text("{}", encoding="utf-8")
+
+    from specify_cli.status import reducer
+
+    def raise_reducer_oserror(mission_dir: Path) -> object:
+        assert mission_dir == tmp_path
+        raise FileNotFoundError(2, "No such file or directory", str(path))
+
+    monkeypatch.setattr(reducer, "materialize_snapshot", raise_reducer_oserror)
+
+    findings = classify_status_json(tmp_path)
+
+    drift = [f for f in findings if f.code == "SNAPSHOT_DRIFT"]
+    assert len(drift) == 1
+    assert drift[0].detail == (
+        "reducer raised during drift check: FileNotFoundError: "
+        "[Errno 2] No such file or directory"
+    )
+    _assert_no_absolute_path_leak(drift[0].detail, path)
 
 
 def test_status_json_retrospective_materialized_snapshot_is_not_drift(
@@ -324,6 +433,32 @@ def test_mission_events_corrupt(tmp_path: Path) -> None:
     _write_corrupt_jsonl(tmp_path / "mission-events.jsonl")
     findings = classify_mission_events_jsonl(tmp_path)
     assert "CORRUPT_JSONL" in _codes(findings)
+
+
+def test_mission_events_read_oserror_detail_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unreadable mission-events.jsonl must not leak absolute paths."""
+    path = tmp_path / "mission-events.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def raise_for_mission_events(self: Path, *args: object, **kwargs: object) -> str:
+        if self == path:
+            raise PermissionError(13, "Permission denied", str(path))
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", raise_for_mission_events)
+
+    findings = classify_mission_events_jsonl(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSONL"
+    assert findings[0].detail == (
+        "could not read file: PermissionError: [Errno 13] Permission denied"
+    )
+    _assert_no_absolute_path_leak(findings[0].detail, path)
 
 
 def test_mission_events_legacy_key(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add deterministic audit exception detail formatting for OSError paths
- sanitize status.events.jsonl, mission-events JSONL, and status.json drift/read failure findings
- add regression coverage for errno-backed and message-only OSError path leaks

Fixes https://github.com/Priivacy-ai/spec-kitty/issues/1449

## Verification
- `uv sync --frozen --all-extras`
- `./.venv/bin/pytest tests/audit/test_audit_classifiers.py -k oserror`
- `./.venv/bin/pytest tests/audit/test_audit_classifiers.py tests/audit/test_audit_engine.py tests/audit/test_audit_serializer.py tests/audit/test_audit_cli.py`
- `./.venv/bin/ruff check src/specify_cli/audit/classifiers/_details.py src/specify_cli/audit/classifiers/mission_events.py src/specify_cli/audit/classifiers/status_events.py src/specify_cli/audit/classifiers/status_json.py tests/audit/test_audit_classifiers.py`
- `git diff --check`

Note: full `./.venv/bin/ruff check` was run and fails on pre-existing unrelated files under `.kittify/`, `kitty-specs/`, and `scripts/` (22 existing findings); changed-file ruff passes.