### PR TITLE
Fix audit classifiers for non-object JSON roots

### DIFF
--- a/src/specify_cli/audit/classifiers/meta.py
+++ b/src/specify_cli/audit/classifiers/meta.py
@@ -34,7 +34,7 @@ def classify_meta_json(mission_dir: Path) -> list[MissionFinding]:
     findings: list[MissionFinding] = []
 
     try:
-        obj: dict[str, object] = json.loads(path.read_text(encoding="utf-8"))
+        obj = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         return [
             MissionFinding(
@@ -42,6 +42,16 @@ def classify_meta_json(mission_dir: Path) -> list[MissionFinding]:
                 severity=Severity.ERROR,
                 artifact_path="meta.json",
                 detail=f"JSON decode error: {exc.msg}",
+            )
+        ]
+
+    if not isinstance(obj, dict):
+        return [
+            MissionFinding(
+                code="CORRUPT_JSON",
+                severity=Severity.ERROR,
+                artifact_path="meta.json",
+                detail="top-level JSON value must be an object",
             )
         ]
 

--- a/src/specify_cli/audit/classifiers/status_json.py
+++ b/src/specify_cli/audit/classifiers/status_json.py
@@ -41,7 +41,7 @@ def classify_status_json(
 
     try:
         raw_text = path.read_text(encoding="utf-8")
-        obj: dict[str, object] = json.loads(raw_text)
+        obj = json.loads(raw_text)
     except OSError as exc:
         return [
             MissionFinding(
@@ -58,6 +58,16 @@ def classify_status_json(
                 severity=Severity.ERROR,
                 artifact_path="status.json",
                 detail=f"JSON decode error: {exc.msg}",
+            )
+        ]
+
+    if not isinstance(obj, dict):
+        return [
+            MissionFinding(
+                code="CORRUPT_JSON",
+                severity=Severity.ERROR,
+                artifact_path="status.json",
+                detail="top-level JSON value must be an object",
             )
         ]
 

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -191,6 +191,19 @@ def test_meta_classifier_corrupt_json(tmp_path: Path) -> None:
     assert findings[0].severity == Severity.ERROR
 
 
+@pytest.mark.parametrize("payload", ["[]", '"x"', "42", "true", "null"])
+def test_meta_classifier_non_object_json_returns_corrupt_json(
+    tmp_path: Path, payload: str
+) -> None:
+    """Valid non-object meta.json → CORRUPT_JSON finding, not a crash."""
+    (tmp_path / "meta.json").write_text(payload, encoding="utf-8")
+    findings = classify_meta_json(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSON"
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].detail == "top-level JSON value must be an object"
+
+
 def test_meta_classifier_unknown_key(tmp_path: Path) -> None:
     """meta.json with unrecognised key → UNKNOWN_SHAPE finding (info)."""
     data = {**_MODERN_META, "unrecognised_field_xyz": "value"}
@@ -365,6 +378,19 @@ def test_status_json_corrupt_json(tmp_path: Path) -> None:
     (tmp_path / "status.json").write_text("{broken", encoding="utf-8")
     findings = classify_status_json(tmp_path)
     assert "CORRUPT_JSON" in _codes(findings)
+
+
+@pytest.mark.parametrize("payload", ["[]", '"x"', "42", "true", "null"])
+def test_status_json_non_object_json_returns_corrupt_json(
+    tmp_path: Path, payload: str
+) -> None:
+    """Valid non-object status.json → CORRUPT_JSON finding, not a crash."""
+    (tmp_path / "status.json").write_text(payload, encoding="utf-8")
+    findings = classify_status_json(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].code == "CORRUPT_JSON"
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].detail == "top-level JSON value must be an object"
 
 
 def test_status_json_read_oserror_detail_is_deterministic(

--- a/tests/audit/test_audit_engine.py
+++ b/tests/audit/test_audit_engine.py
@@ -205,6 +205,33 @@ def test_corrupt_jsonl_does_not_crash_engine(tmp_path: Path) -> None:
     assert "SNAPSHOT_DRIFT" not in codes, f"SNAPSHOT_DRIFT should be suppressed, got {codes}"
 
 
+def test_non_object_meta_and_status_json_do_not_crash_engine(tmp_path: Path) -> None:
+    """Engine emits findings for valid non-object meta/status JSON roots."""
+    specs_dir = tmp_path / "kitty-specs"
+    mission_dir = specs_dir / "non-object-json-mission"
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "meta.json").write_text("[]", encoding="utf-8")
+    (mission_dir / "status.json").write_text("true", encoding="utf-8")
+
+    report = run_audit(_options(tmp_path))
+
+    assert len(report.missions) == 1
+    result = report.missions[0]
+    findings_by_artifact = {
+        (finding.artifact_path, finding.code): finding for finding in result.findings
+    }
+    assert ("meta.json", "CORRUPT_JSON") in findings_by_artifact
+    assert ("status.json", "CORRUPT_JSON") in findings_by_artifact
+    assert (
+        findings_by_artifact[("meta.json", "CORRUPT_JSON")].detail
+        == "top-level JSON value must be an object"
+    )
+    assert (
+        findings_by_artifact[("status.json", "CORRUPT_JSON")].detail
+        == "top-level JSON value must be an object"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 6: test_repo_summary_counts
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Guard `meta.json` and `status.json` classifiers after `json.loads` so valid non-object JSON roots return `CORRUPT_JSON` findings instead of crashing or drifting
- Add classifier regressions for array, string, number, boolean, and null roots
- Add engine regression proving `run_audit` emits findings for non-object `meta.json`/`status.json` without aborting

Closes #1425

## Tests
- `.venv/bin/pytest tests/audit/test_audit_classifiers.py -k 'non_object_json_returns_corrupt_json'`\n- `.venv/bin/pytest tests/audit/test_audit_classifiers.py`\n- `.venv/bin/pytest tests/audit/test_audit_engine.py -k 'non_object_meta_and_status_json_do_not_crash_engine'`\n- `.venv/bin/pytest tests/audit/test_audit_classifiers.py tests/audit/test_audit_engine.py`\n- `.venv/bin/ruff check src/specify_cli/audit/classifiers/meta.py src/specify_cli/audit/classifiers/status_json.py tests/audit/test_audit_classifiers.py tests/audit/test_audit_engine.py`\n- `.venv/bin/pytest tests/audit`