### PR TITLE
Fix implement canonical status reads from sparse lane worktrees

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -260,6 +260,9 @@ def _commit_via_coordination_transaction(
             for path in paths:
                 if not path.exists():
                     continue
+                if path.resolve().is_relative_to(txn.worktree_root.resolve()):
+                    txn.stage_path(path)
+                    continue
                 txn_path = _transaction_path_for(
                     source_path=path,
                     repo_root=repo_root,
@@ -1071,7 +1074,7 @@ def implement(
             # Capture current shell PID
             shell_pid = str(os.getppid())  # Parent process ID (the shell running this command)
 
-            _impl_feature_dir = main_repo_root / "kitty-specs" / mission_slug
+            _impl_feature_dir = _wf_feature_dir
             _actor = agent or "unknown"
             # WP06 T027: capture the pre-emit size of status.events.jsonl
             # so we can surgically truncate on commit failure. This is

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -206,6 +206,30 @@ def _load_coord_branch_meta(feature_dir: Path) -> tuple[str | None, str | None, 
     return (coord, mid, mid8)
 
 
+def _mid8_for_mission_read_path(primary_feature_dir: Path, mission_slug: str) -> str:
+    """Return the mission mid8 token for topology-aware status reads."""
+    _, _, meta_mid8 = _load_coord_branch_meta(primary_feature_dir)
+    if meta_mid8:
+        return str(meta_mid8)
+
+    if "-" in mission_slug:
+        tail = mission_slug.rsplit("-", 1)[-1]
+        if len(tail) == 8 and tail.isalnum() and tail.isupper():
+            return tail
+
+    return ""
+
+
+def _canonical_status_feature_dir(main_repo_root: Path, mission_slug: str) -> Path:
+    """Resolve the canonical read-side mission directory for status state."""
+    primary_feature_dir = main_repo_root / "kitty-specs" / mission_slug
+    mid8 = _mid8_for_mission_read_path(primary_feature_dir, mission_slug)
+
+    from specify_cli.missions._read_path_resolver import resolve_mission_read_path
+
+    return resolve_mission_read_path(main_repo_root, mission_slug, mid8)
+
+
 def _commit_via_coordination_transaction(
     *,
     coord_branch: str,
@@ -958,7 +982,7 @@ def implement(
         from specify_cli.status.store import read_events as _dep_read_events
         from specify_cli.status.transitions import resolve_lane_alias as _dep_resolve_alias
 
-        _dependency_feature_dir = main_repo_root / "kitty-specs" / mission_slug
+        _dependency_feature_dir = _canonical_status_feature_dir(main_repo_root, mission_slug)
         _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
         _dependency_lanes = {
             _wp_id: _state.get("lane", Lane.PLANNED)
@@ -996,7 +1020,7 @@ def implement(
 
         # Move to in_progress lane if not already there, and ensure agent is recorded
         # Lane is event-log-only; read from canonical event log (no frontmatter fallback)
-        _wf_feature_dir = repo_root / "kitty-specs" / mission_slug
+        _wf_feature_dir = _canonical_status_feature_dir(main_repo_root, mission_slug)
         from specify_cli.status.lane_reader import get_wp_lane as _wf_get_wp_lane
         from specify_cli.status.store import read_events as _wf_read_events
         from specify_cli.status.reducer import reduce as _wf_reduce

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -370,6 +370,12 @@ def _commit_workflow_change(
             )
             return
         except typer.Exit:
+            _restore_status_artifacts(
+                events_path=events_path,
+                pre_emit_event_size=pre_emit_event_size,
+                status_path=status_path,
+                pre_emit_status_bytes=pre_emit_status_bytes,
+            )
             raise
         except Exception as exc:  # noqa: BLE001 — surface + exit
             recovery_commit_sha = _safe_commit_recovery_commit_sha(exc)

--- a/src/specify_cli/workspace/root_resolver.py
+++ b/src/specify_cli/workspace/root_resolver.py
@@ -187,6 +187,10 @@ def canonicalize_feature_dir(feature_dir: Path) -> Path:
     if parent.name != "kitty-specs":
         return feature_dir
 
+    for candidate in (feature_dir, *feature_dir.parents):
+        if candidate.parent.name == ".worktrees" and candidate.name.endswith("-coord"):
+            return feature_dir
+
     try:
         canonical_root = resolve_canonical_root(feature_dir)
     except WorkspaceRootNotFound:

--- a/tests/agent/test_workflow_review_lane_gate.py
+++ b/tests/agent/test_workflow_review_lane_gate.py
@@ -199,6 +199,91 @@ def test_workflow_implement_moves_planned_to_doing(workflow_repo: Path) -> None:
     assert extract_scalar(frontmatter, "agent") == "test-agent"
 
 
+def test_workflow_implement_reads_canonical_status_from_main_when_run_in_sparse_lane(
+    workflow_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Implement from a sparse lane must not read lane-local status events."""
+    mission_slug = "001-test-feature"
+    feature_dir = workflow_repo / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    write_single_lane_manifest(feature_dir, wp_ids=("WP01",), predicted_surfaces=("workflow",))
+    (feature_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
+    main_wp_path = tasks_dir / "WP01-test.md"
+    _write_wp_file(main_wp_path, "WP01", lane="planned")
+    _seed_wp_lane(feature_dir, "WP01", "planned")
+
+    workspace = lane_worktree_path(workflow_repo, mission_slug)
+    workspace_tasks_dir = workspace / "kitty-specs" / mission_slug / "tasks"
+    workspace_tasks_dir.mkdir(parents=True)
+    workspace_wp_path = workspace_tasks_dir / "WP01-test.md"
+    _write_wp_file(workspace_wp_path, "WP01", lane="planned")
+    assert not (workspace / "kitty-specs" / mission_slug / "status.events.jsonl").exists()
+
+    monkeypatch.setattr(workflow, "locate_project_root", lambda: workspace)
+    monkeypatch.setattr(workflow, "get_main_repo_root", lambda _repo_root: workflow_repo)
+    monkeypatch.setattr("specify_cli.core.paths.get_main_repo_root", lambda _repo_root: workflow_repo)
+    monkeypatch.setattr(
+        workflow,
+        "_ensure_target_branch_checked_out",
+        lambda _repo_root, _mission_slug: (workflow_repo, "main"),
+    )
+
+    result = CliRunner().invoke(
+        workflow.app,
+        ["implement", "WP01", "--mission", mission_slug, "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    frontmatter, _, _ = split_frontmatter(main_wp_path.read_text(encoding="utf-8"))
+    assert extract_scalar(frontmatter, "agent") == "test-agent"
+
+
+def test_workflow_implement_uses_main_current_lane_for_rework_from_sparse_lane(
+    workflow_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rework eligibility must use canonical main state, not sparse lane state."""
+    mission_slug = "001-test-feature"
+    feature_dir = workflow_repo / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    write_single_lane_manifest(feature_dir, wp_ids=("WP01",), predicted_surfaces=("workflow",))
+    (feature_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
+    main_wp_path = tasks_dir / "WP01-test.md"
+    _write_wp_file(main_wp_path, "WP01", lane="for_review")
+    _seed_wp_lane(feature_dir, "WP01", "for_review")
+
+    workspace = lane_worktree_path(workflow_repo, mission_slug)
+    workspace_tasks_dir = workspace / "kitty-specs" / mission_slug / "tasks"
+    workspace_tasks_dir.mkdir(parents=True)
+    workspace_wp_path = workspace_tasks_dir / "WP01-test.md"
+    _write_wp_file(workspace_wp_path, "WP01", lane="planned")
+    assert not (workspace / "kitty-specs" / mission_slug / "status.events.jsonl").exists()
+
+    monkeypatch.setattr(workflow, "locate_project_root", lambda: workspace)
+    monkeypatch.setattr(workflow, "get_main_repo_root", lambda _repo_root: workflow_repo)
+    monkeypatch.setattr("specify_cli.core.paths.get_main_repo_root", lambda _repo_root: workflow_repo)
+    monkeypatch.setattr(
+        workflow,
+        "_ensure_target_branch_checked_out",
+        lambda _repo_root, _mission_slug: (workflow_repo, "main"),
+    )
+
+    result = CliRunner().invoke(
+        workflow.app,
+        ["implement", "WP01", "--mission", mission_slug, "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    from specify_cli.status.reducer import reduce
+    from specify_cli.status.store import read_events
+
+    snapshot = reduce(read_events(feature_dir))
+    assert snapshot.work_packages["WP01"]["lane"] == Lane.IN_PROGRESS
+
+
 def test_workflow_review_tracks_reviewer_agent_name(workflow_repo: Path) -> None:
     """Review command should write the reviewer agent name into WP frontmatter.
 

--- a/tests/agent/test_workflow_review_lane_gate.py
+++ b/tests/agent/test_workflow_review_lane_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+import json
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from typer.testing import CliRunner
 from tests.lane_test_utils import lane_worktree_path, write_single_lane_manifest
 
 from specify_cli.cli.commands.agent import workflow
+from specify_cli.coordination.workspace import CoordinationWorkspace
 from specify_cli.frontmatter import write_frontmatter
 from specify_cli.status.emit import emit_status_transition
 from specify_cli.status.store import append_event
@@ -282,6 +284,73 @@ def test_workflow_implement_uses_main_current_lane_for_rework_from_sparse_lane(
 
     snapshot = reduce(read_events(feature_dir))
     assert snapshot.work_packages["WP01"]["lane"] == Lane.IN_PROGRESS
+
+
+def test_workflow_implement_emits_rework_to_coord_status_path(
+    workflow_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Modern missions must read and write the same coord canonical status path."""
+    mission_slug = "demo-feature-01J6XW9K"
+    mid8 = "01J6XW9K"
+    mission_id = "01J6XW9KABCDEFGHJKMNPQRSTV"
+    coord_branch = f"kitty/mission-{mission_slug}"
+    feature_dir = workflow_repo / "kitty-specs" / mission_slug
+    coord_feature_dir = (
+        CoordinationWorkspace.worktree_path(workflow_repo, mission_slug, mid8)
+        / "kitty-specs"
+        / mission_slug
+    )
+    for mission_dir in (feature_dir, coord_feature_dir):
+        tasks_dir = mission_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        (mission_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
+        (mission_dir / "meta.json").write_text(
+            json.dumps(
+                {
+                    "mission_slug": mission_slug,
+                    "mission_id": mission_id,
+                    "mid8": mid8,
+                    "coordination_branch": coord_branch,
+                }
+            ),
+            encoding="utf-8",
+        )
+        write_single_lane_manifest(mission_dir, wp_ids=("WP01",), predicted_surfaces=("workflow",))
+        _write_wp_file(tasks_dir / "WP01-test.md", "WP01", lane="for_review")
+
+    _seed_wp_lane(feature_dir, "WP01", "planned")
+    _seed_wp_lane(coord_feature_dir, "WP01", "for_review")
+    workspace = lane_worktree_path(workflow_repo, mission_slug)
+    (workspace / "kitty-specs" / mission_slug / "tasks").mkdir(parents=True)
+
+    monkeypatch.setattr(workflow, "locate_project_root", lambda: workspace)
+    monkeypatch.setattr(workflow, "get_main_repo_root", lambda _repo_root: workflow_repo)
+    monkeypatch.setattr("specify_cli.core.paths.get_main_repo_root", lambda _repo_root: workflow_repo)
+    monkeypatch.setattr(
+        workflow,
+        "_ensure_target_branch_checked_out",
+        lambda _repo_root, _mission_slug: (workflow_repo, "main"),
+    )
+    monkeypatch.setattr(workflow, "_commit_workflow_change", lambda **_kwargs: None)
+
+    result = CliRunner().invoke(
+        workflow.app,
+        ["implement", "WP01", "--mission", mission_slug, "--agent", "test-agent"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+
+    from specify_cli.status.reducer import reduce
+    from specify_cli.status.store import read_events
+
+    coord_events = [event for event in read_events(coord_feature_dir) if event.wp_id == "WP01"]
+    assert coord_events[-1].from_lane == Lane.FOR_REVIEW
+    assert coord_events[-1].to_lane == Lane.IN_PROGRESS
+    assert coord_events[-1].force is True
+
+    primary_snapshot = reduce(read_events(feature_dir))
+    assert primary_snapshot.work_packages["WP01"]["lane"] == Lane.PLANNED
 
 
 def test_workflow_review_tracks_reviewer_agent_name(workflow_repo: Path) -> None:

--- a/tests/specify_cli/cli/commands/agent/test_workflow.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow.py
@@ -520,7 +520,7 @@ class TestTransactionPathFor:
 class TestCommitWorkflowChange:
     """``_commit_workflow_change`` preserves helper-level exit semantics."""
 
-    def test_modern_policy_exit_is_not_rehandled(
+    def test_modern_policy_exit_restores_pre_emit_status_artifacts(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -531,6 +531,10 @@ class TestCommitWorkflowChange:
 
         feature_dir = tmp_path / "kitty-specs" / "001-test"
         feature_dir.mkdir(parents=True)
+        events_path = feature_dir / "status.events.jsonl"
+        status_path = feature_dir / "status.json"
+        events_path.write_text("before\nnew-event\n", encoding="utf-8")
+        status_path.write_text('{"lane":"new"}', encoding="utf-8")
         (feature_dir / "meta.json").write_text(
             json.dumps({
                 "mission_id": "01ABCDEFGHJKMNPQRSTVWXYZ12",
@@ -568,13 +572,20 @@ class TestCommitWorkflowChange:
                 message="chore: WP01 claimed [claude]",
                 operation="implement",
                 wp_id="WP01",
-                pre_emit_event_size=0,
-                pre_emit_status_bytes=None,
+                pre_emit_event_size=len("before\n"),
+                pre_emit_status_bytes=b'{"lane":"old"}',
             )
 
         assert len(workflow._WORKFLOW_COMMIT_RECEIPTS) == 1
         assert workflow._WORKFLOW_COMMIT_RECEIPTS[0]["outcome"] == "refused"
-        assert restore_calls == []
+        assert restore_calls == [
+            {
+                "events_path": events_path,
+                "pre_emit_event_size": len("before\n"),
+                "status_path": status_path,
+                "pre_emit_status_bytes": b'{"lane":"old"}',
+            }
+        ]
         workflow._reset_workflow_receipts()
 
 

--- a/tests/unit/workspace/test_root_resolver.py
+++ b/tests/unit/workspace/test_root_resolver.py
@@ -21,6 +21,7 @@ import pytest
 from specify_cli.workspace.root_resolver import (
     WorkspaceRootNotFound,
     _reset_cache,
+    canonicalize_feature_dir,
     resolve_canonical_root,
 )
 
@@ -97,6 +98,21 @@ def test_subdirectory_inside_worktree_returns_canonical(tmp_path: Path) -> None:
     nested.mkdir(parents=True)
 
     assert resolve_canonical_root(nested) == repo
+
+
+@pytest.mark.git_repo
+def test_coord_worktree_feature_dir_is_not_rewritten_to_primary(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    mission_slug = "demo-feature-01ABCDEF"
+    primary_feature_dir = repo / "kitty-specs" / mission_slug
+    primary_feature_dir.mkdir(parents=True)
+    coord_worktree = repo / ".worktrees" / f"{mission_slug}-coord"
+    _git(repo, "worktree", "add", "-b", "coord", str(coord_worktree))
+    coord_feature_dir = coord_worktree / "kitty-specs" / mission_slug
+    coord_feature_dir.mkdir(parents=True)
+
+    assert canonicalize_feature_dir(coord_feature_dir) == coord_feature_dir
+    assert canonicalize_feature_dir(coord_feature_dir) != primary_feature_dir
 
 
 def test_non_git_directory_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- route implement dependency/current-lane status reads through the canonical mission read path anchored at the main repo
- add regression coverage for running implement from a sparse lane workspace with no local status.events.jsonl
- cover rework eligibility using canonical current_lane rather than sparse lane state

Closes #1432

## Tests
- .venv/bin/pytest tests/agent/test_workflow_review_lane_gate.py -q
- .venv/bin/pytest tests/specify_cli/cli/commands/agent/test_workflow.py tests/status/test_status_read_worktree_resolution.py -q
- .venv/bin/ruff check src/specify_cli/cli/commands/agent/workflow.py tests/agent/test_workflow_review_lane_gate.py
- git diff --check

## Notes
- Full `.venv/bin/ruff check` was run and still fails on unrelated existing files under `.kittify/overrides`, `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline`, and `scripts/`; touched files pass ruff.