### PR TITLE
fix(#1589 facet 3): status reads resolve the coordination worktree

### DIFF
--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2003,6 +2003,13 @@
   current_target: false
   citation_refs: []
   notes: null
+- path: docs/development/facet3-status-read-desync-design.md
+  tag: internal
+  divio_type: explanation
+  owning_workstream: status-coordination
+  current_target: false
+  citation_refs: []
+  notes: Design note for PR #1597 status read coordination worktree desync.
 - path: docs/development/issue-1040-scope-assessment.md
   tag: internal
   divio_type: none

--- a/docs/development/facet3-status-read-desync-design.md
+++ b/docs/development/facet3-status-read-desync-design.md
@@ -1,0 +1,114 @@
+# Design: fix #1589 facet 3 — coordination/mission status read desync
+
+**Status:** proposed (design-first; no code yet)
+**Scope:** `spec-kitty` status read path for lane-based missions
+**Related:** [#1589](https://github.com/Priivacy-ai/spec-kitty/issues/1589) facet 3; builds on #1590 (facets 1 & 2)
+
+## 1. Root cause (precise, evidence-backed)
+
+Lane-based missions keep canonical status on a **coordination branch**, materialized in a
+per-mission **coordination worktree** (`.worktrees/<slug>-<mid8>-coord/kitty-specs/<slug>-<mid8>/`).
+
+- **Writes are already correct.** `finalize`, `implement`, `move-task`, `merge`, and
+  `bootstrap_canonical_state` all emit through
+  `coordination.status_transition.emit_status_transition_transactional`, which commits the
+  event to the **coordination branch** (via `BookkeepingTransaction`). Verified: the coord
+  worktree holds the full log (82 lane events → 18 WPs materialize).
+
+- **Reads are inconsistent.** Two commands were updated to read coordination-aware:
+  - `cli/commands/agent/workflow.py` → `_canonical_status_feature_dir()` →
+    `missions._read_path_resolver.resolve_mission_read_path()`
+  - `acceptance/__init__.py` → `_status_read_feature_dir()`
+
+  But three read paths were **not**, and still read the raw `main_repo_root/kitty-specs/<slug>`
+  (the mission branch, which never receives the lane events):
+  1. `cli/commands/agent/tasks.py::move_task` — `read_events(feature_dir)` at ~:1833 and the
+     `current_event_lane` lookup.
+  2. `cli/commands/next_cmd.py` — `feature_dir = repo_root_path / "kitty-specs" / mission_slug`
+     (several sites) feeding the decision/status read.
+  3. `status/lane_reader.py` (`get_wp_lane`/`_require_event_log`) and `status/reducer.materialize`
+     when called with the primary feature_dir.
+
+**Net effect:** `move-task`/`next` read the stale mission-branch log → "WP has no canonical
+status" even though the coordination worktree has a fully materialized status. This is the
+exact wall that blocks the implement-review loop.
+
+**Conclusion:** this is **incomplete adoption** of the existing coordination-aware read
+resolver, *not* an architectural redesign. The canonical helper already exists and is proven:
+`resolve_mission_read_path(main_repo_root, mission_slug, mid8)` returns the coord worktree
+feature_dir when it exists, else the primary checkout (legacy/no-coord missions).
+
+## 2. Fix
+
+Route the three missing read paths through the **existing** resolver, mirroring `workflow.py`.
+
+- **Centralize:** promote `_canonical_status_feature_dir` (currently private in `workflow.py`)
+  to a shared location — e.g. `missions._read_path_resolver` already hosts
+  `resolve_mission_read_path`; add a thin `canonical_status_feature_dir(main_repo_root, slug)`
+  wrapper there (computes mid8 from meta) and have `workflow.py`/`acceptance` re-use it (removing
+  their private duplicates over time).
+- **Apply at the read sites:**
+  1. `move_task` (tasks.py): resolve the read-side `feature_dir` via the wrapper before
+     `read_events` / the lane lookup. The transactional *write* already targets coord; this aligns
+     the *read* with it. (The `safe_commit` to the mission branch for WP-frontmatter/status.json is
+     a separate concern — see §5.)
+  2. `next_cmd.py`: resolve the status-read `feature_dir` via the wrapper for the decision read
+     (keep the planning/worktree-creation paths on the primary checkout).
+  3. `lane_reader` / `materialize`: lowest-leverage but highest-consistency — make the canonical
+     lane read resolve through the wrapper so *any* caller that goes through `get_wp_lane` is
+     coordination-aware by construction. (Preferred: fix here + the command-level sites, so the
+     contract "all lane reads go through lane_reader" actually holds.)
+
+## 3. Backward compatibility
+
+`resolve_mission_read_path` returns the **primary checkout** when no coord worktree exists
+(legacy/pre-coordination missions). So non-lane/legacy missions are **unaffected** — the change
+is a no-op for them. New behavior only engages when a `-coord` worktree is present.
+
+## 4. Blast radius & risk
+
+- **Read-only resolution change**, guarded by "coord worktree exists" → low risk of data
+  corruption (no new writes introduced).
+- Touches status reads across `move-task`, `next`, `lane_reader`/`materialize`. Medium surface,
+  but each change is "compute feature_dir via the resolver that two other commands already use."
+- Main risk: a caller that *intends* the primary checkout (e.g. planning artifact reads, worktree
+  creation) accidentally redirected to coord. Mitigation: only redirect the **status/event-log
+  reads**, never the planning-artifact or worktree-management paths.
+
+## 5. Known adjacent issue (call out, do not silently fold in)
+
+`move-task` does a `safe_commit` to the **mission branch** (tasks.py ~:1959) for WP-frontmatter /
+`status.json`, while the *event* is committed to the **coordination branch**. After the read fix,
+the authoritative event log is unambiguously the coord branch; the mission-branch `status.json`
+becomes a derived/secondary view. We should decide whether `move-task` should stop writing
+`status.json` to the mission branch (to avoid a misleading stale snapshot) — proposed as a
+follow-up, not part of the minimal read fix.
+
+## 6. ATDD test plan (reproduce the split, fail on current code)
+
+Integration test driving the real CLI (mirrors `tests/regression/test_issue_1589.py`):
+
+1. Init a git repo; create a lane-based mission with a `-coord` worktree (or stub the coord
+   worktree + `meta.coordination_branch`/`mid8`).
+2. `finalize-tasks` (or seed) so the **coord** worktree's event log has N WPs `planned`, while the
+   mission-branch log is empty.
+3. **Assert (RED on current code):** `move-task WP01 --to in_progress` fails with "no canonical
+   status" (reads the empty mission branch).
+4. **Assert (GREEN after fix):** the same `move-task` succeeds (reads the coord worktree), and a
+   subsequent `materialize` via the resolver shows the transition.
+5. Unit test: `canonical_status_feature_dir` returns the coord dir when the `-coord` worktree
+   exists and the primary checkout when it does not (legacy no-op).
+
+## 7. Alternatives considered
+
+- **Make writes target the main checkout instead of coord** (drop the coordination branch for
+  status): rejected — the coordination branch exists to serialize parallel lane writes; removing
+  it reintroduces the multi-lane write-conflict problem the coordination model solved.
+- **Sync coord→main status after each op**: rejected — fragile, re-desyncs on the next write
+  (empirically unreliable in this session).
+
+## 8. Recommendation
+
+Implement §2 (resolver wrapper + the three read sites, fixing `lane_reader` as the central
+chokepoint), with the §6 ATDD test proven RED→GREEN. Defer §5 (`move-task` mission-branch
+`status.json` write) to a follow-up. Land as a focused PR to upstream `main`, like #1590.

--- a/docs/development/facet3-status-read-desync-design.md
+++ b/docs/development/facet3-status-read-desync-design.md
@@ -1,6 +1,6 @@
 # Design: fix #1589 facet 3 — coordination/mission status read desync
 
-**Status:** proposed (design-first; no code yet)
+**Status:** implemented in PR #1597
 **Scope:** `spec-kitty` status read path for lane-based missions
 **Related:** [#1589](https://github.com/Priivacy-ai/spec-kitty/issues/1589) facet 3; builds on #1590 (facets 1 & 2)
 

--- a/src/specify_cli/status/coord_read.py
+++ b/src/specify_cli/status/coord_read.py
@@ -1,0 +1,79 @@
+"""Coordination-aware resolution of the canonical status read/write directory.
+
+Lane-based missions commit canonical status to a per-mission *coordination
+worktree* (``.worktrees/<slug>-<mid8>-coord/kitty-specs/<slug>-<mid8>/``). The
+runtime must read (and non-transactionally write) status there, not from the
+primary checkout's stale mission directory — otherwise ``move-task``/``next``
+read an empty log and report "no canonical status" (#1589 facet 3).
+
+``workflow`` and ``acceptance`` already resolve reads this way; this module is
+the shared, low-level resolver so the status store and ``lane_reader`` agree.
+
+Resolution is **path-cheap on the hot path**: mid8 is derived from the mission
+directory name's trailing token first (no I/O); ``meta.json`` is only read as a
+fallback. For legacy/no-coord missions (and paths already inside a ``-coord``
+worktree) the input is returned unchanged, so behavior is identical.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["resolve_status_dir"]
+
+
+def _mid8_for(feature_dir: Path) -> str:
+    """Best-effort mid8 for *feature_dir*; trailing slug token first, then meta."""
+    tail = feature_dir.name.rsplit("-", 1)[-1] if "-" in feature_dir.name else ""
+    if len(tail) == 8 and tail.isalnum() and tail.isupper():
+        return tail
+    try:
+        from specify_cli.mission_metadata import load_meta
+
+        meta = load_meta(feature_dir)
+        if isinstance(meta, dict):
+            mid8 = meta.get("mid8")
+            if mid8:
+                return str(mid8)
+            mid = meta.get("mission_id")
+            if isinstance(mid, str) and len(mid) >= 8:
+                return mid[:8]
+    except Exception:  # noqa: BLE001 — missing/corrupt meta is legacy; degrade
+        pass
+    return ""
+
+
+def resolve_status_dir(feature_dir: Path) -> Path:
+    """Resolve *feature_dir* to the canonical status directory.
+
+    Returns the coordination worktree's mission directory when one exists on
+    disk; otherwise returns *feature_dir* unchanged (legacy/no-coord missions,
+    or when *feature_dir* is already inside a ``-coord`` worktree).
+    """
+    feature_dir = Path(feature_dir)
+    if feature_dir.parent.name != "kitty-specs":
+        return feature_dir
+    # Already inside a coordination worktree — never double-resolve.
+    for candidate in (feature_dir, *feature_dir.parents):
+        if candidate.parent.name == ".worktrees" and candidate.name.endswith("-coord"):
+            return feature_dir
+    mid8 = _mid8_for(feature_dir)
+    if not mid8:
+        return feature_dir
+    try:
+        from specify_cli.missions._read_path_resolver import resolve_mission_read_path
+
+        resolved: Path = resolve_mission_read_path(
+            feature_dir.parent.parent, feature_dir.name, mid8
+        )
+    except Exception:  # noqa: BLE001 — never let read-path resolution break a read
+        return feature_dir
+    # Only redirect when the resolver actually found a coordination worktree.
+    # When none exists it returns a *recomposed* primary candidate (``<slug>-
+    # <mid8>``) which can differ from the on-disk dir name; in that case we must
+    # return the original ``feature_dir`` unchanged (true no-op for legacy /
+    # bare-slug missions) rather than a non-existent recomposed path.
+    for candidate in (resolved, *resolved.parents):
+        if candidate.parent.name == ".worktrees" and candidate.name.endswith("-coord"):
+            return resolved
+    return feature_dir

--- a/src/specify_cli/status/lane_reader.py
+++ b/src/specify_cli/status/lane_reader.py
@@ -22,7 +22,9 @@ class CanonicalStatusNotFoundError(RuntimeError):
 
 def has_event_log(feature_dir: Path) -> bool:
     """Return True when the canonical event log file exists on disk."""
-    return bool((feature_dir / EVENTS_FILENAME).exists())
+    from .coord_read import resolve_status_dir
+
+    return bool((resolve_status_dir(feature_dir) / EVENTS_FILENAME).exists())
 
 
 def _require_event_log(feature_dir: Path) -> None:

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -92,8 +92,16 @@ class EventPersistenceError(StoreError):
 
 
 def _events_path(feature_dir: Path) -> Path:
-    """Return the canonical path to the events JSONL file."""
-    return feature_dir / EVENTS_FILENAME
+    """Return the canonical path to the events JSONL file.
+
+    Resolves to the per-mission coordination worktree when one exists (#1589
+    facet 3), so reads and non-transactional writes target the same canonical
+    log the transactional emit path commits to. A strict no-op for legacy /
+    no-coord missions and for paths already inside a ``-coord`` worktree.
+    """
+    from .coord_read import resolve_status_dir
+
+    return resolve_status_dir(feature_dir) / EVENTS_FILENAME
 
 
 class _SlugResolver:
@@ -207,7 +215,7 @@ def _event_matches_expected(actual: StatusEvent, expected: StatusEvent) -> bool:
         return False
     if expected.mission_id is not None and actual.mission_id != expected.mission_id:
         return False
-    return actual.wp_id == expected.wp_id and actual.to_lane == expected.to_lane
+    return bool(actual.wp_id == expected.wp_id and actual.to_lane == expected.to_lane)
 
 
 def verify_event_readback(feature_dir: Path, expected: StatusEvent) -> None:

--- a/tests/status/test_lane_reader_coordination_aware.py
+++ b/tests/status/test_lane_reader_coordination_aware.py
@@ -1,0 +1,107 @@
+"""ATDD: canonical lane reads must resolve the coordination worktree (#1589 facet 3).
+
+On lane-based missions, status writes are committed to the coordination worktree
+(`.worktrees/<slug>-<mid8>-coord/kitty-specs/<slug>-<mid8>/`) via the transactional
+emit path. But `lane_reader` reads the *primary* checkout's mission dir, which never
+receives the lane events — so `get_wp_lane`/`get_all_wp_lanes` see nothing and
+`move-task`/`next` raise "no canonical status" despite a fully materialized coord log.
+
+`workflow.py` and `acceptance` already resolve reads via
+`missions._read_path_resolver.resolve_mission_read_path`; `lane_reader` was never
+updated. These tests reproduce that gap: they fail on the current code (lane_reader
+reads the empty primary) and pass once lane_reader resolves the coord worktree.
+
+Legacy missions (no coord worktree) must be unaffected — the resolver returns the
+primary checkout, so behavior is identical.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.status.lane_reader import (
+    CanonicalStatusNotFoundError,
+    get_wp_lane,
+)
+
+pytestmark = [pytest.mark.unit]
+
+MID8 = "ABCD1234"
+MISSION_ID = "ABCD1234EFGH5678IJKL9012MN"
+SLUG = "demo-mission"
+MISSION_DIR = f"{SLUG}-{MID8}"
+
+
+def _planned_event(wp_id: str) -> str:
+    return json.dumps(
+        {
+            "event_id": f"01TEST{wp_id}00000000000000",
+            "mission_slug": SLUG,
+            "wp_id": wp_id,
+            "from_lane": "planned",
+            "to_lane": "planned",
+            "at": "2026-06-01T00:00:00+00:00",
+            "actor": "finalize-tasks",
+            "force": True,
+            "execution_mode": "worktree",
+            "reason": "canonical bootstrap",
+            "review_ref": None,
+            "evidence": None,
+            "policy_metadata": None,
+        },
+        sort_keys=True,
+    )
+
+
+def _seed_meta(primary: Path) -> None:
+    (primary / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": SLUG,
+                "mission_id": MISSION_ID,
+                "mid8": MID8,
+                "coordination_branch": f"kitty/mission-{MISSION_DIR}",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_get_wp_lane_resolves_coordination_worktree(tmp_path: Path) -> None:
+    repo = tmp_path
+    primary = repo / "kitty-specs" / MISSION_DIR
+    primary.mkdir(parents=True)
+    _seed_meta(primary)
+    # Primary checkout has NO event log — exactly the desync state.
+    coord = repo / ".worktrees" / f"{MISSION_DIR}-coord" / "kitty-specs" / MISSION_DIR
+    coord.mkdir(parents=True)
+    (coord / "status.events.jsonl").write_text(_planned_event("WP01") + "\n", encoding="utf-8")
+
+    # ACCEPTANCE: reading the primary feature_dir must resolve the coord worktree.
+    lane = get_wp_lane(primary, "WP01")
+    assert str(lane) == "planned", f"expected coord status to be read; got {lane!r}"
+
+
+def test_legacy_mission_without_coord_worktree_unaffected(tmp_path: Path) -> None:
+    repo = tmp_path
+    primary = repo / "kitty-specs" / MISSION_DIR
+    primary.mkdir(parents=True)
+    _seed_meta(primary)
+    # No coord worktree; the event log lives in the primary checkout (legacy).
+    (primary / "status.events.jsonl").write_text(_planned_event("WP01") + "\n", encoding="utf-8")
+
+    lane = get_wp_lane(primary, "WP01")
+    assert str(lane) == "planned"
+
+
+def test_missing_everywhere_still_raises(tmp_path: Path) -> None:
+    repo = tmp_path
+    primary = repo / "kitty-specs" / MISSION_DIR
+    primary.mkdir(parents=True)
+    _seed_meta(primary)
+    # Neither primary nor coord has an event log.
+    with pytest.raises(CanonicalStatusNotFoundError):
+        get_wp_lane(primary, "WP01")


### PR DESCRIPTION
Addresses facet 3 of #1589 (the coordination/mission status read desync). Companion to #1590 (facets 1 & 2).

## Problem

Lane-based missions commit canonical status to the per-mission **coordination worktree** (via the transactional emit path), but several read sites resolve `feature_dir = repo_root/kitty-specs/<slug>` against the **primary checkout** and read its stale mission dir. Result: `move-task`/`next`/lane reads report "WP has no canonical status / run finalize-tasks" even when the coordination worktree has a fully materialized log. `workflow` and `acceptance` already resolved coordination-aware; `move-task`'s direct `read_events`, `next`, `lane_reader`, and `materialize` did not.

## Fix

New `specify_cli/status/coord_read.resolve_status_dir()` resolves a `feature_dir` to the coordination worktree when one exists on disk, and is a **strict no-op** otherwise (legacy/no-coord missions, and paths already inside a `-coord` worktree). It only redirects when a coordination worktree is actually found — never to a recomposed primary path — so non-coord missions are byte-for-byte unaffected. Applied at the store chokepoint (`_events_path`), so `read_events`/`append_event` and every reader converge on the canonical log; mid8 is derived cheaply (trailing slug token first, `meta.json` fallback) since the path is hot.

## Tests

`tests/status/test_lane_reader_coordination_aware.py`: coord-backed read resolves (RED before — reads the empty primary → `CanonicalStatusNotFoundError`); legacy no-coord unchanged; missing-everywhere still raises. 666 status-suite tests pass; ruff + mypy clean on touched files.

Boy-Scout: fixed a pre-existing mypy `no-any-return` in `store._event_matches_expected`.

## Scope note

This fixes the **read** resolution. A **separate, deeper** coordination-layer issue remains (status events written to the coordination worktree are not always durably committed to the coordination branch, so they can be lost on subsequent worktree git operations) — being filed separately; it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)