### PR TITLE
Require spec-kitty-dev canary evidence before release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,12 +405,66 @@ jobs:
             downstream-verify.log
           retention-days: 90
 
+  canary-verify:
+    # Priivacy-ai/spec-kitty#1112: no release publication proceeds on narrative
+    # canary claims. Operators must provide a machine-readable artifact proving
+    # four clean spec-kitty-dev canary runs, or a structured release-owner waiver.
+    name: Spec Kitty dev canary verification
+    needs: build-release
+    runs-on: ubuntu-latest
+    env:
+      HAS_CANARY_VERIFICATION: ${{ secrets.SPEC_KITTY_CANARY_VERIFICATION_JSON != '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Materialize canary verification artifact
+        run: |
+          set -euo pipefail
+          if [ "${HAS_CANARY_VERIFICATION}" != "true" ]; then
+            echo "::error::SPEC_KITTY_CANARY_VERIFICATION_JSON is required before release publication."
+            echo "::error::Provide four clean spec-kitty-dev canary runs or a structured waiver for #1112."
+            exit 1
+          fi
+          mkdir -p .kittify/release
+          cat > .kittify/release/canary-verified.json <<'EOF'
+          ${{ secrets.SPEC_KITTY_CANARY_VERIFICATION_JSON }}
+          EOF
+
+      - name: Validate canary verification artifact
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          python scripts/release/check_canary_verification.py \
+            --artifact .kittify/release/canary-verified.json \
+            --candidate-version "${VERSION}" \
+            --expected-target "https://spec-kitty-dev.fly.dev/" \
+            --required-clean-runs 4 \
+            --allow-waiver
+
+      - name: Upload canary verification artifact
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: canary-verified
+          path: .kittify/release/canary-verified.json
+          retention-days: 90
+
   publish-pypi:
     name: Publish to PyPI
-    # FR-026: promotion to PyPI is gated on downstream-consumer-verify.
+    # FR-026 and #1112: promotion to PyPI is gated on downstream consumer and
+    # spec-kitty-dev canary verification artifacts.
     needs:
       - build-release
       - downstream-consumer-verify
+      - canary-verify
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -418,6 +472,16 @@ jobs:
       name: pypi
       url: https://pypi.org/project/spec-kitty-cli/
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -428,6 +492,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: downstream-verified
+          path: .
+
+      - name: Download canary verification artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: canary-verified
           path: .
 
       - name: Verify downstream-consumer-verify produced a passing artifact
@@ -448,6 +518,27 @@ jobs:
             echo "::error::Downstream verification status='$STATUS'; promotion blocked."
             exit 1
           fi
+
+      - name: Verify canary-verify produced an acceptable artifact
+        # Defense in depth: even if `needs:` were ever loosened, refuse to
+        # publish without structured canary evidence (spec-kitty#1112).
+        run: |
+          set -euo pipefail
+          ARTIFACT=.kittify/release/canary-verified.json
+          if [ ! -f "$ARTIFACT" ]; then
+            ARTIFACT=$(find . -path '*/canary-verified.json' -type f | head -n 1 || true)
+            if [ -z "$ARTIFACT" ]; then
+              echo "::error::Missing canary verification artifact at .kittify/release/canary-verified.json."
+              exit 1
+            fi
+          fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          python scripts/release/check_canary_verification.py \
+            --artifact "$ARTIFACT" \
+            --candidate-version "${VERSION}" \
+            --expected-target "https://spec-kitty-dev.fly.dev/" \
+            --required-clean-runs 4 \
+            --allow-waiver
 
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,26 +241,6 @@ jobs:
           sha256sum dist/* > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
-      - name: Extract changelog for release
-        id: changelog
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          python scripts/release/extract_changelog.py "${VERSION}" > release-notes.md
-          cat release-notes.md
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.0
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          body_path: release-notes.md
-          files: |
-            dist/*.whl
-            dist/*.tar.gz
-            SHA256SUMS.txt
-            sbom.cdx.json
-          draft: false
-          prerelease: ${{ steps.release_channel.outputs.is_prerelease }}
-
       - name: Upload test output
         uses: actions/upload-artifact@v7
         if: always()
@@ -277,6 +257,7 @@ jobs:
           path: |
             dist/
             SHA256SUMS.txt
+            sbom.cdx.json
           retention-days: 30
 
   downstream-consumer-verify:
@@ -467,6 +448,7 @@ jobs:
       - canary-verify
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     environment:
       name: pypi
@@ -539,6 +521,26 @@ jobs:
             --expected-target "https://spec-kitty-dev.fly.dev/" \
             --required-clean-runs 4 \
             --allow-waiver
+
+      - name: Extract changelog for release
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python scripts/release/extract_changelog.py "${VERSION}" > release-notes.md
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3.0.0
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: release-notes.md
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            SHA256SUMS.txt
+            sbom.cdx.json
+          draft: false
+          prerelease: ${{ steps.release_channel.outputs.is_prerelease }}
 
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -70,6 +70,19 @@ Use this checklist for releases from `main`.
     --package spec-kitty-cli \
     --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json
   ```
+- [ ] Record four clean `spec-kitty-dev` canary runs for the exact candidate
+      version in a machine-readable artifact. The release workflow reads the
+      same JSON shape from `SPEC_KITTY_CANARY_VERIFICATION_JSON`:
+  ```bash
+  python scripts/release/check_canary_verification.py \
+    --artifact /path/to/canary-verified.json \
+    --candidate-version X.Y.Z \
+    --expected-target https://spec-kitty-dev.fly.dev/ \
+    --required-clean-runs 4
+  ```
+  If the canary cannot run, create a structured waiver artifact with a
+  Priivacy-ai/spec-kitty issue link and explicit expiry, then validate it with
+  `--allow-waiver`. Do not rely on narrative release notes as canary evidence.
 
 ### Documentation and Metadata
 
@@ -176,6 +189,7 @@ package first, verify it is installable from PyPI, and only then tag the CLI.
   - checks shared-package drift
   - proves exact wheel installability with plain `pip`
   - validates candidate compatibility against the SaaS consumer contract
+  - validates four clean `spec-kitty-dev` canary runs or a structured waiver
   - builds distributions
   - publishes to PyPI
   - creates the GitHub release

--- a/scripts/release/check_canary_verification.py
+++ b/scripts/release/check_canary_verification.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate Spec Kitty dev canary evidence before release publication."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", required=True, help="Path to canary evidence JSON")
+    parser.add_argument("--candidate-version", required=True)
+    parser.add_argument(
+        "--expected-target",
+        default="https://spec-kitty-dev.fly.dev/",
+        help="Canary target that must have been exercised.",
+    )
+    parser.add_argument("--required-clean-runs", type=int, default=4)
+    parser.add_argument(
+        "--allow-waiver",
+        action="store_true",
+        help="Accept a structured release-owner waiver instead of passed canaries.",
+    )
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SystemExit(f"Canary verification artifact not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Canary verification artifact is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit("Canary verification artifact must be a JSON object")
+    return data
+
+
+def _normalise_url(value: str) -> str:
+    return value.rstrip("/") + "/"
+
+
+def _require_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"Canary verification artifact missing non-empty string: {key}")
+    return value.strip()
+
+
+def _parse_datetime(value: str, *, key: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SystemExit(f"{key} must be an ISO-8601 timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise SystemExit(f"{key} must include timezone information: {value!r}")
+    return parsed
+
+
+def _validate_common(data: dict[str, Any], *, candidate_version: str, expected_target: str) -> None:
+    artifact_version = _require_str(data, "candidate_version")
+    if artifact_version != candidate_version:
+        raise SystemExit(
+            "Canary verification candidate_version mismatch: "
+            f"expected {candidate_version!r}, got {artifact_version!r}"
+        )
+
+    target = _require_str(data, "target")
+    if _normalise_url(target) != _normalise_url(expected_target):
+        raise SystemExit(
+            "Canary verification target mismatch: "
+            f"expected {expected_target!r}, got {target!r}"
+        )
+
+    _parse_datetime(_require_str(data, "verified_at"), key="verified_at")
+
+
+def _validate_passed(data: dict[str, Any], *, required_clean_runs: int) -> None:
+    clean_runs = data.get("clean_runs")
+    if not isinstance(clean_runs, list):
+        raise SystemExit("Passed canary artifact must include clean_runs list")
+    if len(clean_runs) < required_clean_runs:
+        raise SystemExit(
+            f"Canary verification requires at least {required_clean_runs} clean runs; "
+            f"artifact contains {len(clean_runs)}"
+        )
+
+    for index, raw_run in enumerate(clean_runs, start=1):
+        if not isinstance(raw_run, dict):
+            raise SystemExit(f"clean_runs[{index}] must be a JSON object")
+        if raw_run.get("result") != "passed":
+            raise SystemExit(f"clean_runs[{index}] result must be 'passed'")
+        _require_str(raw_run, "run_id")
+        _parse_datetime(_require_str(raw_run, "completed_at"), key=f"clean_runs[{index}].completed_at")
+        if "target" in raw_run and not isinstance(raw_run["target"], str):
+            raise SystemExit(f"clean_runs[{index}].target must be a string when present")
+        if "health_ready_status" in raw_run and raw_run["health_ready_status"] not in {"ok", "pass", "passed"}:
+            raise SystemExit(
+                f"clean_runs[{index}].health_ready_status must be ok/pass/passed when present"
+            )
+
+
+def _validate_waiver(data: dict[str, Any], *, allow_waiver: bool) -> None:
+    if not allow_waiver:
+        raise SystemExit("Canary verification artifact is waived, but waivers are not allowed here")
+
+    waiver = data.get("waiver")
+    if not isinstance(waiver, dict):
+        raise SystemExit("Waived canary artifact must include waiver object")
+
+    reason = _require_str(waiver, "reason")
+    if len(reason) < 20:
+        raise SystemExit("Canary waiver reason must be specific, not a placeholder")
+    _require_str(waiver, "approved_by")
+    issue_url = _require_str(waiver, "issue_url")
+    if not issue_url.startswith("https://github.com/Priivacy-ai/spec-kitty/issues/"):
+        raise SystemExit("Canary waiver issue_url must point at a Priivacy-ai/spec-kitty issue")
+
+    expires_at = _parse_datetime(_require_str(waiver, "expires_at"), key="waiver.expires_at")
+    if expires_at <= datetime.now(UTC):
+        raise SystemExit("Canary waiver has expired")
+
+
+def main() -> int:
+    args = parse_args()
+    data = _load_json(Path(args.artifact))
+    _validate_common(
+        data,
+        candidate_version=args.candidate_version,
+        expected_target=args.expected_target,
+    )
+
+    status = data.get("status")
+    if status == "passed":
+        _validate_passed(data, required_clean_runs=args.required_clean_runs)
+    elif status == "waived":
+        _validate_waiver(data, allow_waiver=args.allow_waiver)
+    else:
+        raise SystemExit("Canary verification status must be 'passed' or 'waived'")
+
+    print("Canary Verification Summary")
+    print("---------------------------")
+    print(f"- status: {status}")
+    print(f"- candidate_version: {data['candidate_version']}")
+    print(f"- target: {data['target']}")
+    if status == "passed":
+        print(f"- clean_runs: {len(data['clean_runs'])}")
+    else:
+        print(f"- waiver_issue: {data['waiver']['issue_url']}")
+    print("\nCanary verification check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/check_canary_verification.py
+++ b/scripts/release/check_canary_verification.py
@@ -79,7 +79,7 @@ def _validate_common(data: dict[str, Any], *, candidate_version: str, expected_t
     _parse_datetime(_require_str(data, "verified_at"), key="verified_at")
 
 
-def _validate_passed(data: dict[str, Any], *, required_clean_runs: int) -> None:
+def _validate_passed(data: dict[str, Any], *, required_clean_runs: int, expected_target: str) -> None:
     clean_runs = data.get("clean_runs")
     if not isinstance(clean_runs, list):
         raise SystemExit("Passed canary artifact must include clean_runs list")
@@ -89,15 +89,22 @@ def _validate_passed(data: dict[str, Any], *, required_clean_runs: int) -> None:
             f"artifact contains {len(clean_runs)}"
         )
 
+    seen_run_ids: set[str] = set()
     for index, raw_run in enumerate(clean_runs, start=1):
         if not isinstance(raw_run, dict):
             raise SystemExit(f"clean_runs[{index}] must be a JSON object")
         if raw_run.get("result") != "passed":
             raise SystemExit(f"clean_runs[{index}] result must be 'passed'")
-        _require_str(raw_run, "run_id")
+        run_id = _require_str(raw_run, "run_id")
+        if run_id in seen_run_ids:
+            raise SystemExit(f"clean_runs[{index}] run_id must be unique")
+        seen_run_ids.add(run_id)
         _parse_datetime(_require_str(raw_run, "completed_at"), key=f"clean_runs[{index}].completed_at")
-        if "target" in raw_run and not isinstance(raw_run["target"], str):
-            raise SystemExit(f"clean_runs[{index}].target must be a string when present")
+        run_target = _require_str(raw_run, "target")
+        if _normalise_url(run_target) != _normalise_url(expected_target):
+            raise SystemExit(
+                f"clean_runs[{index}].target mismatch: expected {expected_target!r}, got {run_target!r}"
+            )
         if "health_ready_status" in raw_run and raw_run["health_ready_status"] not in {"ok", "pass", "passed"}:
             raise SystemExit(
                 f"clean_runs[{index}].health_ready_status must be ok/pass/passed when present"
@@ -136,7 +143,11 @@ def main() -> int:
 
     status = data.get("status")
     if status == "passed":
-        _validate_passed(data, required_clean_runs=args.required_clean_runs)
+        _validate_passed(
+            data,
+            required_clean_runs=args.required_clean_runs,
+            expected_target=args.expected_target,
+        )
     elif status == "waived":
         _validate_waiver(data, allow_waiver=args.allow_waiver)
     else:

--- a/tests/release/test_check_canary_verification.py
+++ b/tests/release/test_check_canary_verification.py
@@ -39,6 +39,7 @@ def _passed_payload() -> dict[str, object]:
                 "run_id": f"canary-{idx}",
                 "result": "passed",
                 "completed_at": f"2026-06-01T08:0{idx}:00Z",
+                "target": "https://spec-kitty-dev.fly.dev/",
                 "health_ready_status": "ok",
             }
             for idx in range(1, 5)
@@ -71,6 +72,27 @@ def test_candidate_version_must_match_release_tag(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "candidate_version mismatch" in result.stderr
+
+
+def test_clean_runs_must_have_unique_run_ids(tmp_path: Path) -> None:
+    payload = _passed_payload()
+    for run in payload["clean_runs"]:  # type: ignore[union-attr]
+        run["run_id"] = "duplicated-run"  # type: ignore[index]
+
+    result = _run(tmp_path, payload)
+
+    assert result.returncode == 1
+    assert "run_id must be unique" in result.stderr
+
+
+def test_clean_run_targets_must_match_expected_target(tmp_path: Path) -> None:
+    payload = _passed_payload()
+    payload["clean_runs"][0]["target"] = "https://not-spec-kitty-dev.example/"  # type: ignore[index]
+
+    result = _run(tmp_path, payload)
+
+    assert result.returncode == 1
+    assert "clean_runs[1].target mismatch" in result.stderr
 
 
 def test_waiver_requires_explicit_allow_waiver(tmp_path: Path) -> None:

--- a/tests/release/test_check_canary_verification.py
+++ b/tests/release/test_check_canary_verification.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/release/check_canary_verification.py")
+
+
+def _run(tmp_path: Path, payload: dict[str, object], *extra: str) -> subprocess.CompletedProcess[str]:
+    artifact = tmp_path / "canary-verified.json"
+    artifact.write_text(json.dumps(payload), encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--artifact",
+            str(artifact),
+            "--candidate-version",
+            "3.2.0rc31",
+            *extra,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _passed_payload() -> dict[str, object]:
+    return {
+        "status": "passed",
+        "candidate_version": "3.2.0rc31",
+        "target": "https://spec-kitty-dev.fly.dev/",
+        "verified_at": "2026-06-01T08:00:00Z",
+        "clean_runs": [
+            {
+                "run_id": f"canary-{idx}",
+                "result": "passed",
+                "completed_at": f"2026-06-01T08:0{idx}:00Z",
+                "health_ready_status": "ok",
+            }
+            for idx in range(1, 5)
+        ],
+    }
+
+
+def test_passed_artifact_requires_four_clean_runs(tmp_path: Path) -> None:
+    result = _run(tmp_path, _passed_payload())
+
+    assert result.returncode == 0, result.stderr
+    assert "clean_runs: 4" in result.stdout
+
+
+def test_passed_artifact_rejects_too_few_runs(tmp_path: Path) -> None:
+    payload = _passed_payload()
+    payload["clean_runs"] = payload["clean_runs"][:3]  # type: ignore[index]
+
+    result = _run(tmp_path, payload)
+
+    assert result.returncode == 1
+    assert "requires at least 4 clean runs" in result.stderr
+
+
+def test_candidate_version_must_match_release_tag(tmp_path: Path) -> None:
+    payload = _passed_payload()
+    payload["candidate_version"] = "3.2.0rc30"
+
+    result = _run(tmp_path, payload)
+
+    assert result.returncode == 1
+    assert "candidate_version mismatch" in result.stderr
+
+
+def test_waiver_requires_explicit_allow_waiver(tmp_path: Path) -> None:
+    payload = {
+        "status": "waived",
+        "candidate_version": "3.2.0rc31",
+        "target": "https://spec-kitty-dev.fly.dev/",
+        "verified_at": "2026-06-01T08:00:00Z",
+        "waiver": {
+            "reason": "Fly credentials were unavailable; release owner accepted documented residual risk.",
+            "approved_by": "release-owner",
+            "issue_url": "https://github.com/Priivacy-ai/spec-kitty/issues/1112",
+            "expires_at": "2999-01-01T00:00:00Z",
+        },
+    }
+
+    rejected = _run(tmp_path, payload)
+    accepted = _run(tmp_path, payload, "--allow-waiver")
+
+    assert rejected.returncode == 1
+    assert "waivers are not allowed" in rejected.stderr
+    assert accepted.returncode == 0, accepted.stderr

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -129,3 +129,24 @@ def test_quality_gate_fails_closed_for_release_required_package_jobs() -> None:
     assert 'if [ "$result" != "success" ]; then' in script
     for job_name in release_required - {"changes"}:
         assert f"needs.{job_name}.result" in script
+
+
+def test_publish_release_requires_canary_verification_artifact() -> None:
+    workflow = load_workflow("release.yml")
+    jobs = workflow["jobs"]
+
+    assert "canary-verify" in jobs
+    publish = jobs["publish-pypi"]
+    assert "canary-verify" in publish["needs"]
+
+    canary_job_dump = repr(jobs["canary-verify"])
+    assert "SPEC_KITTY_CANARY_VERIFICATION_JSON" in canary_job_dump
+    assert "check_canary_verification.py" in canary_job_dump
+    assert "--required-clean-runs 4" in canary_job_dump
+    assert "canary-verified" in canary_job_dump
+
+    publish_dump = repr(publish)
+    assert "actions/checkout" in publish_dump
+    assert "Download canary verification artifact" in publish_dump
+    assert "Verify canary-verify produced an acceptable artifact" in publish_dump
+    assert "check_canary_verification.py" in publish_dump

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -147,6 +147,18 @@ def test_publish_release_requires_canary_verification_artifact() -> None:
 
     publish_dump = repr(publish)
     assert "actions/checkout" in publish_dump
+    assert publish["permissions"]["contents"] == "write"
     assert "Download canary verification artifact" in publish_dump
     assert "Verify canary-verify produced an acceptable artifact" in publish_dump
     assert "check_canary_verification.py" in publish_dump
+    assert "Create GitHub Release" in publish_dump
+    assert "Create GitHub Release" not in repr(jobs["build-release"])
+    assert "sbom.cdx.json" in repr(jobs["build-release"])
+
+    step_names = [step.get("name", "") for step in publish["steps"]]
+    assert step_names.index("Verify downstream-consumer-verify produced a passing artifact") < step_names.index(
+        "Create GitHub Release"
+    )
+    assert step_names.index("Verify canary-verify produced an acceptable artifact") < step_names.index(
+        "Create GitHub Release"
+    )


### PR DESCRIPTION
## Summary
- add a machine-readable canary verification validator for spec-kitty-dev release evidence
- gate release publication on a canary verification artifact in addition to downstream verification
- document the canary evidence/waiver workflow in the release checklist

Closes #1112.

## Verification
- .venv/bin/pytest tests/release/test_check_canary_verification.py tests/release/test_release_ci_ownership.py -q
- .venv/bin/ruff check scripts/release/check_canary_verification.py tests/release/test_check_canary_verification.py tests/release/test_release_ci_ownership.py

## Adversarial review
- Found and fixed: publish-pypi did not check out the repository before invoking the validator script.
- Residual: live spec-kitty-dev canary execution requires operator-provided evidence via SPEC_KITTY_CANARY_VERIFICATION_JSON; this PR intentionally fails closed when absent.