### PR TITLE
docs(release): require local canary and e2e hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Clarified that live canary and cross-repo end-to-end runs remain required
+  release-candidate hygiene under the charter, but are run locally before
+  tagging instead of as tag-time PyPI publish workflow blockers.
+
 ## [3.2.0rc33] - 2026-06-01
 
 ### Changed
 
 - Tag-time PyPI publishing now stays focused on release-local checks. Live
   canary evidence and the cross-repo end-to-end consumer scenario are no longer
-  blocking jobs in `.github/workflows/release.yml`; operators can still run
-  those suites locally before cutting a release.
+  blocking jobs in `.github/workflows/release.yml`; they remain required local
+  release-candidate hygiene before tagging.
 - Release metadata now aligns `.kittify/metadata.yaml` with `pyproject.toml`
   for `3.2.0rc33`.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -74,6 +74,30 @@ Use this checklist for releases from `main`.
     --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json
   ```
 
+### Release-Candidate Hygiene
+
+The charter requires release-candidate verification to include the full CLI
+suite and cross-repo behavior evidence. Run these locally from a trusted runner
+before tagging; do not rely on the tag-time publish workflow to run live
+canary or cross-repo end-to-end suites.
+
+- [ ] Record the full CLI test-suite result from `pytest tests/ -v`.
+- [ ] Run the cross-repo end-to-end suite locally:
+  ```bash
+  cd ../../spec-kitty-end-to-end-testing
+  uv sync
+  SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/ -v
+  ```
+- [ ] Run the live deployed-dev canary from the trusted-runner profile:
+  ```bash
+  cd ../../spec-kitty-end-to-end-testing
+  ./scripts/run-canary.sh --profile local --phase all
+  ```
+- [ ] Record the e2e and canary result in the release PR, changelog note, or
+  release issue. If either fails or is inconclusive, do not tag until the
+  product issue is fixed or an explicit maintainer waiver with an issue link is
+  recorded.
+
 ### Documentation and Metadata
 
 - [ ] Bump `version` in `pyproject.toml`.
@@ -181,10 +205,12 @@ package first, verify it is installable from PyPI, and only then tag the CLI.
   - validates candidate compatibility against the SaaS consumer contract
   - builds distributions
   - publishes after tag-time release checks pass
-  - validates four clean `spec-kitty-dev` canary runs or a structured waiver
   - creates the GitHub release
   - publishes to PyPI
   - verifies exact installability from PyPI with no local wheel
+- [ ] Confirm release-candidate hygiene was already recorded before the tag:
+  live canary and cross-repo end-to-end suites are required pre-release
+  operator evidence, not tag-time publish workflow jobs.
 - [ ] If this is a prerelease, confirm GitHub marks the release as `Pre-release`.
 - [ ] Verify the publishing workflow result separately from branch health.
   A successful PyPI/GitHub release proves publication only; it does not prove

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -114,6 +114,12 @@ Release PR check ownership:
 2. `CI Quality` owns tests, wheel build, lockfile checks, exact install verification, and SaaS consumer compatibility evidence.
 3. `Check Shared Package Drift` owns shared-package pin drift evidence.
 
+Live canary and cross-repo end-to-end runs are release-candidate hygiene, not
+tag-time publish jobs. The charter still requires them before a release
+candidate is tagged; the release owner must run them locally from a trusted
+runner and record the pass, product failure, inconclusive result, or explicit
+maintainer waiver.
+
 Tag-time publish workflow sequence:
 
 1. run tests
@@ -149,21 +155,28 @@ python scripts/release/check_candidate_consumer_compat.py \
   --consumer-contract ../spec-kitty-saas/contracts/consumer-compatibility.json
 twine check dist/*
 
-# 3) clean build artifacts
+# 3) release-candidate hygiene (local trusted-runner evidence, before tagging)
+pushd ../../spec-kitty-end-to-end-testing
+uv sync
+SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/ -v
+./scripts/run-canary.sh --profile local --phase all
+popd
+
+# 4) clean build artifacts
 rm -rf dist/ build/
 
-# 4) commit, push, and merge the release metadata through a PR
+# 5) commit, push, and merge the release metadata through a PR
 spec-kitty safe-commit --message "chore(release): prepare 3.1.0a0" pyproject.toml CHANGELOG.md
 git push origin release/3.1.0a0
 gh pr create --base main --title "Release 3.1.0a0" --fill
 
-# 5a) prerelease publish from updated main
+# 6a) prerelease publish from updated main
 git checkout main
 git pull origin main
 git tag v3.1.0a0 -m "Release 3.1.0a0"
 git push origin v3.1.0a0
 
-# 5b) stable publish from updated main
+# 6b) stable publish from updated main
 #     Edit pyproject.toml to "3.1.0" and rename the changelog heading to [3.1.0]
 git tag v3.1.0 -m "Release 3.1.0"
 git push origin v3.1.0

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc32"
+version = "3.2.0rc33"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- Document charter-required release-candidate hygiene for local live canary and cross-repo end-to-end runs
- Clarify tag-time publish workflow does not run those trusted-runner suites
- Update changelog wording so canary/e2e are required pre-tag evidence, not optional CI blockers

## Validation
- .venv/bin/python -m pytest tests/release -v --import-mode=importlib