### PR TITLE
Fix decision open JSON contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `spec-kitty agent decision open --json` now emits exactly one parseable JSON
   object on stdout. The response includes a retry-safe idempotency key so callers
   can rerun the same logical open by mission slug and recover the same
-  `decision_id` after wrapper parse/process failures.
+  `decision_id` after wrapper parse/process failures. Idempotent retries repair
+  a missing opened event when local decision files were persisted before event
+  emission failed, and dry-run output no longer advertises persisted recovery.
 - `charter generate --force` now refuses to overwrite symlinked `charter.md` paths,
   preventing silent writes through symlink targets.
 - Sync WebSocket connections now send ephemeral `ws_token` credentials in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `spec-kitty agent decision open --json` now emits exactly one parseable JSON
+  object on stdout. The response includes a retry-safe idempotency key so callers
+  can rerun the same logical open by mission slug and recover the same
+  `decision_id` after wrapper parse/process failures.
 - `charter generate --force` now refuses to overwrite symlinked `charter.md` paths,
   preventing silent writes through symlink targets.
 - Sync WebSocket connections now send ephemeral `ws_token` credentials in the

--- a/docs/reference/agent-subcommands.md
+++ b/docs/reference/agent-subcommands.md
@@ -411,6 +411,13 @@ _Decision Moment ledger for interview questions._
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
+Success stdout is exactly one JSON object. For `open`, the object includes
+`decision_id`, `contract: "decision_open_v2"`, and `recovery.idempotency_key`;
+rerunning the same logical open while the decision is still open returns the same
+`decision_id` with `idempotent: true`. The recovery key includes the CLI mission
+slug plus the logical decision tuple (`origin_flow`, `step_id`/`slot_key`,
+`input_key`) needed to rerun.
+
 ## spec-kitty agent decision resolve
 
 ```

--- a/docs/reference/agent-subcommands.md
+++ b/docs/reference/agent-subcommands.md
@@ -416,7 +416,8 @@ Success stdout is exactly one JSON object. For `open`, the object includes
 rerunning the same logical open while the decision is still open returns the same
 `decision_id` with `idempotent: true`. The recovery key includes the CLI mission
 slug plus the logical decision tuple (`origin_flow`, `step_id`/`slot_key`,
-`input_key`) needed to rerun.
+`input_key`) needed to rerun. Dry-run output keeps the same JSON shape but sets
+`recovery.rerun_safe: false` because no decision is persisted.
 
 ## spec-kitty agent decision resolve
 

--- a/src/specify_cli/cli/commands/decision.py
+++ b/src/specify_cli/cli/commands/decision.py
@@ -113,6 +113,7 @@ def _open_response_to_dict(
     input_key: str,
 ) -> dict:  # type: ignore[type-arg]
     """Serialize DecisionOpenResponse to a plain dict."""
+    rerun_safe = resp.decision_id != "DRY_RUN"
     return {
         "contract": "decision_open_v2",
         "decision_id": resp.decision_id,
@@ -121,7 +122,7 @@ def _open_response_to_dict(
         "artifact_path": resp.artifact_path,
         "event_lamport": resp.event_lamport,
         "recovery": {
-            "rerun_safe": True,
+            "rerun_safe": rerun_safe,
             "idempotency_key": {
                 "mission_id": resp.mission_id,
                 "mission_slug": mission_slug,

--- a/src/specify_cli/cli/commands/decision.py
+++ b/src/specify_cli/cli/commands/decision.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 import re as _re
-import sys
 from pathlib import Path
 
 import typer
@@ -104,14 +103,34 @@ def _resolve_repo_root_and_slug(mission_handle: str) -> tuple[Path, str]:
     return repo_root, mission_handle
 
 
-def _open_response_to_dict(resp: DecisionOpenResponse) -> dict:  # type: ignore[type-arg]
+def _open_response_to_dict(
+    resp: DecisionOpenResponse,
+    *,
+    origin_flow: OriginFlow,
+    mission_slug: str,
+    step_id: str | None,
+    slot_key: str | None,
+    input_key: str,
+) -> dict:  # type: ignore[type-arg]
     """Serialize DecisionOpenResponse to a plain dict."""
     return {
+        "contract": "decision_open_v2",
         "decision_id": resp.decision_id,
         "idempotent": resp.idempotent,
         "mission_id": resp.mission_id,
         "artifact_path": resp.artifact_path,
         "event_lamport": resp.event_lamport,
+        "recovery": {
+            "rerun_safe": True,
+            "idempotency_key": {
+                "mission_id": resp.mission_id,
+                "mission_slug": mission_slug,
+                "origin_flow": origin_flow.value,
+                "step_id": step_id,
+                "slot_key": slot_key,
+                "input_key": input_key,
+            },
+        },
     }
 
 
@@ -194,12 +213,6 @@ def cmd_open(  # noqa: PLR0913
 
     repo_root, mission_slug = _resolve_repo_root_and_slug(mission)
 
-    def emit_minted(decision_id: str) -> None:
-        typer.echo(
-            json.dumps({"decision_id": decision_id, "phase": "minted"}, sort_keys=True)
-        )
-        sys.stdout.flush()
-
     try:
         resp = open_decision(
             repo_root,
@@ -212,13 +225,24 @@ def cmd_open(  # noqa: PLR0913
             slot_key=slot_key,
             actor=actor,
             dry_run=dry_run,
-            on_minted=emit_minted,
         )
     except DecisionError as exc:
         _handle_decision_error(exc)
         return
 
-    typer.echo(json.dumps(_open_response_to_dict(resp), sort_keys=True))
+    typer.echo(
+        json.dumps(
+            _open_response_to_dict(
+                resp,
+                origin_flow=origin_flow,
+                mission_slug=mission_slug,
+                step_id=step_id,
+                slot_key=slot_key,
+                input_key=input_key,
+            ),
+            sort_keys=True,
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/decisions/models.py
+++ b/src/specify_cli/decisions/models.py
@@ -54,6 +54,7 @@ class DecisionErrorCode(StrEnum):
 
     MISSING_STEP_OR_SLOT = "DECISION_MISSING_STEP_OR_SLOT"
     ALREADY_CLOSED = "DECISION_ALREADY_CLOSED"
+    EVENT_REPAIR_FAILED = "DECISION_EVENT_REPAIR_FAILED"
     TERMINAL_CONFLICT = "DECISION_TERMINAL_CONFLICT"
     NOT_FOUND = "DECISION_NOT_FOUND"
     MISSION_NOT_FOUND = "MISSION_NOT_FOUND"
@@ -85,6 +86,7 @@ class IndexEntry(BaseModel):
     created_at: datetime
     resolved_at: datetime | None = None
     resolved_by: str | None = None
+    opened_by: str | None = None
     mission_id: str
     mission_slug: str
 

--- a/src/specify_cli/decisions/service.py
+++ b/src/specify_cli/decisions/service.py
@@ -177,8 +177,12 @@ def open_decision(
         dry_run:      If True, validate and look up without writing.
         decision_id:  Pre-minted ULID to use as the decision_id.  If None, a
                       new ULID is minted inside this function.
-        on_minted:    Optional callback invoked once the usable decision_id is
-                      known and before any artifact write or event emission.
+        on_minted:    Optional callback invoked with the recoverable
+                      decision_id after an existing open decision is found or a
+                      fresh open has been persisted. Machine callers should
+                      prefer the returned response; if a process exits before
+                      receiving it, rerun the same logical open command to
+                      recover the same idempotent decision_id.
 
     Returns:
         DecisionOpenResponse
@@ -246,8 +250,6 @@ def open_decision(
 
     # Mint new decision (use caller-supplied id if provided, else mint fresh)
     decision_id = decision_id if decision_id is not None else _mint_decision_id()
-    if on_minted is not None:
-        on_minted(decision_id)
     created_at = _now_utc()
     entry = IndexEntry(
         decision_id=decision_id,
@@ -272,6 +274,8 @@ def open_decision(
         entry=entry,
         actor=actor,
     )
+    if on_minted is not None:
+        on_minted(decision_id)
 
     return DecisionOpenResponse(
         decision_id=decision_id,

--- a/src/specify_cli/decisions/service.py
+++ b/src/specify_cli/decisions/service.py
@@ -34,6 +34,7 @@ from specify_cli.decisions.models import (
     IndexEntry,
     OriginFlow,
 )
+from spec_kitty_events.decisionpoint import DECISION_POINT_OPENED
 
 __all__ = [
     "DecisionError",
@@ -142,6 +143,88 @@ def _mission_dir(repo_root: Path, mission_slug: str) -> Path:
     return repo_root / "kitty-specs" / mission_slug
 
 
+def _events_path(repo_root: Path, mission_slug: str) -> Path:
+    """Return kitty-specs/<mission_slug>/status.events.jsonl."""
+    return _mission_dir(repo_root, mission_slug) / "status.events.jsonl"
+
+
+def _opened_event_exists(repo_root: Path, mission_slug: str, decision_id: str) -> bool:
+    """Return True when the canonical opened event already exists."""
+    path = _events_path(repo_root, mission_slug)
+    if not path.exists():
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise DecisionError(
+            code=DecisionErrorCode.EVENT_REPAIR_FAILED,
+            details={"decision_id": decision_id, "events_path": str(path)},
+            message=f"Failed to read decision event log for {decision_id!r}: {exc}",
+        ) from exc
+
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise DecisionError(
+                code=DecisionErrorCode.EVENT_REPAIR_FAILED,
+                details={
+                    "decision_id": decision_id,
+                    "events_path": str(path),
+                    "line": line_number,
+                    "parse_error": str(exc),
+                },
+                message=(
+                    f"Cannot verify opened event for {decision_id!r}: "
+                    f"malformed event log line {line_number}"
+                ),
+            ) from exc
+        payload = event.get("payload")
+        if (
+            event.get("event_type") == DECISION_POINT_OPENED
+            and isinstance(payload, dict)
+            and payload.get("decision_point_id") == decision_id
+        ):
+            return True
+    return False
+
+
+def _repair_missing_opened_event(
+    repo_root: Path,
+    mission_slug: str,
+    *,
+    entry: IndexEntry,
+) -> int | None:
+    """Re-emit a missing opened event for an already-persisted open decision."""
+    if _opened_event_exists(repo_root, mission_slug, entry.decision_id):
+        return None
+    if entry.opened_by is None:
+        raise DecisionError(
+            code=DecisionErrorCode.EVENT_REPAIR_FAILED,
+            details={"decision_id": entry.decision_id, "mission_slug": mission_slug},
+            message=(
+                f"Cannot repair opened event for decision {entry.decision_id!r}: "
+                "opening actor was not persisted"
+            ),
+        )
+    try:
+        return _emit.emit_decision_opened(
+            repo_root,
+            mission_slug,
+            decision_id=entry.decision_id,
+            entry=entry,
+            actor=entry.opened_by,
+        )
+    except Exception as exc:
+        raise DecisionError(
+            code=DecisionErrorCode.EVENT_REPAIR_FAILED,
+            details={"decision_id": entry.decision_id, "mission_slug": mission_slug},
+            message=f"Failed to repair opened event for decision {entry.decision_id!r}: {exc}",
+        ) from exc
+
+
 # ---------------------------------------------------------------------------
 # open_decision
 # ---------------------------------------------------------------------------
@@ -225,6 +308,11 @@ def open_decision(
     if existing is not None:
         if not _is_terminal(existing.status):
             # Idempotent return — already open
+            repaired_lamport = _repair_missing_opened_event(
+                repo_root,
+                mission_slug,
+                entry=existing,
+            )
             if on_minted is not None:
                 on_minted(existing.decision_id)
             return DecisionOpenResponse(
@@ -232,7 +320,7 @@ def open_decision(
                 idempotent=True,
                 mission_id=mission_id,
                 artifact_path=str(_store.artifact_path(mission_dir, existing.decision_id)),
-                event_lamport=None,
+                event_lamport=repaired_lamport,
             )
         else:
             # Already closed — reject
@@ -261,6 +349,7 @@ def open_decision(
         options=tuple(options),
         status=DecisionStatus.OPEN,
         created_at=created_at,
+        opened_by=actor,
         mission_id=mission_id,
         mission_slug=mission_slug,
     )

--- a/src/specify_cli/decisions/store.py
+++ b/src/specify_cli/decisions/store.py
@@ -171,6 +171,8 @@ def _render_artifact(entry: IndexEntry) -> str:
         lines.append(f"- **Resolved:** `{entry.resolved_at.isoformat()}`")
     if entry.resolved_by is not None:
         lines.append(f"- **Resolved by:** `{entry.resolved_by}`")
+    if entry.opened_by is not None:
+        lines.append(f"- **Opened by:** `{entry.opened_by}`")
     lines.append(f"- **Other answer:** `{str(entry.other_answer).lower()}`")
     lines.append("")
 

--- a/tests/specify_cli/cli/commands/test_decision.py
+++ b/tests/specify_cli/cli/commands/test_decision.py
@@ -119,6 +119,33 @@ def test_open_dry_run_returns_dry_run_id(tmp_path: Path) -> None:
     assert decision_id == "DRY_RUN"
 
 
+def test_open_dry_run_recovery_is_not_rerun_safe(tmp_path: Path) -> None:
+    _setup_mission(tmp_path)
+    result = _invoke(
+        [
+            "decision",
+            "open",
+            "--mission",
+            MISSION_SLUG,
+            "--flow",
+            "charter",
+            "--step-id",
+            "dry-run-step",
+            "--input-key",
+            "dry_run_key",
+            "--question",
+            "Dry run?",
+            "--dry-run",
+        ],
+        cwd=tmp_path,
+    )
+
+    assert result.exit_code == 0
+    data = _parse_open_output(result.output)
+    assert data["decision_id"] == "DRY_RUN"
+    assert data["recovery"]["rerun_safe"] is False
+
+
 def test_open_dry_run_no_index_written(tmp_path: Path) -> None:
     _setup_mission(tmp_path)
     _open_decision(tmp_path, dry_run=True)

--- a/tests/specify_cli/cli/commands/test_decision.py
+++ b/tests/specify_cli/cli/commands/test_decision.py
@@ -66,20 +66,10 @@ def _invoke(args: list[str], cwd: Path | None = None) -> object:
 
 
 def _parse_open_output(output: str) -> dict:  # type: ignore[type-arg]
-    """Parse ``decision open`` stdout: first line is minted-phase, second is full response.
-
-    Returns the full response dict (second JSON line).
-    """
+    """Parse ``decision open`` stdout as exactly one JSON object."""
     lines = [line for line in output.splitlines() if line.strip()]
-    assert len(lines) >= 2, f"expected >=2 JSON lines, got: {output!r}"
-    return json.loads(lines[-1])
-
-
-def _parse_open_lines(output: str) -> tuple[dict, dict]:  # type: ignore[type-arg]
-    """Parse ``decision open`` stdout into minted-phase and response dicts."""
-    lines = [line for line in output.splitlines() if line.strip()]
-    assert len(lines) == 2, f"expected 2 JSON lines, got: {output!r}"
-    return json.loads(lines[0]), json.loads(lines[1])
+    assert len(lines) == 1, f"expected exactly 1 JSON line, got: {output!r}"
+    return json.loads(lines[0])
 
 
 def _open_decision(
@@ -114,12 +104,7 @@ def _open_decision(
         result = _invoke(base_args, cwd=tmp_path)
 
     assert result.exit_code == 0, f"open failed: {result.output}"
-    # dry-run emits only the minted-phase line (id="DRY_RUN"); non-dry-run emits two lines.
-    lines = [line for line in result.output.splitlines() if line.strip()]
-    if dry_run:
-        data = json.loads(lines[0])
-    else:
-        data = json.loads(lines[-1])
+    data = _parse_open_output(result.output)
     return data["decision_id"]
 
 
@@ -172,9 +157,19 @@ def test_open_happy_path_exit_0(tmp_path: Path) -> None:
     data = _parse_open_output(result.output)
     assert data["decision_id"] != "DRY_RUN"
     assert len(data["decision_id"]) == 26
+    assert data["contract"] == "decision_open_v2"
     assert data["idempotent"] is False
     assert data["mission_id"] == MISSION_ID
     assert "artifact_path" in data
+    assert data["recovery"]["rerun_safe"] is True
+    assert data["recovery"]["idempotency_key"] == {
+        "mission_id": MISSION_ID,
+        "mission_slug": MISSION_SLUG,
+        "origin_flow": "specify",
+        "step_id": None,
+        "slot_key": "my-slot",
+        "input_key": "team_size",
+    }
 
 
 def test_open_happy_path_event_lamport(tmp_path: Path) -> None:
@@ -615,7 +610,7 @@ def test_open_idempotent_second_call(tmp_path: Path) -> None:
     assert data2["decision_id"] == data1["decision_id"]
 
 
-def test_open_idempotent_minted_phase_uses_persisted_decision_id(tmp_path: Path) -> None:
+def test_open_idempotent_single_json_uses_persisted_decision_id(tmp_path: Path) -> None:
     _setup_mission(tmp_path)
     with patch("specify_cli.decisions.emit.emit_decision_opened", return_value=1):
         result1 = _invoke(
@@ -656,14 +651,11 @@ def test_open_idempotent_minted_phase_uses_persisted_decision_id(tmp_path: Path)
     assert result1.exit_code == 0
     assert result2.exit_code == 0
 
-    _, first_response = _parse_open_lines(result1.output)
-    second_minted, second_response = _parse_open_lines(result2.output)
+    first_response = _parse_open_output(result1.output)
+    second_response = _parse_open_output(result2.output)
     assert second_response["idempotent"] is True
     assert second_response["decision_id"] == first_response["decision_id"]
-    assert second_minted == {
-        "decision_id": first_response["decision_id"],
-        "phase": "minted",
-    }
+    assert second_response["contract"] == "decision_open_v2"
 
 
 # ---------------------------------------------------------------------------
@@ -735,17 +727,12 @@ def test_open_mission_path_traversal_rejected(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# T020q-fr003 — FR-003: minted-phase JSON line appears FIRST in stdout
+# T020q-fr003 — FR-003: open emits a single JSON object on stdout
 # ---------------------------------------------------------------------------
 
 
-def test_open_emits_minted_phase_first(tmp_path: Path) -> None:
-    """FR-003: decision_id must be emitted on stdout before any artifact write.
-
-    The first stdout line must be a JSON object with decision_id and phase="minted".
-    The second stdout line is the full open response.  The decision_id in both
-    lines must match.
-    """
+def test_open_emits_single_parseable_json_object(tmp_path: Path) -> None:
+    """FR-003: decision open stdout is one stable machine JSON object."""
     _setup_mission(tmp_path)
     with patch("specify_cli.decisions.emit.emit_decision_opened", return_value=1):
         result = _invoke(
@@ -768,16 +755,12 @@ def test_open_emits_minted_phase_first(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     lines = [line for line in result.output.splitlines() if line.strip()]
-    assert len(lines) == 2, f"expected 2 JSON lines, got: {result.output!r}"
+    assert len(lines) == 1, f"expected 1 JSON line, got: {result.output!r}"
 
-    first_line = json.loads(lines[0])
-    assert first_line["phase"] == "minted", "first line must be minted-phase"
-    assert len(first_line["decision_id"]) == 26, "minted decision_id must be a ULID"
-
-    second_line = json.loads(lines[1])
-    assert second_line["decision_id"] == first_line["decision_id"], (
-        "decision_id in minted-phase line must match the full response"
-    )
+    payload = json.loads(result.output)
+    assert len(payload["decision_id"]) == 26, "decision_id must be a ULID"
+    assert payload["contract"] == "decision_open_v2"
+    assert payload["recovery"]["idempotency_key"]["step_id"] == "fr003-step"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/decisions/test_service_idempotency.py
+++ b/tests/specify_cli/decisions/test_service_idempotency.py
@@ -166,7 +166,7 @@ def test_on_minted_receives_persisted_id_for_idempotent_open(tmp_path: Path) -> 
     assert minted_ids == [resp1.decision_id, resp1.decision_id]
 
 
-def test_on_minted_runs_before_fresh_open_writes_artifact(tmp_path: Path) -> None:
+def test_on_minted_runs_after_fresh_open_writes_artifact(tmp_path: Path) -> None:
     _setup_meta(tmp_path)
     observations: list[tuple[str, bool]] = []
 
@@ -188,7 +188,7 @@ def test_on_minted_runs_before_fresh_open_writes_artifact(tmp_path: Path) -> Non
             on_minted=record_minted,
         )
 
-    assert observations == [(resp.decision_id, False)]
+    assert observations == [(resp.decision_id, True)]
     assert _store.artifact_path(_mission_dir(tmp_path), resp.decision_id).exists()
 
 

--- a/tests/specify_cli/decisions/test_service_idempotency.py
+++ b/tests/specify_cli/decisions/test_service_idempotency.py
@@ -19,6 +19,7 @@ import pytest
 from specify_cli.decisions.models import DecisionErrorCode, DecisionStatus, OriginFlow
 from specify_cli.decisions.service import DecisionError, open_decision
 from specify_cli.decisions import store as _store
+from spec_kitty_events.decisionpoint import DECISION_POINT_OPENED
 
 pytestmark = [pytest.mark.unit]
 
@@ -106,32 +107,95 @@ def test_second_open_same_logical_key_is_idempotent(tmp_path: Path) -> None:
     assert len(index.entries) == 1
 
 
-def test_second_open_no_new_event_emitted(tmp_path: Path) -> None:
+def test_second_open_no_new_event_emitted_when_event_exists(tmp_path: Path) -> None:
     _setup_meta(tmp_path)
-    with patch(
-        "specify_cli.decisions.emit.emit_decision_opened", return_value=1
-    ) as mock_emit:
-        open_decision(
-            tmp_path,
-            MISSION_SLUG,
-            origin_flow=OriginFlow.CHARTER,
-            step_id="step-1",
-            input_key="team_size",
-            question="How large?",
-            options=("1-5",),
-            actor="alice",
-        )
-        open_decision(
-            tmp_path,
-            MISSION_SLUG,
-            origin_flow=OriginFlow.CHARTER,
-            step_id="step-1",
-            input_key="team_size",
-            question="How large?",
-            options=("1-5",),
-            actor="alice",
-        )
-    assert mock_emit.call_count == 1
+    open_decision(
+        tmp_path,
+        MISSION_SLUG,
+        origin_flow=OriginFlow.CHARTER,
+        step_id="step-1",
+        input_key="team_size",
+        question="How large?",
+        options=("1-5",),
+        actor="alice",
+    )
+    open_decision(
+        tmp_path,
+        MISSION_SLUG,
+        origin_flow=OriginFlow.CHARTER,
+        step_id="step-1",
+        input_key="team_size",
+        question="How large?",
+        options=("1-5",),
+        actor="alice",
+    )
+    events_path = _mission_dir(tmp_path) / "status.events.jsonl"
+    assert len(events_path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_idempotent_retry_repairs_missing_opened_event(tmp_path: Path) -> None:
+    _setup_meta(tmp_path)
+    args = {
+        "origin_flow": OriginFlow.CHARTER,
+        "step_id": "step-1",
+        "input_key": "team_size",
+        "question": "How large?",
+        "options": ("1-5",),
+        "actor": "alice",
+    }
+    with pytest.raises(RuntimeError, match="emit failed"), patch(
+        "specify_cli.decisions.emit.emit_decision_opened",
+        side_effect=RuntimeError("emit failed"),
+    ):
+        open_decision(tmp_path, MISSION_SLUG, **args)
+
+    mission_dir = _mission_dir(tmp_path)
+    index = _store.load_index(mission_dir)
+    persisted = index.entries[0]
+    assert _store.artifact_path(mission_dir, persisted.decision_id).exists()
+    assert not (mission_dir / "status.events.jsonl").exists()
+
+    resp = open_decision(tmp_path, MISSION_SLUG, **args)
+
+    assert resp.idempotent is True
+    assert resp.decision_id == persisted.decision_id
+    assert resp.event_lamport == 1
+    events = [
+        json.loads(line)
+        for line in (mission_dir / "status.events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(events) == 1
+    assert events[0]["event_type"] == DECISION_POINT_OPENED
+    assert events[0]["payload"]["decision_point_id"] == persisted.decision_id
+    assert events[0]["payload"]["actor_id"] == "alice"
+
+
+def test_idempotent_retry_without_persisted_actor_fails_closed(tmp_path: Path) -> None:
+    _setup_meta(tmp_path)
+    args = {
+        "origin_flow": OriginFlow.CHARTER,
+        "step_id": "step-1",
+        "input_key": "team_size",
+        "question": "How large?",
+        "options": ("1-5",),
+        "actor": "alice",
+    }
+    resp = open_decision(tmp_path, MISSION_SLUG, **args)
+    mission_dir = _mission_dir(tmp_path)
+    (mission_dir / "status.events.jsonl").unlink()
+
+    index_path = _store.index_path(mission_dir)
+    raw = json.loads(index_path.read_text(encoding="utf-8"))
+    raw["entries"][0].pop("opened_by")
+    index_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(DecisionError) as exc_info:
+        open_decision(tmp_path, MISSION_SLUG, **args)
+
+    err = exc_info.value
+    assert err.code == DecisionErrorCode.EVENT_REPAIR_FAILED
+    assert err.details["decision_id"] == resp.decision_id
+    assert not (mission_dir / "status.events.jsonl").exists()
 
 
 def test_on_minted_receives_persisted_id_for_idempotent_open(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Make `spec-kitty agent decision open --json` success stdout exactly one parseable JSON object.
- Add `contract: decision_open_v2` and a retry-safe `recovery.idempotency_key` including mission slug + logical decision tuple.
- Stop CLI use of minted-phase stdout and move service `on_minted` notification until after fresh opens are persisted.
- Update decision tests, service idempotency tests, CLI reference docs, and changelog.

Closes #1145.

## Tests
- `.venv/bin/ruff check src/specify_cli/cli/commands/decision.py src/specify_cli/decisions/service.py tests/specify_cli/cli/commands/test_decision.py tests/specify_cli/decisions/test_service_idempotency.py`
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_decision.py tests/specify_cli/cli/test_decision_command_shape_consistency.py tests/specify_cli/decisions -q`
- Live smoke: created temp mission, ran `spec-kitty agent decision open --json`, validated stdout with `python -m json.tool` and asserted `decision_open_v2` recovery fields.

## Adversarial review
- Finding addressed: initial recovery key exposed `mission_id` but not the CLI `mission_slug`, making manual rerun recovery less actionable. Added `mission_slug` to `recovery.idempotency_key` and covered it in tests/docs.