### PR TITLE
Fix top-level tasks --mission selector

### DIFF
--- a/src/specify_cli/cli/commands/lifecycle.py
+++ b/src/specify_cli/cli/commands/lifecycle.py
@@ -7,7 +7,9 @@ agent lifecycle implementations.
 from __future__ import annotations
 
 import contextlib
+import json
 import re
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -152,12 +154,62 @@ def plan(
                     )
 
 
+def _emit_tasks_missing_mission_guidance(repo_root: Path, *, json_output: bool) -> None:
+    payload = agent_feature._build_setup_plan_detection_error(  # noqa: SLF001
+        repo_root,
+        "--mission <slug> is required",
+        None,
+        error_code="FEATURE_CONTEXT_UNRESOLVED",
+        command_name="finalize-tasks",
+        command_args=["--json"] if json_output else [],
+    )
+    missions = payload.get("available_missions")
+    if isinstance(missions, list) and missions:
+        args_suffix = " --json" if json_output else ""
+        payload["example_command"] = f"spec-kitty tasks --mission {missions[0]}{args_suffix}"
+
+    if json_output:
+        print(json.dumps(payload))
+    else:
+        _console.print(f"[red]Error:[/red] {payload['error']}")
+        if isinstance(missions, list):
+            for slug in missions[:10]:
+                _console.print(f"  - {slug}")
+        if "example_command" in payload:
+            _console.print(f"  {payload['example_command']}")
+
+
 def tasks(
+    mission: str | None = typer.Option(None, "--mission", help="Mission slug (e.g., 001-user-authentication)"),
+    feature: str | None = typer.Option(None, "--feature", hidden=True, help="(deprecated) Use --mission"),
     json_output: bool = typer.Option(False, "--json", help="Emit JSON result"),
 ) -> None:
     """Finalize tasks metadata after task generation."""
     _enforce_initialized()
-    agent_feature.finalize_tasks(json_output=json_output)
+    resolved_mission = None
+    if mission is not None or feature is not None:
+        try:
+            resolved = resolve_selector(
+                canonical_value=mission,
+                canonical_flag="--mission",
+                alias_value=feature,
+                alias_flag="--feature",
+                suppress_env_var="SPEC_KITTY_SUPPRESS_FEATURE_DEPRECATION",
+                command_hint="--mission <slug>",
+            )
+        except typer.BadParameter as exc:
+            if json_output:
+                print(json.dumps({"error": str(exc)}))
+            else:
+                _console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1) from exc
+        resolved_mission = resolved.canonical_value
+    else:
+        repo_root = locate_project_root()
+        if repo_root is not None:
+            _emit_tasks_missing_mission_guidance(repo_root, json_output=json_output)
+            raise typer.Exit(1)
+    agent_feature.finalize_tasks(feature=resolved_mission, json_output=json_output)
 
 
 __all__ = ["specify", "plan", "tasks"]

--- a/tests/specify_cli/cli/commands/test_selector_resolution.py
+++ b/tests/specify_cli/cli/commands/test_selector_resolution.py
@@ -28,13 +28,18 @@ from specify_cli.cli.selector_resolution import resolve_selector
 
 pytestmark = [pytest.mark.fast, pytest.mark.non_sandbox]  # non_sandbox: warning assertion fails in sandbox
 runner = CliRunner()
-top_level_lifecycle_app = typer.Typer()
-top_level_lifecycle_app.command(name="tasks")(lifecycle_tasks)
 
 
-@top_level_lifecycle_app.command(name="noop")
-def _noop() -> None:
-    """Force Typer to exercise subcommand parsing in this local test app."""
+def _build_top_level_lifecycle_app() -> typer.Typer:
+    """Build a fresh local app for top-level lifecycle command tests."""
+    app = typer.Typer()
+    app.command(name="tasks")(lifecycle_tasks)
+
+    @app.command(name="noop")
+    def _noop() -> None:
+        """Force Typer to exercise subcommand parsing in this local test app."""
+
+    return app
 
 
 @pytest.fixture(autouse=True)
@@ -623,7 +628,7 @@ def test_top_level_tasks_mission_selector_forwards_to_finalize_tasks() -> None:
         patch("specify_cli.cli.commands.lifecycle.agent_feature.finalize_tasks", side_effect=fake_finalize_tasks),
     ):
         result = runner.invoke(
-            top_level_lifecycle_app,
+            _build_top_level_lifecycle_app(),
             ["tasks", "--mission", "077-demo-mission", "--json"],
         )
 
@@ -634,7 +639,7 @@ def test_top_level_tasks_mission_selector_forwards_to_finalize_tasks() -> None:
 def test_top_level_tasks_selector_conflict_gives_ambiguity_guidance() -> None:
     with patch("specify_cli.cli.commands.lifecycle._enforce_initialized"):
         result = runner.invoke(
-            top_level_lifecycle_app,
+            _build_top_level_lifecycle_app(),
             ["tasks", "--mission", "077-a", "--feature", "077-b", "--json"],
         )
 
@@ -656,7 +661,7 @@ def test_top_level_tasks_without_selector_emits_mission_disambiguation(
         patch("specify_cli.cli.commands.lifecycle._enforce_initialized"),
         patch("specify_cli.cli.commands.lifecycle.locate_project_root", return_value=tmp_path),
     ):
-        result = runner.invoke(top_level_lifecycle_app, ["tasks", "--json"])
+        result = runner.invoke(_build_top_level_lifecycle_app(), ["tasks", "--json"])
 
     assert result.exit_code == 1, result.output
     payload = _extract_json(result.output)

--- a/tests/specify_cli/cli/commands/test_selector_resolution.py
+++ b/tests/specify_cli/cli/commands/test_selector_resolution.py
@@ -21,12 +21,20 @@ from typer.testing import CliRunner
 from specify_cli.cli import selector_resolution
 from specify_cli.cli.commands.agent.mission import app as agent_mission_app
 from specify_cli.cli.commands.agent.tasks import app as tasks_app
+from specify_cli.cli.commands.lifecycle import tasks as lifecycle_tasks
 from specify_cli.cli.commands.mission import app as mission_app
 from specify_cli.cli.commands.next_cmd import next_step
 from specify_cli.cli.selector_resolution import resolve_selector
 
 pytestmark = [pytest.mark.fast, pytest.mark.non_sandbox]  # non_sandbox: warning assertion fails in sandbox
 runner = CliRunner()
+top_level_lifecycle_app = typer.Typer()
+top_level_lifecycle_app.command(name="tasks")(lifecycle_tasks)
+
+
+@top_level_lifecycle_app.command(name="noop")
+def _noop() -> None:
+    """Force Typer to exercise subcommand parsing in this local test app."""
 
 
 @pytest.fixture(autouse=True)
@@ -601,3 +609,58 @@ def test_agent_tasks_status_dual_flag_conflict_fails(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "Conflicting selectors" in result.output
+
+
+def test_top_level_tasks_mission_selector_forwards_to_finalize_tasks() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_finalize_tasks(*, feature: str | None = None, json_output: bool = False) -> None:
+        captured["feature"] = feature
+        captured["json_output"] = json_output
+
+    with (
+        patch("specify_cli.cli.commands.lifecycle._enforce_initialized"),
+        patch("specify_cli.cli.commands.lifecycle.agent_feature.finalize_tasks", side_effect=fake_finalize_tasks),
+    ):
+        result = runner.invoke(
+            top_level_lifecycle_app,
+            ["tasks", "--mission", "077-demo-mission", "--json"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {"feature": "077-demo-mission", "json_output": True}
+
+
+def test_top_level_tasks_selector_conflict_gives_ambiguity_guidance() -> None:
+    with patch("specify_cli.cli.commands.lifecycle._enforce_initialized"):
+        result = runner.invoke(
+            top_level_lifecycle_app,
+            ["tasks", "--mission", "077-a", "--feature", "077-b", "--json"],
+        )
+
+    assert result.exit_code != 0
+    assert "Conflicting selectors" in result.output
+    assert "pass only --mission" in result.output
+
+
+def test_top_level_tasks_without_selector_emits_mission_disambiguation(
+    tmp_path: Path,
+) -> None:
+    specs_dir = tmp_path / "kitty-specs"
+    for slug in ("077-alpha", "078-beta"):
+        mission_dir = specs_dir / slug
+        mission_dir.mkdir(parents=True)
+        (mission_dir / "spec.md").write_text(f"# {slug}\n", encoding="utf-8")
+
+    with (
+        patch("specify_cli.cli.commands.lifecycle._enforce_initialized"),
+        patch("specify_cli.cli.commands.lifecycle.locate_project_root", return_value=tmp_path),
+    ):
+        result = runner.invoke(top_level_lifecycle_app, ["tasks", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = _extract_json(result.output)
+    assert payload["error"] == "2 missions found, pass --mission <slug> to disambiguate"
+    assert payload["available_missions"] == ["077-alpha", "078-beta"]
+    assert payload["example_command"] == "spec-kitty tasks --mission 077-alpha --json"
+    assert payload["remediation"] == "Re-run with --mission <slug>"


### PR DESCRIPTION
## Summary
- add `--mission` support to top-level `spec-kitty tasks` and forward it to `agent mission finalize-tasks`
- keep hidden `--feature` alias conflict handling consistent with other lifecycle commands
- emit top-level disambiguation guidance (`spec-kitty tasks --mission ...`) before delegated finalize preflight

Closes #1116

## Tests
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_selector_resolution.py -q`
- `.venv/bin/ruff check src/specify_cli/cli/commands/lifecycle.py tests/specify_cli/cli/commands/test_selector_resolution.py`
- `git diff --check`
- `SPEC_KITTY_NO_UPGRADE_CHECK=1 .venv/bin/spec-kitty tasks --help`
- `SPEC_KITTY_NO_UPGRADE_CHECK=1 SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/spec-kitty tasks --json`