### PR TITLE
Fix neutrality allowlist glob matching

### DIFF
--- a/src/charter/neutrality/lint.py
+++ b/src/charter/neutrality/lint.py
@@ -13,7 +13,6 @@ Mission: charter-ownership-consolidation-and-neutrality-hardening-01KPD880
 
 from __future__ import annotations
 
-import fnmatch
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -82,6 +81,14 @@ class _CompiledTerm:
     compiled: re.Pattern[str] | None  # regex terms, plus case-insensitive literals
 
 
+@dataclass(frozen=True)
+class _ResolvedAllowlist:
+    """Repo-relative allowlist paths expanded with one glob implementation."""
+
+    paths: frozenset[str]
+    stale_entries: tuple[str, ...]
+
+
 def _is_glob_pattern(path_spec: str) -> bool:
     """Return True when the allowlist entry uses glob syntax."""
     return any(char in path_spec for char in "*?[")
@@ -123,31 +130,29 @@ def _load_allowlist(path: Path) -> list[str]:
     return [entry["path"] for entry in raw.get("paths", [])]
 
 
-def _is_allowlisted(repo_relative: str, allowlist: list[str]) -> bool:
-    """Return True if repo_relative matches any allowlist entry (literal or glob)."""
-    for entry in allowlist:
-        # Glob entries contain wildcards; literals are exact matches.
-        if _is_glob_pattern(entry):
-            if fnmatch.fnmatchcase(repo_relative, entry):
-                return True
-        else:
-            if repo_relative == entry:
-                return True
-    return False
-
-
-def _check_stale(repo_root: Path, allowlist_paths: list[str]) -> list[str]:
-    """Return allowlist path strings that resolve to zero files."""
-    stale: list[str] = []
+def _resolve_allowlist(repo_root: Path, allowlist_paths: list[str]) -> _ResolvedAllowlist:
+    """Expand allowlist entries once so stale checks and exemptions agree."""
+    resolved_paths: set[str] = set()
+    stale_entries: list[str] = []
     for entry in allowlist_paths:
         if _is_glob_pattern(entry):
-            matches = list(repo_root.glob(entry))
+            matches = [path for path in repo_root.glob(entry) if path.is_file()]
             if not matches:
-                stale.append(entry)
+                stale_entries.append(entry)
+            else:
+                resolved_paths.update(path.relative_to(repo_root).as_posix() for path in matches)
         else:
-            if not (repo_root / entry).exists():
-                stale.append(entry)
-    return stale
+            path = repo_root / entry
+            if path.is_file():
+                resolved_paths.add(path.relative_to(repo_root).as_posix())
+            else:
+                stale_entries.append(entry)
+    return _ResolvedAllowlist(paths=frozenset(resolved_paths), stale_entries=tuple(stale_entries))
+
+
+def _is_allowlisted(repo_relative: str, allowlist: _ResolvedAllowlist) -> bool:
+    """Return True if repo_relative is in the resolved allowlist."""
+    return repo_relative in allowlist.paths
 
 
 def _relative_parts(path: Path, root: Path) -> tuple[str, ...]:
@@ -408,8 +413,8 @@ def run_neutrality_lint(
     terms = _load_banned_terms(banned_terms_path)
     allowlist_paths = _load_allowlist(allowlist_path)
 
-    # Check for stale allowlist entries
-    stale = _check_stale(repo_root, allowlist_paths)
+    # Resolve allowlist entries once; stale checks and exemptions share semantics.
+    allowlist = _resolve_allowlist(repo_root, allowlist_paths)
 
     # Collect files
     all_files = _iter_scannable_files(effective_roots)
@@ -420,14 +425,14 @@ def run_neutrality_lint(
     for file_path in all_files:
         scanned += 1
         repo_relative_str = _repo_relative_string(file_path, repo_root)
-        if _is_allowlisted(repo_relative_str, allowlist_paths):
+        if _is_allowlisted(repo_relative_str, allowlist):
             continue
         hits = _scan_file(file_path, repo_root, terms)
         all_hits.extend(hits)
 
     return NeutralityLintResult(
         hits=tuple(all_hits),
-        stale_allowlist_entries=tuple(stale),
+        stale_allowlist_entries=allowlist.stale_entries,
         scanned_file_count=scanned,
         banned_term_count=len(terms),
         allowlisted_path_count=len(allowlist_paths),

--- a/tests/charter/test_neutrality_lint.py
+++ b/tests/charter/test_neutrality_lint.py
@@ -303,6 +303,52 @@ def test_glob_allowlist_matches_files(tmp_path: Path) -> None:
     assert result.passed, f"Expected glob allowlist to suppress all hits; got hits={result.hits} stale={result.stale_allowlist_entries}"
 
 
+def test_glob_allowlist_star_does_not_cross_directory_segments(tmp_path: Path) -> None:
+    """Allowlist exemption matching must use the same segment semantics as stale checks."""
+    scoped_dir = tmp_path / "src" / "doctrine" / "python-scoped"
+    nested_dir = scoped_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (scoped_dir / "allowed.md").write_text("run pytest here\n", encoding="utf-8")
+    (nested_dir / "not-allowed.md").write_text("run pytest here too\n", encoding="utf-8")
+
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text(
+        "schema_version: '1'\npaths:\n  - path: src/doctrine/python-scoped/*.md\n    rationale: One directory only.\n    added_in: '3.2.0'\n",
+        encoding="utf-8",
+    )
+
+    result = run_neutrality_lint(
+        repo_root=tmp_path,
+        scan_roots=[tmp_path / "src" / "doctrine"],
+        allowlist_path=allowlist,
+    )
+
+    assert not result.stale_allowlist_entries
+    hit_files = {hit.file.as_posix() for hit in result.hits}
+    assert hit_files == {"src/doctrine/python-scoped/nested/not-allowed.md"}
+
+
+def test_glob_allowlist_double_star_matches_zero_directory_segments(tmp_path: Path) -> None:
+    """``**`` exemptions must match the same paths that make the entry non-stale."""
+    scoped_dir = tmp_path / "src" / "doctrine" / "python-scoped"
+    scoped_dir.mkdir(parents=True)
+    (scoped_dir / "guide.md").write_text("run pytest here\n", encoding="utf-8")
+
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text(
+        "schema_version: '1'\npaths:\n  - path: src/doctrine/python-scoped/**/*.md\n    rationale: Recursive python guide exemption.\n    added_in: '3.2.0'\n",
+        encoding="utf-8",
+    )
+
+    result = run_neutrality_lint(
+        repo_root=tmp_path,
+        scan_roots=[tmp_path / "src" / "doctrine"],
+        allowlist_path=allowlist,
+    )
+
+    assert result.passed, f"Expected ** glob to suppress top-level guide; got hits={result.hits} stale={result.stale_allowlist_entries}"
+
+
 def test_regex_term_reports_accurate_column(tmp_path: Path) -> None:
     """A regex-kind banned term must report file:line:column that points at the match."""
     scan_root = tmp_path / "src" / "doctrine"


### PR DESCRIPTION
## Summary

- resolve neutrality allowlist entries once with `Path.glob` semantics
- use the resolved path set for both stale detection and exemption checks
- add regression coverage for documented `**/*.md` zero-segment matching and `*` not crossing directory segments

Closes #1435.

## Verification

- `.venv/bin/pytest tests/charter/test_neutrality_lint.py -q`
- `.venv/bin/pytest tests/charter/test_neutrality_lint.py tests/doctrine/test_generic_artifact_language_bias.py tests/charter/test_chokepoint_coverage.py -q`
- `.venv/bin/pytest tests/charter -q`
- `.venv/bin/ruff check src/charter/neutrality/lint.py tests/charter/test_neutrality_lint.py`
- `git diff --check`

Note: full `.venv/bin/ruff check` was also run and fails on unchanged pre-existing findings under `.kittify/overrides/scripts/tasks/tasks_cli.py`, `scripts/generate_schemas.py`, `scripts/lint_canonical_producers.py`, `scripts/sync_all_contributors.py`, `scripts/tasks/*.py`, `scripts/verify_occurrences.py`, and `kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py`.

## Self-review

Adversarial self-review verdict: SAFE. No merge-blocking findings survived after normalizing literal resolved paths through `Path.relative_to(repo_root).as_posix()` as well.
