### PR TITLE
Default top-level command groups to help

### DIFF
--- a/src/specify_cli/cli/commands/__init__.py
+++ b/src/specify_cli/cli/commands/__init__.py
@@ -4,7 +4,108 @@ from __future__ import annotations
 
 import sys
 
+import click
 import typer
+from typer.core import TyperGroup
+from typer.models import DefaultPlaceholder, TyperInfo
+
+
+class HelpOnEmptyTopLevelGroup(TyperGroup):
+    """Render help with exit 0 for empty top-level command-group invocation."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not args and self.no_args_is_help and not ctx.resilient_parsing:
+            click.echo(ctx.get_help(), color=ctx.color)
+            ctx.exit(0)
+        return super().parse_args(ctx, args)
+
+
+_HELP_ON_EMPTY_GROUP_CLASS_CACHE: dict[type[TyperGroup], type[TyperGroup]] = {}
+
+_TOP_LEVEL_GROUP_EMPTY_INVOCATION_EXCEPTIONS = frozenset(
+    {
+        # These groups intentionally run a default action when invoked without
+        # a subcommand.
+        "context",
+        "migrate",
+        # This surface is JSON-first; even usage failures must remain JSON
+        # envelopes, not Rich/prose help.
+        "orchestrator-api",
+    }
+)
+
+
+def _is_explicit_typer_setting(value: object) -> bool:
+    return not isinstance(value, DefaultPlaceholder)
+
+
+def _top_level_group_name(group_info: TyperInfo) -> str | None:
+    if _is_explicit_typer_setting(group_info.name) and group_info.name is not None:
+        return str(group_info.name)
+
+    child_name = group_info.typer_instance.info.name
+    if _is_explicit_typer_setting(child_name) and child_name is not None:
+        return str(child_name)
+
+    return None
+
+
+def _top_level_group_invokes_without_command(group_info: TyperInfo) -> bool:
+    values = (
+        group_info.invoke_without_command,
+        group_info.typer_instance.info.invoke_without_command,
+    )
+    return any(_is_explicit_typer_setting(value) and bool(value) for value in values)
+
+
+def _top_level_group_base_class(group_info: TyperInfo) -> type[TyperGroup]:
+    if _is_explicit_typer_setting(group_info.cls):
+        return group_info.cls
+
+    child_cls = group_info.typer_instance.info.cls
+    if _is_explicit_typer_setting(child_cls):
+        return child_cls
+
+    return TyperGroup
+
+
+def _help_on_empty_group_class(base_class: type[TyperGroup]) -> type[TyperGroup]:
+    if issubclass(base_class, HelpOnEmptyTopLevelGroup):
+        return base_class
+    if base_class is TyperGroup:
+        return HelpOnEmptyTopLevelGroup
+
+    cached = _HELP_ON_EMPTY_GROUP_CLASS_CACHE.get(base_class)
+    if cached is not None:
+        return cached
+
+    wrapped = type(
+        f"HelpOnEmpty{base_class.__name__}",
+        (HelpOnEmptyTopLevelGroup, base_class),
+        {},
+    )
+    _HELP_ON_EMPTY_GROUP_CLASS_CACHE[base_class] = wrapped
+    return wrapped
+
+
+def _enforce_top_level_empty_group_help(app: typer.Typer) -> None:
+    """Make empty top-level command groups render help by default.
+
+    Typer defaults nested command groups to "Missing command" unless each group
+    opts into no_args_is_help.  Enforcing that policy at root registration keeps
+    future top-level groups consistent while preserving explicit default-action
+    and machine-contract exceptions.
+    """
+    for group_info in app.registered_groups:
+        group_name = _top_level_group_name(group_info)
+        if group_name in _TOP_LEVEL_GROUP_EMPTY_INVOCATION_EXCEPTIONS:
+            continue
+        if _top_level_group_invokes_without_command(group_info):
+            continue
+
+        group_info.no_args_is_help = True
+        group_info.cls = _help_on_empty_group_class(_top_level_group_base_class(group_info))
+        group_info.typer_instance.info.no_args_is_help = True
 
 
 def _is_next_fast_path(argv: list[str]) -> bool:
@@ -45,6 +146,7 @@ def register_commands(app: typer.Typer) -> None:
         from . import doctor as doctor_module
 
         app.add_typer(doctor_module.app, name="doctor", help="Project health diagnostics")
+        _enforce_top_level_empty_group_help(app)
         return
 
     from . import accept as accept_module
@@ -136,6 +238,7 @@ def register_commands(app: typer.Typer) -> None:
 
     from specify_cli.cli.commands.retrospect import app as retrospect_app  # WP05 (replaces WP09 single-command registration)
     app.add_typer(retrospect_app, name="retrospect", help="Retrospective authoring and summary (create / backfill / summary)")
+    _enforce_top_level_empty_group_help(app)
 
 
 __all__ = ["register_commands"]

--- a/tests/cli/test_top_level_group_empty_invocation.py
+++ b/tests/cli/test_top_level_group_empty_invocation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import typer
+from typer.core import TyperGroup
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import (
+    _TOP_LEVEL_GROUP_EMPTY_INVOCATION_EXCEPTIONS,
+    _enforce_top_level_empty_group_help,
+    _top_level_group_invokes_without_command,
+    _top_level_group_name,
+    register_commands,
+)
+
+
+def _registered_root() -> typer.Typer:
+    app = typer.Typer()
+    register_commands(app)
+    return app
+
+
+def test_registered_top_level_groups_default_to_help(monkeypatch) -> None:
+    monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+    app = _registered_root()
+    command = get_command(app)
+
+    for group_info in app.registered_groups:
+        name = _top_level_group_name(group_info)
+        if name in _TOP_LEVEL_GROUP_EMPTY_INVOCATION_EXCEPTIONS:
+            continue
+        if _top_level_group_invokes_without_command(group_info):
+            continue
+
+        assert command.commands[str(name)].no_args_is_help is True, name
+
+
+def test_empty_doctor_invocation_shows_help(monkeypatch) -> None:
+    monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+    result = CliRunner().invoke(_registered_root(), ["doctor"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "Project health diagnostics" in result.output
+    assert "Missing command" not in result.output
+
+
+def test_future_top_level_groups_are_covered_by_registration_guard() -> None:
+    app = typer.Typer()
+    future_app = typer.Typer(help="Future command group")
+    future_app.command("ping")(lambda: None)
+    app.add_typer(future_app, name="future")
+
+    _enforce_top_level_empty_group_help(app)
+    result = CliRunner().invoke(app, ["future"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "Future command group" in result.output
+    assert "Missing command" not in result.output
+
+
+def test_future_custom_top_level_group_classes_are_preserved() -> None:
+    class CustomGroup(TyperGroup):
+        pass
+
+    app = typer.Typer()
+    future_app = typer.Typer(help="Future custom group", cls=CustomGroup)
+    future_app.command("ping")(lambda: None)
+    app.add_typer(future_app, name="future")
+
+    _enforce_top_level_empty_group_help(app)
+    command = get_command(app).commands["future"]
+    result = CliRunner().invoke(app, ["future"])
+
+    assert isinstance(command, CustomGroup)
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "Future custom group" in result.output
+    assert "Missing command" not in result.output


### PR DESCRIPTION
## Summary
- enforce help-on-empty behavior centrally for top-level Typer command groups
- preserve explicit default-action groups (context, migrate) and orchestrator-api JSON error behavior
- add regression coverage for existing and future top-level command groups, including custom group classes

## Verification
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/cli/test_top_level_group_empty_invocation.py tests/agent/test_json_envelope_contract_integration.py::TestRootCLIPath::test_bare_group_invocation_through_root_returns_json tests/specify_cli/cli/commands/test_doctor_restart_daemon.py::test_doctor_help_lists_restart_daemon -q
- .venv/bin/ruff check src/specify_cli/cli/commands/__init__.py tests/cli/test_top_level_group_empty_invocation.py
- smoke: spec-kitty doctor exits 0 and renders help
