### PR TITLE
Fix audit classification for DecisionPoint status events

### DIFF
--- a/src/specify_cli/audit/classifiers/status_events.py
+++ b/src/specify_cli/audit/classifiers/status_events.py
@@ -12,7 +12,7 @@ from ..detectors import (
     detect_legacy_keys,
 )
 from ..models import MissionFinding, Severity
-from ..shape_registry import check_unknown_keys
+from ..shape_registry import check_unknown_keys, status_event_row_artifact_type
 
 # Actor format research (from real event logs and tests):
 #
@@ -128,6 +128,12 @@ def classify_status_events_jsonl(
             )
 
         # Unknown key detection
-        findings.extend(check_unknown_keys("status_event_row", obj, "status.events.jsonl"))
+        findings.extend(
+            check_unknown_keys(
+                status_event_row_artifact_type(obj),
+                obj,
+                "status.events.jsonl",
+            )
+        )
 
     return findings, has_corrupt_jsonl

--- a/src/specify_cli/audit/detectors.py
+++ b/src/specify_cli/audit/detectors.py
@@ -116,12 +116,12 @@ def detect_forbidden_keys(
 ) -> list[MissionFinding]:
     """Return one ``FORBIDDEN_KEY`` finding for each forbidden key in *obj*.
 
-    Row-family scoping: rows classified as mission-lifecycle rows by
-    :func:`specify_cli.audit.shape_registry.is_mission_lifecycle_row` are
-    skipped entirely — they legitimately carry ``event_type``. All other
-    rows are checked against :data:`FORBIDDEN_KEYS`, so a malformed
-    status-transition row that carries ``event_type`` without
-    ``aggregate_type == "Mission"`` is still flagged.
+    Row-family scoping: rows classified as mission-lifecycle rows or
+    DecisionPoint event envelopes by ``shape_registry`` are skipped entirely
+    — they legitimately carry ``event_type``. All other rows are checked
+    against :data:`FORBIDDEN_KEYS`, so a malformed status-transition row
+    that carries ``event_type`` without an accepted event-row shape is still
+    flagged.
 
     Args:
         obj: Parsed artifact dict.
@@ -129,13 +129,13 @@ def detect_forbidden_keys(
 
     Returns:
         A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
-        Empty list when none are found or when *obj* is a lifecycle row.
+        Empty list when none are found or when *obj* is an accepted event row.
     """
     # Local import to avoid a module-load cycle with ``shape_registry``,
     # which imports ``FORBIDDEN_KEYS`` / ``LEGACY_KEYS`` from this module.
-    from .shape_registry import is_mission_lifecycle_row
+    from .shape_registry import is_decisionpoint_status_event_row, is_mission_lifecycle_row
 
-    if is_mission_lifecycle_row(obj):
+    if is_mission_lifecycle_row(obj) or is_decisionpoint_status_event_row(obj):
         return []
 
     findings: list[MissionFinding] = []

--- a/src/specify_cli/audit/shape_registry.py
+++ b/src/specify_cli/audit/shape_registry.py
@@ -7,16 +7,10 @@ name to the set of top-level keys that are expected in that artifact type.
 for any top-level key that is not in the known set, not a legacy key, and not
 a forbidden key (those have dedicated finding codes).
 
-Also exposes ``is_mission_lifecycle_row()`` — a row-family classifier that
-distinguishes legitimate lifecycle event rows (those carrying a non-empty
-``event_type`` AND an ``aggregate_type`` in the known lifecycle set
-``{"Mission", "Project", "WorkPackage", "MissionDossier"}``) from canonical
-status-transition rows (``from_lane`` / ``to_lane``). The audit engine
-consults this predicate to scope the ``FORBIDDEN_KEYS`` rule to non-lifecycle
-rows. Issue #1142 broadened the accepted set beyond ``"Mission"`` so that
-``Project``, ``WorkPackage``, and ``MissionDossier`` lifecycle rows emitted
-by the events package no longer raise ``FORBIDDEN_KEY`` findings on
-legitimate keys.
+Also exposes row-family classifiers for mixed ``status.events.jsonl`` rows.
+The audit engine uses these predicates to scope status-transition-only
+``FORBIDDEN_KEYS`` checks away from legitimate lifecycle and DecisionPoint
+event envelopes while still flagging malformed transition rows.
 
 Reference: ``kitty-specs/unblock-sync-identity-boundary-canary-01KRZJ07/
 contracts/audit-row-family.md``.
@@ -182,6 +176,9 @@ KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT: dict[str, frozenset[str]] = {
 LIFECYCLE_AGGREGATE_TYPES: frozenset[str] = frozenset(
     {"Mission", "Project", "WorkPackage", "MissionDossier"}
 )
+DECISIONPOINT_STATUS_EVENT_KEYS: frozenset[str] = KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT[
+    "decision_event_row"
+]
 
 
 def is_mission_lifecycle_row(row: Mapping[str, Any]) -> bool:
@@ -223,6 +220,31 @@ def is_mission_lifecycle_row(row: Mapping[str, Any]) -> bool:
         return False
     event_type = row.get("event_type")
     return isinstance(event_type, str) and bool(event_type)
+
+
+def is_decisionpoint_status_event_row(row: Mapping[str, Any]) -> bool:
+    """Return ``True`` iff *row* matches a DecisionPoint event envelope.
+
+    Decision Moment producers append DecisionPoint events to
+    ``status.events.jsonl`` with ``{event_id, at, event_type, payload}``.
+    These rows are mission-level events, not lane-transition rows, and match
+    the same skip boundary used by ``status.store.read_events()``.
+    """
+    if not isinstance(row, Mapping):
+        return False
+    if not set(row).issubset(DECISIONPOINT_STATUS_EVENT_KEYS):
+        return False
+    event_type = row.get("event_type")
+    if not (isinstance(event_type, str) and event_type.startswith("DecisionPoint")):
+        return False
+    return isinstance(row.get("payload"), Mapping)
+
+
+def status_event_row_artifact_type(row: Mapping[str, Any]) -> str:
+    """Return the shape registry artifact type for a ``status.events.jsonl`` row."""
+    if is_decisionpoint_status_event_row(row):
+        return "decision_event_row"
+    return "status_event_row"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/audit/fixtures/missing_evidence/status.events.jsonl
+++ b/tests/audit/fixtures/missing_evidence/status.events.jsonl
@@ -1,0 +1,1 @@
+{"actor":"claude","at":"2026-05-31T12:00:00+00:00","event_id":"01KTESTMISSINGEVIDENCE000001","execution_mode":"worktree","force":false,"from_lane":"approved","mission_id":"01JAAAAAAAAAAAAAAAAAAAAAN0","mission_slug":"missing-evidence","policy_metadata":null,"reason":null,"review_ref":null,"evidence":null,"to_lane":"done","wp_id":"WP01"}

--- a/tests/audit/test_audit_architecture.py
+++ b/tests/audit/test_audit_architecture.py
@@ -24,7 +24,9 @@ from specify_cli.audit import AuditOptions, run_audit
 from specify_cli.audit.classifiers.meta import classify_meta_json
 from specify_cli.audit.classifiers.status_events import classify_status_events_jsonl
 from specify_cli.audit.classifiers.status_json import classify_status_json
+from specify_cli.audit.models import is_teamspace_blocker
 from specify_cli.audit.classifiers.wp_files import classify_wp_files
+from spec_kitty_events.decisionpoint import DECISION_POINT_OPENED
 
 # ---------------------------------------------------------------------------
 # Fixture root
@@ -120,6 +122,27 @@ def test_forbidden_event_name() -> None:
     """forbidden_event_name: event_name key triggers FORBIDDEN_KEY."""
     findings, _ = classify_status_events_jsonl(FX / "forbidden_event_name")
     assert "FORBIDDEN_KEY" in _codes(findings)
+
+
+def test_decisionpoint_events_in_status_events_are_not_teamspace_blockers(tmp_path: Path) -> None:
+    """DecisionPoint event envelopes share status.events.jsonl but are not status transitions."""
+    mission_dir = tmp_path / "kitty-specs" / "001-decisionpoint"
+    mission_dir.mkdir(parents=True)
+    (mission_dir / "status.events.jsonl").write_text(
+        (
+            '{"event_id":"01KTESTDECISIONEVENT0000001",'
+            '"at":"2026-05-31T12:00:00+00:00",'
+            f'"event_type":"{DECISION_POINT_OPENED}",'
+            '"payload":{"decision_point_id":"01KTESTDECISION0000000001"}}\n'
+        ),
+        encoding="utf-8",
+    )
+
+    findings, has_corrupt = classify_status_events_jsonl(mission_dir)
+
+    assert not has_corrupt
+    assert _codes(findings).isdisjoint({"FORBIDDEN_KEY", "UNKNOWN_SHAPE"})
+    assert not any(is_teamspace_blocker(finding) for finding in findings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -153,7 +153,10 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
 
     assert dry_run.valid
     assert dry_run.schema_version == "3.0.0"
-    assert dry_run.events_package_version == "5.0.0"
+    import spec_kitty_events
+
+    assert dry_run.events_package_version == spec_kitty_events.__version__
+    assert Version(dry_run.events_package_version) >= Version("5.0.0")
     assert dry_run.envelope_count == 1
     assert dry_run.errors == ()
     assert len(dry_run.row_mappings) == 1

--- a/tests/migration/test_teamspace_migration_rehearsal.py
+++ b/tests/migration/test_teamspace_migration_rehearsal.py
@@ -179,9 +179,9 @@ def test_teamspace_mission_state_rehearsal_is_deterministic_across_clones(tmp_pa
     assert {error["error"] for error in raw_dry_run.errors} == {
         "MISSION_STATE_AUDIT_BLOCKER",
     }
-    assert {"FORBIDDEN_KEY", "LEGACY_KEY"} <= {
-        error["finding_code"] for error in raw_dry_run.errors
-    }
+    finding_codes = {error["finding_code"] for error in raw_dry_run.errors}
+    assert "LEGACY_KEY" in finding_codes
+    assert "FORBIDDEN_KEY" not in finding_codes
     first_raw_row = _jsonl_rows(clone_a / "kitty-specs/042-historical-shape/status.events.jsonl")[0]
     with pytest.raises(ValidationError):
         Event.model_validate(first_raw_row)

--- a/tests/specify_cli/audit/test_detectors_row_family.py
+++ b/tests/specify_cli/audit/test_detectors_row_family.py
@@ -40,7 +40,10 @@ pytestmark = [pytest.mark.unit]
 from specify_cli.audit.detectors import detect_forbidden_keys
 from specify_cli.audit.engine import run_audit
 from specify_cli.audit.models import AuditOptions
-from specify_cli.audit.shape_registry import is_mission_lifecycle_row
+from specify_cli.audit.shape_registry import (
+    is_decisionpoint_status_event_row,
+    is_mission_lifecycle_row,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +168,33 @@ class TestIsMissionLifecycleRow:
         assert is_mission_lifecycle_row(row) is False
 
 
+class TestIsDecisionPointStatusEventRow:
+    """Direct tests for DecisionPoint rows sharing ``status.events.jsonl``."""
+
+    def test_decisionpoint_event_envelope_is_decisionpoint_row(self) -> None:
+        row = {
+            "event_id": "01KTESTDECISIONEVENT0000001",
+            "at": "2026-05-31T12:00:00+00:00",
+            "event_type": "DecisionPointOpened",
+            "payload": {"decision_point_id": "01KTESTDECISION0000000001"},
+        }
+        assert is_decisionpoint_status_event_row(row) is True
+
+    def test_decisionpoint_event_without_payload_is_not_decisionpoint_row(self) -> None:
+        row = {"event_type": "DecisionPointOpened"}
+        assert is_decisionpoint_status_event_row(row) is False
+
+    def test_hybrid_transition_keys_are_not_decisionpoint_row(self) -> None:
+        row = {
+            "event_id": "01KTESTDECISIONEVENT0000001",
+            "at": "2026-05-31T12:00:00+00:00",
+            "event_type": "DecisionPointOpened",
+            "payload": {"decision_point_id": "01KTESTDECISION0000000001"},
+            "wp_id": "WP01",
+        }
+        assert is_decisionpoint_status_event_row(row) is False
+
+
 # ---------------------------------------------------------------------------
 # Behavioral contract matrix — one test per row in the contract table
 # ---------------------------------------------------------------------------
@@ -259,6 +289,34 @@ class TestDetectForbiddenKeysRowFamily:
     def test_event_name_without_aggregate_is_flagged(self) -> None:
         """Sibling regression guard for the second forbidden key (event_name)."""
         row: dict[str, object] = {"event_name": "legacy_thing"}
+        findings = detect_forbidden_keys(row, "status.events.jsonl")
+        codes = _finding_codes(findings)
+        assert codes == ["FORBIDDEN_KEY"]
+
+    def test_decisionpoint_event_envelope_skipped(self) -> None:
+        row: dict[str, object] = {
+            "event_id": "01KTESTDECISIONEVENT0000001",
+            "at": "2026-05-31T12:00:00+00:00",
+            "event_type": "DecisionPointOpened",
+            "payload": {"decision_point_id": "01KTESTDECISION0000000001"},
+        }
+        findings = detect_forbidden_keys(row, "status.events.jsonl")
+        assert findings == []
+
+    def test_decisionpoint_event_without_payload_is_flagged(self) -> None:
+        row: dict[str, object] = {"event_type": "DecisionPointOpened"}
+        findings = detect_forbidden_keys(row, "status.events.jsonl")
+        codes = _finding_codes(findings)
+        assert codes == ["FORBIDDEN_KEY"]
+
+    def test_hybrid_decisionpoint_transition_row_is_flagged(self) -> None:
+        row: dict[str, object] = {
+            "event_id": "01KTESTDECISIONEVENT0000001",
+            "at": "2026-05-31T12:00:00+00:00",
+            "event_type": "DecisionPointOpened",
+            "payload": {"decision_point_id": "01KTESTDECISION0000000001"},
+            "wp_id": "WP01",
+        }
         findings = detect_forbidden_keys(row, "status.events.jsonl")
         codes = _finding_codes(findings)
         assert codes == ["FORBIDDEN_KEY"]


### PR DESCRIPTION
## Summary
- classify DecisionPoint event envelopes in status.events.jsonl as non-transition event rows
- skip status-transition-only FORBIDDEN_KEY checks for valid DecisionPoint envelopes while preserving malformed-row blockers
- route DecisionPoint rows through decision_event_row shape keys to avoid payload UNKNOWN_SHAPE noise

Fixes #1439

## Verification
- uv run pytest tests/audit/test_audit_architecture.py::test_decisionpoint_events_in_status_events_are_not_teamspace_blockers -q (failed before fix with FORBIDDEN_KEY/UNKNOWN_SHAPE)
- uv run pytest tests/audit/test_audit_architecture.py tests/specify_cli/audit/test_detectors_row_family.py tests/specify_cli/decisions/test_emit.py -q
- uv run ruff check src tests
- git diff --check
- self-review via /Users/robert/.codex/skills/adversarial-pr-review/SKILL.md: SAFE after tightening hybrid malformed-row handling

## Note
- Bare `uv run ruff check` still reports pre-existing lint debt under .kittify/overrides and scripts outside this change; scoped `src tests` ruff passes.