### PR TITLE
Fix managed lane sparse-checkout detection

### DIFF
--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -830,7 +830,7 @@ def _render_sparse_finding(report: object) -> None:
                 f"    pattern file: {pf_rel} ({report.primary.pattern_line_count} lines)",
                 soft_wrap=True,
             )
-    active_wts = [w for w in report.worktrees if w.is_active]
+    active_wts = [w for w in report.worktrees if w.is_blocking]
     if active_wts:
         console.print(
             f"  Lane worktrees: {len(active_wts)} affected", soft_wrap=True
@@ -872,7 +872,7 @@ def _render_remediation_plan(report: object) -> None:
     step += 1
     console.print(f"  {step}. git checkout HEAD -- . (primary)")
     for wt in report.worktrees:
-        if not wt.is_active:
+        if not wt.is_blocking:
             continue
         step += 1
         console.print(f"  {step}. repeat steps 1–4 in {wt.path}")
@@ -921,7 +921,7 @@ def sparse_checkout(
 
     # No state detected — emit the "nothing to do" message in both modes
     # and exit cleanly.
-    if not report.any_active:
+    if not report.any_blocking:
         if fix:
             console.print("No sparse-checkout state to remediate.")
         else:

--- a/src/specify_cli/git/sparse_checkout.py
+++ b/src/specify_cli/git/sparse_checkout.py
@@ -226,10 +226,18 @@ def scan_path(path: Path, *, is_worktree: bool) -> SparseCheckoutState:
 @dataclass(frozen=True)
 class _ManagedLanePolicy:
     mission_slug: str
+    coordination_branch: str
     expected_patterns: frozenset[str]
 
     def matches_path(self, path: Path) -> bool:
         return path.name.startswith(f"{self.mission_slug}-lane-")
+
+    def expected_branch_for(self, path: Path) -> str | None:
+        prefix = f"{self.mission_slug}-"
+        if not path.name.startswith(prefix):
+            return None
+        lane_id = path.name.removeprefix(prefix)
+        return f"{self.coordination_branch}-{lane_id}"
 
 
 def _read_patterns(path: Path) -> frozenset[str] | None:
@@ -278,6 +286,7 @@ def _load_managed_lane_policies(repo_root: Path) -> tuple[_ManagedLanePolicy, ..
         policies.append(
             _ManagedLanePolicy(
                 mission_slug=mission_slug,
+                coordination_branch=coord_branch,
                 expected_patterns=frozenset(
                     lane_sparse_checkout_patterns(mission_slug, mid8)
                 ),
@@ -302,6 +311,22 @@ def _registered_worktree_paths(repo_root: Path) -> frozenset[Path]:
     return frozenset(paths)
 
 
+def _current_branch(path: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
 def _classify_worktree_state(
     state: SparseCheckoutState,
     *,
@@ -314,6 +339,9 @@ def _classify_worktree_state(
     if not candidates:
         return state
     if len(candidates) != 1:
+        return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
+    expected_branch = candidates[0].expected_branch_for(state.path)
+    if expected_branch is None or _current_branch(state.path) != expected_branch:
         return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
     if state.path.resolve(strict=False) not in registered_worktrees:
         return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)

--- a/src/specify_cli/git/sparse_checkout.py
+++ b/src/specify_cli/git/sparse_checkout.py
@@ -29,14 +29,17 @@ git configuration or sparse-checkout state; remediation lives in WP03.
 
 from __future__ import annotations
 
+import enum
+import json
 import logging
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "SparseCheckoutKind",
     "SparseCheckoutState",
     "SparseCheckoutScanReport",
     "SparseCheckoutPreflightError",
@@ -46,6 +49,14 @@ __all__ = [
     "require_no_sparse_checkout",
     "_reset_session_warning_state",
 ]
+
+
+class SparseCheckoutKind(enum.StrEnum):
+    """Classification for active sparse-checkout state."""
+
+    LEGACY_USER = "legacy_user_sparse_checkout"
+    MANAGED_LANE = "managed_lane_sparse_checkout"
+    UNKNOWN = "unknown_sparse_checkout"
 
 
 @dataclass(frozen=True)
@@ -58,6 +69,7 @@ class SparseCheckoutState:
     pattern_file_present: bool
     pattern_line_count: int
     is_worktree: bool
+    sparse_checkout_kind: SparseCheckoutKind = SparseCheckoutKind.LEGACY_USER
 
     @property
     def is_active(self) -> bool:
@@ -69,6 +81,16 @@ class SparseCheckoutState:
         ``is_active`` to True.
         """
         return self.config_enabled
+
+    @property
+    def is_managed_lane(self) -> bool:
+        """True iff this active sparse-checkout state is owned by lane policy."""
+        return self.is_active and self.sparse_checkout_kind is SparseCheckoutKind.MANAGED_LANE
+
+    @property
+    def is_blocking(self) -> bool:
+        """True iff sparse-checkout should block legacy preflights/remediation."""
+        return self.is_active and not self.is_managed_lane
 
 
 @dataclass(frozen=True)
@@ -84,12 +106,17 @@ class SparseCheckoutScanReport:
         return self.primary.is_active or any(w.is_active for w in self.worktrees)
 
     @property
+    def any_blocking(self) -> bool:
+        """True iff legacy/unknown sparse-checkout state is active."""
+        return self.primary.is_blocking or any(w.is_blocking for w in self.worktrees)
+
+    @property
     def affected_paths(self) -> tuple[Path, ...]:
-        """Paths (primary + worktrees) where sparse-checkout is active."""
+        """Paths where legacy/unknown sparse-checkout is active."""
         hits: list[Path] = []
-        if self.primary.is_active:
+        if self.primary.is_blocking:
             hits.append(self.primary.path)
-        hits.extend(w.path for w in self.worktrees if w.is_active)
+        hits.extend(w.path for w in self.worktrees if w.is_blocking)
         return tuple(hits)
 
 
@@ -196,6 +223,111 @@ def scan_path(path: Path, *, is_worktree: bool) -> SparseCheckoutState:
     )
 
 
+@dataclass(frozen=True)
+class _ManagedLanePolicy:
+    mission_slug: str
+    expected_patterns: frozenset[str]
+
+    def matches_path(self, path: Path) -> bool:
+        return path.name.startswith(f"{self.mission_slug}-lane-")
+
+
+def _read_patterns(path: Path) -> frozenset[str] | None:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return frozenset(
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    )
+
+
+def _load_managed_lane_policies(repo_root: Path) -> tuple[_ManagedLanePolicy, ...]:
+    specs_dir = repo_root / "kitty-specs"
+    if not specs_dir.is_dir():
+        return ()
+
+    try:
+        from specify_cli.coordination.workspace import lane_sparse_checkout_patterns
+    except ImportError:
+        return ()
+
+    policies: list[_ManagedLanePolicy] = []
+    for meta_path in sorted(specs_dir.glob("*/meta.json")):
+        try:
+            raw = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        coord_branch = raw.get("coordination_branch")
+        mission_slug = raw.get("mission_slug") or raw.get("slug")
+        mission_id = raw.get("mission_id")
+        if not (
+            isinstance(coord_branch, str)
+            and coord_branch
+            and isinstance(mission_slug, str)
+            and mission_slug
+            and isinstance(mission_id, str)
+            and len(mission_id) >= 8
+        ):
+            continue
+        mid8 = mission_id[:8]
+        policies.append(
+            _ManagedLanePolicy(
+                mission_slug=mission_slug,
+                expected_patterns=frozenset(
+                    lane_sparse_checkout_patterns(mission_slug, mid8)
+                ),
+            )
+        )
+    return tuple(policies)
+
+
+def _registered_worktree_paths(repo_root: Path) -> frozenset[Path]:
+    try:
+        output = subprocess.check_output(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return frozenset()
+    paths: set[Path] = set()
+    for line in output.splitlines():
+        if line.startswith("worktree "):
+            paths.add(Path(line.removeprefix("worktree ")).resolve(strict=False))
+    return frozenset(paths)
+
+
+def _classify_worktree_state(
+    state: SparseCheckoutState,
+    *,
+    policies: tuple[_ManagedLanePolicy, ...],
+    registered_worktrees: frozenset[Path],
+) -> SparseCheckoutState:
+    if not state.is_active:
+        return state
+    candidates = [policy for policy in policies if policy.matches_path(state.path)]
+    if not candidates:
+        return state
+    if len(candidates) != 1:
+        return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
+    if state.path.resolve(strict=False) not in registered_worktrees:
+        return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
+    if not state.pattern_file_present or state.pattern_file_path is None:
+        return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
+
+    present = _read_patterns(state.pattern_file_path)
+    if present is None:
+        return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
+    if candidates[0].expected_patterns.issubset(present):
+        return replace(state, sparse_checkout_kind=SparseCheckoutKind.MANAGED_LANE)
+    return replace(state, sparse_checkout_kind=SparseCheckoutKind.UNKNOWN)
+
+
 def scan_repo(repo_root: Path) -> SparseCheckoutScanReport:
     """Probe the primary repo and every lane worktree beneath ``.worktrees/``.
 
@@ -204,6 +336,8 @@ def scan_repo(repo_root: Path) -> SparseCheckoutScanReport:
     use a file pointer). Non-worktree directories are skipped silently.
     """
     primary = scan_path(repo_root, is_worktree=False)
+    policies = _load_managed_lane_policies(repo_root)
+    registered_worktrees = _registered_worktree_paths(repo_root)
     worktrees_dir = repo_root / ".worktrees"
     worktree_states: list[SparseCheckoutState] = []
     if worktrees_dir.exists() and worktrees_dir.is_dir():
@@ -212,7 +346,14 @@ def scan_repo(repo_root: Path) -> SparseCheckoutScanReport:
                 continue
             if not (child / ".git").exists():
                 continue
-            worktree_states.append(scan_path(child, is_worktree=True))
+            state = scan_path(child, is_worktree=True)
+            worktree_states.append(
+                _classify_worktree_state(
+                    state,
+                    policies=policies,
+                    registered_worktrees=registered_worktrees,
+                )
+            )
     return SparseCheckoutScanReport(primary=primary, worktrees=tuple(worktree_states))
 
 
@@ -242,7 +383,7 @@ def warn_if_sparse_once(repo_root: Path, *, command: str) -> None:
         report = scan_repo(repo_root)
     except Exception:  # noqa: BLE001 — never let detection block the command
         return
-    if not report.any_active:
+    if not report.any_blocking:
         return
     affected = ", ".join(str(p) for p in report.affected_paths)
     logger.warning(
@@ -308,7 +449,7 @@ def require_no_sparse_checkout(
     ``override_flag``.
     """
     report = scan_repo(repo_root)
-    if not report.any_active:
+    if not report.any_blocking:
         return
     if override_flag:
         logger.warning(

--- a/src/specify_cli/git/sparse_checkout_remediation.py
+++ b/src/specify_cli/git/sparse_checkout_remediation.py
@@ -359,7 +359,8 @@ def remediate(
         (report.primary.path, report.primary, False)
     ]
     for wt_state in report.worktrees:
-        targets.append((wt_state.path, wt_state, True))
+        if wt_state.is_blocking:
+            targets.append((wt_state.path, wt_state, True))
 
     # All-or-nothing dirty-tree pre-check. We probe EVERY target before
     # touching any of them.

--- a/src/specify_cli/status/doctor.py
+++ b/src/specify_cli/status/doctor.py
@@ -303,7 +303,7 @@ def check_sparse_checkout(repo_root: Path) -> list[Finding]:
         logger.debug("sparse-checkout scan failed", exc_info=True)
         return findings
 
-    if not report.any_active:
+    if not report.any_blocking:
         return findings
 
     affected_paths = [str(p) for p in report.affected_paths]
@@ -319,7 +319,7 @@ def check_sparse_checkout(repo_root: Path) -> list[Finding]:
                 f"{report.primary.pattern_line_count} lines)"
             )
         lines.append(f"Primary: {report.primary.path}{pattern_note}")
-    active_wts = [w for w in report.worktrees if w.is_active]
+    active_wts = [w for w in report.worktrees if w.is_blocking]
     if active_wts:
         lines.append(f"Lane worktrees affected: {len(active_wts)}")
         for wt in active_wts:

--- a/tests/integration/sparse_checkout/test_detection.py
+++ b/tests/integration/sparse_checkout/test_detection.py
@@ -283,6 +283,34 @@ class TestEndToEndDetection:
         assert report.affected_paths == (lane_path,)
         assert report.worktrees[0].sparse_checkout_kind is SparseCheckoutKind.UNKNOWN
 
+    def test_manual_matching_worktree_is_blocking_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        repo = tmp_path / "r"
+        _init_coordination_lane_repo(repo)
+        manual_path = repo / ".worktrees" / f"{MISSION_SLUG}-lane-b"
+        _run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "worktree",
+                "add",
+                "-b",
+                "feature/unrelated-sparse-worktree",
+                str(manual_path),
+                COORD_BRANCH,
+            ],
+        )
+        register_lane_sparse_checkout(manual_path, MISSION_SLUG, MID8)
+
+        report = scan_repo(repo)
+        manual_state = next(w for w in report.worktrees if w.path == manual_path)
+
+        assert manual_state.sparse_checkout_kind is SparseCheckoutKind.UNKNOWN
+        assert manual_state.is_blocking is True
+        assert manual_path in report.affected_paths
+
 
 # ---------------------------------------------------------------------------
 # Preflight wiring

--- a/tests/integration/sparse_checkout/test_detection.py
+++ b/tests/integration/sparse_checkout/test_detection.py
@@ -9,13 +9,16 @@ break first.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from specify_cli.coordination import register_lane_sparse_checkout
 from specify_cli.git.sparse_checkout import (
     SparseCheckoutPreflightError,
+    SparseCheckoutKind,
     require_no_sparse_checkout,
     scan_path,
     scan_repo,
@@ -47,6 +50,57 @@ def _init_repo_with_commit(repo: Path) -> None:
     (repo / "README.md").write_text("hello\n", encoding="utf-8")
     _run(["git", "-C", str(repo), "add", "README.md"])
     _run(["git", "-C", str(repo), "commit", "-m", "init"])
+
+
+MISSION_SLUG = "demo-feature-01J6XW9K"
+MISSION_ID = "01J6XW9KABCDEFGHJKMNPQRSTV"
+MID8 = "01J6XW9K"
+COORD_BRANCH = f"kitty/mission-{MISSION_SLUG}"
+
+
+def _init_coordination_lane_repo(repo: Path) -> Path:
+    repo.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-q", "-b", "main", str(repo)])
+    _run(["git", "-C", str(repo), "config", "user.email", "test@example.com"])
+    _run(["git", "-C", str(repo), "config", "user.name", "Test User"])
+    _run(["git", "-C", str(repo), "config", "commit.gpgsign", "false"])
+    (repo / ".kittify").mkdir()
+    spec_dir = repo / "kitty-specs" / MISSION_SLUG
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "spec.md").write_text("# spec\n", encoding="utf-8")
+    (spec_dir / "status.events.jsonl").write_text("{}\n", encoding="utf-8")
+    (spec_dir / "status.json").write_text("{}\n", encoding="utf-8")
+    (spec_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": MISSION_SLUG,
+                "mission_id": MISSION_ID,
+                "coordination_branch": COORD_BRANCH,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _run(["git", "-C", str(repo), "add", "-A"])
+    _run(["git", "-C", str(repo), "commit", "-m", "seed"])
+    _run(["git", "-C", str(repo), "branch", COORD_BRANCH])
+    exclude = repo / ".git" / "info" / "exclude"
+    exclude.write_text(exclude.read_text(encoding="utf-8") + ".worktrees/\n")
+    lane_path = repo / ".worktrees" / f"{MISSION_SLUG}-lane-a"
+    _run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-b",
+            f"{COORD_BRANCH}-lane-a",
+            str(lane_path),
+            COORD_BRANCH,
+        ],
+    )
+    register_lane_sparse_checkout(lane_path, MISSION_SLUG, MID8)
+    return lane_path
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +245,44 @@ class TestEndToEndDetection:
         assert state.pattern_file_present is True
         assert state.pattern_line_count == 3
 
+    def test_managed_lane_sparse_checkout_is_not_blocking(
+        self, tmp_path: Path
+    ) -> None:
+        repo = tmp_path / "r"
+        lane_path = _init_coordination_lane_repo(repo)
+
+        report = scan_repo(repo)
+
+        assert report.any_active is True
+        assert report.any_blocking is False
+        assert report.affected_paths == ()
+        assert len(report.worktrees) == 1
+        assert report.worktrees[0].path == lane_path
+        assert (
+            report.worktrees[0].sparse_checkout_kind
+            is SparseCheckoutKind.MANAGED_LANE
+        )
+
+    def test_managed_lane_sparse_checkout_with_drift_is_blocking_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        repo = tmp_path / "r"
+        lane_path = _init_coordination_lane_repo(repo)
+        raw = _run(
+            ["git", "-C", str(lane_path), "rev-parse", "--git-path", "info/sparse-checkout"],
+        ).stdout.strip()
+        sparse_file = Path(raw)
+        if not sparse_file.is_absolute():
+            sparse_file = lane_path / sparse_file
+        sparse_file.write_text("/*\n", encoding="utf-8")
+
+        report = scan_repo(repo)
+
+        assert report.any_active is True
+        assert report.any_blocking is True
+        assert report.affected_paths == (lane_path,)
+        assert report.worktrees[0].sparse_checkout_kind is SparseCheckoutKind.UNKNOWN
+
 
 # ---------------------------------------------------------------------------
 # Preflight wiring
@@ -270,3 +362,18 @@ class TestPreflight:
         assert "mission_id=01HXYZ" in msg
         assert "actor=tester" in msg
         assert str(repo) in msg
+
+    def test_managed_lane_sparse_checkout_passes_preflight(
+        self, tmp_path: Path
+    ) -> None:
+        repo = tmp_path / "r"
+        _init_coordination_lane_repo(repo)
+
+        require_no_sparse_checkout(
+            repo,
+            command="merge",
+            override_flag=False,
+            actor="tester",
+            mission_slug=MISSION_SLUG,
+            mission_id=MISSION_ID,
+        )

--- a/tests/integration/sparse_checkout/test_doctor_finding.py
+++ b/tests/integration/sparse_checkout/test_doctor_finding.py
@@ -18,6 +18,7 @@ would be triggered simultaneously.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -25,6 +26,7 @@ import pytest
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.doctor import app as doctor_app
+from specify_cli.coordination import register_lane_sparse_checkout
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
@@ -52,6 +54,38 @@ def _init_bare_repo(repo: Path) -> None:
     # Mark as a spec-kitty project so locate_project_root() resolves to
     # the fixture directory.
     (repo / ".kittify").mkdir()
+
+
+MISSION_SLUG = "demo-feature-01J6XW9K"
+MISSION_ID = "01J6XW9KABCDEFGHJKMNPQRSTV"
+MID8 = "01J6XW9K"
+COORD_BRANCH = f"kitty/mission-{MISSION_SLUG}"
+
+
+def _init_managed_lane_repo(repo: Path) -> Path:
+    _init_bare_repo(repo)
+    spec_dir = repo / "kitty-specs" / MISSION_SLUG
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "spec.md").write_text("# spec\n", encoding="utf-8")
+    (spec_dir / "status.events.jsonl").write_text("{}\n", encoding="utf-8")
+    (spec_dir / "status.json").write_text("{}\n", encoding="utf-8")
+    (spec_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": MISSION_SLUG,
+                "mission_id": MISSION_ID,
+                "coordination_branch": COORD_BRANCH,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _run(["git", "-C", str(repo), "add", "-A"])
+    _run(["git", "-C", str(repo), "commit", "-m", "mission"])
+    _run(["git", "-C", str(repo), "branch", COORD_BRANCH])
+    wt = _add_worktree(repo, f"{MISSION_SLUG}-lane-a")
+    _run(["git", "-C", str(wt), "checkout", "-q", COORD_BRANCH])
+    register_lane_sparse_checkout(wt, MISSION_SLUG, MID8)
+    return wt
 
 
 def _enable_sparse(repo: Path, pattern: str = "README.md\n") -> None:
@@ -149,3 +183,49 @@ def test_doctor_sparse_primary_and_worktrees_lists_all_paths(
     assert str(wt_a) in result.stdout
     assert str(wt_b) in result.stdout
     assert str(repo) in result.stdout
+
+
+def test_doctor_managed_lane_sparse_checkout_is_not_legacy_finding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Managed lane sparse-checkout must not be remediated as legacy state."""
+    repo = tmp_path / "managed"
+    wt = _init_managed_lane_repo(repo)
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.doctor.locate_project_root",
+        lambda: repo,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(doctor_app, ["sparse-checkout"])
+    assert result.exit_code == 0, result.stdout
+    assert "No legacy sparse-checkout state detected" in result.stdout
+    assert "Legacy sparse-checkout state detected" not in result.stdout
+    assert "spec-kitty doctor sparse-checkout --fix" not in result.stdout
+    assert str(wt) not in result.stdout
+
+
+def test_doctor_fix_plan_skips_managed_lane_sparse_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "mixed"
+    wt = _init_managed_lane_repo(repo)
+    _enable_sparse(repo, pattern="README.md\n")
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.doctor.locate_project_root",
+        lambda: repo,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.doctor._is_interactive_environment",
+        lambda: True,
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    runner = CliRunner()
+    result = runner.invoke(doctor_app, ["sparse-checkout", "--fix"])
+    assert result.exit_code == 0, result.stdout
+    assert "git sparse-checkout disable (primary)" in result.stdout
+    assert "repeat steps" not in result.stdout
+    assert str(wt) not in result.stdout

--- a/tests/integration/sparse_checkout/test_doctor_finding.py
+++ b/tests/integration/sparse_checkout/test_doctor_finding.py
@@ -83,7 +83,18 @@ def _init_managed_lane_repo(repo: Path) -> Path:
     _run(["git", "-C", str(repo), "commit", "-m", "mission"])
     _run(["git", "-C", str(repo), "branch", COORD_BRANCH])
     wt = _add_worktree(repo, f"{MISSION_SLUG}-lane-a")
-    _run(["git", "-C", str(wt), "checkout", "-q", COORD_BRANCH])
+    _run(
+        [
+            "git",
+            "-C",
+            str(wt),
+            "checkout",
+            "-q",
+            "-B",
+            f"{COORD_BRANCH}-lane-a",
+            COORD_BRANCH,
+        ],
+    )
     register_lane_sparse_checkout(wt, MISSION_SLUG, MID8)
     return wt
 

--- a/tests/status/test_doctor.py
+++ b/tests/status/test_doctor.py
@@ -624,7 +624,7 @@ class TestCheckSparseCheckout:
             assert check_sparse_checkout(tmp_path) == []
 
     def test_inactive_repo_returns_empty(self, tmp_path: Path):
-        fake_report = SimpleNamespace(any_active=False)
+        fake_report = SimpleNamespace(any_active=False, any_blocking=False)
         fake_module = SimpleNamespace(scan_repo=lambda _repo_root: fake_report)
 
         with patch.dict(sys.modules, {"specify_cli.git.sparse_checkout": fake_module}):
@@ -634,15 +634,17 @@ class TestCheckSparseCheckout:
         primary_pattern = tmp_path / ".git" / "info" / "sparse-checkout"
         primary = SimpleNamespace(
             is_active=True,
+            is_blocking=True,
             path=tmp_path,
             pattern_file_present=True,
             pattern_file_path=primary_pattern,
             pattern_line_count=3,
         )
         lane_path = tmp_path / ".worktrees" / "mission-lane-a"
-        lane = SimpleNamespace(is_active=True, path=lane_path)
+        lane = SimpleNamespace(is_active=True, is_blocking=True, path=lane_path)
         fake_report = SimpleNamespace(
             any_active=True,
+            any_blocking=True,
             affected_paths=(tmp_path, lane_path),
             primary=primary,
             worktrees=(lane,),


### PR DESCRIPTION
## Summary
- classify active sparse-checkout as legacy, managed lane, or unknown
- exclude verified managed lane sparse-checkout from legacy preflight, doctor findings, and remediation targets
- keep drifted/missing lane sparse-checkout policy blocking/fail-closed

Fixes #1413

## Tests
- uv run ruff check src/specify_cli/git/sparse_checkout.py src/specify_cli/git/sparse_checkout_remediation.py src/specify_cli/cli/commands/doctor.py src/specify_cli/status/doctor.py tests/integration/sparse_checkout/test_detection.py tests/integration/sparse_checkout/test_doctor_finding.py
- uv run pytest tests/unit/git/test_sparse_checkout_detection.py tests/unit/git/test_sparse_checkout_remediation.py tests/integration/sparse_checkout tests/specify_cli/cli/commands/test_doctor_coordination.py tests/specify_cli/coordination/test_sparse_checkout.py tests/specify_cli/lanes/test_worktree_allocator_coord.py -q
- uv run pytest tests/integration/sparse_checkout/test_detection.py::TestEndToEndDetection::test_managed_lane_sparse_checkout_is_not_blocking tests/integration/sparse_checkout/test_detection.py::TestEndToEndDetection::test_managed_lane_sparse_checkout_with_drift_is_blocking_unknown tests/integration/sparse_checkout/test_detection.py::TestPreflight::test_managed_lane_sparse_checkout_passes_preflight tests/integration/sparse_checkout/test_doctor_finding.py::test_doctor_managed_lane_sparse_checkout_is_not_legacy_finding tests/integration/sparse_checkout/test_doctor_finding.py::test_doctor_fix_plan_skips_managed_lane_sparse_checkout -q