### PR TITLE
Fix mark-status HistoryAdded WP attribution

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -2131,7 +2131,30 @@ def _update_pipe_table_status(line: str, status: str, header_map: dict[str, int]
     return "|" + "|".join(inner_cells) + "|"
 
 
-_WP_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<wp_id>WP\d+)\b", re.IGNORECASE)
+_WP_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<title>.+?)\s*$")
+_WP_ID_TITLE_RE = re.compile(r"^(?:Work Package\s+)?(?P<wp_id>WP\d+)(?:\b|:)", re.IGNORECASE)
+
+
+def _match_history_wp_heading(line: str) -> str | None:
+    """Return the owning WP id from supported tasks.md section headings."""
+    heading_match = _WP_HEADING_RE.match(line)
+    if not heading_match:
+        return None
+
+    title = heading_match.group("title").strip()
+    if wp_match := _WP_ID_TITLE_RE.match(title):
+        return wp_match.group("wp_id").upper()
+    work_package_prefix = "Work Package "
+    if title.startswith(work_package_prefix):
+        suffix = title[len(work_package_prefix) :]
+        digit_count = 0
+        while digit_count < len(suffix) and digit_count < 2 and suffix[digit_count].isdigit():
+            digit_count += 1
+        if digit_count and (digit_count == len(suffix) or not suffix[digit_count].isdigit()):
+            remainder = suffix[digit_count:]
+            if not remainder or remainder[0].isspace() or remainder[0] in ":-" or ord(remainder[0]) == 0x2014:
+                return f"WP{int(suffix[:digit_count]):02d}"
+    return None
 
 
 def _extract_pipe_table_wp_id(line: str, header_map: dict[str, int]) -> str | None:
@@ -2158,9 +2181,9 @@ def _resolve_history_wp_id(tasks_content: str, task_id: str) -> str | None:
     lines = tasks_content.split("\n")
 
     for line_index, line in enumerate(lines):
-        heading_match = _WP_HEADING_RE.match(line)
-        if heading_match:
-            current_wp_id = heading_match.group("wp_id").upper()
+        heading_wp_id = _match_history_wp_heading(line)
+        if heading_wp_id:
+            current_wp_id = heading_wp_id
 
         if _is_pipe_table_task_row(line, normalized_task_id):
             header_map = _parse_pipe_table_header(lines, line_index)

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -2601,21 +2601,28 @@ def mark_status(
         # Emit HistoryAdded event for subtask status changes (T014)
         try:
             if updated_tasks:
-                task_list_str = ", ".join(updated_tasks)
-                history_wp_id = _resolve_history_wp_id(
-                    tasks_md.read_text(encoding="utf-8"),
-                    updated_tasks[0],
-                )
-                if history_wp_id is not None:
+                resolved_tasks_by_wp: dict[str, list[str]] = {}
+                unresolved_tasks: list[str] = []
+                tasks_content = tasks_md.read_text(encoding="utf-8")
+                for task_id in updated_tasks:
+                    history_wp_id = _resolve_history_wp_id(tasks_content, task_id)
+                    if history_wp_id is None:
+                        unresolved_tasks.append(task_id)
+                    else:
+                        resolved_tasks_by_wp.setdefault(history_wp_id, []).append(task_id)
+
+                for history_wp_id, task_ids_for_wp in resolved_tasks_by_wp.items():
+                    task_list_str = ", ".join(task_ids_for_wp)
                     emit_history_added(
                         wp_id=history_wp_id,
                         entry_type="note",
                         entry_content=f"Subtask(s) {task_list_str} marked as {status}",
                         author="user",
                     )
-                elif not json_output:
+                if unresolved_tasks and not json_output:
                     console.print(
-                        f"[yellow]Warning:[/yellow] Could not resolve owning WP for HistoryAdded event: {updated_tasks[0]}"
+                        "[yellow]Warning:[/yellow] Could not resolve owning WP for HistoryAdded event: "
+                        + ", ".join(unresolved_tasks)
                     )
         except Exception as e:
             if not json_output:

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -2131,6 +2131,58 @@ def _update_pipe_table_status(line: str, status: str, header_map: dict[str, int]
     return "|" + "|".join(inner_cells) + "|"
 
 
+_WP_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<wp_id>WP\d+)\b", re.IGNORECASE)
+
+
+def _extract_pipe_table_wp_id(line: str, header_map: dict[str, int]) -> str | None:
+    """Return the owning WP id from a pipe-table task row, when present."""
+    cells = [cell.strip() for cell in line.split("|")[1:-1]]
+    for column_name in ("wp", "work package", "work_package", "work package id", "work_package_id"):
+        column_index = header_map.get(column_name)
+        if column_index is not None and column_index < len(cells):
+            candidate = cells[column_index].upper()
+            wp_match = re.search(r"\b(WP\d+)\b", candidate)
+            if wp_match:
+                return wp_match.group(1)
+    for cell in cells:
+        candidate = cell.upper()
+        if re.fullmatch(r"WP\d+", candidate):
+            return candidate
+    return None
+
+
+def _resolve_history_wp_id(tasks_content: str, task_id: str) -> str | None:
+    """Resolve the WP that owns *task_id* from tasks.md structure."""
+    normalized_task_id = task_id.upper()
+    current_wp_id: str | None = None
+    lines = tasks_content.split("\n")
+
+    for line_index, line in enumerate(lines):
+        heading_match = _WP_HEADING_RE.match(line)
+        if heading_match:
+            current_wp_id = heading_match.group("wp_id").upper()
+
+        if _is_pipe_table_task_row(line, normalized_task_id):
+            header_map = _parse_pipe_table_header(lines, line_index)
+            return _extract_pipe_table_wp_id(line, header_map) or current_wp_id
+
+        if re.search(rf"-\s*\[[ x]\]\s*{re.escape(normalized_task_id)}\b", line, re.IGNORECASE):
+            if current_wp_id:
+                return current_wp_id
+            explicit_wp = re.search(r"\b(WP\d+)\b", line, re.IGNORECASE)
+            if explicit_wp:
+                return explicit_wp.group(1).upper()
+            return None
+
+        inline_match = _INLINE_SUBTASKS_RE.search(line)
+        if inline_match:
+            ids = [value.strip().upper() for value in inline_match.group("ids").split(",")]
+            if normalized_task_id in ids:
+                return current_wp_id
+
+    return None
+
+
 _INLINE_SUBTASKS_RE = re.compile(
     r"(?:Subtasks|\*\*Subtasks\*\*):\s*(?P<ids>(?:T|WP)\d+(?:\s*,\s*(?:T|WP)\d+)*)",
     re.IGNORECASE,
@@ -2527,12 +2579,21 @@ def mark_status(
         try:
             if updated_tasks:
                 task_list_str = ", ".join(updated_tasks)
-                emit_history_added(
-                    wp_id=updated_tasks[0].replace("T", "WP")[:4],
-                    entry_type="note",
-                    entry_content=f"Subtask(s) {task_list_str} marked as {status}",
-                    author="user",
+                history_wp_id = _resolve_history_wp_id(
+                    tasks_md.read_text(encoding="utf-8"),
+                    updated_tasks[0],
                 )
+                if history_wp_id is not None:
+                    emit_history_added(
+                        wp_id=history_wp_id,
+                        entry_type="note",
+                        entry_content=f"Subtask(s) {task_list_str} marked as {status}",
+                        author="user",
+                    )
+                elif not json_output:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] Could not resolve owning WP for HistoryAdded event: {updated_tasks[0]}"
+                    )
         except Exception as e:
             if not json_output:
                 console.print(f"[yellow]Warning:[/yellow] Event emission failed: {e}")

--- a/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
@@ -230,6 +230,77 @@ def test_existing_checkbox_unchanged(tmp_path: Path) -> None:
     assert "- [x] T001 First task" in (mission_dir / "tasks.md").read_text(encoding="utf-8")
 
 
+def test_history_added_uses_owning_wp_for_checkbox_task(tmp_path: Path) -> None:
+    slug = "007-history-checkbox"
+    _write_mission(tmp_path, slug, "# Tasks\n\n## WP01 Build\n- [ ] T001 First task\n")
+
+    with (
+        patch("specify_cli.cli.commands.agent.tasks.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.tasks._find_mission_slug", return_value=slug),
+        patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out", return_value=(tmp_path, "main")),
+        patch("specify_cli.cli.commands.agent.tasks._emit_sparse_session_warning"),
+        patch("specify_cli.cli.commands.agent.tasks.feature_status_lock", _null_lock),
+        patch("specify_cli.cli.commands.agent.tasks.emit_history_added") as emit_history,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "mark-status",
+                "T001",
+                "--status",
+                "done",
+                "--mission",
+                slug,
+                "--json",
+                "--no-auto-commit",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    emit_history.assert_called_once()
+    assert emit_history.call_args.kwargs["wp_id"] == "WP01"
+
+
+def test_history_added_uses_explicit_wp_column_for_non_derivable_task_id(tmp_path: Path) -> None:
+    slug = "007-history-pipe-table"
+    _write_mission(
+        tmp_path,
+        slug,
+        (
+            "# Tasks\n\n"
+            "| ID | Description | WP | Parallel |\n"
+            "|----|-------------|----|----------|\n"
+            "| T010 | Tenth task | WP02 | [P] |\n"
+        ),
+    )
+
+    with (
+        patch("specify_cli.cli.commands.agent.tasks.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.tasks._find_mission_slug", return_value=slug),
+        patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out", return_value=(tmp_path, "main")),
+        patch("specify_cli.cli.commands.agent.tasks._emit_sparse_session_warning"),
+        patch("specify_cli.cli.commands.agent.tasks.feature_status_lock", _null_lock),
+        patch("specify_cli.cli.commands.agent.tasks.emit_history_added") as emit_history,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "mark-status",
+                "T010",
+                "--status",
+                "done",
+                "--mission",
+                slug,
+                "--json",
+                "--no-auto-commit",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    emit_history.assert_called_once()
+    assert emit_history.call_args.kwargs["wp_id"] == "WP02"
+
+
 def test_existing_pipe_table_unchanged(tmp_path: Path) -> None:
     slug = "008-pipe-table"
     mission_dir = _write_mission(

--- a/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
@@ -261,6 +261,37 @@ def test_history_added_uses_owning_wp_for_checkbox_task(tmp_path: Path) -> None:
     assert emit_history.call_args.kwargs["wp_id"] == "WP01"
 
 
+def test_history_added_uses_work_package_heading_for_checkbox_task(tmp_path: Path) -> None:
+    slug = "007-history-work-package-heading"
+    _write_mission(tmp_path, slug, "# Tasks\n\n## Work Package WP01: Build\n- [ ] T001 First task\n")
+
+    with (
+        patch("specify_cli.cli.commands.agent.tasks.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.tasks._find_mission_slug", return_value=slug),
+        patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out", return_value=(tmp_path, "main")),
+        patch("specify_cli.cli.commands.agent.tasks._emit_sparse_session_warning"),
+        patch("specify_cli.cli.commands.agent.tasks.feature_status_lock", _null_lock),
+        patch("specify_cli.cli.commands.agent.tasks.emit_history_added") as emit_history,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "mark-status",
+                "T001",
+                "--status",
+                "done",
+                "--mission",
+                slug,
+                "--json",
+                "--no-auto-commit",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    emit_history.assert_called_once()
+    assert emit_history.call_args.kwargs["wp_id"] == "WP01"
+
+
 def test_history_added_uses_explicit_wp_column_for_non_derivable_task_id(tmp_path: Path) -> None:
     slug = "007-history-pipe-table"
     _write_mission(

--- a/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
@@ -332,6 +332,47 @@ def test_history_added_uses_explicit_wp_column_for_non_derivable_task_id(tmp_pat
     assert emit_history.call_args.kwargs["wp_id"] == "WP02"
 
 
+def test_history_added_groups_multi_wp_updates_by_owning_wp(tmp_path: Path) -> None:
+    slug = "007-history-multi-wp"
+    _write_mission(
+        tmp_path,
+        slug,
+        "# Tasks\n\n## WP01 Build\n- [ ] T001 First task\n\n## WP02 Ship\n- [ ] T010 Tenth task\n",
+    )
+
+    with (
+        patch("specify_cli.cli.commands.agent.tasks.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.tasks._find_mission_slug", return_value=slug),
+        patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out", return_value=(tmp_path, "main")),
+        patch("specify_cli.cli.commands.agent.tasks._emit_sparse_session_warning"),
+        patch("specify_cli.cli.commands.agent.tasks.feature_status_lock", _null_lock),
+        patch("specify_cli.cli.commands.agent.tasks.emit_history_added") as emit_history,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "mark-status",
+                "T001",
+                "T010",
+                "--status",
+                "done",
+                "--mission",
+                slug,
+                "--json",
+                "--no-auto-commit",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert [
+        (call.kwargs["wp_id"], call.kwargs["entry_content"])
+        for call in emit_history.call_args_list
+    ] == [
+        ("WP01", "Subtask(s) T001 marked as done"),
+        ("WP02", "Subtask(s) T010 marked as done"),
+    ]
+
+
 def test_existing_pipe_table_unchanged(tmp_path: Path) -> None:
     slug = "008-pipe-table"
     mission_dir = _write_mission(


### PR DESCRIPTION
## Summary
- Resolve HistoryAdded WP attribution from tasks.md ownership evidence instead of deriving from task id text
- Cover checkbox ownership and non-derivable pipe-table IDs such as T010 -> WP02
- Avoid emitting a phantom HistoryAdded event when no owning WP can be resolved

Closes #1443

## Verification
- uv run pytest tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py -q
- uv run pytest tests/git_ops/test_mark_status_pipe_table.py tests/git_ops/test_atomic_status_commits_unit.py::TestMarkStatusAtomicCommit -q
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py -q
- uv run ruff check src/specify_cli/cli/commands/agent/tasks.py tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
- git diff --check

Note: full repo ruff check still fails on pre-existing unrelated files under .kittify/, scripts/, and kitty-specs/; touched-file ruff passes.