### PR TITLE
Harden doctrine trust boundaries

### DIFF
--- a/src/charter/README.md
+++ b/src/charter/README.md
@@ -24,6 +24,14 @@ catalog and turns selections into project-specific governance.
 
 **Dependency direction:** `charter` -> `doctrine`. Never the reverse.
 
+Runtime prompt generation under `src/specify_cli/next/` must resolve doctrine
+through charter facades (`context.py`, `resolver.py`, `catalog.py`,
+`scope_router.py`) so project and org governance remains scoped by the charter
+trust boundary. CLI org-pack tooling under `src/specify_cli/doctrine/` is the
+documented exception: validators and assemblers may import doctrine artifact
+models directly because they validate and package doctrine artifacts as data,
+not prompt-runtime governance context.
+
 ## Key entry points
 
 | Entry point | Purpose |

--- a/src/charter/__init__.py
+++ b/src/charter/__init__.py
@@ -52,6 +52,12 @@ from .schemas import (
     CharterTestingConfig,
     emit_yaml,
 )
+from .scope import (
+    CharterScope,
+    CharterScopeConfig,
+    CharterScopeConflict,
+    CharterScopeNotFound,
+)
 from .sync import (
     SyncResult,
     load_directives_config,
@@ -118,6 +124,10 @@ __all__ = [
     "SectionsParsed",
     "CharterTestingConfig",
     "emit_yaml",
+    "CharterScope",
+    "CharterScopeConfig",
+    "CharterScopeConflict",
+    "CharterScopeNotFound",
     "SyncResult",
     "load_directives_config",
     "load_governance_config",

--- a/src/charter/scope_router.py
+++ b/src/charter/scope_router.py
@@ -20,12 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from charter.context import CharterContextResult, build_charter_context
-from charter.scope import (
-    CharterScope,
-    CharterScopeConfig,  # noqa: F401 — live-caller import for dead-symbol gate
-    CharterScopeConflict,  # noqa: F401 — live-caller import for dead-symbol gate
-    CharterScopeNotFound,  # noqa: F401 — live-caller import for dead-symbol gate
-)
+from charter.scope import CharterScope
 
 __all__ = ["build_with_scope"]
 

--- a/src/specify_cli/doctrine/pack_assembler.py
+++ b/src/specify_cli/doctrine/pack_assembler.py
@@ -34,6 +34,8 @@ from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
 from .pack_validator import validate_pack
+from .snapshot import write_pack_manifest
+from .sources.protocol import FetchResult
 
 __all__ = [
     "ConflictItem",
@@ -289,6 +291,17 @@ def assemble_pack(
                 )
                 _maybe_write_conflicts(conflicts_out, result)
                 return result
+            if not _has_recognisable_pack_manifest(output_dir):
+                result = AssemblyResult(
+                    ok=False,
+                    errors=[
+                        f"refusing to delete non-pack output directory {output_dir}; "
+                        "with --force, the directory must contain a recognisable "
+                        "pack-manifest.yaml"
+                    ],
+                )
+                _maybe_write_conflicts(conflicts_out, result)
+                return result
             shutil.rmtree(output_dir)
             output_dir.mkdir(parents=True)
     else:
@@ -329,6 +342,17 @@ def assemble_pack(
         artifacts_written=artifacts_written,
         conflicts=all_conflicts if force else [],
     )
+    write_pack_manifest(
+        output_dir,
+        FetchResult(
+            ok=True,
+            artifacts_written=artifacts_written,
+            pack_version=None,
+            errors=[],
+        ),
+        source_url=",".join(str(p) for p in input_packs),
+        source_type="assemble",
+    )
     _maybe_write_conflicts(conflicts_out, result)
     return result
 
@@ -336,6 +360,30 @@ def assemble_pack(
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
+
+
+def _has_recognisable_pack_manifest(output_dir: Path) -> bool:
+    manifest = output_dir / "pack-manifest.yaml"
+    if not manifest.is_file():
+        return False
+    try:
+        payload = _yaml().load(manifest)
+    except (YAMLError, OSError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    required_keys = {
+        "artifact_counts",
+        "fetched_at",
+        "pack_version",
+        "source_type",
+        "source_url",
+    }
+    if not required_keys.issubset(payload):
+        return False
+    if not isinstance(payload.get("artifact_counts"), dict):
+        return False
+    return payload.get("source_type") in {"assemble", "git", "https", "api"}
 
 
 def _copy_artifacts(

--- a/src/specify_cli/doctrine/snapshot.py
+++ b/src/specify_cli/doctrine/snapshot.py
@@ -118,10 +118,28 @@ def write_snapshot(
             ],
         )
 
-    # Replace local_path atomically.
-    if local_path.exists():
-        shutil.rmtree(local_path)
-    shutil.move(str(tmp_dir), str(local_path))
+    # Replace local_path by first moving the old snapshot aside. This avoids
+    # the delete-then-move ENOENT window and preserves the old tree if promote
+    # fails before the new snapshot is in place.
+    old_dir: Path | None = None
+    try:
+        if local_path.exists():
+            old_dir = local_path.parent / f".old-{local_path.name}-{uuid4().hex}"
+            local_path.replace(old_dir)
+        tmp_dir.replace(local_path)
+    except OSError as exc:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        if old_dir is not None and old_dir.exists() and not local_path.exists():
+            old_dir.replace(local_path)
+        return FetchResult(
+            ok=False,
+            artifacts_written=result.artifacts_written,
+            pack_version=result.pack_version,
+            errors=[f"Failed to replace snapshot: {exc}"],
+        )
+    finally:
+        if old_dir is not None and old_dir.exists():
+            shutil.rmtree(old_dir, ignore_errors=True)
 
     resolved_url = source_url if source_url is not None else getattr(source, "url", "")
     resolved_type = source_type or _infer_source_type(source)

--- a/src/specify_cli/doctrine/sources/git_source.py
+++ b/src/specify_cli/doctrine/sources/git_source.py
@@ -13,6 +13,7 @@ CI can pass a short-lived token without modifying ``~/.gitconfig``.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -61,7 +62,10 @@ class GitSource:
                 ok=False,
                 artifacts_written=0,
                 pack_version=None,
-                errors=[clone_proc.stderr.strip() or "git clone failed"],
+                errors=[
+                    _redact_git_tokens(clone_proc.stderr.strip())
+                    or "git clone failed"
+                ],
             )
 
         if self.ref:
@@ -74,7 +78,10 @@ class GitSource:
                     ok=False,
                     artifacts_written=0,
                     pack_version=None,
-                    errors=[checkout_proc.stderr.strip() or "git checkout failed"],
+                    errors=[
+                        _redact_git_tokens(checkout_proc.stderr.strip())
+                        or "git checkout failed"
+                    ],
                 )
 
         return self._success_result(target_dir)
@@ -89,7 +96,10 @@ class GitSource:
                 ok=False,
                 artifacts_written=0,
                 pack_version=None,
-                errors=[fetch_proc.stderr.strip() or "git fetch failed"],
+                errors=[
+                    _redact_git_tokens(fetch_proc.stderr.strip())
+                    or "git fetch failed"
+                ],
             )
 
         reset_target = self.ref if self.ref else "origin/HEAD"
@@ -101,7 +111,10 @@ class GitSource:
                 ok=False,
                 artifacts_written=0,
                 pack_version=None,
-                errors=[reset_proc.stderr.strip() or "git reset failed"],
+                errors=[
+                    _redact_git_tokens(reset_proc.stderr.strip())
+                    or "git reset failed"
+                ],
             )
 
         return self._success_result(target_dir)
@@ -130,8 +143,8 @@ class GitSource:
             return url
         if not url.startswith("https://"):
             return url
-        # Insert token as oauth2 user. The token never appears in logs because
-        # this transformed URL is only passed to subprocess as an argv member.
+        # Insert token as oauth2 user. Git may echo argv URLs on failure; stderr
+        # is redacted before returning errors to callers.
         return url.replace("https://", f"https://oauth2:{token}@", 1)
 
     @staticmethod
@@ -154,3 +167,8 @@ def _count_yaml_files(target_dir: Path) -> int:
             continue
         count += 1
     return count
+
+
+def _redact_git_tokens(text: str) -> str:
+    """Remove OAuth2 credentials from git stderr before operator-facing output."""
+    return re.sub(r"oauth2:[^@\s'\"]+@", "oauth2:<redacted>@", text)

--- a/src/specify_cli/doctrine/sources/git_source.py
+++ b/src/specify_cli/doctrine/sources/git_source.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import quote
 
 from .protocol import FetchResult
 
@@ -143,9 +144,9 @@ class GitSource:
             return url
         if not url.startswith("https://"):
             return url
-        # Insert token as oauth2 user. Git may echo argv URLs on failure; stderr
-        # is redacted before returning errors to callers.
-        return url.replace("https://", f"https://oauth2:{token}@", 1)
+        # Insert token as oauth2 user. URL-encode so reserved chars cannot
+        # split the credential field; stderr is redacted before returning.
+        return url.replace("https://", f"https://oauth2:{quote(token, safe='')}@", 1)
 
     @staticmethod
     def _run_git(argv: list[str]) -> subprocess.CompletedProcess[str]:
@@ -171,4 +172,8 @@ def _count_yaml_files(target_dir: Path) -> int:
 
 def _redact_git_tokens(text: str) -> str:
     """Remove OAuth2 credentials from git stderr before operator-facing output."""
-    return re.sub(r"oauth2:[^@\s'\"]+@", "oauth2:<redacted>@", text)
+    return re.sub(
+        r"oauth2:[^\s'\"]+@(?=[^@\s/'\"]+(?::\d+)?(?:/|$))",
+        "oauth2:<redacted>@",
+        text,
+    )

--- a/src/specify_cli/doctrine/sources/https_source.py
+++ b/src/specify_cli/doctrine/sources/https_source.py
@@ -20,6 +20,14 @@ import requests
 
 from .protocol import FetchResult
 
+MAX_ARCHIVE_BYTES = 100 * 1024 * 1024
+MAX_EXTRACTED_BYTES = 512 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 10_000
+
+
+class ArchiveSizeLimitError(Exception):
+    """Raised when a fetched archive exceeds doctrine source safety limits."""
+
 
 @dataclass
 class HttpsBundleSource:
@@ -85,15 +93,29 @@ class HttpsBundleSource:
                 ],
             )
 
+        tmp_path: Path | None = None
         try:
+            content_length = _parse_content_length(response.headers.get("Content-Length"))
+            if content_length is not None and content_length > MAX_ARCHIVE_BYTES:
+                raise ArchiveSizeLimitError(
+                    f"Archive exceeds raw byte limit: {content_length} > {MAX_ARCHIVE_BYTES}"
+                )
             with tempfile.NamedTemporaryFile(
                 delete=False, suffix=f".{archive_kind}"
             ) as tmp:
+                tmp_path = Path(tmp.name)
+                total = 0
                 for chunk in response.iter_content(chunk_size=64 * 1024):
                     if chunk:
+                        total += len(chunk)
+                        if total > MAX_ARCHIVE_BYTES:
+                            raise ArchiveSizeLimitError(
+                                f"Archive exceeds raw byte limit: {total} > {MAX_ARCHIVE_BYTES}"
+                            )
                         tmp.write(chunk)
-                tmp_path = Path(tmp.name)
-        except OSError as exc:
+        except (ArchiveSizeLimitError, OSError) as exc:
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
             return FetchResult(
                 ok=False,
                 artifacts_written=0,
@@ -102,8 +124,9 @@ class HttpsBundleSource:
             )
 
         try:
+            assert tmp_path is not None
             extracted = self._extract(tmp_path, target_dir, archive_kind)
-        except (tarfile.TarError, zipfile.BadZipFile, OSError) as exc:
+        except (ArchiveSizeLimitError, tarfile.TarError, zipfile.BadZipFile, OSError) as exc:
             return FetchResult(
                 ok=False,
                 artifacts_written=0,
@@ -195,6 +218,16 @@ def _parse_retry_after(value: Any) -> float:
         return 2.0
 
 
+def _parse_content_length(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
 def _safe_extract_tar(tf: tarfile.TarFile, target_dir: Path) -> None:
     """Extract *tf* into *target_dir* with defence against common tar attacks.
 
@@ -210,7 +243,13 @@ def _safe_extract_tar(tf: tarfile.TarFile, target_dir: Path) -> None:
        FIFOs and other special files are refused.
     """
     base = target_dir.resolve()
-    for member in tf.getmembers():
+    members = tf.getmembers()
+    if len(members) > MAX_ARCHIVE_MEMBERS:
+        raise ArchiveSizeLimitError(
+            f"Archive exceeds member count limit: {len(members)} > {MAX_ARCHIVE_MEMBERS}"
+        )
+    extracted_bytes = 0
+    for member in members:
         # --- type guard (before path check) ---
         if member.issym() or member.islnk():
             raise tarfile.TarError(
@@ -221,6 +260,13 @@ def _safe_extract_tar(tf: tarfile.TarFile, target_dir: Path) -> None:
                 f"Refusing non-file/non-dir entry: {member.name} "
                 f"(type={member.type!r})"
             )
+        if member.isfile():
+            extracted_bytes += member.size
+            if extracted_bytes > MAX_EXTRACTED_BYTES:
+                raise ArchiveSizeLimitError(
+                    "Archive exceeds extracted byte limit: "
+                    f"{extracted_bytes} > {MAX_EXTRACTED_BYTES}"
+                )
         # --- path traversal guard (use relative_to, not startswith) ---
         member_path = (target_dir / member.name).resolve()
         try:
@@ -239,7 +285,21 @@ def _safe_extract_zip(zf: zipfile.ZipFile, target_dir: Path) -> None:
     which was vulnerable to the sibling-prefix bypass (P1 fix 2026-05).
     """
     base = target_dir.resolve()
-    for name in zf.namelist():
+    members = zf.infolist()
+    if len(members) > MAX_ARCHIVE_MEMBERS:
+        raise ArchiveSizeLimitError(
+            f"Archive exceeds member count limit: {len(members)} > {MAX_ARCHIVE_MEMBERS}"
+        )
+    extracted_bytes = 0
+    for info in members:
+        name = info.filename
+        if not info.is_dir():
+            extracted_bytes += info.file_size
+            if extracted_bytes > MAX_EXTRACTED_BYTES:
+                raise ArchiveSizeLimitError(
+                    "Archive exceeds extracted byte limit: "
+                    f"{extracted_bytes} > {MAX_EXTRACTED_BYTES}"
+                )
         member_path = (target_dir / name).resolve()
         try:
             member_path.relative_to(base)

--- a/src/specify_cli/next/prompt_builder.py
+++ b/src/specify_cli/next/prompt_builder.py
@@ -18,6 +18,7 @@ import tempfile
 from pathlib import Path
 
 from charter.context import build_charter_context
+from charter.scope import CharterScopeConflict, CharterScopeNotFound
 from charter.scope_router import build_with_scope
 from charter.mission_type_profiles import (
     UnknownMissionTypeError,
@@ -402,6 +403,11 @@ def _governance_context(
                 )
             if context.mode != "missing":
                 return context.text
+        except (CharterScopeConflict, CharterScopeNotFound):
+            # Scope routing failures mean the operator-authored monorepo
+            # governance config does not cover this feature path. Falling back
+            # to root governance would silently cross a trust boundary.
+            raise
         except Exception:
             # Non-fatal: fall back to compact governance rendering.
             pass

--- a/tests/agent/test_workflow_charter_context.py
+++ b/tests/agent/test_workflow_charter_context.py
@@ -212,6 +212,22 @@ class TestPromptBuilderGovernanceContext:
         assert isinstance(text, str)
         assert text.strip()
 
+    def test_scope_not_found_is_not_swallowed(self, tmp_path: Path) -> None:
+        from charter.scope import CharterScopeNotFound
+
+        with (
+            patch(
+                "specify_cli.next.prompt_builder.build_with_scope",
+                side_effect=CharterScopeNotFound("outside configured scopes"),
+            ),
+            pytest.raises(CharterScopeNotFound, match="outside configured scopes"),
+        ):
+            _governance_context(
+                tmp_path,
+                action="implement",
+                feature_dir=tmp_path / "outside" / "mission",
+            )
+
     def test_no_action_uses_legacy_governance(self, tmp_path: Path) -> None:
         """Calling _governance_context without action uses legacy path directly."""
         _make_charter_bundle(tmp_path)

--- a/tests/next/test_prompt_builder_unit.py
+++ b/tests/next/test_prompt_builder_unit.py
@@ -546,3 +546,20 @@ class TestGovernanceContext:
         mock_resolve.side_effect = RuntimeError("boom")
         text = _governance_context(feature_dir.parent.parent)
         assert "Governance: unavailable" in text
+
+    @pytest.mark.fast
+    def test_scope_not_found_is_not_swallowed(self, feature_dir: Path) -> None:
+        from charter.scope import CharterScopeNotFound
+
+        with (
+            patch(
+                "specify_cli.next.prompt_builder.build_with_scope",
+                side_effect=CharterScopeNotFound("outside configured scopes"),
+            ),
+            pytest.raises(CharterScopeNotFound, match="outside configured scopes"),
+        ):
+            _governance_context(
+                feature_dir.parent.parent,
+                action="implement",
+                feature_dir=feature_dir,
+            )

--- a/tests/specify_cli/doctrine/test_pack_assembler.py
+++ b/tests/specify_cli/doctrine/test_pack_assembler.py
@@ -89,6 +89,7 @@ class TestAssemblePack:
         assert result.artifacts_written == 3
         assert (output / "directives").is_dir()
         assert len(list((output / "directives").glob("*.directive.yaml"))) == 3
+        assert (output / "pack-manifest.yaml").is_file()
 
     def test_two_packs_no_conflict(self, tmp_path: Path) -> None:
         a = _make_pack(tmp_path, "alpha", directives=["A-001"])
@@ -212,6 +213,56 @@ class TestAssemblePack:
         result = assemble_pack([ghost], tmp_path / "out")
         assert result.ok is False
         assert any("not found" in e for e in result.errors)
+
+    def test_force_refuses_to_delete_non_pack_output_dir(
+        self, tmp_path: Path
+    ) -> None:
+        pack = _make_pack(tmp_path, "alpha", directives=["SAFE-001"])
+        output = tmp_path / "important-data"
+        output.mkdir()
+        marker = output / "do-not-delete.txt"
+        marker.write_text("keep\n", encoding="utf-8")
+
+        result = assemble_pack([pack], output, force=True)
+
+        assert result.ok is False
+        assert "refusing to delete non-pack" in " ".join(result.errors)
+        assert marker.read_text(encoding="utf-8") == "keep\n"
+
+    def test_force_refuses_spoofed_minimal_pack_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        pack = _make_pack(tmp_path, "alpha", directives=["SAFE-002"])
+        output = tmp_path / "important-data"
+        output.mkdir()
+        (output / "pack-manifest.yaml").write_text(
+            "source_type: assemble\n",
+            encoding="utf-8",
+        )
+        marker = output / "do-not-delete.txt"
+        marker.write_text("keep\n", encoding="utf-8")
+
+        result = assemble_pack([pack], output, force=True)
+
+        assert result.ok is False
+        assert "refusing to delete non-pack" in " ".join(result.errors)
+        assert marker.read_text(encoding="utf-8") == "keep\n"
+
+    def test_force_allows_replacing_previous_pack_output(
+        self, tmp_path: Path
+    ) -> None:
+        first = _make_pack(tmp_path, "alpha", directives=["OLD-001"])
+        second = _make_pack(tmp_path, "bravo", directives=["NEW-001"])
+        output = tmp_path / "out"
+
+        first_result = assemble_pack([first], output)
+        assert first_result.ok is True, first_result.errors
+
+        second_result = assemble_pack([second], output, force=True)
+
+        assert second_result.ok is True, second_result.errors
+        assert not (output / "directives" / "old-001.directive.yaml").exists()
+        assert (output / "directives" / "new-001.directive.yaml").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/doctrine/test_snapshot.py
+++ b/tests/specify_cli/doctrine/test_snapshot.py
@@ -111,6 +111,35 @@ class TestWriteSnapshot:
         assert (local_path / "directives" / "new.directive.yaml").is_file()
         assert not (local_path / "stale.txt").exists()
 
+    def test_replace_failure_restores_existing_snapshot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        local_path = tmp_path / "doctrine"
+        _populate_valid_pack(local_path)
+        (local_path / "marker").write_text("keep-me\n")
+
+        source = _ScriptedSource(
+            layout=_populate_valid_pack,
+            result=FetchResult(ok=True, artifacts_written=2, pack_version="v2"),
+        )
+
+        original_replace = Path.replace
+
+        def _flaky_replace(self: Path, target: Path) -> Path:
+            if self.name.startswith(".tmp-"):
+                raise OSError("promote failed")
+            return original_replace(self, target)
+
+        monkeypatch.setattr(Path, "replace", _flaky_replace)
+
+        result = write_snapshot(source, local_path)
+
+        assert result.ok is False
+        assert "promote failed" in " ".join(result.errors)
+        assert (local_path / "marker").read_text() == "keep-me\n"
+        assert not list(tmp_path.glob(".tmp-*"))
+        assert not list(tmp_path.glob(".old-*"))
+
     def test_empty_snapshot_rejected(self, tmp_path: Path) -> None:
         local_path = tmp_path / "doctrine"
 

--- a/tests/specify_cli/doctrine/test_sources_security.py
+++ b/tests/specify_cli/doctrine/test_sources_security.py
@@ -19,6 +19,7 @@ import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
+from urllib.parse import quote
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -422,19 +423,20 @@ def test_git_source_redacts_injected_oauth_token_from_stderr(
 ) -> None:
     from specify_cli.doctrine.sources.git_source import GitSource  # noqa: PLC0415
 
-    token = "ghp_secret/with-slash"
+    token = "ghp_secret/with@reserved"
     monkeypatch.setenv("GIT_TOKEN", token)
     source = GitSource(url="https://github.com/acme/private-pack.git")
 
     def _fake_git(argv: list[str]) -> subprocess.CompletedProcess[str]:
-        assert any(token in part for part in argv)
+        assert all(token not in part for part in argv)
+        assert any(quote(token, safe="") in part for part in argv)
         return subprocess.CompletedProcess(
             argv,
             128,
             stdout="",
             stderr=(
                 "fatal: unable to access "
-                "'https://oauth2:ghp_secret/with-slash@github.com/acme/private-pack.git/'"
+                "'https://oauth2:ghp_secret/with@reserved@github.com/acme/private-pack.git/'"
             ),
         )
 

--- a/tests/specify_cli/doctrine/test_sources_security.py
+++ b/tests/specify_cli/doctrine/test_sources_security.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
@@ -70,6 +71,21 @@ def _make_zip(members: list[tuple[str, bytes]]) -> bytes:
         for name, data in members:
             zf.writestr(name, data)
     return buf.getvalue()
+
+
+def _make_stream_response(
+    chunks: list[bytes],
+    *,
+    url: str = "https://example.com/pack.zip",
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.reason = "OK"
+    resp.url = url
+    resp.headers = headers or {}
+    resp.iter_content.return_value = iter(chunks)
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -314,3 +330,119 @@ class TestApiSourceFilenameTraversal:
         assert written == 0, (
             f"Evil DRG filename {evil_filename!r} must not be written; got written={written}"
         )
+
+
+# ---------------------------------------------------------------------------
+# HttpsBundleSource — size-limit / decompression-bomb guards
+# ---------------------------------------------------------------------------
+
+
+class TestHttpsBundleSourceSizeLimits:
+    def test_declared_raw_archive_limit_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from specify_cli.doctrine.sources import https_source  # noqa: PLC0415
+        from specify_cli.doctrine.sources.https_source import HttpsBundleSource  # noqa: PLC0415
+
+        monkeypatch.setattr(https_source, "MAX_ARCHIVE_BYTES", 4)
+        source = HttpsBundleSource(url="https://example.com/pack.zip")
+        response = _make_stream_response(
+            [],
+            headers={"Content-Length": "5"},
+        )
+        monkeypatch.setattr(source, "_get_with_retry", lambda: response)
+
+        result = source.fetch(tmp_path)
+
+        assert result.ok is False
+        assert "raw byte limit" in " ".join(result.errors)
+        assert not any(tmp_path.iterdir())
+
+    def test_streamed_raw_archive_limit_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from specify_cli.doctrine.sources import https_source  # noqa: PLC0415
+        from specify_cli.doctrine.sources.https_source import HttpsBundleSource  # noqa: PLC0415
+
+        monkeypatch.setattr(https_source, "MAX_ARCHIVE_BYTES", 3)
+        source = HttpsBundleSource(url="https://example.com/pack.zip")
+        response = _make_stream_response([b"ab", b"cd"])
+        monkeypatch.setattr(source, "_get_with_retry", lambda: response)
+
+        result = source.fetch(tmp_path)
+
+        assert result.ok is False
+        assert "raw byte limit" in " ".join(result.errors)
+        assert not any(tmp_path.iterdir())
+
+    def test_tar_extracted_byte_limit_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from specify_cli.doctrine.sources import https_source  # noqa: PLC0415
+        from specify_cli.doctrine.sources.https_source import _safe_extract_tar  # noqa: PLC0415
+
+        monkeypatch.setattr(https_source, "MAX_EXTRACTED_BYTES", 1)
+        data = _make_tar_gz([("file.yaml", b"xx")])
+
+        with (
+            tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf,
+            pytest.raises(
+                https_source.ArchiveSizeLimitError,
+                match="extracted byte limit",
+            ),
+        ):
+            _safe_extract_tar(tf, tmp_path)
+
+    def test_zip_member_count_limit_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from specify_cli.doctrine.sources import https_source  # noqa: PLC0415
+        from specify_cli.doctrine.sources.https_source import _safe_extract_zip  # noqa: PLC0415
+
+        monkeypatch.setattr(https_source, "MAX_ARCHIVE_MEMBERS", 0)
+        data = _make_zip([("file.yaml", b"x")])
+
+        with (
+            zipfile.ZipFile(io.BytesIO(data)) as zf,
+            pytest.raises(
+                https_source.ArchiveSizeLimitError,
+                match="member count limit",
+            ),
+        ):
+            _safe_extract_zip(zf, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# GitSource — token redaction
+# ---------------------------------------------------------------------------
+
+
+def test_git_source_redacts_injected_oauth_token_from_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from specify_cli.doctrine.sources.git_source import GitSource  # noqa: PLC0415
+
+    token = "ghp_secret/with-slash"
+    monkeypatch.setenv("GIT_TOKEN", token)
+    source = GitSource(url="https://github.com/acme/private-pack.git")
+
+    def _fake_git(argv: list[str]) -> subprocess.CompletedProcess[str]:
+        assert any(token in part for part in argv)
+        return subprocess.CompletedProcess(
+            argv,
+            128,
+            stdout="",
+            stderr=(
+                "fatal: unable to access "
+                "'https://oauth2:ghp_secret/with-slash@github.com/acme/private-pack.git/'"
+            ),
+        )
+
+    monkeypatch.setattr(source, "_run_git", _fake_git)
+
+    result = source.fetch(tmp_path / "clone")
+
+    assert result.ok is False
+    error_text = " ".join(result.errors)
+    assert token not in error_text
+    assert "oauth2:<redacted>@" in error_text

--- a/tests/specify_cli/next/test_wp_prompt_governance_contract.py
+++ b/tests/specify_cli/next/test_wp_prompt_governance_contract.py
@@ -57,6 +57,7 @@ from unittest.mock import patch
 import pytest
 
 from charter.context import build_charter_context
+from charter.scope import CharterScopeNotFound
 from specify_cli.next.prompt_builder import _build_wp_prompt, _governance_context
 from tests.lane_test_utils import write_single_lane_manifest
 
@@ -1089,3 +1090,18 @@ class TestGovernanceContextUsesMonorepoAwarePath:
             "Without it, monorepo operators always get the root-project charter."
         )
         assert captured_feature_dir[0] == feature_dir
+
+    def test_governance_context_does_not_mask_scope_routing_failures(
+        self, project_with_implement_wp: tuple[Path, Path, str]
+    ) -> None:
+        """Scope resolver failures must fail closed instead of falling back."""
+        repo_root, feature_dir, _mission_slug = project_with_implement_wp
+
+        with (
+            patch(
+                "specify_cli.next.prompt_builder.build_with_scope",
+                side_effect=CharterScopeNotFound("feature outside configured charter scopes"),
+            ),
+            pytest.raises(CharterScopeNotFound),
+        ):
+            _governance_context(repo_root, feature_dir=feature_dir, action="implement")


### PR DESCRIPTION
## Summary

Closes #1128.

- Adds raw archive, extracted-byte, and member-count limits for HTTPS doctrine bundles.
- Redacts injected git OAuth tokens from returned git stderr.
- Replaces fetched snapshots via old-dir swap instead of delete-then-move.
- Lets typed CharterScope failures hard-fail instead of silently falling back to root governance.
- Hardens `doctrine pack assemble --force` so it refuses non-pack output directories and writes a pack manifest for assembled outputs.
- Removes fake scope-router dead-symbol imports, exposes scope types via the charter facade, and documents the `specify_cli.doctrine` pack-tooling facade exception.

Already present on main and covered by focused tests: workflow unreachable-cycle rejection, workflow_id filename cross-check, and the DRG no-op cleanup noted in #1128. The pack checksum/signature item is intentionally left out because #1128 calls it a larger separate mission and it is not in this Slice F CLI follow-up scope.

## Tests

- `.venv/bin/ruff check src/specify_cli/doctrine/sources/https_source.py src/specify_cli/doctrine/sources/git_source.py src/specify_cli/doctrine/snapshot.py src/specify_cli/doctrine/pack_assembler.py src/specify_cli/next/prompt_builder.py src/charter/scope_router.py src/charter/__init__.py tests/specify_cli/doctrine/test_sources_security.py tests/specify_cli/doctrine/test_snapshot.py tests/specify_cli/doctrine/test_pack_assembler.py tests/agent/test_workflow_charter_context.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/specify_cli/doctrine/test_sources_security.py tests/specify_cli/doctrine/test_snapshot.py tests/specify_cli/doctrine/test_pack_assembler.py tests/specify_cli/next/test_workflow_registry.py tests/agent/test_workflow_charter_context.py tests/architectural/test_layer_rules.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/specify_cli/next/test_wp_prompt_governance_contract.py`

## Adversarial review fixes

- Strengthened `--force` manifest recognition so `source_type: assemble` alone cannot spoof pack ownership.
- Broadened git token redaction to cover OAuth token text containing `/` before `@`.
