### PR TITLE
Fix styleguide pattern list schema parity

### DIFF
--- a/src/doctrine/styleguides/models.py
+++ b/src/doctrine/styleguides/models.py
@@ -66,8 +66,8 @@ class Styleguide(BaseModel):
         description="ID of a built-in styleguide this artifact augments via field-merge.",
     )
     principles: list[str] = Field(min_length=1)
-    patterns: list[Pattern] = Field(default_factory=list)
-    anti_patterns: list[AntiPattern] = Field(default_factory=list)
+    patterns: list[Pattern] = Field(default_factory=list, min_length=1)
+    anti_patterns: list[AntiPattern] = Field(default_factory=list, min_length=1)
     tooling: dict[str, str] = Field(default_factory=dict)
     quality_test: str | None = None
     applies_to_languages: list[str] = Field(default_factory=list)

--- a/src/doctrine/styleguides/repository.py
+++ b/src/doctrine/styleguides/repository.py
@@ -65,6 +65,10 @@ class StyleguideRepository(BaseDoctrineRepository[Styleguide]):
         """Recursive scan — styleguides may live in subdirectories."""
         return sorted(project_dir.rglob(self._glob))
 
+    def _merge(self, built_in: Styleguide, project_data: dict[str, Any]) -> Styleguide:
+        merged = {**built_in.model_dump(exclude_defaults=True), **project_data}
+        return Styleguide.model_validate(merged)
+
     def save(self, styleguide: Styleguide) -> Path:
         """Save styleguide to project directory.
 
@@ -87,7 +91,9 @@ class StyleguideRepository(BaseDoctrineRepository[Styleguide]):
         yaml.default_flow_style = False
         yaml_file = self._project_dir / filename
 
-        data = styleguide.model_dump(mode="json", exclude_none=True)
+        data = styleguide.model_dump(
+            mode="json", exclude_defaults=True, exclude_none=True
+        )
 
         with yaml_file.open("w") as f:
             yaml.dump(data, f)

--- a/tests/doctrine/styleguides/test_repository.py
+++ b/tests/doctrine/styleguides/test_repository.py
@@ -6,6 +6,7 @@ import pytest
 from ruamel.yaml import YAML
 
 from doctrine.styleguides.repository import StyleguideRepository
+from doctrine.styleguides.validation import validate_styleguide
 pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
 
 
@@ -74,6 +75,30 @@ class TestStyleguideRepository:
 
         assert repo.list_all() == []
 
+    def test_empty_pattern_lists_skipped_with_warning(self, tmp_path: Path) -> None:
+        shipped = tmp_path / "built-in"
+        shipped.mkdir()
+        yaml = YAML()
+        yaml.default_flow_style = False
+        with (shipped / "bad.styleguide.yaml").open("w") as f:
+            yaml.dump(
+                {
+                    "schema_version": "1.0",
+                    "id": "bad",
+                    "title": "Bad",
+                    "scope": "code",
+                    "principles": ["Write clear code"],
+                    "patterns": [],
+                    "anti_patterns": [],
+                },
+                f,
+            )
+
+        with pytest.warns(UserWarning, match="Skipping invalid"):
+            repo = StyleguideRepository(built_in_dir=shipped)
+
+        assert repo.list_all() == []
+
     def test_save_writes_valid_yaml(
         self, tmp_path: Path, sample_styleguide_data: dict
     ) -> None:
@@ -93,6 +118,7 @@ class TestStyleguideRepository:
         yaml = YAML(typ="safe")
         data = yaml.load(path)
         assert data["id"] == "test-style"
+        assert validate_styleguide(data) == []
 
     def test_save_raises_without_project_dir(
         self, tmp_path: Path, sample_styleguide_data: dict

--- a/tests/doctrine/styleguides/test_validation.py
+++ b/tests/doctrine/styleguides/test_validation.py
@@ -1,7 +1,10 @@
 """Unit tests for styleguide schema validation."""
 
-from doctrine.styleguides.validation import validate_styleguide
 import pytest
+from pydantic import ValidationError
+
+from doctrine.styleguides.models import Styleguide
+from doctrine.styleguides.validation import validate_styleguide
 pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
 
 
@@ -39,3 +42,21 @@ class TestValidateStyleguide:
         }
         errors = validate_styleguide(data)
         assert any("principles" in e for e in errors)
+
+    def test_empty_pattern_lists_rejected_by_schema_and_model(self) -> None:
+        data = {
+            "schema_version": "1.0",
+            "id": "test",
+            "title": "Test",
+            "scope": "code",
+            "principles": ["Write clear code"],
+            "patterns": [],
+            "anti_patterns": [],
+        }
+
+        errors = validate_styleguide(data)
+        assert any(error.startswith("patterns:") for error in errors)
+        assert any(error.startswith("anti_patterns:") for error in errors)
+
+        with pytest.raises(ValidationError):
+            Styleguide.model_validate(data)


### PR DESCRIPTION
Fixes #1457

## Summary
- Align `Styleguide` Pydantic validation with the JSON schema: explicit empty `patterns` and `anti_patterns` lists are rejected, while omitted optional lists remain valid.
- Keep repository merge/save output schema-valid by omitting default-only empty fields when materializing YAML.
- Add regression coverage for schema/model parity, repository rejection, and saved YAML validity.

## Tests
- `.venv/bin/pytest tests/doctrine/styleguides/test_validation.py::TestValidateStyleguide::test_empty_pattern_lists_rejected_by_schema_and_model tests/doctrine/styleguides/test_repository.py::TestStyleguideRepository::test_save_writes_valid_yaml -q` — passed
- `.venv/bin/pytest tests/doctrine/styleguides tests/doctrine/test_schema_utils.py tests/specify_cli/cli/commands/test_doctrine_new.py -q` — 48 passed, 1 existing collision warning
- `.venv/bin/ruff check src/doctrine/styleguides/models.py src/doctrine/styleguides/repository.py tests/doctrine/styleguides/test_repository.py tests/doctrine/styleguides/test_validation.py` — passed
- `git diff --check` — passed
- `.venv/bin/ruff check` — failed on 22 unrelated existing findings in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, `scripts/generate_schemas.py`, `scripts/lint_canonical_producers.py`, `scripts/sync_all_contributors.py`, `scripts/tasks/*`, and `scripts/verify_occurrences.py`; none are touched by this PR.

## Self-review
- Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` against the local diff.
- Finding addressed: direct schema/model parity coverage did not prove the production repository load path, so I added `test_empty_pattern_lists_skipped_with_warning`.
- Final self-review verdict: SAFE; no remaining merge-blocking findings in the touched styleguide contract surface.