### PR TITLE
Report acceptance blockers for in-review lanes

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -56,6 +56,13 @@ PRIMARY_ARTIFACT_FILES = (
     DATA_MODEL_FILE,
 )
 _DECISION_ID_MARKER = "decision_id:"
+_ACCEPTED_READY_LANES = frozenset({"approved", "done"})
+_LEGACY_NOT_DONE_LANES = ("planned", "claimed", "doing", "in_progress", "for_review")
+_ACTIONABLE_LANE_BLOCKER_HINTS = {
+    "in_review": "review is still in progress; complete the review and move the work package to approved or done",
+    "blocked": "work package is blocked; resolve the blocker and move the work package to approved or done",
+    "canceled": "work package is canceled; reopen or replace it, then move the work package to approved or done",
+}
 
 
 class AcceptanceError(TaskCliError):
@@ -94,6 +101,13 @@ class AcceptanceCheckDiagnostic:
         return {"check": self.check, "detail": self.detail}
 
 
+def _format_lane_blocker(lane: str, wp_id: str) -> str:
+    hint = _ACTIONABLE_LANE_BLOCKER_HINTS.get(lane)
+    if hint is None:
+        hint = "move the work package to approved or done"
+    return f"{wp_id}: canonical lane is '{lane}'; {hint}."
+
+
 @dataclass
 class AcceptanceSummary:
     feature: str
@@ -121,8 +135,7 @@ class AcceptanceSummary:
     @property
     def all_done(self) -> bool:
         """True when all WPs are approved or done (no WPs still in progress or review)."""
-        accepted_ready_lanes = {"approved", "done"}
-        return not any(wp_ids for lane, wp_ids in self.lanes.items() if lane not in accepted_ready_lanes)
+        return not any(wp_ids for lane, wp_ids in self.lanes.items() if lane not in _ACCEPTED_READY_LANES)
 
     @property
     def ok(self) -> bool:
@@ -140,11 +153,12 @@ class AcceptanceSummary:
     def outstanding(self) -> dict[str, list[str]]:
         buckets = {
             "not_done": [
-                *self.lanes.get("planned", []),
-                *self.lanes.get("claimed", []),
-                *self.lanes.get("doing", []),
-                *self.lanes.get("in_progress", []),
-                *self.lanes.get("for_review", []),
+                *(wp_id for lane in _LEGACY_NOT_DONE_LANES for wp_id in self.lanes.get(lane, [])),
+            ],
+            "lane_blockers": [
+                _format_lane_blocker(lane, wp_id)
+                for lane in _ACTIONABLE_LANE_BLOCKER_HINTS
+                for wp_id in self.lanes.get(lane, [])
             ],
             "metadata": self.metadata_issues,
             "activity": self.activity_issues,

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -77,6 +77,50 @@ def test_acceptance_summary_all_done_rejects_non_accepted_ready_lanes(tmp_path: 
     assert summary.ok is False
 
 
+@pytest.mark.parametrize(
+    ("lane", "expected_action"),
+    [
+        ("in_review", "complete the review"),
+        ("blocked", "resolve the blocker"),
+        ("canceled", "reopen or replace it"),
+    ],
+)
+def test_acceptance_summary_reports_actionable_lane_blockers(
+    tmp_path: Path, lane: str, expected_action: str
+) -> None:
+    summary = _summary_with_lanes(tmp_path, {"approved": ["WP01"], lane: ["WP02"]})
+
+    outstanding = summary.outstanding()
+    failed_checks = summary.failed_checks()
+    payload = summary.to_dict()
+
+    assert "lane_blockers" in outstanding
+    assert len(outstanding["lane_blockers"]) == 1
+    assert f"WP02: canonical lane is '{lane}'" in outstanding["lane_blockers"][0]
+    assert expected_action in outstanding["lane_blockers"][0]
+    assert "approved or done" in outstanding["lane_blockers"][0]
+    assert any(item.check == "lane_blockers" and expected_action in item.detail for item in failed_checks)
+    assert any(item["check"] == "lane_blockers" and expected_action in item["detail"] for item in payload["failed_checks"])
+
+
+def test_acceptance_summary_preserves_existing_not_done_bucket(tmp_path: Path) -> None:
+    summary = _summary_with_lanes(
+        tmp_path,
+        {
+            "planned": ["WP01"],
+            "claimed": ["WP02"],
+            "in_progress": ["WP03"],
+            "for_review": ["WP04"],
+            "in_review": ["WP05"],
+        },
+    )
+
+    outstanding = summary.outstanding()
+
+    assert outstanding["not_done"] == ["WP01", "WP02", "WP03", "WP04"]
+    assert any("WP05: canonical lane is 'in_review'" in item for item in outstanding["lane_blockers"])
+
+
 def test_acceptance_lane_derivations_are_shared(tmp_path: Path) -> None:
     summary = _summary_with_lanes(tmp_path, {"approved": ["WP01"], "done": ["WP02"]})
 


### PR DESCRIPTION
## Summary
- add explicit `lane_blockers` diagnostics for `in_review`, `blocked`, and `canceled` acceptance blockers
- keep the existing `not_done` bucket behavior for planned/claimed/in_progress/for_review lanes
- cover text diagnostics plus JSON `failed_checks` output for the affected lanes

Closes #1448

## Verification
- `.venv/bin/pytest tests/specify_cli/test_acceptance_regressions.py -q` — 35 passed
- `.venv/bin/pytest tests/cross_cutting/misc/test_acceptance_support.py -q` — 18 passed, 1 warning
- `.venv/bin/pytest tests/specify_cli/test_canonical_acceptance.py -q` — 18 passed
- `.venv/bin/ruff check src/specify_cli/acceptance/__init__.py tests/specify_cli/test_acceptance_regressions.py` — passed
- `git diff --check` — passed

## Self-review
- Used `adversarial-pr-review` locally against the diff.
- No merge-blocking findings survived. Compatibility risk around `not_done` bucket is covered by regression coverage.

## Note
- `.venv/bin/mypy --strict src/specify_cli/acceptance/__init__.py` still reports pre-existing module-level Any errors unrelated to this patch.