### PR TITLE
chore(release): prepare 3.2.0rc33

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc32
+  version: 3.2.0rc33
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc33] - 2026-06-01
+
+### Changed
+
+- Tag-time PyPI publishing now stays focused on release-local checks. Live
+  canary evidence and the cross-repo end-to-end consumer scenario are no longer
+  blocking jobs in `.github/workflows/release.yml`; operators can still run
+  those suites locally before cutting a release.
+- Release metadata now aligns `.kittify/metadata.yaml` with `pyproject.toml`
+  for `3.2.0rc33`.
+
+## [Unreleased - rc32 follow-ups]
+
 ### Added
 
 - Charter governance references: `governance_references` declarations in `charter.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc32"
+version = "3.2.0rc33"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- bump spec-kitty-cli release metadata to 3.2.0rc33
- add 3.2.0rc33 changelog entry for release workflow simplification

## Test
- python scripts/release/validate_release.py --mode tag --tag v3.2.0rc33 --tag-pattern 'v*.*.*'
- python -m pytest tests/release -v --import-mode=importlib
