### PR TITLE
Normalize agent profile role casing

### DIFF
--- a/src/doctrine/agent_profiles/profile.py
+++ b/src/doctrine/agent_profiles/profile.py
@@ -16,6 +16,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from pydantic.functional_validators import BeforeValidator
 
 
+def _normalize_role_value(value: str) -> str:
+    return value.lower()
+
+
 class Role(str):
     """Half-open role value object.
 
@@ -51,12 +55,12 @@ class Role(str):
     def __new__(cls, value: str) -> Role:
         if not value:
             raise ValueError("Role value must be a non-empty string")
-        return str.__new__(cls, value)
+        return str.__new__(cls, _normalize_role_value(value))
 
     @classmethod
     def is_known(cls, role: Role | str) -> bool:
         """Return True iff *role* is one of the well-known static constants."""
-        return str(role) in cls._KNOWN
+        return _normalize_role_value(str(role)) in cls._KNOWN
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> Any:

--- a/src/doctrine/agent_profiles/repository.py
+++ b/src/doctrine/agent_profiles/repository.py
@@ -459,7 +459,11 @@ class AgentProfileRepository:
         Returns:
             List of all profiles where role appears at any position in profile.roles
         """
-        return [p for p in self._profiles.values() if role in p.roles]
+        role_value = str(role)
+        if not role_value:
+            return []
+        normalized_role = Role(role_value)
+        return [p for p in self._profiles.values() if normalized_role in p.roles]
 
     def _build_hierarchy_index(self) -> None:
         """Build hierarchy index mapping parent_id -> [child_ids]."""

--- a/tests/doctrine/test_capabilities.py
+++ b/tests/doctrine/test_capabilities.py
@@ -3,7 +3,7 @@ Test suite for RoleCapabilities.
 """
 
 from doctrine.agent_profiles.capabilities import DEFAULT_ROLE_CAPABILITIES, RoleCapabilities, get_capabilities
-from doctrine.agent_profiles.profile import Role
+from doctrine.agent_profiles.profile import AgentProfile, Role
 import pytest
 pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
 
@@ -43,6 +43,21 @@ class TestRoleCapabilities:
         caps_upper = get_capabilities("REVIEWER")
         assert caps_upper is not None
         assert caps_upper.role == Role.REVIEWER
+
+    def test_get_capabilities_for_profile_role_from_mixed_case_roles_list(self):
+        """Profile-owned role normalization keeps capability lookup case-insensitive."""
+        profile = AgentProfile(
+            profile_id="casey",
+            name="Casey",
+            purpose="Case normalization",
+            roles=["IMPLEMENTER"],
+            specialization={"primary-focus": "Testing"},
+        )
+
+        caps = get_capabilities(profile.role)
+
+        assert caps is not None
+        assert caps.role == Role.IMPLEMENTER
 
     def test_get_capabilities_for_custom_role_returns_none(self):
         """get_capabilities() returns None for unknown custom roles."""

--- a/tests/doctrine/test_profile_repository.py
+++ b/tests/doctrine/test_profile_repository.py
@@ -1000,6 +1000,11 @@ class TestMultiRoleRouting:
         p = _make_profile("arch-alex", ["architect", "researcher"])
         assert p in _filter_candidates_by_role([p], "researcher")
 
+    def test_mixed_case_role_included_in_filter(self):
+        """Profile role list case is normalized before routing filters run."""
+        p = _make_profile("arch-alex", ["ARCHITECT", "Researcher"])
+        assert p in _filter_candidates_by_role([p], "researcher")
+
     def test_primary_role_included_in_filter(self):
         p = _make_profile("arch-alex", ["architect", "researcher"])
         assert p in _filter_candidates_by_role([p], "architect")
@@ -1011,6 +1016,11 @@ class TestMultiRoleRouting:
     def test_primary_role_signal_is_1_0(self):
         p = _make_profile("arch-alex", ["architect", "researcher"])
         ctx = TaskContext(required_role=Role("architect"))
+        assert _exact_id_signal(ctx, p) == 1.0
+
+    def test_mixed_case_primary_role_signal_is_1_0(self):
+        p = _make_profile("arch-alex", ["ARCHITECT", "researcher"])
+        ctx = TaskContext(required_role="architect")
         assert _exact_id_signal(ctx, p) == 1.0
 
     def test_secondary_role_signal_is_0_5(self):
@@ -1070,11 +1080,21 @@ class TestRoleLookup:
         repo = self._repo_with(p)
         assert repo.find_by_role("implementer") == []
 
+    def test_find_by_role_returns_empty_for_blank_query(self):
+        p = _make_profile("arch-alex", ["architect"])
+        repo = self._repo_with(p)
+        assert repo.find_by_role("") == []
+
     def test_find_by_role_with_role_instance(self):
         """find_by_role accepts a Role instance."""
         p = _make_profile("impl-ivan", ["implementer"])
         repo = self._repo_with(p)
         assert p in repo.find_by_role(Role.IMPLEMENTER)
+
+    def test_find_by_role_normalizes_query_case(self):
+        p = _make_profile("impl-ivan", ["implementer"])
+        repo = self._repo_with(p)
+        assert p in repo.find_by_role("IMPLEMENTER")
 
     def test_get_returns_profile_for_known_id(self):
         p = _make_profile("arch-alex", ["architect"])

--- a/tests/doctrine/test_role_value_object.py
+++ b/tests/doctrine/test_role_value_object.py
@@ -54,6 +54,9 @@ class TestRoleIsKnown:
     def test_plain_string_known_returns_true(self):
         assert Role.is_known("implementer")
 
+    def test_plain_string_known_is_case_insensitive(self):
+        assert Role.is_known("IMPLEMENTER")
+
     def test_custom_role_returns_false(self):
         assert not Role.is_known(Role("data-engineer"))
 
@@ -106,6 +109,12 @@ class TestAgentProfileModel:
         p = AgentProfile(**_BASE, roles=["implementer", "reviewer"])
         assert p.roles == [Role.IMPLEMENTER, Role.REVIEWER]
         assert p.role == Role.IMPLEMENTER
+
+    def test_roles_list_normalizes_case(self):
+        p = AgentProfile(**_BASE, roles=["IMPLEMENTER", "Reviewer", "Org-Lead"])
+        assert p.roles == [Role.IMPLEMENTER, Role.REVIEWER, Role("org-lead")]
+        assert Role.is_known(p.roles[0])
+        assert Role.is_known(p.roles[1])
 
     def test_scalar_role_coerces_to_list_with_warning(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
## Summary
- Normalize agent profile role identifiers at the `Role` value-object boundary, so `roles:` lists load as lowercase canonical role values.
- Normalize `find_by_role` query input while preserving blank-query empty results.
- Add regression coverage for mixed-case profile roles across capability lookup and routing/role lookup.

Closes #1436

## Verification
- TDD proof before implementation: focused regression selection failed 5/5 on current code.
- `.venv/bin/pytest tests/doctrine/test_role_value_object.py tests/doctrine/test_profile_model.py tests/doctrine/test_capabilities.py tests/doctrine/test_profile_repository.py tests/doctrine/test_shipped_profiles.py tests/charter/test_resolver.py` -> 385 passed, 14 warnings.
- `.venv/bin/ruff check src/doctrine/agent_profiles/profile.py src/doctrine/agent_profiles/repository.py tests/doctrine/test_role_value_object.py tests/doctrine/test_capabilities.py tests/doctrine/test_profile_repository.py` -> passed.
- `git diff --check` -> passed.
- Full `.venv/bin/ruff check` was run and fails on unrelated pre-existing lint debt outside this patch, including `.kittify/overrides/scripts/tasks/tasks_cli.py`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`, and `scripts/*`.

## Self-review
- Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` against the local diff before PR handoff. Verdict: SAFE after adding the blank `find_by_role("")` regression.

## Residual Risk
- Custom role identifiers are now lowercased consistently with the deprecated scalar `role:` path; if a downstream consumer treated custom role case as meaningful, it will now see canonical lowercase role IDs.