### PR TITLE
Fix runtime-next --result default docs

### DIFF
--- a/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-next/SKILL.md
@@ -356,7 +356,8 @@ spec-kitty next --agent <agent> --mission <mission-slug> --result blocked --json
 > Always use `--mission` in new scripts.
 
 The `--result` flag tells the runtime the outcome of the previous step.
-Defaults to `success` if omitted.
+If omitted, `spec-kitty next` returns current state without advancing (query mode).
+It does not report success for the previous step.
 
 ---
 

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc30_fix_runtime_next_result_default.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc30_fix_runtime_next_result_default.py
@@ -1,0 +1,95 @@
+"""Migration: correct stale runtime-next ``--result`` default docs.
+
+The runtime-next skill used to claim that omitting ``--result`` defaults to
+``success``. The CLI contract is the opposite: a bare ``spec-kitty next`` call
+is read-only query mode and does not advance the DAG.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+from ..registry import MigrationRegistry
+from ..skill_update import file_contains_any, find_skill_files, write_skill_text
+from .base import BaseMigration, MigrationResult
+
+_SKILL_NAME = "spec-kitty-runtime-next"
+
+_OLD_MARKERS = [
+    "Defaults to `success` if omitted.",
+]
+
+
+@MigrationRegistry.register
+class FixRuntimeNextResultDefaultMigration(BaseMigration):
+    """Refresh runtime-next SKILL.md copies with correct query-mode docs."""
+
+    migration_id = "3.2.0rc30_fix_runtime_next_result_default"
+    description = (
+        "Correct runtime-next skill docs: omitted --result is query mode, "
+        "not success (#1456)."
+    )
+    target_version = "3.2.0rc30"
+
+    def detect(self, project_path: Path) -> bool:
+        return any(
+            file_contains_any(info.path, _OLD_MARKERS)
+            for info in find_skill_files(project_path, _SKILL_NAME, ["SKILL.md"])
+        )
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:  # noqa: ARG002
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        changes: list[str] = []
+        errors: list[str] = []
+
+        try:
+            doctrine_root = files("doctrine")
+            canonical_path = doctrine_root.joinpath(
+                "skills", _SKILL_NAME, "SKILL.md"
+            )
+            new_content = canonical_path.read_text(encoding="utf-8")
+        except Exception:
+            fallback = (
+                Path(__file__).resolve().parents[3]
+                / "doctrine"
+                / "skills"
+                / _SKILL_NAME
+                / "SKILL.md"
+            )
+            if fallback.is_file():
+                new_content = fallback.read_text(encoding="utf-8")
+            else:
+                return MigrationResult(
+                    success=False,
+                    errors=["Cannot locate canonical SKILL.md for runtime-next"],
+                )
+
+        for info in find_skill_files(project_path, _SKILL_NAME, ["SKILL.md"]):
+            if not file_contains_any(info.path, _OLD_MARKERS):
+                continue
+            rel = str(info.path.relative_to(project_path))
+            if dry_run:
+                changes.append(f"Would replace {rel}")
+            else:
+                try:
+                    wrote, warning = write_skill_text(
+                        info.path, new_content, project_path
+                    )
+                    if wrote:
+                        changes.append(f"Replaced {rel}")
+                    elif warning is not None:
+                        changes.append(warning)
+                except OSError as exc:
+                    errors.append(f"Failed to write {rel}: {exc}")
+
+        if not changes and not errors:
+            changes.append("All runtime-next skill files already up to date")
+
+        return MigrationResult(
+            success=len(errors) == 0,
+            changes_made=changes,
+            errors=errors,
+        )

--- a/tests/specify_cli/docs/test_readme_governance.py
+++ b/tests/specify_cli/docs/test_readme_governance.py
@@ -73,3 +73,14 @@ def test_runtime_next_skill_references_resolve() -> None:
             continue
         target = (skill.parent / link).resolve()
         assert target.exists(), f"Broken link in runtime-next/SKILL.md: {link}"
+
+
+def test_runtime_next_skill_documents_omitted_result_as_query_mode() -> None:
+    skill = REPO_ROOT / "src/doctrine/skills/spec-kitty-runtime-next/SKILL.md"
+    content = skill.read_text()
+
+    assert "Defaults to `success` if omitted." not in content
+    assert (
+        "If omitted, `spec-kitty next` returns current state without advancing "
+        "(query mode)."
+    ) in content

--- a/tests/upgrade/migrations/test_m_3_2_0rc30_fix_runtime_next_result_default.py
+++ b/tests/upgrade/migrations/test_m_3_2_0rc30_fix_runtime_next_result_default.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.migrations.m_3_2_0rc30_fix_runtime_next_result_default import (
+    FixRuntimeNextResultDefaultMigration,
+)
+from specify_cli.upgrade.registry import MigrationRegistry
+
+pytestmark = pytest.mark.unit
+
+
+def _write_runtime_next_skill(project: Path, content: str) -> Path:
+    skill_path = project / ".claude" / "skills" / "spec-kitty-runtime-next" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(content, encoding="utf-8")
+    return skill_path
+
+
+def test_migration_detects_stale_success_default_doc(tmp_path: Path) -> None:
+    _write_runtime_next_skill(
+        tmp_path,
+        "The `--result` flag tells the runtime the outcome of the previous step.\n"
+        "Defaults to `success` if omitted.\n",
+    )
+
+    assert FixRuntimeNextResultDefaultMigration().detect(tmp_path) is True
+
+
+def test_migration_refreshes_runtime_next_skill_doc(tmp_path: Path) -> None:
+    skill_path = _write_runtime_next_skill(
+        tmp_path,
+        "The `--result` flag tells the runtime the outcome of the previous step.\n"
+        "Defaults to `success` if omitted.\n",
+    )
+
+    result = FixRuntimeNextResultDefaultMigration().apply(tmp_path)
+
+    assert result.success is True
+    assert result.changes_made == [
+        "Replaced .claude/skills/spec-kitty-runtime-next/SKILL.md"
+    ]
+    content = skill_path.read_text(encoding="utf-8")
+    assert "Defaults to `success` if omitted." not in content
+    assert (
+        "If omitted, `spec-kitty next` returns current state without advancing "
+        "(query mode)."
+    ) in content
+
+
+def test_migration_applies_to_same_version_when_stale_doc_detected(
+    tmp_path: Path,
+) -> None:
+    _write_runtime_next_skill(
+        tmp_path,
+        "The `--result` flag tells the runtime the outcome of the previous step.\n"
+        "Defaults to `success` if omitted.\n",
+    )
+
+    applicable = MigrationRegistry.get_applicable(
+        "3.2.0rc30",
+        "3.2.0rc30",
+        project_path=tmp_path,
+    )
+
+    assert any(
+        migration.migration_id == "3.2.0rc30_fix_runtime_next_result_default"
+        for migration in applicable
+    )


### PR DESCRIPTION
## Summary
- Correct runtime-next skill docs: omitted `--result` is query/read-only mode, not implicit `success`.
- Add a same-version upgrade migration to refresh installed runtime-next skill copies with the stale text.
- Add focused docs and migration regression coverage for issue #1456.

Fixes #1456.

## Verification
- `.venv/bin/pytest tests/specify_cli/docs/test_readme_governance.py::test_runtime_next_skill_documents_omitted_result_as_query_mode tests/upgrade/migrations/test_m_3_2_0rc30_fix_runtime_next_result_default.py -q` -> 3 passed
- `.venv/bin/pytest tests/contract/test_next_no_implicit_success.py tests/next/test_query_mode_unit.py tests/specify_cli/docs/test_readme_governance.py tests/upgrade/migrations/test_m_3_2_0rc30_fix_runtime_next_result_default.py tests/upgrade/test_auto_discovery.py -q` -> 56 passed, 1 warning
- `.venv/bin/ruff check src/doctrine/skills/spec-kitty-runtime-next/SKILL.md src/specify_cli/upgrade/migrations/m_3_2_0rc30_fix_runtime_next_result_default.py tests/specify_cli/docs/test_readme_governance.py tests/upgrade/migrations/test_m_3_2_0rc30_fix_runtime_next_result_default.py` -> all checks passed
- `git diff --cached --check` -> passed before commit

## Self-review
- Ran adversarial review on the local diff. Finding addressed: initial migration target would have delayed repair for current-version installs; retargeted to `3.2.0rc30` and added same-version applicability coverage.