### PR TITLE
Fix step-contract runtime inputs

### DIFF
--- a/src/charter/mission_steps.py
+++ b/src/charter/mission_steps.py
@@ -11,11 +11,16 @@ This file is a **pure re-export** module — no behaviour, no wrappers, no
 type aliases.
 """
 
-from doctrine.mission_step_contracts.models import MissionStep, MissionStepContract
+from doctrine.mission_step_contracts.models import (
+    MissionStep,
+    MissionStepContract,
+    MissionStepInput,
+)
 from doctrine.mission_step_contracts.repository import MissionStepContractRepository
 
 __all__ = [
     "MissionStep",
     "MissionStepContract",
+    "MissionStepInput",
     "MissionStepContractRepository",
 ]

--- a/src/doctrine/mission_step_contracts/__init__.py
+++ b/src/doctrine/mission_step_contracts/__init__.py
@@ -11,6 +11,7 @@ from doctrine.mission_step_contracts.models import (
     DelegatesTo,
     MissionStep,
     MissionStepContract,
+    MissionStepInput,
 )
 from doctrine.mission_step_contracts.repository import MissionStepContractRepository
 
@@ -19,5 +20,6 @@ __all__ = [
     "DelegatesTo",
     "MissionStep",
     "MissionStepContract",
+    "MissionStepInput",
     "MissionStepContractRepository",
 ]

--- a/src/doctrine/mission_step_contracts/models.py
+++ b/src/doctrine/mission_step_contracts/models.py
@@ -20,7 +20,7 @@ class DelegatesTo(BaseModel):
     the charter's selections determine which one actually applies at runtime.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     kind: ArtifactKind
     candidates: list[str] = Field(min_length=1)
@@ -29,7 +29,7 @@ class DelegatesTo(BaseModel):
 class MissionStepInput(BaseModel):
     """Declared runtime input for a command-backed mission step."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     flag: str = Field(min_length=1)
     source: str = Field(min_length=1)
@@ -42,7 +42,7 @@ class MissionStep(BaseModel):
     Steps describe *what* must happen, not *how* (governance comes from doctrine).
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     id: str
     description: str
@@ -61,7 +61,7 @@ class MissionStepContract(BaseModel):
     freeform ``guidance`` for step-specific instructions.
     """
 
-    model_config = ConfigDict(frozen=True, populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
     id: str
     schema_version: str = Field(alias="schema_version")

--- a/src/doctrine/mission_step_contracts/models.py
+++ b/src/doctrine/mission_step_contracts/models.py
@@ -26,6 +26,16 @@ class DelegatesTo(BaseModel):
     candidates: list[str] = Field(min_length=1)
 
 
+class MissionStepInput(BaseModel):
+    """Declared runtime input for a command-backed mission step."""
+
+    model_config = ConfigDict(frozen=True)
+
+    flag: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+    optional: bool = False
+
+
 class MissionStep(BaseModel):
     """A single structural step within a mission action contract.
 
@@ -37,6 +47,7 @@ class MissionStep(BaseModel):
     id: str
     description: str
     command: str | None = None
+    inputs: list[MissionStepInput] = Field(default_factory=list)
     delegates_to: DelegatesTo | None = None
     guidance: str | None = None
 

--- a/src/specify_cli/mission_step_contracts/executor.py
+++ b/src/specify_cli/mission_step_contracts/executor.py
@@ -18,6 +18,7 @@ from charter.mission_steps import (
     MissionStep,
     MissionStepContract,
     MissionStepContractRepository,
+    MissionStepInput,
 )
 from specify_cli.invocation.executor import InvocationPayload, ProfileInvocationExecutor
 from specify_cli.invocation.modes import ModeOfWork
@@ -97,6 +98,7 @@ class StepContractStepResult:
     command: str | None
     command_declared: bool
     guidance: str | None
+    inputs: tuple[MissionStepInput, ...] = field(default_factory=tuple)
     resolved_delegations: tuple[ResolvedStepDelegation, ...] = field(default_factory=tuple)
     unresolved_candidates: tuple[str, ...] = field(default_factory=tuple)
     invocation_payload: InvocationPayload | None = None
@@ -199,6 +201,7 @@ class StepContractExecutor:
                         description=step.description,
                         command=step.command,
                         command_declared=step.command is not None,
+                        inputs=tuple(step.inputs),
                         guidance=step.guidance,
                         resolved_delegations=tuple(resolved),
                         unresolved_candidates=tuple(unresolved),
@@ -327,8 +330,13 @@ class StepContractExecutor:
         if context.request_text:
             lines.append(f"Run request: {context.request_text}")
         if step.command:
-            lines.append(f"Declared command: {step.command}")
+            lines.append(f"Declared command: {self._render_declared_command(step)}")
             lines.append("Command status: declared only; the host/operator owns execution.")
+        elif step.inputs:
+            joined = " ".join(
+                self._format_step_input(input_spec) for input_spec in step.inputs
+            )
+            lines.append(f"Declared step inputs: {joined}")
         if resolved_delegations:
             joined = ", ".join(delegation.urn for delegation in resolved_delegations)
             lines.append(f"Resolved delegations: {joined}")
@@ -338,6 +346,21 @@ class StepContractExecutor:
         if step.guidance:
             lines.append(f"Step guidance: {step.guidance}")
         return "\n".join(lines)
+
+    def _render_declared_command(self, step: MissionStep) -> str:
+        if not step.command or not step.inputs:
+            return step.command or ""
+        joined = " ".join(
+            self._format_step_input(input_spec) for input_spec in step.inputs
+        )
+        return f"{step.command} {joined}"
+
+    @staticmethod
+    def _format_step_input(input_spec: MissionStepInput) -> str:
+        rendered = f"{input_spec.flag} {{{input_spec.source}}}"
+        if input_spec.optional:
+            return f"[{rendered}]"
+        return rendered
 
 
 __all__ = [

--- a/tests/architectural/test_charter_facades_reexport_doctrine.py
+++ b/tests/architectural/test_charter_facades_reexport_doctrine.py
@@ -35,6 +35,7 @@ _FACADE_TABLE: dict[str, list[tuple[str, str]]] = {
     "charter.mission_steps": [
         ("MissionStep", "doctrine.mission_step_contracts.models"),
         ("MissionStepContract", "doctrine.mission_step_contracts.models"),
+        ("MissionStepInput", "doctrine.mission_step_contracts.models"),
         ("MissionStepContractRepository", "doctrine.mission_step_contracts.repository"),
     ],
     "charter.drg": [

--- a/tests/charter/test_mission_steps_facade.py
+++ b/tests/charter/test_mission_steps_facade.py
@@ -1,0 +1,19 @@
+"""Tests for the charter mission-step-contract facade."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_mission_steps_facade_reexports_step_inputs() -> None:
+    """The charter facade exposes the doctrine input model by identity."""
+    from doctrine.mission_step_contracts.models import MissionStepInput
+
+    facade = importlib.reload(importlib.import_module("charter.mission_steps"))
+
+    assert facade.MissionStepInput is MissionStepInput

--- a/tests/doctrine/mission_step_contracts/conftest.py
+++ b/tests/doctrine/mission_step_contracts/conftest.py
@@ -33,6 +33,18 @@ def full_step_contract_data() -> dict:
                 "id": "bootstrap",
                 "description": "Load charter context for this action",
                 "command": "spec-kitty charter context --action implement --json",
+                "inputs": [
+                    {
+                        "flag": "--profile",
+                        "source": "wp.agent_profile",
+                        "optional": True,
+                    },
+                    {
+                        "flag": "--tool",
+                        "source": "env.agent_tool",
+                        "optional": True,
+                    },
+                ],
             },
             {
                 "id": "workspace",

--- a/tests/doctrine/mission_step_contracts/test_models.py
+++ b/tests/doctrine/mission_step_contracts/test_models.py
@@ -41,12 +41,20 @@ class TestMissionStep:
         assert step.command is None
         assert step.delegates_to is None
         assert step.guidance is None
+        assert step.inputs == []
 
     def test_full_construction(self) -> None:
         step = MissionStep(
             id="workspace",
             description="Create workspace",
             command="spec-kitty implement {wp_id}",
+            inputs=[
+                {
+                    "flag": "--profile",
+                    "source": "wp.agent_profile",
+                    "optional": True,
+                },
+            ],
             delegates_to=DelegatesTo(
                 kind=ArtifactKind.PARADIGM,
                 candidates=["execution-lanes", "shared-branch-ci"],
@@ -58,6 +66,24 @@ class TestMissionStep:
         assert step.delegates_to.kind == ArtifactKind.PARADIGM
         assert len(step.delegates_to.candidates) == 2
         assert step.guidance is not None
+        assert len(step.inputs) == 1
+        assert step.inputs[0].flag == "--profile"
+        assert step.inputs[0].source == "wp.agent_profile"
+        assert step.inputs[0].optional is True
+
+    def test_inputs_require_non_empty_flag_and_source(self) -> None:
+        with pytest.raises(ValidationError):
+            MissionStep(
+                id="bootstrap",
+                description="Load context",
+                inputs=[{"flag": "", "source": "wp.agent_profile"}],
+            )
+        with pytest.raises(ValidationError):
+            MissionStep(
+                id="bootstrap",
+                description="Load context",
+                inputs=[{"flag": "--profile", "source": ""}],
+            )
 
 
 class TestMissionStepContract:
@@ -84,6 +110,14 @@ class TestMissionStepContract:
         commit_step = contract.steps[4]
         assert commit_step.guidance is not None
         assert "conventional commit" in commit_step.guidance
+
+        # Check command inputs are schema-owned, not silently discarded.
+        bootstrap_step = contract.steps[0]
+        assert [input.flag for input in bootstrap_step.inputs] == ["--profile", "--tool"]
+        assert [input.source for input in bootstrap_step.inputs] == [
+            "wp.agent_profile",
+            "env.agent_tool",
+        ]
 
     def test_frozen_model(self, minimal_step_contract_data: dict) -> None:
         contract = MissionStepContract.model_validate(minimal_step_contract_data)

--- a/tests/doctrine/mission_step_contracts/test_models.py
+++ b/tests/doctrine/mission_step_contracts/test_models.py
@@ -85,6 +85,28 @@ class TestMissionStep:
                 inputs=[{"flag": "--profile", "source": ""}],
             )
 
+    def test_unknown_step_fields_are_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            MissionStep(
+                id="bootstrap",
+                description="Load context",
+                inputz=[{"flag": "--profile", "source": "wp.agent_profile"}],  # type: ignore[call-arg]
+            )
+
+    def test_unknown_input_fields_are_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            MissionStep(
+                id="bootstrap",
+                description="Load context",
+                inputs=[
+                    {
+                        "flag": "--profile",
+                        "source": "wp.agent_profile",
+                        "optional_typo": True,
+                    },
+                ],
+            )
+
 
 class TestMissionStepContract:
     def test_minimal_construction(self, minimal_step_contract_data: dict) -> None:
@@ -173,3 +195,16 @@ class TestMissionStepContract:
             }
         )
         assert contract.schema_version == "1.0"
+
+    def test_unknown_contract_fields_are_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            MissionStepContract.model_validate(
+                {
+                    "schema_version": "1.0",
+                    "id": "bad",
+                    "action": "implement",
+                    "mission": "software-dev",
+                    "steps": [{"id": "s1", "description": "S1"}],
+                    "inputz": [],
+                }
+            )

--- a/tests/doctrine/mission_step_contracts/test_models.py
+++ b/tests/doctrine/mission_step_contracts/test_models.py
@@ -208,3 +208,19 @@ class TestMissionStepContract:
                     "inputz": [],
                 }
             )
+
+    def test_json_schema_exposes_step_inputs_and_forbids_unknown_fields(self) -> None:
+        schema = MissionStepContract.model_json_schema()
+
+        step_schema = schema["$defs"]["MissionStep"]
+        assert step_schema["additionalProperties"] is False
+        assert step_schema["properties"]["inputs"] == {
+            "items": {"$ref": "#/$defs/MissionStepInput"},
+            "title": "Inputs",
+            "type": "array",
+        }
+
+        input_schema = schema["$defs"]["MissionStepInput"]
+        assert input_schema["additionalProperties"] is False
+        assert input_schema["required"] == ["flag", "source"]
+        assert input_schema["properties"]["optional"]["default"] is False

--- a/tests/doctrine/mission_step_contracts/test_repository.py
+++ b/tests/doctrine/mission_step_contracts/test_repository.py
@@ -134,17 +134,33 @@ class TestMissionStepContractRepository:
             "env.agent_tool",
         ]
 
-    def test_shipped_contract_inputs_are_preserved(self) -> None:
+    def test_shipped_contract_inputs_are_preserved_for_every_declaring_contract(self) -> None:
         repo = MissionStepContractRepository()
-        contract = repo.get_by_action("software-dev", "implement")
+        shipped_dir = Path("src/doctrine/mission_step_contracts/built-in")
+        yaml = YAML(typ="safe")
 
-        assert contract is not None
-        bootstrap_step = contract.steps[0]
-        assert [input.flag for input in bootstrap_step.inputs] == ["--profile", "--tool"]
-        assert [input.source for input in bootstrap_step.inputs] == [
-            "wp.agent_profile",
-            "env.agent_tool",
-        ]
+        declared: dict[str, list[dict[str, object]]] = {}
+        for contract_path in sorted(shipped_dir.glob("*.step-contract.yaml")):
+            raw = yaml.load(contract_path)
+            first_step = raw["steps"][0]
+            if first_step.get("inputs"):
+                declared[raw["id"]] = first_step["inputs"]
+
+        assert declared
+
+        for contract_id, expected_inputs in declared.items():
+            contract = repo.get(contract_id)
+            assert contract is not None
+            bootstrap_step = contract.steps[0]
+            assert [input.flag for input in bootstrap_step.inputs] == [
+                input_data["flag"] for input_data in expected_inputs
+            ]
+            assert [input.source for input in bootstrap_step.inputs] == [
+                input_data["source"] for input_data in expected_inputs
+            ]
+            assert [input.optional for input in bootstrap_step.inputs] == [
+                input_data.get("optional", False) for input_data in expected_inputs
+            ]
 
 
 class TestMissionStepContractRepositoryLookup:

--- a/tests/doctrine/mission_step_contracts/test_repository.py
+++ b/tests/doctrine/mission_step_contracts/test_repository.py
@@ -126,6 +126,26 @@ class TestMissionStepContractRepository:
         # Verify guidance survived round-trip
         assert loaded.steps[4].guidance is not None
 
+        # Verify command inputs survived round-trip.
+        bootstrap_step = loaded.steps[0]
+        assert [input.flag for input in bootstrap_step.inputs] == ["--profile", "--tool"]
+        assert [input.source for input in bootstrap_step.inputs] == [
+            "wp.agent_profile",
+            "env.agent_tool",
+        ]
+
+    def test_shipped_contract_inputs_are_preserved(self) -> None:
+        repo = MissionStepContractRepository()
+        contract = repo.get_by_action("software-dev", "implement")
+
+        assert contract is not None
+        bootstrap_step = contract.steps[0]
+        assert [input.flag for input in bootstrap_step.inputs] == ["--profile", "--tool"]
+        assert [input.source for input in bootstrap_step.inputs] == [
+            "wp.agent_profile",
+            "env.agent_tool",
+        ]
+
 
 class TestMissionStepContractRepositoryLookup:
     """Tests for the by_action lookup method."""

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -222,6 +222,83 @@ def test_command_step_is_declared_not_shell_executed(tmp_path: Path) -> None:
     assert len(result.invocation_ids) == 1
 
 
+def test_command_step_inputs_are_rendered_into_runtime_request_text(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_project_graph(repo_root)
+
+    contract = {
+        "schema_version": "1.0",
+        "id": "command-inputs-contract",
+        "mission": "fixture",
+        "action": "composer",
+        "steps": [
+            {
+                "id": "bootstrap",
+                "description": "Load context",
+                "command": "spec-kitty charter context --action composer --json",
+                "inputs": [
+                    {
+                        "flag": "--profile",
+                        "source": "wp.agent_profile",
+                        "optional": True,
+                    },
+                    {
+                        "flag": "--tool",
+                        "source": "env.agent_tool",
+                        "optional": True,
+                    },
+                ],
+            }
+        ],
+    }
+    built_in_dir = tmp_path / "contracts"
+    _write_yaml(built_in_dir / "command-inputs.step-contract.yaml", contract)
+
+    class FakeInvocationExecutor:
+        def __init__(self) -> None:
+            self.request_texts: list[str] = []
+
+        def invoke(self, request_text: str, **_kwargs: object) -> object:
+            self.request_texts.append(request_text)
+            return SimpleNamespace(invocation_id="inv-1")
+
+        def complete_invocation(self, _invocation_id: str, *, outcome: str) -> None:
+            assert outcome == "done"
+
+    fake_invocations = FakeInvocationExecutor()
+    result = StepContractExecutor(
+        repo_root=repo_root,
+        contract_repository=MissionStepContractRepository(built_in_dir=built_in_dir),
+        invocation_executor=fake_invocations,  # type: ignore[arg-type]
+    ).execute(
+        StepContractExecutionContext(
+            repo_root=repo_root,
+            mission="fixture",
+            action="composer",
+            actor="pytest",
+            profile_hint="implementer-fixture",
+        )
+    )
+
+    assert result.steps[0].command_declared is True
+    assert [input.flag for input in result.steps[0].inputs] == ["--profile", "--tool"]
+    assert [input.source for input in result.steps[0].inputs] == [
+        "wp.agent_profile",
+        "env.agent_tool",
+    ]
+    assert fake_invocations.request_texts == [
+        "\n".join(
+            [
+                "Execute mission step contract command-inputs-contract (fixture/composer).",
+                "Step bootstrap: Load context",
+                "Declared command: spec-kitty charter context --action composer --json [--profile {wp.agent_profile}] [--tool {env.agent_tool}]",
+                "Command status: declared only; the host/operator owns execution.",
+            ]
+        )
+    ]
+
+
 def test_directive_slug_candidate_resolves_to_drg_urn(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import shutil
 from collections.abc import Mapping
 from pathlib import Path
@@ -21,6 +22,15 @@ from specify_cli.mission_step_contracts.executor import (
 
 
 pytestmark = pytest.mark.fast
+
+
+def test_charter_mission_steps_facade_reexports_step_inputs() -> None:
+    """The runtime-facing facade exposes the doctrine input model by identity."""
+    from doctrine.mission_step_contracts.models import MissionStepInput
+
+    facade = importlib.reload(importlib.import_module("charter.mission_steps"))
+
+    assert facade.MissionStepInput is MissionStepInput
 
 
 def _write_yaml(path: Path, data: Mapping[str, object]) -> None:
@@ -294,6 +304,72 @@ def test_command_step_inputs_are_rendered_into_runtime_request_text(tmp_path: Pa
                 "Step bootstrap: Load context",
                 "Declared command: spec-kitty charter context --action composer --json [--profile {wp.agent_profile}] [--tool {env.agent_tool}]",
                 "Command status: declared only; the host/operator owns execution.",
+            ]
+        )
+    ]
+
+
+def test_input_only_step_renders_required_inputs_into_runtime_request_text(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_project_graph(repo_root)
+
+    contract = {
+        "schema_version": "1.0",
+        "id": "input-only-contract",
+        "mission": "fixture",
+        "action": "composer",
+        "steps": [
+            {
+                "id": "collect",
+                "description": "Collect required context",
+                "inputs": [
+                    {
+                        "flag": "--profile",
+                        "source": "wp.agent_profile",
+                    },
+                ],
+            }
+        ],
+    }
+    built_in_dir = tmp_path / "contracts"
+    _write_yaml(built_in_dir / "input-only.step-contract.yaml", contract)
+
+    class FakeInvocationExecutor:
+        def __init__(self) -> None:
+            self.request_texts: list[str] = []
+
+        def invoke(self, request_text: str, **_kwargs: object) -> object:
+            self.request_texts.append(request_text)
+            return SimpleNamespace(invocation_id="inv-1")
+
+        def complete_invocation(self, _invocation_id: str, *, outcome: str) -> None:
+            assert outcome == "done"
+
+    fake_invocations = FakeInvocationExecutor()
+    result = StepContractExecutor(
+        repo_root=repo_root,
+        contract_repository=MissionStepContractRepository(built_in_dir=built_in_dir),
+        invocation_executor=fake_invocations,  # type: ignore[arg-type]
+    ).execute(
+        StepContractExecutionContext(
+            repo_root=repo_root,
+            mission="fixture",
+            action="composer",
+            actor="pytest",
+            profile_hint="implementer-fixture",
+        )
+    )
+
+    assert result.steps[0].inputs[0].optional is False
+    assert fake_invocations.request_texts == [
+        "\n".join(
+            [
+                "Execute mission step contract input-only-contract (fixture/composer).",
+                "Step collect: Collect required context",
+                "Declared step inputs: --profile {wp.agent_profile}",
             ]
         )
     ]


### PR DESCRIPTION
## Summary
- add schema-owned MissionStepInput so step-contract inputs survive YAML load/save
- expose structured inputs on step execution results
- render declared command inputs into the runtime request command text

Closes #1433.

## Tests
- .venv/bin/pytest tests/doctrine/mission_step_contracts/test_models.py tests/doctrine/mission_step_contracts/test_repository.py tests/doctrine/mission_step_contracts/test_shipped_contracts.py tests/specify_cli/mission_step_contracts/test_executor.py tests/specify_cli/mission_step_contracts/test_software_dev_composition.py tests/specify_cli/mission_step_contracts/test_research_composition.py tests/specify_cli/mission_step_contracts/test_documentation_composition.py tests/cross_cutting/test_mypy_strict_mission_step_contracts.py -q
- .venv/bin/ruff check src/charter/mission_steps.py src/doctrine/mission_step_contracts src/specify_cli/mission_step_contracts tests/doctrine/mission_step_contracts tests/specify_cli/mission_step_contracts/test_executor.py
- git diff --check

## Notes
- Full repo `.venv/bin/ruff check` still reports pre-existing lint failures in .kittify/overrides, kitty-specs baseline, and scripts paths outside this change.