### PR TITLE
Fix agent profile schema generation drift

### DIFF
--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -317,10 +317,8 @@ def _agent_profile_fixups(schema: dict) -> dict:
         "description": "Optional brief description",
         "schema-version": "Schema version for compatibility",
         "purpose": "The agent's primary purpose or mission statement",
-        "role": (
-            "Agent role (architect, implementer, reviewer, planner, etc.) "
-            "- accepts both known roles and custom roles"
-        ),
+        "role": "Agent role - deprecated scalar form; prefer roles array",
+        "avatar-image": "Path or URL to agent avatar image",
         "capabilities": "List of capabilities this agent can perform",
         "specializes-from": "Parent profile ID this agent specializes from (for hierarchy)",
         "routing-priority": "Priority for routing tasks to this agent (0-100, higher is more preferred)",
@@ -783,11 +781,13 @@ def _order_schema(schema: dict) -> OrderedDict:
     key_order = [
         "$schema",
         "$id",
+        "$comment",
         "title",
         "description",
         "type",
         "additionalProperties",
         "required",
+        "anyOf",
         "definitions",
         "properties",
         "allOf",

--- a/src/doctrine/agent_profiles/schema_models.py
+++ b/src/doctrine/agent_profiles/schema_models.py
@@ -19,7 +19,9 @@ The generated schema targets Draft 2020-12 (like all other generated schemas).
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +156,15 @@ class AgentProfileSchema(BaseModel):
     see ``doctrine.agent_profiles.profile.AgentProfile``.
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        populate_by_name=True,
+        json_schema_extra={
+            "$comment": "schema-version: 2 — roles list support added",
+            "anyOf": [{"required": ["role"]}, {"required": ["roles"]}],
+        },
+    )
 
     # Core identity
     profile_id: str = Field(alias="profile-id", pattern=r"^[a-z][a-z0-9-]*$")
@@ -164,15 +174,33 @@ class AgentProfileSchema(BaseModel):
         default=None, alias="schema-version", pattern=r"^1\.0$"
     )
     purpose: str
-    role: str | None = None
-    roles: list[str] | None = Field(default=None, min_length=1)
+    role: str | None = Field(
+        default=None,
+        description="Agent role - deprecated scalar form; prefer roles array",
+    )
+    roles: list[str] | None = Field(
+        default=None,
+        min_length=1,
+        description="Agent roles list (first entry is primary role)",
+    )
     avatar_image: str | None = Field(default=None, alias="avatar-image")
     sentinel: bool = Field(default=False)
     tags: list[str] = Field(default_factory=list)
     capabilities: list[str] = Field(default_factory=list)
     specializes_from: str | None = Field(default=None, alias="specializes-from")
+    overrides: str | None = Field(
+        default=None,
+        pattern=r"^[a-z][a-z0-9-]*$",
+        description="ID of a built-in agent profile this artifact replaces in full.",
+    )
+    enhances: str | None = Field(
+        default=None,
+        pattern=r"^[a-z][a-z0-9-]*$",
+        description="ID of a built-in agent profile this artifact augments via field-merge.",
+    )
     routing_priority: int | None = Field(default=None, alias="routing-priority", ge=0, le=100)
     max_concurrent_tasks: int | None = Field(default=None, alias="max-concurrent-tasks", ge=1)
+    applies_to_languages: list[str] = Field(default_factory=list)
 
     # Section 1: Context sources
     context_sources: AgentContextSources | None = Field(default=None, alias="context-sources")
@@ -218,3 +246,9 @@ class AgentProfileSchema(BaseModel):
     self_review_protocol: SelfReviewProtocol | None = Field(
         default=None, alias="self-review-protocol"
     )
+
+    @model_validator(mode="after")
+    def _requires_role_or_roles(self) -> Self:
+        if self.role is None and self.roles is None:
+            raise ValueError("agent profile requires either role or roles")
+        return self

--- a/src/doctrine/schemas/agent-profile.schema.yaml
+++ b/src/doctrine/schemas/agent-profile.schema.yaml
@@ -1,6 +1,6 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://spec-kitty.dev/schemas/doctrine/agent-profile.schema.yaml
-$comment: "schema-version: 2 — roles list support added"
+$comment: 'schema-version: 2 — roles list support added'
 title: Agent Profile
 description: Rich agent profile schema with 6-section structure for spec-kitty doctrine framework
 type: object
@@ -270,14 +270,13 @@ properties:
     description: The agent's primary purpose or mission statement
   role:
     type: string
-    description: Agent role (architect, implementer, reviewer, planner, etc.) — deprecated scalar form; prefer roles
-      array
+    description: Agent role - deprecated scalar form; prefer roles array
   roles:
     type: array
     description: Agent roles list (first entry is primary role)
+    minItems: 1
     items:
       type: string
-    minItems: 1
   avatar-image:
     type: string
     description: Path or URL to agent avatar image

--- a/tests/doctrine/agent_profiles/test_schema_generation.py
+++ b/tests/doctrine/agent_profiles/test_schema_generation.py
@@ -1,0 +1,60 @@
+"""Regression tests for generated agent-profile JSON schema parity."""
+
+from pathlib import Path
+
+import jsonschema
+import pytest
+from ruamel.yaml import YAML
+
+from scripts.generate_schemas import generate_schema
+
+pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
+
+BUILT_IN_DIR = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "doctrine"
+    / "agent_profiles"
+    / "built-in"
+)
+
+
+def test_generated_agent_profile_schema_preserves_extension_fields() -> None:
+    """Schema model must not drop shipped scoping and augmentation fields."""
+    schema = generate_schema("agent-profile")
+    properties = schema["properties"]
+
+    assert "overrides" in properties
+    assert "enhances" in properties
+    assert "applies_to_languages" in properties
+    assert schema["anyOf"] == [{"required": ["role"]}, {"required": ["roles"]}]
+
+
+def test_generated_agent_profile_schema_validates_shipped_scoped_profile() -> None:
+    """Freshly generated schema must accept built-in profiles, not only committed YAML."""
+    yaml = YAML(typ="safe")
+    with (BUILT_IN_DIR / "python-pedro.agent.yaml").open() as f:
+        profile = yaml.load(f)
+
+    validator = jsonschema.Draft202012Validator(generate_schema("agent-profile"))
+    errors = sorted(validator.iter_errors(profile), key=lambda error: list(error.path))
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("field_name", ["overrides", "enhances"])
+def test_generated_agent_profile_schema_validates_augmentation_fields(field_name: str) -> None:
+    """Generated schema must accept declared profile override/enhance intent."""
+    profile = {
+        "profile-id": "org-python-pedro",
+        "name": "Org Python Pedro",
+        "roles": ["implementer"],
+        "purpose": "Validate augmentation intent fields.",
+        "specialization": {"primary-focus": "Python implementation"},
+        field_name: "python-pedro",
+    }
+
+    validator = jsonschema.Draft202012Validator(generate_schema("agent-profile"))
+    errors = sorted(validator.iter_errors(profile), key=lambda error: list(error.path))
+
+    assert errors == []


### PR DESCRIPTION
## Summary
- Restore agent-profile schema-generation ownership for overrides, enhances, applies_to_languages, role/roles anyOf, and schema comment metadata.
- Regenerate src/doctrine/schemas/agent-profile.schema.yaml from the Pydantic model.
- Add generated-schema regression coverage for shipped scoped profiles and augmentation intent fields.

Closes #1446

## Verification
- uv run pytest tests/doctrine/agent_profiles/test_schema_generation.py -q
- uv run pytest tests/doctrine/agent_profiles/test_schema_generation.py tests/doctrine/test_profile_schema_validation.py tests/doctrine/test_shipped_profiles.py tests/doctrine/test_augmentation_fields.py -q
- uv run python scripts/generate_schemas.py --check agent-profile
- git diff --check
- .venv/bin/ruff check src/doctrine/agent_profiles/schema_models.py tests/doctrine/agent_profiles/test_schema_generation.py

## Notes
- Full repo .venv/bin/ruff check currently reports existing baseline lint issues outside this change, plus preexisting complexity in scripts/generate_schemas.py.