### PR TITLE
Fix unchanged mission artifact safe_commit handling

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -497,6 +497,7 @@ def _commit_to_branch(
         if "nothing to commit" in stderr or "nothing added to commit" in stderr:
             # Benign - file unchanged
             _print_artifact_unchanged(artifact_type, json_output)
+            return
         else:
             # Actual error
             _warn_commit_failed(artifact_type, file_path, e, json_output)

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -421,6 +421,39 @@ def _ensure_branch_checked_out(
         console.print(f"[green]✓[/green] Switched to branch [bold]{target_branch}[/bold]")
 
 
+def _artifact_has_no_git_changes(repo_root: Path, file_path: Path) -> bool:
+    candidate = file_path
+    if candidate.is_absolute():
+        with contextlib.suppress(ValueError):
+            candidate = candidate.relative_to(repo_root)
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--", str(candidate)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return status.returncode == 0 and not status.stdout.strip()
+
+
+def _safe_commit_empty_changeset_error(exc: RuntimeError) -> bool:
+    return str(exc).startswith("safe_commit: git commit failed")
+
+
+def _print_artifact_unchanged(artifact_type: str, json_output: bool) -> None:
+    if not json_output:
+        console.print(f"[dim]{artifact_type.capitalize()} unchanged, no commit needed[/dim]")
+
+
+def _warn_commit_failed(artifact_type: str, file_path: Path, exc: BaseException, json_output: bool) -> None:
+    if not json_output:
+        console.print(f"[yellow]Warning:[/yellow] Failed to commit {artifact_type}: {exc}")
+        console.print(f"[yellow]You may need to commit manually:[/yellow] git add {file_path} && git commit")
+
+
 def _commit_to_branch(
     file_path: Path,
     mission_slug: str,
@@ -441,14 +474,15 @@ def _commit_to_branch(
 
     Raises:
         subprocess.CalledProcessError: If commit fails unexpectedly
+        RuntimeError: If safe_commit fails for anything other than an unchanged artifact
     """
-    try:
-        current_branch = get_current_branch(repo_root)
-        if current_branch is None:
-            raise RuntimeError("Not in a git repository")
+    current_branch = get_current_branch(repo_root)
+    if current_branch is None:
+        raise RuntimeError("Not in a git repository")
 
-        # Commit only this file (preserves staging area)
-        commit_msg = f"Add {artifact_type} for feature {mission_slug}"
+    # Commit only this file (preserves staging area)
+    commit_msg = f"Add {artifact_type} for feature {mission_slug}"
+    try:
         safe_commit(
             repo_root=repo_root,
             worktree_root=repo_root,
@@ -457,22 +491,26 @@ def _commit_to_branch(
             paths=(file_path,),
         )
 
-        if not json_output:
-            console.print(f"[green]✓[/green] {artifact_type.capitalize()} committed to {current_branch}")
-
     except subprocess.CalledProcessError as e:
         # Check if it's just "nothing to commit" (benign)
         stderr = e.stderr if hasattr(e, "stderr") and e.stderr else ""
         if "nothing to commit" in stderr or "nothing added to commit" in stderr:
             # Benign - file unchanged
-            if not json_output:
-                console.print(f"[dim]{artifact_type.capitalize()} unchanged, no commit needed[/dim]")
+            _print_artifact_unchanged(artifact_type, json_output)
         else:
             # Actual error
-            if not json_output:
-                console.print(f"[yellow]Warning:[/yellow] Failed to commit {artifact_type}: {e}")
-                console.print(f"[yellow]You may need to commit manually:[/yellow] git add {file_path} && git commit")
+            _warn_commit_failed(artifact_type, file_path, e, json_output)
             raise
+    except RuntimeError as e:
+        if _safe_commit_empty_changeset_error(e) and _artifact_has_no_git_changes(repo_root, file_path):
+            _print_artifact_unchanged(artifact_type, json_output)
+            return
+
+        _warn_commit_failed(artifact_type, file_path, e, json_output)
+        raise
+
+    if not json_output:
+        console.print(f"[green]✓[/green] {artifact_type.capitalize()} committed to {current_branch}")
 
 
 def _find_feature_directory(

--- a/tests/cli/commands/test_agent_mission_commit_to_branch.py
+++ b/tests/cli/commands/test_agent_mission_commit_to_branch.py
@@ -1,0 +1,88 @@
+"""Regression tests for mission artifact commit handling."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.cli.commands.agent.mission import _commit_to_branch
+
+pytestmark = pytest.mark.git_repo
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test User")
+    (repo / "plan.md").write_text("# Plan\n")
+    _run_git(repo, "add", "plan.md")
+    _run_git(repo, "commit", "-m", "Initial plan")
+    _run_git(repo, "checkout", "-b", "mission/work")
+
+
+def test_commit_to_branch_treats_empty_safe_commit_as_benign(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    plan_file = tmp_path / "plan.md"
+    head_before = _run_git(tmp_path, "rev-parse", "HEAD")
+
+    _commit_to_branch(
+        plan_file,
+        "001-demo",
+        "plan",
+        tmp_path,
+        "mission/work",
+        json_output=True,
+    )
+
+    assert _run_git(tmp_path, "rev-parse", "HEAD") == head_before
+
+
+def test_commit_to_branch_still_commits_changed_artifact(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("# Plan\n\nUpdated.\n")
+
+    _commit_to_branch(
+        plan_file,
+        "001-demo",
+        "plan",
+        tmp_path,
+        "mission/work",
+        json_output=True,
+    )
+
+    assert _run_git(tmp_path, "log", "-1", "--pretty=%s") == "Add plan for feature 001-demo"
+
+
+def test_commit_to_branch_reraises_empty_safe_commit_shape_when_artifact_is_dirty(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    plan_file = tmp_path / "plan.md"
+    plan_file.write_text("# Plan\n\nUpdated.\n")
+
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="safe_commit: git commit failed"):
+        _commit_to_branch(
+            plan_file,
+            "001-demo",
+            "plan",
+            tmp_path,
+            "mission/work",
+            json_output=True,
+        )
+
+    assert _run_git(tmp_path, "status", "--porcelain", "--", "plan.md") == "M plan.md"

--- a/tests/cli/commands/test_agent_mission_commit_to_branch.py
+++ b/tests/cli/commands/test_agent_mission_commit_to_branch.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import subprocess
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 
+import specify_cli.cli.commands.agent.mission as mission_module
 from specify_cli.cli.commands.agent.mission import _commit_to_branch
 
 pytestmark = pytest.mark.git_repo
@@ -47,6 +50,42 @@ def test_commit_to_branch_treats_empty_safe_commit_as_benign(tmp_path: Path) -> 
     )
 
     assert _run_git(tmp_path, "rev-parse", "HEAD") == head_before
+
+
+def test_commit_to_branch_legacy_called_process_empty_commit_does_not_print_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_repo(tmp_path)
+    plan_file = tmp_path / "plan.md"
+    output = io.StringIO()
+
+    def fake_safe_commit(**_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(
+            1,
+            ["git", "commit"],
+            stderr="nothing to commit, working tree clean",
+        )
+
+    monkeypatch.setattr(mission_module, "safe_commit", fake_safe_commit)
+    monkeypatch.setattr(
+        mission_module,
+        "console",
+        Console(file=output, force_terminal=False, color_system=None, width=120),
+    )
+
+    _commit_to_branch(
+        plan_file,
+        "001-demo",
+        "plan",
+        tmp_path,
+        "mission/work",
+        json_output=False,
+    )
+
+    rendered = output.getvalue()
+    assert "Plan unchanged, no commit needed" in rendered
+    assert "Plan committed" not in rendered
 
 
 def test_commit_to_branch_still_commits_changed_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fixes #1452.
- Treats `safe_commit()`'s empty staged-changes `RuntimeError` as the existing benign "unchanged, no commit needed" path only when the requested artifact has no git changes.
- Preserves real commit failures: dirty artifacts with the same `safe_commit: git commit failed` shape still re-raise.

## TDD / Self-review
- Added regression first; it failed on current code with `RuntimeError: safe_commit: git commit failed ...` for unchanged `plan.md`.
- Ran adversarial self-review against the local diff. Finding: missing negative coverage for real commit failures using the same error shape. Addressed with a failing pre-commit hook regression.

## Verification
- `uv run --frozen --extra test pytest tests/cli/commands/test_agent_mission_commit_to_branch.py -q` failed before production fix: 1 failed, 1 passed.
- `.venv/bin/pytest tests/cli/commands/test_agent_mission_commit_to_branch.py -q` passed: 3 passed.
- `.venv/bin/pytest tests/cli/commands/test_agent_mission_commit_to_branch.py tests/runtime/test_setup_plan_sync_evidence.py tests/git_ops/test_safe_commit_helper_integration.py::test_safe_commit_nothing_to_commit_graceful -q` passed: 14 passed, 1 warning.
- `.venv/bin/ruff check src tests` passed.
- `git diff --check` passed.
- `.venv/bin/ruff check` was run and currently fails on pre-existing unrelated lint in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `scripts/generate_schemas.py`, `scripts/lint_canonical_producers.py`, `scripts/sync_all_contributors.py`, `scripts/tasks/*.py`, and `scripts/verify_occurrences.py`; changed-file and `src tests` lint are clean.
