### PR TITLE
Harden bookkeeping artifact writes

### DIFF
--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -18,8 +18,10 @@ C-013, NFR-001, NFR-008, NFR-010.
 
 from __future__ import annotations
 
+import errno
 import json as _json
 import logging
+import os
 import subprocess
 import sys
 import threading
@@ -309,6 +311,159 @@ def _confine_path_to_worktree(worktree_root: Path, path: Path) -> Path:
             f"{resolved_candidate}"
         )
     return candidate
+
+
+def _resolve_confined_artifact_path(worktree_root: Path, path: Path) -> Path:
+    """Return a canonical artifact path that remains inside ``worktree_root``."""
+    candidate = _confine_path_to_worktree(worktree_root, path)
+    resolved_worktree = worktree_root.resolve()
+    resolved_path = candidate.resolve(strict=False)
+    if resolved_path == resolved_worktree:
+        raise ValueError(
+            "Refusing to write artifact outside coordination worktree "
+            "(target is worktree root): "
+            f"{path}"
+        )
+    if not resolved_path.is_relative_to(resolved_worktree):
+        raise ValueError(
+            "Refusing to write artifact outside coordination worktree "
+            "(outside worktree): "
+            f"{resolved_path}"
+        )
+    return resolved_path
+
+
+def _write_confined_artifact_bytes(
+    worktree_root: Path,
+    path: Path,
+    content: bytes,
+) -> Path:
+    """Write bytes after revalidating containment at the I/O boundary."""
+    resolved_path = _resolve_confined_artifact_path(worktree_root, path)
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_path = _resolve_confined_artifact_path(worktree_root, resolved_path)
+    if resolved_path.exists() and not resolved_path.is_file():
+        raise ValueError(
+            "Refusing to write artifact outside coordination worktree "
+            "(target is not a regular file): "
+            f"{resolved_path}"
+        )
+    existing_mode = (
+        resolved_path.stat().st_mode & 0o777
+        if resolved_path.exists()
+        else None
+    )
+
+    parent_fd: int | None = None
+    tmp_name = f".spec-kitty-{_generate_ulid()}.tmp"
+    try:
+        parent_fd = _open_confined_parent_fd(worktree_root, resolved_path)
+        _write_and_replace_via_parent_fd(
+            parent_fd=parent_fd,
+            target_name=resolved_path.name,
+            tmp_name=tmp_name,
+            content=content,
+            existing_mode=existing_mode,
+        )
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+            raise ValueError(
+                "Refusing to write artifact outside coordination worktree "
+                "(unsafe path changed during write): "
+                f"{resolved_path}"
+            ) from exc
+        raise
+    finally:
+        if parent_fd is not None:
+            try:
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                logger.debug(
+                    "BookkeepingTransaction: failed to remove temp artifact %s/%s",
+                    resolved_path.parent,
+                    tmp_name,
+                )
+            os.close(parent_fd)
+    return resolved_path
+
+
+def _open_confined_parent_fd(worktree_root: Path, path: Path) -> int:
+    """Open ``path.parent`` component-by-component without following symlinks."""
+    if not (
+        os.open in os.supports_dir_fd
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+    ):
+        raise ValueError(
+            "Refusing to write artifact outside coordination worktree "
+            "(fd-relative no-follow writes unsupported on this platform): "
+            f"{path}"
+        )
+
+    resolved_worktree = worktree_root.resolve()
+    relative_parent = path.parent.relative_to(resolved_worktree)
+    dir_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    fd = os.open(resolved_worktree, dir_flags)
+    try:
+        for part in relative_parent.parts:
+            next_fd = os.open(part, dir_flags, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _write_and_replace_via_parent_fd(
+    *,
+    parent_fd: int,
+    target_name: str,
+    tmp_name: str,
+    content: bytes,
+    existing_mode: int | None,
+) -> None:
+    """Create temp file and replace target relative to an already-open parent."""
+    tmp_fd = os.open(
+        tmp_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    try:
+        if existing_mode is not None:
+            os.fchmod(tmp_fd, existing_mode)
+        remaining = memoryview(content)
+        while remaining:
+            written = os.write(tmp_fd, remaining)
+            remaining = remaining[written:]
+    finally:
+        os.close(tmp_fd)
+    os.replace(tmp_name, target_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+
+
+def _unlink_confined_artifact_path(worktree_root: Path, path: Path) -> None:
+    """Unlink an artifact relative to a verified no-follow parent directory."""
+    resolved_path = _resolve_confined_artifact_path(worktree_root, path)
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_confined_parent_fd(worktree_root, resolved_path)
+        os.unlink(resolved_path.name, dir_fd=parent_fd)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise ValueError(
+                "Refusing to unlink artifact outside coordination worktree "
+                "(unsafe path changed during unlink): "
+                f"{resolved_path}"
+            ) from exc
+        raise
+    finally:
+        if parent_fd is not None:
+            os.close(parent_fd)
 
 
 # WP06 swap: the canonical builder now lives in ``status.emit`` so the
@@ -673,31 +828,26 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         rollback path.
         """
         try:
-            candidate = _confine_path_to_worktree(self.worktree_root, path)
+            resolved_path = _resolve_confined_artifact_path(self.worktree_root, path)
         except ValueError as exc:
             raise ValueError(
                 "Refusing to write artifact outside coordination worktree "
                 "(outside worktree): "
                 f"{path}"
             ) from exc
-        resolved_worktree = self.worktree_root.resolve()
         # Capture snapshot ONLY if we have not seen this path yet.
         # Re-writing the same path repeatedly in one transaction still
         # rolls back to the *original* pre-transaction state.
-        resolved_path = candidate.resolve(strict=False)
-        if not resolved_path.is_relative_to(resolved_worktree):
-            raise ValueError(
-                "Refusing to write artifact outside coordination worktree "
-                "(outside worktree): "
-                f"{resolved_path}"
-            )
         if resolved_path not in self._snapshots:
             self._snapshots[resolved_path] = (
                 resolved_path.read_bytes() if resolved_path.exists() else None
             )
 
-        resolved_path.parent.mkdir(parents=True, exist_ok=True)
-        resolved_path.write_bytes(content)
+        resolved_path = _write_confined_artifact_bytes(
+            self.worktree_root,
+            resolved_path,
+            content,
+        )
 
         if resolved_path not in self._staged_paths:
             self._staged_paths.append(resolved_path)
@@ -844,11 +994,10 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         for path, prev in self._snapshots.items():
             try:
                 if prev is None:
-                    path.unlink(missing_ok=True)
+                    _unlink_confined_artifact_path(self.worktree_root, path)
                 else:
-                    path.parent.mkdir(parents=True, exist_ok=True)
-                    path.write_bytes(prev)
-            except OSError as exc:
+                    _write_confined_artifact_bytes(self.worktree_root, path, prev)
+            except (OSError, ValueError) as exc:
                 logger.error(
                     "BookkeepingTransaction rollback: restore of %s "
                     "failed: %s",

--- a/tests/specify_cli/coordination/test_transaction.py
+++ b/tests/specify_cli/coordination/test_transaction.py
@@ -437,6 +437,54 @@ def test_rollback_skips_deferred_outbound(repo: Path) -> None:
     assert ran == []
 
 
+def test_rollback_artifact_restore_refuses_parent_symlink_escape(
+    repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Rollback restore must not write snapshots through a swapped parent."""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    worktree = CoordinationWorkspace.resolve(repo, MISSION_SLUG, MID8)
+
+    def fail_commit(**_kwargs: object) -> None:
+        raise RuntimeError("forced commit failure")
+
+    monkeypatch.setattr(transaction_module, "safe_commit", fail_commit)
+
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(BookkeepingCommitFailed),
+        BookkeepingTransaction.acquire(
+            repo_root=repo,
+            mission_id=MISSION_ID,
+            mission_slug=MISSION_SLUG,
+            mid8=MID8,
+            destination_ref=COORD_BRANCH,
+            operation="rollback_artifact_symlink_escape",
+        ) as txn,
+    ):
+        link_path = worktree / "kitty-specs" / FEATURE_DIRNAME / "rollback-link"
+        artifact = link_path / "artifact.txt"
+        link_path.mkdir(parents=True, exist_ok=True)
+        artifact.write_bytes(b"old-inside")
+
+        txn.write_artifact(artifact, b"new-inside")
+
+        backup_path = link_path.with_name("rollback-link-backup")
+        link_path.rename(backup_path)
+        link_path.symlink_to(outside_dir, target_is_directory=True)
+        txn.commit("status: should reject")
+
+    assert not (outside_dir / "artifact.txt").exists()
+    assert any(
+        "rollback: restore of" in record.getMessage()
+        and "resolves outside worktree" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 # ---------------------------------------------------------------------------
 # Double event_id
 # ---------------------------------------------------------------------------
@@ -544,6 +592,109 @@ def test_write_artifact_refuses_symlink_escape(repo: Path, tmp_path: Path) -> No
 
         with pytest.raises(ValueError, match="outside worktree"):
             txn.write_artifact(link_path / "artifact.txt", b"bad")
+
+
+def test_write_artifact_rechecks_after_parent_creation(
+    repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parent creation must not open a post-validation symlink escape."""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    original_mkdir = Path.mkdir
+    swapped = False
+
+    with BookkeepingTransaction.acquire(
+        repo_root=repo,
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        destination_ref=COORD_BRANCH,
+        operation="artifact_late_symlink_escape",
+    ) as txn:
+        link_path = txn.worktree_root / "kitty-specs" / FEATURE_DIRNAME / "late-link"
+
+        def swap_to_symlink_after_mkdir(
+            self: Path,
+            mode: int = 0o777,
+            parents: bool = False,
+            exist_ok: bool = False,
+        ) -> None:
+            nonlocal swapped
+            original_mkdir(self, mode=mode, parents=parents, exist_ok=exist_ok)
+            if self == link_path and not swapped:
+                swapped = True
+                self.rmdir()
+                self.symlink_to(outside_dir, target_is_directory=True)
+
+        monkeypatch.setattr(Path, "mkdir", swap_to_symlink_after_mkdir)
+
+        with pytest.raises(ValueError, match="outside worktree"):
+            txn.write_artifact(link_path / "artifact.txt", b"bad")
+        assert not (outside_dir / "artifact.txt").exists()
+
+
+def test_write_artifact_refuses_parent_swap_after_final_validation(
+    repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Final write must bind to a verified parent instead of a swapped symlink."""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    original_resolve = transaction_module._resolve_confined_artifact_path
+    resolve_count = 0
+
+    with BookkeepingTransaction.acquire(
+        repo_root=repo,
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        destination_ref=COORD_BRANCH,
+        operation="artifact_post_validation_symlink_escape",
+    ) as txn:
+        link_path = txn.worktree_root / "kitty-specs" / FEATURE_DIRNAME / "late-link"
+
+        def swap_after_final_validation(worktree_root: Path, path: Path) -> Path:
+            nonlocal resolve_count
+            resolved = original_resolve(worktree_root, path)
+            resolve_count += 1
+            if resolve_count == 3:
+                link_path.rmdir()
+                link_path.symlink_to(outside_dir, target_is_directory=True)
+            return resolved
+
+        monkeypatch.setattr(
+            transaction_module,
+            "_resolve_confined_artifact_path",
+            swap_after_final_validation,
+        )
+
+        with pytest.raises(ValueError, match="unsafe path changed during write"):
+            txn.write_artifact(link_path / "artifact.txt", b"bad")
+        assert not (outside_dir / "artifact.txt").exists()
+
+
+def test_write_artifact_preserves_existing_file_mode(repo: Path) -> None:
+    """Atomic temp replace must not strip executable/user mode bits."""
+    with BookkeepingTransaction.acquire(
+        repo_root=repo,
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        destination_ref=COORD_BRANCH,
+        operation="artifact_mode_preservation",
+    ) as txn:
+        artifact = txn.worktree_root / "kitty-specs" / FEATURE_DIRNAME / "script.sh"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_bytes(b"old\n")
+        artifact.chmod(0o744)
+
+        txn.write_artifact(artifact, b"new\n")
+
+        assert artifact.read_bytes() == b"new\n"
+        assert artifact.stat().st_mode & 0o777 == 0o744
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #1521.
- Adds confined artifact path resolution for `BookkeepingTransaction.write_artifact()`.
- Revalidates artifact containment after parent directory creation.
- Performs final writes with fd-relative, no-follow parent traversal and fd-relative `os.replace()` on POSIX to close post-validation parent-swap races.
- Routes artifact rollback restore/unlink through the same confined fd-relative boundary.
- Preserves existing file mode bits across temp-file replacement.
- Adds regression coverage for symlink escape during parent creation, after final validation, during rollback restore, and file-mode preservation.

## Security note

Code scanning alert 37 (`pythonsecurity:S2083`) was real enough to fix: existing checks rejected direct path traversal and existing symlink escapes, but write/rollback sinks still used mutable pathnames after validation. This patch binds artifact writes and restores to a verified parent directory instead of following mutable pathname state at the I/O boundary.

## Verification

- `.venv/bin/ruff check src/specify_cli/coordination/transaction.py tests/specify_cli/coordination/test_transaction.py`
- `.venv/bin/pytest tests/specify_cli/coordination/test_transaction.py -q`
