### PR TITLE
Fix grep absence verifier failures

### DIFF
--- a/architecture/3.x/adr/2026-04-03-3-feature-acceptance-runs-on-the-integrated-mission-branch.md
+++ b/architecture/3.x/adr/2026-04-03-3-feature-acceptance-runs-on-the-integrated-mission-branch.md
@@ -78,6 +78,28 @@ At minimum, the following must be checked where applicable:
 4. no fallback code path or secondary entrypoint can still render the removed
    surface.
 
+### Negative Invariant Verifier Model
+
+Negative invariant evidence MUST distinguish absence from verifier failure.
+`grep_absence` remains a cheap textual fallback, but only `grep` exit code 1
+proves absence. Exit code 0 means the forbidden surface is still present. Exit
+codes greater than 1 mean verifier failure and MUST produce a blocking
+`verification_error`, not `confirmed_absent`.
+
+Structured surfaces SHOULD use typed verifiers instead of grep:
+
+1. command registry inspection for command absence,
+2. route table inspection for route absence,
+3. AST or import graph checks for code-level bans,
+4. parsed config or manifest inspection for configuration invariants,
+5. orchestrator/state APIs for workflow-state invariants.
+
+Every verifier SHOULD declare the checked surface, absence semantics, evidence
+shape, and blocking behavior. Its tests MUST prove both positive detection
+(`still_present`) and negative absence (`confirmed_absent`), and SHOULD include
+a verifier-failure case (`verification_error`) where the verifier depends on
+parsing, external commands, or structured inputs.
+
 ### Manual QA Evidence Rule
 
 Manual QA evidence MUST include, at minimum:

--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -21,7 +21,7 @@ from specify_cli.configured_command import ConfiguredCommandUnsupported, run_con
 from specify_cli.mission_metadata import mission_identity_fields, resolve_mission_identity
 
 CRITERION_VERDICTS = frozenset({"pass", "fail", "pending"})
-NEGATIVE_INVARIANT_RESULTS = frozenset({"confirmed_absent", "still_present", "pending"})
+NEGATIVE_INVARIANT_RESULTS = frozenset({"confirmed_absent", "still_present", "pending", "verification_error"})
 
 
 def _is_allowed_value(value: Any, allowed: frozenset[str]) -> bool:
@@ -75,7 +75,7 @@ class NegativeInvariant:
     description: str
     verification_method: str  # "grep_absence" | "route_check" | "custom_command"
     verification_command: str | None = None
-    result: str = "pending"  # "confirmed_absent" | "still_present" | "pending"
+    result: str = "pending"  # "confirmed_absent" | "still_present" | "pending" | "verification_error"
     evidence: str | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
@@ -120,7 +120,7 @@ class AcceptanceMatrix:
             return "fail"
         if any(v == "fail" for v in criterion_results):
             return "fail"
-        if any(v == "still_present" for v in invariant_results):
+        if any(v in {"still_present", "verification_error"} for v in invariant_results):
             return "fail"
         if any(v == "pending" for v in criterion_results + invariant_results):
             return "pending"
@@ -321,7 +321,7 @@ def enforce_negative_invariants(
     """Run all negative invariant checks. Returns updated invariants.
 
     Verification methods:
-    - grep_absence: Run grep for pattern in repo, assert zero matches.
+    - grep_absence: Run grep for pattern in repo; exit code 1 means absent.
     - custom_command: Run a command, check exit code (0 = absent/pass).
     """
     results: list[NegativeInvariant] = []
@@ -351,7 +351,7 @@ def _check_invariant(repo_root: Path, ni: NegativeInvariant) -> NegativeInvarian
 
 
 def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvariant:
-    """Grep for pattern — zero matches means confirmed absent."""
+    """Grep for pattern; exit code 1 means confirmed absent."""
     if not ni.verification_command:
         return NegativeInvariant(
             invariant_id=ni.invariant_id,
@@ -363,21 +363,32 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             extras=ni.extras,
         )
 
-    result = subprocess.run(
-        [
-            "grep",
-            "-r",
-            "--exclude=acceptance-matrix.json",
-            "--exclude-dir=.git",
-            "--",
-            ni.verification_command,
-            ".",
-        ],
-        cwd=str(repo_root),
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0 and not result.stdout.strip():
+    try:
+        result = subprocess.run(
+            [
+                "grep",
+                "-r",
+                "--exclude=acceptance-matrix.json",
+                "--exclude-dir=.git",
+                "--",
+                ni.verification_command,
+                ".",
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        return NegativeInvariant(
+            invariant_id=ni.invariant_id,
+            description=ni.description,
+            verification_method=ni.verification_method,
+            verification_command=ni.verification_command,
+            result="verification_error",
+            evidence=f"grep failed to start: {exc}",
+            extras=ni.extras,
+        )
+    if result.returncode == 1:
         # No matches — pattern is absent
         return NegativeInvariant(
             invariant_id=ni.invariant_id,
@@ -388,7 +399,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             evidence="grep found zero matches",
             extras=ni.extras,
         )
-    else:
+    if result.returncode == 0:
         matches = result.stdout.strip().splitlines()[:5]
         return NegativeInvariant(
             invariant_id=ni.invariant_id,
@@ -399,6 +410,16 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             evidence=f"grep found matches: {'; '.join(matches)}",
             extras=ni.extras,
         )
+    details = (result.stderr or result.stdout).strip()[:500]
+    return NegativeInvariant(
+        invariant_id=ni.invariant_id,
+        description=ni.description,
+        verification_method=ni.verification_method,
+        verification_command=ni.verification_command,
+        result="verification_error",
+        evidence=f"grep verification failed (exit {result.returncode}): {details}",
+        extras=ni.extras,
+    )
 
 
 def _check_custom_command(repo_root: Path, ni: NegativeInvariant) -> NegativeInvariant:

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -5,6 +5,7 @@ import sys
 
 import pytest
 
+from specify_cli.acceptance import matrix as acceptance_matrix_module
 from specify_cli.acceptance_matrix import (
     AcceptanceCriterion,
     AcceptanceMatrix,
@@ -68,6 +69,18 @@ class TestAcceptanceMatrix:
             ],
             negative_invariants=[
                 NegativeInvariant("NI-01", "Old route gone", "grep_absence", result="still_present"),
+            ],
+        )
+        assert m.overall_verdict == "fail"
+
+    def test_verdict_invariant_verification_error_fails_closed(self):
+        m = AcceptanceMatrix(
+            mission_slug="test",
+            criteria=[
+                AcceptanceCriterion("AC-01", "Test", "automated_test", pass_fail="pass"),
+            ],
+            negative_invariants=[
+                NegativeInvariant("NI-01", "Old route gone", "grep_absence", result="verification_error"),
             ],
         )
         assert m.overall_verdict == "fail"
@@ -238,7 +251,7 @@ class TestManualEvidence:
         errors = validate_matrix_evidence(m)
 
         assert "AC-01: pass_fail must be one of fail, pass, pending; got 'failed'" in errors
-        assert "NI-01: result must be one of confirmed_absent, pending, still_present; got 'absent'" in errors
+        assert "NI-01: result must be one of confirmed_absent, pending, still_present, verification_error; got 'absent'" in errors
 
 
 class TestNegativeInvariants:
@@ -256,6 +269,43 @@ class TestNegativeInvariants:
         ]
         results = enforce_negative_invariants(tmp_path, invariants)
         assert results[0].result == "confirmed_absent"
+
+    def test_grep_absence_invalid_regex_is_not_confirmed_absent(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("forbidden_thing()\n")
+
+        invariants = [
+            NegativeInvariant(
+                "NI-01", "No forbidden call",
+                "grep_absence",
+                verification_command="forbidden[",
+            ),
+        ]
+        results = enforce_negative_invariants(tmp_path, invariants)
+
+        assert results[0].result == "verification_error"
+        assert "grep verification failed (exit 2)" in (results[0].evidence or "")
+
+    def test_grep_absence_execution_failure_is_not_confirmed_absent(self, tmp_path, monkeypatch):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("def main(): pass\n")
+
+        def fail_to_start(*_args, **_kwargs):
+            raise OSError("grep unavailable")
+
+        monkeypatch.setattr(acceptance_matrix_module.subprocess, "run", fail_to_start)
+
+        invariants = [
+            NegativeInvariant(
+                "NI-01", "No legacy route",
+                "grep_absence",
+                verification_command="old_legacy_route",
+            ),
+        ]
+        results = enforce_negative_invariants(tmp_path, invariants)
+
+        assert results[0].result == "verification_error"
+        assert "grep failed to start: grep unavailable" in (results[0].evidence or "")
 
     def test_grep_absence_still_present(self, tmp_path):
         (tmp_path / "src").mkdir()


### PR DESCRIPTION
## Summary

- Fix `grep_absence` negative invariants to distinguish `grep` rc=0, rc=1, and rc>1.
- Add blocking `verification_error` result so invalid regexes or grep execution failures cannot become `confirmed_absent` acceptance evidence.
- Document typed-verifier direction for stronger negative invariant proofs.

Closes #1420.

## Tests

- `.venv/bin/python -m pytest tests/lanes/test_acceptance_matrix.py tests/specify_cli/cli/commands/test_accept_clean_tree.py tests/cross_cutting/misc/test_acceptance_support.py -q`
- `.venv/bin/ruff check src/specify_cli/acceptance/matrix.py tests/lanes/test_acceptance_matrix.py`
- `git diff --check`

## Self-review

Used adversarial review against the local diff. Finding fixed before PR: stale grep docstring still implied all zero-output cases meant absence. No remaining merge blockers found.
