### PR TITLE
fix: reduce actionable sonar findings

### DIFF
--- a/src/charter/pack_manager.py
+++ b/src/charter/pack_manager.py
@@ -126,6 +126,9 @@ YAML_KEY_MAP: dict[str, str] = {
 #: order. ``specify_cli`` resolves the org/project *roots* (C-008); this module
 #: only knows the directory-segment names.
 _LAYER_SEGMENTS: tuple[str, ...] = ("built-in", "org", "project")
+_KITTIFY_DIRNAME = ".kittify"
+_CONFIG_FILENAME = "config.yaml"
+_CHARTER_FILENAME = "charter.md"
 
 
 def _resolve_kind(token: str) -> ArtifactKind | None:
@@ -397,7 +400,7 @@ class CharterPackManager:
         yaml_key = YAML_KEY_MAP[kind]
 
         repo_root = ctx.require_repo_root()
-        config_path = repo_root / ".kittify" / "config.yaml"
+        config_path = repo_root / _KITTIFY_DIRNAME / _CONFIG_FILENAME
         data, yaml_inst = _load_config(config_path)
 
         available = self.list_available(ctx, kind, layer_roots=layer_roots)
@@ -471,7 +474,7 @@ class CharterPackManager:
         yaml_key = YAML_KEY_MAP[kind]
 
         repo_root = ctx.require_repo_root()
-        config_path = repo_root / ".kittify" / "config.yaml"
+        config_path = repo_root / _KITTIFY_DIRNAME / _CONFIG_FILENAME
         data, yaml_inst = _load_config(config_path)
 
         plan = plan_deactivation(
@@ -512,7 +515,7 @@ class CharterPackManager:
             Mapping of charter kind token to activated IDs (or ``None``).
         """
         repo_root = ctx.require_repo_root()
-        config_path = repo_root / ".kittify" / "config.yaml"
+        config_path = repo_root / _KITTIFY_DIRNAME / _CONFIG_FILENAME
         data, _ = _load_config(config_path)
 
         result: dict[str, frozenset[str] | None] = {}
@@ -604,6 +607,7 @@ class CharterPackManager:
         ValueError
             If ``kind`` is not in the canonical charter kind universe.
         """
+        _ = ctx
         kind_enum = self._require_kind(kind)
         yaml = YAML(typ="safe")
         _base_dir, glob, _layered = _scan_layout_for(kind_enum)
@@ -688,15 +692,15 @@ class CharterPackManager:
         from datetime import UTC, datetime
 
         repo_root = ctx.require_repo_root()
-        config_path = repo_root / ".kittify" / "config.yaml"
-        charter_path = repo_root / ".kittify" / "charter" / "charter.md"
+        config_path = repo_root / _KITTIFY_DIRNAME / _CONFIG_FILENAME
+        charter_path = repo_root / _KITTIFY_DIRNAME / "charter" / _CHARTER_FILENAME
 
         result = MergeResult()
 
         # Backup charter.md if it exists before any write
         if charter_path.exists():
             ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-            backup_dir = repo_root / ".kittify" / "charter" / "backups"
+            backup_dir = repo_root / _KITTIFY_DIRNAME / "charter" / "backups"
             backup_dir.mkdir(parents=True, exist_ok=True)
             backup_path = backup_dir / f"charter-{ts}.md"
             backup_path.write_bytes(charter_path.read_bytes())

--- a/src/doctrine/missions/mission_step_repository.py
+++ b/src/doctrine/missions/mission_step_repository.py
@@ -60,6 +60,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 _YAML = YAML(typ="safe")
+_STEP_FILENAME = "step.yaml"
 
 # ---------------------------------------------------------------------------
 # Public value objects
@@ -133,6 +134,28 @@ def _load_step_yaml(step_file: Path) -> MissionStep | None:
         return MissionStep.model_validate(mapped)
     except Exception:  # noqa: BLE001
         return None
+
+
+def _add_step_ids_from_dir(step_ids: set[str], mission_type_dir: Path) -> None:
+    """Add step ids from ``mission_type_dir`` when ``step.yaml`` exists."""
+    if not mission_type_dir.is_dir():
+        return
+    for entry in mission_type_dir.iterdir():
+        if entry.is_dir() and (entry / _STEP_FILENAME).exists():
+            step_ids.add(entry.name)
+
+
+def _project_mission_type_dir(
+    pack_context: _PackContextLike, mission_type_id: str,
+) -> Path:
+    """Return the project override directory for a mission type."""
+    return (
+        pack_context.repo_root
+        / ".kittify"
+        / "overrides"
+        / "mission-steps"
+        / mission_type_id
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -248,11 +271,7 @@ class MissionStepRepository:
         step_ids: set[str] = set()
 
         # Built-in layer
-        builtin_mt_dir = self._builtin_root / mission_type_id
-        if builtin_mt_dir.is_dir():
-            for entry in builtin_mt_dir.iterdir():
-                if entry.is_dir() and (entry / "step.yaml").exists():
-                    step_ids.add(entry.name)
+        _add_step_ids_from_dir(step_ids, self._builtin_root / mission_type_id)
 
         # Org layer (collect any extra step_ids present in org packs)
         if pack_context is not None:
@@ -260,17 +279,9 @@ class MissionStepRepository:
 
         # Project layer (collect any extra step_ids present in project overrides)
         if pack_context is not None:
-            project_mt_dir = (
-                pack_context.repo_root
-                / ".kittify"
-                / "overrides"
-                / "mission-steps"
-                / mission_type_id
+            _add_step_ids_from_dir(
+                step_ids, _project_mission_type_dir(pack_context, mission_type_id),
             )
-            if project_mt_dir.is_dir():
-                for entry in project_mt_dir.iterdir():
-                    if entry.is_dir() and (entry / "step.yaml").exists():
-                        step_ids.add(entry.name)
 
         # Resolve each step_id through the full layer stack.
         for step_id in step_ids:
@@ -298,17 +309,14 @@ class MissionStepRepository:
             if pack_root == builtin_pack_root:
                 continue
             org_mt_dir = pack_root / "mission-steps" / mission_type_id
-            if org_mt_dir.is_dir():
-                for entry in org_mt_dir.iterdir():
-                    if entry.is_dir() and (entry / "step.yaml").exists():
-                        step_ids.add(entry.name)
+            _add_step_ids_from_dir(step_ids, org_mt_dir)
         return step_ids
 
     def _resolve_builtin_layer(
         self, mission_type_id: str, step_id: str
     ) -> MissionStep | None:
         """Attempt to load ``{builtin_steps_root}/{mission_type_id}/{step_id}/step.yaml``."""
-        step_file = self._builtin_root / mission_type_id / step_id / "step.yaml"
+        step_file = self._builtin_root / mission_type_id / step_id / _STEP_FILENAME
         return _load_step_yaml(step_file)
 
     def _resolve_org_layer(
@@ -334,7 +342,7 @@ class MissionStepRepository:
             if pack_root == builtin_pack_root:
                 continue
             step_file = (
-                pack_root / "mission-steps" / mission_type_id / step_id / "step.yaml"
+                pack_root / "mission-steps" / mission_type_id / step_id / _STEP_FILENAME
             )
             step = _load_step_yaml(step_file)
             if step is not None:
@@ -351,13 +359,7 @@ class MissionStepRepository:
 
         Project-layer shadow wins over both org and built-in layers.
         """
-        step_file = (
-            pack_context.repo_root
-            / ".kittify"
-            / "overrides"
-            / "mission-steps"
-            / mission_type_id
-            / step_id
-            / "step.yaml"
-        )
+        step_file = _project_mission_type_dir(
+            pack_context, mission_type_id,
+        ) / step_id / _STEP_FILENAME
         return _load_step_yaml(step_file)

--- a/src/runtime/next/_internal_runtime/engine.py
+++ b/src/runtime/next/_internal_runtime/engine.py
@@ -960,7 +960,7 @@ def resolve_context(
     context_name: str,
     context_type: ContextType,
     available_bindings: dict[str, Any],
-    registry: ContextTypeRegistry,  # noqa: ARG001
+    _registry: ContextTypeRegistry,
     local_discovery_root: Path | None = None
 ) -> Any | RemediationPayload:
     """Resolve a context using the 5-point precedence chain.
@@ -1252,7 +1252,7 @@ def _resolve_mission_metadata(
 
 def _resolve_local_discovery(
     context_name: str,
-    context_type: ContextType,  # noqa: ARG001
+    _context_type: ContextType,
     available_bindings: dict[str, Any],
     local_discovery_root: Path
 ) -> list[dict[str, Any]]:

--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -192,43 +192,20 @@ class QueryModeValidationError(ValueError):
 # ---------------------------------------------------------------------------
 
 _FEATURE_RUNS_FILE = "feature-runs.json"
-
-
-def _wp_heading_id(line: str) -> str | None:
-    """Return the WP id carried by a markdown heading line, if any."""
-    heading = line.lstrip()
-    hash_count = len(heading) - len(heading.lstrip("#"))
-    if not 2 <= hash_count <= 4:
-        return None
-    if len(heading) <= hash_count or heading[hash_count] != " ":
-        return None
-
-    title = heading[hash_count:].strip()
-    if title.startswith("Work Package "):
-        title = title.removeprefix("Work Package ").lstrip()
-    if len(title) < 4 or not title.startswith("WP"):
-        return None
-    if not title[2:4].isdigit():
-        return None
-    if len(title) > 4 and title[4] not in {":", " ", "\t"}:
-        return None
-    return title[:4]
+_WP_SECTION_HEADING_RE = re.compile(
+    r"(?m)^#{2,4}\s+(?:Work Package\s+)?(WP\d{2})(?:\b|:)",
+)
 
 
 def _parse_wp_sections_from_tasks_md(tasks_content: str) -> dict[str, str]:
     """Extract WP sections from tasks.md keyed by WP ID."""
     sections: dict[str, str] = {}
-    matches: list[tuple[str, int, int]] = []
-    offset = 0
-    for line in tasks_content.splitlines(keepends=True):
-        wp_id = _wp_heading_id(line)
-        if wp_id is not None:
-            matches.append((wp_id, offset, offset + len(line)))
-        offset += len(line)
+    matches = list(_WP_SECTION_HEADING_RE.finditer(tasks_content))
 
-    for idx, (wp_id, _heading_start, heading_end) in enumerate(matches):
-        start = heading_end
-        end = matches[idx + 1][1] if idx + 1 < len(matches) else len(tasks_content)
+    for idx, match in enumerate(matches):
+        wp_id = match.group(1)
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(tasks_content)
         sections[wp_id] = tasks_content[start:end]
 
     return sections

--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -64,6 +64,8 @@ from specify_cli.sync.runtime_event_emitter import SyncRuntimeEventEmitter
 
 logger = logging.getLogger(__name__)
 
+_MISSION_META_FILENAME = "meta.json"
+
 
 class DecisionGitLogUnavailable(RuntimeError):
     """Decision audit logging cannot be made durable for a modern mission."""
@@ -75,7 +77,7 @@ def _resolve_coordination_branch(mission_slug: str, repo_root: Path) -> str:
     Falls back to ``kitty/mission-<slug>`` when meta.json is absent or
     does not carry the ``coordination_branch`` key.
     """
-    meta_path = repo_root / "kitty-specs" / mission_slug / "meta.json"
+    meta_path = repo_root / "kitty-specs" / mission_slug / _MISSION_META_FILENAME
     if meta_path.exists():
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -93,7 +95,7 @@ def _resolve_mission_ulid(mission_slug: str, repo_root: Path) -> str:
     Returns the ULID string when present, or the slug as a fallback so that
     callers always receive a non-empty identifier.
     """
-    meta_path = repo_root / "kitty-specs" / mission_slug / "meta.json"
+    meta_path = repo_root / "kitty-specs" / mission_slug / _MISSION_META_FILENAME
     if meta_path.exists():
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -107,7 +109,7 @@ def _resolve_mission_ulid(mission_slug: str, repo_root: Path) -> str:
 
 def _mission_declares_coordination_branch(mission_slug: str, repo_root: Path) -> bool:
     """Return True when meta.json explicitly declares coord-branch topology."""
-    meta_path = repo_root / "kitty-specs" / mission_slug / "meta.json"
+    meta_path = repo_root / "kitty-specs" / mission_slug / _MISSION_META_FILENAME
     if not meta_path.exists():
         return False
     try:
@@ -192,20 +194,41 @@ class QueryModeValidationError(ValueError):
 _FEATURE_RUNS_FILE = "feature-runs.json"
 
 
+def _wp_heading_id(line: str) -> str | None:
+    """Return the WP id carried by a markdown heading line, if any."""
+    heading = line.lstrip()
+    hash_count = len(heading) - len(heading.lstrip("#"))
+    if not 2 <= hash_count <= 4:
+        return None
+    if len(heading) <= hash_count or heading[hash_count] != " ":
+        return None
+
+    title = heading[hash_count:].strip()
+    if title.startswith("Work Package "):
+        title = title.removeprefix("Work Package ").lstrip()
+    if len(title) < 4 or not title.startswith("WP"):
+        return None
+    if not title[2:4].isdigit():
+        return None
+    if len(title) > 4 and title[4] not in {":", " ", "\t"}:
+        return None
+    return title[:4]
+
+
 def _parse_wp_sections_from_tasks_md(tasks_content: str) -> dict[str, str]:
     """Extract WP sections from tasks.md keyed by WP ID."""
     sections: dict[str, str] = {}
-    matches = list(
-        re.finditer(
-            r"(?m)^#{2,4}\s+(?:Work Package\s+)?(WP\d{2})(?:\b|:)",
-            tasks_content,
-        )
-    )
+    matches: list[tuple[str, int, int]] = []
+    offset = 0
+    for line in tasks_content.splitlines(keepends=True):
+        wp_id = _wp_heading_id(line)
+        if wp_id is not None:
+            matches.append((wp_id, offset, offset + len(line)))
+        offset += len(line)
 
-    for idx, match in enumerate(matches):
-        wp_id = match.group(1)
-        start = match.end()
-        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(tasks_content)
+    for idx, (wp_id, _heading_start, heading_end) in enumerate(matches):
+        start = heading_end
+        end = matches[idx + 1][1] if idx + 1 < len(matches) else len(tasks_content)
         sections[wp_id] = tasks_content[start:end]
 
     return sections
@@ -338,7 +361,7 @@ def _resolve_mission_id_for_terminus(feature_dir: Path) -> str:
     when meta.json is missing or malformed (older missions predating the
     ULID identity rollout); the gate handles missing identities defensively.
     """
-    meta_path = feature_dir / "meta.json"
+    meta_path = feature_dir / _MISSION_META_FILENAME
     if not meta_path.exists():
         return feature_dir.name
     try:

--- a/tests/charter/test_chokepoint_coverage.py
+++ b/tests/charter/test_chokepoint_coverage.py
@@ -59,6 +59,10 @@ _CARVE_OUTS: frozenset[str] = frozenset(
         "src/charter/resolution.py",
         # Producers (they WRITE, not read manifest derivatives)
         "src/charter/extractor.py",
+        # Project init stamps the top-level ``.kittify/metadata.yaml`` file.
+        # This is project bootstrap metadata, not the charter bundle's
+        # ``.kittify/charter/metadata.yaml`` derivative surface.
+        "src/specify_cli/cli/commands/init.py",
         # Compiler pipeline (C-012 — references.yaml, out of v1.0.0 scope)
         "src/charter/compiler.py",
         # metadata.yaml hash-reader used by the chokepoint itself

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -1081,6 +1081,63 @@ class TestAtomicTaskSteps:
         assert failures == []
 
     @pytest.mark.git_repo
+    def test_tasks_packages_guard_rejects_indented_legacy_tasks_md_heading(self, tmp_path: Path) -> None:
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
+        (feature_dir / "tasks.md").write_text(
+            "  ## Work Package WP01\n\n**Requirement Refs**: FR-001\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert failures
+        assert "missing refs for WPs: WP01" in failures[0]
+
+    @pytest.mark.git_repo
+    def test_tasks_packages_guard_accepts_tab_after_hashes_in_legacy_tasks_md_heading(self, tmp_path: Path) -> None:
+        repo_root = _scaffold_project(tmp_path)
+        feature_dir = repo_root / "kitty-specs" / "042-test-feature"
+        (feature_dir / "spec.md").write_text(
+            "# Spec\n\n"
+            "## Functional Requirements\n\n"
+            "| ID | Requirement | Acceptance Criteria | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| FR-001 | First | Covered by WP01. | proposed |\n",
+            encoding="utf-8",
+        )
+        (feature_dir / "tasks.md").write_text(
+            "##\tWork Package WP01\n\n**Requirement Refs**: FR-001\n",
+            encoding="utf-8",
+        )
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        (tasks_dir / "WP01.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: WP01\n---\n# WP01\n",
+            encoding="utf-8",
+        )
+
+        from specify_cli.next.runtime_bridge import _check_cli_guards
+
+        failures = _check_cli_guards("tasks_packages", feature_dir)
+        assert failures == []
+
+    @pytest.mark.git_repo
     def test_tasks_packages_guard_blocks_missing_requirement_refs(self, tmp_path: Path) -> None:
         """WP has no requirement_refs at all → missing-refs branch."""
         repo_root = _scaffold_project(tmp_path)


### PR DESCRIPTION
## Summary
- remove a Sonar hotspot-prone WP heading regex by parsing headings line-by-line in `runtime_bridge`
- factor repeated path literals in `pack_manager`, `mission_step_repository`, and `runtime_bridge`
- clear actionable unused-parameter findings in the runtime engine

## Validation
- `uv run ruff check src/runtime/next/runtime_bridge.py src/runtime/next/_internal_runtime/engine.py src/charter/pack_manager.py src/doctrine/missions/mission_step_repository.py`
- `uv run pytest -q tests/doctrine/missions/test_mission_step_resolver.py tests/charter/test_pack_manager.py tests/charter/test_pack_manager_catalog.py tests/next/test_runtime_bridge_unit.py`

## Sonar / security triage
- GitHub alerts reviewed: 0 open dependabot, 0 open secret-scanning, 0 open code-scanning alerts.
- SonarCloud overnight `main` scan (`2026-06-02T07:11:42Z`, scheduled run `26803809392`) still has inherited gate debt, but these code changes address actionable code-backed findings in touched files.
- Investigated remaining Sonar hotspots on localhost `HTTPServer` bind sites (`dashboard/server.py`, `sync/daemon.py`): both are loopback-only control planes, so no code change here; hotspot review/rationale remains a Sonar UI task if maintainers want the gate metric to move.
