### PR TITLE
Fix shipped agent profile README IDs

### DIFF
--- a/src/doctrine/agent_profiles/README.md
+++ b/src/doctrine/agent_profiles/README.md
@@ -29,8 +29,8 @@ Profiles are loaded from layered sources with field-level merge:
 - **Organization profiles** — Optional organization-level pack overlays
 - **Project profiles** (`.kittify/charter/agents/`) — Custom overrides per project
 
-Project profiles override shipped profiles at field level when sharing the same
-`profile-id`.
+Each higher layer can override a lower-layer profile at field level when sharing
+the same `profile-id`; project profiles have final precedence.
 
 ## Shipped Profiles
 
@@ -55,7 +55,7 @@ Project profiles override shipped profiles at field level when sharing the same
 ## Python API
 
 - `AgentProfile` — Pydantic domain model
-- `AgentProfileRepository` — Two-source loading, hierarchy, weighted matching
+- `AgentProfileRepository` — Layered loading, hierarchy, weighted matching
 - `validate_agent_profile_yaml()` — JSON Schema (Draft 7) validation
 - `RoleCapabilities` / `DEFAULT_ROLE_CAPABILITIES` — Role-based capability defaults
 

--- a/src/doctrine/agent_profiles/README.md
+++ b/src/doctrine/agent_profiles/README.md
@@ -21,11 +21,12 @@ Each profile defines:
 5. **Mode Defaults** — Operating modes with descriptions and use-cases
 6. **Initialization Declaration** — Self-description loaded at session start
 
-## Two-Source Loading
+## Layered Loading
 
-Profiles are loaded from two sources with field-level merge:
+Profiles are loaded from layered sources with field-level merge:
 
-- **Shipped profiles** (`shipped/`) — 7 reference profiles included in the package
+- **Shipped profiles** (`built-in/`) — Reference profiles included in the package
+- **Organization profiles** — Optional organization-level pack overlays
 - **Project profiles** (`.kittify/charter/agents/`) — Custom overrides per project
 
 Project profiles override shipped profiles at field level when sharing the same
@@ -33,15 +34,23 @@ Project profiles override shipped profiles at field level when sharing the same
 
 ## Shipped Profiles
 
-| Profile ID    | Name               | Role        |
-|---------------|--------------------|-------------|
-| `implementer` | Implementer Ivan   | implementer |
-| `reviewer`    | Reviewer Renata    | reviewer    |
-| `architect`   | Architect Alphonso | architect   |
-| `planner`     | Planner Petra      | planner     |
-| `designer`    | Designer           | designer    |
-| `researcher`  | Researcher Rosa    | researcher  |
-| `curator`     | Curator Carla      | curator     |
+| Profile ID | Name | Role |
+|------------|------|------|
+| `architect-alphonso` | Architect Alphonso | architect |
+| `curator-carla` | Curator Carla | curator |
+| `debugger-debbie` | Debugger Debbie | investigator |
+| `designer-dagmar` | Designer Dagmar | designer |
+| `frontend-freddy` | Frontend Freddy | implementer |
+| `generic-agent` | Generic Agent | implementer |
+| `human-in-charge` | Human in Charge | human-in-charge |
+| `implementer-ivan` | Implementer Ivan | implementer |
+| `java-jenny` | Java Jenny | implementer |
+| `node-norris` | Node Norris | implementer |
+| `planner-priti` | Planner Priti | planner |
+| `python-pedro` | Python Pedro | implementer |
+| `researcher-robbie` | Researcher Robbie | researcher |
+| `retrospective-facilitator` | Retrospective Facilitator | facilitator |
+| `reviewer-renata` | Reviewer Renata | reviewer |
 
 ## Python API
 

--- a/src/doctrine/agent_profiles/built-in/README.md
+++ b/src/doctrine/agent_profiles/built-in/README.md
@@ -11,13 +11,16 @@ with the language name) extend the base `implementer-ivan` role for polyglot pro
 | `curator-carla.agent.yaml` | `curator-carla` | curator |
 | `debugger-debbie.agent.yaml` | `debugger-debbie` | investigator |
 | `designer-dagmar.agent.yaml` | `designer-dagmar` | designer |
+| `frontend-freddy.agent.yaml` | `frontend-freddy` | implementer |
 | `generic-agent.agent.yaml` | `generic-agent` | implementer |
 | `human-in-charge.agent.yaml` | `human-in-charge` | human-in-charge |
 | `implementer-ivan.agent.yaml` | `implementer-ivan` | implementer |
 | `java-jenny.agent.yaml` | `java-jenny` | implementer (Java specialist) |
+| `node-norris.agent.yaml` | `node-norris` | implementer |
 | `planner-priti.agent.yaml` | `planner-priti` | planner |
 | `python-pedro.agent.yaml` | `python-pedro` | implementer (Python specialist) |
 | `researcher-robbie.agent.yaml` | `researcher-robbie` | researcher |
+| `retrospective-facilitator.agent.yaml` | `retrospective-facilitator` | facilitator |
 | `reviewer-renata.agent.yaml` | `reviewer-renata` | reviewer |
 
 Shipped profiles are read-only at the package level. Project-level overrides in

--- a/tests/doctrine/test_shipped_profiles.py
+++ b/tests/doctrine/test_shipped_profiles.py
@@ -21,6 +21,8 @@ from doctrine.agent_profiles.validation import validate_agent_profile_yaml
 pytestmark = [pytest.mark.fast, pytest.mark.doctrine]
 
 BUILT_IN_DIR = Path(__file__).parent.parent.parent / "src" / "doctrine" / "agent_profiles" / "built-in"
+AGENT_PROFILES_README = BUILT_IN_DIR.parent / "README.md"
+BUILT_IN_README = BUILT_IN_DIR / "README.md"
 
 EXPECTED_PROFILE_IDS = {
     "architect-alphonso",
@@ -44,6 +46,33 @@ EXPECTED_PROFILE_IDS = {
 # have empty context sources and directive references.
 _SENTINEL_PROFILES = {"human-in-charge"}
 _AGENT_PROFILE_IDS = EXPECTED_PROFILE_IDS - _SENTINEL_PROFILES
+
+
+def _profile_ids_from_yaml_files() -> set[str]:
+    yaml = YAML(typ="safe")
+    profile_ids = set()
+    for yaml_file in BUILT_IN_DIR.glob("*.agent.yaml"):
+        with yaml_file.open() as f:
+            data = yaml.load(f)
+        profile_ids.add(data["profile-id"])
+    return profile_ids
+
+
+def _profile_ids_from_readme_table(readme_path: Path, profile_id_column: str) -> set[str]:
+    lines = readme_path.read_text().splitlines()
+    for index, line in enumerate(lines):
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if profile_id_column not in cells:
+            continue
+        column_index = cells.index(profile_id_column)
+        profile_ids = set()
+        for row in lines[index + 2 :]:
+            if not row.startswith("|"):
+                break
+            row_cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+            profile_ids.add(row_cells[column_index].strip("`"))
+        return profile_ids
+    raise AssertionError(f"No markdown table with column {profile_id_column!r} in {readme_path}")
 
 
 @pytest.fixture(scope="module")
@@ -91,6 +120,23 @@ class TestShippedProfilesLoad:
         profile = repo.get(profile_id)
         assert profile is not None, f"Profile '{profile_id}' not found in repository"
         assert profile.profile_id == profile_id
+
+    @pytest.mark.parametrize(
+        "readme_path,profile_id_column",
+        [
+            (AGENT_PROFILES_README, "Profile ID"),
+            (BUILT_IN_README, "Profile ID"),
+        ],
+    )
+    def test_readme_profile_ids_match_shipped_yaml(
+        self,
+        readme_path: Path,
+        profile_id_column: str,
+    ):
+        """README shipped-profile tables list exactly the packaged profile ids."""
+        actual_ids = _profile_ids_from_yaml_files()
+        readme_ids = _profile_ids_from_readme_table(readme_path, profile_id_column)
+        assert readme_ids == actual_ids, f"{readme_path} drifted from shipped profiles"
 
 
 class TestShippedProfilesRoles:


### PR DESCRIPTION
## Summary
- Replace stale bare agent profile ids in `src/doctrine/agent_profiles/README.md` with actual built-in profile ids.
- Update the built-in profile README for profiles added after the table was written.
- Add a drift guard comparing README profile-id tables to shipped `*.agent.yaml` ids.

Fixes #1468

## Verification
- `.venv/bin/pytest tests/doctrine/test_shipped_profiles.py -q`
- `.venv/bin/ruff check tests/doctrine/test_shipped_profiles.py src/doctrine/agent_profiles/README.md src/doctrine/agent_profiles/built-in/README.md`
- `.venv/bin/pytest tests/doctrine/test_wheel_packaging.py::test_wheel_contains_doctrine_package_data tests/doctrine/test_package_smoke.py::test_doctrine_import_and_profile_repo_smoke -q`

## Self-review
- Ran adversarial self-review per requested skill; no remaining merge blockers after removing hardcoded count drift.