### PR TITLE
fix: exempt raw event sanitizer envelopes

### DIFF
--- a/src/specify_cli/events/decision_log.py
+++ b/src/specify_cli/events/decision_log.py
@@ -152,6 +152,7 @@ class DecisionGitLog:
         else:
             payload_dict = dict(payload) if payload is not None else {}
 
+        # canonical-producer-exempt: #1198 -- canonical local-only decision git-log envelope.
         return {
             "at": datetime.now(UTC).isoformat(),
             "event_id": _generate_event_id(),

--- a/tests/specify_cli/events/test_decision_log.py
+++ b/tests/specify_cli/events/test_decision_log.py
@@ -303,6 +303,7 @@ class TestQueueExclusion:
 
         q = OfflineQueue.__new__(OfflineQueue)
         result = q.queue_event(
+            # canonical-producer-exempt: #1198 -- queue exclusion guard needs a minimal raw event envelope.
             {
                 "event_id": "e001",
                 "event_type": "DecisionInputRequested",
@@ -317,6 +318,7 @@ class TestQueueExclusion:
 
         q = OfflineQueue.__new__(OfflineQueue)
         result = q.queue_event(
+            # canonical-producer-exempt: #1198 -- queue exclusion guard needs a minimal raw event envelope.
             {
                 "event_id": "e002",
                 "event_type": "DecisionInputAnswered",

--- a/tests/specify_cli/events/test_sanitizer.py
+++ b/tests/specify_cli/events/test_sanitizer.py
@@ -50,6 +50,7 @@ def test_pii_field_stripped_top_level(pii_field: str) -> None:
 )
 def test_pii_field_stripped_nested(pii_field: str) -> None:
     """Each PII field is removed when nested inside a payload dict."""
+    # canonical-producer-exempt: #1198 -- sanitizer unit test must exercise raw envelope input.
     envelope = {
         "event_type": "TestEvent",
         "payload": {pii_field: "sensitive-value", "safe_field": "keep"},
@@ -79,6 +80,7 @@ def test_all_pii_fields_stripped_together() -> None:
 
 def test_pii_stripped_from_nested_payload() -> None:
     """PII is removed from nested payload dict; safe fields survive."""
+    # canonical-producer-exempt: #1198 -- sanitizer unit test must exercise raw envelope input.
     envelope = {
         "event_type": "E",
         "payload": {"machine_name": "x", "safe_field": "keep"},
@@ -135,6 +137,7 @@ def test_does_not_mutate_input() -> None:
 
 def test_non_pii_fields_preserved() -> None:
     """Fields that are explicitly NOT PII are passed through unchanged."""
+    # canonical-producer-exempt: #1198 -- sanitizer unit test must exercise raw envelope input.
     preserved_fields = {
         "node_id": "node-abc",
         "build_id": "build-123",
@@ -158,6 +161,7 @@ def test_empty_envelope_returned_unchanged() -> None:
 
 def test_envelope_with_no_pii_unchanged() -> None:
     """Envelope with no PII or timestamp fields is returned structurally identical."""
+    # canonical-producer-exempt: #1198 -- sanitizer unit test must exercise raw envelope input.
     envelope = {
         "event_type": "Foo",
         "mission_id": "m1",
@@ -274,6 +278,7 @@ def test_session_duration_already_present_not_overwritten() -> None:
 
 def test_pii_and_timestamps_stripped_together() -> None:
     """PII removal and timestamp replacement operate correctly in combination."""
+    # canonical-producer-exempt: #1198 -- sanitizer unit test must exercise raw envelope input.
     envelope = {
         "event_type": "DecisionInputRequested",
         "machine_name": "roberts-mbp",

--- a/tests/specify_cli/status/test_store_sanitized.py
+++ b/tests/specify_cli/status/test_store_sanitized.py
@@ -200,6 +200,7 @@ def test_pii_absent_from_decision_point_opened_event_top_level(
     from specify_cli.decisions.emit import _append_raw_event
 
     events_path = tmp_path / "status.events.jsonl"
+    # canonical-producer-exempt: #1198 -- sanitizer regression test injects top-level PII into raw event envelope.
     event_dict: dict = {
         "event_id": "01HXYZ0123456789ABCDEFGHJK",
         "at": "2026-06-01T10:00:00+00:00",
@@ -231,6 +232,7 @@ def test_pii_absent_from_decision_point_opened_event_nested(
     from specify_cli.decisions.emit import _append_raw_event
 
     events_path = tmp_path / "status.events.jsonl"
+    # canonical-producer-exempt: #1198 -- sanitizer regression test injects nested PII into raw event envelope.
     event_dict: dict = {
         "event_id": "01HXYZ0123456789ABCDEFGHJK",
         "at": "2026-06-01T10:00:00+00:00",
@@ -263,6 +265,7 @@ def test_pii_absent_from_decision_point_resolved_event(
     from specify_cli.decisions.emit import _append_raw_event
 
     events_path = tmp_path / "status.events.jsonl"
+    # canonical-producer-exempt: #1198 -- sanitizer regression test injects nested PII into raw event envelope.
     event_dict: dict = {
         "event_id": "01HXYZ0123456789ABCDEFGHJM",
         "at": "2026-06-01T10:01:00+00:00",
@@ -292,6 +295,7 @@ def test_non_pii_fields_preserved_in_decision_event(tmp_path: Path) -> None:
     from specify_cli.decisions.emit import _append_raw_event
 
     events_path = tmp_path / "status.events.jsonl"
+    # canonical-producer-exempt: #1198 -- sanitizer regression test asserts raw decision envelope preservation.
     event_dict = {
         "event_id": "01HXYZ0123456789ABCDEFGHJK",
         "at": "2026-06-01T10:00:00+00:00",


### PR DESCRIPTION
## Summary

- Adds auditable canonical-producer exemptions for local-only/raw JSONL envelopes introduced around PR #1564.
- Keeps production decision payloads canonical while allowing sanitizer tests to exercise raw envelope inputs.

## Verification

- .venv/bin/python scripts/lint_canonical_producers.py --paths src scripts tests --baseline scripts/canonical_producer_lint_baseline.txt
- .venv/bin/pytest tests/specify_cli/events/test_decision_log.py tests/specify_cli/events/test_sanitizer.py tests/specify_cli/status/test_store_sanitized.py -q
- .venv/bin/ruff check src/specify_cli/events/decision_log.py tests/specify_cli/events/test_decision_log.py tests/specify_cli/events/test_sanitizer.py tests/specify_cli/status/test_store_sanitized.py