### PR TITLE
Add split brain authority detection tactic

### DIFF
--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -529,6 +529,9 @@ nodes:
   label: Secure Regex — Avoid Catastrophic Backtracking
 - urn: tactic:single-diagram-architecture
   kind: tactic
+- urn: tactic:split-brain-authority-detection
+  kind: tactic
+  label: Split Brain Authority Detection
 - urn: tactic:stakeholder-alignment
   kind: tactic
   label: Stakeholder Alignment

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -2251,6 +2251,18 @@ edges:
   target: tactic:secure-design-checklist
   relation: suggests
   when: Treat regex hardening as a design-phase property of any component that parses untrusted input, not as a post-hoc fix
+- source: tactic:split-brain-authority-detection
+  target: tactic:forensic-repository-audit
+  relation: suggests
+  when: Use when repository history may reveal repeated fixes, reverts, or ownership churn around split brain incidents.
+- source: tactic:split-brain-authority-detection
+  target: tactic:premortem-risk-identification
+  relation: suggests
+  when: Use before introducing multiple writers, active-active regions, offline clients, queue workers, or control-plane rollouts.
+- source: tactic:split-brain-authority-detection
+  target: tactic:quality-gate-verification
+  relation: suggests
+  when: Use to prove the detector, chaos drill, or invariant test is part of the release gate.
 - source: tactic:stakeholder-alignment
   target: template:stakeholder-persona-template
   relation: suggests

--- a/src/doctrine/tactics/built-in/analysis/split-brain-authority-detection.tactic.yaml
+++ b/src/doctrine/tactics/built-in/analysis/split-brain-authority-detection.tactic.yaml
@@ -1,0 +1,170 @@
+schema_version: "1.0"
+id: split-brain-authority-detection
+name: Split Brain Authority Detection
+purpose: >
+  Detect split brain failures by proving which actor is allowed to decide,
+  write, route, or reconcile each scoped fact at each moment. Use this tactic
+  whenever two nodes, services, stores, regions, clients, config planes, or
+  business domains can each believe they are authoritative. The core move is
+  always the same: make authority explicit, attach a monotonic epoch or version
+  to every decision, and probe from outside the system for impossible
+  concurrent authorities.
+steps:
+  - title: Define the authority scope
+    description: >
+      Name the exact fact under investigation and its authority boundary before
+      looking at symptoms. A useful scope is small enough to have one owner:
+      one cluster shard, database key range, tenant placement, queue job,
+      session, feature flag bundle, domain field, or client entity version.
+      State who is allowed to decide, who is allowed to write, who may only
+      observe, and which durable record proves the answer.
+    examples:
+      - "Shard 42 leader for writes; tenant acme placement epoch; invoice.status owner; job 123 claim owner."
+  - title: Require monotonic authority evidence
+    description: >
+      Every decision or mutation in scope must carry evidence that can be
+      ordered: term, epoch, lease generation, fencing token, commit index, LSN,
+      binlog position, config generation, placement epoch, entity version, ETag,
+      or event sequence number. A system that cannot order authority claims
+      cannot reliably distinguish lag from split brain.
+    examples:
+      - "Reject any write whose fencing token is lower than the durable token recorded for the resource."
+      - "Log leader term and quorum membership next to each accepted shard write."
+  - title: Assert single active authority as an invariant
+    description: >
+      Convert the investigation into an impossible-state detector. For the
+      selected scope and epoch, there must be at most one active writer,
+      primary, router, config source, job claimant, domain owner, or client
+      base version accepted for mutation. Alert on invariant violations rather
+      than vague lag thresholds.
+    examples:
+      - "At most one primary per shard per term accepts writes."
+      - "At most one region accepts tenant mutations for placement epoch N."
+      - "At most one worker owns a job claim for lease generation N."
+  - title: Probe from outside the trusted path
+    description: >
+      Use an independent observer that queries every participant and compares
+      claimed role, epoch, token, version, route, and last accepted write. Do
+      not rely only on internal health checks, because a split-brain participant
+      often reports itself healthy. The probe should ask each side what it
+      believes and then diff those beliefs against the durable authority record.
+    examples:
+      - "Poll all cluster nodes for role, term, and commit index; fail if two report primary in the same shard scope."
+      - "Sample gateways by point of presence and compare tenant routing decisions with the placement ledger."
+  - title: Inject controlled disagreement
+    description: >
+      Reproduce the class, not just the incident. Introduce network partitions,
+      delayed messages, clock skew, stale config, stale DNS, replica lag,
+      offline clients, restarted workers, control-plane rollback, or partial
+      migration state. The test passes only when stale actors are fenced or
+      rejected and the invariant from the previous step still holds.
+    examples:
+      - "Cut network between quorum halves and verify only the quorum side can accept writes."
+      - "Move a synthetic tenant, then verify the old region rejects writes for the superseded placement epoch."
+  - title: Diff durable truth against reported truth
+    description: >
+      Compare the durable source of authority with every reported copy or
+      cached belief. Use checksums, sentinel writes, read-your-write probes,
+      idempotency ledgers, event lineage, config hashes, routing census data,
+      and entity versions to separate harmless propagation delay from divergent
+      truth.
+    examples:
+      - "Write a sentinel record through the primary, then verify one canonical order across replicas."
+      - "Compare active runtime config hashes across the fleet with the control-plane generation."
+  - title: Record the red flag and the fence
+    description: >
+      Close the investigation by naming the exact red flag that would have
+      detected the failure earlier and the fence that prevents damage: token
+      rejection, quorum proof, stale-version rejection, single-writer ledger,
+      placement epoch check, idempotency ledger, or owner-only mutation
+      contract. If no fence exists, the system still has an unresolved split
+      brain risk.
+    examples:
+      - "Red flag: two regions accepted tenant writes for epoch 17. Fence: write path checks placement epoch before mutation."
+      - "Red flag: duplicate job processing with overlapping lease generations. Fence: durable claim token on every side effect."
+failure_modes:
+  - "Treating split brain as ordinary lag: lag resolves by waiting; split brain creates competing authorities that may both mutate state."
+  - "Health-check myopia: each partition can report healthy from its own view while global authority is already violated."
+  - "No monotonic evidence: without terms, epochs, versions, or fencing tokens, investigators cannot prove which claim is stale."
+  - "Control-plane optimism: desired state says one authority, but runtime state still contains stale routers, configs, leaders, or clients."
+  - "Overbroad scope: asking who owns the whole system hides split brain at the shard, tenant, key range, job, field, or entity-version level."
+  - "Silent repair bias: reconciliation jobs can mask evidence unless they preserve origin, sequence, conflict, and overwrite telemetry."
+references:
+  - name: Forensic Repository Audit
+    type: tactic
+    id: forensic-repository-audit
+    when: Use when repository history may reveal repeated fixes, reverts, or ownership churn around split brain incidents.
+  - name: Premortem Risk Identification
+    type: tactic
+    id: premortem-risk-identification
+    when: Use before introducing multiple writers, active-active regions, offline clients, queue workers, or control-plane rollouts.
+  - name: Quality Gate Verification
+    type: tactic
+    id: quality-gate-verification
+    when: Use to prove the detector, chaos drill, or invariant test is part of the release gate.
+notes: |
+  Universal best detective pattern.
+
+  1. Define authority: who may decide, write, route, claim, or reconcile this
+     exact scoped fact?
+  2. Attach monotonic evidence: every authority claim must carry an epoch,
+     term, fencing token, generation, sequence, version, ETag, placement epoch,
+     config hash, LSN, or equivalent ordered proof.
+  3. Assert uniqueness: for one scope and one epoch, there is at most one active
+     authority.
+  4. Observe externally: query every participant and compare their claimed state
+     with the durable authority record.
+  5. Inject disagreement: partitions, delay, stale config, stale routing,
+     offline clients, failover, rollback, and migration overlap must not produce
+     two accepted authorities.
+  6. Diff durable truth vs reported truth: separate acceptable propagation lag
+     from divergent mutation authority.
+  7. Name the red flag and fence: every finding should end with an earlier
+     detector and a write-path rejection rule.
+
+  Context-specific detective moves.
+
+  Distributed systems and clusters:
+  - Look for two leaders or primaries in the same shard and term.
+  - Require quorum proof on leader decisions.
+  - Require fencing tokens on writes so stale leaders cannot mutate state.
+  - Compare role, term, quorum membership, and commit index from every node.
+
+  Database replication:
+  - Look for multiple writable primaries, divergent replica checksums, or the
+    same key updated independently on different origins.
+  - Run sentinel writes and verify one canonical order.
+  - Compare key-range checksums, LSNs, binlog positions, mutation origins, and
+    conflict telemetry.
+
+  Cache, queue, locks, and session state:
+  - Look for duplicate job processing, double resource claims, or cache state
+    that contradicts the durable store.
+  - Require current lease generation or fencing token on every side effect.
+  - Maintain an idempotency ledger for processed jobs and messages.
+
+  Config, feature flags, and control planes:
+  - Look for services that believe different config generations are current.
+  - Census runtime config hashes, not just desired control-plane state.
+  - Alert when mutually exclusive flags or policy generations are active
+    together for one tenant, service, or environment.
+
+  Microservices and domain ownership:
+  - Look for two APIs or services that can mutate the same business fact.
+  - Maintain a source-of-truth map per entity, field, and event type.
+  - Diff cross-service invariants and preserve event lineage for every state
+    mutation.
+
+  UI, mobile, offline clients, and server state:
+  - Look for clients saving against stale entity versions or showing committed
+    state that the server rejected.
+  - Use versioned entities, ETags, optimistic-update reconciliation, hydration
+    diffs, and offline conflict tests.
+  - Server writes must reject stale base versions instead of silently
+    overwriting newer truth.
+
+  Multi-region SaaS, tenant routing, and shard migration:
+  - Look for the same tenant accepting writes in two regions or shards.
+  - Use a durable tenant placement ledger with monotonic placement epochs.
+  - Sample gateways across points of presence and verify old placements reject
+    mutations after migration.


### PR DESCRIPTION
## Summary
- Add a built-in doctrine tactic for split brain authority detection
- Lead with the universal authority/epoch/invariant/external-probe pattern
- Cover context-specific detection moves for clusters, databases, queues/caches, config planes, domain ownership, clients, and multi-region tenant routing
- Register the tactic in the doctrine DRG graph

## Verification
- `uv run pytest tests/doctrine/test_tactic_compliance.py tests/doctrine/test_directive_consistency.py::test_tactic_reference_graph_has_no_cycles tests/doctrine/test_directive_consistency.py::test_tactic_references_resolve_to_known_tactics`
- Result: 398 passed
