### PR TITLE
Fix DRG mission step contract node kind

### DIFF
--- a/src/doctrine/drg/models.py
+++ b/src/doctrine/drg/models.py
@@ -27,7 +27,7 @@ _URN_RE = re.compile(r"^[a-z_]+:[A-Za-z0-9_/.\-]+$")
 class NodeKind(StrEnum):
     """Canonical DRG node kinds.
 
-    Superset of ``ArtifactKind`` -- adds ``ACTION`` and ``GLOSSARY_SCOPE``.
+    Superset of ``ArtifactKind`` plus action and glossary node kinds.
     """
 
     DIRECTIVE = "directive"
@@ -37,6 +37,7 @@ class NodeKind(StrEnum):
     TOOLGUIDE = "toolguide"
     PROCEDURE = "procedure"
     AGENT_PROFILE = "agent_profile"
+    MISSION_STEP_CONTRACT = "mission_step_contract"
     TEMPLATE = "template"
     ACTION = "action"
     GLOSSARY_SCOPE = "glossary_scope"

--- a/src/doctrine/drg/query.py
+++ b/src/doctrine/drg/query.py
@@ -149,6 +149,7 @@ class ResolveTransitiveRefsResult:
     toolguides: list[str] = field(default_factory=list)
     procedures: list[str] = field(default_factory=list)
     agent_profiles: list[str] = field(default_factory=list)
+    mission_step_contracts: list[str] = field(default_factory=list)
     templates: list[str] = field(default_factory=list)
     # Edges whose target URN was not found in the graph, stored as
     # ``(source_urn, target_urn)``. Always ``[]`` when the input graph has
@@ -233,6 +234,7 @@ def resolve_transitive_refs(
         toolguides=buckets[NodeKind.TOOLGUIDE],
         procedures=buckets[NodeKind.PROCEDURE],
         agent_profiles=buckets[NodeKind.AGENT_PROFILE],
+        mission_step_contracts=buckets[NodeKind.MISSION_STEP_CONTRACT],
         templates=buckets[NodeKind.TEMPLATE],
         unresolved=unresolved,
     )

--- a/src/specify_cli/mission_step_contracts/executor.py
+++ b/src/specify_cli/mission_step_contracts/executor.py
@@ -31,6 +31,7 @@ _ARTIFACT_TO_NODE_KIND: dict[ArtifactKind, NodeKind] = {
     ArtifactKind.TOOLGUIDE: NodeKind.TOOLGUIDE,
     ArtifactKind.PROCEDURE: NodeKind.PROCEDURE,
     ArtifactKind.AGENT_PROFILE: NodeKind.AGENT_PROFILE,
+    ArtifactKind.MISSION_STEP_CONTRACT: NodeKind.MISSION_STEP_CONTRACT,
     ArtifactKind.TEMPLATE: NodeKind.TEMPLATE,
 }
 

--- a/tests/charter/test_org_drg_loader.py
+++ b/tests/charter/test_org_drg_loader.py
@@ -387,6 +387,35 @@ class TestMergeThreeLayers:
             getattr(n, "provenance", None) == "org:acme" for n in merged.nodes
         )
 
+    def test_org_fragment_mission_step_contract_node_merges(self) -> None:
+        built_in = _empty_built_in()
+        fragment = OrgDRGFragment.model_validate(
+            {
+                "pack_name": "mission-pack",
+                "source_kind": "local_path",
+                "source_ref": "/tmp/mission-pack",
+                "layer_index": 1,
+                "provenance_marker": "org",
+                "nodes": [
+                    {
+                        "id": "implement-step",
+                        "kind": "mission_step_contracts",
+                        "title": "Implement step",
+                    }
+                ],
+                "edges": [],
+            }
+        )
+
+        merged = merge_three_layers(
+            built_in=built_in, org_fragments=[fragment], project=None
+        )
+
+        node = merged.get_node("mission_step_contract:implement-step")
+        assert node is not None
+        assert node.kind is NodeKind.MISSION_STEP_CONTRACT
+        assert getattr(node, "provenance", None) == "org:mission-pack"
+
     def test_project_layer_nodes_tagged_project(self) -> None:
         built_in = _empty_built_in()
         project = DRGGraph(

--- a/tests/doctrine/drg/test_nodekind_artifactkind.py
+++ b/tests/doctrine/drg/test_nodekind_artifactkind.py
@@ -1,0 +1,27 @@
+"""Regression coverage for the DRG node-kind artifact-kind contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from doctrine.artifact_kinds import ArtifactKind
+from doctrine.drg.models import DRGNode, NodeKind
+
+
+pytestmark = [pytest.mark.fast]
+
+
+def test_node_kind_remains_superset_of_artifact_kind() -> None:
+    artifact_values = {kind.value for kind in ArtifactKind}
+    node_values = {kind.value for kind in NodeKind}
+
+    assert artifact_values <= node_values
+
+
+def test_mission_step_contract_is_valid_drg_node_kind() -> None:
+    node = DRGNode(
+        urn="mission_step_contract:implement-step",
+        kind=NodeKind.MISSION_STEP_CONTRACT,
+    )
+
+    assert node.kind is NodeKind.MISSION_STEP_CONTRACT

--- a/tests/doctrine/drg/test_resolve_transitive_refs.py
+++ b/tests/doctrine/drg/test_resolve_transitive_refs.py
@@ -214,6 +214,7 @@ def test_bucketing_by_kind_and_prefix_stripping() -> None:
             ("toolguide:TG1", NodeKind.TOOLGUIDE),
             ("procedure:PR1", NodeKind.PROCEDURE),
             ("agent_profile:AP1", NodeKind.AGENT_PROFILE),
+            ("mission_step_contract:MSC1", NodeKind.MISSION_STEP_CONTRACT),
             ("template:TPL1", NodeKind.TEMPLATE),
         ],
         edges=[
@@ -223,6 +224,7 @@ def test_bucketing_by_kind_and_prefix_stripping() -> None:
             ("directive:D1", "toolguide:TG1", Relation.REQUIRES),
             ("directive:D1", "procedure:PR1", Relation.REQUIRES),
             ("directive:D1", "agent_profile:AP1", Relation.REQUIRES),
+            ("directive:D1", "mission_step_contract:MSC1", Relation.REQUIRES),
             ("directive:D1", "template:TPL1", Relation.REQUIRES),
         ],
     )
@@ -240,6 +242,7 @@ def test_bucketing_by_kind_and_prefix_stripping() -> None:
     assert result.toolguides == ["TG1"]
     assert result.procedures == ["PR1"]
     assert result.agent_profiles == ["AP1"]
+    assert result.mission_step_contracts == ["MSC1"]
     assert result.templates == ["TPL1"]
     assert result.is_complete
 

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -62,9 +62,19 @@ def _write_project_graph(repo_root: Path) -> None:
                     "label": "Fixture directive composer action",
                 },
                 {
+                    "urn": "action:fixture/contract-composer",
+                    "kind": "action",
+                    "label": "Fixture contract composer action",
+                },
+                {
                     "urn": "directive:DIRECTIVE_030",
                     "kind": "directive",
                     "label": "Test and Typecheck Quality Gate",
+                },
+                {
+                    "urn": "mission_step_contract:child-contract",
+                    "kind": "mission_step_contract",
+                    "label": "Child contract",
                 },
             ],
             "edges": [
@@ -86,6 +96,11 @@ def _write_project_graph(repo_root: Path) -> None:
                 {
                     "source": "action:fixture/directive-composer",
                     "target": "directive:DIRECTIVE_030",
+                    "relation": "scope",
+                },
+                {
+                    "source": "action:fixture/contract-composer",
+                    "target": "mission_step_contract:child-contract",
                     "relation": "scope",
                 },
             ],
@@ -263,6 +278,53 @@ def test_directive_slug_candidate_resolves_to_drg_urn(tmp_path: Path) -> None:
         )
 
     assert result.steps[0].resolved_delegations[0].urn == "directive:DIRECTIVE_030"
+    assert result.steps[0].unresolved_candidates == ()
+
+
+def test_mission_step_contract_candidate_resolves_to_drg_urn(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _setup_fixture_profiles(repo_root)
+    _write_project_graph(repo_root)
+
+    contract = {
+        "schema_version": "1.0",
+        "id": "contract-delegation",
+        "mission": "fixture",
+        "action": "contract-composer",
+        "steps": [
+            {
+                "id": "child",
+                "description": "Run child contract",
+                "delegates_to": {
+                    "kind": "mission_step_contract",
+                    "candidates": ["child-contract"],
+                },
+            }
+        ],
+    }
+    built_in_dir = tmp_path / "contracts"
+    _write_yaml(built_in_dir / "contract.step-contract.yaml", contract)
+
+    context_result = SimpleNamespace(mode="compact", text="fixture governance context")
+    with patch("specify_cli.invocation.executor.build_charter_context", return_value=context_result):
+        result = StepContractExecutor(
+            repo_root=repo_root,
+            contract_repository=MissionStepContractRepository(built_in_dir=built_in_dir),
+        ).execute(
+            StepContractExecutionContext(
+                repo_root=repo_root,
+                mission="fixture",
+                action="contract-composer",
+                actor="pytest",
+                profile_hint="implementer-fixture",
+            )
+        )
+
+    assert (
+        result.steps[0].resolved_delegations[0].urn
+        == "mission_step_contract:child-contract"
+    )
     assert result.steps[0].unresolved_candidates == ()
 
 


### PR DESCRIPTION
## Summary
- Add `mission_step_contract` to canonical DRG `NodeKind`, preserving the documented `ArtifactKind` superset invariant.
- Cover org-pack `mission_step_contracts` merge behavior and DRG query bucketing.
- Keep step-contract executor delegation mapping complete for `ArtifactKind.MISSION_STEP_CONTRACT`.

Closes #1437

## Tests
- `.venv/bin/pytest tests/specify_cli/mission_step_contracts/test_executor.py tests/charter/test_org_drg_loader.py tests/doctrine/drg/test_resolve_transitive_refs.py tests/doctrine/test_artifact_kinds.py tests/doctrine/drg/test_nodekind_artifactkind.py`
- `.venv/bin/ruff check src/doctrine/drg/models.py src/doctrine/drg/query.py src/specify_cli/mission_step_contracts/executor.py tests/doctrine/drg/test_nodekind_artifactkind.py tests/charter/test_org_drg_loader.py tests/doctrine/drg/test_resolve_transitive_refs.py tests/specify_cli/mission_step_contracts/test_executor.py`
- `git diff --check`

## Self-review
- Ran adversarial self-review per `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md`.
- Finding fixed before PR: `specify_cli.mission_step_contracts.executor` had an incomplete `ArtifactKind -> NodeKind` map after adding the DRG kind.
- Current verdict: SAFE for touched surface.

## Known unrelated check state
- Repo-wide `.venv/bin/ruff check` currently fails on existing unrelated lint in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`. Touched-file ruff passes.