### PR TITLE
Fix audit status JSON UTF-8 drift check

### DIFF
--- a/src/specify_cli/audit/classifiers/status_json.py
+++ b/src/specify_cli/audit/classifiers/status_json.py
@@ -105,7 +105,13 @@ def classify_status_json(
     # Normalise both sides: parse + re-serialise with identical options
     try:
         persisted_normalised = (
-            json.dumps(json.loads(raw_text), sort_keys=True, indent=2) + "\n"
+            json.dumps(
+                json.loads(raw_text),
+                sort_keys=True,
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n"
         )
     except Exception:
         # raw_text is already parsed above, so this branch is unreachable in practice

--- a/tests/audit/test_audit_classifiers.py
+++ b/tests/audit/test_audit_classifiers.py
@@ -534,6 +534,41 @@ def test_status_json_retrospective_materialized_snapshot_is_not_drift(
     assert "SNAPSHOT_DRIFT" not in _codes(findings)
 
 
+def test_status_json_non_ascii_materialized_snapshot_is_not_drift(
+    tmp_path: Path,
+) -> None:
+    """Fresh UTF-8 status.json content must not be normalised into drift."""
+    from specify_cli.status.reducer import materialize
+
+    _write_json(
+        tmp_path / "meta.json",
+        {
+            "mission_id": _VALID_ULID,
+            "mission_slug": "test-mission",
+            "mission_number": 1,
+            "mission_type": "software-dev",
+        },
+    )
+    _write_jsonl(
+        tmp_path / "status.events.jsonl",
+        [
+            {
+                **_MODERN_EVENT,
+                "actor": "José",
+                "reason": "résolu",
+            },
+        ],
+    )
+    materialize(tmp_path)
+
+    status_text = (tmp_path / "status.json").read_text(encoding="utf-8")
+    assert "José" in status_text
+
+    findings = classify_status_json(tmp_path)
+
+    assert "SNAPSHOT_DRIFT" not in _codes(findings)
+
+
 # ---------------------------------------------------------------------------
 # T014/mission_events.jsonl classifier
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- align audit status.json normalization with reducer serialization by preserving UTF-8 during json.dumps
- add regression coverage for freshly materialized non-ASCII status.json content

Closes #1440

## Verification
- `.venv/bin/pytest tests/audit/test_audit_classifiers.py::test_status_json_non_ascii_materialized_snapshot_is_not_drift tests/audit/test_audit_classifiers.py::test_snapshot_drift_detected -q` — 2 passed
- `.venv/bin/pytest tests/audit/test_audit_classifiers.py tests/audit/test_audit_architecture.py tests/audit/test_audit_engine.py -q` — 101 passed
- `.venv/bin/pytest tests/status/test_validate.py -q` — 52 passed
- `.venv/bin/ruff check src/specify_cli/audit/classifiers/status_json.py tests/audit/test_audit_classifiers.py` — passed
- `git diff --check` — passed

## Self-review
- Ran adversarial self-review per requested skill. Fixed one test-strength issue by asserting the fixture actually writes literal UTF-8 to status.json. No remaining blockers found.