### PR TITLE
Fix review independence fallback surfaces

### DIFF
--- a/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/SKILL.md
@@ -36,9 +36,6 @@ Spec-kitty selects agents from `.kittify/config.yaml`:
 ```yaml
 agents:
   available: [claude, codex, opencode]
-  selection:
-    preferred_implementer: claude
-    preferred_reviewer: codex
   auto_commit: true
 ```
 
@@ -383,6 +380,29 @@ claude -p "$(cat /tmp/review-prompt-WP##.md)" --output-format json -C "$WORKTREE
 gemini -p "$(cat /tmp/review-prompt-WP##.md)" --yolo --output-format json -C "$WORKTREE"
 ```
 
+Capture the reviewer command exit status. If the configured/chosen reviewer
+fails, do not silently approve and do not fall back to the implementing agent.
+Print a structured error and halt in unattended/noninteractive mode:
+
+```text
+ERROR: Configured reviewer '<agent>' failed (<exit code or reason>).
+Options:
+  a) Retry with '<agent>' after fixing the error
+  b) Switch reviewer: spec-kitty agent action review WP## --mission <slug> --agent <other-reviewer>
+  c) Proceed with self-review -- WARNING: no independent review
+```
+
+Self-review fallback is only allowed after an explicit operator decision. The
+approval command must preserve the failure metadata:
+
+```bash
+spec-kitty agent tasks move-task WP## --to approved --force \
+  --self-review-fallback \
+  --intended-reviewer <failed-agent> \
+  --reviewer-failure-reason "<exit code or reason>" \
+  --note "Self-review fallback after reviewer failure: <summary>"
+```
+
 **If the reviewer is Tier 3 (GUI-only) or cannot run move-task:**
 
 After the reviewer completes, the orchestrator must:
@@ -410,6 +430,11 @@ spec-kitty agent tasks status
 # If reviewer output was captured to a file:
 cat /tmp/review-result-WP##.md
 ```
+
+Before final approval, if `spec.md` references GitHub issues, ensure
+`issue-matrix.md` exists and every referenced issue has a final verdict:
+`fixed`, `verified-already-fixed`, or a documented follow-up. `unknown` verdicts
+block approval. The CLI enforces this guard on `move-task --to approved/done`.
 
 ---
 

--- a/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
@@ -74,10 +74,13 @@ cat kitty-specs/<slug>/status.events.jsonl
 ```
 
 The event log tells you: how many rejection cycles each WP had, which WPs were
-forced (unusual transitions that bypassed normal flow), and whether any WPs
-were approved by arbiter override rather than clean review. A WP with 3+
-rejection cycles that ended in an arbiter-forced approval is a high-priority
-target for your analysis — the disagreement history is a signal.
+forced (unusual transitions that bypassed normal flow), whether any WPs were
+approved by arbiter override rather than clean review, and whether any WP has a
+`ReviewerSelfApproval` event. A WP with 3+ rejection cycles that ended in an
+arbiter-forced approval is a high-priority target for your analysis — the
+disagreement history is a signal. A WP with `ReviewerSelfApproval` is also
+high-priority: flag it as an independence/process risk and verify whether an
+independent reviewer later re-reviewed it.
 
 ---
 

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -152,9 +152,13 @@ def _issue_matrix_approval_blocker(feature_dir: Path) -> str | None:
         from specify_cli.tasks.issue_matrix import detect_issue_references
 
         refs = detect_issue_references(spec_path)
-    except Exception as exc:  # noqa: BLE001 -- approval guard must fail closed only on concrete diagnostics
+    except Exception as exc:  # noqa: BLE001 -- approval guard must fail closed
         logger.debug("Could not evaluate issue-matrix approval blocker: %s", exc)
-        return None
+        return (
+            "ERROR: issue-matrix.md could not be evaluated before approval.\n"
+            f"Reason: {exc}\n"
+            "Fix the issue-matrix check before approving."
+        )
 
     if not refs:
         return None
@@ -169,7 +173,14 @@ def _issue_matrix_approval_blocker(feature_dir: Path) -> str | None:
         )
 
     result = validate_issue_matrix(matrix_path)
-    if result.passed:
+    referenced_issues = {f"#{ref.number}" for ref in refs}
+    matrix_issues = {row.issue for row in result.rows}
+    for diagnostic in result.diagnostics:
+        match = re.search(r"Row for issue '([^']+)'", diagnostic.get("message", ""))
+        if match:
+            matrix_issues.add(match.group(1))
+    missing_issues = sorted(referenced_issues - matrix_issues)
+    if result.passed and not missing_issues:
         return None
 
     unknown_issues: list[str] = []
@@ -183,6 +194,8 @@ def _issue_matrix_approval_blocker(feature_dir: Path) -> str | None:
             other_messages.append(message)
 
     lines = ["ERROR: issue-matrix.md has unresolved entries. Fill in verdicts before approving."]
+    if missing_issues:
+        lines.append(f"Missing rows: {', '.join(missing_issues)}")
     if unknown_issues:
         lines.append(f"Unknown: {', '.join(sorted(set(unknown_issues)))}")
     for message in other_messages:

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -140,6 +140,81 @@ _VALID_VERDICTS: frozenset[str] = frozenset(
 )
 
 
+def _issue_matrix_approval_blocker(feature_dir: Path) -> str | None:
+    """Return a blocking message when referenced issues still lack final verdicts."""
+    spec_path = feature_dir / "spec.md"
+    if not spec_path.exists():
+        return None
+
+    try:
+        from specify_cli.cli.commands.review._diagnostics import MissionReviewDiagnostic
+        from specify_cli.cli.commands.review._issue_matrix import validate_issue_matrix
+        from specify_cli.tasks.issue_matrix import detect_issue_references
+
+        refs = detect_issue_references(spec_path)
+    except Exception as exc:  # noqa: BLE001 -- approval guard must fail closed only on concrete diagnostics
+        logger.debug("Could not evaluate issue-matrix approval blocker: %s", exc)
+        return None
+
+    if not refs:
+        return None
+
+    matrix_path = feature_dir / "issue-matrix.md"
+    if not matrix_path.exists():
+        issue_list = ", ".join(f"#{ref.number}" for ref in refs)
+        return (
+            "ERROR: issue-matrix.md is required before approval.\n"
+            f"Referenced issues: {issue_list}\n"
+            "Fill verdicts before approving."
+        )
+
+    result = validate_issue_matrix(matrix_path)
+    if result.passed:
+        return None
+
+    unknown_issues: list[str] = []
+    other_messages: list[str] = []
+    for diagnostic in result.diagnostics:
+        message = diagnostic.get("message", "")
+        if diagnostic.get("diagnostic_code") == str(MissionReviewDiagnostic.ISSUE_MATRIX_VERDICT_UNKNOWN):
+            match = re.search(r"issue '([^']+)'", message)
+            unknown_issues.append(match.group(1) if match else message)
+        else:
+            other_messages.append(message)
+
+    lines = ["ERROR: issue-matrix.md has unresolved entries. Fill in verdicts before approving."]
+    if unknown_issues:
+        lines.append(f"Unknown: {', '.join(sorted(set(unknown_issues)))}")
+    for message in other_messages:
+        lines.append(f"- {message}")
+    return "\n".join(lines)
+
+
+def _self_review_fallback_option_error(
+    *,
+    enabled: bool,
+    target_lane: str,
+    force: bool,
+    intended_reviewer: str | None,
+    failure_reason: str | None,
+) -> str | None:
+    """Validate explicit self-review fallback metadata before approval."""
+    if not enabled:
+        if intended_reviewer or failure_reason:
+            return "--intended-reviewer/--reviewer-failure-reason require --self-review-fallback."
+        return None
+
+    if resolve_lane_alias(target_lane) not in (Lane.APPROVED, Lane.DONE):
+        return "--self-review-fallback is only valid when approving or marking done."
+    if not force:
+        return "--self-review-fallback requires --force so force_count records the independence override."
+    if not (intended_reviewer or "").strip():
+        return "--self-review-fallback requires --intended-reviewer <agent>."
+    if not (failure_reason or "").strip():
+        return "--self-review-fallback requires --reviewer-failure-reason <reason>."
+    return None
+
+
 # ---------------------------------------------------------------------------
 # WP01: Backward transition detection
 # ---------------------------------------------------------------------------
@@ -1415,6 +1490,21 @@ def move_task(
     ] = None,
     approval_ref: Annotated[str | None, typer.Option("--approval-ref", help="Approval reference for approval/done transitions (e.g., PR#42)")] = None,
     reviewer: Annotated[str | None, typer.Option("--reviewer", help="Reviewer name (auto-detected from git if omitted)")] = None,
+    self_review_fallback: Annotated[
+        bool,
+        typer.Option(
+            "--self-review-fallback",
+            help="Record that approval is a self-review fallback after the intended reviewer failed.",
+        ),
+    ] = False,
+    intended_reviewer: Annotated[
+        str | None,
+        typer.Option("--intended-reviewer", help="Reviewer that should have reviewed this WP before fallback."),
+    ] = None,
+    reviewer_failure_reason: Annotated[
+        str | None,
+        typer.Option("--reviewer-failure-reason", help="Reason the intended reviewer failed."),
+    ] = None,
     done_override_reason: Annotated[
         str | None,
         typer.Option("--done-override-reason", help="Required when --to done and merge ancestry cannot be verified; recorded in history/event reason"),
@@ -1454,6 +1544,16 @@ def move_task(
     try:
         # Validate lane
         target_lane = ensure_lane(to)
+        self_review_error = _self_review_fallback_option_error(
+            enabled=self_review_fallback,
+            target_lane=str(target_lane),
+            force=force,
+            intended_reviewer=intended_reviewer,
+            failure_reason=reviewer_failure_reason,
+        )
+        if self_review_error:
+            _output_error(json_output, self_review_error)
+            raise typer.Exit(1)
 
         # Get repo root and feature slug
         repo_root = locate_project_root()
@@ -1794,6 +1894,12 @@ def move_task(
         except ImportError:
             pass  # review package not available yet
 
+        if target_lane in (Lane.APPROVED, Lane.DONE):
+            issue_matrix_blocker = _issue_matrix_approval_blocker(feature_dir)
+            if issue_matrix_blocker:
+                _output_error(json_output, issue_matrix_blocker)
+                raise typer.Exit(1)
+
         # Keep force semantics strict: only user-requested --force should bypass guards.
         emit_force = force
         if not emit_reason:
@@ -1904,6 +2010,19 @@ def move_task(
                 ))
                 # review_ref only applies to rollback transitions, never to forward chain hops
                 emit_review_ref = None
+
+            if self_review_fallback:
+                from specify_cli.status.lifecycle_events import emit_reviewer_self_approval
+
+                emit_reviewer_self_approval(
+                    feature_dir,
+                    mission_slug=mission_slug,
+                    wp_id=task_id,
+                    implementing_actor=actor,
+                    intended_reviewer=(intended_reviewer or "").strip(),
+                    failure_reason=(reviewer_failure_reason or "").strip(),
+                    fallback_approved=True,
+                )
 
             # --- Post-emit: apply operational metadata fields to WP file ---
             # The event log is the sole authority for lane/review state.

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from pathlib import Path
 
@@ -72,6 +73,7 @@ from specify_cli.sync import emit_diff_summary_recorded, emit_mission_closed
 from specify_cli.sync.dossier_pipeline import trigger_feature_dossier_sync_if_enabled
 from specify_cli.status.wp_metadata import read_wp_frontmatter
 from specify_cli.task_utils import TaskCliError, find_repo_root
+from specify_cli.status.lifecycle_events import REVIEWER_SELF_APPROVAL
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +92,7 @@ LINEAR_HISTORY_REJECTION_TOKENS: tuple[str, ...] = (
 )
 
 MissionBranchBlocker = dict[str, str | bool]
+HollowReviewWarnings = dict[str, list[str]]
 
 
 class BaselineMergeCommitError(RuntimeError):
@@ -1361,6 +1364,85 @@ def _enforce_review_artifact_consistency(
     raise typer.Exit(1)
 
 
+def _collect_hollow_review_warnings(feature_dir: Path, wp_ids: list[str]) -> HollowReviewWarnings:
+    """Return WPs whose approval history indicates missing independent review."""
+    warnings: HollowReviewWarnings = {}
+    wp_set = set(wp_ids)
+
+    status_path = feature_dir / _STATUS_FILENAME
+    if status_path.exists():
+        try:
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            status = {}
+        work_packages = status.get("work_packages", {}) if isinstance(status, dict) else {}
+        if isinstance(work_packages, dict):
+            for wp_id in sorted(wp_set):
+                wp_state = work_packages.get(wp_id, {})
+                if not isinstance(wp_state, dict):
+                    continue
+                try:
+                    force_count = int(wp_state.get("force_count", 0))
+                except (TypeError, ValueError):
+                    force_count = 0
+                if force_count >= 2:
+                    warnings.setdefault(wp_id, []).append(f"force_count={force_count}")
+
+    events_path = feature_dir / _STATUS_EVENTS_FILENAME
+    if events_path.exists():
+        try:
+            raw_lines = events_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            raw_lines = []
+        for raw_line in raw_lines:
+            try:
+                event = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict) or event.get("event_type") != REVIEWER_SELF_APPROVAL:
+                continue
+            payload = event.get("payload", {})
+            if not isinstance(payload, dict):
+                continue
+            wp_id = str(payload.get("wp_id") or "")
+            if wp_id not in wp_set:
+                continue
+            intended = str(payload.get("intended_reviewer") or "unknown")
+            actor = str(payload.get("implementing_actor") or "unknown")
+            reason = str(payload.get("failure_reason") or "reviewer_failed")
+            warnings.setdefault(wp_id, []).append(
+                f"ReviewerSelfApproval ({intended} failed: {reason}; {actor} self-reviewed)"
+            )
+
+    return warnings
+
+
+def _warn_or_confirm_hollow_reviews(
+    *,
+    feature_dir: Path,
+    wp_ids: list[str],
+    assume_yes: bool,
+) -> None:
+    warnings = _collect_hollow_review_warnings(feature_dir, wp_ids)
+    if not warnings:
+        return
+
+    console.print("\n[bold yellow]MERGE WARNING: Hollow reviews detected[/bold yellow]\n")
+    console.print("The following WPs were approved without clear independent review:")
+    for wp_id in sorted(warnings):
+        console.print(f"  {wp_id}: {' + '.join(warnings[wp_id])}")
+    console.print()
+    console.print("These WPs may have been approved by the implementing agent, not an independent reviewer.")
+    console.print("Consider re-reviewing before merge.\n")
+
+    if assume_yes or not sys.stdin.isatty():
+        console.print("[yellow]Proceeding without interactive confirmation.[/yellow]")
+        return
+
+    if not typer.confirm("Proceed?", default=False):
+        raise typer.Exit(1)
+
+
 def _run_lane_based_merge(
     repo_root: Path,
     mission_slug: str,
@@ -1371,6 +1453,7 @@ def _run_lane_based_merge(
     target_override: str | None = None,
     strategy: MergeStrategy = MergeStrategy.SQUASH,
     allow_sparse_checkout: bool = False,
+    assume_yes: bool = False,
 ) -> None:
     """Execute the lane-only merge flow with MergeState lifecycle for recovery.
 
@@ -1462,6 +1545,7 @@ def _run_lane_based_merge(
             delete_branch=delete_branch,
             remove_worktree=remove_worktree,
             strategy=strategy,
+            assume_yes=assume_yes,
         )
     finally:
         release_merge_lock(_GLOBAL_MERGE_LOCK_ID, main_repo)
@@ -1478,6 +1562,7 @@ def _run_lane_based_merge_locked(
     delete_branch: bool,
     remove_worktree: bool,
     strategy: MergeStrategy = MergeStrategy.SQUASH,
+    assume_yes: bool = False,
 ) -> None:
     """Inner merge flow, called with the global merge lock held."""
     from specify_cli.lanes.branch_naming import lane_branch_name
@@ -1541,6 +1626,11 @@ def _run_lane_based_merge_locked(
         feature_dir=feature_dir,
         mission_slug=mission_slug,
         wp_ids=all_wp_ids,
+    )
+    _warn_or_confirm_hollow_reviews(
+        feature_dir=feature_dir,
+        wp_ids=all_wp_ids,
+        assume_yes=assume_yes,
     )
 
     # -- Lane merges (skip lanes whose WPs are all already completed) --
@@ -1982,6 +2072,7 @@ def merge(
             "data-loss backstop."
         ),
     ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Proceed after merge warnings without prompts"),
 ) -> None:
     """Merge a lane-based feature into its target branch."""
     del context_token, keep_workspace
@@ -2240,6 +2331,7 @@ def merge(
             target_override=resolved_target_branch,
             strategy=resolved_strategy,
             allow_sparse_checkout=allow_sparse_checkout,
+            assume_yes=yes,
         )
     except SparseCheckoutPreflightError as exc:
         # WP05/T020: surface sparse-checkout preflight as user-facing error

--- a/src/specify_cli/retrospective/generator.py
+++ b/src/specify_cli/retrospective/generator.py
@@ -34,6 +34,7 @@ from specify_cli.retrospective.schema import (
     ProvenanceKind,
     validate_record,
 )
+from specify_cli.status.lifecycle_events import REVIEWER_SELF_APPROVAL
 
 if TYPE_CHECKING:
     from specify_cli.retrospective.policy import RetrospectivePolicy
@@ -319,6 +320,34 @@ def _detect_force_overrides(events: list[dict]) -> dict[str, int]:
     return counts
 
 
+def _event_wp_id(event: dict) -> str:
+    """Return WP id from status event top-level fields or lifecycle payload."""
+    wp_id = event.get("wp_id")
+    if isinstance(wp_id, str) and wp_id:
+        return wp_id
+    payload = event.get("payload")
+    if isinstance(payload, dict):
+        payload_wp_id = payload.get("wp_id")
+        if isinstance(payload_wp_id, str):
+            return payload_wp_id
+    return ""
+
+
+def _is_reviewer_self_approval_event(event: dict) -> bool:
+    return event.get("event_type") == REVIEWER_SELF_APPROVAL
+
+
+def _detect_reviewer_self_approvals(events: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for event in events:
+        if not _is_reviewer_self_approval_event(event):
+            continue
+        wp_id = _event_wp_id(event)
+        if wp_id:
+            counts[wp_id] = counts.get(wp_id, 0) + 1
+    return counts
+
+
 def _event_note(event: dict) -> str:
     """Return the human-readable note/reason text from an event, lower-cased."""
     parts: list[str] = []
@@ -413,7 +442,7 @@ def _event_id_range_for(events: list[dict], wp_id: str, predicate) -> str:  # ty
     ids = [
         str(ev.get("event_id", ""))
         for ev in events
-        if ev.get("wp_id") == wp_id and predicate(ev)
+        if _event_wp_id(ev) == wp_id and predicate(ev)
     ]
     if len(ids) > 1:
         return f"{ids[0]}..{ids[-1]}"
@@ -447,6 +476,33 @@ def _build_event_mining_findings(
                     f"WP {wp_id} required {count} operator-driven --force lane transition(s). "
                     "Force overrides typically indicate the runtime guard failed or "
                     "the operator routed around it; investigate the underlying cause."
+                ),
+                evidence_refs=[ev_id],
+            )
+        )
+
+    # Self-review fallback → not_helpful
+    for wp_id, count in sorted(_detect_reviewer_self_approvals(events).items()):
+        range_str = _event_id_range_for(events, wp_id, _is_reviewer_self_approval_event)
+        ev_id = ev_reg.add_event_range(events_rel, range_str or "reviewer_self_approval", f"reviewer_self_approval_{wp_id}")
+        matching_payloads = [
+            ev.get("payload", {})
+            for ev in events
+            if _event_wp_id(ev) == wp_id and _is_reviewer_self_approval_event(ev)
+        ]
+        first_payload = matching_payloads[0] if matching_payloads and isinstance(matching_payloads[0], dict) else {}
+        intended = str(first_payload.get("intended_reviewer") or "unknown")
+        actor = str(first_payload.get("implementing_actor") or "unknown")
+        reason = str(first_payload.get("failure_reason") or "reviewer_failed")
+        not_helpful.append(
+            GenFinding(
+                id=_next_finding_id("n", finding_id_counters),
+                category="process",
+                summary=f"{wp_id} used self-review fallback instead of independent review",
+                details=(
+                    f"WP {wp_id} recorded {count} ReviewerSelfApproval event(s): "
+                    f"{actor} self-reviewed after intended reviewer {intended} failed "
+                    f"({reason}). Treat this as a review-independence gap."
                 ),
                 evidence_refs=[ev_id],
             )

--- a/src/specify_cli/status/doctor.py
+++ b/src/specify_cli/status/doctor.py
@@ -32,6 +32,8 @@ class Category(StrEnum):
     ORPHAN_WORKSPACE = "orphan_workspace"
     MATERIALIZATION_DRIFT = "materialization_drift"
     DERIVED_VIEW_DRIFT = "derived_view_drift"
+    REVIEW_INDEPENDENCE = "review_independence"
+    ISSUE_MATRIX = "issue_matrix"
     SPARSE_CHECKOUT = "sparse_checkout"
     UNINITIALIZED_STATUS = "uninitialized_status"
 
@@ -319,6 +321,92 @@ def check_drift(feature_dir: Path) -> list[Finding]:
     return findings
 
 
+def check_reviewer_self_approval(feature_dir: Path) -> list[Finding]:
+    """Flag explicit self-review fallback events as review-independence risk."""
+    findings: list[Finding] = []
+    try:
+        from specify_cli.status.lifecycle_events import (
+            REVIEWER_SELF_APPROVAL,
+            mission_event_log_path,
+            read_lifecycle_events,
+        )
+    except ImportError:
+        return findings
+
+    for event in read_lifecycle_events(mission_event_log_path(feature_dir)):
+        if event.get("event_type") != REVIEWER_SELF_APPROVAL:
+            continue
+        payload = event.get("payload", {})
+        if not isinstance(payload, dict):
+            payload = {}
+        wp_id = str(payload.get("wp_id") or event.get("aggregate_id") or "")
+        implementing_actor = str(payload.get("implementing_actor") or "unknown")
+        intended_reviewer = str(payload.get("intended_reviewer") or "unknown")
+        failure_reason = str(payload.get("failure_reason") or "reviewer_failed")
+        findings.append(
+            Finding(
+                severity=Severity.WARNING,
+                category=Category.REVIEW_INDEPENDENCE,
+                wp_id=wp_id or None,
+                message=(
+                    f"{wp_id or 'A work package'} used self-review fallback: "
+                    f"{implementing_actor} approved after intended reviewer "
+                    f"{intended_reviewer} failed ({failure_reason})."
+                ),
+                recommended_action="Re-review with an independent reviewer before merge/release.",
+            )
+        )
+
+    return findings
+
+
+def check_issue_matrix(feature_dir: Path) -> list[Finding]:
+    """Flag missions with issue references whose issue-matrix verdicts are missing."""
+    spec_path = feature_dir / "spec.md"
+    if not spec_path.exists():
+        return []
+
+    try:
+        from specify_cli.cli.commands.review._issue_matrix import validate_issue_matrix
+        from specify_cli.tasks.issue_matrix import detect_issue_references
+
+        refs = detect_issue_references(spec_path)
+    except Exception:
+        logger.debug("Could not evaluate issue-matrix doctor check", exc_info=True)
+        return []
+
+    if not refs:
+        return []
+
+    matrix_path = feature_dir / "issue-matrix.md"
+    if not matrix_path.exists():
+        issue_list = ", ".join(f"#{ref.number}" for ref in refs)
+        return [
+            Finding(
+                severity=Severity.WARNING,
+                category=Category.ISSUE_MATRIX,
+                wp_id=None,
+                message=f"spec.md references GitHub issues but issue-matrix.md is missing: {issue_list}.",
+                recommended_action="Create issue-matrix.md and record final verdicts before approval/merge.",
+            )
+        ]
+
+    result = validate_issue_matrix(matrix_path)
+    findings: list[Finding] = []
+    for diagnostic in result.diagnostics:
+        findings.append(
+            Finding(
+                severity=Severity.WARNING,
+                category=Category.ISSUE_MATRIX,
+                wp_id=None,
+                message=str(diagnostic.get("message", "issue-matrix.md contains an unresolved issue verdict.")),
+                recommended_action="Replace unknown/deferred issue verdicts with fixed, verified-already-fixed, or a documented follow-up.",
+            )
+        )
+
+    return findings
+
+
 def check_sparse_checkout(repo_root: Path) -> list[Finding]:
     """Repo-level check: legacy sparse-checkout state lingering from pre-3.x.
 
@@ -448,6 +536,9 @@ def run_doctor(
         )
         result.findings.extend(check_orphan_workspaces(repo_root, mission_slug, snapshot))
         result.findings.extend(check_drift(feature_dir))
+
+    result.findings.extend(check_reviewer_self_approval(feature_dir))
+    result.findings.extend(check_issue_matrix(feature_dir))
 
     # Repo-level sparse-checkout finding (FR-002). Appended last so existing
     # findings keep their position — scripts scraping doctor output rely on

--- a/src/specify_cli/status/doctor.py
+++ b/src/specify_cli/status/doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
 from enum import StrEnum
@@ -371,9 +372,17 @@ def check_issue_matrix(feature_dir: Path) -> list[Finding]:
         from specify_cli.tasks.issue_matrix import detect_issue_references
 
         refs = detect_issue_references(spec_path)
-    except Exception:
+    except Exception as exc:
         logger.debug("Could not evaluate issue-matrix doctor check", exc_info=True)
-        return []
+        return [
+            Finding(
+                severity=Severity.WARNING,
+                category=Category.ISSUE_MATRIX,
+                wp_id=None,
+                message=f"issue-matrix.md could not be evaluated: {exc}",
+                recommended_action="Fix the issue-matrix check before approval/merge.",
+            )
+        ]
 
     if not refs:
         return []
@@ -393,6 +402,26 @@ def check_issue_matrix(feature_dir: Path) -> list[Finding]:
 
     result = validate_issue_matrix(matrix_path)
     findings: list[Finding] = []
+    referenced_issues = {f"#{ref.number}" for ref in refs}
+    matrix_issues = {row.issue for row in result.rows}
+    for diagnostic in result.diagnostics:
+        match = re.search(r"Row for issue '([^']+)'", diagnostic.get("message", ""))
+        if match:
+            matrix_issues.add(match.group(1))
+    missing_issues = sorted(referenced_issues - matrix_issues)
+    if missing_issues:
+        findings.append(
+            Finding(
+                severity=Severity.WARNING,
+                category=Category.ISSUE_MATRIX,
+                wp_id=None,
+                message=(
+                    "issue-matrix.md is missing rows for referenced issue(s): "
+                    f"{', '.join(missing_issues)}."
+                ),
+                recommended_action="Add one row per referenced issue before approval/merge.",
+            )
+        )
     for diagnostic in result.diagnostics:
         findings.append(
             Finding(

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -60,6 +60,7 @@ PLAN_COMPLETED = "PlanCompleted"
 TASKS_STARTED = "TasksStarted"
 TASKS_COMPLETED = "TasksCompleted"
 WP_CREATED = "WPCreated"
+REVIEWER_SELF_APPROVAL = "ReviewerSelfApproval"
 
 LIFECYCLE_EVENT_TYPES = frozenset({
     PROJECT_INITIALIZED,
@@ -71,6 +72,7 @@ LIFECYCLE_EVENT_TYPES = frozenset({
     TASKS_STARTED,
     TASKS_COMPLETED,
     WP_CREATED,
+    REVIEWER_SELF_APPROVAL,
 })
 
 PROJECT_EVENTS_FILENAME = "canonical-events.jsonl"
@@ -633,6 +635,48 @@ def emit_wp_created_local(
     )
 
 
+def emit_reviewer_self_approval(
+    feature_dir: Path,
+    *,
+    mission_slug: str,
+    wp_id: str,
+    implementing_actor: str,
+    intended_reviewer: str,
+    failure_reason: str,
+    fallback_approved: bool = True,
+    project_uuid: str | None = None,
+    project_slug: str | None = None,
+    at: str | None = None,
+) -> dict[str, Any] | None:
+    """Record that a WP was approved by its implementing actor after reviewer failure."""
+    payload = {
+        "mission_slug": mission_slug,
+        "wp_id": wp_id,
+        "implementing_actor": implementing_actor,
+        "intended_reviewer": intended_reviewer,
+        "failure_reason": failure_reason,
+        "fallback_approved": fallback_approved,
+        "timestamp": at or _now_iso(),
+    }
+    log_path = mission_event_log_path(feature_dir)
+    return append_lifecycle_event(
+        log_path,
+        REVIEWER_SELF_APPROVAL,
+        payload,
+        aggregate_id=wp_id,
+        aggregate_type="WorkPackage",
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+        dedup_keys={
+            "mission_slug": mission_slug,
+            "wp_id": wp_id,
+            "implementing_actor": implementing_actor,
+            "intended_reviewer": intended_reviewer,
+            "failure_reason": failure_reason,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Diagnostics / merge guard helpers
 # ---------------------------------------------------------------------------
@@ -704,6 +748,7 @@ __all__ = [
     "TASKS_STARTED",
     "TASKS_COMPLETED",
     "WP_CREATED",
+    "REVIEWER_SELF_APPROVAL",
     "LIFECYCLE_EVENT_TYPES",
     "PROJECT_EVENTS_FILENAME",
     "MISSION_EVENTS_FILENAME",
@@ -715,6 +760,7 @@ __all__ = [
     "emit_mission_created_local",
     "emit_artifact_phase",
     "emit_wp_created_local",
+    "emit_reviewer_self_approval",
     "read_lifecycle_events",
     "has_non_bootstrap_status_history",
 ]

--- a/tests/agent/cli/commands/test_tasks_helpers.py
+++ b/tests/agent/cli/commands/test_tasks_helpers.py
@@ -32,13 +32,18 @@ from specify_cli.cli.commands.agent.tasks import (
 pytestmark = pytest.mark.fast
 
 
-def _write_issue_matrix(feature_dir: Path, verdict: str, evidence_ref: str = "tests/test_demo.py") -> None:
+def _write_issue_matrix(
+    feature_dir: Path,
+    verdict: str,
+    evidence_ref: str = "tests/test_demo.py",
+    issue: str = "#1582",
+) -> None:
     (feature_dir / "issue-matrix.md").write_text(
         "\n".join(
             [
                 "| issue | verdict | evidence_ref |",
                 "| --- | --- | --- |",
-                f"| #1582 | {verdict} | {evidence_ref} |",
+                f"| {issue} | {verdict} | {evidence_ref} |",
             ]
         ),
         encoding="utf-8",
@@ -99,8 +104,33 @@ def test_issue_matrix_approval_blocker_requires_resolved_verdicts(tmp_path: Path
     assert blocker is not None
     assert "Unknown: #1582" in blocker
 
+    _write_issue_matrix(feature_dir, "fixed", issue="#1111")
+    blocker = _issue_matrix_approval_blocker(feature_dir)
+    assert blocker is not None
+    assert "Missing rows: #1582" in blocker
+
     _write_issue_matrix(feature_dir, "fixed")
     assert _issue_matrix_approval_blocker(feature_dir) is None
+
+
+def test_issue_matrix_approval_blocker_fails_closed_on_evaluation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "demo"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("Fix Priivacy-ai/spec-kitty issue #1582.\n", encoding="utf-8")
+
+    def _boom(_path: Path):
+        raise RuntimeError("parser unavailable")
+
+    monkeypatch.setattr("specify_cli.tasks.issue_matrix.detect_issue_references", _boom)
+
+    blocker = _issue_matrix_approval_blocker(feature_dir)
+
+    assert blocker is not None
+    assert "could not be evaluated" in blocker
+    assert "parser unavailable" in blocker
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/cli/commands/test_tasks_helpers.py
+++ b/tests/agent/cli/commands/test_tasks_helpers.py
@@ -19,15 +19,88 @@ from specify_cli.cli.commands.agent.tasks import (
     _check_unchecked_subtasks,
     _collect_status_artifacts,
     _detect_reviewer_name,
+    _issue_matrix_approval_blocker,
     _is_pipe_table_task_row,
     _output_error,
     _output_result,
     _parse_pipe_table_header,
     _resolve_git_common_dir,
     _resolve_wp_slug,
+    _self_review_fallback_option_error,
 )
 
 pytestmark = pytest.mark.fast
+
+
+def _write_issue_matrix(feature_dir: Path, verdict: str, evidence_ref: str = "tests/test_demo.py") -> None:
+    (feature_dir / "issue-matrix.md").write_text(
+        "\n".join(
+            [
+                "| issue | verdict | evidence_ref |",
+                "| --- | --- | --- |",
+                f"| #1582 | {verdict} | {evidence_ref} |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# review-independence / issue-matrix approval guards
+# ---------------------------------------------------------------------------
+
+
+def test_self_review_fallback_requires_explicit_force_and_metadata() -> None:
+    assert _self_review_fallback_option_error(
+        enabled=False,
+        target_lane="approved",
+        force=False,
+        intended_reviewer="codex",
+        failure_reason=None,
+    ) == "--intended-reviewer/--reviewer-failure-reason require --self-review-fallback."
+
+    assert _self_review_fallback_option_error(
+        enabled=True,
+        target_lane="for_review",
+        force=True,
+        intended_reviewer="codex",
+        failure_reason="exit 1",
+    ) == "--self-review-fallback is only valid when approving or marking done."
+
+    assert _self_review_fallback_option_error(
+        enabled=True,
+        target_lane="approved",
+        force=False,
+        intended_reviewer="codex",
+        failure_reason="exit 1",
+    ) == "--self-review-fallback requires --force so force_count records the independence override."
+
+    assert _self_review_fallback_option_error(
+        enabled=True,
+        target_lane="approved",
+        force=True,
+        intended_reviewer="codex",
+        failure_reason="exit 1",
+    ) is None
+
+
+def test_issue_matrix_approval_blocker_requires_resolved_verdicts(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "demo"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("Fix Priivacy-ai/spec-kitty issue #1582.\n", encoding="utf-8")
+
+    blocker = _issue_matrix_approval_blocker(feature_dir)
+    assert blocker is not None
+    assert "issue-matrix.md is required" in blocker
+    assert "#1582" in blocker
+
+    _write_issue_matrix(feature_dir, "unknown")
+    blocker = _issue_matrix_approval_blocker(feature_dir)
+    assert blocker is not None
+    assert "Unknown: #1582" in blocker
+
+    _write_issue_matrix(feature_dir, "fixed")
+    assert _issue_matrix_approval_blocker(feature_dir) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/merge/test_hollow_review_warnings.py
+++ b/tests/merge/test_hollow_review_warnings.py
@@ -11,7 +11,7 @@ from specify_cli.cli.commands.merge import (
     _collect_hollow_review_warnings,
     _warn_or_confirm_hollow_reviews,
 )
-from specify_cli.status.lifecycle_events import REVIEWER_SELF_APPROVAL
+from specify_cli.status.lifecycle_events import emit_reviewer_self_approval
 
 pytestmark = pytest.mark.fast
 
@@ -23,18 +23,14 @@ def test_collect_hollow_review_warnings_reads_force_count_and_self_approval(tmp_
         json.dumps({"work_packages": {"WP01": {"force_count": 3}, "WP02": {"force_count": 0}}}),
         encoding="utf-8",
     )
-    event = {
-        "event_id": "evt-reviewer-self-approval",
-        "event_type": REVIEWER_SELF_APPROVAL,
-        "aggregate_id": "WP02",
-        "payload": {
-            "wp_id": "WP02",
-            "implementing_actor": "codex",
-            "intended_reviewer": "claude",
-            "failure_reason": "exit 1",
-        },
-    }
-    (feature_dir / "status.events.jsonl").write_text(json.dumps(event) + "\n", encoding="utf-8")
+    emit_reviewer_self_approval(
+        feature_dir,
+        mission_slug="034-test",
+        wp_id="WP02",
+        implementing_actor="codex",
+        intended_reviewer="claude",
+        failure_reason="exit 1",
+    )
 
     warnings = _collect_hollow_review_warnings(feature_dir, ["WP01", "WP02", "WP03"])
 

--- a/tests/merge/test_hollow_review_warnings.py
+++ b/tests/merge/test_hollow_review_warnings.py
@@ -1,0 +1,58 @@
+"""Unit tests for merge-time hollow review warnings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.cli.commands.merge import (
+    _collect_hollow_review_warnings,
+    _warn_or_confirm_hollow_reviews,
+)
+from specify_cli.status.lifecycle_events import REVIEWER_SELF_APPROVAL
+
+pytestmark = pytest.mark.fast
+
+
+def test_collect_hollow_review_warnings_reads_force_count_and_self_approval(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "034-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "status.json").write_text(
+        json.dumps({"work_packages": {"WP01": {"force_count": 3}, "WP02": {"force_count": 0}}}),
+        encoding="utf-8",
+    )
+    event = {
+        "event_id": "evt-reviewer-self-approval",
+        "event_type": REVIEWER_SELF_APPROVAL,
+        "aggregate_id": "WP02",
+        "payload": {
+            "wp_id": "WP02",
+            "implementing_actor": "codex",
+            "intended_reviewer": "claude",
+            "failure_reason": "exit 1",
+        },
+    }
+    (feature_dir / "status.events.jsonl").write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+    warnings = _collect_hollow_review_warnings(feature_dir, ["WP01", "WP02", "WP03"])
+
+    assert warnings["WP01"] == ["force_count=3"]
+    assert warnings["WP02"] == ["ReviewerSelfApproval (claude failed: exit 1; codex self-reviewed)"]
+    assert "WP03" not in warnings
+
+
+def test_warn_or_confirm_hollow_reviews_assume_yes_does_not_prompt(tmp_path: Path, capsys) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "034-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "status.json").write_text(
+        json.dumps({"work_packages": {"WP01": {"force_count": 2}}}),
+        encoding="utf-8",
+    )
+
+    _warn_or_confirm_hollow_reviews(feature_dir=feature_dir, wp_ids=["WP01"], assume_yes=True)
+
+    out = capsys.readouterr().out
+    assert "Hollow reviews detected" in out
+    assert "Proceeding without interactive confirmation" in out

--- a/tests/retrospective/test_generator.py
+++ b/tests/retrospective/test_generator.py
@@ -29,9 +29,12 @@ pytestmark = [pytest.mark.unit]
 from specify_cli.retrospective.generator import (
     GENERATOR_VERSION,
     LOW_RISK_PROPOSAL_KINDS,
+    _EvidenceRegistry,
+    _build_event_mining_findings,
     _classify_risk,
     generate_retrospective,
 )
+from specify_cli.status.lifecycle_events import REVIEWER_SELF_APPROVAL
 from specify_cli.retrospective.policy import default_policy
 from specify_cli.retrospective.schema import (
     GenActor,
@@ -214,6 +217,34 @@ class TestFindingsClassification:
 
         assert _detect_rejection_cycles(events) == {"WP02": 1}
         assert _detect_lane_friction(events) == {"WP01": 1, "WP03": 1}
+
+    def test_reviewer_self_approval_is_process_finding(self) -> None:
+        events = [
+            {
+                "event_id": "evt-1",
+                "event_type": REVIEWER_SELF_APPROVAL,
+                "payload": {
+                    "wp_id": "WP02",
+                    "implementing_actor": "codex",
+                    "intended_reviewer": "claude",
+                    "failure_reason": "exit 1",
+                },
+            }
+        ]
+
+        not_helpful, gaps = _build_event_mining_findings(
+            events=events,
+            events_rel="kitty-specs/demo/status.events.jsonl",
+            finding_id_counters={},
+            ev_reg=_EvidenceRegistry(),
+        )
+
+        assert gaps == []
+        assert len(not_helpful) == 1
+        finding = not_helpful[0]
+        assert finding.category == "process"
+        assert "self-review fallback" in finding.summary
+        assert "claude failed" in finding.details
 
     def test_mid_with_backward_moves_has_lane_friction(self) -> None:
         """Backward moves without reviewer feedback are process friction, not rejections."""

--- a/tests/retrospective/test_generator.py
+++ b/tests/retrospective/test_generator.py
@@ -34,7 +34,7 @@ from specify_cli.retrospective.generator import (
     _classify_risk,
     generate_retrospective,
 )
-from specify_cli.status.lifecycle_events import REVIEWER_SELF_APPROVAL
+from specify_cli.status.lifecycle_events import emit_reviewer_self_approval
 from specify_cli.retrospective.policy import default_policy
 from specify_cli.retrospective.schema import (
     GenActor,
@@ -218,22 +218,21 @@ class TestFindingsClassification:
         assert _detect_rejection_cycles(events) == {"WP02": 1}
         assert _detect_lane_friction(events) == {"WP01": 1, "WP03": 1}
 
-    def test_reviewer_self_approval_is_process_finding(self) -> None:
-        events = [
-            {
-                "event_id": "evt-1",
-                "event_type": REVIEWER_SELF_APPROVAL,
-                "payload": {
-                    "wp_id": "WP02",
-                    "implementing_actor": "codex",
-                    "intended_reviewer": "claude",
-                    "failure_reason": "exit 1",
-                },
-            }
-        ]
+    def test_reviewer_self_approval_is_process_finding(self, tmp_path: Path) -> None:
+        feature_dir = tmp_path / "kitty-specs" / "demo"
+        feature_dir.mkdir(parents=True)
+        event = emit_reviewer_self_approval(
+            feature_dir,
+            mission_slug="demo",
+            wp_id="WP02",
+            implementing_actor="codex",
+            intended_reviewer="claude",
+            failure_reason="exit 1",
+        )
+        assert event is not None
 
         not_helpful, gaps = _build_event_mining_findings(
-            events=events,
+            events=[event],
             events_rel="kitty-specs/demo/status.events.jsonl",
             finding_id_counters={},
             ev_reg=_EvidenceRegistry(),

--- a/tests/status/test_doctor.py
+++ b/tests/status/test_doctor.py
@@ -289,6 +289,50 @@ def test_check_issue_matrix_reports_missing_and_unknown(tmp_path: Path) -> None:
     assert len(unresolved) == 1
     assert "verdict 'unknown'" in unresolved[0].message
 
+    (feature_dir / "issue-matrix.md").write_text(
+        "\n".join(
+            [
+                "| issue | verdict | evidence_ref |",
+                "| --- | --- | --- |",
+                "| #1111 | fixed | tests/test_demo.py |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    missing_row = check_issue_matrix(feature_dir)
+    assert len(missing_row) == 1
+    assert "missing rows" in missing_row[0].message
+    assert "#1582" in missing_row[0].message
+
+
+def test_check_issue_matrix_reports_evaluation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "034-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("Addresses Priivacy-ai/spec-kitty issue #1582.\n", encoding="utf-8")
+
+    def _boom(_path: Path):
+        raise RuntimeError("parser unavailable")
+
+    monkeypatch.setattr("specify_cli.tasks.issue_matrix.detect_issue_references", _boom)
+
+    findings = check_issue_matrix(feature_dir)
+
+    assert len(findings) == 1
+    assert findings[0].category == Category.ISSUE_MATRIX
+    assert "could not be evaluated" in findings[0].message
+    assert "parser unavailable" in findings[0].message
+
+
+def test_check_issue_matrix_no_refs_is_clean(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "034-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("No GitHub issue references here.\n", encoding="utf-8")
+
+    assert check_issue_matrix(feature_dir) == []
+
 
 # ---------------------------------------------------------------------------
 # check_stale_claims tests

--- a/tests/status/test_doctor.py
+++ b/tests/status/test_doctor.py
@@ -18,11 +18,14 @@ from specify_cli.status.doctor import (
     Finding,
     Severity,
     check_drift,
+    check_issue_matrix,
     check_orphan_workspaces,
+    check_reviewer_self_approval,
     check_sparse_checkout,
     check_stale_claims,
     run_doctor,
 )
+from specify_cli.status.lifecycle_events import emit_reviewer_self_approval
 
 pytestmark = pytest.mark.fast
 
@@ -238,6 +241,53 @@ class TestEnums:
         assert Category.ORPHAN_WORKSPACE == "orphan_workspace"
         assert Category.MATERIALIZATION_DRIFT == "materialization_drift"
         assert Category.DERIVED_VIEW_DRIFT == "derived_view_drift"
+        assert Category.REVIEW_INDEPENDENCE == "review_independence"
+        assert Category.ISSUE_MATRIX == "issue_matrix"
+
+
+def test_check_reviewer_self_approval_reports_independence_risk(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "034-test"
+    feature_dir.mkdir(parents=True)
+    emit_reviewer_self_approval(
+        feature_dir,
+        mission_slug="034-test",
+        wp_id="WP02",
+        implementing_actor="codex:gpt-5:implementer",
+        intended_reviewer="claude:sonnet:reviewer",
+        failure_reason="exit 1",
+    )
+
+    findings = check_reviewer_self_approval(feature_dir)
+
+    assert len(findings) == 1
+    assert findings[0].category == Category.REVIEW_INDEPENDENCE
+    assert findings[0].wp_id == "WP02"
+    assert "self-review fallback" in findings[0].message
+
+
+def test_check_issue_matrix_reports_missing_and_unknown(tmp_path: Path) -> None:
+    feature_dir = tmp_path / "kitty-specs" / "034-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("Addresses Priivacy-ai/spec-kitty issue #1582.\n", encoding="utf-8")
+
+    missing = check_issue_matrix(feature_dir)
+    assert len(missing) == 1
+    assert missing[0].category == Category.ISSUE_MATRIX
+    assert "#1582" in missing[0].message
+
+    (feature_dir / "issue-matrix.md").write_text(
+        "\n".join(
+            [
+                "| issue | verdict | evidence_ref |",
+                "| --- | --- | --- |",
+                "| #1582 | unknown | tests/test_demo.py |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    unresolved = check_issue_matrix(feature_dir)
+    assert len(unresolved) == 1
+    assert "verdict 'unknown'" in unresolved[0].message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -21,6 +21,7 @@ from specify_cli.status.lifecycle_events import (
     LIFECYCLE_EVENT_TYPES,
     MISSION_CREATED,
     PROJECT_INITIALIZED,
+    REVIEWER_SELF_APPROVAL,
     SPECIFY_COMPLETED,
     TASKS_COMPLETED,
     WP_CREATED,
@@ -28,6 +29,7 @@ from specify_cli.status.lifecycle_events import (
     emit_artifact_phase,
     emit_mission_created_local,
     emit_project_initialized,
+    emit_reviewer_self_approval,
     emit_wp_created_local,
     has_lifecycle_event,
     has_non_bootstrap_status_history,
@@ -267,6 +269,34 @@ def test_wp_created_full_roster_writes_one_event_per_wp(feature_dir: Path) -> No
     assert sorted(e["aggregate_id"] for e in entries) == ["WP01", "WP02", "WP03"]
 
 
+def test_reviewer_self_approval_persists_and_dedupes(feature_dir: Path) -> None:
+    env1 = emit_reviewer_self_approval(
+        feature_dir,
+        mission_slug="demo-mission",
+        wp_id="WP01",
+        implementing_actor="codex:gpt-5:implementer",
+        intended_reviewer="claude:sonnet:reviewer",
+        failure_reason="reviewer exited 1",
+    )
+    env2 = emit_reviewer_self_approval(
+        feature_dir,
+        mission_slug="demo-mission",
+        wp_id="WP01",
+        implementing_actor="codex:gpt-5:implementer",
+        intended_reviewer="claude:sonnet:reviewer",
+        failure_reason="reviewer exited 1",
+    )
+
+    assert env1 is not None
+    assert env1["event_type"] == REVIEWER_SELF_APPROVAL
+    assert env2 is None
+    entries = read_lifecycle_events(mission_event_log_path(feature_dir))
+    assert len(entries) == 1
+    assert entries[0]["aggregate_id"] == "WP01"
+    assert entries[0]["payload"]["intended_reviewer"] == "claude:sonnet:reviewer"
+    assert entries[0]["payload"]["fallback_approved"] is True
+
+
 def test_wp_created_records_optional_metadata(feature_dir: Path) -> None:
     emit_wp_created_local(
         feature_dir,
@@ -453,6 +483,7 @@ def test_lifecycle_event_types_complete() -> None:
         SPECIFY_COMPLETED,
         TASKS_COMPLETED,
         WP_CREATED,
+        REVIEWER_SELF_APPROVAL,
     } <= LIFECYCLE_EVENT_TYPES
 
 


### PR DESCRIPTION
## Summary
- Add explicit `ReviewerSelfApproval` lifecycle events and `move-task --self-review-fallback` metadata requirements.
- Block approval/done transitions when referenced GitHub issues still lack a resolved `issue-matrix.md` verdict.
- Surface hollow review risk in `spec-kitty merge`, `doctor`, retrospective generation, and mission-review doctrine.
- Update implement-review doctrine to halt on reviewer CLI failure unless an operator explicitly chooses self-review fallback.

## Freshness / relevance validation
- Issues #1579-#1582 were still open and recently created/updated on 2026-06-01 when validated.
- `preferred_reviewer` wording in the issue set is stale: current config only exposes `agents.available` and `auto_commit` after the 3.2.1 selection-config migration.
- The underlying review-independence failure remains relevant, so this PR addresses it directly at runtime, merge, doctor, retrospective, and doctrine layers.

## Verification
- `.venv/bin/ruff check src/specify_cli/cli/commands/merge.py src/specify_cli/status/doctor.py src/specify_cli/retrospective/generator.py src/specify_cli/cli/commands/agent/tasks.py tests/status/test_lifecycle_events.py tests/agent/cli/commands/test_tasks_helpers.py tests/status/test_doctor.py tests/merge/test_hollow_review_warnings.py tests/retrospective/test_generator.py`
- `.venv/bin/python -m pytest tests/status/test_lifecycle_events.py tests/agent/cli/commands/test_tasks_helpers.py tests/status/test_doctor.py tests/merge/test_hollow_review_warnings.py tests/retrospective/test_generator.py` (177 passed)

Closes #1579
Closes #1580
Closes #1581
Closes #1582
