### PR TITLE
Fix status JSON output for corrupt event logs

### DIFF
--- a/src/specify_cli/cli/commands/agent/status.py
+++ b/src/specify_cli/cli/commands/agent/status.py
@@ -19,7 +19,7 @@ from rich.table import Table
 from specify_cli.cli.selector_resolution import resolve_mission_handle, resolve_selector
 from specify_cli.core.paths import locate_project_root, get_main_repo_root
 from specify_cli.status.locking import feature_status_lock
-from specify_cli.status.store import EVENTS_FILENAME, EventPersistenceError
+from specify_cli.status.store import EVENTS_FILENAME, EventPersistenceError, StoreError
 
 logger = logging.getLogger(__name__)
 
@@ -533,7 +533,11 @@ def lifecycle(
     from specify_cli.status.lifecycle import derive_mission_lifecycle
 
     feature_dir, mission_slug, _repo_root = _resolve_feature_dir(mission, feature, json_output=json_output)
-    result = derive_mission_lifecycle(feature_dir)
+    try:
+        result = derive_mission_lifecycle(feature_dir)
+    except StoreError as exc:
+        _output_error(json_output, str(exc))
+        raise typer.Exit(1)
 
     if json_output:
         print(json.dumps(result.to_dict()))
@@ -696,6 +700,42 @@ def migrate(
 # ---------------------------------------------------------------------------
 
 
+def _collect_status_validation_findings(feature_dir: Path, result: Any) -> bool:
+    """Populate validation findings from status.events.jsonl.
+
+    Returns False when there are no events to validate.
+    """
+    from specify_cli.status.store import read_events, read_events_raw
+    from specify_cli.status.validate import (
+        validate_done_evidence,
+        validate_event_schema,
+        validate_materialization_drift,
+        validate_transition_legality,
+    )
+
+    try:
+        raw_events = read_events_raw(feature_dir)
+
+        if not raw_events:
+            return False
+
+        status_events = [event.to_dict() for event in read_events(feature_dir)]
+
+        for event in status_events:
+            result.errors.extend(validate_event_schema(event))
+
+        result.errors.extend(validate_transition_legality(status_events))
+        result.errors.extend(validate_done_evidence(status_events))
+
+        # Drift detection: event log is sole authority, drift is always an error
+        drift_findings = validate_materialization_drift(feature_dir)
+        result.errors.extend(drift_findings)
+    except StoreError as exc:
+        result.errors.append(f"status.events.jsonl is corrupt: {exc}")
+
+    return True
+
+
 @app.command()
 def validate(
     mission: Annotated[
@@ -724,14 +764,7 @@ def validate(
         spec-kitty agent status validate --mission 034-my-feature
         spec-kitty agent status validate --json
     """
-    from specify_cli.status.store import read_events, read_events_raw
-    from specify_cli.status.validate import (
-        ValidationResult,
-        validate_done_evidence,
-        validate_event_schema,
-        validate_materialization_drift,
-        validate_transition_legality,
-    )
+    from specify_cli.status.validate import ValidationResult
 
     cwd = Path.cwd().resolve()
     repo_root = locate_project_root(cwd)
@@ -757,9 +790,8 @@ def validate(
 
     result = ValidationResult()
 
-    raw_events = read_events_raw(feature_dir)
-
-    if not raw_events:
+    has_events = _collect_status_validation_findings(feature_dir, result)
+    if not has_events:
         if json_output:
             print(
                 json.dumps(
@@ -780,18 +812,6 @@ def validate(
             console.print("No events to validate.")
             console.print("[green]Result: PASS[/green]")
         raise typer.Exit(0)
-
-    status_events = [event.to_dict() for event in read_events(feature_dir)]
-
-    for event in status_events:
-        result.errors.extend(validate_event_schema(event))
-
-    result.errors.extend(validate_transition_legality(status_events))
-    result.errors.extend(validate_done_evidence(status_events))
-
-    # Drift detection: event log is sole authority, drift is always an error
-    drift_findings = validate_materialization_drift(feature_dir)
-    result.errors.extend(drift_findings)
 
     if json_output:
         print(

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -306,6 +306,10 @@ def read_events_raw(feature_dir: Path) -> list[dict[str, Any]]:
                 obj = json.loads(stripped)
             except json.JSONDecodeError as exc:
                 raise StoreError(f"Invalid JSON on line {line_number}: {exc}") from exc
+            if not isinstance(obj, dict):
+                raise StoreError(
+                    f"Invalid event structure on line {line_number}: expected JSON object"
+                )
             results.append(obj)
     return results
 
@@ -376,6 +380,10 @@ def read_events(feature_dir: Path) -> list[StatusEvent]:
                 obj = json.loads(stripped)
             except json.JSONDecodeError as exc:
                 raise StoreError(f"Invalid JSON on line {line_number}: {exc}") from exc
+            if not isinstance(obj, dict):
+                raise StoreError(
+                    f"Invalid event structure on line {line_number}: expected JSON object"
+                )
             if _should_skip_status_event(obj):
                 continue
 

--- a/tests/agent/cli/commands/test_status_cli.py
+++ b/tests/agent/cli/commands/test_status_cli.py
@@ -693,3 +693,28 @@ class TestLifecycleCommand:
         assert data["mission_slug"] == "034-test-feature"
         assert data["state"] == "active"
         assert data["surface_state"] == "active"
+
+    def test_lifecycle_json_reports_corrupt_event_log(
+        self,
+        tmp_path: Path,
+        feature_dir: Path,
+    ):
+        (feature_dir / "status.events.jsonl").write_text("not json\n", encoding="utf-8")
+        patches = _patch_detection(tmp_path)
+        with (
+            patches["locate_project_root"],
+            patches["get_main_repo_root"],
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "lifecycle",
+                    "--mission",
+                    "034-test-feature",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 1
+        data = _extract_json(result.output)
+        assert data["error"] == "Invalid JSON on line 1: Expecting value: line 1 column 1 (char 0)"

--- a/tests/agent/cli/commands/test_status_validate.py
+++ b/tests/agent/cli/commands/test_status_validate.py
@@ -273,6 +273,37 @@ class TestValidateCommand:
         result = runner.invoke(app, ["validate", "--mission", mission_slug])
         assert result.exit_code == 1
 
+    @patch("specify_cli.cli.commands.agent.status.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.status.get_main_repo_root")
+    def test_validate_json_reports_corrupt_event_log(
+        self,
+        mock_main_root,
+        mock_locate,
+        tmp_path,
+    ):
+        """Corrupt status.events.jsonl returns a JSON error payload."""
+        mission_slug = "034-test-feature"
+        feature_dir = _setup_feature(
+            tmp_path,
+            mission_slug,
+            events=None,
+            materialize=False,
+        )
+        (feature_dir / "status.events.jsonl").write_text("not json\n", encoding="utf-8")
+
+        mock_locate.return_value = tmp_path
+        mock_main_root.return_value = tmp_path
+
+        result = runner.invoke(
+            app, ["validate", "--mission", mission_slug, "--json"]
+        )
+
+        assert result.exit_code == 1
+        data = _extract_json(result.output)
+        assert data["mission_slug"] == mission_slug
+        assert data["passed"] is False
+        assert data["error_count"] == 1
+        assert "Invalid JSON on line 1" in data["errors"][0]
 
     @patch("specify_cli.cli.commands.agent.status.locate_project_root")
     @patch("specify_cli.cli.commands.agent.status.get_main_repo_root")

--- a/tests/status/test_store.py
+++ b/tests/status/test_store.py
@@ -377,6 +377,15 @@ def test_corruption_invalid_event_structure(tmp_path: Path) -> None:
         read_events(tmp_path)
 
 
+def test_corruption_non_object_event_line(tmp_path: Path) -> None:
+    """Valid JSON that is not an object raises StoreError."""
+    events_file = tmp_path / EVENTS_FILENAME
+    events_file.write_text('["not", "an", "object"]\n', encoding="utf-8")
+
+    with pytest.raises(StoreError, match="Invalid event structure on line 1"):
+        read_events(tmp_path)
+
+
 # --- read_events_raw ---
 
 
@@ -389,6 +398,15 @@ def test_read_raw_returns_dicts(tmp_path: Path) -> None:
     assert len(raw) == 1
     assert isinstance(raw[0], dict)
     assert raw[0]["wp_id"] == "WP01"
+
+
+def test_read_raw_rejects_non_object_event_line(tmp_path: Path) -> None:
+    """read_events_raw returns dicts or fails closed."""
+    events_file = tmp_path / EVENTS_FILENAME
+    events_file.write_text('["not", "an", "object"]\n', encoding="utf-8")
+
+    with pytest.raises(StoreError, match="Invalid event structure on line 1"):
+        read_events_raw(tmp_path)
 
 
 # --- deterministic ordering ---


### PR DESCRIPTION
## Summary
- Fix `agent status validate --json` so corrupt `status.events.jsonl` produces a validation JSON payload instead of an uncaught `StoreError`.
- Fix `agent status lifecycle --json` so corrupt logs produce a JSON error payload.
- Harden status event readers to fail closed on non-object JSONL rows.

Fixes #1453

## Verification
- `.venv/bin/pytest tests/agent/cli/commands/test_status_validate.py::TestValidateCommand::test_validate_json_reports_corrupt_event_log -q` (fails before fix, passes after)
- `.venv/bin/pytest tests/agent/cli/commands/test_status_cli.py::TestLifecycleCommand::test_lifecycle_json_reports_corrupt_event_log -q` (fails before fix, passes after)
- `.venv/bin/pytest tests/status/test_store.py::test_corruption_non_object_event_line tests/status/test_store.py::test_read_raw_rejects_non_object_event_line -q` (fails before store hardening, passes after)
- `.venv/bin/pytest tests/agent/cli/commands/test_status_validate.py tests/agent/cli/commands/test_status_cli.py tests/specify_cli/status/test_lifecycle.py tests/status/test_store.py tests/status/test_read_events_tolerates_decision_events.py tests/retrospective/test_gate_decision.py::TestTypedErrors::test_non_dict_json_lines_are_skipped -q` (67 passed, 1 warning)
- `.venv/bin/ruff check src/specify_cli/cli/commands/agent/status.py src/specify_cli/status/store.py tests/agent/cli/commands/test_status_validate.py tests/agent/cli/commands/test_status_cli.py tests/status/test_store.py`
- `git diff --check`

## Notes
- Full `.venv/bin/ruff check` was run and still reports 22 pre-existing unrelated lint findings in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`; touched-file ruff passes.
- Self-run adversarial review found no remaining merge blockers in the changed status CLI/store paths.
