### PR TITLE
Fix activation when-doing clause contract

### DIFF
--- a/src/charter/_activation_render.py
+++ b/src/charter/_activation_render.py
@@ -14,16 +14,17 @@ emits a two-line *fetch + when-doing* stanza pinned by the
 prompt-governance contract::
 
     Run: spec-kitty charter context --include <kind>:<artifact_id>
-    When you <verb-clause>, run this command and apply the returned rule.
+    When you are about to <verb-clause>, run this command and apply the returned rule.
 
 Verb-clause synthesis (per WP05 T022 wildcard handling):
 
 * declared ``mission_type`` is absent / ``generic`` / ``any``
-  -> qualifier omitted ("When you <action>, ...")
+  -> qualifier omitted ("When you are about to <action>, ...")
 * declared ``mission_type`` is concrete
-  -> qualifier appended ("When you <action> in a <mission_type> mission, ...")
+  -> qualifier appended ("When you are about to <action> in a
+  <mission_type> mission, ...")
 * declared ``action`` is absent / ``generic`` / ``any``
-  -> the runtime action label is used ("When you implement, ...")
+  -> the runtime action label is used ("When you are about to implement, ...")
 * declared ``action`` is concrete
   -> the declared action label is used, with underscores expanded into
   natural prose for the four fine-grained tokens (``write_comment``
@@ -83,15 +84,24 @@ _WILDCARD_TOKENS: frozenset[str] = frozenset({"generic", "any"})
 
 #: Operator-friendly prose for the four fine-grained sub-action tokens
 #: that live in ``REGISTERED_TRIGGERS`` but not ``ALLOWED_ACTIONS``.  The
-#: ATDD test ``test_case_1_styleguide_render_includes_trigger_stanza``
-#: pins the regex ``when\s+you\s+write\s+(a\s+)?(code\s+)?comment`` so
-#: the ``write_comment`` mapping in particular MUST resolve to the
-#: phrase "write a code comment".
+#: ATDD test ``test_case_1_styleguide_render_includes_trigger_stanza`` pins
+#: the canonical conditional plus the phrase "write a code comment", so the
+#: ``write_comment`` mapping in particular MUST resolve to that phrase.
 _FINE_GRAINED_ACTION_PROSE: dict[str, str] = {
     "write_comment": "write a code comment",
     "write_docstring": "write a docstring",
     "rename_identifier": "rename an identifier",
     "add_dependency": "add a dependency",
+}
+
+
+#: Operator-facing prose for mission/action tokens whose raw token is not
+#: grammatical after ``are about to``.
+_ACTION_PROSE: dict[str, str] = {
+    "tasks": "work on tasks",
+    "charter.interview": "conduct a charter interview",
+    "charter.generate": "generate a charter",
+    "charter.context": "load charter context",
 }
 
 
@@ -206,15 +216,15 @@ def _render_when_clause(
     *,
     action: str,
 ) -> str:
-    """Synthesise the ``when you <clause>`` verb-phrase for *entry*.
+    """Synthesise the canonical when-doing verb phrase for *entry*.
 
     See module docstring for the full wildcard / fine-grained rules.
     The returned string is passed verbatim to
     :func:`fetch_stanza_lines`, which prepends ``"When you "`` and
     appends the trailing clause ``", run this command and apply the
     returned rule."`` — so this function returns ONLY the verb-clause
-    body (``"write a code comment"``, ``"implement in a software-dev
-    mission"``, etc.).
+    body (``"are about to write a code comment"``,
+    ``"are about to implement in a software-dev mission"``, etc.).
     """
     declared_mt = entry.activation_context.get("mission_type")
     declared_action = entry.activation_context.get("action")
@@ -235,7 +245,7 @@ def _render_when_clause(
         else f" in a {declared_mt} mission"
     )
 
-    return f"{action_label}{qualifier}"
+    return f"are about to {action_label}{qualifier}"
 
 
 def _action_label_for(action_token: str) -> str:
@@ -245,11 +255,14 @@ def _action_label_for(action_token: str) -> str:
     ``rename_identifier``, ``add_dependency``) get explicit natural-prose
     mappings -- the ATDD test pins ``"write a code comment"`` for
     ``write_comment``.  Mission-type / charter-loop verbs in
-    ``ALLOWED_ACTIONS`` (``implement``, ``review``, etc.) are used
-    verbatim.  Unknown tokens fall through verbatim.
+    ``ALLOWED_ACTIONS`` (``implement``, ``review``, etc.) are usually
+    used verbatim; non-verb tokens are mapped to grammatical prose.
+    Unknown tokens fall through verbatim.
     """
     if action_token in _FINE_GRAINED_ACTION_PROSE:
         return _FINE_GRAINED_ACTION_PROSE[action_token]
+    if action_token in _ACTION_PROSE:
+        return _ACTION_PROSE[action_token]
     if action_token in ALLOWED_ACTIONS:
         return action_token
     return action_token

--- a/tests/charter/test_context_activation_render.py
+++ b/tests/charter/test_context_activation_render.py
@@ -20,13 +20,21 @@ Coverage (per WP05 T025):
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from charter._activation_render import render_activation_stanza
-from charter.activations import ActivationEntry
+from charter.activations import ALLOWED_ACTIONS, ActivationEntry, REGISTERED_TRIGGERS
 
 
 pytestmark = [pytest.mark.unit]
+
+
+_CANONICAL_WHEN_DOING_RE = re.compile(
+    r"when\s+you\s+(are\s+about\s+to|need\s+to|encounter|introduce|rename|review)",
+    re.IGNORECASE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +104,9 @@ def test_single_entry_with_both_qualifiers_renders_one_stanza(
         "Run: spec-kitty charter context --include styleguide:caveman-comments"
         in rendered
     ), rendered
-    assert "When you implement in a software-dev mission" in rendered, rendered
+    assert (
+        "When you are about to implement in a software-dev mission" in rendered
+    ), rendered
 
 
 # ---------------------------------------------------------------------------
@@ -127,11 +137,42 @@ def test_entry_with_fine_grained_action_only_renders_without_mission_qualifier(
     )
 
     assert "Selected activations:" in rendered
-    assert "When you write a code comment," in rendered, rendered
+    assert "When you are about to write a code comment," in rendered, rendered
     # Mission-type qualifier MUST be dropped (the entry's mission_type is
     # absent, which is wildcard).
     assert "in a software-dev mission" not in rendered, rendered
     assert "in a generic mission" not in rendered, rendered
+
+
+@pytest.mark.parametrize("declared_action", sorted(REGISTERED_TRIGGERS))
+def test_activation_when_clauses_match_canonical_when_doing_contract(
+    service_with_caveman: _FakeService,
+    declared_action: str,
+) -> None:
+    """Every activation trigger must emit a fetch stanza whose conditional
+    satisfies the canonical prompt-governance ``_WHEN_DOING_RE``.
+    """
+    runtime_action = (
+        declared_action if declared_action in ALLOWED_ACTIONS else "implement"
+    )
+    entry = ActivationEntry(
+        activation_context={"action": declared_action},
+        doctrine_pack_id="project",
+        artifact_id="caveman-comments",
+        artifact_kind="styleguide",
+    )
+
+    rendered = render_activation_stanza(
+        [entry],
+        service_with_caveman,
+        mission_type="software-dev",
+        action=runtime_action,
+    )
+
+    assert (
+        "spec-kitty charter context --include styleguide:caveman-comments" in rendered
+    )
+    assert _CANONICAL_WHEN_DOING_RE.search(rendered), rendered
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +198,7 @@ def test_entry_with_generic_mission_type_renders_without_qualifier(
     )
 
     assert "Selected activations:" in rendered
-    assert "When you implement," in rendered, rendered
+    assert "When you are about to implement," in rendered, rendered
     assert "in a generic mission" not in rendered, rendered
     assert "in a software-dev mission" not in rendered, rendered
 
@@ -202,8 +243,8 @@ def test_two_matching_entries_render_two_stanzas_in_declaration_order(
     assert fetch_count == 2, rendered
     # Declaration order: ``implement`` clause appears before
     # ``write a code comment`` clause.
-    first_idx = rendered.find("When you implement,")
-    second_idx = rendered.find("When you write a code comment,")
+    first_idx = rendered.find("When you are about to implement,")
+    second_idx = rendered.find("When you are about to write a code comment,")
     assert first_idx != -1 and second_idx != -1, rendered
     assert first_idx < second_idx, (
         "Stanzas must render in declaration order (concatenation policy). "
@@ -277,7 +318,7 @@ def test_wildcard_only_entry_matches_every_context(
         action="implement",
     )
     assert "Selected activations:" in rendered_a
-    assert "When you implement," in rendered_a
+    assert "When you are about to implement," in rendered_a
     assert "in a" not in rendered_a, rendered_a
 
     # Documentation / review
@@ -288,7 +329,7 @@ def test_wildcard_only_entry_matches_every_context(
         action="review",
     )
     assert "Selected activations:" in rendered_b
-    assert "When you review," in rendered_b
+    assert "When you are about to review," in rendered_b
     assert "in a" not in rendered_b, rendered_b
 
 

--- a/tests/integration/test_user_doctrine_artifact_lifecycle.py
+++ b/tests/integration/test_user_doctrine_artifact_lifecycle.py
@@ -53,7 +53,7 @@ _FETCH_CMD_RE = re.compile(
     re.IGNORECASE,
 )
 _WHEN_DOING_RE = re.compile(
-    r"when\s+you\s+(write|are\s+about\s+to|need\s+to|introduce|rename|review)",
+    r"when\s+you\s+(are\s+about\s+to|need\s+to|encounter|introduce|rename|review)",
     re.IGNORECASE,
 )
 
@@ -277,7 +277,7 @@ def test_case_1_project_styleguide_appears_in_implement_prompt(
     ), (
         "The implement charter context MUST surface the project-selected styleguide "
         "`caveman-comments` — either by ID + body or by ID + fetch command + "
-        "'when you write a code comment' conditional. Today the resolver ignores "
+        "canonical when-doing conditional. Today the resolver ignores "
         "`selected_styleguides` because `DoctrineSelectionConfig` has no such field "
         "(see src/charter/schemas.py). Mission B WP04 adds the field and the "
         "matching renderer (_render_selected_styleguides). See "
@@ -419,10 +419,10 @@ def test_case_1_styleguide_render_includes_trigger_stanza(
 
     Acceptable phrasing (any one):
 
-      * "When you write a code comment, run
+      * "When you are about to write a code comment, run
         `spec-kitty charter context --include styleguide:caveman-comments`
          and apply the returned rule."
-      * "When you write a code comment, fetch styleguide caveman-comments"
+      * "When you are about to write a code comment, fetch styleguide caveman-comments"
       * Any text containing both the action verb ("write a code comment" /
         "write a comment") and the artifact id.
 
@@ -446,19 +446,24 @@ def test_case_1_styleguide_render_includes_trigger_stanza(
     )
 
     text = result.text.lower()
-    write_comment_phrase = re.search(
-        r"when\s+you\s+write\s+(a\s+)?(code\s+)?comment", text
-    )
+    canonical_conditional = _WHEN_DOING_RE.search(text)
+    write_comment_phrase = "write a code comment" in text or "write a comment" in text
     references_artifact = "caveman-comments" in text or "caveman" in text
     has_fetch_command = bool(_FETCH_CMD_RE.search(result.text))
 
-    assert write_comment_phrase and references_artifact and has_fetch_command, (
+    assert (
+        canonical_conditional
+        and write_comment_phrase
+        and references_artifact
+        and has_fetch_command
+    ), (
         "The implement prompt MUST carry an activation stanza shaped like\n"
-        '  "When you write a code comment, run '
+        '  "When you are about to write a code comment, run '
         "`spec-kitty charter context --include styleguide:caveman-comments` "
         'and apply the returned rule."\n'
         "Required surfaces:\n"
-        f"  - 'when you write [a] [code] comment' phrase: {bool(write_comment_phrase)}\n"
+        f"  - canonical when-doing conditional: {bool(canonical_conditional)}\n"
+        f"  - 'write [a] [code] comment' phrase: {bool(write_comment_phrase)}\n"
         f"  - artifact id (caveman / caveman-comments) present: {references_artifact}\n"
         f"  - fetch command (spec-kitty charter context / doctrine): {has_fetch_command}\n"
         "Mission B WP05 introduces the charter-level activation registry and the "


### PR DESCRIPTION
## Summary
- Fix activation fetch stanzas to emit canonical `When you are about to ...` conditionals so `_WHEN_DOING_RE` matches every registered activation trigger.
- Preserve fine-grained action prose and add readable prose for non-verb action tokens like `tasks` and `charter.context`.
- Add regression coverage across all `REGISTERED_TRIGGERS` and align the integration helper with the canonical prompt-governance regex.

Fixes #1445

## Verification
- `uv run pytest tests/charter/test_context_activation_render.py tests/integration/test_user_doctrine_artifact_lifecycle.py tests/specify_cli/next/test_wp_prompt_governance_contract.py -q`
- `uv run ruff check src tests`
- `git diff --check`

## Self-review
- Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` locally against the branch diff.
- Verdict: SAFE. One stale-prose finding was fixed before PR creation.
