### PR TITLE
Fix implement canonical status root from lane env

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -842,6 +842,7 @@ def implement(
         if repo_root is None:
             print("Error: Could not locate project root")
             raise typer.Exit(1)
+        repo_root = get_main_repo_root(repo_root)
 
         mission_slug = _find_mission_slug(explicit_mission=mission, explicit_feature=feature, repo_root=repo_root)
 

--- a/src/specify_cli/core/paths.py
+++ b/src/specify_cli/core/paths.py
@@ -76,7 +76,7 @@ def locate_project_root(start: Path | None = None) -> Path | None:
     if env_root := os.getenv("SPECIFY_REPO_ROOT"):
         env_path = Path(env_root).resolve()
         if env_path.exists() and (env_path / KITTIFY_DIR).is_dir():
-            return env_path
+            return get_main_repo_root(env_path)
         # Invalid env var - fall through to other methods
 
     # Tier 2: Walk up directory tree, handling worktree .git files
@@ -248,6 +248,8 @@ def get_main_repo_root(current_path: Path) -> Path:
                 # Validate the gitdir path is not empty (bug discovered via mutation testing)
                 if gitdir_str:
                     gitdir = Path(gitdir_str)
+                    if not _is_worktree_gitdir(gitdir):
+                        return current_path.resolve()
                     # Navigate: .git/worktrees/name -> .git -> main repo root
                     main_git_dir = gitdir.parent.parent
                     main_repo_root = main_git_dir.parent

--- a/tests/runtime/test_paths_unit.py
+++ b/tests/runtime/test_paths_unit.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from specify_cli.core.paths import (
+    get_main_repo_root,
     locate_project_root,
     is_worktree_context,
     resolve_with_context,
@@ -58,6 +59,25 @@ def test_locate_project_root_with_env_var(mock_main_repo: Path, monkeypatch: pyt
 
     # Assert env var was used
     assert repo_root == mock_main_repo
+
+
+def test_locate_project_root_env_var_worktree_resolves_main_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SPECIFY_REPO_ROOT may point at a lane worktree; callers still need the main repo."""
+    main_repo = tmp_path / "repo"
+    worktree = main_repo / ".worktrees" / "feature-lane-a"
+    gitdir = main_repo / ".git" / "worktrees" / "feature-lane-a"
+    gitdir.mkdir(parents=True)
+    (main_repo / ".kittify").mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    (worktree / ".kittify").mkdir()
+    (worktree / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+
+    monkeypatch.setenv("SPECIFY_REPO_ROOT", str(worktree))
+
+    assert locate_project_root() == main_repo
 
 
 def test_locate_project_root_from_nested_dir(mock_main_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -122,6 +142,17 @@ def test_locate_project_root_from_external_worktree_pointer(tmp_path: Path) -> N
     )
 
     assert locate_project_root(external_wt) == main_repo
+
+
+def test_get_main_repo_root_ignores_non_worktree_git_file(tmp_path: Path) -> None:
+    """Separate-git-dir and submodule-style .git files are not worktree roots."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    gitdir = tmp_path / "external-git-dir"
+    gitdir.mkdir()
+    (repo / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+
+    assert get_main_repo_root(repo) == repo.resolve()
 
 
 def test_is_worktree_context_bare_repo_worktree(tmp_path: Path) -> None:

--- a/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
@@ -279,6 +279,42 @@ class TestImplementHardFailNoCanonical:
 
         assert result.exit_code == 0, f"Expected success: {result.stdout}"
 
+    def test_implement_uses_main_status_when_env_root_points_at_lane_worktree(
+        self,
+        workflow_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A lane-scoped SPECIFY_REPO_ROOT must not make implement read lane-local status."""
+        mission_slug = "060-test-feature"
+        feature_dir = workflow_repo / "kitty-specs" / mission_slug
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        write_single_lane_manifest(feature_dir, wp_ids=("WP01",), predicted_surfaces=("workflow",))
+        (feature_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
+        _write_wp_file(tasks_dir / "WP01-test.md", "WP01", lane="planned")
+        _seed_wp_lane(feature_dir, "WP01", "planned")
+
+        workspace = lane_worktree_path(workflow_repo, mission_slug)
+        workspace.mkdir(parents=True)
+        (workspace / ".kittify").mkdir()
+        gitdir = workflow_repo / ".git" / "worktrees" / workspace.name
+        gitdir.mkdir(parents=True)
+        (workspace / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+        (workspace / "kitty-specs" / mission_slug).mkdir(parents=True)
+        monkeypatch.setenv("SPECIFY_REPO_ROOT", str(workspace))
+        monkeypatch.setattr(
+            workflow,
+            "_ensure_target_branch_checked_out",
+            lambda _repo_root, _mission_slug: (workflow_repo, "main"),
+        )
+
+        result = CliRunner().invoke(
+            workflow.app,
+            ["implement", "WP01", "--mission", mission_slug, "--agent", "test-agent"],
+        )
+
+        assert result.exit_code == 0, result.stdout
+
 
 # ---------------------------------------------------------------------------
 # T014: review hard-fails when no canonical state


### PR DESCRIPTION
## Summary
- Fixes #1432.
- Normalize `SPECIFY_REPO_ROOT` when it points at a lane worktree so project-root resolution returns the main repository root.
- Normalize `agent action implement`'s located root before status/dependency reads.
- Guard `get_main_repo_root()` against non-worktree `.git` files so separate-git-dir/submodule-style pointers are not treated as worktrees.

## Regression Coverage
- Added a path resolver regression where `SPECIFY_REPO_ROOT` is a lane worktree.
- Added an `agent action implement` regression where lane-local status is absent/stale but main canonical status exists.

## Verification
- `.venv/bin/pytest tests/runtime/test_paths_unit.py::test_locate_project_root_env_var_worktree_resolves_main_repo -q` failed before the fix, then passed after.
- `.venv/bin/pytest tests/runtime/test_paths_unit.py tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py -q` -> 41 passed, 1 warning.
- `.venv/bin/ruff check src/specify_cli/core/paths.py src/specify_cli/cli/commands/agent/workflow.py tests/runtime/test_paths_unit.py tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py` -> passed.
- `git diff --check` -> passed.

## Self-Review
Ran `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` locally on the diff. Finding: env-root fix expanded use of `get_main_repo_root()`, whose `.git` file handling did not reject non-worktree pointers. Addressed by validating worktree topology and adding regression coverage.
