### PR TITLE
Fix implement worktree paradigm delegation

### DIFF
--- a/src/doctrine/drg/migration/extractor.py
+++ b/src/doctrine/drg/migration/extractor.py
@@ -486,6 +486,7 @@ def extract_action_edges(
         scope_fields: list[tuple[str, str]] = [
             ("directives", "directive"),
             ("tactics", "tactic"),
+            ("paradigms", "paradigm"),
             ("styleguides", "styleguide"),
             ("toolguides", "toolguide"),
             ("procedures", "procedure"),

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -190,12 +190,24 @@ nodes:
 - urn: paradigm:domain-driven-design
   kind: paradigm
   label: Domain-Driven Design
+- urn: paradigm:execution-lanes
+  kind: paradigm
+  label: Execution Lanes
+- urn: paradigm:git-flow
+  kind: paradigm
+  label: Git Flow
+- urn: paradigm:shared-branch-ci
+  kind: paradigm
+  label: Shared-Branch CI
 - urn: paradigm:specification-by-example
   kind: paradigm
   label: Specification by Example
 - urn: paradigm:structured-prompt-driven-development
   kind: paradigm
   label: Structured-Prompt-Driven Development
+- urn: paradigm:trunk-based
+  kind: paradigm
+  label: Trunk-Based Development
 - urn: procedure:bdd-scenario-lifecycle
   kind: procedure
   label: BDD Scenario Lifecycle
@@ -830,6 +842,18 @@ edges:
   target: directive:DIRECTIVE_037
   relation: scope
 - source: action:software-dev/implement
+  target: paradigm:execution-lanes
+  relation: scope
+- source: action:software-dev/implement
+  target: paradigm:git-flow
+  relation: scope
+- source: action:software-dev/implement
+  target: paradigm:shared-branch-ci
+  relation: scope
+- source: action:software-dev/implement
+  target: paradigm:trunk-based
+  relation: scope
+- source: action:software-dev/implement
   target: procedure:disciplined-defect-diagnosis
   relation: scope
 - source: action:software-dev/implement
@@ -1378,6 +1402,39 @@ edges:
   target: tactic:database-driven-design
   relation: replaces
   reason: 'Starting from a database schema and generating code around it inverts the DDD priority: the domain model should drive persistence, not the other way around. Schema-first thinking produces models shaped by storage constraints rather than business rules.'
+- source: paradigm:execution-lanes
+  target: directive:DIRECTIVE_024
+  relation: requires
+- source: paradigm:execution-lanes
+  target: directive:DIRECTIVE_028
+  relation: requires
+- source: paradigm:execution-lanes
+  target: directive:DIRECTIVE_029
+  relation: requires
+- source: paradigm:execution-lanes
+  target: directive:DIRECTIVE_030
+  relation: requires
+- source: paradigm:execution-lanes
+  target: directive:DIRECTIVE_033
+  relation: requires
+- source: paradigm:git-flow
+  target: directive:DIRECTIVE_029
+  relation: requires
+- source: paradigm:git-flow
+  target: directive:DIRECTIVE_030
+  relation: requires
+- source: paradigm:git-flow
+  target: directive:DIRECTIVE_033
+  relation: requires
+- source: paradigm:shared-branch-ci
+  target: directive:DIRECTIVE_029
+  relation: requires
+- source: paradigm:shared-branch-ci
+  target: directive:DIRECTIVE_030
+  relation: requires
+- source: paradigm:shared-branch-ci
+  target: directive:DIRECTIVE_033
+  relation: requires
 - source: paradigm:specification-by-example
   target: directive:DIRECTIVE_010
   relation: requires
@@ -1398,6 +1455,15 @@ edges:
   relation: requires
 - source: paradigm:structured-prompt-driven-development
   target: directive:DIRECTIVE_038
+  relation: requires
+- source: paradigm:trunk-based
+  target: directive:DIRECTIVE_029
+  relation: requires
+- source: paradigm:trunk-based
+  target: directive:DIRECTIVE_030
+  relation: requires
+- source: paradigm:trunk-based
+  target: directive:DIRECTIVE_033
   relation: requires
 - source: procedure:bdd-scenario-lifecycle
   target: directive:DIRECTIVE_034

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -998,6 +998,18 @@ edges:
   target: directive:DIRECTIVE_037
   relation: scope
 - source: action:software-dev/review
+  target: paradigm:execution-lanes
+  relation: scope
+- source: action:software-dev/review
+  target: paradigm:git-flow
+  relation: scope
+- source: action:software-dev/review
+  target: paradigm:shared-branch-ci
+  relation: scope
+- source: action:software-dev/review
+  target: paradigm:trunk-based
+  relation: scope
+- source: action:software-dev/review
   target: procedure:disciplined-defect-diagnosis
   relation: scope
 - source: action:software-dev/review
@@ -1026,9 +1038,6 @@ edges:
   relation: scope
 - source: action:software-dev/review
   target: tactic:dependency-hygiene
-  relation: scope
-- source: action:software-dev/review
-  target: tactic:focused-function-complexity-check
   relation: scope
 - source: action:software-dev/review
   target: tactic:quality-gate-verification

--- a/src/doctrine/missions/action_index.py
+++ b/src/doctrine/missions/action_index.py
@@ -16,6 +16,7 @@ class ActionIndex:
     action: str
     directives: list[str] = field(default_factory=list)
     tactics: list[str] = field(default_factory=list)
+    paradigms: list[str] = field(default_factory=list)
     styleguides: list[str] = field(default_factory=list)
     toolguides: list[str] = field(default_factory=list)
     procedures: list[str] = field(default_factory=list)
@@ -57,6 +58,7 @@ def load_action_index(missions_root: Path, mission: str, action: str) -> ActionI
             action=str(data.get("action", action)),
             directives=_str_list("directives"),
             tactics=_str_list("tactics"),
+            paradigms=_str_list("paradigms"),
             styleguides=_str_list("styleguides"),
             toolguides=_str_list("toolguides"),
             procedures=_str_list("procedures"),

--- a/src/doctrine/missions/software-dev/actions/implement/index.yaml
+++ b/src/doctrine/missions/software-dev/actions/implement/index.yaml
@@ -28,6 +28,11 @@ tactics:
   - stopping-conditions
   - test-boundaries-by-responsibility
   - testing-select-appropriate-level
+paradigms:
+  - execution-lanes
+  - shared-branch-ci
+  - git-flow
+  - trunk-based
 styleguides: []
 toolguides:
   - efficient-local-tooling

--- a/src/doctrine/paradigms/built-in/execution-lanes.paradigm.yaml
+++ b/src/doctrine/paradigms/built-in/execution-lanes.paradigm.yaml
@@ -1,0 +1,17 @@
+schema_version: "1.0"
+id: execution-lanes
+name: Execution Lanes
+summary: >
+  The default Spec Kitty implementation workspace paradigm. Each work package
+  runs in an isolated execution-lane worktree so agents can implement, test,
+  review, and hand off changes without mutating another lane's checkout.
+  Execution lanes keep task status, branch state, prompt files, and verification
+  evidence aligned around one work package at a time. Shared mainline state is
+  reached only through explicit review, merge, and quality gates.
+
+directive_refs:
+  - DIRECTIVE_024
+  - DIRECTIVE_028
+  - DIRECTIVE_029
+  - DIRECTIVE_030
+  - DIRECTIVE_033

--- a/src/doctrine/paradigms/built-in/git-flow.paradigm.yaml
+++ b/src/doctrine/paradigms/built-in/git-flow.paradigm.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+id: git-flow
+name: Git Flow
+summary: >
+  A branch-management paradigm built around long-lived integration and release
+  branches, with feature and hotfix branches feeding controlled release points.
+  In Spec Kitty this exists as a resolvable compatibility paradigm for projects
+  whose charter already requires Git Flow. It is not the default implementation
+  workspace model; execution-lane worktrees remain the supported default when no
+  project-specific branching paradigm is selected.
+
+directive_refs:
+  - DIRECTIVE_029
+  - DIRECTIVE_030
+  - DIRECTIVE_033

--- a/src/doctrine/paradigms/built-in/shared-branch-ci.paradigm.yaml
+++ b/src/doctrine/paradigms/built-in/shared-branch-ci.paradigm.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+id: shared-branch-ci
+name: Shared-Branch CI
+summary: >
+  A collaborative workspace paradigm where multiple contributors integrate
+  through a shared branch protected by continuous integration, staging hygiene,
+  and explicit commit attribution. In Spec Kitty this is a resolvable
+  compatibility paradigm for teams whose charter selects a shared branch model.
+  It must still preserve isolated verification evidence and quality gates before
+  shared state is promoted.
+
+directive_refs:
+  - DIRECTIVE_029
+  - DIRECTIVE_030
+  - DIRECTIVE_033

--- a/src/doctrine/paradigms/built-in/trunk-based.paradigm.yaml
+++ b/src/doctrine/paradigms/built-in/trunk-based.paradigm.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+id: trunk-based
+name: Trunk-Based Development
+summary: >
+  A branch-management paradigm where contributors integrate small, verified
+  changes into the mainline frequently, avoiding long-lived divergence. In Spec
+  Kitty this exists as a resolvable compatibility paradigm for projects whose
+  charter selects trunk-based development. Work remains gated by targeted
+  staging, commit attribution, and test/typecheck verification before mainline
+  integration.
+
+directive_refs:
+  - DIRECTIVE_029
+  - DIRECTIVE_030
+  - DIRECTIVE_033

--- a/tests/doctrine/drg/migration/test_extractor.py
+++ b/tests/doctrine/drg/migration/test_extractor.py
@@ -111,6 +111,7 @@ def _count_inline_refs(doctrine_root: Path) -> int:  # noqa: C901
             for field in (
                 "directives",
                 "tactics",
+                "paradigms",
                 "styleguides",
                 "toolguides",
                 "procedures",
@@ -344,6 +345,21 @@ class TestExtractActionEdges:
         assert any(
             e.source == "action:software-dev/retrospect"
             and e.target == "agent_profile:retrospective-facilitator"
+            and e.relation == Relation.SCOPE
+            for e in edges
+        )
+
+    def test_paradigm_scope_edges(self) -> None:
+        """Action indexes may scope built-in paradigms."""
+        nodes, edges = extract_action_edges(DOCTRINE_ROOT)
+        assert any(
+            n.urn == "paradigm:execution-lanes"
+            and n.kind == NodeKind.PARADIGM
+            for n in nodes
+        )
+        assert any(
+            e.source == "action:software-dev/implement"
+            and e.target == "paradigm:execution-lanes"
             and e.relation == Relation.SCOPE
             for e in edges
         )
@@ -585,6 +601,7 @@ class TestEdgeCountCompleteness:
             for field in (
                 "directives",
                 "tactics",
+                "paradigms",
                 "styleguides",
                 "toolguides",
                 "procedures",

--- a/tests/doctrine/mission_step_contracts/test_shipped_contracts.py
+++ b/tests/doctrine/mission_step_contracts/test_shipped_contracts.py
@@ -108,6 +108,21 @@ class TestImplementContractStructure:
         assert workspace.delegates_to.kind == ArtifactKind.PARADIGM
         assert "execution-lanes" in workspace.delegates_to.candidates
 
+    def test_workspace_paradigm_candidates_exist_as_shipped_artifacts(
+        self, contract: MissionStepContract
+    ) -> None:
+        workspace = next((s for s in contract.steps if s.id == "workspace"), None)
+        assert workspace is not None
+        assert workspace.delegates_to is not None
+
+        paradigms = DoctrineService().paradigms
+        missing = [
+            candidate
+            for candidate in workspace.delegates_to.candidates
+            if paradigms.get(candidate) is None
+        ]
+        assert missing == []
+
     def test_has_quality_gate_step(self, contract: MissionStepContract) -> None:
         gate = next((s for s in contract.steps if s.id == "quality_gate"), None)
         assert gate is not None

--- a/tests/doctrine/missions/test_action_index.py
+++ b/tests/doctrine/missions/test_action_index.py
@@ -125,6 +125,7 @@ class TestLoadActionIndexFields:
             "action: custom-action\n"
             "directives:\n  - DIR-001\n"
             "tactics:\n  - tactic-a\n"
+            "paradigms:\n  - paradigm-b\n"
             "styleguides:\n  - style-b\n"
             "toolguides:\n  - tool-c\n"
             "procedures:\n  - proc-d\n"
@@ -134,6 +135,7 @@ class TestLoadActionIndexFields:
         assert result.action == "custom-action"
         assert result.directives == ["DIR-001"]
         assert result.tactics == ["tactic-a"]
+        assert result.paradigms == ["paradigm-b"]
         assert result.styleguides == ["style-b"]
         assert result.toolguides == ["tool-c"]
         assert result.procedures == ["proc-d"]
@@ -142,6 +144,7 @@ class TestLoadActionIndexFields:
         _write_index(tmp_path, "m", "a", "directives:\n  - DIR-001\n")
         result = load_action_index(tmp_path, "m", "a")
         assert result.tactics == []
+        assert result.paradigms == []
         assert result.styleguides == []
         assert result.toolguides == []
         assert result.procedures == []

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 import pytest
 from ruamel.yaml import YAML
 
+from charter._drg_helpers import load_validated_graph
+from charter.drg import resolve_context
 from doctrine.mission_step_contracts.repository import MissionStepContractRepository
 from specify_cli.invocation.writer import EVENTS_DIR
 from specify_cli.mission_step_contracts.executor import (
@@ -264,6 +266,40 @@ def test_directive_slug_candidate_resolves_to_drg_urn(tmp_path: Path) -> None:
 
     assert result.steps[0].resolved_delegations[0].urn == "directive:DIRECTIVE_030"
     assert result.steps[0].unresolved_candidates == ()
+
+
+def test_shipped_implement_workspace_paradigms_resolve_through_built_in_drg(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    graph = load_validated_graph(repo_root)
+    contract = MissionStepContractRepository().get_by_action("software-dev", "implement")
+    assert contract is not None
+    workspace = next(step for step in contract.steps if step.id == "workspace")
+
+    resolved, unresolved = StepContractExecutor(
+        repo_root=repo_root,
+        graph=graph,
+    )._resolve_step_delegations(
+        graph=graph,
+        action_context=resolve_context(graph, "action:software-dev/implement"),
+        step=workspace,
+    )
+
+    assert unresolved == []
+    assert [delegation.candidate for delegation in resolved] == [
+        "execution-lanes",
+        "shared-branch-ci",
+        "git-flow",
+        "trunk-based",
+    ]
+    assert [delegation.urn for delegation in resolved] == [
+        "paradigm:execution-lanes",
+        "paradigm:shared-branch-ci",
+        "paradigm:git-flow",
+        "paradigm:trunk-based",
+    ]
 
 
 def test_profile_hint_required_when_no_action_default_exists(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add shipped paradigm artifacts for the implement workspace candidates: execution-lanes, shared-branch-ci, git-flow, and trunk-based.
- Add matching DRG nodes plus software-dev/implement scope edges so StepContractExecutor resolves workspace delegations instead of reporting unresolved candidates.
- Add regression coverage for shipped artifact presence and runtime DRG delegation resolution.

Closes #1429.

## Self-review

Ran /Users/robert/.codex/skills/adversarial-pr-review/SKILL.md against the local diff before opening this PR. No merge-blocking code findings survived. Process finding addressed: staged the four new paradigm artifacts explicitly and left IMPLEMENTATION_PROMPT_ISSUE_1429.md untracked/out of commit.

## Verification

- Failing-before-fix regression: `.venv/bin/pytest tests/doctrine/mission_step_contracts/test_shipped_contracts.py::TestImplementContractStructure::test_workspace_paradigm_candidates_exist_as_shipped_artifacts -q` failed with missing candidates `[execution-lanes, shared-branch-ci, git-flow, trunk-based]`.
- Failing-before-fix regression: `.venv/bin/pytest tests/specify_cli/mission_step_contracts/test_executor.py::test_shipped_implement_workspace_paradigms_resolve_through_built_in_drg -q` failed with all four candidates unresolved.
- `.venv/bin/pytest tests/doctrine/mission_step_contracts/test_shipped_contracts.py tests/specify_cli/mission_step_contracts/test_executor.py tests/doctrine/paradigms/test_repository.py tests/doctrine/test_directive_consistency.py tests/doctrine/test_schema_validation.py tests/doctrine/paradigms/test_validation.py tests/doctrine/paradigms/test_models.py -q` -> 89 passed, 7 warnings.
- `.venv/bin/pytest tests/doctrine/test_tactic_compliance.py tests/doctrine/test_procedure_consistency.py tests/doctrine/test_service.py::test_service_exposes_specification_by_example_artifacts -q` -> 396 passed.
- `.venv/bin/ruff check tests/doctrine/mission_step_contracts/test_shipped_contracts.py tests/specify_cli/mission_step_contracts/test_executor.py` -> All checks passed.
- `.venv/bin/python - <<PY ... load_validated_graph(Path.cwd()) ... PY` -> validated.
