### PR TITLE
Fix refresh lock timeout handling in auth transport

### DIFF
--- a/src/specify_cli/auth/http/transport.py
+++ b/src/specify_cli/auth/http/transport.py
@@ -40,6 +40,7 @@ from specify_cli.auth.errors import (
     NotAuthenticatedError,
     TokenRefreshError,
 )
+from specify_cli.auth.refresh_transaction import RefreshLockTimeoutError
 
 # Default timeout for all HTTP operations (per WP08 spec).
 DEFAULT_TIMEOUT_SECONDS = 30.0
@@ -219,6 +220,8 @@ class OAuthHttpClient(_BaseHttpClient):
         # First attempt: inject the current access token (auto-refresh if near expiry).
         try:
             access_token = await tm.get_access_token()
+        except RefreshLockTimeoutError as exc:
+            raise TokenRefreshError(str(exc)) from exc
         except (NotAuthenticatedError, TokenRefreshError):
             # Propagate auth errors unchanged — callers differentiate these.
             raise
@@ -239,10 +242,16 @@ class OAuthHttpClient(_BaseHttpClient):
             # Force a refresh. If the server invalidated our session mid-flight,
             # `refresh_if_needed()` will raise RefreshTokenExpiredError /
             # SessionInvalidError (both subclasses of TokenRefreshError).
-            await tm.refresh_if_needed()
+            try:
+                await tm.refresh_if_needed()
+            except RefreshLockTimeoutError as exc:
+                raise TokenRefreshError(str(exc)) from exc
 
             # Re-fetch the (now-refreshed) access token.
-            access_token = await tm.get_access_token()
+            try:
+                access_token = await tm.get_access_token()
+            except RefreshLockTimeoutError as exc:
+                raise TokenRefreshError(str(exc)) from exc
 
             response = await self._send(method, url, access_token, kwargs)
 

--- a/src/specify_cli/auth/transport.py
+++ b/src/specify_cli/auth/transport.py
@@ -63,6 +63,7 @@ from specify_cli.auth.errors import (
     TokenRefreshError,
 )
 from specify_cli.auth.http import request_with_fallback_sync
+from specify_cli.auth.refresh_transaction import RefreshLockTimeoutError
 from specify_cli.diagnostics import report_once
 
 
@@ -70,6 +71,7 @@ logger = logging.getLogger(__name__)
 AUTH_RELOGIN_MESSAGE = (
     "Authentication expired. Run `spec-kitty auth login` to re-authenticate."
 )
+REFRESH_LOCK_TIMEOUT_ERROR_CODE = "refresh_lock_timeout"
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +174,19 @@ def _user_facing_failure_was_emitted() -> bool:
         return _user_facing_failure_emitted
 
 
+def _message_for_auth_refresh_failure(exc: AuthRefreshFailed) -> str:
+    if exc.error_code == REFRESH_LOCK_TIMEOUT_ERROR_CODE:
+        return str(exc)
+    return AUTH_RELOGIN_MESSAGE
+
+
+def _refresh_lock_timeout_cause(exc: BaseException) -> RefreshLockTimeoutError | None:
+    cause = exc.__cause__
+    if isinstance(cause, RefreshLockTimeoutError):
+        return cause
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Refresh helpers (sync bridge over the async TokenManager)
 # ---------------------------------------------------------------------------
@@ -202,6 +217,11 @@ def _fetch_access_token_sync() -> str | None:
     try:
         token = _run_in_fresh_loop(tm.get_access_token())
         return str(token) if token is not None else None
+    except RefreshLockTimeoutError as exc:
+        raise AuthRefreshFailed(
+            str(exc),
+            error_code=REFRESH_LOCK_TIMEOUT_ERROR_CODE,
+        ) from exc
     except AuthenticationError:
         return None
 
@@ -223,6 +243,11 @@ def _force_refresh_sync() -> None:
     session.access_token_expires_at = datetime.now(UTC) - timedelta(seconds=60)
     try:
         _run_in_fresh_loop(tm.refresh_if_needed())
+    except RefreshLockTimeoutError as exc:
+        raise AuthRefreshFailed(
+            str(exc),
+            error_code=REFRESH_LOCK_TIMEOUT_ERROR_CODE,
+        ) from exc
     except TokenRefreshError as exc:
         raise AuthRefreshFailed(
             f"Token refresh failed: {exc}",
@@ -294,7 +319,11 @@ class AuthenticatedClient:
             NotAuthenticatedError: No session available.
             AuthRefreshFailed: Forced refresh exhausted recoverable paths.
         """
-        access_token = _fetch_access_token_sync()
+        try:
+            access_token = _fetch_access_token_sync()
+        except AuthRefreshFailed as exc:
+            _emit_user_facing_failure_once(_message_for_auth_refresh_failure(exc))
+            raise
         if access_token is None:
             raise NotAuthenticatedError(
                 "Authentication required. Run `spec-kitty auth login`."
@@ -308,12 +337,14 @@ class AuthenticatedClient:
             try:
                 _force_refresh_sync()
             except AuthRefreshFailed as exc:
-                _emit_user_facing_failure_once(
-                    AUTH_RELOGIN_MESSAGE
-                )
+                _emit_user_facing_failure_once(_message_for_auth_refresh_failure(exc))
                 raise exc
 
-            access_token = _fetch_access_token_sync()
+            try:
+                access_token = _fetch_access_token_sync()
+            except AuthRefreshFailed as exc:
+                _emit_user_facing_failure_once(_message_for_auth_refresh_failure(exc))
+                raise
             if access_token is None:
                 _emit_user_facing_failure_once(AUTH_RELOGIN_MESSAGE)
                 raise AuthRefreshFailed(
@@ -411,7 +442,20 @@ class AsyncAuthenticatedClient:
     ) -> httpx.Response:
         try:
             return await self._inner.request(method, url, **kwargs)
+        except RefreshLockTimeoutError as exc:
+            _emit_user_facing_failure_once(str(exc))
+            raise AuthRefreshFailed(
+                str(exc),
+                error_code=REFRESH_LOCK_TIMEOUT_ERROR_CODE,
+            ) from exc
         except TokenRefreshError as exc:
+            lock_exc = _refresh_lock_timeout_cause(exc)
+            if lock_exc is not None:
+                _emit_user_facing_failure_once(str(lock_exc))
+                raise AuthRefreshFailed(
+                    str(lock_exc),
+                    error_code=REFRESH_LOCK_TIMEOUT_ERROR_CODE,
+                ) from exc
             _emit_user_facing_failure_once(AUTH_RELOGIN_MESSAGE)
             raise AuthRefreshFailed(str(exc), error_code="refresh_token_invalid") from exc
 

--- a/tests/auth/test_auth_transport_refresh_lock.py
+++ b/tests/auth/test_auth_transport_refresh_lock.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from specify_cli.auth.errors import TokenRefreshError
+from specify_cli.auth.refresh_transaction import RefreshLockTimeoutError
+from specify_cli.auth.transport import (
+    AsyncAuthenticatedClient,
+    AuthRefreshFailed,
+    AuthenticatedClient,
+    reset_user_facing_dedup,
+)
+
+
+LOCK_MESSAGE = (
+    "Another spec-kitty process is refreshing the auth session; retry in a moment."
+)
+
+
+class _LockingTokenManager:
+    is_authenticated = True
+
+    def __init__(
+        self,
+        *,
+        lock_on_refresh: bool = False,
+        refresh_succeeds: bool = False,
+        lock_after_refresh: bool = False,
+    ) -> None:
+        self.lock_on_refresh = lock_on_refresh
+        self.refresh_succeeds = refresh_succeeds
+        self.lock_after_refresh = lock_after_refresh
+        self.refresh_calls = 0
+        self.session = SimpleNamespace(access_token_expires_at=None)
+
+    async def get_access_token(self) -> str:
+        if self.lock_on_refresh and not (
+            self.lock_after_refresh and self.refresh_calls
+        ):
+            return "access-v1"
+        raise RefreshLockTimeoutError(LOCK_MESSAGE)
+
+    async def refresh_if_needed(self) -> bool:
+        self.refresh_calls += 1
+        if self.refresh_succeeds:
+            return True
+        raise RefreshLockTimeoutError(LOCK_MESSAGE)
+
+    def get_current_session(self) -> SimpleNamespace:
+        return self.session
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup() -> None:
+    reset_user_facing_dedup()
+    yield
+    reset_user_facing_dedup()
+
+
+def test_sync_transport_maps_initial_refresh_lock_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from specify_cli.auth import transport as transport_mod
+
+    monkeypatch.setattr(
+        transport_mod,
+        "get_token_manager",
+        lambda: _LockingTokenManager(),
+    )
+
+    def _should_not_send(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("request should not be sent without an access token")
+
+    client = AuthenticatedClient(
+        client=httpx.Client(transport=httpx.MockTransport(_should_not_send))
+    )
+
+    with pytest.raises(AuthRefreshFailed) as exc_info:
+        client.get("https://api.example.test/v1/resource")
+
+    assert exc_info.value.error_code == "refresh_lock_timeout"
+    assert LOCK_MESSAGE in str(exc_info.value)
+    captured = capsys.readouterr()
+    assert LOCK_MESSAGE in captured.err
+    assert "Authentication expired" not in captured.err
+
+
+def test_sync_transport_maps_401_forced_refresh_lock_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from specify_cli.auth import transport as transport_mod
+
+    monkeypatch.setattr(
+        transport_mod,
+        "get_token_manager",
+        lambda: _LockingTokenManager(lock_on_refresh=True),
+    )
+    attempts = 0
+
+    def _unauthorized(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(401, request=request)
+
+    client = AuthenticatedClient(
+        client=httpx.Client(transport=httpx.MockTransport(_unauthorized))
+    )
+
+    with pytest.raises(AuthRefreshFailed) as exc_info:
+        client.get("https://api.example.test/v1/resource")
+
+    assert attempts == 1
+    assert exc_info.value.error_code == "refresh_lock_timeout"
+    assert LOCK_MESSAGE in str(exc_info.value)
+    captured = capsys.readouterr()
+    assert LOCK_MESSAGE in captured.err
+    assert "Authentication expired" not in captured.err
+
+
+def test_sync_transport_maps_post_refresh_token_fetch_lock_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from specify_cli.auth import transport as transport_mod
+
+    token_manager = _LockingTokenManager(
+        lock_on_refresh=True,
+        refresh_succeeds=True,
+        lock_after_refresh=True,
+    )
+    monkeypatch.setattr(
+        transport_mod,
+        "get_token_manager",
+        lambda: token_manager,
+    )
+    attempts = 0
+
+    def _unauthorized(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(401, request=request)
+
+    client = AuthenticatedClient(
+        client=httpx.Client(transport=httpx.MockTransport(_unauthorized))
+    )
+
+    with pytest.raises(AuthRefreshFailed) as exc_info:
+        client.get("https://api.example.test/v1/resource")
+
+    assert attempts == 1
+    assert token_manager.refresh_calls == 1
+    assert exc_info.value.error_code == "refresh_lock_timeout"
+    assert LOCK_MESSAGE in str(exc_info.value)
+    captured = capsys.readouterr()
+    assert LOCK_MESSAGE in captured.err
+    assert "Authentication expired" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_oauth_http_transport_maps_initial_refresh_lock_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from specify_cli.auth.http import transport as http_transport_mod
+
+    monkeypatch.setattr(
+        http_transport_mod,
+        "get_token_manager",
+        lambda: _LockingTokenManager(),
+    )
+
+    async def _should_not_send(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("request should not be sent without an access token")
+
+    async with (
+        httpx.AsyncClient(transport=httpx.MockTransport(_should_not_send)) as raw_client,
+        http_transport_mod.OAuthHttpClient(client=raw_client) as client,
+    ):
+        with pytest.raises(TokenRefreshError) as exc_info:
+            await client.get("https://api.example.test/v1/resource")
+
+    assert LOCK_MESSAGE in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, RefreshLockTimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_async_authenticated_client_preserves_refresh_lock_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from specify_cli.auth.http import transport as http_transport_mod
+
+    monkeypatch.setattr(
+        http_transport_mod,
+        "get_token_manager",
+        lambda: _LockingTokenManager(),
+    )
+
+    async def _should_not_send(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("request should not be sent without an access token")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_should_not_send)
+    ) as raw_client:
+        client = AsyncAuthenticatedClient(client=raw_client)
+        with pytest.raises(AuthRefreshFailed) as exc_info:
+            await client.get("https://api.example.test/v1/resource")
+
+    assert exc_info.value.error_code == "refresh_lock_timeout"
+    assert LOCK_MESSAGE in str(exc_info.value)
+    captured = capsys.readouterr()
+    assert LOCK_MESSAGE in captured.err
+    assert "Authentication expired" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_oauth_http_transport_maps_401_forced_refresh_lock_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from specify_cli.auth.http import transport as http_transport_mod
+
+    monkeypatch.setattr(
+        http_transport_mod,
+        "get_token_manager",
+        lambda: _LockingTokenManager(lock_on_refresh=True),
+    )
+    attempts = 0
+
+    async def _unauthorized(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(401, request=request)
+
+    async with (
+        httpx.AsyncClient(transport=httpx.MockTransport(_unauthorized)) as raw_client,
+        http_transport_mod.OAuthHttpClient(client=raw_client) as client,
+    ):
+        with pytest.raises(TokenRefreshError) as exc_info:
+            await client.get("https://api.example.test/v1/resource")
+
+    assert attempts == 1
+    assert LOCK_MESSAGE in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, RefreshLockTimeoutError)


### PR DESCRIPTION
## Summary

- Map `RefreshLockTimeoutError` at the centralized sync and async auth transport boundaries instead of letting the bare exception escape.
- Preserve the retry-in-a-moment lock contention hint through user-facing dedup, without misclassifying it as expired auth/relogin.
- Add focused regression coverage for initial token fetch, 401 forced refresh, post-refresh token re-fetch, direct `OAuthHttpClient`, and `AsyncAuthenticatedClient` wrapper paths.

Closes #1434.

## Verification

- RED first: `tests/auth/test_auth_transport_refresh_lock.py` failed 5/5 before production changes.
- `./.venv/bin/pytest tests/auth/test_auth_transport_refresh_lock.py -q`
- `./.venv/bin/pytest tests/auth/test_http_transport.py tests/integration/test_token_refresh_dedup.py tests/auth/test_auth_transport_refresh_lock.py tests/auth/test_token_manager.py -q`
- `./.venv/bin/ruff check src/specify_cli/auth/transport.py src/specify_cli/auth/http/transport.py tests/auth/test_auth_transport_refresh_lock.py`
- `git diff --check`

## Notes

- Full `./.venv/bin/ruff check` was run and still reports 22 pre-existing unrelated lint failures in `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`. The changed files pass scoped ruff.
- Self-review with `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md`: SAFE after fixing one self-found gap in the sync post-refresh token re-fetch path.
