### PR TITLE
fix: harden bookkeeping and planning auto-commit

### DIFF
--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -213,7 +213,10 @@ def _git_stdout(repo_root: Path, args: list[str]) -> str:
 
 
 def _feature_dir_status_paths(repo_root: Path, feature_dir: Path) -> list[str]:
-    output = _git_stdout(repo_root, ["status", "--porcelain", str(feature_dir)])
+    output = _git_stdout(
+        repo_root,
+        ["status", "--porcelain", "--untracked-files=all", str(feature_dir)],
+    )
     if not output:
         return []
     return [line[3:].strip() for line in output.splitlines() if len(line) >= 4]
@@ -373,9 +376,11 @@ def _ensure_planning_artifacts_committed_git(  # noqa: C901 -- legacy orchestrat
         operation=f"planning artifacts for {mission_slug}",
     ) as txn:
         for path_str in files_to_commit:
-            p = (repo_root / path_str).resolve()
-            if p.exists():
-                txn.stage_path(p)
+            repo_path = Path(path_str)
+            source_path = (repo_root / repo_path).resolve()
+            if not source_path.exists():
+                continue
+            txn.write_artifact(repo_path, source_path.read_bytes())
         try:
             txn.commit(commit_msg)
         except Exception as exc:  # noqa: BLE001 — surface as exit-1

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -151,9 +151,11 @@ def _kitty_specs_dir_name(mission_slug: str, mid8: str) -> str:
 
 def _validate_safe_segment(name: str, value: str) -> str:
     """Return a single safe path segment or raise a bookkeeping error."""
-    candidate = value.strip()
-    if not candidate:
+    if not value:
         raise BookkeepingError(f"{name} cannot be empty")
+    if value != value.strip():
+        raise BookkeepingError(f"{name} must not contain leading or trailing whitespace")
+    candidate = value
     if candidate in {".", ".."} or "/" in candidate or "\\" in candidate:
         raise BookkeepingError(f"{name} must be a single safe path segment")
     if _SAFE_PATH_SEGMENT_RE.fullmatch(candidate) is None:
@@ -275,7 +277,8 @@ def _resolve_legacy_lane_destination(
 
 def _legacy_warning_marker_path(repo_root: Path, mission_id: str) -> Path:
     """Path of the per-mission once-only deprecation warning marker."""
-    return repo_root / ".kittify" / f"legacy-warning-shown-{mission_id}"
+    safe_mission_id = _validate_safe_segment("mission_id", mission_id)
+    return repo_root / ".kittify" / f"legacy-warning-shown-{safe_mission_id}"
 
 
 def _emit_legacy_warning_once(

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -847,13 +847,14 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
         )
 
     # 7-9. Stage + backstop + commit, with prior-staging preservation.
+    resolved_worktree_root = worktree_root.resolve()
     normalized_files: list[str] = []
     for path in paths:
         candidate: Path = path
         if candidate.is_absolute():
             # If the path is not under worktree_root, pass as-is.
             with contextlib.suppress(ValueError):
-                candidate = candidate.relative_to(worktree_root)
+                candidate = candidate.resolve().relative_to(resolved_worktree_root)
         normalized_files.append(str(candidate))
 
     stash_message = f"spec-kitty-safe-commit:{uuid.uuid4()}"

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -618,7 +618,9 @@ def _write_daemon_owner_record(port: int, daemon_token: str | None, *, allow_net
         write_owner_record(record)
     except OSError as exc:  # pragma: no cover - filesystem catastrophe
         logger.warning("Failed to write daemon owner record: %s", exc)
-    except Exception:  # noqa: BLE001 — health remains valid with local-only owner data
+    except Exception:
+        if not allow_network:
+            raise
         logger.debug("Failed to enrich daemon owner record", exc_info=True)
 
 

--- a/tests/specify_cli/cli/commands/test_implement.py
+++ b/tests/specify_cli/cli/commands/test_implement.py
@@ -13,6 +13,7 @@ the small pure-Python shape changes.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -89,3 +90,68 @@ class TestImplementModuleImports:
 
         # Just ensure the symbol is importable as a Typer command.
         assert callable(implement)
+
+
+class TestPlanningArtifactAutoCommit:
+    """Planning artifacts stage from the transaction worktree, not the caller checkout."""
+
+    def test_auto_commit_uses_coordination_worktree_paths(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.implement import _ensure_planning_artifacts_committed_git
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+        mission_slug = "demo-feature"
+        mission_id = "01J6XW9K00000000000000000P"
+        mid8 = mission_id[:8]
+        coord_branch = f"kitty/mission-{mission_slug}-{mid8}"
+
+        git("init", "-q", "-b", "main")
+        git("config", "user.email", "t@example.com")
+        git("config", "user.name", "Test")
+        git("config", "commit.gpgsign", "false")
+        (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        git("add", "seed.txt")
+        git("commit", "-q", "-m", "initial")
+        git("branch", coord_branch)
+
+        feature_dir = repo / "kitty-specs" / mission_slug
+        _make_meta(
+            feature_dir,
+            with_coord=True,
+            mission_id=mission_id,
+            mission_slug=mission_slug,
+        )
+        (feature_dir / "tasks.md").write_text("# tasks\n", encoding="utf-8")
+
+        _ensure_planning_artifacts_committed_git(
+            repo_root=repo,
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            planning_branch="main",
+            auto_commit=True,
+        )
+
+        assert git("rev-parse", "main") != git("rev-parse", coord_branch)
+        assert (
+            git("show", f"{coord_branch}:kitty-specs/{mission_slug}/tasks.md").strip()
+            == "# tasks"
+        )
+        main_tasks = subprocess.run(
+            ["git", "show", f"main:kitty-specs/{mission_slug}/tasks.md"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert main_tasks.returncode != 0

--- a/tests/specify_cli/coordination/test_transaction.py
+++ b/tests/specify_cli/coordination/test_transaction.py
@@ -222,6 +222,37 @@ def test_mission_slug_path_traversal_is_rejected(repo: Path) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("field_name", "mission_slug", "mid8"),
+    [
+        ("mission_slug", " demo-feature", MID8),
+        ("mission_slug", "demo-feature ", MID8),
+        ("mid8", MISSION_SLUG, " 01J6XW9K"),
+        ("mid8", MISSION_SLUG, "01J6XW9K "),
+    ],
+)
+def test_whitespace_bearing_selectors_are_rejected(
+    repo: Path, field_name: str, mission_slug: str, mid8: str,
+) -> None:
+    with pytest.raises(
+        BookkeepingError,
+        match=rf"{field_name} must not contain leading or trailing whitespace",
+    ):
+        BookkeepingTransaction.acquire(
+            repo_root=repo,
+            mission_id=MISSION_ID,
+            mission_slug=mission_slug,
+            mid8=mid8,
+            destination_ref=COORD_BRANCH,
+            operation="unsafe_whitespace",
+        )
+
+
+def test_legacy_warning_marker_confines_mission_id(repo: Path) -> None:
+    with pytest.raises(BookkeepingError, match="mission_id must be a single safe path segment"):
+        transaction_module._legacy_warning_marker_path(repo, "../escape")
+
+
 # ---------------------------------------------------------------------------
 # Rollback (byte-identical via SHA-256)
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/git/test_commit_helpers.py
+++ b/tests/specify_cli/git/test_commit_helpers.py
@@ -99,6 +99,25 @@ def test_safe_commit_happy_path(lane_repo: Path) -> None:
     assert "WP01: add alpha" in log
 
 
+def test_safe_commit_accepts_realpath_under_symlinked_worktree(lane_repo: Path, tmp_path: Path) -> None:
+    """Absolute paths resolved via the real path still normalize under a symlinked worktree."""
+    repo_alias = tmp_path / "repo-alias"
+    repo_alias.symlink_to(lane_repo, target_is_directory=True)
+
+    target = (lane_repo / "alpha.txt").resolve()
+    target.write_text("alpha v1\n", encoding="utf-8")
+
+    result = safe_commit(
+        repo_root=repo_alias,
+        worktree_root=repo_alias,
+        destination_ref="kitty/mission-test-01ABCDEF",
+        message="WP01: add alpha via alias",
+        paths=(target,),
+    )
+
+    assert isinstance(result, CommitResult)
+
+
 def test_safe_commit_head_mismatch(lane_repo: Path) -> None:
     """Worktree on a different branch → SafeCommitHeadMismatch with structured fields."""
     # Create + check out an *other* branch.

--- a/tests/sync/test_daemon.py
+++ b/tests/sync/test_daemon.py
@@ -147,6 +147,40 @@ class TestBackgroundScript:
         assert "'abc'" in script
 
 
+class TestDaemonOwnerRecordWrite:
+    """Initial owner-record write fails closed; enrichment stays best-effort."""
+
+    def test_initial_write_propagates_non_oserror(self, monkeypatch):
+        monkeypatch.setattr(
+            "specify_cli.sync.owner.build_record_for_current_process",
+            lambda **kwargs: {"pid": kwargs["pid"], "port": kwargs["port"]},
+        )
+
+        def fail_write(_record):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("specify_cli.sync.owner.write_owner_record", fail_write)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            daemon._write_daemon_owner_record(9410, "tok", allow_network=False)
+
+    def test_enrichment_write_swallows_non_oserror(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "specify_cli.sync.owner.build_record_for_current_process",
+            lambda **kwargs: {"pid": kwargs["pid"], "port": kwargs["port"]},
+        )
+
+        def fail_write(_record):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("specify_cli.sync.owner.write_owner_record", fail_write)
+
+        with caplog.at_level("DEBUG"):
+            daemon._write_daemon_owner_record(9410, "tok", allow_network=True)
+
+        assert "Failed to enrich daemon owner record" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # Fix #3 — Daemon log file for stderr/stdout
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- reject whitespace-bearing bookkeeping selectors and confine legacy warning marker filenames\n- fail closed on initial daemon owner-record write while keeping background enrichment best-effort\n- mirror planning artifacts into the coordination worktree for auto-commit, including untracked files, and normalize symlinked worktree paths for safe_commit\n\n## Testing\n- pytest -q tests/specify_cli/git/test_commit_helpers.py tests/specify_cli/coordination/test_transaction.py tests/sync/test_daemon.py tests/specify_cli/cli/commands/test_implement.py\n- ruff check src/specify_cli/git/commit_helpers.py src/specify_cli/coordination/transaction.py src/specify_cli/sync/daemon.py src/specify_cli/cli/commands/implement.py tests/specify_cli/git/test_commit_helpers.py tests/specify_cli/coordination/test_transaction.py tests/sync/test_daemon.py tests/specify_cli/cli/commands/test_implement.py\n- direct Python repro of _ensure_planning_artifacts_committed_git against a temp git repo