### PR TITLE
Fix #1356: route status emits through bookkeeping transactions

### DIFF
--- a/src/specify_cli/cli/commands/agent/status.py
+++ b/src/specify_cli/cli/commands/agent/status.py
@@ -225,13 +225,15 @@ def emit(
                 raise typer.Exit(1)
 
         # Lazy import to avoid circular imports
+        from specify_cli.coordination.status_transition import (
+            emit_status_transition_transactional,
+        )
         from specify_cli.status.emit import (
             TransitionError,
-            emit_status_transition,
         )
         from specify_cli.status.models import TransitionRequest
 
-        event = emit_status_transition(TransitionRequest(
+        event = emit_status_transition_transactional(TransitionRequest(
             feature_dir=feature_dir,
             mission_slug=mission_slug,
             wp_id=wp_id,

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -24,7 +24,7 @@ from specify_cli.sync.events import (
     emit_error_logged,
 )
 
-from specify_cli.status.emit import emit_status_transition
+from specify_cli.coordination.status_transition import emit_status_transition_transactional
 from specify_cli.status.models import Lane, StatusEvent, TransitionRequest
 from specify_cli.status.preflight import is_dossier_snapshot as _is_dossier_snapshot
 from specify_cli.status.progress import PROGRESS_SEMANTICS, compute_done_percentage, compute_weighted_progress
@@ -1880,7 +1880,7 @@ def move_task(
                         verdict=review_section.get("verdict", Lane.APPROVED),
                         reference=review_section.get("reference", f"auto-forward:{task_id}"),
                     )
-                event = emit_status_transition(TransitionRequest(
+                event = emit_status_transition_transactional(TransitionRequest(
                     feature_dir=feature_dir,
                     mission_slug=mission_slug,
                     wp_id=task_id,

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -28,7 +28,8 @@ from specify_cli.git import safe_commit
 from specify_cli.git.commit_helpers import protected_branches
 from specify_cli.lanes.implement_support import create_lane_workspace
 from specify_cli.lanes.persistence import CorruptLanesError, MissingLanesError, require_lanes_json
-from specify_cli.status.emit import TransitionError, emit_status_transition
+from specify_cli.coordination.status_transition import emit_status_transition_transactional
+from specify_cli.status.emit import TransitionError
 from specify_cli.status.models import Lane, TransitionRequest
 from specify_cli.status.work_package_lifecycle import WorkPackageClaimConflict, start_implementation_status
 from specify_cli.task_utils import TaskCliError, find_repo_root
@@ -775,17 +776,19 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         current_lane = _get_wp_lane_from_event_log(feature_dir, wp_id)
         if current_lane in {Lane.PLANNED, Lane.CLAIMED, Lane.IN_PROGRESS}:
             try:
-                emit_status_transition(TransitionRequest(
-                    feature_dir=feature_dir,
-                    mission_slug=mission_slug,
-                    wp_id=wp_id,
-                    to_lane=Lane.BLOCKED,
-                    actor=effective_actor,
-                    execution_mode=status_execution_mode,
-                    reason="worktree_alloc_failed",
-                    policy_metadata={"evidence": str(exc)},
-                    repo_root=repo_root,
-                ))
+                emit_status_transition_transactional(
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug=mission_slug,
+                        wp_id=wp_id,
+                        to_lane=Lane.BLOCKED,
+                        actor=effective_actor,
+                        execution_mode=status_execution_mode,
+                        reason="worktree_alloc_failed",
+                        policy_metadata={"evidence": str(exc)},
+                        repo_root=repo_root,
+                    )
+                )
             except Exception as _blocked_exc:
                 console.print(
                     f"[yellow]Warning:[/yellow] Could not emit blocked transition after alloc failure: {_blocked_exc}"

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -192,15 +192,27 @@ def _emit_remediation_hint(hint_console: Console) -> None:
     )
 
 
-def _has_transition_to(feature_dir: Path, wp_id: str, to_lane: str) -> bool:
+def _has_transition_to(
+    feature_dir: Path,
+    mission_slug: str,
+    wp_id: str,
+    to_lane: str,
+    repo_root: Path,
+) -> bool:
     """Check whether the event log already contains a transition for *wp_id* to *to_lane*.
 
     This dedup guard prevents duplicate events when ``_mark_wp_merged_done`` is
     called again on retry/resume.
     """
-    from specify_cli.status.store import read_events
+    from specify_cli.coordination.status_transition import has_transition_to_transactional
 
-    return any(event.wp_id == wp_id and event.to_lane == to_lane for event in read_events(feature_dir))
+    return has_transition_to_transactional(
+        feature_dir=feature_dir,
+        mission_slug=mission_slug,
+        wp_id=wp_id,
+        to_lane=to_lane,
+        repo_root=repo_root,
+    )
 
 
 def _mark_wp_merged_done(
@@ -224,21 +236,28 @@ def _mark_wp_merged_done(
         return
 
     metadata, _body = read_wp_frontmatter(wp_path)
-    from specify_cli.status.lane_reader import get_wp_lane
     from specify_cli.status.models import DoneEvidence, ReviewApproval
-    from specify_cli.status.emit import emit_status_transition, TransitionError
+    from specify_cli.coordination.status_transition import (
+        emit_status_transition_transactional,
+        read_current_wp_state_transactional,
+    )
+    from specify_cli.status.emit import TransitionError
+    from specify_cli.status.models import TransitionRequest
     from specify_cli.status.history_parser import extract_done_evidence
-    from specify_cli.status.transitions import resolve_lane_alias
 
     from specify_cli.status.models import Lane as _Lane
 
-    lane_str = resolve_lane_alias(get_wp_lane(feature_dir, wp_id))
-    lane = _Lane(lane_str)
+    lane, _actor = read_current_wp_state_transactional(
+        feature_dir=feature_dir,
+        mission_slug=mission_slug,
+        wp_id=wp_id,
+        repo_root=repo_root,
+    )
     if lane == _Lane.DONE:
         return
 
     # Dedup guard: if we already have a done transition in the log, skip everything.
-    if _has_transition_to(feature_dir, wp_id, "done"):
+    if _has_transition_to(feature_dir, mission_slug, wp_id, "done", repo_root):
         logger.debug("Dedup: %s already has 'done' transition, skipping", wp_id)
         return
 
@@ -259,26 +278,28 @@ def _mark_wp_merged_done(
     _pre_approved_lanes = frozenset({_Lane.PLANNED, _Lane.CLAIMED, _Lane.IN_PROGRESS, _Lane.FOR_REVIEW})
     if lane in _pre_approved_lanes and evidence is not None:
         # Dedup guard for the intermediate approved transition
-        if _has_transition_to(feature_dir, wp_id, "approved"):
+        if _has_transition_to(feature_dir, mission_slug, wp_id, "approved", repo_root):
             logger.debug("Dedup: %s already has 'approved' transition, skipping emit", wp_id)
         else:
             try:
-                emit_status_transition(
-                    feature_dir=feature_dir,
-                    mission_slug=mission_slug,
-                    wp_id=wp_id,
-                    to_lane="approved",
-                    actor="merge",
-                    reason=f"Recorded prior review approval for merged {wp_id}",
-                    evidence=evidence.to_dict(),
-                    workspace_context=f"merge:{repo_root}",
-                    repo_root=repo_root,
+                emit_status_transition_transactional(
+                    TransitionRequest(
+                        feature_dir=feature_dir,
+                        mission_slug=mission_slug,
+                        wp_id=wp_id,
+                        to_lane="approved",
+                        actor="merge",
+                        reason=f"Recorded prior review approval for merged {wp_id}",
+                        evidence=evidence.to_dict(),
+                        workspace_context=f"merge:{repo_root}",
+                        repo_root=repo_root,
+                        policy_metadata={
+                            "merge_phase": "lane_integrated",
+                            "target_branch": target_branch,
+                        },
+                    ),
                     ensure_sync_daemon=False,
                     sync_dossier=False,
-                    policy_metadata={
-                        "merge_phase": "lane_integrated",
-                        "target_branch": target_branch,
-                    },
                 )
             except TransitionError as exc:
                 console.print(f"[yellow]Warning:[/yellow] Failed to mark {wp_id} approved before done: {exc}")
@@ -296,22 +317,24 @@ def _mark_wp_merged_done(
         # which target branch they landed on. The transition is emitted once
         # per WP after Stage 1 (lane->coord) completes and before Stage 2
         # (coord->target) runs the post-merge bookkeeping.
-        emit_status_transition(
-            feature_dir=feature_dir,
-            mission_slug=mission_slug,
-            wp_id=wp_id,
-            to_lane="done",
-            actor="merge",
-            reason=f"Merged {wp_id} into {target_branch}",
-            evidence=evidence.to_dict(),
-            workspace_context=f"merge:{repo_root}",
-            repo_root=repo_root,
+        emit_status_transition_transactional(
+            TransitionRequest(
+                feature_dir=feature_dir,
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                to_lane="done",
+                actor="merge",
+                reason=f"Merged {wp_id} into {target_branch}",
+                evidence=evidence.to_dict(),
+                workspace_context=f"merge:{repo_root}",
+                repo_root=repo_root,
+                policy_metadata={
+                    "merge_phase": "lane_integrated",
+                    "target_branch": target_branch,
+                },
+            ),
             ensure_sync_daemon=False,
             sync_dossier=False,
-            policy_metadata={
-                "merge_phase": "lane_integrated",
-                "target_branch": target_branch,
-            },
         )
     except TransitionError as exc:
         console.print(f"[yellow]Warning:[/yellow] Failed to mark {wp_id} done after merge: {exc}")
@@ -355,6 +378,7 @@ def _assert_merged_wps_reached_done(
 def _reconcile_completed_wps_for_resume(
     *,
     feature_dir: Path,
+    mission_slug: str,
     merge_state: MergeState,
     repo_root: Path,
 ) -> set[str]:
@@ -372,7 +396,7 @@ def _reconcile_completed_wps_for_resume(
     confirmed = [
         wp_id
         for wp_id in merge_state.completed_wps
-        if _has_transition_to(feature_dir, wp_id, "done")
+        if _has_transition_to(feature_dir, mission_slug, wp_id, "done", repo_root)
     ]
     if len(confirmed) != len(merge_state.completed_wps):
         dropped = sorted(set(merge_state.completed_wps) - set(confirmed))
@@ -1635,6 +1659,7 @@ def _run_lane_based_merge_locked(
     console.print("  [dim]Recording merged work packages as done...[/dim]")
     completed_set = _reconcile_completed_wps_for_resume(
         feature_dir=feature_dir,
+        mission_slug=mission_slug,
         merge_state=state,
         repo_root=main_repo,
     )

--- a/src/specify_cli/coordination/outbound.py
+++ b/src/specify_cli/coordination/outbound.py
@@ -44,6 +44,7 @@ def queue_saas_emission(
     *,
     mission_slug: str | None = None,
     repo_root: Any = None,
+    ensure_sync_daemon: bool = True,
 ) -> None:
     """Register a SaaS outbound emission to fire after the local commit succeeds.
 
@@ -57,6 +58,8 @@ def queue_saas_emission(
         Optional override; defaults to ``txn.mission_slug`` when omitted.
     repo_root:
         Optional override; defaults to ``txn.repo_root`` when omitted.
+    ensure_sync_daemon:
+        Passed through to the SaaS sync adapter after commit.
 
     The emission is **not** fired synchronously.  It is appended to the
     transaction's ``_deferred`` queue and runs only after
@@ -72,7 +75,12 @@ def queue_saas_emission(
     resolved_repo = repo_root if repo_root is not None else txn.repo_root
 
     def _fire() -> None:
-        _send_to_saas(event, resolved_slug, resolved_repo)
+        _send_to_saas(
+            event,
+            resolved_slug,
+            resolved_repo,
+            ensure_sync_daemon=ensure_sync_daemon,
+        )
 
     txn.defer_outbound(_fire)
 
@@ -81,6 +89,8 @@ def _send_to_saas(
     event: StatusEvent,
     mission_slug: str,
     repo_root: Any,
+    *,
+    ensure_sync_daemon: bool = True,
 ) -> None:
     """Forward ``event`` to the canonical SaaS fanout adapter.
 
@@ -95,8 +105,21 @@ def _send_to_saas(
     """
     from specify_cli.status.adapters import fire_saas_fanout  # noqa: PLC0415
 
+    _ = repo_root
     fire_saas_fanout(
-        event=event,
+        wp_id=event.wp_id,
+        from_lane=str(event.from_lane),
+        to_lane=str(event.to_lane),
+        actor=event.actor,
         mission_slug=mission_slug,
-        repo_root=repo_root,
+        mission_id=event.mission_id,
+        causation_id=event.event_id,
+        policy_metadata=event.policy_metadata,
+        force=event.force,
+        reason=event.reason,
+        review_ref=event.review_ref,
+        execution_mode=event.execution_mode,
+        evidence=event.evidence.to_dict() if event.evidence else None,
+        occurred_at=event.at,
+        ensure_daemon=ensure_sync_daemon,
     )

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -1,0 +1,487 @@
+"""Transactional status-transition emission helpers.
+
+Production workflow callers must append status events through
+``BookkeepingTransaction`` so SaaS/dossier fanout runs only after the
+bookkeeping commit succeeds.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from specify_cli.coordination.outbound import queue_saas_emission
+from specify_cli.coordination.transaction import BookkeepingTransaction
+from specify_cli.mission_metadata import load_meta
+from specify_cli.status import emit as _emit
+from specify_cli.status.adapters import fire_dossier_sync
+from specify_cli.status.models import DoneEvidence, GuardContext, Lane, StatusEvent, TransitionRequest
+from specify_cli.status.reducer import reduce
+from specify_cli.status.store import read_events
+from specify_cli.status.transitions import resolve_lane_alias, validate_transition
+from specify_cli.workspace import canonicalize_feature_dir
+
+
+@dataclass(frozen=True)
+class _TransactionIdentity:
+    repo_root: Path
+    feature_dir: Path
+    mission_id: str
+    mid8: str
+    destination_ref: str
+    meta_exists: bool
+    coordination_branch: str | None
+    transaction_meta_exists: bool
+
+
+def _repo_root_for_feature(feature_dir: Path, repo_root: Path | None) -> Path:
+    if repo_root is not None:
+        return repo_root
+    if feature_dir.parent.name == "kitty-specs":
+        return feature_dir.parent.parent
+    return feature_dir
+
+
+def _current_branch(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    branch = result.stdout.strip()
+    return branch if result.returncode == 0 and branch else "HEAD"
+
+
+def _repo_supports_transactions(repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--is-inside-work-tree"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _branch_exists(repo_root: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _transaction_topology_available(identity: _TransactionIdentity, mission_slug: str) -> bool:
+    if not _repo_supports_transactions(identity.repo_root):
+        return False
+    if identity.coordination_branch is not None:
+        return _branch_exists(identity.repo_root, identity.coordination_branch)
+    if identity.meta_exists:
+        # Legacy missions with meta but no coordination_branch are handled by
+        # BookkeepingTransaction's legacy lane fallback when its derived
+        # kitty-specs/<slug>-<mid8>/meta.json path can see that meta.
+        return identity.transaction_meta_exists
+
+    from specify_cli.coordination.workspace import CoordinationWorkspace  # noqa: PLC0415
+
+    return _branch_exists(
+        identity.repo_root,
+        CoordinationWorkspace.branch_name(mission_slug, identity.mid8),
+    )
+
+
+def _identity_for_request(request: TransitionRequest) -> _TransactionIdentity:
+    raw_feature_dir = request.feature_dir or request.mission_dir
+    if raw_feature_dir is None:
+        raise TypeError("transactional status emit requires feature_dir/mission_dir")
+
+    feature_dir = canonicalize_feature_dir(raw_feature_dir)
+    repo_root = _repo_root_for_feature(feature_dir, request.repo_root)
+    mission_slug = request.mission_slug or request._legacy_mission_slug
+    if mission_slug is None:
+        raise TypeError("transactional status emit requires mission_slug")
+
+    try:
+        meta = load_meta(feature_dir)
+    except Exception:  # noqa: BLE001 -- legacy/corrupt meta degrades to legacy ids
+        meta = None
+
+    coord_branch: str | None = None
+    mission_id: str | None = None
+    mid8: str | None = None
+    meta_exists = isinstance(meta, dict)
+    if meta_exists:
+        raw_coord = meta.get("coordination_branch")
+        raw_mission_id = meta.get("mission_id")
+        raw_mid8 = meta.get("mid8")
+        coord_branch = str(raw_coord) if raw_coord else None
+        mission_id = str(raw_mission_id) if raw_mission_id else None
+        mid8 = str(raw_mid8) if raw_mid8 else None
+        if mid8 is None and mission_id and len(mission_id) >= 8:
+            mid8 = mission_id[:8]
+
+    effective_mission_id = mission_id or f"legacy-{mission_slug}"
+    effective_mid8 = mid8 or (
+        mission_id[:8] if mission_id and len(mission_id) >= 8 else (mission_slug.replace("-", "") + "00000000")[:8]
+    )
+    transaction_dir_name = (
+        mission_slug
+        if mission_slug.endswith(f"-{effective_mid8}")
+        else f"{mission_slug}-{effective_mid8}"
+    )
+    return _TransactionIdentity(
+        repo_root=repo_root,
+        feature_dir=feature_dir,
+        mission_id=effective_mission_id,
+        mid8=effective_mid8,
+        destination_ref=coord_branch or _current_branch(repo_root),
+        meta_exists=meta_exists,
+        coordination_branch=coord_branch,
+        transaction_meta_exists=(feature_dir.parent / transaction_dir_name / "meta.json").exists(),
+    )
+
+
+def _prepare_event(
+    *,
+    feature_dir: Path,
+    request: TransitionRequest,
+    mission_slug: str,
+    mission_id: str | None,
+    from_lane: str,
+    at: str | None = None,
+) -> tuple[StatusEvent | None, str]:
+    if request.wp_id is None or request.to_lane is None or request.actor is None:
+        raise TypeError("Each status transition requires wp_id, to_lane, and actor")
+
+    raw_to_lane = str(request.to_lane).strip().lower()
+    resolved_lane = resolve_lane_alias(str(request.to_lane))
+
+    workspace_context = request.workspace_context
+    if workspace_context is None:
+        context_root = request.repo_root if request.repo_root is not None else feature_dir
+        workspace_context = f"{request.execution_mode}:{context_root}"
+
+    subtasks_complete = request.subtasks_complete
+    implementation_evidence_present = request.implementation_evidence_present
+    if subtasks_complete is None and from_lane == Lane.IN_PROGRESS and resolved_lane == Lane.FOR_REVIEW:
+        subtasks_complete = _emit._infer_subtasks_complete(feature_dir, request.wp_id)
+    if implementation_evidence_present is None and from_lane == Lane.IN_PROGRESS and resolved_lane == Lane.FOR_REVIEW:
+        implementation_evidence_present = _emit._infer_implementation_evidence(feature_dir, request.wp_id)
+
+    if _emit._legacy_alias_collapses_to_current_lane(raw_to_lane, resolved_lane, from_lane):
+        _emit._mirror_phase1_frontmatter_lane(feature_dir, request.wp_id, resolved_lane)
+        return None, resolved_lane
+
+    done_evidence: DoneEvidence | None = None
+    if request.evidence is not None:
+        done_evidence = _emit._build_done_evidence(request.evidence)
+
+    ok, error_msg = validate_transition(
+        from_lane,
+        resolved_lane,
+        GuardContext(
+            force=request.force,
+            actor=request.actor,
+            workspace_context=workspace_context,
+            subtasks_complete=subtasks_complete,
+            implementation_evidence_present=implementation_evidence_present,
+            reason=request.reason,
+            review_ref=request.review_ref,
+            evidence=done_evidence,
+            review_result=request.review_result,
+            current_actor=request.current_actor,
+        ),
+    )
+    if not ok:
+        raise _emit.TransitionError(error_msg)
+
+    return (
+        _emit.build_status_event(
+            mission_slug=mission_slug,
+            wp_id=request.wp_id,
+            from_lane=from_lane,
+            to_lane=resolved_lane,
+            actor=request.actor,
+            at=at,
+            mission_id=mission_id,
+            force=request.force,
+            execution_mode=request.execution_mode,
+            reason=request.reason,
+            review_ref=request.review_ref,
+            evidence=done_evidence,
+            policy_metadata=request.policy_metadata,
+        ),
+        resolved_lane,
+    )
+
+
+def _defer_dossier_sync(
+    txn: BookkeepingTransaction,
+    *,
+    feature_dir: Path,
+    mission_slug: str,
+    repo_root: Path | None,
+    sync_dossier: bool,
+) -> None:
+    if not sync_dossier or repo_root is None:
+        return
+    txn.defer_outbound(lambda: fire_dossier_sync(feature_dir, mission_slug, repo_root))
+
+
+def read_current_wp_state_transactional(
+    *,
+    feature_dir: Path,
+    mission_slug: str,
+    wp_id: str,
+    repo_root: Path | None = None,
+) -> tuple[Lane, str | None]:
+    """Read current WP lane/actor from the transaction's write target."""
+    identity = _identity_for_request(
+        TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            to_lane=Lane.PLANNED,
+            actor="status-read",
+            repo_root=repo_root,
+        )
+    )
+    if not _transaction_topology_available(identity, mission_slug):
+        events = read_events(identity.feature_dir)
+        if not events:
+            from specify_cli.status.lane_reader import get_wp_lane  # noqa: PLC0415
+
+            try:
+                return Lane(resolve_lane_alias(get_wp_lane(identity.feature_dir, wp_id))), None
+            except Exception:  # noqa: BLE001 -- non-git test fixtures may lack WP files
+                return Lane.PLANNED, None
+        snapshot = reduce(events)
+        state = snapshot.work_packages.get(wp_id)
+        if not state:
+            return Lane.PLANNED, None
+        try:
+            lane = Lane(str(state.get("lane", Lane.PLANNED)))
+        except ValueError:
+            lane = Lane.PLANNED
+        actor = state.get("actor")
+        actor_key = str(actor).strip() if actor is not None else ""
+        return lane, actor_key or None
+
+    with BookkeepingTransaction.acquire(
+        repo_root=identity.repo_root,
+        mission_id=identity.mission_id,
+        mission_slug=mission_slug,
+        mid8=identity.mid8,
+        destination_ref=identity.destination_ref,
+        operation=f"read status state {wp_id}",
+    ) as txn:
+        events = read_events(txn.feature_dir)
+        if not events:
+            return Lane.PLANNED, None
+        snapshot = reduce(events)
+        state = snapshot.work_packages.get(wp_id)
+        if not state:
+            return Lane.PLANNED, None
+        try:
+            lane = Lane(str(state.get("lane", Lane.PLANNED)))
+        except ValueError:
+            lane = Lane.PLANNED
+        actor = state.get("actor")
+        actor_key = str(actor).strip() if actor is not None else ""
+        return lane, actor_key or None
+
+
+def has_transition_to_transactional(
+    *,
+    feature_dir: Path,
+    mission_slug: str,
+    wp_id: str,
+    to_lane: str,
+    repo_root: Path | None = None,
+) -> bool:
+    """Return whether the transaction write target already has a lane event."""
+    identity = _identity_for_request(
+        TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            to_lane=Lane.PLANNED,
+            actor="status-read",
+            repo_root=repo_root,
+        )
+    )
+    if not _transaction_topology_available(identity, mission_slug):
+        return any(
+            event.wp_id == wp_id and str(event.to_lane) == str(to_lane)
+            for event in read_events(identity.feature_dir)
+        )
+
+    with BookkeepingTransaction.acquire(
+        repo_root=identity.repo_root,
+        mission_id=identity.mission_id,
+        mission_slug=mission_slug,
+        mid8=identity.mid8,
+        destination_ref=identity.destination_ref,
+        operation=f"read status events {wp_id}",
+    ) as txn:
+        return any(
+            event.wp_id == wp_id and str(event.to_lane) == str(to_lane)
+            for event in read_events(txn.feature_dir)
+        )
+
+
+def emit_status_transition_transactional(
+    request: TransitionRequest,
+    *,
+    ensure_sync_daemon: bool = True,
+    sync_dossier: bool = True,
+    operation: str | None = None,
+) -> StatusEvent:
+    """Validate, append, commit, then fan out one status transition."""
+    feature_dir = request.feature_dir or request.mission_dir
+    mission_slug = request.mission_slug or request._legacy_mission_slug
+    if feature_dir is None or mission_slug is None or request.wp_id is None:
+        raise TypeError("transactional status emit requires feature_dir, mission_slug, and wp_id")
+
+    identity = _identity_for_request(request)
+    if not _transaction_topology_available(identity, mission_slug):
+        return _emit.emit_status_transition(
+            request,
+            ensure_sync_daemon=ensure_sync_daemon,
+            sync_dossier=sync_dossier,
+        )
+
+    with BookkeepingTransaction.acquire(
+        repo_root=identity.repo_root,
+        mission_id=identity.mission_id,
+        mission_slug=mission_slug,
+        mid8=identity.mid8,
+        destination_ref=identity.destination_ref,
+        operation=operation or f"status transition {request.wp_id}",
+    ) as txn:
+        mission_id_for_event = None if identity.mission_id.startswith("legacy-") else identity.mission_id
+        from_lane = str(_emit._derive_from_lane(txn.feature_dir, request.wp_id))
+        event, _resolved_lane = _prepare_event(
+            feature_dir=txn.feature_dir,
+            request=request,
+            mission_slug=mission_slug,
+            mission_id=mission_id_for_event,
+            from_lane=from_lane,
+        )
+        if event is None:
+            return _emit.build_status_event(
+                mission_slug=mission_slug,
+                wp_id=request.wp_id,
+                from_lane=from_lane,
+                to_lane=from_lane,
+                actor=request.actor or "unknown",
+                mission_id=mission_id_for_event,
+                force=request.force,
+                execution_mode=request.execution_mode,
+                reason=request.reason,
+                review_ref=request.review_ref,
+                policy_metadata=request.policy_metadata,
+            )
+        txn.append_event(event)
+        queue_saas_emission(
+            txn,
+            event,
+            mission_slug=mission_slug,
+            repo_root=request.repo_root,
+            ensure_sync_daemon=ensure_sync_daemon,
+        )
+        _defer_dossier_sync(
+            txn,
+            feature_dir=txn.feature_dir,
+            mission_slug=mission_slug,
+            repo_root=request.repo_root,
+            sync_dossier=sync_dossier,
+        )
+        return event
+
+
+def emit_status_transition_batch_transactional(
+    requests: list[TransitionRequest],
+    *,
+    ensure_sync_daemon: bool = True,
+    sync_dossier: bool = True,
+    operation: str | None = None,
+) -> list[StatusEvent]:
+    """Validate, append, commit, then fan out a same-WP transition batch."""
+    if not requests:
+        return []
+
+    first = requests[0]
+    mission_slug = first.mission_slug or first._legacy_mission_slug
+    if mission_slug is None or first.wp_id is None:
+        raise TypeError("transactional status batch requires mission_slug and wp_id")
+
+    identity = _identity_for_request(first)
+    if not _transaction_topology_available(identity, mission_slug):
+        return _emit.emit_status_transition_batch(
+            requests,
+            ensure_sync_daemon=ensure_sync_daemon,
+            sync_dossier=sync_dossier,
+        )
+
+    with BookkeepingTransaction.acquire(
+        repo_root=identity.repo_root,
+        mission_id=identity.mission_id,
+        mission_slug=mission_slug,
+        mid8=identity.mid8,
+        destination_ref=identity.destination_ref,
+        operation=operation or f"status transition batch {first.wp_id}",
+    ) as txn:
+        mission_id_for_event = None if identity.mission_id.startswith("legacy-") else identity.mission_id
+        from_lane = str(_emit._derive_from_lane(txn.feature_dir, first.wp_id))
+        built: list[tuple[StatusEvent, TransitionRequest]] = []
+        started_at = datetime.now(UTC)
+
+        for request in requests:
+            request_feature_dir = request.feature_dir or request.mission_dir
+            request_mission_slug = request.mission_slug or request._legacy_mission_slug
+            if (
+                request_feature_dir is None
+                or canonicalize_feature_dir(request_feature_dir) != identity.feature_dir
+                or request_mission_slug != mission_slug
+                or request.wp_id != first.wp_id
+            ):
+                raise TypeError("transactional status batch only supports one feature/mission/wp")
+
+            event, resolved_lane = _prepare_event(
+                feature_dir=txn.feature_dir,
+                request=request,
+                mission_slug=mission_slug,
+                mission_id=mission_id_for_event,
+                from_lane=from_lane,
+                at=(started_at + timedelta(microseconds=len(built))).isoformat(),
+            )
+            if event is None:
+                from_lane = resolved_lane
+                continue
+            built.append((event, request))
+            from_lane = resolved_lane
+
+        for event, request in built:
+            txn.append_event(event)
+            queue_saas_emission(
+                txn,
+                event,
+                mission_slug=mission_slug,
+                repo_root=request.repo_root,
+                ensure_sync_daemon=ensure_sync_daemon,
+            )
+
+        repo_root = next((request.repo_root for request in requests if request.repo_root is not None), None)
+        _defer_dossier_sync(
+            txn,
+            feature_dir=txn.feature_dir,
+            mission_slug=mission_slug,
+            repo_root=repo_root,
+            sync_dossier=sync_dossier,
+        )
+        return [event for event, _request in built]

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -79,7 +79,7 @@ def _transaction_topology_available(identity: _TransactionIdentity, mission_slug
     if not _repo_supports_transactions(identity.repo_root):
         return False
     if identity.coordination_branch is not None:
-        return _branch_exists(identity.repo_root, identity.coordination_branch)
+        return True
     if identity.meta_exists:
         # Legacy missions with meta but no coordination_branch are handled by
         # BookkeepingTransaction's legacy lane fallback when its derived
@@ -105,10 +105,7 @@ def _identity_for_request(request: TransitionRequest) -> _TransactionIdentity:
     if mission_slug is None:
         raise TypeError("transactional status emit requires mission_slug")
 
-    try:
-        meta = load_meta(feature_dir)
-    except Exception:  # noqa: BLE001 -- legacy/corrupt meta degrades to legacy ids
-        meta = None
+    meta = load_meta(feature_dir)
 
     coord_branch: str | None = None
     mission_id: str | None = None

--- a/src/specify_cli/lanes/recovery.py
+++ b/src/specify_cli/lanes/recovery.py
@@ -45,7 +45,7 @@ def _get_recovery_transitions(current_lane: Lane) -> list[Lane]:
     canonical matrix and (b) at or below the ceiling (IN_PROGRESS) are included.
 
     Guard conditions (actor, workspace_context, etc.) are not checked here
-    because the actual ``emit_status_transition()`` call in ``reconcile_status``
+    because the actual transactional status emit in ``reconcile_status``
     uses ``RECOVERY_ACTOR`` and handles guard failures by catching exceptions.
     This function only validates structural matrix membership.
 
@@ -613,7 +613,7 @@ def reconcile_status(
 
     Returns the number of transitions emitted.
     """
-    from specify_cli.status.emit import emit_status_transition
+    from specify_cli.coordination.status_transition import emit_status_transition_transactional
     from specify_cli.status.models import TransitionRequest
 
     feature_dir = repo_root / "kitty-specs" / mission_slug
@@ -638,17 +638,19 @@ def reconcile_status(
     emitted = 0
     for next_lane in transitions:
         try:
-            emit_status_transition(TransitionRequest(
-                feature_dir=feature_dir,
-                mission_slug=mission_slug,
-                wp_id=state.wp_id,
-                to_lane=next_lane,
-                actor=RECOVERY_ACTOR,
-                reason=f"Recovered after crash -- branch {state.branch_name} exists"
-                + (" with commits" if state.has_commits else ""),
-                execution_mode="worktree",
-                repo_root=repo_root,
-            ))
+            emit_status_transition_transactional(
+                TransitionRequest(
+                    feature_dir=feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=state.wp_id,
+                    to_lane=next_lane,
+                    actor=RECOVERY_ACTOR,
+                    reason=f"Recovered after crash -- branch {state.branch_name} exists"
+                    + (" with commits" if state.has_commits else ""),
+                    execution_mode="worktree",
+                    repo_root=repo_root,
+                )
+            )
             emitted += 1
         except Exception:
             break

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -911,30 +911,31 @@ def transition(
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
 
-    from specify_cli.status.reducer import materialize
-    from specify_cli.status.emit import emit_status_transition, TransitionError
+    from specify_cli.coordination.status_transition import emit_status_transition_transactional
+    from specify_cli.status.emit import TransitionError
     from specify_cli.status.models import TransitionRequest
 
-    snapshot = materialize(mission_dir)
-    wp_snapshot = snapshot.work_packages.get(wp, {})
-    from_lane = wp_snapshot.get("lane", Lane.PLANNED)
-
     try:
-        emit_status_transition(TransitionRequest(
-            feature_dir=mission_dir,
-            mission_slug=mission,
-            wp_id=wp,
-            to_lane=to_lane,
-            actor=actor,
-            reason=note,
-            force=force,
-            evidence=evidence,
-            review_ref=review_ref,
-            subtasks_complete=subtasks_complete,
-            implementation_evidence_present=implementation_evidence_present,
-            execution_mode="worktree",
-            policy_metadata=policy_dict,
-        ), ensure_sync_daemon=False, sync_dossier=False)
+        event = emit_status_transition_transactional(
+            TransitionRequest(
+                feature_dir=mission_dir,
+                mission_slug=mission,
+                wp_id=wp,
+                to_lane=to_lane,
+                actor=actor,
+                reason=note,
+                force=force,
+                evidence=evidence,
+                review_ref=review_ref,
+                subtasks_complete=subtasks_complete,
+                implementation_evidence_present=implementation_evidence_present,
+                execution_mode="worktree",
+                repo_root=main_repo_root,
+                policy_metadata=policy_dict,
+            ),
+            ensure_sync_daemon=False,
+            sync_dossier=False,
+        )
     except TransitionError as exc:
         _fail(cmd, "TRANSITION_REJECTED", str(exc))
         return
@@ -942,8 +943,8 @@ def transition(
     data = {
         **_mission_identity_payload(mission_dir),
         "wp_id": wp,
-        "from_lane": from_lane,
-        "to_lane": to_lane,
+        "from_lane": str(event.from_lane),
+        "to_lane": str(event.to_lane),
         "policy_metadata_recorded": policy_dict is not None,
     }
     validate_outbound_payload(data, "orchestrator_api")

--- a/src/specify_cli/status/bootstrap.py
+++ b/src/specify_cli/status/bootstrap.py
@@ -5,8 +5,8 @@ for existing state, and emits initial ``planned`` events for any WP
 that lacks one.  After seeding, materializes ``status.json`` so the
 snapshot is immediately consistent.
 
-This module uses the existing ``emit_status_transition`` pipeline --
-it does **not** reimplement event emission or validation.
+This module uses the transactional status-transition pipeline; it does
+not reimplement event emission or validation.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from specify_cli.frontmatter import FrontmatterError
-from specify_cli.status.emit import emit_status_transition
+from specify_cli.coordination.status_transition import emit_status_transition_transactional
 from specify_cli.status.models import TransitionRequest
 from specify_cli.status.reducer import materialize
 from specify_cli.status.store import read_events
@@ -97,7 +97,7 @@ def bootstrap_canonical_state(
     Scans ``feature_dir/tasks/`` for ``WP*.md`` files, reads each
     file's frontmatter to extract ``work_package_id``, then checks
     the canonical event log for existing events.  Uninitialized WPs
-    receive a ``planned`` event via :func:`emit_status_transition`.
+    receive a ``planned`` event via the transactional status emitter.
 
     After all events are emitted (unless *dry_run*), calls
     :func:`materialize` to write a fresh ``status.json``.
@@ -137,20 +137,22 @@ def bootstrap_canonical_state(
 
     # Emit planned events for uninitialized WPs
     for wp_id in wps_to_seed:
-        emit_status_transition(TransitionRequest(
-            feature_dir=feature_dir,
-            mission_slug=mission_slug,
-            wp_id=wp_id,
-            to_lane="planned",
-            actor="finalize-tasks",
-            force=True,
-            reason="canonical bootstrap",
-        ))
+        emit_status_transition_transactional(
+            TransitionRequest(
+                feature_dir=feature_dir,
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                to_lane="planned",
+                actor="finalize-tasks",
+                force=True,
+                reason="canonical bootstrap",
+            )
+        )
         result.newly_seeded += 1
         result.wp_details[wp_id] = _INITIALIZED
 
     # Materialize snapshot after all events are emitted.
-    # emit_status_transition already calls materialize per event, but
+    # The transactional emitter materializes per event, but
     # we call it once more to guarantee the final snapshot is coherent
     # across all newly seeded WPs.
     if wps_to_seed:

--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -104,9 +104,9 @@ def _now_utc() -> str:
 #
 # Workflow call sites compose ``build_status_event`` + the coordination
 # transaction's ``append_event`` (which calls into store + reducer).
-# Legacy callers that haven't migrated yet continue to use
-# ``emit_status_transition`` -- it now composes these helpers internally
-# and emits a DeprecationWarning when used outside a transaction.
+# Compatibility callers may still use ``emit_status_transition``.
+# Production workflow code routes through coordination.status_transition
+# so event append + outbound fanout are transactionally ordered.
 
 def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass constructor
     *,
@@ -115,6 +115,7 @@ def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass construc
     from_lane: str,
     to_lane: str,
     actor: str,
+    at: str | None = None,
     mission_id: str | None = None,
     force: bool = False,
     execution_mode: str = "worktree",
@@ -135,6 +136,7 @@ def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass construc
         from_lane: Canonical lane the WP is leaving.
         to_lane: Canonical lane the WP enters.
         actor: Identity of the actor performing the transition.
+        at: Optional producer occurrence timestamp; defaults to now.
         mission_id: ULID-based machine identity (optional for legacy).
         force: True if this transition bypasses guard conditions.
         execution_mode: ``"worktree"`` or ``"direct_repo"``.
@@ -152,7 +154,7 @@ def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass construc
         wp_id=wp_id,
         from_lane=Lane(from_lane),
         to_lane=Lane(to_lane),
-        at=_now_utc(),
+        at=at or _now_utc(),
         actor=actor,
         force=force,
         execution_mode=execution_mode,

--- a/src/specify_cli/status/work_package_lifecycle.py
+++ b/src/specify_cli/status/work_package_lifecycle.py
@@ -11,11 +11,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from specify_cli.status.emit import TransitionError, emit_status_transition, emit_status_transition_batch
+from specify_cli.coordination.status_transition import (
+    emit_status_transition_batch_transactional,
+    emit_status_transition_transactional,
+    read_current_wp_state_transactional,
+)
+from specify_cli.status.emit import TransitionError
 from specify_cli.status.locking import feature_status_lock
 from specify_cli.status.models import Lane, StatusEvent, TransitionRequest
-from specify_cli.status.reducer import reduce
-from specify_cli.status.store import read_events
 from specify_cli.workspace import canonicalize_feature_dir
 
 _GENERIC_IMPLEMENTATION_ACTORS = frozenset({"implement-command", "unknown"})
@@ -78,23 +81,6 @@ def _actors_compatible(existing: object | None, requested: object | None, *, all
     return allow_generic_existing and existing_key in _GENERIC_IMPLEMENTATION_ACTORS
 
 
-def _current_lane_and_actor(feature_dir: Path, wp_id: str) -> tuple[Lane, str | None]:
-    events = read_events(feature_dir)
-    if not events:
-        return Lane.PLANNED, None
-
-    snapshot = reduce(events)
-    state = snapshot.work_packages.get(wp_id)
-    if not state:
-        return Lane.PLANNED, None
-
-    try:
-        lane = Lane(str(state.get("lane", Lane.PLANNED)))
-    except ValueError:
-        lane = Lane.PLANNED
-    return lane, _actor_key(state.get("actor"))
-
-
 def start_implementation_status(
     *,
     feature_dir: Path,
@@ -115,10 +101,15 @@ def start_implementation_status(
     lock_root = _repo_root_for_lock(feature_dir, repo_root)
 
     with feature_status_lock(lock_root, mission_slug):
-        current_lane, current_actor = _current_lane_and_actor(feature_dir, wp_id)
+        current_lane, current_actor = read_current_wp_state_transactional(
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            repo_root=repo_root,
+        )
 
         if current_lane == Lane.PLANNED:
-            events = emit_status_transition_batch(
+            events = emit_status_transition_batch_transactional(
                 [
                     TransitionRequest(
                         feature_dir=feature_dir,
@@ -150,7 +141,7 @@ def start_implementation_status(
         if current_lane == Lane.CLAIMED:
             if not _actors_compatible(current_actor, actor, allow_generic_existing=True):
                 raise WorkPackageClaimConflict(wp_id, current_actor or "unknown", actor)
-            events = emit_status_transition_batch(
+            events = emit_status_transition_batch_transactional(
                 [
                     TransitionRequest(
                         feature_dir=feature_dir,
@@ -175,7 +166,7 @@ def start_implementation_status(
             return WorkPackageStartResult(wp_id, Lane.IN_PROGRESS, Lane.IN_PROGRESS, actor, (), no_op=True, claimed_by=current_actor)
 
         if allow_rework and current_lane in {Lane.FOR_REVIEW, Lane.APPROVED, Lane.IN_REVIEW}:
-            event = emit_status_transition(
+            event = emit_status_transition_transactional(
                 TransitionRequest(
                     feature_dir=feature_dir,
                     mission_slug=mission_slug,
@@ -216,10 +207,15 @@ def start_review_status(
     lock_root = _repo_root_for_lock(feature_dir, repo_root)
 
     with feature_status_lock(lock_root, mission_slug):
-        current_lane, current_actor = _current_lane_and_actor(feature_dir, wp_id)
+        current_lane, current_actor = read_current_wp_state_transactional(
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            repo_root=repo_root,
+        )
 
         if current_lane == Lane.FOR_REVIEW:
-            event = emit_status_transition(
+            event = emit_status_transition_transactional(
                 TransitionRequest(
                     feature_dir=feature_dir,
                     mission_slug=mission_slug,

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -836,7 +836,7 @@ class TestTransition:
                 return_value=repo_root,
             ),
             patch(
-                "specify_cli.status.emit.emit_status_transition",
+                "specify_cli.coordination.status_transition.emit_status_transition_transactional",
                 emit_mock,
             ),
         ):
@@ -875,7 +875,7 @@ class TestTransition:
                 return_value=repo_root,
             ),
             patch(
-                "specify_cli.status.emit.emit_status_transition",
+                "specify_cli.coordination.status_transition.emit_status_transition_transactional",
                 emit_mock,
             ),
         ):

--- a/tests/agent/test_review_feedback_pointer_2x_unit.py
+++ b/tests/agent/test_review_feedback_pointer_2x_unit.py
@@ -154,7 +154,7 @@ def _patch_move_task_dependencies(monkeypatch: pytest.MonkeyPatch, repo: Path, m
             force=kwargs.get("force", False),
         )
     )
-    monkeypatch.setattr(tasks_module, "emit_status_transition", emit_mock)
+    monkeypatch.setattr(tasks_module, "emit_status_transition_transactional", emit_mock)
     return emit_mock
 
 

--- a/tests/architectural/_baselines.yaml
+++ b/tests/architectural/_baselines.yaml
@@ -37,16 +37,8 @@ test_no_dead_modules:
   # justification: 8 documented backward-compat shim modules whose
   # absence of static src/ callers is the point.
   category_4_backcompat_shims: 8
-  # justification: 3 compat-shim WP-in-flight adapters + 1 added
-  # 2026-05-28 by post-merge remediation of mission
-  # `mission-coordination-branch-atomic-event-log-01KSPTVW` (#1348):
-  # specify_cli.coordination.outbound is the new SaaS-fanout deferral
-  # helper landed by WP05/WP09 but the 30+ production callers of
-  # ``emit_status_transition`` have NOT been migrated yet (DRIFT-6 in
-  # the mission's post-merge review). Migration is tracked under
-  # Priivacy-ai/spec-kitty#1356; once landed, the module gains a
-  # runtime caller and this baseline can drop back to 3.
-  category_5_wp_in_flight_adapters: 4  # justification: specify_cli.compat._adapters.{detector,gate,version_checker} + specify_cli.coordination.outbound; doctrine.missions.mission_step_repository wired in charter-pack-activation-layer-01KSYE4V (removed)
+  # justification: 3 compat-shim WP-in-flight adapters.
+  category_5_wp_in_flight_adapters: 3  # justification: specify_cli.compat._adapters.{detector,gate,version_checker}; doctrine.missions.mission_step_repository wired in charter-pack-activation-layer-01KSYE4V (removed)
   # justification: 3 frozen-contract internal re-exports under
   # next/_internal_runtime/ frozen by shared-package-boundary-cutover.
   category_6_frozen_runtime_reexports: 3

--- a/tests/architectural/test_no_dead_modules.py
+++ b/tests/architectural/test_no_dead_modules.py
@@ -267,16 +267,6 @@ _CATEGORY_5_WP_IN_FLIGHT_ADAPTERS: frozenset[str] = frozenset(
         # charter.scope_router removed: post-merge remediation cycle 1
         # wired prompt_builder._governance_context through build_with_scope.
         #
-        # specify_cli.coordination.outbound: new SaaS-fanout deferral
-        # helper landed by mission #1348 WP05/WP09. The new code path
-        # (``BookkeepingTransaction.queue_saas_emission``) is tested by
-        # ``tests/specify_cli/coordination/test_outbound.py`` but the 30+
-        # production callers of ``emit_status_transition`` have NOT
-        # been migrated yet (DRIFT-6 in mission #1348's post-merge
-        # review). Migration is tracked under
-        # Priivacy-ai/spec-kitty#1356; once landed, the module gains a
-        # runtime caller and this entry can be removed.
-        "specify_cli.coordination.outbound",
         # doctrine.missions.mission_step_repository: live caller landed in
         # charter.mission_steps (charter-pack-activation-layer-01KSYE4V WP09)
     }

--- a/tests/architectural/test_no_legacy_status_emit_callers.py
+++ b/tests/architectural/test_no_legacy_status_emit_callers.py
@@ -1,0 +1,63 @@
+"""Architectural guardrail for transactional status emits.
+
+Production status writes must route through
+``coordination.status_transition`` so outbound fanout is deferred until
+``BookkeepingTransaction`` commits successfully.  The legacy
+``status.emit.emit_status_transition`` functions remain as compatibility
+wrappers, but new production call sites must not use them directly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.architectural
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC_ROOT = _REPO_ROOT / "src" / "specify_cli"
+_LEGACY_NAMES = {"emit_status_transition", "emit_status_transition_batch"}
+_ALLOWED = {
+    _SRC_ROOT / "coordination" / "status_transition.py",
+    _SRC_ROOT / "status" / "emit.py",
+    _SRC_ROOT / "status" / "__init__.py",
+}
+
+
+def _legacy_status_emit_uses(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits: list[str] = []
+    imported_aliases: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "specify_cli.status.emit":
+            for alias in node.names:
+                if alias.name in _LEGACY_NAMES:
+                    imported_aliases.add(alias.asname or alias.name)
+                    hits.append(f"{path}:{node.lineno} imports {alias.name}")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in imported_aliases:
+            hits.append(f"{path}:{node.lineno} calls {func.id}")
+        elif isinstance(func, ast.Attribute) and func.attr in _LEGACY_NAMES:
+            hits.append(f"{path}:{node.lineno} calls .{func.attr}")
+    return hits
+
+
+def test_production_code_has_no_legacy_status_emit_callers() -> None:
+    offenders: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        if path in _ALLOWED:
+            continue
+        offenders.extend(_legacy_status_emit_uses(path))
+
+    assert not offenders, (
+        "Production status transitions must use "
+        "coordination.status_transition + BookkeepingTransaction.append_event:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/cli/commands/test_merge_status_commit.py
+++ b/tests/cli/commands/test_merge_status_commit.py
@@ -398,7 +398,7 @@ class TestMergeDoneTransitions:
             patch("specify_cli.status.lane_reader.get_wp_lane", return_value="approved"),
             patch("specify_cli.cli.commands.merge._has_transition_to", return_value=False),
             patch("specify_cli.status.history_parser.extract_done_evidence", return_value=None),
-            patch("specify_cli.status.emit.emit_status_transition") as mock_emit,
+            patch("specify_cli.coordination.status_transition.emit_status_transition_transactional") as mock_emit,
         ):
             _mark_wp_merged_done(tmp_path, mission_slug, "WP01", "main")
 

--- a/tests/conftest_saas_sink.py
+++ b/tests/conftest_saas_sink.py
@@ -30,7 +30,7 @@ class _RecordingSink:
     """Records every SaaS-fanout call so tests can assert on it.
 
     The instance exposes a ``calls`` list of ``(args, kwargs)`` tuples
-    and convenience helpers (``call_count``, ``last_event``) that keep
+    and convenience helpers (``call_count``, ``last_kwargs``) that keep
     test code compact.
     """
 
@@ -48,10 +48,14 @@ class _RecordingSink:
     def last_event(self) -> Any:
         if not self.calls:
             return None
-        # fire_saas_fanout is invoked with ``event=event`` per the
-        # outbound.py contract, so it's always in kwargs.
         _, kwargs = self.calls[-1]
         return kwargs.get("event")
+
+    @property
+    def last_kwargs(self) -> dict[str, Any]:
+        if not self.calls:
+            return {}
+        return self.calls[-1][1]
 
 
 @pytest.fixture

--- a/tests/git_ops/test_atomic_status_commits_unit.py
+++ b/tests/git_ops/test_atomic_status_commits_unit.py
@@ -579,14 +579,14 @@ Test content.
         )
 
         recorded_targets: list[str] = []
-        real_emit = tasks_cli.emit_status_transition
+        real_emit = tasks_cli.emit_status_transition_transactional
 
         def tracking_emit(request):
             recorded_targets.append(str(request.to_lane))
             return real_emit(request)
 
         with (
-            patch("specify_cli.cli.commands.agent.tasks.emit_status_transition", side_effect=tracking_emit),
+            patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional", side_effect=tracking_emit),
             patch("specify_cli.cli.commands.agent.tasks.safe_commit", return_value=True),
             patch("specify_cli.cli.commands.agent.tasks.console.print") as mock_print,
         ):

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -46,7 +46,7 @@ def test_mark_wp_merged_done_emits_done_transition(tmp_path: Path, monkeypatch) 
     _write_wp(tasks_dir / "WP01-test.md", review_status="approved", reviewed_by="reviewer-1")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     # Lane is event-log-driven; seed it as "approved" via lane_reader
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
@@ -56,11 +56,11 @@ def test_mark_wp_merged_done_emits_done_transition(tmp_path: Path, monkeypatch) 
     _mark_wp_merged_done(repo_root, "021-test", "WP01", "main")
 
     emit_mock.assert_called_once()
-    kwargs = emit_mock.call_args.kwargs
-    assert kwargs["to_lane"] == "done"
-    assert kwargs["actor"] == "merge"
-    assert kwargs["reason"] == "Merged WP01 into main"
-    assert kwargs["evidence"]["review"]["reviewer"] == "reviewer-1"
+    request = emit_mock.call_args.args[0]
+    assert request.to_lane == "done"
+    assert request.actor == "merge"
+    assert request.reason == "Merged WP01 into main"
+    assert request.evidence["review"]["reviewer"] == "reviewer-1"
 
 
 def test_mark_wp_merged_done_approved_without_review_metadata_synthesizes_evidence(tmp_path: Path, monkeypatch) -> None:
@@ -72,7 +72,7 @@ def test_mark_wp_merged_done_approved_without_review_metadata_synthesizes_eviden
     _write_wp(tasks_dir / "WP01-test.md")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "approved",
@@ -81,11 +81,11 @@ def test_mark_wp_merged_done_approved_without_review_metadata_synthesizes_eviden
     _mark_wp_merged_done(repo_root, "021-test", "WP01", "main")
 
     emit_mock.assert_called_once()
-    kwargs = emit_mock.call_args.kwargs
-    assert kwargs["to_lane"] == "done"
-    assert kwargs["actor"] == "merge"
-    assert kwargs["evidence"]["review"]["verdict"] == "approved"
-    assert kwargs["evidence"]["review"]["reference"] == "lane-approved:WP01"
+    request = emit_mock.call_args.args[0]
+    assert request.to_lane == "done"
+    assert request.actor == "merge"
+    assert request.evidence["review"]["verdict"] == "approved"
+    assert request.evidence["review"]["reference"] == "lane-approved:WP01"
 
 
 def test_mark_wp_merged_done_for_review_without_metadata_skips(tmp_path: Path, monkeypatch) -> None:
@@ -97,7 +97,7 @@ def test_mark_wp_merged_done_for_review_without_metadata_skips(tmp_path: Path, m
     _write_wp(tasks_dir / "WP01-test.md")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "for_review",
@@ -119,7 +119,7 @@ def test_mark_wp_merged_done_records_approved_before_done_for_legacy_for_review(
     _write_wp(tasks_dir / "WP01-test.md", review_status="approved", reviewed_by="reviewer-1")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "for_review",
@@ -128,10 +128,10 @@ def test_mark_wp_merged_done_records_approved_before_done_for_legacy_for_review(
     _mark_wp_merged_done(repo_root, "021-test", "WP01", "main")
 
     assert emit_mock.call_count == 2
-    first_kwargs = emit_mock.call_args_list[0].kwargs
-    second_kwargs = emit_mock.call_args_list[1].kwargs
-    assert first_kwargs["to_lane"] == "approved"
-    assert second_kwargs["to_lane"] == "done"
+    first_request = emit_mock.call_args_list[0].args[0]
+    second_request = emit_mock.call_args_list[1].args[0]
+    assert first_request.to_lane == "approved"
+    assert second_request.to_lane == "done"
 
 
 @pytest.mark.parametrize("lane_name", ["planned", "claimed", "in_progress"])
@@ -147,7 +147,7 @@ def test_mark_wp_merged_done_recovers_reviewed_wps_from_pre_review_lanes(
     _write_wp(tasks_dir / "WP01-test.md", review_status="approved", reviewed_by="reviewer-1")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: lane_name,
@@ -156,8 +156,8 @@ def test_mark_wp_merged_done_recovers_reviewed_wps_from_pre_review_lanes(
     _mark_wp_merged_done(repo_root, "021-test", "WP01", "main")
 
     assert emit_mock.call_count == 2
-    assert emit_mock.call_args_list[0].kwargs["to_lane"] == "approved"
-    assert emit_mock.call_args_list[1].kwargs["to_lane"] == "done"
+    assert emit_mock.call_args_list[0].args[0].to_lane == "approved"
+    assert emit_mock.call_args_list[1].args[0].to_lane == "done"
 
 
 def test_mark_wp_merged_done_synthesized_evidence_uses_typed_agent(
@@ -172,7 +172,7 @@ def test_mark_wp_merged_done_synthesized_evidence_uses_typed_agent(
     _write_wp(tasks_dir / "WP01-test.md", agent="gemini-cli")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "approved",
@@ -181,8 +181,8 @@ def test_mark_wp_merged_done_synthesized_evidence_uses_typed_agent(
     _mark_wp_merged_done(repo_root, "021-test", "WP01", "main")
 
     emit_mock.assert_called_once()
-    kwargs = emit_mock.call_args.kwargs
-    assert kwargs["evidence"]["review"]["reviewer"] == "gemini-cli"
+    request = emit_mock.call_args.args[0]
+    assert request.evidence["review"]["reviewer"] == "gemini-cli"
 
 
 def test_mark_wp_merged_done_uses_typed_frontmatter(

--- a/tests/merge/test_merge_recovery.py
+++ b/tests/merge/test_merge_recovery.py
@@ -227,7 +227,7 @@ class TestEventDedupGuard:
         feature_dir = tmp_path / "kitty-specs" / MISSION_ID
         feature_dir.mkdir(parents=True)
 
-        assert _has_transition_to(feature_dir, "WP01", "done") is False
+        assert _has_transition_to(feature_dir, MISSION_ID, "WP01", "done", tmp_path) is False
 
     def test_has_transition_to_finds_match(self, tmp_path: Path):
         """Returns True when the target transition exists in the log."""
@@ -251,7 +251,7 @@ class TestEventDedupGuard:
         }
         events_file.write_text(json.dumps(event, sort_keys=True) + "\n", encoding="utf-8")
 
-        assert _has_transition_to(feature_dir, "WP01", "done") is True
+        assert _has_transition_to(feature_dir, MISSION_ID, "WP01", "done", tmp_path) is True
 
     def test_has_transition_to_no_match(self, tmp_path: Path):
         """Returns False when the target transition does not match."""
@@ -275,8 +275,8 @@ class TestEventDedupGuard:
         events_file.write_text(json.dumps(event, sort_keys=True) + "\n", encoding="utf-8")
 
         # WP01 has approved but NOT done
-        assert _has_transition_to(feature_dir, "WP01", "done") is False
-        assert _has_transition_to(feature_dir, "WP01", "approved") is True
+        assert _has_transition_to(feature_dir, MISSION_ID, "WP01", "done", tmp_path) is False
+        assert _has_transition_to(feature_dir, MISSION_ID, "WP01", "approved", tmp_path) is True
 
     def test_has_transition_to_different_wp(self, tmp_path: Path):
         """Dedup is per-WP: WP02 done does not match WP01."""
@@ -299,8 +299,8 @@ class TestEventDedupGuard:
         }
         events_file.write_text(json.dumps(event, sort_keys=True) + "\n", encoding="utf-8")
 
-        assert _has_transition_to(feature_dir, "WP01", "done") is False
-        assert _has_transition_to(feature_dir, "WP02", "done") is True
+        assert _has_transition_to(feature_dir, MISSION_ID, "WP01", "done", tmp_path) is False
+        assert _has_transition_to(feature_dir, MISSION_ID, "WP02", "done", tmp_path) is True
 
     def test_reconcile_completed_wps_drops_missing_done_evidence(self, tmp_path: Path):
         """Resume state cannot skip a WP when its uncommitted done event was lost."""
@@ -319,6 +319,7 @@ class TestEventDedupGuard:
 
         confirmed = _reconcile_completed_wps_for_resume(
             feature_dir=feature_dir,
+            mission_slug=MISSION_ID,
             merge_state=state,
             repo_root=tmp_path,
         )
@@ -363,6 +364,7 @@ class TestEventDedupGuard:
 
         confirmed = _reconcile_completed_wps_for_resume(
             feature_dir=feature_dir,
+            mission_slug=MISSION_ID,
             merge_state=state,
             repo_root=tmp_path,
         )

--- a/tests/specify_cli/cli/commands/agent/test_tasks.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks.py
@@ -198,7 +198,7 @@ class TestVerdictGuardInMoveTask:
     """move_task blocks force-approve/force-done when verdict == rejected."""
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
@@ -271,7 +271,7 @@ class TestVerdictGuardInMoveTask:
         assert "arbiter override" in result.output
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
@@ -342,7 +342,7 @@ class TestVerdictGuardInMoveTask:
         mock_emit.assert_not_called()
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
@@ -415,7 +415,7 @@ class TestSkipReviewArtifactCheck:
     """--skip-review-artifact-check records a durable override."""
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
@@ -504,7 +504,7 @@ class TestSkipReviewArtifactCheck:
         assert "review_artifact_override_reason:" in artifact_text
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")

--- a/tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py
@@ -232,7 +232,7 @@ class TestBodyNotesNoLane:
     """Body notes written by move_task and add_history must NOT contain lane=."""
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
@@ -459,7 +459,7 @@ class TestMoveTaskHardFail:
         )
 
     @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.read_events")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")

--- a/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py
@@ -130,7 +130,7 @@ def test_wp_id_rejected_with_move_task_guidance(tmp_path: Path) -> None:
     slug = "003-wp-mark-done"
     _write_mission(tmp_path, slug, "# Tasks\n\n## WP02\n", wp_ids=("WP02",))
 
-    with patch("specify_cli.cli.commands.agent.tasks.emit_status_transition") as emit_mock:
+    with patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional") as emit_mock:
         payload = _invoke_mark_status(tmp_path, slug, "WP02", expected_exit_code=1)
 
     result = _result_by_id(payload, "WP02")
@@ -152,7 +152,7 @@ def test_wp_id_rejection_is_actionable_in_human_output(tmp_path: Path) -> None:
         patch("specify_cli.cli.commands.agent.tasks._emit_sparse_session_warning"),
         patch("specify_cli.cli.commands.agent.tasks.feature_status_lock", _null_lock),
         patch("specify_cli.cli.commands.agent.tasks.emit_history_added"),
-        patch("specify_cli.cli.commands.agent.tasks.emit_status_transition") as emit_mock,
+        patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional") as emit_mock,
     ):
         result = runner.invoke(
             app,

--- a/tests/specify_cli/cli/commands/agent/test_tasks_planning_artifact_lifecycle.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_planning_artifact_lifecycle.py
@@ -76,7 +76,7 @@ def _make_wp_record(mission_slug: str, wp_file: Path, current_lane: str, executi
 
 
 class TestPlanningArtifactLifecycle:
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
     @patch("specify_cli.cli.commands.agent.tasks._check_unchecked_subtasks")
@@ -129,7 +129,7 @@ class TestPlanningArtifactLifecycle:
         assert result.exit_code == 0, f"CLI error: {result.output}"
 
     @patch("specify_cli.cli.commands.agent.tasks._wp_branch_merged_into_target")
-    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition")
+    @patch("specify_cli.cli.commands.agent.tasks.emit_status_transition_transactional")
     @patch("specify_cli.cli.commands.agent.tasks.feature_status_lock")
     @patch("specify_cli.cli.commands.agent.tasks._validate_ready_for_review")
     @patch("specify_cli.cli.commands.agent.tasks._check_unchecked_subtasks")

--- a/tests/specify_cli/cli/commands/test_merge.py
+++ b/tests/specify_cli/cli/commands/test_merge.py
@@ -20,6 +20,7 @@ Verifies that:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -219,12 +220,12 @@ def test_mark_wp_merged_done_emits_done_when_lane_is_approved(
     tasks_dir.mkdir(parents=True)
     _write_wp(tasks_dir / "WP01-test.md", reviewed_by="reviewer-1")
 
-    emit_calls: list[dict[str, object]] = []
+    emit_calls: list[Any] = []
 
-    def fake_emit(**kwargs: object) -> None:
-        emit_calls.append(kwargs)
+    def fake_emit(request: Any, **_kwargs: object) -> None:
+        emit_calls.append(request)
 
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", fake_emit)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", fake_emit)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "approved",
@@ -233,8 +234,8 @@ def test_mark_wp_merged_done_emits_done_when_lane_is_approved(
     _mark_wp_merged_done(tmp_path, mission_slug, "WP01", "main")
 
     assert len(emit_calls) == 1
-    assert emit_calls[0]["to_lane"] == "done"
-    assert emit_calls[0]["actor"] == "merge"
+    assert emit_calls[0].to_lane == "done"
+    assert emit_calls[0].actor == "merge"
 
 
 def test_mark_wp_merged_done_skips_when_already_done(
@@ -248,7 +249,7 @@ def test_mark_wp_merged_done_skips_when_already_done(
     _write_wp(tasks_dir / "WP01-test.md")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "done",
@@ -271,7 +272,7 @@ def test_mark_wp_merged_done_skips_when_no_approval_metadata_for_non_approved(
     _write_wp(tasks_dir / "WP01-test.md", review_status="", reviewed_by="")
 
     emit_mock = Mock()
-    monkeypatch.setattr("specify_cli.status.emit.emit_status_transition", emit_mock)
+    monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.status.lane_reader.get_wp_lane",
         lambda *_a, **_kw: "in_progress",

--- a/tests/specify_cli/coordination/test_outbound.py
+++ b/tests/specify_cli/coordination/test_outbound.py
@@ -105,14 +105,16 @@ def test_saas_emits_after_commit_success(repo: Path, mock_saas_sink: Any) -> Non
     assert mock_saas_sink.call_count == 1, (
         f"expected 1 SaaS emission; got {mock_saas_sink.call_count}"
     )
-    assert mock_saas_sink.last_event is event
+    assert mock_saas_sink.last_kwargs["causation_id"] == event.event_id
+    assert mock_saas_sink.last_kwargs["wp_id"] == event.wp_id
+    assert mock_saas_sink.last_kwargs["from_lane"] == str(event.from_lane)
+    assert mock_saas_sink.last_kwargs["to_lane"] == str(event.to_lane)
 
 
 def test_saas_emission_preserves_mission_slug_and_repo_root(
     repo: Path, mock_saas_sink: Any,
 ) -> None:
-    """The deferred call routes through ``fire_saas_fanout(event=, mission_slug=,
-    repo_root=)`` with the txn's identity fields by default."""
+    """The deferred call routes through the canonical WPStatusChanged kwargs."""
     event = _make_event()
 
     with BookkeepingTransaction.acquire(
@@ -129,7 +131,8 @@ def test_saas_emission_preserves_mission_slug_and_repo_root(
     assert mock_saas_sink.call_count == 1
     _, kwargs = mock_saas_sink.calls[-1]
     assert kwargs["mission_slug"] == MISSION_SLUG
-    assert kwargs["repo_root"] == repo
+    assert kwargs["mission_id"] == MISSION_ID
+    assert kwargs["ensure_daemon"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/coordination/test_status_transition.py
+++ b/tests/specify_cli/coordination/test_status_transition.py
@@ -1,0 +1,110 @@
+"""Transactional status-transition integration tests for issue #1356."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from specify_cli.coordination.status_transition import emit_status_transition_transactional
+from specify_cli.coordination.transaction import BookkeepingCommitFailed
+from specify_cli.status.models import TransitionRequest
+
+pytest_plugins = ("tests.conftest_saas_sink",)
+
+pytestmark = [pytest.mark.unit, pytest.mark.git_repo]
+
+MISSION_SLUG = "status-transaction"
+MID8 = "01KT1356"
+MISSION_ID = "01KT1356000000000000000000"
+MISSION_DIRNAME = f"{MISSION_SLUG}-{MID8}"
+COORD_BRANCH = f"kitty/mission-{MISSION_DIRNAME}"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@example.invalid")
+    _git(r, "config", "user.name", "Test")
+    _git(r, "config", "commit.gpgsign", "false")
+    feature_dir = r / "kitty-specs" / MISSION_DIRNAME
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": MISSION_SLUG,
+                "mission_id": MISSION_ID,
+                "mid8": MID8,
+                "coordination_branch": COORD_BRANCH,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _git(r, "add", "kitty-specs")
+    _git(r, "commit", "-q", "-m", "seed mission")
+    _git(r, "branch", COORD_BRANCH)
+    return r
+
+
+def _request(repo: Path) -> TransitionRequest:
+    return TransitionRequest(
+        feature_dir=repo / "kitty-specs" / MISSION_DIRNAME,
+        mission_slug=MISSION_SLUG,
+        wp_id="WP01",
+        to_lane="claimed",
+        actor="issue-1356-test",
+        repo_root=repo,
+    )
+
+
+def test_transactional_emit_fans_out_only_after_commit(
+    repo: Path,
+    mock_saas_sink: Any,
+) -> None:
+    event = emit_status_transition_transactional(_request(repo), sync_dossier=False)
+
+    assert mock_saas_sink.call_count == 1
+    assert mock_saas_sink.last_kwargs["causation_id"] == event.event_id
+
+    show = _git(repo, "show", f"{COORD_BRANCH}:kitty-specs/{MISSION_DIRNAME}/status.events.jsonl")
+    assert event.event_id in show.stdout
+
+
+def test_transactional_emit_skips_fanout_when_commit_rolls_back(
+    repo: Path,
+    mock_saas_sink: Any,
+) -> None:
+    hooks_dir = repo / ".git" / "hooks-reject"
+    hooks_dir.mkdir()
+    hook = hooks_dir / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+    _git(repo, "config", "core.hooksPath", str(hooks_dir))
+
+    with pytest.raises(BookkeepingCommitFailed):
+        emit_status_transition_transactional(_request(repo), sync_dossier=False)
+
+    assert mock_saas_sink.call_count == 0
+    missing = _git(
+        repo,
+        "show",
+        f"{COORD_BRANCH}:kitty-specs/{MISSION_DIRNAME}/status.events.jsonl",
+        check=False,
+    )
+    assert missing.returncode != 0

--- a/tests/specify_cli/coordination/test_status_transition.py
+++ b/tests/specify_cli/coordination/test_status_transition.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from specify_cli.coordination.status_transition import emit_status_transition_transactional
-from specify_cli.coordination.transaction import BookkeepingCommitFailed
+from specify_cli.coordination.transaction import BookkeepingCommitFailed, BookkeepingWorktreeMissing
 from specify_cli.status.models import TransitionRequest
 
 pytest_plugins = ("tests.conftest_saas_sink",)
@@ -108,3 +108,32 @@ def test_transactional_emit_skips_fanout_when_commit_rolls_back(
         check=False,
     )
     assert missing.returncode != 0
+
+
+def test_transactional_emit_fails_closed_when_coordination_branch_missing(
+    repo: Path,
+    mock_saas_sink: Any,
+) -> None:
+    _git(repo, "branch", "-D", COORD_BRANCH)
+
+    with pytest.raises(BookkeepingWorktreeMissing):
+        emit_status_transition_transactional(_request(repo), sync_dossier=False)
+
+    assert mock_saas_sink.call_count == 0
+    assert not (repo / "kitty-specs" / MISSION_DIRNAME / "status.events.jsonl").exists()
+
+
+def test_transactional_emit_fails_closed_on_malformed_meta(
+    repo: Path,
+    mock_saas_sink: Any,
+) -> None:
+    (repo / "kitty-specs" / MISSION_DIRNAME / "meta.json").write_text(
+        "{bad json",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Malformed JSON"):
+        emit_status_transition_transactional(_request(repo), sync_dossier=False)
+
+    assert mock_saas_sink.call_count == 0
+    assert not (repo / "kitty-specs" / MISSION_DIRNAME / "status.events.jsonl").exists()


### PR DESCRIPTION
## Summary
- Add `coordination.status_transition` as the production transactional status emit/read adapter.
- Migrate CLI status/task/implement, merge, lifecycle, recovery, bootstrap, and orchestrator API callers off direct `emit_status_transition`/batch usage.
- Queue SaaS fanout through `BookkeepingTransaction.defer_outbound` after commit and preserve compatibility fallback only for non-transactional/no-topology fixtures and legacy wrapper consumers.
- Add architectural guard preventing new production legacy emit callers.

Closes #1356.

## Tests
- `.venv/bin/ruff check src tests/architectural/test_no_legacy_status_emit_callers.py tests/specify_cli/coordination/test_status_transition.py tests/merge/test_merge_done_recording.py tests/specify_cli/cli/commands/test_merge.py tests/git_ops/test_atomic_status_commits_unit.py tests/specify_cli/coordination/test_outbound.py tests/conftest_saas_sink.py`
- `.venv/bin/python -m pytest tests/specify_cli/coordination/test_transaction.py tests/specify_cli/coordination/test_outbound.py tests/specify_cli/coordination/test_status_transition.py tests/specify_cli/coordination/test_policy.py tests/status/test_work_package_lifecycle.py tests/merge/test_merge_done_recording.py tests/cli/commands/test_merge_status_commit.py::TestMergeDoneTransitions tests/specify_cli/cli/commands/test_merge.py tests/agent/test_orchestrator_commands_integration.py::TestTransition tests/git_ops/test_atomic_status_commits_unit.py::TestMoveTaskAtomicCommit tests/architectural/test_no_legacy_status_emit_callers.py tests/architectural/test_no_dead_modules.py -q`
- `.venv/bin/python -m pytest tests/status/test_emit.py tests/status/test_emit_fanout_after_adapter.py tests/sync/test_dual_write_integration.py tests/status/test_status_e2e_integration.py tests/status/test_event_mission_id.py tests/status/test_views.py tests/status/test_sync_lane_mapping.py -q`
- `.venv/bin/python -m pytest tests/specify_cli/cli/commands/agent/test_tasks_mark_status.py tests/specify_cli/cli/commands/agent/test_tasks_planning_artifact_lifecycle.py tests/specify_cli/cli/commands/agent/test_tasks.py tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py tests/agent/test_review_feedback_pointer_2x_unit.py -q`
- `git diff --check`
