### PR TITLE
docs(glossary): segregate decision-like terms in orchestration context

### DIFF
--- a/glossary/README.md
+++ b/glossary/README.md
@@ -27,7 +27,7 @@ Use policy docs to answer "what should this mean?" and runtime artifacts to answ
 | Execution | CLI/tool invocation, generation boundaries, and collaboration modes. | `glossary/contexts/execution.md` |
 | Identity | Actors, roles, mission participation, and Human-in-Charge (HiC). | `glossary/contexts/identity.md` |
 | Lexical | Glossary internal data model — term surfaces, senses, provenance. | `glossary/contexts/lexical.md` |
-| Orchestration | Project/mission/feature/work-package lifecycle and runtime terms. | `glossary/contexts/orchestration.md` |
+| Orchestration | Project/mission/feature/work-package lifecycle and runtime terms. Includes **Decision**, **Decision Input Request**, and **Decision Input Answer** — see disambiguation note in that file and in the SaaS `architecture/domain-glossary.md`. | `glossary/contexts/orchestration.md` |
 | Governance | Charter/ADR/policy precedence and rules. | `glossary/contexts/governance.md` |
 | Doctrine | Doctrine domain model and artifact taxonomy. | `glossary/contexts/doctrine.md` |
 | System Events | Event envelope, replay, glossary evolution, and system event types. | `glossary/contexts/system-events.md` |

--- a/glossary/contexts/orchestration.md
+++ b/glossary/contexts/orchestration.md
@@ -268,11 +268,11 @@ Terms describing lifecycle and runtime orchestration semantics.
 
 | | |
 |---|---|
-| **Definition** | An ephemeral structured choice presented to the Human-in-Charge (HiC) or their delegated agent during the next-command loop. Each decision describes what needs to happen next and offers options to advance the mission. A Decision exists only for the duration of the loop iteration; once answered it is closed and has no further CLI lifecycle. |
+| **Definition** | A structured choice presented to the Human-in-Charge (HiC) or their delegated agent during the next-command loop. Each decision describes what needs to happen next and offers options to advance the mission. In event-backed runtimes, a pending Decision is tracked until answered, then closed. |
 | **Context** | Orchestration |
 | **Status** | canonical |
-| **Applicable to** | `1.x`, `2.x` |
-| **Lifecycle** | Opened by [Decision Input Request](#decision-input-request); closed by [Decision Input Answer](#decision-input-answer). |
+| **Applicable to** | `1.x`, `2.x`, `3.x` |
+| **Lifecycle** | In event-backed runtimes, opened by [Decision Input Request](#decision-input-request); closed by [Decision Input Answer](#decision-input-answer). |
 | **SaaS projection** | Materialised as a `DecisionInboxItem` (pending → answered) in the TeamSpace. |
 | **Not to be confused with** | SaaS `Decision` (an immutable recorded past collaboration choice); SaaS `DecisionPoint` (a first-class team-consultation entity that can be widened, deferred, or resolved independently of the loop). See the SaaS domain glossary at `architecture/domain-glossary.md`. |
 | **Related terms** | [Decision Kind](#decision-kind), [Decision Input Request](#decision-input-request), [Decision Input Answer](#decision-input-answer), [Human-in-Charge (HiC)](./identity.md#human-in-charge-hic) |
@@ -283,10 +283,10 @@ Terms describing lifecycle and runtime orchestration semantics.
 
 | | |
 |---|---|
-| **Definition** | The type of choice being presented — for example, selecting which step to run next, resolving a conflict, or assigning a work package to an agent. Carried in the `DecisionInputRequested` event payload as the `kind` field. |
+| **Definition** | The type of choice being presented — for example, selecting which step to run next, resolving a conflict, or assigning a work package to an agent. In the `spec-kitty next --json` contract this is carried as the top-level `kind` field; `DecisionInputRequested` events are emitted only for `decision_required` choices and do not repeat that field. |
 | **Context** | Orchestration |
 | **Status** | canonical |
-| **Applicable to** | `1.x`, `2.x` |
+| **Applicable to** | `1.x`, `2.x`, `3.x` |
 | **Related terms** | [Decision](#decision), [Decision Input Request](#decision-input-request) |
 
 ---

--- a/glossary/contexts/orchestration.md
+++ b/glossary/contexts/orchestration.md
@@ -268,11 +268,14 @@ Terms describing lifecycle and runtime orchestration semantics.
 
 | | |
 |---|---|
-| **Definition** | A structured choice presented to the Human-in-Charge (HiC) or their delegated agent during the next-command loop. Each decision describes what needs to happen next and offers options to advance the mission. |
+| **Definition** | An ephemeral structured choice presented to the Human-in-Charge (HiC) or their delegated agent during the next-command loop. Each decision describes what needs to happen next and offers options to advance the mission. A Decision exists only for the duration of the loop iteration; once answered it is closed and has no further CLI lifecycle. |
 | **Context** | Orchestration |
 | **Status** | canonical |
 | **Applicable to** | `1.x`, `2.x` |
-| **Related terms** | [Decision Kind](#decision-kind), [Human-in-Charge (HiC)](./identity.md#human-in-charge-hic) |
+| **Lifecycle** | Opened by [Decision Input Request](#decision-input-request); closed by [Decision Input Answer](#decision-input-answer). |
+| **SaaS projection** | Materialised as a `DecisionInboxItem` (pending → answered) in the TeamSpace. |
+| **Not to be confused with** | SaaS `Decision` (an immutable recorded past collaboration choice); SaaS `DecisionPoint` (a first-class team-consultation entity that can be widened, deferred, or resolved independently of the loop). See the SaaS domain glossary at `architecture/domain-glossary.md`. |
+| **Related terms** | [Decision Kind](#decision-kind), [Decision Input Request](#decision-input-request), [Decision Input Answer](#decision-input-answer), [Human-in-Charge (HiC)](./identity.md#human-in-charge-hic) |
 
 ---
 
@@ -280,11 +283,39 @@ Terms describing lifecycle and runtime orchestration semantics.
 
 | | |
 |---|---|
-| **Definition** | The type of choice being presented — for example, selecting which step to run next, resolving a conflict, or assigning a work package to an agent. |
+| **Definition** | The type of choice being presented — for example, selecting which step to run next, resolving a conflict, or assigning a work package to an agent. Carried in the `DecisionInputRequested` event payload as the `kind` field. |
 | **Context** | Orchestration |
 | **Status** | canonical |
 | **Applicable to** | `1.x`, `2.x` |
-| **Related terms** | [Decision](#decision) |
+| **Related terms** | [Decision](#decision), [Decision Input Request](#decision-input-request) |
+
+---
+
+### Decision Input Request
+
+| | |
+|---|---|
+| **Definition** | The event emitted by the runtime when it opens a [Decision](#decision) and requires a response from the HiC or a delegated agent. Carries the question text, candidate options, step context, and a unique `decision_id`. Opening a Decision Input Request is what makes a Decision "pending". |
+| **Context** | Orchestration |
+| **Status** | canonical |
+| **Applicable to** | `2.x`, `3.x` |
+| **Event type** | `DecisionInputRequested` (in `spec-kitty-events`) |
+| **SaaS effect** | Creates a `DecisionInboxItem` row with `state=pending`. |
+| **Related terms** | [Decision](#decision), [Decision Input Answer](#decision-input-answer), [Mission Run](#mission-run) |
+
+---
+
+### Decision Input Answer
+
+| | |
+|---|---|
+| **Definition** | The event emitted when the HiC or a delegated agent answers a pending [Decision](#decision). Carries the chosen answer, the actor identity, and the originating `decision_id`. Answering closes the Decision; the loop continues. |
+| **Context** | Orchestration |
+| **Status** | canonical |
+| **Applicable to** | `2.x`, `3.x` |
+| **Event type** | `DecisionInputAnswered` (in `spec-kitty-events`) |
+| **SaaS effect** | Updates the matching `DecisionInboxItem` to `state=answered`. |
+| **Related terms** | [Decision](#decision), [Decision Input Request](#decision-input-request) |
 
 ---
 


### PR DESCRIPTION
## Summary

The word "decision" was overloaded across CLI and SaaS with at least four distinct meanings that were being conflated. This PR fixes the CLI side of that.

## Changes

**`glossary/contexts/orchestration.md`**
- `Decision` — clarified it is ephemeral and loop-scoped (lives only for one next-command iteration); added `SaaS projection` row pointing to `DecisionInboxItem`; added explicit "Not to be confused with" callout for SaaS `Decision` (immutable past record) and SaaS `DecisionPoint` (team-consultation entity)
- `Decision Kind` — added mapping to `kind` field in `DecisionInputRequested` event payload
- **New: `Decision Input Request`** — canonical term for the `DecisionInputRequested` event that opens a Decision; maps to `DecisionInboxItem(pending)` on SaaS
- **New: `Decision Input Answer`** — canonical term for the `DecisionInputAnswered` event that closes it; maps to `DecisionInboxItem(answered)`

**`glossary/README.md`**
- Updated Orchestration domain index row to mention the new decision terms

## Companion PR

spec-kitty-saas: `glossary/decision-term-segregation` — adds `architecture/domain-glossary.md` with five clusters covering all SaaS-side decision terms and the cross-repo event flow boundary.

## Context

Emerged from architecture review (May 2026). The `kittyfooding` branch in spec-kitty-saas revealed that "pending decision" in the SaaS UI is driven by `WorkPackage.status="for_review"`, not by any `Decision` or `DecisionPoint` model — a semantic mismatch that had been silently accepted.