### PR TITLE
Fix audit mission_dir JSON stability

### DIFF
--- a/src/specify_cli/audit/models.py
+++ b/src/specify_cli/audit/models.py
@@ -37,12 +37,8 @@ def _stable_mission_dir_for_json(mission_dir: Path, mission_slug: str) -> str:
     if not mission_dir.is_absolute():
         return mission_dir.as_posix()
 
-    parts = mission_dir.parts
-    matching_indexes = [
-        index for index, part in enumerate(parts) if part == _MISSION_ROOT_DIRNAME
-    ]
-    if matching_indexes:
-        return Path(*parts[matching_indexes[-1] :]).as_posix()
+    if mission_dir.parent.name == _MISSION_ROOT_DIRNAME:
+        return Path(_MISSION_ROOT_DIRNAME, mission_dir.name).as_posix()
 
     return mission_slug or mission_dir.name
 

--- a/src/specify_cli/audit/models.py
+++ b/src/specify_cli/audit/models.py
@@ -29,6 +29,23 @@ TEAMSPACE_BLOCKER_CODES: frozenset[str] = frozenset(
     }
 )
 
+_MISSION_ROOT_DIRNAME = "kitty-specs"
+
+
+def _stable_mission_dir_for_json(mission_dir: Path, mission_slug: str) -> str:
+    """Return a deterministic, installation-independent mission path."""
+    if not mission_dir.is_absolute():
+        return mission_dir.as_posix()
+
+    parts = mission_dir.parts
+    matching_indexes = [
+        index for index, part in enumerate(parts) if part == _MISSION_ROOT_DIRNAME
+    ]
+    if matching_indexes:
+        return Path(*parts[matching_indexes[-1] :]).as_posix()
+
+    return mission_slug or mission_dir.name
+
 
 class Severity(StrEnum):
     """Audit finding severity level.
@@ -122,15 +139,17 @@ class MissionAuditResult:
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable dict.
 
-        ``mission_dir`` is serialized as a plain string because ``Path`` is
-        opaque across platforms; callers should not parse it.
+        ``mission_dir`` is serialized as a stable, non-absolute string because
+        absolute ``Path`` values are install-location dependent.
         """
         return {
             "finding_count": len(self.findings),
             "findings": [f.to_dict() for f in self.findings],
             "has_errors": self.has_errors,
             "has_teamspace_blockers": self.has_teamspace_blockers,
-            "mission_dir": str(self.mission_dir),
+            "mission_dir": _stable_mission_dir_for_json(
+                self.mission_dir, self.mission_slug
+            ),
             "mission_slug": self.mission_slug,
         }
 

--- a/tests/audit/test_audit_engine.py
+++ b/tests/audit/test_audit_engine.py
@@ -171,6 +171,20 @@ def test_determinism(tmp_path: Path) -> None:
     assert json_1 == json_2, "Two identical run_audit() calls produced different JSON"
 
 
+def test_json_stable_across_checkout_roots(tmp_path: Path) -> None:
+    """Identical audit input in different roots serializes byte-identically."""
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    _make_mission(repo_a / "kitty-specs", "mission-x", _ULID_A, mission_number=1)
+    _make_mission(repo_b / "kitty-specs", "mission-x", _ULID_A, mission_number=1)
+
+    json_a = build_report_json(run_audit(_options(repo_a)))
+    json_b = build_report_json(run_audit(_options(repo_b)))
+
+    assert json_a == json_b
+    assert str(tmp_path) not in json_a
+
+
 # ---------------------------------------------------------------------------
 # Test 5: test_corrupt_jsonl_does_not_crash_engine
 # ---------------------------------------------------------------------------

--- a/tests/audit/test_audit_models.py
+++ b/tests/audit/test_audit_models.py
@@ -287,6 +287,21 @@ class TestMissionAuditResult:
         assert mission_dir == slug
         assert str(tmp_path) not in str(mission_dir)
 
+    def test_to_dict_fixture_dir_under_unrelated_kitty_specs_ancestor_uses_slug(
+        self, tmp_path: Path
+    ) -> None:
+        slug = "fixture-mission"
+        r = MissionAuditResult(
+            mission_slug=slug,
+            mission_dir=tmp_path / "kitty-specs" / "install-root" / "fixtures" / slug,
+            findings=[],
+        )
+
+        mission_dir = r.to_dict()["mission_dir"]
+
+        assert mission_dir == slug
+        assert "install-root" not in str(mission_dir)
+
     def test_to_dict_finding_count(self) -> None:
         r = _make_result(
             findings=[

--- a/tests/audit/test_audit_models.py
+++ b/tests/audit/test_audit_models.py
@@ -261,6 +261,32 @@ class TestMissionAuditResult:
         d = r.to_dict()
         assert isinstance(d["mission_dir"], str)
 
+    def test_to_dict_mission_dir_under_kitty_specs_is_repo_relative(self, tmp_path: Path) -> None:
+        slug = "stable-mission"
+        r = MissionAuditResult(
+            mission_slug=slug,
+            mission_dir=tmp_path / "repo-a" / "kitty-specs" / slug,
+            findings=[],
+        )
+
+        mission_dir = r.to_dict()["mission_dir"]
+
+        assert mission_dir == f"kitty-specs/{slug}"
+        assert str(tmp_path) not in str(mission_dir)
+
+    def test_to_dict_fixture_mission_dir_does_not_leak_absolute_root(self, tmp_path: Path) -> None:
+        slug = "fixture-mission"
+        r = MissionAuditResult(
+            mission_slug=slug,
+            mission_dir=tmp_path / "fixtures" / slug,
+            findings=[],
+        )
+
+        mission_dir = r.to_dict()["mission_dir"]
+
+        assert mission_dir == slug
+        assert str(tmp_path) not in str(mission_dir)
+
     def test_to_dict_finding_count(self) -> None:
         r = _make_result(
             findings=[


### PR DESCRIPTION
## Summary
- Fixes #1431
- Serializes audit `mission_dir` as install-independent text instead of leaking absolute checkout paths
- Adds regression coverage for model serialization, fixture-dir output, and cross-root byte-stability

## Verification
- Failing-first regression confirmed before production change: 3 new tests failed on absolute `mission_dir` output
- `.venv/bin/pytest tests/audit/test_audit_models.py::TestMissionAuditResult::test_to_dict_mission_dir_under_kitty_specs_is_repo_relative tests/audit/test_audit_models.py::TestMissionAuditResult::test_to_dict_fixture_mission_dir_does_not_leak_absolute_root tests/audit/test_audit_engine.py::test_json_stable_across_checkout_roots` -> 3 passed
- `.venv/bin/pytest tests/audit/test_audit_models.py tests/audit/test_audit_serializer.py tests/audit/test_audit_engine.py tests/audit/test_audit_cli.py` -> 77 passed
- `.venv/bin/ruff check src/specify_cli/audit/models.py tests/audit/test_audit_models.py tests/audit/test_audit_engine.py` -> All checks passed
- CLI JSON smoke check: `spec-kitty doctor mission-state --audit --json --fixture-dir <tmp>/fixtures` emitted `"mission_dir": "fixture-mission"` and exit 0

## Self-review
- Ran requested adversarial self-review via `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` on local diff. Verdict: SAFE; no merge-blocking findings. Residual compatibility risk is only consumers relying on undocumented absolute-path parsing, which this issue explicitly requires removing.
