### PR TITLE
Fix Codex command skill install UX

### DIFF
--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -213,6 +213,7 @@ def _check_or_create_configured_agent_dirs(repo_root: Path, config: AgentConfig)
     """Check configured managed surfaces and create legacy local dirs if needed."""
     console.print("\n[cyan]Checking for missing directories...[/cyan]")
     changes_made = False
+    errors_found = False
     missions_dir = repo_root / ".kittify" / "missions" / "software-dev" / "command-templates"
 
     for agent_key in config.available:
@@ -239,11 +240,13 @@ def _check_or_create_configured_agent_dirs(repo_root: Path, config: AgentConfig)
                 changes_made = True
             elif error:
                 console.print(f"  [red]✗[/red] {error}")
+                errors_found = True
             continue
 
         agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)
         if not agent_dir_info:
             console.print(f"  [yellow]⚠[/yellow] Unknown agent: {agent_key}")
+            errors_found = True
             continue
 
         agent_root, subdir = agent_dir_info
@@ -262,6 +265,10 @@ def _check_or_create_configured_agent_dirs(repo_root: Path, config: AgentConfig)
             changes_made = True
         except OSError as exc:
             console.print(f"  [red]✗[/red] Failed to create {agent_root}/{subdir}/: {exc}")
+            errors_found = True
+
+    if errors_found:
+        raise typer.Exit(1)
 
     return changes_made
 

--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -122,7 +122,13 @@ def _load_config_or_exit(repo_root: Path) -> AgentConfig:
         raise typer.Exit(1)
 
 
-def _register_skill_agent(repo_root: Path, config: AgentConfig, agent_key: str) -> tuple[bool, str | None]:
+def _register_skill_agent(
+    repo_root: Path,
+    config: AgentConfig,
+    agent_key: str,
+    *,
+    update_config: bool = True,
+) -> tuple[bool, str | None]:
     """Install command skills for skill-only agents and update config."""
     from specify_cli.skills import command_installer  # noqa: PLC0415
     from specify_cli.skills.vibe_config import ensure_project_skill_path  # noqa: PLC0415
@@ -132,7 +138,8 @@ def _register_skill_agent(repo_root: Path, config: AgentConfig, agent_key: str) 
         if agent_key == "vibe":
             ensure_project_skill_path(repo_root)
         installed = len(report.added) + len(report.reused_shared)
-        config.available.append(agent_key)
+        if update_config:
+            config.available.append(agent_key)
         console.print(
             f"[green]✓[/green] Registered {agent_key} "
             f"({installed} command skills in .agents/skills/)"
@@ -219,6 +226,19 @@ def _check_or_create_configured_agent_dirs(repo_root: Path, config: AgentConfig)
                 console.print(
                     f"  [yellow]⚠[/yellow] Global commands missing for {agent_key} at {_display_path(global_dir)}"
                 )
+            continue
+
+        if agent_key in SKILL_ONLY_AGENTS:
+            ok, error = _register_skill_agent(
+                repo_root,
+                config,
+                agent_key,
+                update_config=False,
+            )
+            if ok:
+                changes_made = True
+            elif error:
+                console.print(f"  [red]✗[/red] {error}")
             continue
 
         agent_dir_info = KEY_TO_AGENT_DIR.get(agent_key)

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -53,6 +53,7 @@ _ensure_executable_scripts: Callable[[Path, StepTracker | None], None] | None = 
 
 _logger = logging.getLogger(__name__)
 _EVENT_LOG_GITATTRIBUTES_ENTRY = "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log"
+_COMMAND_SKILL_AGENTS = {"codex", "pi", "letta"}
 _GITHUB_DIFF_GITATTRIBUTES_ENTRIES = (
     "kitty-specs/**/status.json linguist-generated=true",
     "kitty-specs/**/status.events.jsonl linguist-generated=true",
@@ -386,6 +387,60 @@ def _is_non_interactive_mode(flag: bool) -> bool:
     if _is_truthy_env(os.environ.get("SPEC_KITTY_NON_INTERACTIVE")):
         return True
     return not sys.stdin.isatty()
+
+
+def _primary_next_step_agent(selected_agents: list[str]) -> str:
+    """Choose the selected harness whose command syntax should drive init UX."""
+    for agent in selected_agents:
+        if agent in _COMMAND_SKILL_AGENTS:
+            return agent
+    return selected_agents[0]
+
+
+def _agent_command_token(agent_key: str, command: str) -> str:
+    """Render the command token visible inside the selected harness."""
+    if agent_key == "codex":
+        return f"$spec-kitty.{command}"
+    if agent_key == "pi":
+        return f"/skill:spec-kitty.{command}"
+    if agent_key == "letta":
+        return f"spec-kitty.{command}"
+    return f"/spec-kitty.{command}"
+
+
+def _workflow_lines_for_agent(agent_key: str) -> tuple[str, list[str]]:
+    """Return next-step heading and installed workflow commands for a harness."""
+    if agent_key in _COMMAND_SKILL_AGENTS:
+        heading = "Build your specification with command skills (in workflow order):"
+        commands = [
+            ("charter", "Establish project principles"),
+            ("specify", "Create baseline specification"),
+            ("plan", "Create implementation plan"),
+            ("research", "Run mission-specific Phase 0 research scaffolding"),
+            ("tasks", "Generate work packages"),
+            ("tasks-outline", "Create package outline"),
+            ("tasks-packages", "Generate work packages from outline"),
+            ("tasks-finalize", "Finalize generated work packages"),
+            ("review", "Review prompts and move them to /tasks/done/"),
+        ]
+    else:
+        heading = "Build your specification with slash commands (in workflow order):"
+        commands = [
+            ("dashboard", "Open the real-time kanban dashboard"),
+            ("charter", "Establish project principles"),
+            ("specify", "Create baseline specification"),
+            ("plan", "Create implementation plan"),
+            ("research", "Run mission-specific Phase 0 research scaffolding"),
+            ("tasks", "Generate work packages"),
+            ("review", "Review prompts and move them to /tasks/done/"),
+            ("accept", "Run acceptance checks and verify mission complete"),
+            ("merge", "Merge mission into target branch and cleanup worktree"),
+        ]
+
+    return heading, [
+        f"   - [cyan]{_agent_command_token(agent_key, command)}[/] - {description}"
+        for command, description in commands
+    ]
 
 
 
@@ -853,7 +908,7 @@ def init(  # noqa: C901
         "cursor": ".cursor/",
         "qwen": ".qwen/",
         "opencode": ".opencode/",
-        "codex": ".codex/",
+        "codex": ".agents/skills/",
         "vibe": ".vibe/",
         "windsurf": ".windsurf/",
         "kilocode": ".kilocode/",
@@ -863,8 +918,8 @@ def init(  # noqa: C901
         "roo": ".roo/",
         "q": ".amazonq/",
         "kiro": ".kiro/",
-        "pi": ".pi/",
-        "letta": ".letta/",
+        "pi": ".agents/skills/",
+        "letta": ".agents/skills/",
     }
 
     notice_entries = []
@@ -907,22 +962,17 @@ def init(  # noqa: C901
     step_num += 1
 
     steps_lines.append(
-        f"{step_num}. Available missions: [cyan]software-dev[/cyan], [cyan]research[/cyan] (selected per-mission during [cyan]/spec-kitty.specify[/cyan])"  # noqa: E501
+        f"{step_num}. Available missions: [cyan]software-dev[/cyan], [cyan]research[/cyan] "
+        f"(selected per-mission during [cyan]{_agent_command_token(_primary_next_step_agent(selected_agents), 'specify')}[/cyan])"
     )
     step_num += 1
 
-    steps_lines.append(f"{step_num}. Build your specification with slash commands (in workflow order):")
+    primary_agent = _primary_next_step_agent(selected_agents)
+    workflow_heading, workflow_lines = _workflow_lines_for_agent(primary_agent)
+    steps_lines.append(f"{step_num}. {workflow_heading}")
     step_num += 1
 
-    steps_lines.append("   - [cyan]/spec-kitty.dashboard[/] - Open the real-time kanban dashboard")
-    steps_lines.append("   - [cyan]/spec-kitty.charter[/]   - Establish project principles")
-    steps_lines.append("   - [cyan]/spec-kitty.specify[/]   - Create baseline specification")
-    steps_lines.append("   - [cyan]/spec-kitty.plan[/]      - Create implementation plan")
-    steps_lines.append("   - [cyan]/spec-kitty.research[/]  - Run mission-specific Phase 0 research scaffolding")
-    steps_lines.append("   - [cyan]/spec-kitty.tasks[/]     - Generate work packages")
-    steps_lines.append("   - [cyan]/spec-kitty.review[/]    - Review prompts and move them to /tasks/done/")
-    steps_lines.append("   - [cyan]/spec-kitty.accept[/]    - Run acceptance checks and verify mission complete")
-    steps_lines.append("   - [cyan]/spec-kitty.merge[/]     - Merge mission into target branch and cleanup worktree")
+    steps_lines.extend(workflow_lines)
     steps_lines.append("   - [cyan]spec-kitty retrospect summary[/] - Review retrospective status after merge")
     step_num += 1
 
@@ -999,7 +1049,8 @@ def init(  # noqa: C901
     enhancement_lines = [
         "Optional commands that you can use for your specs [bright_black](improve quality & confidence)[/bright_black]",
         "",
-        "○ [cyan]/spec-kitty.analyze[/] [bright_black](optional)[/bright_black] - Cross-artifact consistency & alignment report (after [cyan]/spec-kitty.tasks[/])",  # noqa: E501
+        f"○ [cyan]{_agent_command_token(primary_agent, 'analyze')}[/] [bright_black](optional)[/bright_black] - "
+        f"Cross-artifact consistency & alignment report (after [cyan]{_agent_command_token(primary_agent, 'tasks')}[/])",
     ]
     enhancements_panel = Panel("\n".join(enhancement_lines), title="Enhancement Commands", border_style="cyan", padding=(1, 2))
     _console.print()

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -53,7 +53,7 @@ _ensure_executable_scripts: Callable[[Path, StepTracker | None], None] | None = 
 
 _logger = logging.getLogger(__name__)
 _EVENT_LOG_GITATTRIBUTES_ENTRY = "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log"
-_COMMAND_SKILL_AGENTS = {"codex", "pi", "letta"}
+_COMMAND_SKILL_AGENTS = {"codex", "vibe", "pi", "letta"}
 _GITHUB_DIFF_GITATTRIBUTES_ENTRIES = (
     "kitty-specs/**/status.json linguist-generated=true",
     "kitty-specs/**/status.events.jsonl linguist-generated=true",
@@ -404,7 +404,7 @@ def _agent_command_token(agent_key: str, command: str) -> str:
     if agent_key == "pi":
         return f"/skill:spec-kitty.{command}"
     if agent_key == "letta":
-        return f"spec-kitty.{command}"
+        return f"/spec-kitty.{command}"
     return f"/spec-kitty.{command}"
 
 
@@ -1035,7 +1035,7 @@ def init(  # noqa: C901
             "2. Launch Letta Code in this project:",
             "     [cyan]letta[/cyan]",
             "3. Ask Letta Code to use the Spec Kitty specify skill:",
-            "     [cyan]Use spec-kitty.specify to specify <describe what you want to build>[/cyan]",
+            "     [cyan]/spec-kitty.specify <describe what you want to build>[/cyan]",
         ]
         letta_panel = Panel(
             "\n".join(letta_steps_lines),

--- a/tests/init/test_init_next_steps.py
+++ b/tests/init/test_init_next_steps.py
@@ -94,6 +94,16 @@ def test_init_next_steps_names_spec_kitty_next(
         f"Actual console output:\n{output}"
     )
 
+    assert "$spec-kitty.specify" in output, (
+        "Codex init next steps must use Codex skill invocation syntax.\n"
+        f"Actual console output:\n{output}"
+    )
+
+    assert "/spec-kitty.dashboard" not in output, (
+        "Codex init next steps must not list slash commands that are not installed as command skills.\n"
+        f"Actual console output:\n{output}"
+    )
+
     # The bare top-level CLI invocation must NOT appear
     assert "spec-kitty implement WP" not in output, (
         "Found forbidden string 'spec-kitty implement WP' in init console output — "

--- a/tests/init/test_init_next_steps.py
+++ b/tests/init/test_init_next_steps.py
@@ -112,6 +112,47 @@ def test_init_next_steps_names_spec_kitty_next(
     )
 
 
+def test_init_letta_next_steps_use_slash_skill_syntax(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app, buf = _make_app_with_buf()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(init_module, "get_local_repo_root", lambda override_path=None: None)
+    monkeypatch.setattr(init_module, "copy_specify_base_from_package", _fake_copy_package)
+
+    result = _run(app, ["init", "letta-proj", "--ai", "letta", "--non-interactive"])
+
+    assert result.exit_code == 0, f"init failed (exit_code={result.exit_code})"
+
+    output = buf.getvalue()
+    assert "/spec-kitty.specify" in output
+    assert "Use spec-kitty.specify" not in output
+
+
+def test_init_vibe_next_steps_list_only_installed_command_skills(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app, buf = _make_app_with_buf()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(init_module, "get_local_repo_root", lambda override_path=None: None)
+    monkeypatch.setattr(init_module, "copy_specify_base_from_package", _fake_copy_package)
+
+    result = _run(app, ["init", "vibe-proj", "--ai", "vibe", "--non-interactive"])
+
+    assert result.exit_code == 0, f"init failed (exit_code={result.exit_code})"
+
+    output = buf.getvalue()
+    assert "Build your specification with command skills" in output
+    assert "/spec-kitty.tasks-finalize" in output
+    assert "/spec-kitty.dashboard" not in output
+    assert "/spec-kitty.accept" not in output
+    assert "/spec-kitty.merge" not in output
+
+
 # ---------------------------------------------------------------------------
 # T1.4b: The literal commit string must be absent from src/
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/cli/commands/test_agent_config_pi_letta.py
+++ b/tests/specify_cli/cli/commands/test_agent_config_pi_letta.py
@@ -68,3 +68,23 @@ def test_sync_create_missing_reinstalls_codex_command_skills(tmp_path: Path) -> 
     for entry in manifest.entries:
         assert entry.agents == ("codex",)
         assert (tmp_path / entry.path).is_file()
+
+
+def test_sync_create_missing_fails_when_codex_repair_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_config(tmp_path, ["codex"])
+
+    def _fail_install(repo_root: Path, agent_key: str) -> object:
+        raise RuntimeError("installer boom")
+
+    monkeypatch.setattr(command_installer, "install", _fail_install)
+
+    with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+        result = runner.invoke(app, ["sync", "--create-missing"])
+
+    assert result.exit_code == 1
+    assert "Failed to install codex skills: installer boom" in result.output
+    assert "No changes needed" not in result.output
+    assert "Sync complete" not in result.output

--- a/tests/specify_cli/cli/commands/test_agent_config_pi_letta.py
+++ b/tests/specify_cli/cli/commands/test_agent_config_pi_letta.py
@@ -52,3 +52,19 @@ def test_remove_pi_letta_removes_skill_claims(tmp_path: Path, agent_key: str) ->
     config = load_agent_config(tmp_path)
     assert agent_key not in config.available
     assert manifest_store.load(tmp_path).entries == []
+
+
+def test_sync_create_missing_reinstalls_codex_command_skills(tmp_path: Path) -> None:
+    _write_config(tmp_path, ["codex"])
+
+    with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
+        result = runner.invoke(app, ["sync", "--create-missing"])
+
+    assert result.exit_code == 0, result.output
+    assert "Unknown agent: codex" not in result.output
+
+    manifest = manifest_store.load(tmp_path)
+    assert len(manifest.entries) == len(command_installer.CANONICAL_COMMANDS)
+    for entry in manifest.entries:
+        assert entry.agents == ("codex",)
+        assert (tmp_path / entry.path).is_file()

--- a/tests/specify_cli/cli/commands/test_init_pi_letta.py
+++ b/tests/specify_cli/cli/commands/test_init_pi_letta.py
@@ -48,7 +48,7 @@ def _fake_copy_package(project_path: Path) -> Path:
     ("agent_key", "agent_dir", "install_snippet", "usage_snippet"),
     [
         ("pi", ".pi/", "https://pi.dev/install.sh", "/skill:spec-kitty.specify"),
-        ("letta", ".letta/", "@letta-ai/letta-code", "Use spec-kitty.specify"),
+        ("letta", ".letta/", "@letta-ai/letta-code", "/spec-kitty.specify"),
     ],
 )
 def test_init_pi_letta_installs_command_skills_and_prints_next_steps(


### PR DESCRIPTION
## Summary
- Render Codex/Pi/Letta init next steps with their command-skill invocation syntax instead of slash-command syntax
- Point Codex/Pi/Letta security notices at `.agents/skills/`
- Make `spec-kitty agent config sync --create-missing` repair configured Codex command skills instead of reporting Codex as unknown
- Add regression coverage for Codex init output and sync repair

Related: #1635

## Testing
- `.venv/bin/ruff check src/specify_cli/cli/commands/init.py src/specify_cli/cli/commands/agent/config.py tests/init/test_init_next_steps.py tests/specify_cli/cli/commands/test_agent_config_pi_letta.py`
- `.venv/bin/pytest tests/init/test_init_next_steps.py tests/specify_cli/cli/commands/test_agent_config_pi_letta.py tests/specify_cli/cli/commands/test_agent_config_vibe.py tests/specify_cli/cli/commands/test_init_vibe.py tests/specify_cli/cli/commands/test_init_pi_letta.py tests/specify_cli/cli/commands/test_init_manifest_coexistence.py tests/specify_cli/skills/test_installer.py tests/specify_cli/upgrade/test_m_3_2_0_codex_to_skills.py tests/specify_cli/cli/commands/test_doctor_skills.py`
