### PR TITLE
Release 3.2.0rc34

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc33
+  version: 3.2.0rc34
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Documentation
+## [3.2.0rc34] - 2026-06-02
+
+### Changed
 
 - Clarified that live canary and cross-repo end-to-end runs remain required
   release-candidate hygiene under the charter, but are run locally before
   tagging instead of as tag-time PyPI publish workflow blockers.
+- Transactional mission status reads now resolve the coordination worktree
+  without creating or mutating checkout state, keeping lane views aligned with
+  the coordination branch.
+
+### Fixed
+
+- Planning-artifact commits now preserve append-only coordination event logs
+  instead of clobbering lane history with stale primary-checkout copies.
+- Planning-artifact claim commits now parse git porcelain status structurally,
+  fail closed on unrelated structural changes, and skip idempotent
+  already-on-coordination content.
+- Move-task transitions now derive source and target lanes from transactional
+  coordination status so review handoffs do not fail after coordination/feature
+  branch desync.
+- `.kittify/sync-state.json` is treated as local relay state, while charter
+  synthesis provenance can be tracked with the required commit reminder.
 
 ## [3.2.0rc33] - 2026-06-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc33"
+version = "3.2.0rc34"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc33"
+version = "3.2.0rc34"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- Bump spec-kitty-cli to 3.2.0rc34.
- Sync .kittify release metadata and uv.lock with pyproject.
- Add changelog entry for the coordination status/event-log fixes merged in #1598 and #1606.

## Local verification
- uv lock --check
- .venv/bin/python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- .venv/bin/pytest tests/release -q
- .venv/bin/python -m build --outdir /tmp/spec-kitty-dist-3.2.0rc34
- uvx twine check /tmp/spec-kitty-dist-3.2.0rc34/*
- .venv/bin/python scripts/release/check_exact_install.py --dist-dir /tmp/spec-kitty-dist-3.2.0rc34 --package spec-kitty-cli --version 3.2.0rc34 --console-script spec-kitty --console-arg=--version

## Notes
- Release PR should be squash-merged per Protect Main/release checklist.
- After merge, tag exact main commit as v3.2.0rc34 and let the tag workflow publish to PyPI.