### PR TITLE
Fix charter cold import status cycle

### DIFF
--- a/src/specify_cli/cli/commands/charter/generate.py
+++ b/src/specify_cli/cli/commands/charter/generate.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import typer
 
-from specify_cli.cli.selector_resolution import resolve_selector
 from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
@@ -232,6 +231,8 @@ def generate(
         answers_path = _interview_path(repo_root)
         resolved_mission_type = None
         if mission_type is not None or mission is not None:
+            from specify_cli.cli.selector_resolution import resolve_selector
+
             resolved = resolve_selector(
                 canonical_value=mission_type,
                 canonical_flag="--mission-type",

--- a/src/specify_cli/cli/commands/charter/interview.py
+++ b/src/specify_cli/cli/commands/charter/interview.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import typer
 
-from specify_cli.cli.selector_resolution import resolve_selector
 from specify_cli.decisions.models import OriginFlow as _DmOriginFlow
 from specify_cli.decisions.service import DecisionError as _DecisionError
 from specify_cli.task_utils import TaskCliError
@@ -88,6 +87,8 @@ def interview(  # noqa: C901
 
         resolved_mission_type = "software-dev"
         if mission_type is not None or mission is not None:
+            from specify_cli.cli.selector_resolution import resolve_selector
+
             resolved = resolve_selector(
                 canonical_value=mission_type,
                 canonical_flag="--mission-type",

--- a/src/specify_cli/status/transitions.py
+++ b/src/specify_cli/status/transitions.py
@@ -8,26 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from specify_cli.status_lanes import CANONICAL_LANES as CANONICAL_LANES
+from specify_cli.status_lanes import LANE_ALIASES, TERMINAL_LANES
+
 from .models import GuardContext, Lane
-
-CANONICAL_LANES: tuple[str, ...] = (
-    "planned",
-    "claimed",
-    "in_progress",
-    "for_review",
-    "in_review",
-    "approved",
-    "done",
-    "blocked",
-    "canceled",
-)
-
-LANE_ALIASES: dict[str, str] = {
-    "doing": "in_progress",
-    # NOTE: "in_review" is NO LONGER an alias — it is a first-class lane (FR-012a)
-}
-
-TERMINAL_LANES: frozenset[str] = frozenset({"done", "canceled"})
 
 # Boy Scout (DIRECTIVE_025): Extract duplicated error messages to constants.
 _FORCE_REQUIRES_ACTOR_AND_REASON = "Force transitions require actor and reason"

--- a/src/specify_cli/status_lanes.py
+++ b/src/specify_cli/status_lanes.py
@@ -1,0 +1,22 @@
+"""Shared status-lane constants without importing status orchestration."""
+
+from __future__ import annotations
+
+CANONICAL_LANES: tuple[str, ...] = (
+    "planned",
+    "claimed",
+    "in_progress",
+    "for_review",
+    "in_review",
+    "approved",
+    "done",
+    "blocked",
+    "canceled",
+)
+
+LANE_ALIASES: dict[str, str] = {
+    "doing": "in_progress",
+    # NOTE: "in_review" is NO LONGER an alias — it is a first-class lane (FR-012a)
+}
+
+TERMINAL_LANES: frozenset[str] = frozenset({"done", "canceled"})

--- a/src/specify_cli/task_utils/support.py
+++ b/src/specify_cli/task_utils/support.py
@@ -14,8 +14,9 @@ from typing import Any, cast
 from specify_cli.core.paths import get_main_repo_root, locate_project_root
 from specify_cli.legacy_detector import is_legacy_format
 
-# Canonical lane tuple — imported from the status package (single source of truth).
-from specify_cli.status import CANONICAL_LANES
+# Canonical lane tuple — imported from the leaf module to avoid pulling in the
+# full status orchestration package during cold command imports.
+from specify_cli.status_lanes import CANONICAL_LANES
 
 LANES: tuple[str, ...] = CANONICAL_LANES
 LANE_ALIASES: dict[str, str] = {"doing": "in_progress"}

--- a/tests/cli/commands/test_charter_package_exports.py
+++ b/tests/cli/commands/test_charter_package_exports.py
@@ -1,11 +1,50 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+
 import pytest
 
 import specify_cli.cli.commands.charter as charter_module
 
 pytestmark = [pytest.mark.fast]
 
+
 def test_charter_all_exports_are_defined() -> None:
     for name in charter_module.__all__:
         assert hasattr(charter_module, name), f"{name} listed in __all__ but not defined"
+
+
+def test_charter_package_cold_import_keeps_status_orchestration_out() -> None:
+    """Regression for #1461: charter package import must not trigger status cycles."""
+    script = """
+from specify_cli.cli.commands.charter import app
+import specify_cli.cli.commands.charter as charter_module
+import sys
+
+print(json.dumps({
+    "app_imported": app is charter_module.app,
+    "find_repo_root_exported": callable(charter_module.find_repo_root),
+    "status_loaded": "specify_cli.status" in sys.modules,
+    "status_emit_loaded": "specify_cli.status.emit" in sys.modules,
+    "workspace_loaded": "specify_cli.workspace" in sys.modules,
+    "agent_utils_status_loaded": "specify_cli.agent_utils.status" in sys.modules,
+}))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", "import json\n" + script],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result == {
+        "app_imported": True,
+        "find_repo_root_exported": True,
+        "status_loaded": False,
+        "status_emit_loaded": False,
+        "workspace_loaded": False,
+        "agent_utils_status_loaded": False,
+    }


### PR DESCRIPTION
## Summary

Closes #1461.

- Added a cold-import subprocess regression for `from specify_cli.cli.commands.charter import app` that proves the legacy app + `find_repo_root` patch surface remains importable without warming `specify_cli.status`, `specify_cli.status.emit`, `specify_cli.workspace`, or `specify_cli.agent_utils.status`.
- Moved status lane constants into a tiny `specify_cli.status_lanes` leaf module so `task_utils` no longer imports the aggregate status package during command-package imports.
- Deferred charter `resolve_selector` imports in `interview` and `generate` until deprecated mission selector handling is actually used.

## Verification

- `pytest tests/cli/commands/test_charter_package_exports.py -q` ✅
- `pytest tests/cli/commands/test_charter_json_error_contract.py -q` ✅
- `pytest tests/specify_cli/cli/commands/test_charter.py -q` ✅
- `pytest tests/agent/cli/commands/test_charter_cli.py -q` ✅
- `pytest tests/status/test_transitions.py -q` ✅
- `pytest tests/tasks/test_tasks_support.py -q` ✅
- `pytest tests/status/test_models.py tests/status/test_validate.py -q` ✅
- `ruff check <changed files>` ✅
- `git diff --check` ✅
- `ruff check` ⚠️ still fails on unrelated pre-existing repo-wide lint issues in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/.../baseline/capture.py`, and `scripts/*`; changed-file ruff passes.

## Self-review

Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` locally against this diff. Verdict: SAFE. No merge-blocking findings survived; checked warmed-test false positives, legacy patch-surface preservation, status lane constant drift, and lazy-import runtime behavior.
