### PR TITLE
Fix agent profile schema-version contract

### DIFF
--- a/src/doctrine/agent_profiles/profile.py
+++ b/src/doctrine/agent_profiles/profile.py
@@ -15,6 +15,8 @@ from typing import Annotated, Any, ClassVar, Self
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.functional_validators import BeforeValidator
 
+from doctrine.agent_profiles.schema_version import AGENT_PROFILE_SCHEMA_VERSION_PATTERN
+
 
 def _normalize_role_value(value: str) -> str:
     return value.lower()
@@ -222,7 +224,7 @@ class AgentProfile(BaseModel):
     profile_id: str = Field(alias="profile-id")
     name: str
     description: str = ""
-    schema_version: str = Field(default="1.0", alias="schema-version")
+    schema_version: str = Field(default="1.0", alias="schema-version", pattern=AGENT_PROFILE_SCHEMA_VERSION_PATTERN)
     roles: list[Role] = Field(min_length=1)
     avatar_image: str | None = Field(default=None, alias="avatar-image")
     capabilities: list[str] = Field(default_factory=list)

--- a/src/doctrine/agent_profiles/schema_models.py
+++ b/src/doctrine/agent_profiles/schema_models.py
@@ -23,6 +23,8 @@ from typing import Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from doctrine.agent_profiles.schema_version import AGENT_PROFILE_SCHEMA_VERSION_PATTERN
+
 
 # ---------------------------------------------------------------------------
 # Value objects
@@ -161,7 +163,7 @@ class AgentProfileSchema(BaseModel):
         extra="forbid",
         populate_by_name=True,
         json_schema_extra={
-            "$comment": "schema-version: 2 — roles list support added",
+            "$comment": "schema-version: 2 — roles list support added; legacy 1.0 remains accepted",
             "anyOf": [{"required": ["role"]}, {"required": ["roles"]}],
         },
     )
@@ -171,7 +173,7 @@ class AgentProfileSchema(BaseModel):
     name: str
     description: str | None = None
     schema_version: str | None = Field(
-        default=None, alias="schema-version", pattern=r"^1\.0$"
+        default=None, alias="schema-version", pattern=AGENT_PROFILE_SCHEMA_VERSION_PATTERN
     )
     purpose: str
     role: str | None = Field(

--- a/src/doctrine/agent_profiles/schema_version.py
+++ b/src/doctrine/agent_profiles/schema_version.py
@@ -1,0 +1,3 @@
+"""Agent-profile schema-version contract constants."""
+
+AGENT_PROFILE_SCHEMA_VERSION_PATTERN = r"^(1\.0|2)$"

--- a/src/doctrine/schemas/agent-profile.schema.yaml
+++ b/src/doctrine/schemas/agent-profile.schema.yaml
@@ -1,6 +1,6 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://spec-kitty.dev/schemas/doctrine/agent-profile.schema.yaml
-$comment: 'schema-version: 2 — roles list support added'
+$comment: 'schema-version: 2 — roles list support added; legacy 1.0 remains accepted'
 title: Agent Profile
 description: Rich agent profile schema with 6-section structure for spec-kitty doctrine framework
 type: object
@@ -262,7 +262,7 @@ properties:
     description: Optional brief description
   schema-version:
     type: string
-    pattern: ^1\.0$
+    pattern: ^(1\.0|2)$
     description: Schema version for compatibility
   purpose:
     type: string

--- a/tests/doctrine/test_profile_schema_validation.py
+++ b/tests/doctrine/test_profile_schema_validation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from ruamel.yaml import YAML
 
+from doctrine.agent_profiles.profile import AgentProfile
 from doctrine.agent_profiles.validation import (
     is_agent_profile_file,
     validate_agent_profile_yaml,
@@ -170,6 +171,37 @@ class TestSchemaValidation:
         }
         errors = validate_agent_profile_yaml(data)
         assert len(errors) > 0
+
+
+class TestAgentProfileSchemaVersionContract:
+    """Schema and runtime model agree on agent-profile schema-version values."""
+
+    def _profile_with_schema_version(self, schema_version: str) -> dict:
+        return {
+            "profile-id": "schema-version-test",
+            "name": "Schema Version Test",
+            "purpose": "Prove schema-version validation is consistent.",
+            "schema-version": schema_version,
+            "roles": ["implementer"],
+            "specialization": {"primary-focus": "Schema validation"},
+        }
+
+    @pytest.mark.parametrize("schema_version", ["1.0", "2"])
+    def test_schema_and_runtime_accept_supported_schema_versions(self, schema_version: str) -> None:
+        data = self._profile_with_schema_version(schema_version)
+
+        assert validate_agent_profile_yaml(data) == []
+        assert AgentProfile.model_validate(data).schema_version == schema_version
+
+    @pytest.mark.parametrize("schema_version", ["1", "2.0", "3", "latest", ""])
+    def test_schema_and_runtime_reject_unsupported_schema_versions(self, schema_version: str) -> None:
+        data = self._profile_with_schema_version(schema_version)
+
+        errors = validate_agent_profile_yaml(data)
+        assert any("schema-version" in error for error in errors)
+
+        with pytest.raises(ValueError, match="schema-version|schema_version|String should match pattern"):
+            AgentProfile.model_validate(data)
 
 
 class TestFileTypeDetection:


### PR DESCRIPTION
## Summary
- align agent-profile schema-version schema/comment/runtime validation around supported values: legacy `1.0` and current `2`
- add shared regex constant used by runtime and schema-generation models
- add regression coverage proving JSON Schema validator and AgentProfile Pydantic model accept/reject the same schema-version values

Fixes #1469

## Verification
- `.venv/bin/pytest tests/doctrine/test_profile_schema_validation.py tests/doctrine/test_schema_validation.py tests/doctrine/agent_profiles/test_schema_generation.py -q` — 53 passed
- `.venv/bin/pytest tests/doctrine/test_shipped_profiles.py tests/doctrine/test_profile_model.py tests/doctrine/test_role_value_object.py -q` — 283 passed, 7 expected deprecation warnings
- `.venv/bin/python scripts/generate_schemas.py --check agent-profile` — OK: agent-profile.schema.yaml
- `.venv/bin/ruff check src/doctrine/agent_profiles/profile.py src/doctrine/agent_profiles/schema_models.py src/doctrine/agent_profiles/schema_version.py tests/doctrine/test_profile_schema_validation.py` — All checks passed
- `.venv/bin/mypy src/doctrine/agent_profiles/profile.py src/doctrine/agent_profiles/schema_models.py src/doctrine/agent_profiles/schema_version.py` — Success: no issues found in 3 source files
- `git diff --check` — passed

## Self-review
Used `/Users/robert/.codex/skills/adversarial-pr-review/SKILL.md` against the local diff. Verdict: SAFE. No surviving merge-blocking findings; checked canonical contract ambiguity, schema-generation staleness, runtime/schema coupling, and shipped-profile compatibility.