### PR TITLE
fix: address SonarCloud and security findings

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -759,7 +759,7 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
         # Toggle fenced-code-block state on ``` or ~~~ markers. Task-like lines
         # inside fenced code blocks (examples in implementation notes) must not
         # be treated as real subtasks.
-        if stripped.startswith("```") or stripped.startswith("~~~"):
+        if stripped.startswith(("```", "~~~")):
             in_code_fence = not in_code_fence
             continue
 

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -197,6 +197,56 @@ def _validate_base_ref(repo_root: Path, base_ref: str) -> str:
     return result.stdout.strip()
 
 
+def _tracked_feature_files(repo_root: Path, feature_dir: Path) -> list[str]:
+    """Return changed planning-artifact paths under ``feature_dir``."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain", str(feature_dir)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+    return [line[3:].strip() for line in result.stdout.strip().splitlines() if len(line) >= 4]
+
+
+def _load_planning_mission_meta(feature_dir: Path) -> dict[str, Any] | None:
+    from specify_cli.mission_metadata import load_meta as _load_meta
+
+    try:
+        mission_meta = _load_meta(feature_dir)
+    except Exception:  # noqa: BLE001 — meta missing/corrupt is legacy
+        return None
+    return mission_meta if isinstance(mission_meta, dict) else None
+
+
+def _effective_bookkeeping_target(
+    mission_slug: str,
+    planning_branch: str,
+    mission_meta: dict[str, Any] | None,
+) -> tuple[str | None, str, str, str, bool]:
+    coord_branch = mission_meta.get("coordination_branch") if mission_meta else None
+    mission_id = mission_meta.get("mission_id") if mission_meta else None
+    mid8 = mission_meta.get("mid8") if mission_meta else None
+    if not mid8 and isinstance(mission_id, str) and len(mission_id) >= 8:
+        mid8 = mission_id[:8]
+
+    effective_mission_id = str(mission_id) if mission_id else f"legacy-{mission_slug}"
+    if mid8:
+        effective_mid8 = str(mid8)
+    elif mission_id and len(str(mission_id)) >= 8:
+        effective_mid8 = str(mission_id)[:8]
+    else:
+        effective_mid8 = (mission_slug.replace("-", "") + "00000000")[:8]
+
+    effective_destination_ref = str(coord_branch) if coord_branch else planning_branch
+    is_legacy = not (coord_branch and mission_id and mid8)
+    return coord_branch, effective_mission_id, effective_mid8, effective_destination_ref, is_legacy
+
+
 def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestration helper; unrelated to issue #1386
     repo_root: Path,
     feature_dir: Path,
@@ -218,22 +268,7 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
     )
     current_branch = result.stdout.strip() if result.returncode == 0 else ""
 
-    result = subprocess.run(
-        ["git", "status", "--porcelain", str(feature_dir)],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        return
-
-    files_to_commit: list[str] = []
-    for line in result.stdout.strip().splitlines():
-        if len(line) >= 4:
-            files_to_commit.append(line[3:].strip())
+    files_to_commit = _tracked_feature_files(repo_root, feature_dir)
 
     if not files_to_commit:
         return
@@ -266,23 +301,7 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
     # Legacy missions (created pre-WP03) have no ``coordination_branch``
     # in meta.json. For those, fall back to the legacy raw-git path.
     # WP08 will replace this fallback with a proper legacy bridge.
-    from specify_cli.mission_metadata import load_meta as _load_meta
-
-    mission_meta: dict[str, Any] | None
-    try:
-        mission_meta = _load_meta(feature_dir)
-    except Exception:  # noqa: BLE001 — meta missing/corrupt is legacy
-        mission_meta = None
-
-    coord_branch: str | None = None
-    mission_id: str | None = None
-    mid8: str | None = None
-    if isinstance(mission_meta, dict):
-        coord_branch = mission_meta.get("coordination_branch") or None
-        mission_id = mission_meta.get("mission_id") or None
-        mid8 = mission_meta.get("mid8") or (
-            mission_id[:8] if isinstance(mission_id, str) and len(mission_id) >= 8 else None
-        )
+    mission_meta = _load_planning_mission_meta(feature_dir)
 
     # Route ALL planning-artifact commits through BookkeepingTransaction.
     # The transaction has a built-in legacy fallback (see
@@ -307,21 +326,13 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
     # destination_ref from HEAD, so the placeholder coord_branch value
     # below is never persisted; the routing just needs *some* shape-valid
     # ref name to satisfy the pre-flight policy gate's normalisation.
-    effective_mission_id = str(mission_id) if mission_id else f"legacy-{mission_slug}"
-    if mid8:
-        effective_mid8 = str(mid8)
-    elif mission_id and len(str(mission_id)) >= 8:
-        effective_mid8 = str(mission_id)[:8]
-    else:
-        # Pre-WP03 mission with no mission_id at all. Derive a stable
-        # 8-char prefix from the mission_slug so kitty_specs_dir_name
-        # resolution stays deterministic across invocations.
-        effective_mid8 = (mission_slug.replace("-", "") + "00000000")[:8]
-    effective_destination_ref = (
-        str(coord_branch) if coord_branch else planning_branch
+    coord_branch, effective_mission_id, effective_mid8, effective_destination_ref, is_legacy = (
+        _effective_bookkeeping_target(
+            mission_slug,
+            planning_branch,
+            mission_meta,
+        )
     )
-
-    is_legacy = not (coord_branch and mission_id and mid8)
     if is_legacy:
         console.print(
             f"\n[cyan]Auto-committing planning artifacts to {planning_branch}...[/cyan] "

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -197,10 +197,9 @@ def _validate_base_ref(repo_root: Path, base_ref: str) -> str:
     return result.stdout.strip()
 
 
-def _tracked_feature_files(repo_root: Path, feature_dir: Path) -> list[str]:
-    """Return changed planning-artifact paths under ``feature_dir``."""
+def _git_stdout(repo_root: Path, args: list[str]) -> str:
     result = subprocess.run(
-        ["git", "status", "--porcelain", str(feature_dir)],
+        ["git", *args],
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -208,43 +207,81 @@ def _tracked_feature_files(repo_root: Path, feature_dir: Path) -> list[str]:
         errors="replace",
         check=False,
     )
-    if result.returncode != 0 or not result.stdout.strip():
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _feature_dir_status_paths(repo_root: Path, feature_dir: Path) -> list[str]:
+    output = _git_stdout(repo_root, ["status", "--porcelain", str(feature_dir)])
+    if not output:
         return []
-    return [line[3:].strip() for line in result.stdout.strip().splitlines() if len(line) >= 4]
+    return [line[3:].strip() for line in output.splitlines() if len(line) >= 4]
 
 
-def _load_planning_mission_meta(feature_dir: Path) -> dict[str, Any] | None:
+def _print_uncommitted_planning_artifacts(files_to_commit: list[str]) -> None:
+    console.print("\n[cyan]Planning artifacts not committed:[/cyan]")
+    for file_path in files_to_commit:
+        console.print(f"  {file_path}")
+
+
+def _print_planning_artifact_commit_instructions(
+    current_branch: str,
+    planning_branch: str,
+    auto_commit: bool,
+    feature_dir: Path,
+    mission_slug: str,
+) -> None:
+    if current_branch != planning_branch:
+        console.print(
+            f"\n[red]Error:[/red] Planning artifacts must be committed on {planning_branch}."
+        )
+        console.print(f"Current branch: {current_branch}")
+        raise typer.Exit(1)
+
+    if auto_commit:
+        return
+
+    console.print(
+        "\n[yellow]Auto-commit disabled.[/yellow] Commit planning artifacts first:"
+    )
+    console.print(f"  git add -f {feature_dir}")
+    console.print(f'  git commit -m "chore: planning artifacts for {mission_slug}"')
+    raise typer.Exit(1)
+
+
+def _resolve_bookkeeping_transaction_identifiers(
+    feature_dir: Path,
+    mission_slug: str,
+) -> tuple[str | None, str | None, str | None, str, str]:
     from specify_cli.mission_metadata import load_meta as _load_meta
 
+    mission_meta: dict[str, Any] | None
     try:
         mission_meta = _load_meta(feature_dir)
     except Exception:  # noqa: BLE001 — meta missing/corrupt is legacy
-        return None
-    return mission_meta if isinstance(mission_meta, dict) else None
+        mission_meta = None
 
+    coord_branch: str | None = None
+    mission_id: str | None = None
+    mid8: str | None = None
+    if isinstance(mission_meta, dict):
+        coord_branch = mission_meta.get("coordination_branch") or None
+        mission_id = mission_meta.get("mission_id") or None
+        mid8 = mission_meta.get("mid8") or (
+            mission_id[:8] if isinstance(mission_id, str) and len(mission_id) >= 8 else None
+        )
 
-def _effective_bookkeeping_target(
-    mission_slug: str,
-    planning_branch: str,
-    mission_meta: dict[str, Any] | None,
-) -> tuple[str | None, str, str, str, bool]:
-    coord_branch = mission_meta.get("coordination_branch") if mission_meta else None
-    mission_id = mission_meta.get("mission_id") if mission_meta else None
-    mid8 = mission_meta.get("mid8") if mission_meta else None
-    if not mid8 and isinstance(mission_id, str) and len(mission_id) >= 8:
-        mid8 = mission_id[:8]
-
-    effective_mission_id = str(mission_id) if mission_id else f"legacy-{mission_slug}"
+    effective_mission_id = (
+        str(mission_id) if mission_id else f"legacy-{mission_slug}"
+    )
     if mid8:
         effective_mid8 = str(mid8)
     elif mission_id and len(str(mission_id)) >= 8:
         effective_mid8 = str(mission_id)[:8]
     else:
         effective_mid8 = (mission_slug.replace("-", "") + "00000000")[:8]
-
-    effective_destination_ref = str(coord_branch) if coord_branch else planning_branch
-    is_legacy = not (coord_branch and mission_id and mid8)
-    return coord_branch, effective_mission_id, effective_mid8, effective_destination_ref, is_legacy
+    return coord_branch, mission_id, mid8, effective_mission_id, effective_mid8
 
 
 def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestration helper; unrelated to issue #1386
@@ -257,36 +294,19 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
     auto_commit: bool,
 ) -> None:
     """Ensure planning artifacts are committed on the feature planning branch."""
-    result = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
-    current_branch = result.stdout.strip() if result.returncode == 0 else ""
-
-    files_to_commit = _tracked_feature_files(repo_root, feature_dir)
-
+    current_branch = _git_stdout(repo_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+    files_to_commit = _feature_dir_status_paths(repo_root, feature_dir)
     if not files_to_commit:
         return
 
-    console.print("\n[cyan]Planning artifacts not committed:[/cyan]")
-    for file_path in files_to_commit:
-        console.print(f"  {file_path}")
-
-    if current_branch != planning_branch:
-        console.print(f"\n[red]Error:[/red] Planning artifacts must be committed on {planning_branch}.")
-        console.print(f"Current branch: {current_branch}")
-        raise typer.Exit(1)
-
-    if not auto_commit:
-        console.print("\n[yellow]Auto-commit disabled.[/yellow] Commit planning artifacts first:")
-        console.print(f"  git add -f {feature_dir}")
-        console.print(f'  git commit -m "chore: planning artifacts for {mission_slug}"')
-        raise typer.Exit(1)
+    _print_uncommitted_planning_artifacts(files_to_commit)
+    _print_planning_artifact_commit_instructions(
+        current_branch,
+        planning_branch,
+        auto_commit,
+        feature_dir,
+        mission_slug,
+    )
 
     commit_msg = (
         f"chore: planning artifacts for {mission_slug}\n\n"
@@ -301,7 +321,13 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
     # Legacy missions (created pre-WP03) have no ``coordination_branch``
     # in meta.json. For those, fall back to the legacy raw-git path.
     # WP08 will replace this fallback with a proper legacy bridge.
-    mission_meta = _load_planning_mission_meta(feature_dir)
+    (
+        coord_branch,
+        mission_id,
+        mid8,
+        effective_mission_id,
+        effective_mid8,
+    ) = _resolve_bookkeeping_transaction_identifiers(feature_dir, mission_slug)
 
     # Route ALL planning-artifact commits through BookkeepingTransaction.
     # The transaction has a built-in legacy fallback (see
@@ -326,13 +352,11 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
     # destination_ref from HEAD, so the placeholder coord_branch value
     # below is never persisted; the routing just needs *some* shape-valid
     # ref name to satisfy the pre-flight policy gate's normalisation.
-    coord_branch, effective_mission_id, effective_mid8, effective_destination_ref, is_legacy = (
-        _effective_bookkeeping_target(
-            mission_slug,
-            planning_branch,
-            mission_meta,
-        )
+    effective_destination_ref = (
+        str(coord_branch) if coord_branch else planning_branch
     )
+
+    is_legacy = not (coord_branch and mission_id and mid8)
     if is_legacy:
         console.print(
             f"\n[cyan]Auto-committing planning artifacts to {planning_branch}...[/cyan] "

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -22,6 +22,7 @@ import os
 import re
 import time
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -938,27 +939,47 @@ def _record_baseline_merge_commit(
     """
     is_modern = bool(mission_id and str(mission_id).strip())
 
-    if not baseline_commit or not baseline_commit.strip():
-        if is_modern:
-            raise BaselineMergeCommitError(
-                f"Cannot record baseline_merge_commit for modern mission "
-                f"{feature_dir.name}: no target baseline SHA was captured."
-            )
-        return None
-
     meta_path = feature_dir / "meta.json"
-    if not meta_path.exists():
-        if is_modern:
-            raise BaselineMergeCommitError(
-                f"Cannot record baseline_merge_commit for modern mission "
-                f"{feature_dir.name}: meta.json is missing."
-            )
-        logger.warning(
-            "Cannot record baseline_merge_commit for %s: meta.json is missing",
-            feature_dir.name,
-        )
+    _require_baseline_input(feature_dir, baseline_commit, is_modern)
+    _require_meta_file(feature_dir, meta_path, is_modern)
+    meta = _load_meta_for_baseline(feature_dir, is_modern)
+    if meta is None:
         return None
 
+    existing = meta.get("baseline_merge_commit")
+    if existing and str(existing).strip():
+        return None
+
+    meta["baseline_merge_commit"] = baseline_commit.strip()
+    write_meta(feature_dir, meta, validate=False)
+    return meta_path
+
+
+def _require_baseline_input(feature_dir: Path, baseline_commit: str | None, is_modern: bool) -> None:
+    if baseline_commit and baseline_commit.strip():
+        return
+    if is_modern:
+        raise BaselineMergeCommitError(
+            f"Cannot record baseline_merge_commit for modern mission "
+            f"{feature_dir.name}: no target baseline SHA was captured."
+        )
+
+
+def _require_meta_file(feature_dir: Path, meta_path: Path, is_modern: bool) -> None:
+    if meta_path.exists():
+        return
+    if is_modern:
+        raise BaselineMergeCommitError(
+            f"Cannot record baseline_merge_commit for modern mission "
+            f"{feature_dir.name}: meta.json is missing."
+        )
+    logger.warning(
+        "Cannot record baseline_merge_commit for %s: meta.json is missing",
+        feature_dir.name,
+    )
+
+
+def _load_meta_for_baseline(feature_dir: Path, is_modern: bool) -> dict[str, Any] | None:
     try:
         meta = load_meta(feature_dir)
     except ValueError as exc:
@@ -974,21 +995,12 @@ def _record_baseline_merge_commit(
         )
         return None
 
-    if meta is None:
-        if is_modern:
-            raise BaselineMergeCommitError(
-                f"Cannot record baseline_merge_commit for modern mission "
-                f"{feature_dir.name}: meta.json could not be loaded."
-            )
-        return None
-
-    existing = meta.get("baseline_merge_commit")
-    if existing and str(existing).strip():
-        return None
-
-    meta["baseline_merge_commit"] = baseline_commit.strip()
-    write_meta(feature_dir, meta, validate=False)
-    return meta_path
+    if meta is None and is_modern:
+        raise BaselineMergeCommitError(
+            f"Cannot record baseline_merge_commit for modern mission "
+            f"{feature_dir.name}: meta.json could not be loaded."
+        )
+    return meta
 
 
 def _assert_baseline_merge_commit_on_target(
@@ -1028,6 +1040,37 @@ def _assert_baseline_merge_commit_on_target(
     if not (mission_id and str(mission_id).strip()):
         return
 
+    expected = _expected_baseline_value(feature_dir, expected_baseline)
+    if not expected:
+        raise BaselineMergeCommitError(
+            f"Cannot verify baseline_merge_commit for modern mission "
+            f"{mission_slug}: no recorded baseline SHA was found."
+        )
+
+    meta_rel = f"kitty-specs/{mission_slug}/meta.json"
+    committed_meta = _load_committed_meta(main_repo, mission_slug, target_branch, meta_rel)
+
+    committed_baseline = str(committed_meta.get("baseline_merge_commit") or "").strip()
+    if not committed_baseline:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"baseline_merge_commit is missing from committed {meta_rel} on "
+            f"{target_branch}. Downstream `spec-kitty review --mode post-merge` "
+            f"would fail with MISSION_REVIEW_MODE_MISMATCH."
+        )
+
+    if committed_baseline != expected:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"committed baseline_merge_commit ({committed_baseline}) on "
+            f"{target_branch} does not match the captured baseline ({expected})."
+        )
+
+
+def _expected_baseline_value(
+    feature_dir: Path | None,
+    expected_baseline: str | None,
+) -> str:
     recorded = ""
     if feature_dir is not None:
         try:
@@ -1036,15 +1079,15 @@ def _assert_baseline_merge_commit_on_target(
             working_meta = None
         if isinstance(working_meta, dict):
             recorded = str(working_meta.get("baseline_merge_commit") or "").strip()
+    return recorded or (expected_baseline or "").strip()
 
-    expected = recorded or (expected_baseline or "").strip()
-    if not expected:
-        raise BaselineMergeCommitError(
-            f"Cannot verify baseline_merge_commit for modern mission "
-            f"{mission_slug}: no recorded baseline SHA was found."
-        )
 
-    meta_rel = f"kitty-specs/{mission_slug}/meta.json"
+def _load_committed_meta(
+    main_repo: Path,
+    mission_slug: str,
+    target_branch: str,
+    meta_rel: str,
+) -> dict[str, Any]:
     ret, out, err = run_command(
         ["git", "show", f"{target_branch}:{meta_rel}"],
         capture=True,
@@ -1071,22 +1114,7 @@ def _assert_baseline_merge_commit_on_target(
             f"Post-merge baseline validation failed for {mission_slug}: "
             f"committed {meta_rel} on {target_branch} is not a JSON object."
         )
-
-    committed_baseline = str(committed_meta.get("baseline_merge_commit") or "").strip()
-    if not committed_baseline:
-        raise BaselineMergeCommitError(
-            f"Post-merge baseline validation failed for {mission_slug}: "
-            f"baseline_merge_commit is missing from committed {meta_rel} on "
-            f"{target_branch}. Downstream `spec-kitty review --mode post-merge` "
-            f"would fail with MISSION_REVIEW_MODE_MISMATCH."
-        )
-
-    if committed_baseline != expected:
-        raise BaselineMergeCommitError(
-            f"Post-merge baseline validation failed for {mission_slug}: "
-            f"committed baseline_merge_commit ({committed_baseline}) on "
-            f"{target_branch} does not match the captured baseline ({expected})."
-        )
+    return committed_meta
 
 
 def _validate_target_branch(

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -22,7 +22,6 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Any
 
 import typer
 from rich.console import Console
@@ -939,47 +938,27 @@ def _record_baseline_merge_commit(
     """
     is_modern = bool(mission_id and str(mission_id).strip())
 
+    if not baseline_commit or not baseline_commit.strip():
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: no target baseline SHA was captured."
+            )
+        return None
+
     meta_path = feature_dir / "meta.json"
-    _require_baseline_input(feature_dir, baseline_commit, is_modern)
-    _require_meta_file(feature_dir, meta_path, is_modern)
-    meta = _load_meta_for_baseline(feature_dir, is_modern)
-    if meta is None:
+    if not meta_path.exists():
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: meta.json is missing."
+            )
+        logger.warning(
+            "Cannot record baseline_merge_commit for %s: meta.json is missing",
+            feature_dir.name,
+        )
         return None
 
-    existing = meta.get("baseline_merge_commit")
-    if existing and str(existing).strip():
-        return None
-
-    meta["baseline_merge_commit"] = baseline_commit.strip()
-    write_meta(feature_dir, meta, validate=False)
-    return meta_path
-
-
-def _require_baseline_input(feature_dir: Path, baseline_commit: str | None, is_modern: bool) -> None:
-    if baseline_commit and baseline_commit.strip():
-        return
-    if is_modern:
-        raise BaselineMergeCommitError(
-            f"Cannot record baseline_merge_commit for modern mission "
-            f"{feature_dir.name}: no target baseline SHA was captured."
-        )
-
-
-def _require_meta_file(feature_dir: Path, meta_path: Path, is_modern: bool) -> None:
-    if meta_path.exists():
-        return
-    if is_modern:
-        raise BaselineMergeCommitError(
-            f"Cannot record baseline_merge_commit for modern mission "
-            f"{feature_dir.name}: meta.json is missing."
-        )
-    logger.warning(
-        "Cannot record baseline_merge_commit for %s: meta.json is missing",
-        feature_dir.name,
-    )
-
-
-def _load_meta_for_baseline(feature_dir: Path, is_modern: bool) -> dict[str, Any] | None:
     try:
         meta = load_meta(feature_dir)
     except ValueError as exc:
@@ -995,12 +974,68 @@ def _load_meta_for_baseline(feature_dir: Path, is_modern: bool) -> dict[str, Any
         )
         return None
 
-    if meta is None and is_modern:
+    if meta is None:
+        if is_modern:
+            raise BaselineMergeCommitError(
+                f"Cannot record baseline_merge_commit for modern mission "
+                f"{feature_dir.name}: meta.json could not be loaded."
+            )
+        return None
+
+    existing = meta.get("baseline_merge_commit")
+    if existing and str(existing).strip():
+        return None
+
+    meta["baseline_merge_commit"] = baseline_commit.strip()
+    write_meta(feature_dir, meta, validate=False)
+    return meta_path
+
+
+def _recorded_baseline_from_working_meta(feature_dir: Path | None) -> str:
+    if feature_dir is None:
+        return ""
+    try:
+        working_meta = load_meta(feature_dir)
+    except ValueError:
+        return ""
+    if not isinstance(working_meta, dict):
+        return ""
+    return str(working_meta.get("baseline_merge_commit") or "").strip()
+
+
+def _read_committed_meta_json(
+    main_repo: Path,
+    target_branch: str,
+    meta_rel: str,
+    mission_slug: str,
+) -> dict[str, object]:
+    ret, out, err = run_command(
+        ["git", "show", f"{target_branch}:{meta_rel}"],
+        capture=True,
+        check_return=False,
+        cwd=main_repo,
+    )
+    if ret != 0:
         raise BaselineMergeCommitError(
-            f"Cannot record baseline_merge_commit for modern mission "
-            f"{feature_dir.name}: meta.json could not be loaded."
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"could not read {meta_rel} from {target_branch} "
+            f"({(err or '').strip() or 'git show failed'})."
         )
-    return meta
+
+    try:
+        committed_meta = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"committed {meta_rel} on {target_branch} is not valid JSON ({exc})."
+        ) from exc
+
+    if not isinstance(committed_meta, dict):
+        raise BaselineMergeCommitError(
+            f"Post-merge baseline validation failed for {mission_slug}: "
+            f"committed {meta_rel} on {target_branch} is not a JSON object."
+        )
+    return committed_meta
 
 
 def _assert_baseline_merge_commit_on_target(
@@ -1040,7 +1075,8 @@ def _assert_baseline_merge_commit_on_target(
     if not (mission_id and str(mission_id).strip()):
         return
 
-    expected = _expected_baseline_value(feature_dir, expected_baseline)
+    recorded = _recorded_baseline_from_working_meta(feature_dir)
+    expected = recorded or (expected_baseline or "").strip()
     if not expected:
         raise BaselineMergeCommitError(
             f"Cannot verify baseline_merge_commit for modern mission "
@@ -1048,8 +1084,9 @@ def _assert_baseline_merge_commit_on_target(
         )
 
     meta_rel = f"kitty-specs/{mission_slug}/meta.json"
-    committed_meta = _load_committed_meta(main_repo, mission_slug, target_branch, meta_rel)
-
+    committed_meta = _read_committed_meta_json(
+        main_repo, target_branch, meta_rel, mission_slug
+    )
     committed_baseline = str(committed_meta.get("baseline_merge_commit") or "").strip()
     if not committed_baseline:
         raise BaselineMergeCommitError(
@@ -1065,56 +1102,6 @@ def _assert_baseline_merge_commit_on_target(
             f"committed baseline_merge_commit ({committed_baseline}) on "
             f"{target_branch} does not match the captured baseline ({expected})."
         )
-
-
-def _expected_baseline_value(
-    feature_dir: Path | None,
-    expected_baseline: str | None,
-) -> str:
-    recorded = ""
-    if feature_dir is not None:
-        try:
-            working_meta = load_meta(feature_dir)
-        except ValueError:
-            working_meta = None
-        if isinstance(working_meta, dict):
-            recorded = str(working_meta.get("baseline_merge_commit") or "").strip()
-    return recorded or (expected_baseline or "").strip()
-
-
-def _load_committed_meta(
-    main_repo: Path,
-    mission_slug: str,
-    target_branch: str,
-    meta_rel: str,
-) -> dict[str, Any]:
-    ret, out, err = run_command(
-        ["git", "show", f"{target_branch}:{meta_rel}"],
-        capture=True,
-        check_return=False,
-        cwd=main_repo,
-    )
-    if ret != 0:
-        raise BaselineMergeCommitError(
-            f"Post-merge baseline validation failed for {mission_slug}: "
-            f"could not read {meta_rel} from {target_branch} "
-            f"({(err or '').strip() or 'git show failed'})."
-        )
-
-    try:
-        committed_meta = json.loads(out)
-    except json.JSONDecodeError as exc:
-        raise BaselineMergeCommitError(
-            f"Post-merge baseline validation failed for {mission_slug}: "
-            f"committed {meta_rel} on {target_branch} is not valid JSON ({exc})."
-        ) from exc
-
-    if not isinstance(committed_meta, dict):
-        raise BaselineMergeCommitError(
-            f"Post-merge baseline validation failed for {mission_slug}: "
-            f"committed {meta_rel} on {target_branch} is not a JSON object."
-        )
-    return committed_meta
 
 
 def _validate_target_branch(

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -22,6 +22,7 @@ import errno
 import json as _json
 import logging
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -133,6 +134,7 @@ class BookkeepingLegacyResolutionFailed(BookkeepingError):
 
 _EVENTS_FILENAME = "status.events.jsonl"
 _SNAPSHOT_FILENAME = "status.json"
+_SAFE_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _kitty_specs_dir_name(mission_slug: str, mid8: str) -> str:
@@ -145,6 +147,20 @@ def _kitty_specs_dir_name(mission_slug: str, mid8: str) -> str:
     if mission_slug.endswith(f"-{mid8}"):
         return mission_slug
     return f"{mission_slug}-{mid8}"
+
+
+def _validate_safe_segment(name: str, value: str) -> str:
+    """Return a single safe path segment or raise a bookkeeping error."""
+    candidate = value.strip()
+    if not candidate:
+        raise BookkeepingError(f"{name} cannot be empty")
+    if candidate in {".", ".."} or "/" in candidate or "\\" in candidate:
+        raise BookkeepingError(f"{name} must be a single safe path segment")
+    if _SAFE_PATH_SEGMENT_RE.fullmatch(candidate) is None:
+        raise BookkeepingError(
+            f"{name} contains unsupported characters: {candidate!r}"
+        )
+    return candidate
 
 
 def _generate_ulid() -> str:
@@ -331,28 +347,6 @@ def _resolve_confined_artifact_path(worktree_root: Path, path: Path) -> Path:
             f"{resolved_path}"
         )
     return resolved_path
-
-
-def _coordination_feature_paths(
-    worktree_root: Path,
-    mission_slug: str,
-    mid8: str,
-) -> tuple[Path, Path, Path]:
-    """Return canonical feature/status paths confined to the coordination worktree."""
-    kitty_dir_name = _kitty_specs_dir_name(mission_slug, mid8)
-    feature_dir = _resolve_confined_artifact_path(
-        worktree_root,
-        worktree_root / "kitty-specs" / kitty_dir_name,
-    )
-    events_path = _resolve_confined_artifact_path(
-        worktree_root,
-        feature_dir / _EVENTS_FILENAME,
-    )
-    snapshot_path = _resolve_confined_artifact_path(
-        worktree_root,
-        feature_dir / _SNAPSHOT_FILENAME,
-    )
-    return feature_dir, events_path, snapshot_path
 
 
 def _write_confined_artifact_bytes(
@@ -640,6 +634,9 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         operation: str,
         lock_cm: AbstractContextManager[Path],
     ) -> BookkeepingTransaction:
+        safe_mission_slug = _validate_safe_segment("mission_slug", mission_slug)
+        safe_mid8 = _validate_safe_segment("mid8", mid8)
+
         # Resolve the worktree.  Two paths exist (WP08 T035–T036, SC-11):
         #
         # (a) **New topology** (default): the mission's meta.json carries
@@ -664,7 +661,7 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         # truncate rollback, and the outbound deferral — applies
         # uniformly to both paths.**  Only ``worktree_root`` and (in
         # legacy mode) ``destination_ref`` differ.
-        legacy_mode = _is_legacy_mission(repo_root, mission_slug, mid8)
+        legacy_mode = _is_legacy_mission(repo_root, safe_mission_slug, safe_mid8)
         if legacy_mode:
             try:
                 worktree_root, lane_branch = _resolve_legacy_lane_destination(
@@ -676,17 +673,17 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
             # lane branch so policy + HEAD assertion both see truth.
             normalised_ref = _normalize_ref(lane_branch)
             destination_ref = normalised_ref
-            _emit_legacy_warning_once(repo_root, mission_id, mission_slug)
+            _emit_legacy_warning_once(repo_root, mission_id, safe_mission_slug)
         else:
             # New topology — create coord worktree on first call.
             try:
                 worktree_root = CoordinationWorkspace.resolve(
-                    repo_root, mission_slug, mid8,
+                    repo_root, safe_mission_slug, safe_mid8,
                 )
             except Exception as exc:  # noqa: BLE001 — domain error surface
                 raise BookkeepingWorktreeMissing(
                     f"Failed to resolve coordination worktree for "
-                    f"{mission_slug}-{mid8}: {exc}"
+                    f"{safe_mission_slug}-{safe_mid8}: {exc}"
                 ) from exc
 
         # 3. Compute the feature_dir + status files INSIDE the resolved
@@ -696,11 +693,10 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         # there is no sparse-checkout policy on the lane, so the files
         # are physically present and the surgical truncate rollback
         # works against the lane worktree without modification.
-        feature_dir, events_path, snapshot_path = _coordination_feature_paths(
-            worktree_root,
-            mission_slug,
-            mid8,
-        )
+        kitty_dir_name = _kitty_specs_dir_name(safe_mission_slug, safe_mid8)
+        feature_dir = worktree_root / "kitty-specs" / kitty_dir_name
+        events_path = feature_dir / _EVENTS_FILENAME
+        snapshot_path = feature_dir / _SNAPSHOT_FILENAME
 
         # 4. Build the change set and run the pre-flight policy gate.
         # This still happens before any bookkeeping write; the lock is

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -333,6 +333,28 @@ def _resolve_confined_artifact_path(worktree_root: Path, path: Path) -> Path:
     return resolved_path
 
 
+def _coordination_feature_paths(
+    worktree_root: Path,
+    mission_slug: str,
+    mid8: str,
+) -> tuple[Path, Path, Path]:
+    """Return canonical feature/status paths confined to the coordination worktree."""
+    kitty_dir_name = _kitty_specs_dir_name(mission_slug, mid8)
+    feature_dir = _resolve_confined_artifact_path(
+        worktree_root,
+        worktree_root / "kitty-specs" / kitty_dir_name,
+    )
+    events_path = _resolve_confined_artifact_path(
+        worktree_root,
+        feature_dir / _EVENTS_FILENAME,
+    )
+    snapshot_path = _resolve_confined_artifact_path(
+        worktree_root,
+        feature_dir / _SNAPSHOT_FILENAME,
+    )
+    return feature_dir, events_path, snapshot_path
+
+
 def _write_confined_artifact_bytes(
     worktree_root: Path,
     path: Path,
@@ -674,10 +696,11 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         # there is no sparse-checkout policy on the lane, so the files
         # are physically present and the surgical truncate rollback
         # works against the lane worktree without modification.
-        kitty_dir_name = _kitty_specs_dir_name(mission_slug, mid8)
-        feature_dir = worktree_root / "kitty-specs" / kitty_dir_name
-        events_path = feature_dir / _EVENTS_FILENAME
-        snapshot_path = feature_dir / _SNAPSHOT_FILENAME
+        feature_dir, events_path, snapshot_path = _coordination_feature_paths(
+            worktree_root,
+            mission_slug,
+            mid8,
+        )
 
         # 4. Build the change set and run the pre-flight policy gate.
         # This still happens before any bookkeeping write; the lock is

--- a/src/specify_cli/next/discovery.py
+++ b/src/specify_cli/next/discovery.py
@@ -134,7 +134,7 @@ def _preview_from_candidates(
             has_active_candidate = True
     return ClaimablePreview(
         wp_id=None,
-        selection_reason=_selection_reason(
+        selection_reason=_claimable_selection_reason(
             has_dependency_blocked_candidate,
             has_active_candidate,
         ),
@@ -142,7 +142,7 @@ def _preview_from_candidates(
     )
 
 
-def _selection_reason(
+def _claimable_selection_reason(
     has_dependency_blocked_candidate: bool,
     has_active_candidate: bool,
 ) -> str:

--- a/src/specify_cli/next/discovery.py
+++ b/src/specify_cli/next/discovery.py
@@ -134,15 +134,23 @@ def _preview_from_candidates(
             has_active_candidate = True
     return ClaimablePreview(
         wp_id=None,
-        selection_reason=(
-            "dependencies_not_satisfied"
-            if has_dependency_blocked_candidate
-            else "all_wps_in_progress"
-            if has_active_candidate
-            else "no_planned_wps"
+        selection_reason=_selection_reason(
+            has_dependency_blocked_candidate,
+            has_active_candidate,
         ),
         candidates=tuple(candidates),
     )
+
+
+def _selection_reason(
+    has_dependency_blocked_candidate: bool,
+    has_active_candidate: bool,
+) -> str:
+    if has_dependency_blocked_candidate:
+        return "dependencies_not_satisfied"
+    if has_active_candidate:
+        return "all_wps_in_progress"
+    return "no_planned_wps"
 
 
 def preview_claimable_wp(feature_dir: Path) -> ClaimablePreview:

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -37,7 +37,7 @@ from enum import Enum
 from functools import cache
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 if sys.platform == "win32":
     import msvcrt
@@ -619,11 +619,62 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
         token=daemon_token or "",
         allow_network=False,
     )
+    _write_initial_owner_record(write_owner_record, record)
+    _start_runtime_thread(
+        port=port,
+        daemon_token=daemon_token,
+        build_record_for_current_process=build_record_for_current_process,
+        write_owner_record=write_owner_record,
+    )
+
+    def _cleanup_owner_record() -> None:
+        _cleanup_owner_record_file(remove_owner_record)
+
+    atexit.register(_cleanup_owner_record)
+
+    def _signal_handler(signum: int, _frame: Any) -> None:
+        logger.info("Received signal %d; shutting down daemon", signum)
+        _cleanup_owner_record()
+        _shutdown_server_async(server)
+
+    # Best-effort signal handlers. ``signal.signal`` only works on the main
+    # thread, which is where ``run_sync_daemon`` always executes; if we are
+    # ever called off-main-thread (tests stubbing this in), we silently
+    # skip rather than raising.
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(_signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            _signal.signal(sig, _signal_handler)
+        except (ValueError, OSError):  # pragma: no cover - off main thread
+            pass
+
+    tick = _start_self_check_tick(server, my_port=port)
+    try:
+        server.serve_forever(poll_interval=DAEMON_SERVE_FOREVER_POLL_SECONDS)
+    finally:
+        tick.cancel()
+        _cleanup_owner_record()
+
+
+def _write_initial_owner_record(
+    write_owner_record: Callable[[Any], None],
+    record: Any,
+) -> None:
     try:
         write_owner_record(record)
     except OSError as exc:  # pragma: no cover - filesystem catastrophe
         logger.warning("Failed to write daemon owner record: %s", exc)
 
+
+def _start_runtime_thread(
+    *,
+    port: int,
+    daemon_token: str | None,
+    build_record_for_current_process: Callable[..., Any],
+    write_owner_record: Callable[[Any], None],
+) -> None:
     def _start_runtime_in_background() -> None:
         try:
             time.sleep(_RUNTIME_BACKGROUND_START_DELAY_SECONDS)
@@ -649,51 +700,22 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
         daemon=True,
     ).start()
 
-    def _cleanup_owner_record() -> None:
-        try:
-            remove_owner_record()
-        # Best-effort cleanup: never block daemon exit on owner-record removal.
-        except Exception:  # noqa: BLE001
-            logger.debug("Owner record cleanup raised; continuing")
 
-    atexit.register(_cleanup_owner_record)
-
-    def _signal_handler(signum: int, _frame: Any) -> None:
-        logger.info("Received signal %d; shutting down daemon", signum)
-        _cleanup_owner_record()
-        # ``HTTPServer.shutdown()`` blocks until ``serve_forever()`` returns.
-        # If we call it on the main thread (where ``serve_forever()`` is
-        # blocking), the signal handler deadlocks against the serve loop and
-        # the process never exits. Spawn a daemon thread so the signal
-        # handler returns immediately and ``serve_forever()`` is free to
-        # observe the shutdown flag and unwind.
-        def _shutdown_off_thread() -> None:
-            try:
-                server.shutdown()
-            except Exception:  # noqa: BLE001 — best-effort during shutdown
-                logger.debug("server.shutdown() raised during signal teardown")
-
-        threading.Thread(target=_shutdown_off_thread, daemon=True).start()
-
-    # Best-effort signal handlers. ``signal.signal`` only works on the main
-    # thread, which is where ``run_sync_daemon`` always executes; if we are
-    # ever called off-main-thread (tests stubbing this in), we silently
-    # skip rather than raising.
-    for sig_name in ("SIGTERM", "SIGINT"):
-        sig = getattr(_signal, sig_name, None)
-        if sig is None:
-            continue
-        try:
-            _signal.signal(sig, _signal_handler)
-        except (ValueError, OSError):  # pragma: no cover - off main thread
-            pass
-
-    tick = _start_self_check_tick(server, my_port=port)
+def _cleanup_owner_record_file(remove_owner_record: Callable[[], None]) -> None:
     try:
-        server.serve_forever(poll_interval=DAEMON_SERVE_FOREVER_POLL_SECONDS)
-    finally:
-        tick.cancel()
-        _cleanup_owner_record()
+        remove_owner_record()
+    except Exception:  # noqa: BLE001
+        logger.debug("Owner record cleanup raised; continuing")
+
+
+def _shutdown_server_async(server: HTTPServer) -> None:
+    def _shutdown_off_thread() -> None:
+        try:
+            server.shutdown()
+        except Exception:  # noqa: BLE001 — best-effort during shutdown
+            logger.debug("server.shutdown() raised during signal teardown")
+
+    threading.Thread(target=_shutdown_off_thread, daemon=True).start()
 
 
 def _background_script(port: int, daemon_token: str | None) -> str:
@@ -841,28 +863,16 @@ def ensure_sync_daemon_running(  # noqa: C901 — lifecycle decision matrix plus
     _daemon_root().mkdir(parents=True, exist_ok=True)
 
     lock_fd = open(DAEMON_LOCK_FILE, "w")  # noqa: SIM115
+    acquired = False
     try:
-        # Use a bounded wait instead of blocking indefinitely (#598).
-        # If another process is starting the daemon, we retry for up to
-        # ~10 seconds before giving up — the daemon is likely already
-        # running and will be reachable on the next CLI call.
-        acquired = False
-        for _ in range(100):
-            try:
-                if sys.platform == "win32":
-                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-                else:
-                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                acquired = True
-                break
-            except OSError as exc:
-                if not _is_daemon_lock_contention(exc):
-                    return DaemonStartOutcome(
-                        started=False,
-                        skipped_reason=f"start_failed: {exc}",
-                        pid=None,
-                    )
-                time.sleep(0.1)
+        try:
+            acquired = _acquire_daemon_lock(lock_fd)
+        except OSError as exc:
+            return DaemonStartOutcome(
+                started=False,
+                skipped_reason=f"start_failed: {exc}",
+                pid=None,
+            )
         if not acquired:
             emit_sync_diagnostic(
                 SyncDiagnosticCode.LOCK_UNAVAILABLE,
@@ -874,25 +884,7 @@ def ensure_sync_daemon_running(  # noqa: C901 — lifecycle decision matrix plus
                 skipped_reason="start_failed: could not acquire daemon lock within 10s",
                 pid=None,
             )
-        try:
-            if health_wait_seconds is None:
-                _url, _port, _started = _ensure_sync_daemon_running_locked()
-            else:
-                _url, _port, _started = _ensure_sync_daemon_running_locked(
-                    health_wait_seconds=health_wait_seconds
-                )
-        except Exception as exc:
-            return DaemonStartOutcome(
-                started=False, skipped_reason=f"start_failed: {exc}", pid=None
-            )
-        # Retrieve the PID from the state file after successful start
-        pid: int | None = None
-        if DAEMON_STATE_FILE.exists():
-            try:
-                _u, _p, _t, pid = _parse_daemon_file(DAEMON_STATE_FILE)
-            except Exception:
-                pid = None
-        return DaemonStartOutcome(started=True, skipped_reason=None, pid=pid)
+        return _start_daemon_locked_outcome(health_wait_seconds)
     finally:
         if acquired:
             if sys.platform == "win32":
@@ -900,6 +892,52 @@ def ensure_sync_daemon_running(  # noqa: C901 — lifecycle decision matrix plus
             else:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
         lock_fd.close()
+
+
+def _acquire_daemon_lock(lock_fd: Any) -> bool:
+    for _ in range(100):
+        try:
+            if sys.platform == "win32":
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError as exc:
+            if not _is_daemon_lock_contention(exc):
+                raise
+            time.sleep(0.1)
+    return False
+
+
+def _start_daemon_locked_outcome(
+    health_wait_seconds: float | None,
+) -> DaemonStartOutcome:
+    try:
+        if health_wait_seconds is None:
+            _ensure_sync_daemon_running_locked()
+        else:
+            _ensure_sync_daemon_running_locked(
+                health_wait_seconds=health_wait_seconds
+            )
+    except Exception as exc:
+        return DaemonStartOutcome(
+            started=False, skipped_reason=f"start_failed: {exc}", pid=None
+        )
+    return DaemonStartOutcome(
+        started=True,
+        skipped_reason=None,
+        pid=_daemon_state_pid(),
+    )
+
+
+def _daemon_state_pid() -> int | None:
+    if not DAEMON_STATE_FILE.exists():
+        return None
+    try:
+        _u, _p, _t, pid = _parse_daemon_file(DAEMON_STATE_FILE)
+    except Exception:
+        return None
+    return pid
 
 
 def _bounded_retry_delays(
@@ -924,31 +962,9 @@ def _ensure_sync_daemon_running_locked(
     health_wait_seconds: float | None = None,
 ) -> tuple[str, int, bool]:
     """Inner implementation — caller must hold the daemon lock file."""
-    if DAEMON_STATE_FILE.exists():
-        existing_url, existing_port, existing_token, existing_pid = _parse_daemon_file(DAEMON_STATE_FILE)
-        if existing_port is not None and _check_sync_daemon_health(
-            existing_port,
-            existing_token,
-            timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
-        ):
-            # Daemon is healthy — check whether it's running the current version.
-            if _daemon_version_matches(
-                existing_port,
-                existing_token,
-                timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
-            ):
-                return existing_url or f"http://127.0.0.1:{existing_port}", existing_port, False
-
-            # Stale version — recycle the daemon.
-            logger.info("Recycling sync daemon (version mismatch)")
-            _stop_daemon_by_http(existing_url or f"http://127.0.0.1:{existing_port}", existing_token)
-            _kill_and_cleanup(existing_pid)
-        elif existing_pid is not None and not _is_process_alive(existing_pid):
-            DAEMON_STATE_FILE.unlink(missing_ok=True)
-        elif existing_pid is not None:
-            _kill_and_cleanup(existing_pid)
-        else:
-            DAEMON_STATE_FILE.unlink(missing_ok=True)
+    existing = _reconcile_existing_daemon_state()
+    if existing is not None:
+        return existing
 
     if preferred_port is not None:
         port = preferred_port
@@ -991,6 +1007,64 @@ def _ensure_sync_daemon_running_locked(
         _kill_and_cleanup(proc.pid)
 
     raise RuntimeError(f"Sync daemon failed health check on port {port}")
+
+
+def _reconcile_existing_daemon_state() -> tuple[str, int, bool] | None:
+    if not DAEMON_STATE_FILE.exists():
+        return None
+
+    existing_url, existing_port, existing_token, existing_pid = _parse_daemon_file(DAEMON_STATE_FILE)
+    if _existing_daemon_is_healthy(existing_port, existing_token):
+        return _reuse_or_recycle_daemon(
+            existing_url,
+            existing_port,
+            existing_token,
+            existing_pid,
+        )
+    _cleanup_unhealthy_existing_daemon(existing_pid)
+    return None
+
+
+def _existing_daemon_is_healthy(
+    existing_port: int | None,
+    existing_token: str | None,
+) -> bool:
+    return existing_port is not None and _check_sync_daemon_health(
+        existing_port,
+        existing_token,
+        timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
+    )
+
+
+def _reuse_or_recycle_daemon(
+    existing_url: str | None,
+    existing_port: int | None,
+    existing_token: str | None,
+    existing_pid: int | None,
+) -> tuple[str, int, bool] | None:
+    if existing_port is None:
+        return None
+    if _daemon_version_matches(
+        existing_port,
+        existing_token,
+        timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
+    ):
+        return existing_url or f"http://127.0.0.1:{existing_port}", existing_port, False
+
+    logger.info("Recycling sync daemon (version mismatch)")
+    _stop_daemon_by_http(existing_url or f"http://127.0.0.1:{existing_port}", existing_token)
+    _kill_and_cleanup(existing_pid)
+    return None
+
+
+def _cleanup_unhealthy_existing_daemon(existing_pid: int | None) -> None:
+    if existing_pid is not None and not _is_process_alive(existing_pid):
+        DAEMON_STATE_FILE.unlink(missing_ok=True)
+        return
+    if existing_pid is not None:
+        _kill_and_cleanup(existing_pid)
+        return
+    DAEMON_STATE_FILE.unlink(missing_ok=True)
 
 
 def _stop_daemon_by_http(url: str, token: str | None) -> None:

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -584,113 +584,14 @@ def _start_self_check_tick(
     return timer
 
 
-def run_sync_daemon(port: int, daemon_token: str | None) -> None:
-    """Run the machine-global sync daemon forever.
-
-    Once the HTTP server is bound, this function writes the canonical
-    :class:`DaemonOwnerRecord` to ``<sync_root>/daemon/owner.json`` so the
-    foreground can detect ownership mismatches (FR-005/FR-006/FR-007) and
-    orphan crashes (FR-010). The record is removed on clean shutdown; if
-    the process is killed (SIGKILL, crash, power loss) the file remains
-    and orphan detection on the foreground side reconciles it.
-    """
-    import atexit
-    import signal as _signal
-
-    from specify_cli.sync.owner import (
-        build_record_for_current_process,
-        remove_owner_record,
-        write_owner_record,
-    )
-
-    handler_class = type(
-        "SyncDaemonRouter",
-        (SyncDaemonHandler,),
-        {"daemon_token": daemon_token},
-    )
-    server = HTTPServer(("127.0.0.1", port), handler_class)  # NOSONAR -- sync daemon control plane binds to localhost only
-
-    # Bind succeeded — record ownership BEFORE accepting traffic so any
-    # health probe that arrives in the first scheduling slice already sees
-    # a coherent owner field.
-    record = build_record_for_current_process(
-        pid=os.getpid(),
-        port=port,
-        token=daemon_token or "",
-        allow_network=False,
-    )
-    _write_initial_owner_record(write_owner_record, record)
-    _start_runtime_thread(
-        port=port,
-        daemon_token=daemon_token,
-        build_record_for_current_process=build_record_for_current_process,
-        write_owner_record=write_owner_record,
-    )
-
-    def _cleanup_owner_record() -> None:
-        _cleanup_owner_record_file(remove_owner_record)
-
-    atexit.register(_cleanup_owner_record)
-
-    def _signal_handler(signum: int, _frame: Any) -> None:
-        logger.info("Received signal %d; shutting down daemon", signum)
-        _cleanup_owner_record()
-        _shutdown_server_async(server)
-
-    # Best-effort signal handlers. ``signal.signal`` only works on the main
-    # thread, which is where ``run_sync_daemon`` always executes; if we are
-    # ever called off-main-thread (tests stubbing this in), we silently
-    # skip rather than raising.
-    for sig_name in ("SIGTERM", "SIGINT"):
-        sig = getattr(_signal, sig_name, None)
-        if sig is None:
-            continue
-        try:
-            _signal.signal(sig, _signal_handler)
-        except (ValueError, OSError):  # pragma: no cover - off main thread
-            pass
-
-    tick = _start_self_check_tick(server, my_port=port)
-    try:
-        server.serve_forever(poll_interval=DAEMON_SERVE_FOREVER_POLL_SECONDS)
-    finally:
-        tick.cancel()
-        _cleanup_owner_record()
-
-
-def _write_initial_owner_record(
-    write_owner_record: Callable[[Any], None],
-    record: Any,
-) -> None:
-    try:
-        write_owner_record(record)
-    except OSError as exc:  # pragma: no cover - filesystem catastrophe
-        logger.warning("Failed to write daemon owner record: %s", exc)
-
-
-def _start_runtime_thread(
-    *,
-    port: int,
-    daemon_token: str | None,
-    build_record_for_current_process: Callable[..., Any],
-    write_owner_record: Callable[[Any], None],
-) -> None:
+def _start_runtime_bootstrap_thread(port: int, daemon_token: str | None) -> None:
     def _start_runtime_in_background() -> None:
         try:
             time.sleep(_RUNTIME_BACKGROUND_START_DELAY_SECONDS)
             from specify_cli.sync.runtime import get_runtime
 
             get_runtime()
-            try:
-                enriched_record = build_record_for_current_process(
-                    pid=os.getpid(),
-                    port=port,
-                    token=daemon_token or "",
-                    allow_network=True,
-                )
-                write_owner_record(enriched_record)
-            except Exception:  # noqa: BLE001 — health remains valid with local-only owner data
-                logger.debug("Failed to enrich daemon owner record", exc_info=True)
+            _write_daemon_owner_record(port, daemon_token, allow_network=True)
         except Exception:  # noqa: BLE001 — health endpoint stays available
             logger.exception("Failed to start sync runtime")
 
@@ -701,21 +602,97 @@ def _start_runtime_thread(
     ).start()
 
 
-def _cleanup_owner_record_file(remove_owner_record: Callable[[], None]) -> None:
+def _write_daemon_owner_record(port: int, daemon_token: str | None, *, allow_network: bool) -> None:
+    from specify_cli.sync.owner import (
+        build_record_for_current_process,
+        write_owner_record,
+    )
+
+    record = build_record_for_current_process(
+        pid=os.getpid(),
+        port=port,
+        token=daemon_token or "",
+        allow_network=allow_network,
+    )
     try:
-        remove_owner_record()
-    except Exception:  # noqa: BLE001
-        logger.debug("Owner record cleanup raised; continuing")
+        write_owner_record(record)
+    except OSError as exc:  # pragma: no cover - filesystem catastrophe
+        logger.warning("Failed to write daemon owner record: %s", exc)
+    except Exception:  # noqa: BLE001 — health remains valid with local-only owner data
+        logger.debug("Failed to enrich daemon owner record", exc_info=True)
 
 
-def _shutdown_server_async(server: HTTPServer) -> None:
-    def _shutdown_off_thread() -> None:
+def _register_daemon_owner_cleanup() -> Callable[[], None]:
+    import atexit
+
+    from specify_cli.sync.owner import remove_owner_record
+
+    def _cleanup_owner_record() -> None:
         try:
-            server.shutdown()
-        except Exception:  # noqa: BLE001 — best-effort during shutdown
-            logger.debug("server.shutdown() raised during signal teardown")
+            remove_owner_record()
+        except Exception:  # noqa: BLE001
+            logger.debug("Owner record cleanup raised; continuing")
 
-    threading.Thread(target=_shutdown_off_thread, daemon=True).start()
+    atexit.register(_cleanup_owner_record)
+    return _cleanup_owner_record
+
+
+def _install_daemon_signal_handlers(server: HTTPServer, cleanup_owner_record: Callable[[], None]) -> None:
+    import signal as _signal
+
+    def _signal_handler(signum: int, _frame: Any) -> None:
+        logger.info("Received signal %d; shutting down daemon", signum)
+        cleanup_owner_record()
+
+        def _shutdown_off_thread() -> None:
+            try:
+                server.shutdown()
+            except Exception:  # noqa: BLE001 — best-effort during shutdown
+                logger.debug("server.shutdown() raised during signal teardown")
+
+        threading.Thread(target=_shutdown_off_thread, daemon=True).start()
+
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(_signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            _signal.signal(sig, _signal_handler)
+        except (ValueError, OSError):  # pragma: no cover - off main thread
+            pass
+
+
+def run_sync_daemon(port: int, daemon_token: str | None) -> None:
+    """Run the machine-global sync daemon forever.
+
+    Once the HTTP server is bound, this function writes the canonical
+    :class:`DaemonOwnerRecord` to ``<sync_root>/daemon/owner.json`` so the
+    foreground can detect ownership mismatches (FR-005/FR-006/FR-007) and
+    orphan crashes (FR-010). The record is removed on clean shutdown; if
+    the process is killed (SIGKILL, crash, power loss) the file remains
+    and orphan detection on the foreground side reconciles it.
+    """
+    handler_class = type(
+        "SyncDaemonRouter",
+        (SyncDaemonHandler,),
+        {"daemon_token": daemon_token},
+    )
+    server = HTTPServer(("127.0.0.1", port), handler_class)  # NOSONAR -- sync daemon control plane binds to localhost only
+
+    # Bind succeeded — record ownership BEFORE accepting traffic so any
+    # health probe that arrives in the first scheduling slice already sees
+    # a coherent owner field.
+    _write_daemon_owner_record(port, daemon_token, allow_network=False)
+    _start_runtime_bootstrap_thread(port, daemon_token)
+    cleanup_owner_record = _register_daemon_owner_cleanup()
+    _install_daemon_signal_handlers(server, cleanup_owner_record)
+
+    tick = _start_self_check_tick(server, my_port=port)
+    try:
+        server.serve_forever(poll_interval=DAEMON_SERVE_FOREVER_POLL_SECONDS)
+    finally:
+        tick.cancel()
+        cleanup_owner_record()
 
 
 def _background_script(port: int, daemon_token: str | None) -> str:
@@ -819,6 +796,54 @@ def _kill_and_cleanup(pid: int | None, *, wait_timeout: float = 2.0) -> None:
     DAEMON_STATE_FILE.unlink(missing_ok=True)
 
 
+def _daemon_start_skip_reason(
+    intent: DaemonIntent,
+    policy: object,
+) -> str | None:
+    from specify_cli.saas.rollout import is_saas_sync_enabled
+    from specify_cli.sync.config import BackgroundDaemonPolicy
+
+    if not is_saas_sync_enabled():
+        return "rollout_disabled"
+    if intent == DaemonIntent.LOCAL_ONLY:
+        return "intent_local_only"
+    if policy == BackgroundDaemonPolicy.MANUAL:
+        return "policy_manual"
+    return None
+
+
+def _acquire_daemon_lock(lock_fd: Any) -> bool:
+    for _ in range(100):
+        try:
+            if sys.platform == "win32":
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError as exc:
+            if not _is_daemon_lock_contention(exc):
+                raise
+            time.sleep(0.1)
+    return False
+
+
+def _release_daemon_lock(lock_fd: Any) -> None:
+    if sys.platform == "win32":
+        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def _read_daemon_pid() -> int | None:
+    if not DAEMON_STATE_FILE.exists():
+        return None
+    try:
+        _u, _p, _t, pid = _parse_daemon_file(DAEMON_STATE_FILE)
+    except Exception:
+        return None
+    return pid
+
+
 def ensure_sync_daemon_running(  # noqa: C901 — lifecycle decision matrix plus lock/retry handling.
     *,
     intent: DaemonIntent,
@@ -840,24 +865,15 @@ def ensure_sync_daemon_running(  # noqa: C901 — lifecycle decision matrix plus
     Uses an advisory file lock (``DAEMON_LOCK_FILE``) to serialise
     concurrent spawn attempts and prevent TOCTOU races.
     """
-    from specify_cli.saas.rollout import is_saas_sync_enabled
     from specify_cli.sync.config import BackgroundDaemonPolicy, SyncConfig as _SyncConfig
 
     if config is None:
         config = _SyncConfig()
     policy = config.get_background_daemon()
 
-    # Row 1: rollout disabled
-    if not is_saas_sync_enabled():
-        return DaemonStartOutcome(started=False, skipped_reason="rollout_disabled", pid=None)
-
-    # Row 2: caller declared local-only intent
-    if intent == DaemonIntent.LOCAL_ONLY:
-        return DaemonStartOutcome(started=False, skipped_reason="intent_local_only", pid=None)
-
-    # Row 3: operator policy is manual
-    if policy == BackgroundDaemonPolicy.MANUAL:
-        return DaemonStartOutcome(started=False, skipped_reason="policy_manual", pid=None)
+    skip_reason = _daemon_start_skip_reason(intent, policy)
+    if skip_reason is not None:
+        return DaemonStartOutcome(started=False, skipped_reason=skip_reason, pid=None)
 
     # Row 4 & 5: AUTO + REMOTE_REQUIRED — attempt to start
     _daemon_root().mkdir(parents=True, exist_ok=True)
@@ -884,60 +900,23 @@ def ensure_sync_daemon_running(  # noqa: C901 — lifecycle decision matrix plus
                 skipped_reason="start_failed: could not acquire daemon lock within 10s",
                 pid=None,
             )
-        return _start_daemon_locked_outcome(health_wait_seconds)
+        try:
+            if health_wait_seconds is None:
+                _url, _port, _started = _ensure_sync_daemon_running_locked()
+            else:
+                _url, _port, _started = _ensure_sync_daemon_running_locked(
+                    health_wait_seconds=health_wait_seconds
+                )
+        except Exception as exc:
+            return DaemonStartOutcome(
+                started=False, skipped_reason=f"start_failed: {exc}", pid=None
+            )
+        pid = _read_daemon_pid()
+        return DaemonStartOutcome(started=True, skipped_reason=None, pid=pid)
     finally:
         if acquired:
-            if sys.platform == "win32":
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            else:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            _release_daemon_lock(lock_fd)
         lock_fd.close()
-
-
-def _acquire_daemon_lock(lock_fd: Any) -> bool:
-    for _ in range(100):
-        try:
-            if sys.platform == "win32":
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-            else:
-                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return True
-        except OSError as exc:
-            if not _is_daemon_lock_contention(exc):
-                raise
-            time.sleep(0.1)
-    return False
-
-
-def _start_daemon_locked_outcome(
-    health_wait_seconds: float | None,
-) -> DaemonStartOutcome:
-    try:
-        if health_wait_seconds is None:
-            _ensure_sync_daemon_running_locked()
-        else:
-            _ensure_sync_daemon_running_locked(
-                health_wait_seconds=health_wait_seconds
-            )
-    except Exception as exc:
-        return DaemonStartOutcome(
-            started=False, skipped_reason=f"start_failed: {exc}", pid=None
-        )
-    return DaemonStartOutcome(
-        started=True,
-        skipped_reason=None,
-        pid=_daemon_state_pid(),
-    )
-
-
-def _daemon_state_pid() -> int | None:
-    if not DAEMON_STATE_FILE.exists():
-        return None
-    try:
-        _u, _p, _t, pid = _parse_daemon_file(DAEMON_STATE_FILE)
-    except Exception:
-        return None
-    return pid
 
 
 def _bounded_retry_delays(
@@ -962,7 +941,7 @@ def _ensure_sync_daemon_running_locked(
     health_wait_seconds: float | None = None,
 ) -> tuple[str, int, bool]:
     """Inner implementation — caller must hold the daemon lock file."""
-    existing = _reconcile_existing_daemon_state()
+    existing = _reuse_or_cleanup_existing_daemon()
     if existing is not None:
         return existing
 
@@ -972,20 +951,7 @@ def _ensure_sync_daemon_running_locked(
         port = _find_free_port()
     token = secrets.token_hex(16)
 
-    # Redirect daemon output to a log file for diagnostics
-    DAEMON_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    log_fh = open(DAEMON_LOG_FILE, "a")  # noqa: SIM115
-
-    proc = subprocess.Popen(
-        [sys.executable, "-c", _background_script(port, token)],
-        stdout=log_fh,
-        stderr=log_fh,
-        stdin=subprocess.DEVNULL,
-        start_new_session=True,
-        env={**os.environ, "SPEC_KITTY_CLI_VERSION": _get_package_version()},
-    )
-    log_fh.close()
-
+    proc = _spawn_sync_daemon_process(port, token)
     url = f"http://127.0.0.1:{port}"
 
     # Wait up to ~20s for the daemon to become healthy (matching dashboard pattern)
@@ -1009,62 +975,54 @@ def _ensure_sync_daemon_running_locked(
     raise RuntimeError(f"Sync daemon failed health check on port {port}")
 
 
-def _reconcile_existing_daemon_state() -> tuple[str, int, bool] | None:
+def _reuse_or_cleanup_existing_daemon() -> tuple[str, int, bool] | None:
     if not DAEMON_STATE_FILE.exists():
         return None
 
-    existing_url, existing_port, existing_token, existing_pid = _parse_daemon_file(DAEMON_STATE_FILE)
-    if _existing_daemon_is_healthy(existing_port, existing_token):
-        return _reuse_or_recycle_daemon(
-            existing_url,
-            existing_port,
-            existing_token,
-            existing_pid,
-        )
-    _cleanup_unhealthy_existing_daemon(existing_pid)
-    return None
-
-
-def _existing_daemon_is_healthy(
-    existing_port: int | None,
-    existing_token: str | None,
-) -> bool:
-    return existing_port is not None and _check_sync_daemon_health(
-        existing_port,
-        existing_token,
-        timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
+    existing_url, existing_port, existing_token, existing_pid = _parse_daemon_file(
+        DAEMON_STATE_FILE
     )
-
-
-def _reuse_or_recycle_daemon(
-    existing_url: str | None,
-    existing_port: int | None,
-    existing_token: str | None,
-    existing_pid: int | None,
-) -> tuple[str, int, bool] | None:
-    if existing_port is None:
-        return None
-    if _daemon_version_matches(
+    if existing_port is not None and _check_sync_daemon_health(
         existing_port,
         existing_token,
         timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
     ):
-        return existing_url or f"http://127.0.0.1:{existing_port}", existing_port, False
+        if _daemon_version_matches(
+            existing_port,
+            existing_token,
+            timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
+        ):
+            return existing_url or f"http://127.0.0.1:{existing_port}", existing_port, False
 
-    logger.info("Recycling sync daemon (version mismatch)")
-    _stop_daemon_by_http(existing_url or f"http://127.0.0.1:{existing_port}", existing_token)
-    _kill_and_cleanup(existing_pid)
+        logger.info("Recycling sync daemon (version mismatch)")
+        _stop_daemon_by_http(
+            existing_url or f"http://127.0.0.1:{existing_port}", existing_token
+        )
+        _kill_and_cleanup(existing_pid)
+        return None
+
+    if existing_pid is not None and not _is_process_alive(existing_pid):
+        DAEMON_STATE_FILE.unlink(missing_ok=True)
+    elif existing_pid is not None:
+        _kill_and_cleanup(existing_pid)
+    else:
+        DAEMON_STATE_FILE.unlink(missing_ok=True)
     return None
 
 
-def _cleanup_unhealthy_existing_daemon(existing_pid: int | None) -> None:
-    if existing_pid is not None and not _is_process_alive(existing_pid):
-        DAEMON_STATE_FILE.unlink(missing_ok=True)
-        return
-    if existing_pid is not None:
-        _kill_and_cleanup(existing_pid)
-        return
-    DAEMON_STATE_FILE.unlink(missing_ok=True)
+def _spawn_sync_daemon_process(port: int, token: str) -> subprocess.Popen[str]:
+    DAEMON_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    log_fh = open(DAEMON_LOG_FILE, "a")  # noqa: SIM115
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _background_script(port, token)],
+        stdout=log_fh,
+        stderr=log_fh,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+        env={**os.environ, "SPEC_KITTY_CLI_VERSION": _get_package_version()},
+    )
+    log_fh.close()
+    return proc
 
 
 def _stop_daemon_by_http(url: str, token: str | None) -> None:

--- a/tests/specify_cli/coordination/test_transaction.py
+++ b/tests/specify_cli/coordination/test_transaction.py
@@ -27,6 +27,7 @@ import specify_cli.coordination.transaction as transaction_module
 from specify_cli.coordination.transaction import (
     BookkeepingCommitFailed,
     BookkeepingDoubleEventId,
+    BookkeepingError,
     BookkeepingLockTimeout,
     BookkeepingPolicyRefused,
     BookkeepingTransaction,
@@ -206,6 +207,19 @@ def test_destination_ref_refs_heads_prefix_refused(repo: Path) -> None:
             operation="long_form",
         )
     assert excinfo.value.verdict.error_code == "DESTINATION_REF_INVALID_SHAPE"
+
+
+def test_mission_slug_path_traversal_is_rejected(repo: Path) -> None:
+    """User-controlled mission selectors must not escape kitty-specs/."""
+    with pytest.raises(BookkeepingError, match="single safe path segment"):
+        BookkeepingTransaction.acquire(
+            repo_root=repo,
+            mission_id=MISSION_ID,
+            mission_slug="../escape",
+            mid8=MID8,
+            destination_ref=COORD_BRANCH,
+            operation="unsafe_slug",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- harden coordination transaction feature/status path construction so all bookkeeping paths are canonically confined to the coordination worktree before I/O
- resolve the latest GitHub/Sonar security finding and the 2026-05-31 SonarCloud maintainability findings with targeted helper extractions and small cleanup fixes
- keep daemon/merge/implement behavior unchanged while reducing cognitive complexity below the configured threshold

## Validation
- `.venv/bin/ruff check src/specify_cli/coordination/transaction.py src/specify_cli/cli/commands/agent/tasks.py src/specify_cli/next/discovery.py src/specify_cli/cli/commands/implement.py src/specify_cli/cli/commands/merge.py src/specify_cli/sync/daemon.py`
- `.venv/bin/ruff check --select C901 src/specify_cli/cli/commands/implement.py src/specify_cli/cli/commands/merge.py src/specify_cli/sync/daemon.py`
- `.venv/bin/pytest -q tests/specify_cli/coordination/test_transaction.py tests/merge/test_merge_done_recording.py tests/sync/test_daemon.py tests/sync/test_daemon_self_retirement.py`
- `.venv/bin/pytest -q tests/specify_cli/cli/commands/test_implement.py tests/specify_cli/coordination/test_transaction.py -k 'planning or transaction or implement'`
- `.venv/bin/pytest -q tests/next/test_next_claimable_payload.py`
