### PR TITLE
Refactor coordination status event-log contracts

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -241,51 +241,12 @@ def _canonical_status_feature_dir(main_repo_root: Path, mission_slug: str) -> Pa
 
 
 def _merge_event_log_bytes(existing: bytes, incoming: bytes) -> bytes:
-    """Append-only union of two JSONL event logs, keyed by ``event_id`` (#1602).
+    """Compatibility wrapper for the explicit coordination merge contract."""
+    from specify_cli.coordination.status_service import (
+        merge_append_preserving_coordination_event_log_bytes,
+    )
 
-    The coordination branch's canonical ``status.events.jsonl`` is authoritative
-    and append-only: a workflow commit must NEVER drop an event already recorded
-    there. But the main-checkout copy fed into the coordination commit can lack
-    lane transitions that only live on the coordination branch (they are emitted
-    straight to the coord worktree), while carrying non-lane lifecycle/decision
-    envelope events the coord copy lacks. Overwriting the coord log with that copy
-    wipes the lane history — ``read_events()`` then returns 0 and the loop wedges
-    with "no canonical status".
-
-    This merge preserves every ``existing`` (coord) line in order, then appends
-    only ``incoming`` lines whose ``event_id`` (or, when absent, raw text) is not
-    already present. Net effect: the canonical log can never be clobbered, yet a
-    genuinely new transition still lands. Appended events are the chronologically
-    newest (the just-emitted transition) or non-lane events the reducer skips, so
-    ordering stays correct.
-    """
-
-    def _key(line: str) -> str:
-        try:
-            obj = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
-            return f"raw:{line}"
-        if isinstance(obj, dict):
-            eid = obj.get("event_id")
-            if isinstance(eid, str) and eid:
-                return f"id:{eid}"
-        return f"raw:{line}"
-
-    existing_lines = [
-        line for line in existing.decode("utf-8", "replace").splitlines() if line.strip()
-    ]
-    seen = {_key(line) for line in existing_lines}
-    merged = list(existing_lines)
-    for line in incoming.decode("utf-8", "replace").splitlines():
-        if not line.strip():
-            continue
-        key = _key(line)
-        if key not in seen:
-            seen.add(key)
-            merged.append(line)
-    if not merged:
-        return b""
-    return ("\n".join(merged) + "\n").encode("utf-8")
+    return merge_append_preserving_coordination_event_log_bytes(existing, incoming)
 
 
 def _commit_via_coordination_transaction(

--- a/src/specify_cli/coordination/status_service.py
+++ b/src/specify_cli/coordination/status_service.py
@@ -1,0 +1,257 @@
+"""Status/coordination source-of-truth boundary.
+
+This module is the explicit contract layer for rc34-adjacent mission state
+surfaces:
+
+* status reads: primary checkout, coordination worktree, or coordination branch
+  ref read via ``git show`` without worktree creation;
+* move-task/review handoff: read-only transactional snapshots use the same
+  target as transactional writes;
+* planning-artifact commits: append-preserving coordination event-log merge is a
+  named helper, never a raw overwrite;
+* event-log writes: primary-checkout appends and coordination-transaction
+  appends are separate write contracts;
+* bootstrap/repair: intentionally mutating paths remain outside read-only
+  contracts and should call primary/coordination write contracts explicitly.
+
+The key rule is visibility at the call site: callers choose a read source or a
+write target by name. There is no global event-log path redirect.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from specify_cli.status.models import Lane, StatusEvent
+
+
+class StatusReadSource(enum.StrEnum):
+    """Explicit status read source."""
+
+    PRIMARY_CHECKOUT = "primary_checkout"
+    COORDINATION_WORKTREE = "coordination_worktree"
+    COORDINATION_BRANCH_REF = "coordination_branch_ref"
+
+
+class EventLogWriteTarget(enum.StrEnum):
+    """Explicit event-log mutation target."""
+
+    PRIMARY_CHECKOUT_APPEND = "primary_checkout_append"
+    COORDINATION_TRANSACTION_APPEND = "coordination_transaction_append"
+
+
+class StatusContractError(TypeError):
+    """Raised when a read-only contract is used for mutation or vice versa."""
+
+
+@dataclass(frozen=True)
+class EventLogReadContract:
+    """Read-only event-log contract.
+
+    ``feature_dir`` is the source directory for filesystem-backed reads. For a
+    branch-ref read it names the mission directory inside the ref path, while
+    ``parser_feature_dir`` points at the primary checkout for legacy
+    slug-to-mission-id resolution.
+    """
+
+    source: StatusReadSource
+    feature_dir: Path
+    repo_root: Path | None = None
+    destination_ref: str | None = None
+    parser_feature_dir: Path | None = None
+
+    @classmethod
+    def primary_checkout(cls, feature_dir: Path) -> EventLogReadContract:
+        return cls(source=StatusReadSource.PRIMARY_CHECKOUT, feature_dir=feature_dir)
+
+    @classmethod
+    def coordination_worktree(cls, feature_dir: Path) -> EventLogReadContract:
+        return cls(source=StatusReadSource.COORDINATION_WORKTREE, feature_dir=feature_dir)
+
+    @classmethod
+    def coordination_branch_ref(
+        cls,
+        *,
+        repo_root: Path,
+        destination_ref: str,
+        feature_dir: Path,
+        parser_feature_dir: Path,
+    ) -> EventLogReadContract:
+        return cls(
+            source=StatusReadSource.COORDINATION_BRANCH_REF,
+            feature_dir=feature_dir,
+            repo_root=repo_root,
+            destination_ref=destination_ref,
+            parser_feature_dir=parser_feature_dir,
+        )
+
+
+@dataclass(frozen=True)
+class EventLogWriteContract:
+    """Mutating event-log contract."""
+
+    target: EventLogWriteTarget
+    feature_dir: Path
+
+    @classmethod
+    def primary_checkout_append(cls, feature_dir: Path) -> EventLogWriteContract:
+        return cls(
+            target=EventLogWriteTarget.PRIMARY_CHECKOUT_APPEND,
+            feature_dir=feature_dir,
+        )
+
+    @classmethod
+    def coordination_transaction_append(cls, feature_dir: Path) -> EventLogWriteContract:
+        return cls(
+            target=EventLogWriteTarget.COORDINATION_TRANSACTION_APPEND,
+            feature_dir=feature_dir,
+        )
+
+
+def read_event_log(contract: EventLogReadContract) -> list[StatusEvent]:
+    """Read events from the contract's explicit source without mutation."""
+    from specify_cli.status.store import EVENTS_FILENAME, read_events, read_events_from_text
+
+    if not isinstance(contract, EventLogReadContract):
+        raise StatusContractError("read_event_log requires EventLogReadContract")
+
+    if contract.source in {
+        StatusReadSource.PRIMARY_CHECKOUT,
+        StatusReadSource.COORDINATION_WORKTREE,
+    }:
+        return read_events(contract.feature_dir)
+
+    if contract.source == StatusReadSource.COORDINATION_BRANCH_REF:
+        if contract.repo_root is None or contract.destination_ref is None:
+            raise StatusContractError(
+                "coordination_branch_ref reads require repo_root and destination_ref"
+            )
+        events_ref = (
+            f"{contract.destination_ref}:"
+            f"kitty-specs/{contract.feature_dir.name}/{EVENTS_FILENAME}"
+        )
+        result = subprocess.run(
+            ["git", "-C", str(contract.repo_root), "show", events_ref],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if result.returncode != 0:
+            return []
+        parser_feature_dir = contract.parser_feature_dir or contract.feature_dir
+        return read_events_from_text(parser_feature_dir, result.stdout)
+
+    raise StatusContractError(f"unsupported status read source: {contract.source}")
+
+
+def read_wp_lane_actor(contract: EventLogReadContract, wp_id: str) -> tuple[Lane, str | None]:
+    """Read a WP lane/actor snapshot from an explicit read contract."""
+    return wp_lane_actor_from_events(read_event_log(contract), wp_id)
+
+
+def wp_lane_actor_from_events(
+    events: list[StatusEvent],
+    wp_id: str,
+) -> tuple[Lane, str | None]:
+    """Reduce already-read events into a WP lane/actor snapshot."""
+    from specify_cli.status.models import Lane
+    from specify_cli.status.reducer import reduce
+
+    if not events:
+        return Lane.PLANNED, None
+    snapshot = reduce(events)
+    state = snapshot.work_packages.get(wp_id)
+    if not state:
+        return Lane.PLANNED, None
+    try:
+        lane = Lane(str(state.get("lane", Lane.PLANNED)))
+    except ValueError:
+        lane = Lane.PLANNED
+    actor = state.get("actor")
+    actor_key = str(actor).strip() if actor is not None else ""
+    return lane, actor_key or None
+
+
+def append_event_log(contract: EventLogWriteContract, event: StatusEvent) -> None:
+    """Append one event using an explicit mutating contract."""
+    from specify_cli.status import store as _store
+
+    if not isinstance(contract, EventLogWriteContract):
+        raise StatusContractError("append_event_log requires EventLogWriteContract")
+    _store.append_event_verified(contract.feature_dir, event)
+
+
+def append_event_log_batch(
+    contract: EventLogWriteContract,
+    events: list[StatusEvent],
+) -> None:
+    """Append event batch using an explicit mutating contract."""
+    from specify_cli.status import store as _store
+
+    if not isinstance(contract, EventLogWriteContract):
+        raise StatusContractError("append_event_log_batch requires EventLogWriteContract")
+    _store.append_events_atomic_verified(contract.feature_dir, events)
+
+
+def merge_append_preserving_coordination_event_log_bytes(
+    existing_coordination: bytes,
+    incoming_primary_checkout: bytes,
+) -> bytes:
+    """Append-only union keyed by ``event_id`` for coordination writes.
+
+    The existing coordination log is authoritative. Incoming primary-checkout
+    rows may add new lifecycle/envelope rows or just-emitted transitions, but
+    they must never remove a row already present on the coordination branch.
+    """
+
+    def _key(line: str) -> str:
+        try:
+            obj: Any = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return f"raw:{line}"
+        if isinstance(obj, dict):
+            event_id = obj.get("event_id")
+            if isinstance(event_id, str) and event_id:
+                return f"id:{event_id}"
+        return f"raw:{line}"
+
+    existing_lines = [
+        line
+        for line in existing_coordination.decode("utf-8", "replace").splitlines()
+        if line.strip()
+    ]
+    seen = {_key(line) for line in existing_lines}
+    merged = list(existing_lines)
+    for line in incoming_primary_checkout.decode("utf-8", "replace").splitlines():
+        if not line.strip():
+            continue
+        key = _key(line)
+        if key not in seen:
+            seen.add(key)
+            merged.append(line)
+    if not merged:
+        return b""
+    return ("\n".join(merged) + "\n").encode("utf-8")
+
+
+__all__ = [
+    "EventLogReadContract",
+    "EventLogWriteContract",
+    "EventLogWriteTarget",
+    "StatusContractError",
+    "StatusReadSource",
+    "append_event_log",
+    "append_event_log_batch",
+    "merge_append_preserving_coordination_event_log_bytes",
+    "read_event_log",
+    "read_wp_lane_actor",
+    "wp_lane_actor_from_events",
+]

--- a/src/specify_cli/coordination/status_service.py
+++ b/src/specify_cli/coordination/status_service.py
@@ -50,6 +50,11 @@ class StatusContractError(TypeError):
     """Raised when a read-only contract is used for mutation or vice versa."""
 
 
+def _is_coordination_worktree_path(path: Path) -> bool:
+    """Return True for paths rooted under the in-repo coordination worktree dir."""
+    return ".worktrees" in path.parts
+
+
 @dataclass(frozen=True)
 class EventLogReadContract:
     """Read-only event-log contract.
@@ -125,6 +130,20 @@ def read_event_log(contract: EventLogReadContract) -> list[StatusEvent]:
         StatusReadSource.PRIMARY_CHECKOUT,
         StatusReadSource.COORDINATION_WORKTREE,
     }:
+        if (
+            contract.source == StatusReadSource.PRIMARY_CHECKOUT
+            and _is_coordination_worktree_path(contract.feature_dir)
+        ):
+            raise StatusContractError(
+                "primary_checkout reads must not target coordination worktree paths"
+            )
+        if (
+            contract.source == StatusReadSource.COORDINATION_WORKTREE
+            and not _is_coordination_worktree_path(contract.feature_dir)
+        ):
+            raise StatusContractError(
+                "coordination_worktree reads require a coordination worktree path"
+            )
         return read_events(contract.feature_dir)
 
     if contract.source == StatusReadSource.COORDINATION_BRANCH_REF:
@@ -186,6 +205,7 @@ def append_event_log(contract: EventLogWriteContract, event: StatusEvent) -> Non
 
     if not isinstance(contract, EventLogWriteContract):
         raise StatusContractError("append_event_log requires EventLogWriteContract")
+    _validate_write_contract(contract)
     _store.append_event_verified(contract.feature_dir, event)
 
 
@@ -198,7 +218,25 @@ def append_event_log_batch(
 
     if not isinstance(contract, EventLogWriteContract):
         raise StatusContractError("append_event_log_batch requires EventLogWriteContract")
+    _validate_write_contract(contract)
     _store.append_events_atomic_verified(contract.feature_dir, events)
+
+
+def _validate_write_contract(contract: EventLogWriteContract) -> None:
+    if (
+        contract.target == EventLogWriteTarget.PRIMARY_CHECKOUT_APPEND
+        and _is_coordination_worktree_path(contract.feature_dir)
+    ):
+        raise StatusContractError(
+            "primary_checkout_append must not target coordination worktree paths"
+        )
+    if (
+        contract.target == EventLogWriteTarget.COORDINATION_TRANSACTION_APPEND
+        and not _is_coordination_worktree_path(contract.feature_dir)
+    ):
+        raise StatusContractError(
+            "coordination_transaction_append requires a coordination worktree path"
+        )
 
 
 def merge_append_preserving_coordination_event_log_bytes(

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -14,13 +14,16 @@ from pathlib import Path
 from typing import cast
 
 from specify_cli.coordination.outbound import queue_saas_emission
+from specify_cli.coordination.status_service import (
+    EventLogReadContract,
+    read_event_log,
+    wp_lane_actor_from_events,
+)
 from specify_cli.coordination.transaction import BookkeepingTransaction
 from specify_cli.mission_metadata import load_meta
 from specify_cli.status import emit as _emit
 from specify_cli.status.adapters import fire_dossier_sync
 from specify_cli.status.models import DoneEvidence, GuardContext, Lane, StatusEvent, TransitionRequest
-from specify_cli.status.reducer import reduce
-from specify_cli.status.store import EVENTS_FILENAME, read_events, read_events_from_text
 from specify_cli.status.transitions import resolve_lane_alias, validate_transition
 from specify_cli.workspace import canonicalize_feature_dir
 
@@ -236,9 +239,9 @@ def _read_events_from_transaction_target(
 ) -> list[StatusEvent]:
     """Read target status events without creating worktrees or commits."""
     if not _transaction_topology_available(identity, mission_slug):
-        return read_events(identity.feature_dir)
+        return read_event_log(EventLogReadContract.primary_checkout(identity.feature_dir))
     if identity.coordination_branch is None:
-        return read_events(identity.feature_dir)
+        return read_event_log(EventLogReadContract.primary_checkout(identity.feature_dir))
 
     from specify_cli.coordination.workspace import CoordinationWorkspace  # noqa: PLC0415
 
@@ -252,39 +255,18 @@ def _read_events_from_transaction_target(
         identity.mid8,
     )
     if worktree_root.exists():
-        return read_events(transaction_feature_dir)
+        return read_event_log(
+            EventLogReadContract.coordination_worktree(transaction_feature_dir)
+        )
 
-    events_ref = (
-        f"{identity.destination_ref}:"
-        f"kitty-specs/{transaction_feature_dir.name}/{EVENTS_FILENAME}"
+    return read_event_log(
+        EventLogReadContract.coordination_branch_ref(
+            repo_root=identity.repo_root,
+            destination_ref=identity.destination_ref,
+            feature_dir=transaction_feature_dir,
+            parser_feature_dir=identity.feature_dir,
+        )
     )
-    result = subprocess.run(
-        ["git", "-C", str(identity.repo_root), "show", events_ref],
-        check=False,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    if result.returncode != 0:
-        return []
-    return read_events_from_text(identity.feature_dir, result.stdout)
-
-
-def _state_from_events(events: list[StatusEvent], wp_id: str) -> tuple[Lane, str | None]:
-    if not events:
-        return Lane.PLANNED, None
-    snapshot = reduce(events)
-    state = snapshot.work_packages.get(wp_id)
-    if not state:
-        return Lane.PLANNED, None
-    try:
-        lane = Lane(str(state.get("lane", Lane.PLANNED)))
-    except ValueError:
-        lane = Lane.PLANNED
-    actor = state.get("actor")
-    actor_key = str(actor).strip() if actor is not None else ""
-    return lane, actor_key or None
 
 
 def read_current_wp_state_transactional(
@@ -305,7 +287,8 @@ def read_current_wp_state_transactional(
             repo_root=repo_root,
         )
     )
-    events = _read_events_from_transaction_target(identity, mission_slug)
+    contract = _read_contract_from_transaction_target(identity, mission_slug)
+    events = read_event_log(contract)
     if not events and not _transaction_topology_available(identity, mission_slug):
         from specify_cli.status.lane_reader import get_wp_lane  # noqa: PLC0415
 
@@ -313,7 +296,38 @@ def read_current_wp_state_transactional(
             return Lane(resolve_lane_alias(get_wp_lane(identity.feature_dir, wp_id))), None
         except Exception:  # noqa: BLE001 -- non-git test fixtures may lack WP files
             return Lane.PLANNED, None
-    return _state_from_events(events, wp_id)
+    return wp_lane_actor_from_events(events, wp_id)
+
+
+def _read_contract_from_transaction_target(
+    identity: _TransactionIdentity,
+    mission_slug: str,
+) -> EventLogReadContract:
+    """Resolve the read-only contract for the transaction write target."""
+    if not _transaction_topology_available(identity, mission_slug):
+        return EventLogReadContract.primary_checkout(identity.feature_dir)
+    if identity.coordination_branch is None:
+        return EventLogReadContract.primary_checkout(identity.feature_dir)
+
+    from specify_cli.coordination.workspace import CoordinationWorkspace  # noqa: PLC0415
+
+    worktree_root = CoordinationWorkspace.worktree_path(
+        identity.repo_root,
+        mission_slug,
+        identity.mid8,
+    )
+    transaction_feature_dir = worktree_root / "kitty-specs" / _transaction_dir_name(
+        mission_slug,
+        identity.mid8,
+    )
+    if worktree_root.exists():
+        return EventLogReadContract.coordination_worktree(transaction_feature_dir)
+    return EventLogReadContract.coordination_branch_ref(
+        repo_root=identity.repo_root,
+        destination_ref=identity.destination_ref,
+        feature_dir=transaction_feature_dir,
+        parser_feature_dir=identity.feature_dir,
+    )
 
 
 def read_events_transactional(

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -39,6 +39,10 @@ from specify_cli.coordination.policy import (
     WorkflowMutationPolicy,
     _normalize_ref,
 )
+from specify_cli.coordination.status_service import (
+    EventLogWriteContract,
+    append_event_log,
+)
 from specify_cli.coordination.types import (
     Allowed,
     CommitReceipt,
@@ -49,7 +53,6 @@ from specify_cli.coordination.types import (
 from specify_cli.coordination.workspace import CoordinationWorkspace
 from specify_cli.git.commit_helpers import SafeCommitRecoveryFailed, safe_commit
 from specify_cli.status import reducer as _reducer
-from specify_cli.status import store as _store
 from specify_cli.status.locking import (
     FeatureStatusLockTimeoutError,
     feature_status_lock,
@@ -819,7 +822,10 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         self.feature_dir.mkdir(parents=True, exist_ok=True)
 
         # Append + verify readback (matches existing emit pipeline).
-        _store.append_event_verified(self.feature_dir, event)
+        append_event_log(
+            EventLogWriteContract.coordination_transaction_append(self.feature_dir),
+            event,
+        )
         # Re-materialise status.json so an external observer sees
         # consistent state immediately after the event is durable.
         try:

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -35,6 +35,8 @@ from .store import (
     append_event,
     append_event_verified,
     append_events_atomic_verified,
+    append_primary_checkout_event_verified,
+    append_primary_checkout_events_atomic_verified,
     read_events,
     read_events_raw,
 )
@@ -145,6 +147,8 @@ __all__ = [
     "append_event",
     "append_event_verified",
     "append_events_atomic_verified",
+    "append_primary_checkout_event_verified",
+    "append_primary_checkout_events_atomic_verified",
     "emit_status_transition",
     "generate_status_view",
     "get_all_wp_lanes",

--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -572,7 +572,7 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
         )
 
         # Step 5: Persist event to JSONL log and require readback before success.
-        _store.append_event_verified(feature_dir, event)
+        _store.append_primary_checkout_event_verified(feature_dir, event)
 
         # Step 6: Materialize snapshot from event log
         try:
@@ -702,7 +702,7 @@ def emit_status_transition_batch(  # noqa: C901 — composite transition orchest
         return []
 
     events = [event for event, _request in built]
-    _store.append_events_atomic_verified(feature_dir, events)
+    _store.append_primary_checkout_events_atomic_verified(feature_dir, events)
 
     try:
         _reducer.materialize(feature_dir)

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -242,6 +242,15 @@ def append_event_verified(feature_dir: Path, event: StatusEvent) -> None:
     verify_event_readback(feature_dir, event)
 
 
+def append_primary_checkout_event_verified(feature_dir: Path, event: StatusEvent) -> None:
+    """Append one event to the primary-checkout event log.
+
+    Coordination worktree callers must not use this helper; they route through
+    ``coordination.status_service.EventLogWriteContract`` instead.
+    """
+    append_event_verified(feature_dir, event)
+
+
 def append_events_atomic(feature_dir: Path, events: list[StatusEvent]) -> None:
     """Atomically persist a batch of StatusEvents as JSONL lines.
 
@@ -288,6 +297,14 @@ def append_events_atomic_verified(feature_dir: Path, events: list[StatusEvent]) 
         ) from exc
     for event in events:
         verify_event_readback(feature_dir, event)
+
+
+def append_primary_checkout_events_atomic_verified(
+    feature_dir: Path,
+    events: list[StatusEvent],
+) -> None:
+    """Append a batch to the primary-checkout event log."""
+    append_events_atomic_verified(feature_dir, events)
 
 
 def read_events_raw(feature_dir: Path) -> list[dict[str, Any]]:

--- a/tests/specify_cli/coordination/test_status_transition.py
+++ b/tests/specify_cli/coordination/test_status_transition.py
@@ -176,6 +176,35 @@ def test_read_contract_cannot_be_used_as_write_contract(repo: Path) -> None:
         )
 
 
+def test_wrong_write_target_fails_loudly(repo: Path) -> None:
+    event = _status_event("01WRONGTARGET000000000000")
+    primary_feature_dir = repo / "kitty-specs" / MISSION_DIRNAME
+    coordination_feature_dir = repo / ".worktrees" / "coord" / "kitty-specs" / MISSION_DIRNAME
+
+    with pytest.raises(StatusContractError, match="primary_checkout_append"):
+        append_event_log(
+            EventLogWriteContract.primary_checkout_append(coordination_feature_dir),
+            event,
+        )
+
+    with pytest.raises(StatusContractError, match="coordination_transaction_append"):
+        append_event_log(
+            EventLogWriteContract.coordination_transaction_append(primary_feature_dir),
+            event,
+        )
+
+
+def test_wrong_read_source_fails_loudly(repo: Path) -> None:
+    primary_feature_dir = repo / "kitty-specs" / MISSION_DIRNAME
+    coordination_feature_dir = repo / ".worktrees" / "coord" / "kitty-specs" / MISSION_DIRNAME
+
+    with pytest.raises(StatusContractError, match="primary_checkout"):
+        read_event_log(EventLogReadContract.primary_checkout(coordination_feature_dir))
+
+    with pytest.raises(StatusContractError, match="coordination_worktree"):
+        read_event_log(EventLogReadContract.coordination_worktree(primary_feature_dir))
+
+
 def test_append_preserving_coordination_merge_keeps_existing_history() -> None:
     coord = b'{"event_id":"existing"}\n'
     incoming = b'{"event_id":"existing"}\n{"event_id":"new"}\n'

--- a/tests/specify_cli/coordination/test_status_transition.py
+++ b/tests/specify_cli/coordination/test_status_transition.py
@@ -13,8 +13,16 @@ from specify_cli.coordination.status_transition import (
     emit_status_transition_transactional,
     read_events_transactional,
 )
+from specify_cli.coordination.status_service import (
+    EventLogReadContract,
+    EventLogWriteContract,
+    StatusContractError,
+    append_event_log,
+    merge_append_preserving_coordination_event_log_bytes,
+    read_event_log,
+)
 from specify_cli.coordination.transaction import BookkeepingCommitFailed, BookkeepingWorktreeMissing
-from specify_cli.status.models import TransitionRequest
+from specify_cli.status.models import Lane, StatusEvent, TransitionRequest
 
 pytest_plugins = ("tests.conftest_saas_sink",)
 
@@ -76,6 +84,21 @@ def _request(repo: Path) -> TransitionRequest:
     )
 
 
+def _status_event(event_id: str, *, to_lane: str = "claimed") -> StatusEvent:
+    return StatusEvent(
+        event_id=event_id,
+        mission_slug=MISSION_SLUG,
+        mission_id=MISSION_ID,
+        wp_id="WP01",
+        from_lane=Lane.PLANNED,
+        to_lane=Lane(to_lane),
+        at="2026-06-01T00:00:00+00:00",
+        actor="contract-test",
+        force=False,
+        execution_mode="worktree",
+    )
+
+
 def test_transactional_emit_fans_out_only_after_commit(
     repo: Path,
     mock_saas_sink: Any,
@@ -100,6 +123,66 @@ def test_transactional_read_targets_coordination_branch(repo: Path) -> None:
 
     assert [e.event_id for e in events] == [event.event_id]
     assert not (repo / "kitty-specs" / MISSION_DIRNAME / "status.events.jsonl").exists()
+
+
+def test_primary_checkout_event_log_read_remains_explicit(repo: Path) -> None:
+    feature_dir = repo / "kitty-specs" / MISSION_DIRNAME
+    event = _status_event("01PRIMARY00000000000000000")
+
+    append_event_log(EventLogWriteContract.primary_checkout_append(feature_dir), event)
+    events = read_event_log(EventLogReadContract.primary_checkout(feature_dir))
+
+    assert [e.event_id for e in events] == [event.event_id]
+    assert (feature_dir / "status.events.jsonl").exists()
+
+
+def test_coordination_branch_ref_read_ignores_stale_primary_checkout(repo: Path) -> None:
+    feature_dir = repo / "kitty-specs" / MISSION_DIRNAME
+    primary_event = _status_event("01PRIMARYSTALE00000000000", to_lane="planned")
+    coord_event = _status_event("01COORDCURRENT00000000000", to_lane="claimed")
+    append_event_log(EventLogWriteContract.primary_checkout_append(feature_dir), primary_event)
+
+    worktree = repo / ".worktrees" / "seed-coord"
+    _git(repo, "worktree", "add", "-q", str(worktree), COORD_BRANCH)
+    coord_feature_dir = worktree / "kitty-specs" / MISSION_DIRNAME
+    append_event_log(
+        EventLogWriteContract.coordination_transaction_append(coord_feature_dir),
+        coord_event,
+    )
+    _git(worktree, "add", "kitty-specs")
+    _git(worktree, "commit", "-q", "-m", "seed coord event")
+    _git(repo, "worktree", "remove", "-f", str(worktree))
+
+    events = read_event_log(
+        EventLogReadContract.coordination_branch_ref(
+            repo_root=repo,
+            destination_ref=COORD_BRANCH,
+            feature_dir=coord_feature_dir,
+            parser_feature_dir=feature_dir,
+        )
+    )
+
+    assert [e.event_id for e in events] == [coord_event.event_id]
+    assert read_event_log(EventLogReadContract.primary_checkout(feature_dir))[0].event_id == primary_event.event_id
+
+
+def test_read_contract_cannot_be_used_as_write_contract(repo: Path) -> None:
+    event = _status_event("01CONTRACTFAIL000000000000")
+
+    with pytest.raises(StatusContractError):
+        append_event_log(  # type: ignore[arg-type]
+            EventLogReadContract.primary_checkout(repo / "kitty-specs" / MISSION_DIRNAME),
+            event,
+        )
+
+
+def test_append_preserving_coordination_merge_keeps_existing_history() -> None:
+    coord = b'{"event_id":"existing"}\n'
+    incoming = b'{"event_id":"existing"}\n{"event_id":"new"}\n'
+
+    merged = merge_append_preserving_coordination_event_log_bytes(coord, incoming)
+
+    assert merged == b'{"event_id":"existing"}\n{"event_id":"new"}\n'
 
 
 def test_transactional_read_does_not_create_coordination_worktree(repo: Path) -> None:


### PR DESCRIPTION
## Summary
- add explicit status/coordination read and write contracts for primary checkout, coordination worktree, and coordination branch-ref event-log access
- route transactional status reads and coordination transaction appends through the contract layer
- keep primary-checkout emits explicit via primary-checkout store helpers
- move append-preserving coordination event-log merge behind a named helper

## Issues
Closes #1612
Closes #1613

## Adversarial review
Verdict: SAFE. No merge blockers found in local hostile review. Residual risk: broader direct `read_events()` call sites outside the rc34 coordination/status surfaces remain intentionally untouched.

## Verification
- `.venv/bin/ruff check src/specify_cli/coordination/status_service.py src/specify_cli/coordination/status_transition.py src/specify_cli/coordination/transaction.py src/specify_cli/status/emit.py src/specify_cli/status/store.py src/specify_cli/status/__init__.py tests/specify_cli/coordination/test_status_transition.py src/specify_cli/cli/commands/agent/workflow.py`
- `.venv/bin/pytest tests/specify_cli/coordination tests/specify_cli/cli/commands/agent/test_workflow_event_log_merge.py tests/specify_cli/cli/commands/agent/test_workflow_safe_commit_recovery.py tests/specify_cli/cli/commands/test_implement.py tests/specify_cli/cli/commands/agent/test_tasks.py tests/specify_cli/cli/commands/agent/test_tasks_canonical_cleanup.py tests/specify_cli/cli/commands/agent/test_tasks_planning_artifact_lifecycle.py -q`
