### PR TITLE
Fix deprecated check-prerequisites alias safety

### DIFF
--- a/src/specify_cli/compat/safety.py
+++ b/src/specify_cli/compat/safety.py
@@ -102,6 +102,7 @@ SAFETY_REGISTRY: dict[tuple[str, ...], SafetyPredicate | None] = {
     # NOTE: ("agent", "mission", "setup-plan") is intentionally absent — it
     # scaffolds plan.md and commits to the target branch (project mutation) and
     # must therefore be treated as UNSAFE under schema mismatch.
+    ("agent", "check-prerequisites"): None,
     ("agent", "mission", "branch-context"): None,
     ("agent", "mission", "check-prerequisites"): None,
     ("agent", "context", "resolve"): None,

--- a/tests/cli_gate/test_nested_safe_commands.py
+++ b/tests/cli_gate/test_nested_safe_commands.py
@@ -75,6 +75,7 @@ _NESTED_SAFE_COMMANDS = [
     # NOTE: "setup-plan" is intentionally excluded — it scaffolds plan.md and
     # commits to the target branch, making it a project mutation.  It is
     # therefore UNSAFE and must block under schema mismatch.  See FIX A.
+    (["agent", "check-prerequisites"], "agent_check-prerequisites_alias"),
     (["agent", "mission", "branch-context"], "agent_mission_branch-context"),
     (["agent", "mission", "check-prerequisites"], "agent_mission_check-prerequisites"),
     (["agent", "context", "resolve"], "agent_context_resolve"),

--- a/tests/specify_cli/compat/test_safety.py
+++ b/tests/specify_cli/compat/test_safety.py
@@ -39,6 +39,7 @@ SEEDED_SAFE_PATHS = [
     ("doctor",),
     ("help",),
     ("version",),
+    ("agent", "check-prerequisites"),
     ("agent", "mission", "branch-context"),
     ("agent", "mission", "check-prerequisites"),
     # NOTE: ("agent", "mission", "setup-plan") is intentionally absent —


### PR DESCRIPTION
## Summary
- register deprecated `spec-kitty agent check-prerequisites` alias as safe under schema mismatch
- add compat registry coverage for the alias path
- add schema-gate regressions for stale and too-new project metadata

Fixes #1462

## Verification
- `.venv/bin/pytest tests/cli_gate/test_nested_safe_commands.py tests/specify_cli/compat/test_safety.py tests/agent/test_agent_alias_check_prerequisites.py -q` — 43 passed
- `.venv/bin/ruff check src/specify_cli/compat/safety.py tests/specify_cli/compat/test_safety.py tests/cli_gate/test_nested_safe_commands.py` — passed
- `git diff --check` — passed
- `.venv/bin/pytest tests/cli_gate tests/specify_cli/compat/test_safety.py tests/specify_cli/compat/test_planner.py -q` — 221 passed

## Self-review
Used adversarial-pr-review locally against this diff. No merge-blocking findings survived: the alias forwards to the already-safe read-only diagnostic command; mutating `agent mission setup-plan` remains unregistered and covered as unsafe under stale/too-new schemas.