### PR TITLE
feat: add agent upgrade prompts

### DIFF
--- a/src/specify_cli/agent_upgrade_prompt.py
+++ b/src/specify_cli/agent_upgrade_prompt.py
@@ -1,0 +1,49 @@
+"""Agent-facing Spec Kitty upgrade prompt instructions."""
+
+from __future__ import annotations
+
+
+AGENT_UPGRADE_CHECK_BLOCK = """## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+"""
+
+
+def prepend_agent_upgrade_check(body: str) -> str:
+    """Prepend the agent upgrade-check block unless already present."""
+    if "spec-kitty upgrade --agent-check --json" in body:
+        return body
+    if not body:
+        return AGENT_UPGRADE_CHECK_BLOCK
+    separator = "\n\n" if not body.startswith("\n") else "\n"
+    return f"{AGENT_UPGRADE_CHECK_BLOCK}{separator}{body}"
+
+
+__all__ = ["AGENT_UPGRADE_CHECK_BLOCK", "prepend_agent_upgrade_check"]

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -39,9 +39,10 @@ See also: docs/how-to/install-and-upgrade.md
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
@@ -277,6 +278,180 @@ def _run_cli_mode(
 
 
 # ---------------------------------------------------------------------------
+# Agent-host upgrade prompt helpers
+# ---------------------------------------------------------------------------
+
+
+def _version_is_newer(latest: str | None, installed: str) -> bool:
+    if latest is None:
+        return False
+    try:
+        from packaging.version import Version
+
+        return Version(latest) > Version(installed)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _is_truthy(raw: str | None) -> bool:
+    if not raw:
+        return False
+    return raw.strip().casefold() in {"1", "true", "yes", "on"}
+
+
+def _agent_check_payload() -> dict[str, object]:
+    """Return machine-readable upgrade readiness for agent prompt preambles."""
+    from specify_cli.compat import (
+        Invocation,
+        NagCache,
+        UpgradeConfig,
+        build_upgrade_hint,
+        detect_install_method,
+        is_ci_env,
+        plan as compat_plan,
+    )
+    from specify_cli.compat._detect.install_method import is_safe_for_auto_upgrade
+    from specify_cli.readiness.upgrade_ux import (
+        ENV_UPGRADE_DISABLED,
+        is_currently_snoozed,
+        needs_reset,
+        resolve_effective_preference,
+    )
+
+    now = datetime.now(UTC)
+    invocation = Invocation(
+        command_path=("upgrade",),
+        raw_args=("--agent-check", "--json"),
+        is_help=False,
+        is_version=False,
+        flag_no_nag=False,
+        env_ci=is_ci_env(),
+        stdout_is_tty=True,
+    )
+    result = compat_plan(invocation, now=now)
+    cli_status = result.cli_status
+    install_method = detect_install_method()
+    hint = build_upgrade_hint(install_method)
+
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "action": "none",
+        "installed_version": cli_status.installed_version,
+        "latest_version": cli_status.latest_version,
+        "latest_source": cli_status.latest_source,
+        "install_method": str(install_method),
+        "upgrade_command": hint.command,
+        "upgrade_note": hint.note,
+        "reason": "up_to_date",
+    }
+
+    config = UpgradeConfig.load()
+    if not config.nag_enabled:
+        payload["reason"] = "nag_disabled"
+        return payload
+
+    latest_version = cli_status.latest_version
+    if not _version_is_newer(latest_version, cli_status.installed_version):
+        return payload
+
+    if _is_truthy(os.environ.get(ENV_UPGRADE_DISABLED)):
+        payload["reason"] = "upgrade_disabled"
+        return payload
+
+    cache = NagCache.default()
+    existing = cache.read()
+    remote_version_seen = existing.remote_version_seen if existing is not None else None
+    reset_anchor = needs_reset(record_remote_version=remote_version_seen, current_latest=latest_version)
+    snoozed_until = None if reset_anchor or existing is None else existing.snoozed_until
+    persisted_never_ask = False if reset_anchor or existing is None else existing.never_ask
+    persisted_always_upgrade = False if existing is None else existing.always_upgrade
+
+    pref = resolve_effective_preference(
+        persisted_never_ask=persisted_never_ask,
+        persisted_always_upgrade=persisted_always_upgrade,
+    )
+    if pref.disabled:
+        payload["reason"] = "upgrade_disabled"
+        return payload
+    if pref.never_ask:
+        payload["reason"] = "never_ask"
+        return payload
+    if is_currently_snoozed(snoozed_until=snoozed_until, now=now):
+        payload["reason"] = "snoozed"
+        return payload
+
+    safe = is_safe_for_auto_upgrade(install_method)
+    if pref.always_upgrade:
+        payload["action"] = "auto_upgrade" if safe and hint.command is not None else "guidance"
+        payload["reason"] = "always_upgrade"
+        return payload
+
+    payload["action"] = "prompt"
+    payload["reason"] = "upgrade_available"
+    return payload
+
+
+def _run_agent_check(*, json_output: bool) -> None:
+    payload = _agent_check_payload()
+    if json_output:
+        print(json.dumps(payload, indent=2))
+    elif payload.get("action") != "none":
+        latest = payload.get("latest_version") or "unknown"
+        installed = payload.get("installed_version") or "unknown"
+        print(f"Spec Kitty upgrade available: {installed} -> {latest}")
+    raise typer.Exit(0)
+
+
+def _record_agent_choice(
+    *,
+    choice_raw: str,
+    latest_version: str | None,
+    json_output: bool,
+) -> None:
+    from specify_cli import __version__
+    from specify_cli.compat import NagCache, NagCacheRecord
+    from specify_cli.readiness.upgrade_ux import UpgradeChoice, apply_choice, needs_reset
+
+    try:
+        choice = UpgradeChoice(choice_raw)
+    except ValueError:
+        payload = {"status": "error", "error": "invalid_agent_choice", "choice": choice_raw}
+        print(json.dumps(payload) if json_output else "Error: invalid agent choice")
+        raise typer.Exit(2) from None
+
+    if not latest_version:
+        payload = {"status": "error", "error": "missing_agent_latest"}
+        print(json.dumps(payload) if json_output else "Error: --agent-latest is required")
+        raise typer.Exit(2)
+
+    now = datetime.now(UTC)
+    cache = NagCache.default()
+    existing = cache.read()
+    reset_anchor = existing is not None and needs_reset(
+        record_remote_version=existing.remote_version_seen,
+        current_latest=latest_version,
+    )
+    record_kwargs: dict[str, object] = {
+        "cli_version_key": __version__,
+        "latest_version": latest_version,
+        "latest_source": "pypi",
+        "fetched_at": now,
+        "last_shown_at": now,
+        "remote_version_seen": None if reset_anchor or existing is None else existing.remote_version_seen,
+        "snooze_step": None if reset_anchor or existing is None else existing.snooze_step,
+        "snoozed_until": None if reset_anchor or existing is None else existing.snoozed_until,
+        "always_upgrade": False if existing is None else existing.always_upgrade,
+        "never_ask": False if reset_anchor or existing is None else existing.never_ask,
+    }
+    updated = apply_choice(record_kwargs, choice=choice, current_latest=latest_version, now=now)
+    cache.write(NagCacheRecord(**updated))
+
+    payload = {"status": "recorded", "choice": choice.value, "latest_version": latest_version}
+    print(json.dumps(payload, indent=2) if json_output else f"Recorded {choice.value}")
+    raise typer.Exit(0)
+
+
+# ---------------------------------------------------------------------------
 # T036 — helpers for project mode (skip CLI nag in output)
 # ---------------------------------------------------------------------------
 
@@ -367,6 +542,9 @@ def upgrade(  # noqa: C901
     project: bool = typer.Option(False, "--project", help="Restrict to current-project compat + migrations (FR-015)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Non-interactive confirmation; alias for --force (FR-017)"),
     no_nag: bool = typer.Option(False, "--no-nag", help="Suppress upgrade-nag output explicitly"),
+    agent_check: bool = typer.Option(False, "--agent-check", help="Emit agent-host upgrade prompt JSON", hidden=True),
+    agent_choice: str | None = typer.Option(None, "--agent-choice", help="Record an agent-host upgrade choice", hidden=True),
+    agent_latest: str | None = typer.Option(None, "--agent-latest", help="Latest version for --agent-choice", hidden=True),
 ) -> None:
     """Upgrade a Spec Kitty project to the current version.
 
@@ -403,6 +581,20 @@ def upgrade(  # noqa: C901
         spec-kitty upgrade --yes        # Non-interactive (same as --force)
         spec-kitty upgrade --dry-run --json  # Machine-readable plan
     """
+    if agent_check and agent_choice is not None:
+        console.print("[red]Error:[/red] --agent-check and --agent-choice are mutually exclusive.")
+        raise typer.Exit(2)
+    if agent_check:
+        _run_agent_check(json_output=json_output)
+        return
+    if agent_choice is not None:
+        _record_agent_choice(
+            choice_raw=agent_choice,
+            latest_version=agent_latest,
+            json_output=json_output,
+        )
+        return
+
     # T034 — mutual exclusion check
     if cli and project:
         console.print("[red]Error:[/red] --cli and --project are mutually exclusive.")

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -386,6 +386,11 @@ def _agent_check_payload() -> dict[str, object]:
         payload["reason"] = "always_upgrade"
         return payload
 
+    if hint.command is None:
+        payload["action"] = "guidance"
+        payload["reason"] = "manual_upgrade_required"
+        return payload
+
     payload["action"] = "prompt"
     payload["reason"] = "upgrade_available"
     return payload

--- a/src/specify_cli/shims/generator.py
+++ b/src/specify_cli/shims/generator.py
@@ -24,6 +24,7 @@ from specify_cli.agent_utils.directories import (
     AGENT_DIR_TO_KEY,
     get_agent_dirs_for_project,
 )
+from specify_cli.agent_upgrade_prompt import prepend_agent_upgrade_check
 from specify_cli.shims.registry import CLI_DRIVEN_COMMANDS
 
 # Human-readable one-line descriptions shown by agent slash-command pickers
@@ -119,16 +120,19 @@ def generate_shim_content(command: str, agent_name: str, arg_placeholder: str) -
     version = _get_cli_version()
     cli_call = _canonical_command(command, agent_name, arg_placeholder)
     description = SHIM_DESCRIPTIONS.get(command, f"spec-kitty {command}")
-    return (
-        "---\n"
-        f"description: {description}\n"
-        "---\n"
-        f"<!-- spec-kitty-command-version: {version} -->\n"
+    body = prepend_agent_upgrade_check(
         "Run this exact command and treat its output as authoritative.\n"
         "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
         "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"
         "\n"
         f"`{cli_call}`\n"
+    )
+    return (
+        "---\n"
+        f"description: {description}\n"
+        "---\n"
+        f"<!-- spec-kitty-command-version: {version} -->\n"
+        f"{body}"
     )
 
 
@@ -151,8 +155,7 @@ def generate_shim_content_toml(
     version = _get_cli_version()
     cli_call = _canonical_command(command, agent_name, arg_placeholder)
     description = SHIM_DESCRIPTIONS.get(command, f"spec-kitty {command}")
-    body = (
-        f"<!-- spec-kitty-command-version: {version} -->\n"
+    body = f"<!-- spec-kitty-command-version: {version} -->\n" + prepend_agent_upgrade_check(
         "Run this exact command and treat its output as authoritative.\n"
         "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
         "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"

--- a/src/specify_cli/shims/generator.py
+++ b/src/specify_cli/shims/generator.py
@@ -24,7 +24,6 @@ from specify_cli.agent_utils.directories import (
     AGENT_DIR_TO_KEY,
     get_agent_dirs_for_project,
 )
-from specify_cli.agent_upgrade_prompt import prepend_agent_upgrade_check
 from specify_cli.shims.registry import CLI_DRIVEN_COMMANDS
 
 # Human-readable one-line descriptions shown by agent slash-command pickers
@@ -120,7 +119,7 @@ def generate_shim_content(command: str, agent_name: str, arg_placeholder: str) -
     version = _get_cli_version()
     cli_call = _canonical_command(command, agent_name, arg_placeholder)
     description = SHIM_DESCRIPTIONS.get(command, f"spec-kitty {command}")
-    body = prepend_agent_upgrade_check(
+    body = (
         "Run this exact command and treat its output as authoritative.\n"
         "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
         "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"
@@ -155,7 +154,8 @@ def generate_shim_content_toml(
     version = _get_cli_version()
     cli_call = _canonical_command(command, agent_name, arg_placeholder)
     description = SHIM_DESCRIPTIONS.get(command, f"spec-kitty {command}")
-    body = f"<!-- spec-kitty-command-version: {version} -->\n" + prepend_agent_upgrade_check(
+    body = (
+        f"<!-- spec-kitty-command-version: {version} -->\n"
         "Run this exact command and treat its output as authoritative.\n"
         "Do not rediscover context from branches, files, prompt contents, or separate charter loads.\n"
         "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug).\n"

--- a/src/specify_cli/skills/command_renderer.py
+++ b/src/specify_cli/skills/command_renderer.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from specify_cli.skills._user_input_block import rewrite as _rewrite_user_input
+from specify_cli.agent_upgrade_prompt import prepend_agent_upgrade_check
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -488,7 +489,7 @@ def render(
     return RenderedSkill(
         name=name,
         frontmatter=frontmatter,
-        body=body,
+        body=prepend_agent_upgrade_check(body),
         source_template=template_path.resolve(),
         source_hash=source_hash,
         agent_key=agent_key,  # type: ignore[arg-type]

--- a/src/specify_cli/template/asset_generator.py
+++ b/src/specify_cli/template/asset_generator.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 import yaml
 
 from specify_cli.core.config import AGENT_COMMAND_CONFIG
+from specify_cli.agent_upgrade_prompt import prepend_agent_upgrade_check
 from specify_cli.template.renderer import parse_frontmatter, render_template_text, rewrite_paths
 
 
@@ -166,6 +167,9 @@ def render_command_template(
         frontmatter_clean = rewrite_paths(frontmatter_clean)
 
     version_marker = f"<!-- spec-kitty-command-version: {_get_cli_version()} -->\n"
+
+    if agent_key in AGENT_COMMAND_CONFIG:
+        rendered_body = prepend_agent_upgrade_check(rendered_body)
 
     if extension == "toml":
         # Convert Markdown variable syntax to TOML/Gemini variable syntax

--- a/tests/specify_cli/cli/commands/test_upgrade_command.py
+++ b/tests/specify_cli/cli/commands/test_upgrade_command.py
@@ -193,6 +193,7 @@ def test_cli_and_project_mutex_error_message(tmp_path: Path) -> None:
 
 
 def test_agent_check_json_prompts_when_update_available(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from specify_cli.compat._detect.install_method import InstallMethod
     from specify_cli.compat.cache import NagCache
     from specify_cli.compat.provider import PyPIProvider
 
@@ -202,6 +203,7 @@ def test_agent_check_json_prompts_when_update_available(tmp_path: Path, monkeypa
         "get_latest",
         lambda self, package: LatestVersionResult("999.0.0", "pypi", None),
     )
+    monkeypatch.setattr("specify_cli.compat.detect_install_method", lambda: InstallMethod.PIPX)
 
     result = _invoke_upgrade(["--agent-check", "--json"], cwd=tmp_path)
 
@@ -211,6 +213,31 @@ def test_agent_check_json_prompts_when_update_available(tmp_path: Path, monkeypa
     assert payload["action"] == "prompt"
     assert payload["latest_version"] == "999.0.0"
     assert "upgrade_command" in payload
+
+
+def test_agent_check_guidance_when_upgrade_command_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from specify_cli.compat._detect.install_method import InstallMethod
+    from specify_cli.compat.cache import NagCache
+    from specify_cli.compat.provider import PyPIProvider
+
+    monkeypatch.setattr("specify_cli.compat.cache.NagCache.default", lambda: NagCache(tmp_path / "agent-cache.json"))
+    monkeypatch.setattr(
+        PyPIProvider,
+        "get_latest",
+        lambda self, package: LatestVersionResult("999.0.0", "pypi", None),
+    )
+    monkeypatch.setattr("specify_cli.compat.detect_install_method", lambda: InstallMethod.UNKNOWN)
+
+    result = _invoke_upgrade(["--agent-check", "--json"], cwd=tmp_path)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["action"] == "guidance"
+    assert payload["reason"] == "manual_upgrade_required"
+    assert payload["upgrade_command"] is None
+    assert payload["upgrade_note"]
 
 
 def test_agent_choice_not_now_records_snooze(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/specify_cli/cli/commands/test_upgrade_command.py
+++ b/tests/specify_cli/cli/commands/test_upgrade_command.py
@@ -35,7 +35,7 @@ from typer.testing import CliRunner
 from specify_cli.cli.commands.upgrade import upgrade
 from specify_cli.compat.planner import Invocation as _Invocation
 from specify_cli.compat.planner import ProjectState
-from specify_cli.compat.provider import FakeLatestVersionProvider
+from specify_cli.compat.provider import FakeLatestVersionProvider, LatestVersionResult
 
 # ---------------------------------------------------------------------------
 # Contract path (relative to repo root)
@@ -190,6 +190,48 @@ def test_cli_and_project_mutex_error_message(tmp_path: Path) -> None:
     result = _invoke_upgrade(["--cli", "--project"], cwd=tmp_path)
     assert "--cli" in result.output or "cli" in result.output.lower()
     assert "--project" in result.output or "project" in result.output.lower()
+
+
+def test_agent_check_json_prompts_when_update_available(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from specify_cli.compat.cache import NagCache
+    from specify_cli.compat.provider import PyPIProvider
+
+    monkeypatch.setattr("specify_cli.compat.cache.NagCache.default", lambda: NagCache(tmp_path / "agent-cache.json"))
+    monkeypatch.setattr(
+        PyPIProvider,
+        "get_latest",
+        lambda self, package: LatestVersionResult("999.0.0", "pypi", None),
+    )
+
+    result = _invoke_upgrade(["--agent-check", "--json"], cwd=tmp_path)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["action"] == "prompt"
+    assert payload["latest_version"] == "999.0.0"
+    assert "upgrade_command" in payload
+
+
+def test_agent_choice_not_now_records_snooze(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from specify_cli.compat.cache import NagCache
+
+    cache = NagCache(tmp_path / "agent-cache.json")
+    monkeypatch.setattr("specify_cli.compat.cache.NagCache.default", lambda: cache)
+
+    result = _invoke_upgrade(
+        ["--agent-choice", "not_now", "--agent-latest", "999.0.0", "--json"],
+        cwd=tmp_path,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "recorded"
+    record = cache.read()
+    assert record is not None
+    assert record.remote_version_seen == "999.0.0"
+    assert record.snooze_step == "24h"
+    assert record.snoozed_until is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/shims/test_direct_commands.py
+++ b/tests/specify_cli/shims/test_direct_commands.py
@@ -81,7 +81,8 @@ class TestDirectAcceptCommand:
     def test_accept_no_agent_flag(self) -> None:
         """Accept is feature-level -- no --agent flag in the canonical command."""
         content = generate_shim_content("accept", "claude", "$ARGUMENTS")
-        assert "--agent" not in content
+        assert "`spec-kitty agent mission accept $ARGUMENTS`" in content
+        assert "spec-kitty agent mission accept $ARGUMENTS --agent" not in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/shims/test_generator.py
+++ b/tests/specify_cli/shims/test_generator.py
@@ -73,8 +73,8 @@ class TestGenerateShimContent:
     def test_total_line_count(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.rstrip("\n").splitlines()
-        assert len(lines) > 9
-        assert "## Startup Upgrade Check" in lines
+        assert len(lines) <= 10
+        assert "## Startup Upgrade Check" not in lines
 
     def test_starts_with_yaml_frontmatter(self) -> None:
         """Line 1 must be ``---`` so Claude Code parses the description."""
@@ -110,19 +110,17 @@ class TestGenerateShimContent:
         lines = content.splitlines()
         assert lines[3].startswith("<!-- spec-kitty-command-version:")
 
-    def test_upgrade_check_after_version_marker(self) -> None:
+    def test_command_instruction_after_version_marker(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.splitlines()
         assert lines[3].startswith("<!-- spec-kitty-command-version:")
-        assert lines[4] == "## Startup Upgrade Check"
-        assert "spec-kitty upgrade --agent-check --json" in content
+        assert lines[4] == "Run this exact command and treat its output as authoritative."
+        assert "spec-kitty upgrade --agent-check --json" not in content
 
     def test_invariant_line_position(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.splitlines()
-        assert lines.index("Run this exact command and treat its output as authoritative.") > lines.index(
-            "## Startup Upgrade Check"
-        )
+        assert lines.index("Run this exact command and treat its output as authoritative.") == 4
 
     def test_prohibition_line_position(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
@@ -417,7 +415,7 @@ class TestGenerateShimContentToml:
         parsed = tomllib.loads(content)
         assert "Run this exact command and treat its output as authoritative." in parsed["prompt"]
         assert "Do not rediscover context" in parsed["prompt"]
-        assert "spec-kitty upgrade --agent-check --json" in parsed["prompt"]
+        assert "spec-kitty upgrade --agent-check --json" not in parsed["prompt"]
 
     def test_canonical_cli_call_in_prompt(self) -> None:
         import tomllib
@@ -434,13 +432,13 @@ class TestGenerateShimContentToml:
 
 class TestGenerateShimContentForAgent:
     @pytest.mark.parametrize("agent_key", sorted(AGENT_COMMAND_CONFIG))
-    def test_all_command_agents_include_upgrade_check(self, agent_key: str) -> None:
+    def test_command_shims_do_not_embed_upgrade_check(self, agent_key: str) -> None:
         import tomllib
 
         content = generate_shim_content_for_agent("implement", agent_key)
         searchable = tomllib.loads(content)["prompt"] if AGENT_COMMAND_CONFIG[agent_key]["ext"] == "toml" else content
-        assert "## Startup Upgrade Check" in searchable
-        assert "spec-kitty upgrade --agent-check --json" in searchable
+        assert "## Startup Upgrade Check" not in searchable
+        assert "spec-kitty upgrade --agent-check --json" not in searchable
 
     def test_gemini_returns_toml(self) -> None:
         import tomllib

--- a/tests/specify_cli/shims/test_generator.py
+++ b/tests/specify_cli/shims/test_generator.py
@@ -15,6 +15,7 @@ from specify_cli.shims.generator import (
     generate_shim_content_for_agent,
     generate_all_shims,
 )
+from specify_cli.core.config import AGENT_COMMAND_CONFIG
 from specify_cli.shims.registry import CLI_DRIVEN_COMMANDS, CONSUMER_SKILLS, PROMPT_DRIVEN_COMMANDS
 
 
@@ -72,9 +73,8 @@ class TestGenerateShimContent:
     def test_total_line_count(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.rstrip("\n").splitlines()
-        # ---, description, ---, version marker, invariant, prohibition,
-        # mission hint, blank, CLI call
-        assert len(lines) == 9
+        assert len(lines) > 9
+        assert "## Startup Upgrade Check" in lines
 
     def test_starts_with_yaml_frontmatter(self) -> None:
         """Line 1 must be ``---`` so Claude Code parses the description."""
@@ -110,18 +110,26 @@ class TestGenerateShimContent:
         lines = content.splitlines()
         assert lines[3].startswith("<!-- spec-kitty-command-version:")
 
+    def test_upgrade_check_after_version_marker(self) -> None:
+        content = generate_shim_content("implement", "claude", "$ARGUMENTS")
+        lines = content.splitlines()
+        assert lines[3].startswith("<!-- spec-kitty-command-version:")
+        assert lines[4] == "## Startup Upgrade Check"
+        assert "spec-kitty upgrade --agent-check --json" in content
+
     def test_invariant_line_position(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.splitlines()
-        # Line 0..2 frontmatter, line 3 marker, line 4 invariant
-        assert lines[4] == "Run this exact command and treat its output as authoritative."
+        assert lines.index("Run this exact command and treat its output as authoritative.") > lines.index(
+            "## Startup Upgrade Check"
+        )
 
     def test_prohibition_line_position(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.splitlines()
-        assert lines[5] == (
+        assert (
             "Do not rediscover context from branches, files, prompt contents, or separate charter loads."
-        )
+        ) in lines
 
     def test_direct_implement_command(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
@@ -165,11 +173,9 @@ class TestGenerateShimContent:
     def test_shim_content_mission_hint_line(self) -> None:
         content = generate_shim_content("implement", "claude", "$ARGUMENTS")
         lines = content.splitlines()
-        # Frontmatter occupies lines 0..2, version marker line 3, invariant
-        # line 4, prohibition line 5, mission hint line 6.
-        assert lines[6] == (
+        assert (
             "When mission selection is required, pass --mission <handle> (mission_id, mid8, or mission_slug)."
-        )
+        ) in lines
 
     def test_shim_content_version_marker_present_in_head(self) -> None:
         """Marker must appear in the file head (no longer line 0 — line 3)."""
@@ -411,6 +417,7 @@ class TestGenerateShimContentToml:
         parsed = tomllib.loads(content)
         assert "Run this exact command and treat its output as authoritative." in parsed["prompt"]
         assert "Do not rediscover context" in parsed["prompt"]
+        assert "spec-kitty upgrade --agent-check --json" in parsed["prompt"]
 
     def test_canonical_cli_call_in_prompt(self) -> None:
         import tomllib
@@ -426,6 +433,15 @@ class TestGenerateShimContentToml:
 
 
 class TestGenerateShimContentForAgent:
+    @pytest.mark.parametrize("agent_key", sorted(AGENT_COMMAND_CONFIG))
+    def test_all_command_agents_include_upgrade_check(self, agent_key: str) -> None:
+        import tomllib
+
+        content = generate_shim_content_for_agent("implement", agent_key)
+        searchable = tomllib.loads(content)["prompt"] if AGENT_COMMAND_CONFIG[agent_key]["ext"] == "toml" else content
+        assert "## Startup Upgrade Check" in searchable
+        assert "spec-kitty upgrade --agent-check --json" in searchable
+
     def test_gemini_returns_toml(self) -> None:
         import tomllib
 

--- a/tests/specify_cli/skills/__snapshots__/codex/accept.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/accept.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.accept
 description: Validate an approved mission before merge
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.accept - Validate Mission Readiness
 
 **Version**: 0.12.0+

--- a/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.analyze
 description: Cross-artifact consistency and quality analysis
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 ## User Input
 
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.

--- a/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.charter
 description: Interview and compile a project charter
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.charter - Interview + Compile Charter
 
 ## User Input

--- a/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.implement
 description: Execute a work package implementation
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.implement - Execute Work Package Implementation
 
 **Version**: 0.12.0+

--- a/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.plan
 description: Create an implementation plan
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.plan - Create Implementation Plan
 
 **Version**: 0.11.0+

--- a/tests/specify_cli/skills/__snapshots__/codex/research.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/research.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.research
 description: Generate research documents for the current mission
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<feature>/tasks/`). Never refer to a folder by name alone.
 
 **In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.

--- a/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.review
 description: Review a work package implementation
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.review - Review Work Package Implementation
 
 **Version**: 0.12.0+

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.specify
 description: Create a mission specification
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.specify - Create Mission Specification
 
 **Version**: 0.11.0+

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks-finalize
 description: "Validate dependencies, finalize WP metadata, and commit all task artifacts."
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks-finalize - Finalize Tasks
 
 **Version**: 3.2.0

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-outline.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-outline.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks-outline
 description: Create a work package manifest
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks-outline - Create Work Package Manifest
 
 **Version**: 3.2.0

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks-packages
 description: Materialize work package files
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks-packages - Generate Work Package Files
 
 **Version**: 3.2.0

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks
 description: Break a plan into work packages
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks - Generate Work Packages
 
 **Version**: 0.11.0+

--- a/tests/specify_cli/skills/__snapshots__/vibe/accept.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/accept.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.accept
 description: Validate an approved mission before merge
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.accept - Validate Mission Readiness
 
 **Version**: 0.12.0+

--- a/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.analyze
 description: Cross-artifact consistency and quality analysis
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 ## User Input
 
 The content of the user's message that invoked this skill (everything after the skill invocation token, e.g. after `/spec-kitty.<command>` or `$spec-kitty.<command>`) is the User Input referenced elsewhere in these instructions.

--- a/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.charter
 description: Interview and compile a project charter
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.charter - Interview + Compile Charter
 
 ## User Input

--- a/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.implement
 description: Execute a work package implementation
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.implement - Execute Work Package Implementation
 
 **Version**: 0.12.0+

--- a/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.plan
 description: Create an implementation plan
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.plan - Create Implementation Plan
 
 **Version**: 0.11.0+

--- a/tests/specify_cli/skills/__snapshots__/vibe/research.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/research.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.research
 description: Generate research documents for the current mission
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 **Path reference rule:** When you mention directories or files, provide either the absolute path or a path relative to the project root (for example, `kitty-specs/<feature>/tasks/`). Never refer to a folder by name alone.
 
 **In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id` (ULID), `mid8` (first 8 chars of the ULID), or `mission_slug`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.

--- a/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.review
 description: Review a work package implementation
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.review - Review Work Package Implementation
 
 **Version**: 0.12.0+

--- a/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.specify
 description: Create a mission specification
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.specify - Create Mission Specification
 
 **Version**: 0.11.0+

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks-finalize
 description: "Validate dependencies, finalize WP metadata, and commit all task artifacts."
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks-finalize - Finalize Tasks
 
 **Version**: 3.2.0

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-outline.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-outline.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks-outline
 description: Create a work package manifest
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks-outline - Create Work Package Manifest
 
 **Version**: 3.2.0

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks-packages
 description: Materialize work package files
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks-packages - Generate Work Package Files
 
 **Version**: 3.2.0

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
@@ -3,6 +3,38 @@ name: spec-kitty.tasks
 description: Break a plan into work packages
 user-invocable: true
 ---
+## Startup Upgrade Check
+
+Before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
 # /spec-kitty.tasks - Generate Work Packages
 
 **Version**: 0.11.0+

--- a/tests/specify_cli/skills/test_command_renderer.py
+++ b/tests/specify_cli/skills/test_command_renderer.py
@@ -169,6 +169,14 @@ def test_unsupported_agent(tmp_path: Path) -> None:
     assert exc_info.value.context["agent_key"] == "claude"
 
 
+def test_render_includes_agent_upgrade_check() -> None:
+    skill = render(_all_templates()[0], "codex", _TEST_VERSION)
+
+    assert skill.body.startswith("## Startup Upgrade Check")
+    assert "spec-kitty upgrade --agent-check --json" in skill.body
+    assert "spec-kitty upgrade --agent-choice" in skill.body
+
+
 def test_template_not_found(tmp_path: Path) -> None:
     """Pointing to a non-existent template raises SkillRenderError(template_not_found)."""
     missing = tmp_path / "nonexistent.md"

--- a/tests/test_template/test_asset_generator.py
+++ b/tests/test_template/test_asset_generator.py
@@ -12,6 +12,8 @@ from specify_cli.template.asset_generator import (
 
 import pytest
 
+from specify_cli.core.config import AGENT_COMMAND_CONFIG
+
 pytestmark = [pytest.mark.unit]
 
 def _write_template(path: Path, with_agent_script: bool = True) -> None:
@@ -55,6 +57,49 @@ def test_render_command_template_generates_markdown(tmp_path: Path) -> None:
 
     assert "scripts:" not in output
     assert "Run echo hi $ARGUMENTS source env for codex." in output
+    assert "spec-kitty upgrade --agent-check --json" not in output
+
+
+def test_render_command_template_injects_claude_upgrade_check(tmp_path: Path) -> None:
+    template_path = tmp_path / "demo.md"
+    _write_template(template_path)
+
+    output = render_command_template(
+        template_path,
+        script_type="sh",
+        agent_key="claude",
+        arg_format="$ARGUMENTS",
+        extension="md",
+    )
+
+    assert "<!-- spec-kitty-command-version:" in output
+    assert "## Startup Upgrade Check" in output
+    assert "spec-kitty upgrade --agent-check --json" in output
+    assert output.index("<!-- spec-kitty-command-version:") < output.index("## Startup Upgrade Check")
+    assert output.index("## Startup Upgrade Check") < output.index("Run echo hi")
+
+
+@pytest.mark.parametrize("agent_key", sorted(AGENT_COMMAND_CONFIG))
+def test_render_command_template_injects_upgrade_check_for_all_command_agents(
+    tmp_path: Path,
+    agent_key: str,
+) -> None:
+    template_path = tmp_path / "demo.md"
+    _write_template(template_path)
+    config = AGENT_COMMAND_CONFIG[agent_key]
+
+    output = render_command_template(
+        template_path,
+        script_type="sh",
+        agent_key=agent_key,
+        arg_format=config["arg_format"],
+        extension=config["ext"],
+    )
+
+    searchable = tomllib.loads(output)["prompt"] if config["ext"] == "toml" else output
+    assert "## Startup Upgrade Check" in searchable
+    assert "spec-kitty upgrade --agent-check --json" in searchable
+    assert "Run echo hi" in searchable
 
 
 def test_render_command_template_handles_toml_extension(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add hidden `spec-kitty upgrade --agent-check --json` and `--agent-choice ...` hooks for agent-host upgrade prompts
- inject the startup upgrade check into generated command files, CLI-driven shims, and command-skill `SKILL.md` outputs
- update coverage for all command-file agents, TOML agents, command-skill snapshots, and upgrade choice persistence

## Verification
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run ruff check src/specify_cli/cli/commands/upgrade.py src/specify_cli/agent_upgrade_prompt.py src/specify_cli/skills/command_renderer.py src/specify_cli/template/asset_generator.py src/specify_cli/shims/generator.py tests/specify_cli/cli/commands/test_upgrade_command.py tests/specify_cli/skills/test_command_renderer.py tests/test_template/test_asset_generator.py tests/specify_cli/shims/test_generator.py tests/specify_cli/shims/test_direct_commands.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run pytest tests/specify_cli/shims/test_generator.py tests/specify_cli/shims/test_direct_commands.py tests/test_template/test_asset_generator.py tests/specify_cli/skills/test_command_renderer.py tests/specify_cli/cli/commands/test_upgrade_command.py`

Note: focused pytest run passes with one pre-existing deprecation warning from `specify_cli.migration.rebuild_state` import.
