### PR TITLE
Fix audit lifecycle row shape classification

### DIFF
--- a/src/specify_cli/audit/detectors.py
+++ b/src/specify_cli/audit/detectors.py
@@ -55,9 +55,10 @@ STATUS_EVENT_ONLY_LEGACY_KEYS: frozenset[str] = frozenset(
 #
 # Row-family scoping (mission ``unblock-sync-identity-boundary-canary``, WP01):
 # ``status.events.jsonl`` carries two distinct row families — status-transition
-# rows and mission-lifecycle rows (``aggregate_type == "Mission"`` plus an
-# ``event_type`` discriminator). The FORBIDDEN_KEYS rule applies only to the
-# non-lifecycle family. ``detect_forbidden_keys`` consults
+# rows and mission-lifecycle rows (accepted lifecycle aggregate type plus an
+# ``event_type`` discriminator, excluding status-transition discriminators).
+# The FORBIDDEN_KEYS rule applies only to the non-lifecycle family.
+# ``detect_forbidden_keys`` consults
 # :func:`specify_cli.audit.shape_registry.is_mission_lifecycle_row` to skip
 # legitimate lifecycle rows while still flagging malformed transition rows
 # that carry ``event_type`` / ``event_name``.

--- a/src/specify_cli/audit/shape_registry.py
+++ b/src/specify_cli/audit/shape_registry.py
@@ -81,6 +81,19 @@ KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT: dict[str, frozenset[str]] = {
             "event_name",
         }
     ),
+    "mission_lifecycle_row": frozenset(
+        {
+            "aggregate_id",
+            "aggregate_type",
+            "event_id",
+            "event_type",
+            "payload",
+            "project_slug",
+            "project_uuid",
+            "schema_version",
+            "timestamp",
+        }
+    ),
     "wp_frontmatter": frozenset(
         {
             "work_package_id",
@@ -176,6 +189,7 @@ KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT: dict[str, frozenset[str]] = {
 LIFECYCLE_AGGREGATE_TYPES: frozenset[str] = frozenset(
     {"Mission", "Project", "WorkPackage", "MissionDossier"}
 )
+STATUS_TRANSITION_DISCRIMINATORS: frozenset[str] = frozenset({"from_lane", "to_lane"})
 DECISIONPOINT_STATUS_EVENT_KEYS: frozenset[str] = KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT[
     "decision_event_row"
 ]
@@ -189,11 +203,10 @@ def is_mission_lifecycle_row(row: Mapping[str, Any]) -> bool:
     discriminator ``event_type`` (e.g. ``"MissionCreated"``,
     ``"SpecifyStarted"``, ``"WPStatusChanged"``) and identify the aggregate
     via ``aggregate_type`` set to one of
-    ``{"Mission", "Project", "WorkPackage", "MissionDossier"}``. **Both**
-    predicates must hold; either alone does NOT classify as a lifecycle
-    row — that distinction is what keeps the ``FORBIDDEN_KEYS`` audit rule
-    effective against malformed status-transition rows that carry
-    ``event_type`` without a matching ``aggregate_type``.
+    ``{"Mission", "Project", "WorkPackage", "MissionDossier"}``. It must
+    also avoid status-transition discriminators (``from_lane`` / ``to_lane``).
+    These predicates keep the ``FORBIDDEN_KEYS`` audit rule effective against
+    malformed status-transition rows that carry lifecycle-looking keys.
 
     Issue #1142 broadened the accepted ``aggregate_type`` set beyond the
     original ``"Mission"``-only check. The events package legitimately
@@ -206,14 +219,17 @@ def is_mission_lifecycle_row(row: Mapping[str, Any]) -> bool:
     Returns:
         ``True`` when *row* is a lifecycle row; ``False`` otherwise
         (including for non-mapping inputs, which are conservatively
-        rejected, and for rows whose ``aggregate_type`` is absent,
-        empty, or outside the known lifecycle set).
+        rejected, for rows whose ``aggregate_type`` is absent, empty, or outside
+        the known lifecycle set, and for hybrid rows that also carry transition
+        discriminators).
 
     Reference:
         ``kitty-specs/unblock-sync-identity-boundary-canary-01KRZJ07/
         contracts/audit-row-family.md``.
     """
     if not isinstance(row, Mapping):
+        return False
+    if STATUS_TRANSITION_DISCRIMINATORS.intersection(row):
         return False
     aggregate_type = row.get("aggregate_type")
     if aggregate_type not in LIFECYCLE_AGGREGATE_TYPES:
@@ -242,6 +258,8 @@ def is_decisionpoint_status_event_row(row: Mapping[str, Any]) -> bool:
 
 def status_event_row_artifact_type(row: Mapping[str, Any]) -> str:
     """Return the shape registry artifact type for a ``status.events.jsonl`` row."""
+    if is_mission_lifecycle_row(row):
+        return "mission_lifecycle_row"
     if is_decisionpoint_status_event_row(row):
         return "decision_event_row"
     return "status_event_row"

--- a/tests/specify_cli/audit/test_detectors_row_family.py
+++ b/tests/specify_cli/audit/test_detectors_row_family.py
@@ -41,8 +41,10 @@ from specify_cli.audit.detectors import detect_forbidden_keys
 from specify_cli.audit.engine import run_audit
 from specify_cli.audit.models import AuditOptions
 from specify_cli.audit.shape_registry import (
+    check_unknown_keys,
     is_decisionpoint_status_event_row,
     is_mission_lifecycle_row,
+    status_event_row_artifact_type,
 )
 
 
@@ -157,6 +159,15 @@ class TestIsMissionLifecycleRow:
         ``FORBIDDEN_KEYS`` rule retains its teeth against malformed rows.
         """
         row = {"aggregate_type": "Foo", "event_type": "Bar"}
+        assert is_mission_lifecycle_row(row) is False
+
+    def test_transition_discriminators_are_not_lifecycle(self) -> None:
+        row = {
+            "aggregate_type": "WorkPackage",
+            "event_type": "WPStatusChanged",
+            "from_lane": "planned",
+            "to_lane": "claimed",
+        }
         assert is_mission_lifecycle_row(row) is False
 
     def test_none_aggregate_is_not_lifecycle(self) -> None:
@@ -383,6 +394,62 @@ class TestDetectForbiddenKeysRowFamily:
 
 
 # ---------------------------------------------------------------------------
+# Unknown-shape row-family tests — pins issue #1426
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEventUnknownShapeRowFamily:
+    """Pins ``UNKNOWN_SHAPE`` routing for mixed ``status.events.jsonl`` rows."""
+
+    def test_lifecycle_envelope_keys_are_known_for_lifecycle_rows(self) -> None:
+        row: dict[str, object] = {
+            "event_id": "01KTESTLIFECYCLE00000000001",
+            "event_type": "WPStatusChanged",
+            "aggregate_id": "WP01",
+            "aggregate_type": "WorkPackage",
+            "schema_version": "5.0.0",
+            "timestamp": "2026-05-31T12:00:00+00:00",
+            "payload": {"wp_id": "WP01", "to_lane": "in_progress"},
+            "project_uuid": "01KTESTPROJECT0000000001",
+            "project_slug": "demo-project",
+        }
+
+        artifact_type = status_event_row_artifact_type(row)
+        findings = check_unknown_keys(artifact_type, row, "status.events.jsonl")
+
+        assert artifact_type == "mission_lifecycle_row"
+        assert findings == []
+
+    def test_malformed_transition_with_lifecycle_keys_still_uses_transition_shape(
+        self,
+    ) -> None:
+        row: dict[str, object] = {
+            "event_id": "01KTESTMALFORMED000000001",
+            "event_type": "WPStatusChanged",
+            "from_lane": "planned",
+            "to_lane": "claimed",
+            "wp_id": "WP01",
+            "aggregate_id": "WP01",
+            "aggregate_type": "WorkPackage",
+            "schema_version": "5.0.0",
+            "timestamp": "2026-05-31T12:00:00+00:00",
+            "payload": {"wp_id": "WP01"},
+        }
+
+        artifact_type = status_event_row_artifact_type(row)
+        findings = check_unknown_keys(artifact_type, row, "status.events.jsonl")
+
+        assert artifact_type == "status_event_row"
+        assert {f.detail for f in findings} >= {
+            "unknown key: 'aggregate_id' (artifact_type='status_event_row')",
+            "unknown key: 'aggregate_type' (artifact_type='status_event_row')",
+            "unknown key: 'schema_version' (artifact_type='status_event_row')",
+            "unknown key: 'timestamp' (artifact_type='status_event_row')",
+            "unknown key: 'payload' (artifact_type='status_event_row')",
+        }
+
+
+# ---------------------------------------------------------------------------
 # End-to-end integration: run_audit against a synthetic mission tree
 # ---------------------------------------------------------------------------
 
@@ -442,6 +509,43 @@ class TestRunAuditRowFamily:
         assert "FORBIDDEN_KEY" not in codes_001, (
             "WP01 regression (#1122): lifecycle rows triggered FORBIDDEN_KEY in "
             f"run_audit output: {codes_001!r}"
+        )
+
+    def test_lifecycle_envelope_rows_yield_no_unknown_shape_findings(
+        self, tmp_path: Path
+    ) -> None:
+        kitty_specs = tmp_path / "kitty-specs"
+        _seed_mission(
+            kitty_specs,
+            "004-lifecycle-envelope",
+            mission_id="01JZZZZZZZZZZZZZZZZZZZZZZC",
+            rows=[
+                {
+                    "event_id": "01KTESTLIFECYCLE00000000002",
+                    "event_type": "WPStatusChanged",
+                    "aggregate_id": "WP01",
+                    "aggregate_type": "WorkPackage",
+                    "schema_version": "5.0.0",
+                    "timestamp": "2026-05-31T12:00:00+00:00",
+                    "payload": {"wp_id": "WP01", "to_lane": "in_progress"},
+                    "project_uuid": "01KTESTPROJECT0000000002",
+                    "project_slug": "demo-project",
+                },
+            ],
+        )
+
+        report = run_audit(AuditOptions(repo_root=tmp_path, scan_root=kitty_specs))
+
+        unknown_findings = [
+            f
+            for m in report.missions
+            if m.mission_slug == "004-lifecycle-envelope"
+            for f in m.findings
+            if f.code == "UNKNOWN_SHAPE"
+        ]
+        assert unknown_findings == [], (
+            "Issue #1426 regression: lifecycle envelopes must not be checked "
+            f"against status_event_row. Got: {unknown_findings!r}"
         )
 
     def test_malformed_transition_row_still_flagged_in_run_audit(


### PR DESCRIPTION
## Summary
- add a dedicated `mission_lifecycle_row` audit shape for lifecycle envelopes in `status.events.jsonl`
- route lifecycle rows through that shape for `UNKNOWN_SHAPE` checks while keeping malformed transition hybrids on `status_event_row`
- refresh detector comments and add regression coverage for #1426

Closes #1426.

## Verification
- ` .venv/bin/pytest tests/specify_cli/audit/test_detectors_row_family.py -q` -> 37 passed
- ` .venv/bin/pytest tests/specify_cli/audit -q` -> 43 passed
- ` .venv/bin/ruff check src/specify_cli/audit/shape_registry.py src/specify_cli/audit/detectors.py tests/specify_cli/audit/test_detectors_row_family.py` -> All checks passed
- `git diff --check` -> passed

## Self-review
Used `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` against the local diff before opening this PR. Findings addressed before commit:
- stale detector comment still described `aggregate_type == "Mission"`; updated to accepted lifecycle aggregate family plus transition-discriminator exclusion
- hybrid unknown-shape regression did not include `aggregate_type`; tightened fixture so lifecycle-looking transition rows stay on `status_event_row`

Residual risk: audit registry remains intentionally schema-shallow; payload internals are still owned by producer/conformance tests, not this audit shape check.