### PR TITLE
fix(auth): validate /me payload fields

### DIFF
--- a/src/specify_cli/auth/flows/_session_payload.py
+++ b/src/specify_cli/auth/flows/_session_payload.py
@@ -1,0 +1,53 @@
+"""Validation helpers for auth session payloads returned by SaaS."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..errors import AuthenticationError
+from ..session import Team
+
+
+def parse_me_payload(payload: Any) -> dict[str, Any]:
+    """Validate that ``/api/v1/me`` returned an object payload."""
+    if not isinstance(payload, dict):
+        raise AuthenticationError("User info response must be a JSON object.")
+    return payload
+
+
+def require_me_field(me: dict[str, Any], field: str) -> Any:
+    """Return a required ``/api/v1/me`` field or raise the auth error contract."""
+    try:
+        return me[field]
+    except KeyError as exc:
+        raise AuthenticationError(
+            f"User info response missing required field '{field}'."
+        ) from exc
+
+
+def parse_me_teams(me: dict[str, Any]) -> list[Team]:
+    """Parse required team fields from ``/api/v1/me`` without leaking KeyError."""
+    raw_teams = me.get("teams", [])
+    if not isinstance(raw_teams, list):
+        raise AuthenticationError("User info response field 'teams' must be a list.")
+
+    teams: list[Team] = []
+    for raw_team in raw_teams:
+        if not isinstance(raw_team, dict):
+            raise AuthenticationError("User info response team entry must be an object.")
+        try:
+            teams.append(
+                Team(
+                    id=raw_team["id"],
+                    name=raw_team["name"],
+                    role=raw_team["role"],
+                    is_private_teamspace=bool(
+                        raw_team.get("is_private_teamspace", False)
+                    ),
+                )
+            )
+        except KeyError as exc:
+            raise AuthenticationError(
+                f"User info response missing required team field '{exc.args[0]}'."
+            ) from exc
+    return teams

--- a/src/specify_cli/auth/flows/authorization_code.py
+++ b/src/specify_cli/auth/flows/authorization_code.py
@@ -323,7 +323,13 @@ class AuthorizationCodeFlow:
             "refresh_token_expires_at"
         )
         if absolute is not None:
-            return _parse_iso_utc(absolute)
+            try:
+                return _parse_iso_utc(absolute)
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise AuthenticationError(
+                    "Refresh token expiry field 'refresh_token_expires_at' "
+                    "must be an ISO-8601 timestamp."
+                ) from exc
 
         relative = tokens.get("refresh_token_expires_in")
         if relative is not None:

--- a/src/specify_cli/auth/flows/authorization_code.py
+++ b/src/specify_cli/auth/flows/authorization_code.py
@@ -46,7 +46,8 @@ from ..loopback.callback_handler import CallbackHandler
 from ..loopback.callback_server import CallbackServer
 from ..loopback.state import PKCEState
 from ..loopback.state_manager import StateManager
-from ..session import StorageBackend, StoredSession, Team, pick_default_team_id
+from ..session import StorageBackend, StoredSession, pick_default_team_id
+from ._session_payload import parse_me_payload, parse_me_teams, require_me_field
 
 log = logging.getLogger(__name__)
 
@@ -257,21 +258,15 @@ class AuthorizationCodeFlow:
             )
 
         try:
-            me = response.json()
+            me = parse_me_payload(response.json())
         except ValueError as exc:
             raise AuthenticationError(
                 f"User info response was not JSON: {exc}"
             ) from exc
 
-        teams = [
-            Team(
-                id=t["id"],
-                name=t["name"],
-                role=t["role"],
-                is_private_teamspace=bool(t.get("is_private_teamspace", False)),
-            )
-            for t in me.get("teams", [])
-        ]
+        user_id = require_me_field(me, "user_id")
+        email = require_me_field(me, "email")
+        teams = parse_me_teams(me)
         if not teams:
             raise AuthenticationError(
                 "User has no team memberships. Contact your administrator."
@@ -291,9 +286,9 @@ class AuthorizationCodeFlow:
         refresh_token_expires_at = self._resolve_refresh_expiry(tokens, me, now)
 
         return StoredSession(
-            user_id=me["user_id"],
-            email=me["email"],  # sourced from /api/v1/me .email per C-011
-            name=me.get("name", me["email"]),
+            user_id=user_id,
+            email=email,  # sourced from /api/v1/me .email per C-011
+            name=me.get("name", email),
             teams=teams,
             default_team_id=default_team_id,
             access_token=tokens["access_token"],

--- a/src/specify_cli/auth/flows/device_code.py
+++ b/src/specify_cli/auth/flows/device_code.py
@@ -332,7 +332,13 @@ class DeviceCodeFlow:
             "refresh_token_expires_at"
         )
         if absolute is not None:
-            return _parse_iso_utc(absolute)
+            try:
+                return _parse_iso_utc(absolute)
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise AuthenticationError(
+                    "Refresh token expiry field 'refresh_token_expires_at' "
+                    "must be an ISO-8601 timestamp."
+                ) from exc
 
         relative = tokens.get("refresh_token_expires_in")
         if relative is not None:

--- a/src/specify_cli/auth/flows/device_code.py
+++ b/src/specify_cli/auth/flows/device_code.py
@@ -44,7 +44,8 @@ from ..errors import (
     AuthenticationError,
     NetworkError,
 )
-from ..session import StorageBackend, StoredSession, Team, pick_default_team_id
+from ..session import StorageBackend, StoredSession, pick_default_team_id
+from ._session_payload import parse_me_payload, parse_me_teams, require_me_field
 
 log = logging.getLogger(__name__)
 
@@ -266,21 +267,15 @@ class DeviceCodeFlow:
             )
 
         try:
-            me = response.json()
+            me = parse_me_payload(response.json())
         except ValueError as exc:
             raise AuthenticationError(
                 f"User info response was not JSON: {exc}"
             ) from exc
 
-        teams = [
-            Team(
-                id=t["id"],
-                name=t["name"],
-                role=t["role"],
-                is_private_teamspace=bool(t.get("is_private_teamspace", False)),
-            )
-            for t in me.get("teams", [])
-        ]
+        user_id = require_me_field(me, "user_id")
+        email = require_me_field(me, "email")
+        teams = parse_me_teams(me)
         if not teams:
             raise AuthenticationError(
                 "User has no team memberships. Contact your administrator."
@@ -300,9 +295,9 @@ class DeviceCodeFlow:
         refresh_token_expires_at = self._resolve_refresh_expiry(tokens, me, now)
 
         return StoredSession(
-            user_id=me["user_id"],
-            email=me["email"],  # sourced from /api/v1/me .email per C-011
-            name=me.get("name", me["email"]),
+            user_id=user_id,
+            email=email,  # sourced from /api/v1/me .email per C-011
+            name=me.get("name", email),
             teams=teams,
             default_team_id=default_team_id,
             access_token=tokens["access_token"],

--- a/tests/auth/test_authorization_code_flow.py
+++ b/tests/auth/test_authorization_code_flow.py
@@ -361,6 +361,20 @@ class TestBuildSession:
         assert session.refresh_token_expires_at == datetime(2099, 1, 1, tzinfo=UTC)
 
     @pytest.mark.asyncio
+    async def test_invalid_me_refresh_expiry_raises_authentication_error(self):
+        flow = AuthorizationCodeFlow(saas_base_url="https://saas.test")
+        tokens = _token_response(refresh_token_expires_at=None)
+        me = _me_response(refresh_token_expires_at=123)
+
+        with patch("specify_cli.auth.flows.authorization_code.PublicHttpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, me)
+
+            with pytest.raises(AuthenticationError, match="must be an ISO-8601 timestamp"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
     async def test_no_teams_raises(self):
         flow = AuthorizationCodeFlow(saas_base_url="https://saas.test")
         tokens = _token_response()

--- a/tests/auth/test_authorization_code_flow.py
+++ b/tests/auth/test_authorization_code_flow.py
@@ -84,11 +84,11 @@ def _me_response(
     return body
 
 
-def _mock_httpx_response(status_code: int, json_body: dict | None = None, text: str = ""):
+def _mock_httpx_response(status_code: int, json_body: object | None = None, text: str = ""):
     r = Mock(spec=httpx.Response)
     r.status_code = status_code
     r.text = text or (str(json_body) if json_body else "")
-    r.json = Mock(return_value=json_body or {})
+    r.json = Mock(return_value=json_body if json_body is not None else {})
     return r
 
 
@@ -372,6 +372,52 @@ class TestBuildSession:
             mock_client.get.return_value = _mock_httpx_response(200, me)
 
             with pytest.raises(AuthenticationError, match="no team memberships"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["user_id", "email"])
+    async def test_missing_me_identity_field_raises_authentication_error(self, field):
+        flow = AuthorizationCodeFlow(saas_base_url="https://saas.test")
+        tokens = _token_response()
+        me = _me_response()
+        del me[field]
+
+        with patch("specify_cli.auth.flows.authorization_code.PublicHttpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, me)
+
+            with pytest.raises(AuthenticationError, match=f"missing required field '{field}'"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
+    async def test_non_object_me_payload_raises_authentication_error(self):
+        flow = AuthorizationCodeFlow(saas_base_url="https://saas.test")
+        tokens = _token_response()
+
+        with patch("specify_cli.auth.flows.authorization_code.PublicHttpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, [])
+
+            with pytest.raises(AuthenticationError, match="must be a JSON object"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["id", "name", "role"])
+    async def test_missing_me_team_field_raises_authentication_error(self, field):
+        flow = AuthorizationCodeFlow(saas_base_url="https://saas.test")
+        tokens = _token_response()
+        team = {"id": "t1", "name": "Team One", "role": "owner"}
+        del team[field]
+        me = _me_response(teams=[team])
+
+        with patch("specify_cli.auth.flows.authorization_code.PublicHttpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, me)
+
+            with pytest.raises(AuthenticationError, match=f"missing required team field '{field}'"):
                 await flow._build_session(tokens)
 
     @pytest.mark.asyncio

--- a/tests/auth/test_device_code_flow.py
+++ b/tests/auth/test_device_code_flow.py
@@ -517,6 +517,20 @@ class TestBuildSession:
         )
 
     @pytest.mark.asyncio
+    async def test_invalid_me_refresh_expiry_raises_authentication_error(self):
+        flow = DeviceCodeFlow(saas_base_url=_SAAS)
+        tokens = _token_response(refresh_token_expires_at=None)
+        me = _me_response(refresh_token_expires_at=123)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, me)
+
+            with pytest.raises(AuthenticationError, match="must be an ISO-8601 timestamp"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
     async def test_no_teams_raises(self):
         flow = DeviceCodeFlow(saas_base_url=_SAAS)
         tokens = _token_response()

--- a/tests/auth/test_device_code_flow.py
+++ b/tests/auth/test_device_code_flow.py
@@ -114,12 +114,12 @@ def _me_response(
 
 
 def _mock_httpx_response(
-    status_code: int, json_body: dict | None = None, text: str = ""
+    status_code: int, json_body: object | None = None, text: str = ""
 ):
     r = Mock(spec=httpx.Response)
     r.status_code = status_code
     r.text = text or (str(json_body) if json_body else "")
-    r.json = Mock(return_value=json_body or {})
+    r.json = Mock(return_value=json_body if json_body is not None else {})
     return r
 
 
@@ -528,6 +528,52 @@ class TestBuildSession:
             mock_client.get.return_value = _mock_httpx_response(200, me)
 
             with pytest.raises(AuthenticationError, match="no team memberships"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["user_id", "email"])
+    async def test_missing_me_identity_field_raises_authentication_error(self, field):
+        flow = DeviceCodeFlow(saas_base_url=_SAAS)
+        tokens = _token_response()
+        me = _me_response()
+        del me[field]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, me)
+
+            with pytest.raises(AuthenticationError, match=f"missing required field '{field}'"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
+    async def test_non_object_me_payload_raises_authentication_error(self):
+        flow = DeviceCodeFlow(saas_base_url=_SAAS)
+        tokens = _token_response()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, [])
+
+            with pytest.raises(AuthenticationError, match="must be a JSON object"):
+                await flow._build_session(tokens)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["id", "name", "role"])
+    async def test_missing_me_team_field_raises_authentication_error(self, field):
+        flow = DeviceCodeFlow(saas_base_url=_SAAS)
+        tokens = _token_response()
+        team = {"id": "tm_acme", "name": "Acme", "role": "admin"}
+        del team[field]
+        me = _me_response(teams=[team])
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = _mock_httpx_response(200, me)
+
+            with pytest.raises(AuthenticationError, match=f"missing required team field '{field}'"):
                 await flow._build_session(tokens)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes #1427.
- Adds shared /api/v1/me session-payload validation for browser and device login flows.
- Converts missing user_id/email, missing team id/name/role, and non-object /me JSON into AuthenticationError instead of raw KeyError/TypeError.

## Verification
- TDD repro before fix: new focused tests failed with raw KeyError in both AuthorizationCodeFlow and DeviceCodeFlow.
- .venv/bin/pytest tests/auth/test_authorization_code_flow.py::TestBuildSession tests/auth/test_device_code_flow.py::TestBuildSession -q -> 32 passed
- .venv/bin/pytest tests/auth/test_authorization_code_flow.py tests/auth/test_device_code_flow.py -q -> 66 passed
- .venv/bin/pytest tests/auth -q -> 385 passed, 2 skipped
- .venv/bin/ruff check src/specify_cli/auth/flows/_session_payload.py src/specify_cli/auth/flows/authorization_code.py src/specify_cli/auth/flows/device_code.py tests/auth/test_authorization_code_flow.py tests/auth/test_device_code_flow.py -> All checks passed
- git diff --check --cached -> passed

## Self-review
- Ran adversarial-pr-review against the staged diff.
- Finding addressed before PR: non-object /me JSON could still produce the wrong contract path; added parse_me_payload() and tests for both flows.
- Final verdict: SAFE; no remaining merge blockers found.