### PR TITLE
Fix charter lint checks shim identity

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc30
+  version: 3.2.0rc31
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `charter generate --force` now refuses to overwrite symlinked `charter.md` paths,
   preventing silent writes through symlink targets.
-- Legacy `specify_cli.charter_lint.checks.*` shim imports now preserve canonical
-  `specify_cli.charter_runtime.lint.checks.*` module identity and fail loudly if a
-  nested alias is missing, preventing duplicate checker module instances.
 
 ### Documentation
 
@@ -30,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than alternate authoritative charter paths.
 - Added migration guidance for constitution-era `.kittify/memory/constitution.md`
   and `.kittify/constitution/*` layouts.
+
+## [3.2.0rc31] - 2026-05-31
+
+### Fixed
+
+- Legacy `specify_cli.charter_lint.checks.*` shim imports now preserve canonical
+  `specify_cli.charter_runtime.lint.checks.*` module identity and fail loudly if a
+  nested alias is missing, preventing duplicate checker module instances.
 
 ## [3.2.0rc30] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `charter generate --force` now refuses to overwrite symlinked `charter.md` paths,
   preventing silent writes through symlink targets.
+- Legacy `specify_cli.charter_lint.checks.*` shim imports now preserve canonical
+  `specify_cli.charter_runtime.lint.checks.*` module identity and fail loudly if a
+  nested alias is missing, preventing duplicate checker module instances.
 
 ### Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc30"
+version = "3.2.0rc31"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/charter_lint/__init__.py
+++ b/src/specify_cli/charter_lint/__init__.py
@@ -8,6 +8,7 @@ Eager sys.modules aliasing — see
 from __future__ import annotations
 
 import importlib
+import importlib.machinery
 import pkgutil
 import sys
 import types
@@ -25,7 +26,14 @@ for _sub in ("_drg", "engine", "findings"):
 _canonical_checks = importlib.import_module(f"{_CANONICAL}.checks")
 _checks_shim_name = f"{__name__}.checks"
 _checks_shim = types.ModuleType(_checks_shim_name, _canonical_checks.__doc__)
+_checks_shim.__loader__ = None
 _checks_shim.__package__ = _checks_shim_name
+_checks_shim.__spec__ = importlib.machinery.ModuleSpec(
+    _checks_shim_name,
+    loader=None,
+    is_package=True,
+)
+_checks_shim.__spec__.submodule_search_locations = []
 _checks_shim.__path__ = []
 _checks_shim.__all__ = getattr(_canonical_checks, "__all__", ())  # type: ignore[attr-defined]
 sys.modules[_checks_shim_name] = _checks_shim

--- a/src/specify_cli/charter_lint/__init__.py
+++ b/src/specify_cli/charter_lint/__init__.py
@@ -8,26 +8,35 @@ Eager sys.modules aliasing — see
 from __future__ import annotations
 
 import importlib
+import pkgutil
 import sys
+import types
 
 from specify_cli.charter_runtime.lint import *  # noqa: F401,F403
 from specify_cli.charter_runtime.lint import __all__  # noqa: F401
 
 _CANONICAL = "specify_cli.charter_runtime.lint"
 
-for _sub in ("_drg", "engine", "findings", "checks"):
+for _sub in ("_drg", "engine", "findings"):
     _module = importlib.import_module(f"{_CANONICAL}.{_sub}")
     sys.modules[f"{__name__}.{_sub}"] = _module
     setattr(sys.modules[__name__], _sub, _module)
 
+_canonical_checks = importlib.import_module(f"{_CANONICAL}.checks")
+_checks_shim_name = f"{__name__}.checks"
+_checks_shim = types.ModuleType(_checks_shim_name, _canonical_checks.__doc__)
+_checks_shim.__package__ = _checks_shim_name
+_checks_shim.__path__ = []
+_checks_shim.__all__ = getattr(_canonical_checks, "__all__", ())  # type: ignore[attr-defined]
+sys.modules[_checks_shim_name] = _checks_shim
+checks = _checks_shim
+
 # Nested ``checks/*`` submodules — tests legitimately import these via the
 # legacy dotted path (e.g. ``specify_cli.charter_lint.checks.staleness``).
-for _sub in (
-    "contradiction",
-    "org_layer",
-    "orphan",
-    "reference_integrity",
-    "staleness",
-):
+# Discover canonical modules dynamically, but keep the legacy parent package's
+# path empty so missing aliases fail loudly instead of creating duplicates.
+for _module_info in pkgutil.iter_modules(_canonical_checks.__path__):
+    _sub = _module_info.name
     _module = importlib.import_module(f"{_CANONICAL}.checks.{_sub}")
-    sys.modules[f"{__name__}.checks.{_sub}"] = _module
+    sys.modules[f"{_checks_shim_name}.{_sub}"] = _module
+    setattr(_checks_shim, _sub, _module)

--- a/tests/architectural/test_charter_runtime_shim_paths.py
+++ b/tests/architectural/test_charter_runtime_shim_paths.py
@@ -15,6 +15,7 @@ This test locks the contract so the shim layer cannot be silently removed:
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import pkgutil
 import sys
 
@@ -125,6 +126,18 @@ def test_all_canonical_lint_checks_have_legacy_aliases() -> None:
         assert legacy_mod is canonical_mod, (
             f"shim identity mismatch: {legacy_path} is not {canonical_path}"
         )
+
+
+def test_legacy_lint_checks_parent_has_package_metadata() -> None:
+    """The synthetic parent package must remain discoverable by importlib."""
+    legacy_checks = importlib.import_module("specify_cli.charter_lint.checks")
+
+    spec = importlib.util.find_spec("specify_cli.charter_lint.checks")
+
+    assert spec is not None
+    assert spec.name == "specify_cli.charter_lint.checks"
+    assert spec.submodule_search_locations == []
+    assert legacy_checks.__spec__ is spec
 
 
 def test_missing_legacy_lint_check_alias_fails_loudly() -> None:

--- a/tests/architectural/test_charter_runtime_shim_paths.py
+++ b/tests/architectural/test_charter_runtime_shim_paths.py
@@ -15,6 +15,8 @@ This test locks the contract so the shim layer cannot be silently removed:
 from __future__ import annotations
 
 import importlib
+import pkgutil
+import sys
 
 import pytest
 
@@ -105,3 +107,45 @@ def test_legacy_submodules_resolve_via_shim() -> None:
         assert hasattr(legacy_mod, sentinel), (
             f"{legacy_path} missing sentinel symbol {sentinel!r}"
         )
+
+
+def test_all_canonical_lint_checks_have_legacy_aliases() -> None:
+    """Every canonical lint checker module must keep legacy identity."""
+    canonical_checks = importlib.import_module(
+        "specify_cli.charter_runtime.lint.checks"
+    )
+
+    for module_info in pkgutil.iter_modules(canonical_checks.__path__):
+        canonical_path = f"specify_cli.charter_runtime.lint.checks.{module_info.name}"
+        legacy_path = f"specify_cli.charter_lint.checks.{module_info.name}"
+
+        canonical_mod = importlib.import_module(canonical_path)
+        legacy_mod = importlib.import_module(legacy_path)
+
+        assert legacy_mod is canonical_mod, (
+            f"shim identity mismatch: {legacy_path} is not {canonical_path}"
+        )
+
+
+def test_missing_legacy_lint_check_alias_fails_loudly() -> None:
+    """Deleted/missing nested aliases must not import duplicate modules.
+
+    This guards issue #1459: if a nested legacy check alias disappears from
+    ``sys.modules``, Python must not discover the canonical file through the
+    legacy parent package and instantiate it as
+    ``specify_cli.charter_lint.checks.<name>``.
+    """
+    legacy_path = "specify_cli.charter_lint.checks.staleness"
+    canonical_path = "specify_cli.charter_runtime.lint.checks.staleness"
+
+    canonical_mod = importlib.import_module(canonical_path)
+    original_legacy_mod = importlib.import_module(legacy_path)
+    assert original_legacy_mod is canonical_mod
+
+    sys.modules.pop(legacy_path, None)
+    try:
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(legacy_path)
+        assert sys.modules.get(legacy_path) is None
+    finally:
+        sys.modules[legacy_path] = canonical_mod

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc30"
+version = "3.2.0rc31"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- Replace the legacy `specify_cli.charter_lint.checks` parent alias with a shim package that has no import search path, so missing nested aliases fail loudly instead of creating duplicate modules.
- Dynamically mirror canonical `specify_cli.charter_runtime.lint.checks.*` modules under the legacy path while preserving module object identity.
- Add regression coverage for issue #1459 and bump CLI version to 3.2.0rc31 per repo `__init__.py` change policy.

Closes #1459.

## Verification
- `.venv/bin/pytest tests/architectural/test_charter_runtime_shim_paths.py -q` -> 5 passed
- `.venv/bin/pytest tests/specify_cli/charter_lint tests/specify_cli/cli/commands/test_charter_lint.py tests/specify_cli/test_provenance_integration.py tests/charter/test_org_drg_edge_source_urn_preserved.py -q` -> 96 passed, 2 expected DoctrineLayerCollisionWarning warnings
- `.venv/bin/ruff check src/specify_cli/charter_lint/__init__.py tests/architectural/test_charter_runtime_shim_paths.py` -> passed
- `.venv/bin/mypy --strict src/specify_cli/charter_lint/__init__.py tests/architectural/test_charter_runtime_shim_paths.py` -> passed
- `uv lock --check` -> passed

## Self-review
Ran required adversarial self-review on the local diff. No merge-blocking findings remained after verifying nested alias deletion fails loudly without duplicate module creation, current canonical check modules preserve legacy identity, and relevant tests/lint/type checks pass.