### PR TITLE
Fix naive auth expiry datetime handling

### DIFF
--- a/src/specify_cli/auth/session.py
+++ b/src/specify_cli/auth/session.py
@@ -132,6 +132,14 @@ class StoredSession:
 
     generation: int | None = None  # Tranche 2 token-family generation counter; None for pre-Tranche-2 sessions
 
+    def __post_init__(self) -> None:
+        """Keep persisted auth timestamps comparable with UTC ``now`` values."""
+        self.issued_at = _coerce_utc(self.issued_at)
+        self.access_token_expires_at = _coerce_utc(self.access_token_expires_at)
+        if self.refresh_token_expires_at is not None:
+            self.refresh_token_expires_at = _coerce_utc(self.refresh_token_expires_at)
+        self.last_used_at = _coerce_utc(self.last_used_at)
+
     def is_access_token_expired(self, buffer_seconds: int = 0) -> bool:
         """Return True if the access token expires within ``buffer_seconds``.
 
@@ -216,3 +224,9 @@ class StoredSession:
     def from_json(cls, raw: str) -> StoredSession:
         """Deserialize from a JSON string produced by the encrypted file store."""
         return cls.from_dict(json.loads(raw))
+
+
+def _coerce_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/tests/auth/test_refresh_flow.py
+++ b/tests/auth/test_refresh_flow.py
@@ -233,6 +233,22 @@ class TestRefreshTTLAmendment:
         assert updated.refresh_token_expires_at == datetime(2099, 1, 1, tzinfo=UTC)
 
     @pytest.mark.asyncio
+    async def test_offsetless_absolute_expires_at_is_treated_as_utc(self):
+        flow = TokenRefreshFlow()
+        session = _make_session()
+        body = _refresh_body(refresh_token_expires_at="2099-01-01T00:00:00")
+
+        with patch("specify_cli.auth.flows.refresh.PublicHttpClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post.return_value = _mock_httpx_response(200, body)
+
+            updated = await flow.refresh(session)
+
+        assert updated.refresh_token_expires_at == datetime(2099, 1, 1, tzinfo=UTC)
+        assert updated.is_refresh_token_expired() is False
+
+    @pytest.mark.asyncio
     async def test_preserves_prior_expiry_when_response_omits_both_forms(self):
         """Non-compliant server: last-resort fallback preserves prior expiry."""
         flow = TokenRefreshFlow()

--- a/tests/auth/test_session.py
+++ b/tests/auth/test_session.py
@@ -200,6 +200,20 @@ def test_from_dict_backward_compat_no_generation() -> None:
     assert session.generation is None
 
 
+def test_from_dict_coerces_naive_expiry_fields_to_utc() -> None:
+    """Legacy/encrypted payloads with offset-less expiry strings must not crash freshness checks."""
+    d = _make_session(refresh_token_expires_at=None).to_dict()
+    d["access_token_expires_at"] = "2099-01-01T00:00:00"
+    d["refresh_token_expires_at"] = "2099-01-02T00:00:00"
+
+    session = StoredSession.from_dict(d)
+
+    assert session.access_token_expires_at == datetime(2099, 1, 1, tzinfo=UTC)
+    assert session.refresh_token_expires_at == datetime(2099, 1, 2, tzinfo=UTC)
+    assert session.is_access_token_expired() is False
+    assert session.is_refresh_token_expired() is False
+
+
 def _make_session_with_teams(
     teams: list[Team], *, default_team_id: str | None = None
 ) -> StoredSession:

--- a/tests/auth/test_token_manager.py
+++ b/tests/auth/test_token_manager.py
@@ -270,6 +270,21 @@ async def test_get_access_token_without_session_raises():
 
 
 @pytest.mark.asyncio
+async def test_get_access_token_raises_typed_error_for_naive_expired_refresh():
+    tm = TokenManager(FakeStorage())
+    naive_past = datetime.now() - timedelta(minutes=1)
+    tm.set_session(
+        _make_session(
+            access_expires_in=-60,
+            refresh_token_expires_at=naive_past,
+        )
+    )
+
+    with pytest.raises(RefreshTokenExpiredError):
+        await tm.get_access_token()
+
+
+@pytest.mark.asyncio
 async def test_get_access_token_returns_current_when_not_expired():
     tm = TokenManager(FakeStorage())
     tm.set_session(_make_session(access_expires_in=900, access_token="still-valid"))


### PR DESCRIPTION
## Summary

Fixes #1441.

- Normalize `StoredSession` auth timestamps to UTC at the session model boundary.
- Treat offset-less persisted/server expiry timestamps as UTC so freshness checks stay comparable with `datetime.now(UTC)`.
- Add regressions for encrypted payloads, token-manager typed errors, and refresh responses without timezone offsets.

## Verification

- `uv run pytest tests/auth/test_session.py::test_from_dict_coerces_naive_expiry_fields_to_utc tests/auth/test_token_manager.py::test_get_access_token_raises_typed_error_for_naive_expired_refresh tests/auth/test_refresh_flow.py::TestRefreshTTLAmendment::test_offsetless_absolute_expires_at_is_treated_as_utc -q`
- `uv run pytest tests/auth/test_session.py tests/auth/test_refresh_flow.py tests/auth/test_token_manager.py -q`
- `uv run pytest tests/auth/concurrency/test_session_hot_path.py tests/auth/test_secure_storage_file.py -q`
- `uv run pytest tests/auth -q`
- `uv run ruff check src/specify_cli/auth/session.py tests/auth/test_session.py tests/auth/test_token_manager.py tests/auth/test_refresh_flow.py`
- `git diff --check`

## Notes

Full `uv run ruff check` still reports existing unrelated violations in scripts/.kittify/kitty-specs paths; changed-file ruff is clean.

Self-review: ran adversarial review per `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md`; no merge-blocking findings after verifying auth boundary, persistence, typed-error behavior, and adjacent hot-path/storage coverage.