### PR TITLE
Fix bulk-edit inference for non-UTF specs

### DIFF
--- a/src/specify_cli/bulk_edit/inference.py
+++ b/src/specify_cli/bulk_edit/inference.py
@@ -143,7 +143,7 @@ def scan_spec_file(feature_dir: Path) -> InferenceResult:
             triggered=False,
         )
 
-    content = spec_path.read_text(encoding="utf-8")
+    content = spec_path.read_text(encoding="utf-8", errors="replace")
     return score_spec_for_bulk_edit(content)
 
 

--- a/tests/cli/test_implement_bulk_edit_planning.py
+++ b/tests/cli/test_implement_bulk_edit_planning.py
@@ -164,3 +164,20 @@ def test_active_rewrite_wp_still_requires_acknowledgement(
     assert "Bulk Edit Inference Warning" in output
     assert "--acknowledge-not-bulk-edit" in output
     create_workspace.assert_not_called()
+
+
+def test_non_utf8_spec_without_bulk_edit_signal_does_not_block_implement(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    feature_dir = _build_feature(tmp_path, owned_file="src/runtime/**")
+    (feature_dir / "spec.md").write_bytes(
+        b"\xff\xfe# Spec\n\nRegular feature work with no occurrence-sensitive wording.\n"
+    )
+
+    with _patched_implement(tmp_path, feature_dir) as create_workspace:
+        implement("WP01", mission=feature_dir.name, recover=False, auto_commit=False)
+
+    output = capsys.readouterr().out
+    assert "Bulk Edit Inference Warning" not in output
+    create_workspace.assert_called_once()

--- a/tests/specify_cli/bulk_edit/test_inference.py
+++ b/tests/specify_cli/bulk_edit/test_inference.py
@@ -156,3 +156,29 @@ class TestScanSpecFile:
 
         assert result.score == 0
         assert result.triggered is False
+
+    def test_scan_non_utf8_spec_does_not_raise(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_bytes(
+            b"\xff\xfeRegular feature work with no occurrence-sensitive wording."
+        )
+
+        result = scan_spec_file(tmp_path)
+
+        assert result.score == 0
+        assert result.triggered is False
+
+    def test_scan_non_utf8_spec_preserves_ascii_bulk_edit_signals(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_bytes(
+            b"\xff\xfeRename across the codebase with find-and-replace."
+        )
+
+        result = scan_spec_file(tmp_path)
+
+        assert result.triggered is True
+        assert ("rename across", 3) in result.matched_phrases
+        assert ("find-and-replace", 3) in result.matched_phrases


### PR DESCRIPTION
## Summary
- Make bulk-edit spec scanning tolerate non-UTF-8 bytes instead of raising UnicodeDecodeError.
- Preserve ASCII bulk-edit signal detection in otherwise invalid files.
- Add scanner and implement-command regressions for issue #1442.

Fixes #1442

## Verification
- TDD red: .venv/bin/pytest tests/specify_cli/bulk_edit/test_inference.py -q failed with 2 UnicodeDecodeError regressions before fix.
- .venv/bin/pytest tests/specify_cli/bulk_edit/test_inference.py -q
- .venv/bin/pytest tests/specify_cli/bulk_edit/test_inference.py tests/cli/test_implement_bulk_edit_planning.py -q
- .venv/bin/pytest tests/specify_cli/bulk_edit tests/specify_cli/cli/commands/test_implement_bulk_edit_flag.py tests/cli/test_implement_bulk_edit_planning.py tests/agent/test_implement_command.py tests/agent/test_bulk_edit_planning_preflight.py -q
- .venv/bin/ruff check src/specify_cli/bulk_edit/inference.py tests/specify_cli/bulk_edit/test_inference.py tests/cli/test_implement_bulk_edit_planning.py
- git diff --check

## Notes
- Full repo-wide .venv/bin/ruff check currently reports pre-existing unrelated lint in .kittify, scripts, and fixture specs; changed-file ruff passes.