### PR TITLE
Fix decision open idempotent minted id

### DIFF
--- a/src/specify_cli/cli/commands/decision.py
+++ b/src/specify_cli/cli/commands/decision.py
@@ -19,7 +19,6 @@ import sys
 from pathlib import Path
 
 import typer
-import ulid as _ulid_mod
 
 from specify_cli.decisions.models import (
     DecisionErrorCode,
@@ -195,13 +194,11 @@ def cmd_open(  # noqa: PLR0913
 
     repo_root, mission_slug = _resolve_repo_root_and_slug(mission)
 
-    # FR-003: mint decision_id BEFORE any artifact write or event emission,
-    # and emit it to stdout immediately so callers always receive the id even
-    # if the process is killed mid-write.  dry_run uses "DRY_RUN" as the id
-    # (matching the service-layer convention) so callers can detect the mode.
-    minted_id = "DRY_RUN" if dry_run else str(_ulid_mod.ULID())
-    typer.echo(json.dumps({"decision_id": minted_id, "phase": "minted"}, sort_keys=True))
-    sys.stdout.flush()
+    def emit_minted(decision_id: str) -> None:
+        typer.echo(
+            json.dumps({"decision_id": decision_id, "phase": "minted"}, sort_keys=True)
+        )
+        sys.stdout.flush()
 
     try:
         resp = open_decision(
@@ -215,7 +212,7 @@ def cmd_open(  # noqa: PLR0913
             slot_key=slot_key,
             actor=actor,
             dry_run=dry_run,
-            decision_id=minted_id if not dry_run else None,
+            on_minted=emit_minted,
         )
     except DecisionError as exc:
         _handle_decision_error(exc)

--- a/src/specify_cli/decisions/service.py
+++ b/src/specify_cli/decisions/service.py
@@ -18,6 +18,7 @@ mission_id resolution:
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -159,6 +160,7 @@ def open_decision(
     actor: str,
     dry_run: bool = False,
     decision_id: str | None = None,
+    on_minted: Callable[[str], None] | None = None,
 ) -> DecisionOpenResponse:
     """Open a new decision or return idempotently if already open.
 
@@ -174,9 +176,9 @@ def open_decision(
         actor:        Identity of the opening actor.
         dry_run:      If True, validate and look up without writing.
         decision_id:  Pre-minted ULID to use as the decision_id.  If None, a
-                      new ULID is minted inside this function.  Callers that
-                      need to emit the id to stdout *before* any write should
-                      mint the ULID themselves and pass it here (FR-003).
+                      new ULID is minted inside this function.
+        on_minted:    Optional callback invoked once the usable decision_id is
+                      known and before any artifact write or event emission.
 
     Returns:
         DecisionOpenResponse
@@ -196,6 +198,8 @@ def open_decision(
     mission_dir = _mission_dir(repo_root, mission_slug)
 
     if dry_run:
+        if on_minted is not None:
+            on_minted("DRY_RUN")
         return DecisionOpenResponse(
             decision_id="DRY_RUN",
             idempotent=False,
@@ -217,6 +221,8 @@ def open_decision(
     if existing is not None:
         if not _is_terminal(existing.status):
             # Idempotent return — already open
+            if on_minted is not None:
+                on_minted(existing.decision_id)
             return DecisionOpenResponse(
                 decision_id=existing.decision_id,
                 idempotent=True,
@@ -240,6 +246,8 @@ def open_decision(
 
     # Mint new decision (use caller-supplied id if provided, else mint fresh)
     decision_id = decision_id if decision_id is not None else _mint_decision_id()
+    if on_minted is not None:
+        on_minted(decision_id)
     created_at = _now_utc()
     entry = IndexEntry(
         decision_id=decision_id,

--- a/tests/specify_cli/cli/commands/test_decision.py
+++ b/tests/specify_cli/cli/commands/test_decision.py
@@ -75,6 +75,13 @@ def _parse_open_output(output: str) -> dict:  # type: ignore[type-arg]
     return json.loads(lines[-1])
 
 
+def _parse_open_lines(output: str) -> tuple[dict, dict]:  # type: ignore[type-arg]
+    """Parse ``decision open`` stdout into minted-phase and response dicts."""
+    lines = [line for line in output.splitlines() if line.strip()]
+    assert len(lines) == 2, f"expected 2 JSON lines, got: {output!r}"
+    return json.loads(lines[0]), json.loads(lines[1])
+
+
 def _open_decision(
     tmp_path: Path,
     *,
@@ -606,6 +613,57 @@ def test_open_idempotent_second_call(tmp_path: Path) -> None:
     data2 = _parse_open_output(result2.output)
     assert data2["idempotent"] is True
     assert data2["decision_id"] == data1["decision_id"]
+
+
+def test_open_idempotent_minted_phase_uses_persisted_decision_id(tmp_path: Path) -> None:
+    _setup_mission(tmp_path)
+    with patch("specify_cli.decisions.emit.emit_decision_opened", return_value=1):
+        result1 = _invoke(
+            [
+                "decision",
+                "open",
+                "--mission",
+                MISSION_SLUG,
+                "--flow",
+                "charter",
+                "--step-id",
+                "s-idem-minted",
+                "--input-key",
+                "idem_minted_key",
+                "--question",
+                "Same Q?",
+            ],
+            cwd=tmp_path,
+        )
+        result2 = _invoke(
+            [
+                "decision",
+                "open",
+                "--mission",
+                MISSION_SLUG,
+                "--flow",
+                "charter",
+                "--step-id",
+                "s-idem-minted",
+                "--input-key",
+                "idem_minted_key",
+                "--question",
+                "Same Q?",
+            ],
+            cwd=tmp_path,
+        )
+
+    assert result1.exit_code == 0
+    assert result2.exit_code == 0
+
+    _, first_response = _parse_open_lines(result1.output)
+    second_minted, second_response = _parse_open_lines(result2.output)
+    assert second_response["idempotent"] is True
+    assert second_response["decision_id"] == first_response["decision_id"]
+    assert second_minted == {
+        "decision_id": first_response["decision_id"],
+        "phase": "minted",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/decisions/test_service_idempotency.py
+++ b/tests/specify_cli/decisions/test_service_idempotency.py
@@ -134,6 +134,64 @@ def test_second_open_no_new_event_emitted(tmp_path: Path) -> None:
     assert mock_emit.call_count == 1
 
 
+def test_on_minted_receives_persisted_id_for_idempotent_open(tmp_path: Path) -> None:
+    _setup_meta(tmp_path)
+    minted_ids: list[str] = []
+    with patch("specify_cli.decisions.emit.emit_decision_opened", return_value=1):
+        resp1 = open_decision(
+            tmp_path,
+            MISSION_SLUG,
+            origin_flow=OriginFlow.CHARTER,
+            step_id="step-1",
+            input_key="team_size",
+            question="How large?",
+            options=("1-5",),
+            actor="alice",
+            on_minted=minted_ids.append,
+        )
+        resp2 = open_decision(
+            tmp_path,
+            MISSION_SLUG,
+            origin_flow=OriginFlow.CHARTER,
+            step_id="step-1",
+            input_key="team_size",
+            question="How large?",
+            options=("1-5",),
+            actor="alice",
+            on_minted=minted_ids.append,
+        )
+
+    assert resp2.idempotent is True
+    assert resp2.decision_id == resp1.decision_id
+    assert minted_ids == [resp1.decision_id, resp1.decision_id]
+
+
+def test_on_minted_runs_before_fresh_open_writes_artifact(tmp_path: Path) -> None:
+    _setup_meta(tmp_path)
+    observations: list[tuple[str, bool]] = []
+
+    def record_minted(decision_id: str) -> None:
+        observations.append(
+            (decision_id, _store.artifact_path(_mission_dir(tmp_path), decision_id).exists())
+        )
+
+    with patch("specify_cli.decisions.emit.emit_decision_opened", return_value=1):
+        resp = open_decision(
+            tmp_path,
+            MISSION_SLUG,
+            origin_flow=OriginFlow.CHARTER,
+            step_id="step-1",
+            input_key="team_size",
+            question="How large?",
+            options=("1-5",),
+            actor="alice",
+            on_minted=record_minted,
+        )
+
+    assert observations == [(resp.decision_id, False)]
+    assert _store.artifact_path(_mission_dir(tmp_path), resp.decision_id).exists()
+
+
 # ---------------------------------------------------------------------------
 # T017c — Open on terminal entry raises ALREADY_CLOSED
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move `decision open` minted-line emission behind the decisions service id selection via an `on_minted` callback.
- Preserve FR-003 fresh-open ordering while making idempotent reopen print the persisted decision id, not a phantom ULID.
- Add CLI and service regression tests for #1430.

Closes #1430

## Verification
- RED before fix: `.venv/bin/pytest tests/specify_cli/cli/commands/test_decision.py::test_open_idempotent_minted_phase_uses_persisted_decision_id tests/specify_cli/decisions/test_service_idempotency.py::test_on_minted_receives_persisted_id_for_idempotent_open tests/specify_cli/decisions/test_service_idempotency.py::test_on_minted_runs_before_fresh_open_writes_artifact -q` -> 3 failed.
- GREEN after fix: same command -> 3 passed, 1 warning.
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_decision.py tests/specify_cli/decisions/test_service_idempotency.py tests/specify_cli/decisions/test_service_terminal.py -q` -> 52 passed, 1 warning.
- `.venv/bin/ruff check src/specify_cli/cli/commands/decision.py src/specify_cli/decisions/service.py tests/specify_cli/cli/commands/test_decision.py tests/specify_cli/decisions/test_service_idempotency.py` -> All checks passed.
- `git diff --check` -> passed.

## Self-review
- Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` against the local diff. Verdict: SAFE; no merge-blocking findings survived.
- Checked that service owns canonical id selection, idempotent reopen emits the stored id without a new event, and fresh-open callback runs before append/artifact/event writes.

## Notes
- `IMPLEMENTATION_PROMPT_ISSUE_1430.md` intentionally left untracked and not committed.