### PR TITLE
Fix 3.2 CLI UX rough edges

### DIFF
--- a/docs/how-to/create-specification.md
+++ b/docs/how-to/create-specification.md
@@ -21,6 +21,8 @@ In your agent:
 
 Run it from the repository root checkout. Planning artifacts are created in `kitty-specs/` on the mission's target branch, and no worktrees are created during specify. If you do not pass `--target-branch`, Spec Kitty uses the current branch.
 
+When you run the direct CLI form (`spec-kitty specify <description>`), it creates the mission scaffold and marks the result as scaffold-only. Fill `spec.md` with the complete specification before running `spec-kitty plan --mission <mission>`.
+
 ## The Discovery Interview
 
 After the command, the CLI interviews you for missing details. You must answer each question before the spec is generated. Expect the agent to respond with `WAITING_FOR_DISCOVERY_INPUT` until the interview is complete.
@@ -37,7 +39,7 @@ After the command, the CLI interviews you for missing details. You must answer e
 /spec-kitty.specify Build a photo organizer that groups albums by date and supports drag-and-drop reordering.
 ```
 
-During discovery, answer follow-up questions (roles, constraints, success criteria). Once complete, the spec is written to `kitty-specs/<feature>/spec.md` on the mission's target branch.
+During discovery, answer follow-up questions (roles, constraints, success criteria). Once complete, write the specification content to `kitty-specs/<feature>/spec.md` on the mission's target branch.
 
 ## Troubleshooting
 

--- a/kitty-specs/charter-ux-and-org-pack-vocabulary-01KSAF14/contracts/charter-preflight-json.md
+++ b/kitty-specs/charter-ux-and-org-pack-vocabulary-01KSAF14/contracts/charter-preflight-json.md
@@ -46,7 +46,8 @@ Options:
   ],
   "auto_refresh_applied": true | false,
   "auto_refresh_actions": ["spec-kitty charter sync", "spec-kitty charter synthesize"],
-  "blocked_reason": "human-readable" | null
+  "blocked_reason": "human-readable" | null,
+  "warnings": ["human-readable advisory"]
 }
 ```
 
@@ -58,6 +59,9 @@ Options:
 | `auto_refresh_applied` | `true` iff `--auto-refresh` was honoured AND at least one refresh action ran. |
 | `auto_refresh_actions` | Ordered list of exact commands executed. |
 | `blocked_reason` | Non-null iff `passed=false` AND `auto_refresh_applied=false`. The string MUST include an actionable next command. |
+| `warnings` | Structured non-blocking advisory messages. Human warning text MUST NOT be prepended to JSON stdout. |
+
+Fresh projects with no authored charter stack (`charter_source`, `synced_bundle`, and `synthesized_drg` all `missing`) are advisory only for read-only/dashboard consumers that explicitly enable missing-charter tolerance. In that mode the runner returns `passed=true`, marks checks `skipped`, and places the missing-charter guidance in `warnings`. Mutation gates leave this tolerance disabled so actions that require charter-derived state still fail closed.
 
 ## Safety rule (FR-008)
 

--- a/kitty-specs/charter-ux-and-org-pack-vocabulary-01KSAF14/contracts/charter-preflight-json.md
+++ b/kitty-specs/charter-ux-and-org-pack-vocabulary-01KSAF14/contracts/charter-preflight-json.md
@@ -59,7 +59,7 @@ Options:
 | `auto_refresh_applied` | `true` iff `--auto-refresh` was honoured AND at least one refresh action ran. |
 | `auto_refresh_actions` | Ordered list of exact commands executed. |
 | `blocked_reason` | Non-null iff `passed=false` AND `auto_refresh_applied=false`. The string MUST include an actionable next command. |
-| `warnings` | Structured non-blocking advisory messages. Human warning text MUST NOT be prepended to JSON stdout. |
+| `warnings` | Optional structured non-blocking advisory messages. Omitted when empty for backward compatibility. Human warning text MUST NOT be prepended to JSON stdout. |
 
 Fresh projects with no authored charter stack (`charter_source`, `synced_bundle`, and `synthesized_drg` all `missing`) are advisory only for read-only/dashboard consumers that explicitly enable missing-charter tolerance. In that mode the runner returns `passed=true`, marks checks `skipped`, and places the missing-charter guidance in `warnings`. Mutation gates leave this tolerance disabled so actions that require charter-derived state still fail closed.
 

--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -332,7 +332,7 @@ def load_governance_config(repo_root: Path) -> GovernanceConfig:
         if charter_path.exists():
             logger.warning("governance.yaml unavailable after charter auto-sync. Using empty governance config.")
         else:
-            logger.warning("governance.yaml not found and charter.md is absent. Using empty governance config.")
+            logger.info("governance.yaml not found and charter.md is absent. Using empty governance config.")
         return GovernanceConfig()
 
     # Check staleness
@@ -378,7 +378,7 @@ def load_directives_config(repo_root: Path) -> DirectivesConfig:
         if charter_path.exists():
             logger.warning("directives.yaml unavailable after charter auto-sync. Using empty directives config.")
         else:
-            logger.warning("directives.yaml not found and charter.md is absent. Using empty directives config.")
+            logger.info("directives.yaml not found and charter.md is absent. Using empty directives config.")
         return DirectivesConfig()
 
     metadata_path = charter_dir / _METADATA_FILENAME

--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -241,14 +241,27 @@ def _parse_wp_sections_from_tasks_md(tasks_content: str) -> dict[str, str]:
     """Extract WP sections from tasks.md keyed by WP ID."""
     sections: dict[str, str] = {}
     matches: list[tuple[str, int, int]] = []
-    offset = 0
+    content_len = len(tasks_content)
+    search_at = 0
 
-    for line in tasks_content.splitlines(keepends=True):
+    while True:
+        wp_pos = tasks_content.find("WP", search_at)
+        if wp_pos == -1:
+            break
+
+        line_start = tasks_content.rfind("\n", 0, wp_pos) + 1
+        newline = tasks_content.find("\n", wp_pos)
+        line_end = content_len if newline == -1 else newline + 1
+        search_at = line_end
+
+        if not tasks_content.startswith("##", line_start):
+            continue
+
+        line = tasks_content[line_start:line_end]
         heading = _extract_wp_heading(line)
         if heading is not None:
             wp_id, matched_prefix_len = heading
-            matches.append((wp_id, offset + matched_prefix_len, offset))
-        offset += len(line)
+            matches.append((wp_id, line_start + matched_prefix_len, line_start))
 
     for idx, (wp_id, start, _line_start) in enumerate(matches):
         end = matches[idx + 1][2] if idx + 1 < len(matches) else len(tasks_content)
@@ -263,13 +276,19 @@ def _parse_requirement_refs_from_tasks_md(tasks_content: str) -> dict[str, list[
 
     for wp_id, section_content in _parse_wp_sections_from_tasks_md(tasks_content).items():
         refs: list[str] = []
-        ref_line_matches = re.findall(
-            r"\*?\*?Requirements?\s*(?:Refs)?\*?\*?\s*:\s*(.+)",
-            section_content,
-            re.IGNORECASE,
-        )
-        for match in ref_line_matches:
-            refs.extend(ref_id.upper() for ref_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", match, re.IGNORECASE))
+        for line in section_content.splitlines():
+            if "Requirement" not in line and "requirement" not in line:
+                continue
+            ref_line_match = re.search(
+                r"\*?\*?Requirements?\s*(?:Refs)?\*?\*?\s*:\s*(.+)",
+                line,
+                re.IGNORECASE,
+            )
+            if ref_line_match:
+                refs.extend(
+                    ref_id.upper()
+                    for ref_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", ref_line_match.group(1), re.IGNORECASE)
+                )
         requirement_refs[wp_id] = list(dict.fromkeys(refs))
 
     return requirement_refs

--- a/src/specify_cli/charter_runtime/preflight/hook.py
+++ b/src/specify_cli/charter_runtime/preflight/hook.py
@@ -113,6 +113,7 @@ def run_preflight_for_dashboard(repo_root: Path) -> CharterPreflightResult:
     result = run_charter_preflight(
         repo_root=repo_root,
         auto_refresh=cfg.auto_refresh,
+        allow_missing_charter=True,
         strict=False,
     )
     if result.passed:

--- a/src/specify_cli/charter_runtime/preflight/result.py
+++ b/src/specify_cli/charter_runtime/preflight/result.py
@@ -84,6 +84,8 @@ class CharterPreflightResult:
         blocked_reason: Non-``None`` iff ``passed`` is ``False`` AND
             ``auto_refresh_applied`` is ``False``.  The string MUST include
             an actionable next command.
+        warnings: Structured non-blocking operator notes.  Machine consumers
+            read these from JSON instead of scraping human warning text.
     """
 
     passed: bool
@@ -91,6 +93,7 @@ class CharterPreflightResult:
     auto_refresh_applied: bool = False
     auto_refresh_actions: list[str] = field(default_factory=list)
     blocked_reason: str | None = None
+    warnings: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-ready dict matching the contract shape.
@@ -98,13 +101,16 @@ class CharterPreflightResult:
         Uses :func:`dataclasses.asdict` so frozen child dataclasses are
         flattened recursively.  Key ordering is fixed (insertion order).
         """
-        return {
+        payload: dict[str, object] = {
             "passed": self.passed,
             "checks": [asdict(c) for c in self.checks],
             "auto_refresh_applied": self.auto_refresh_applied,
             "auto_refresh_actions": list(self.auto_refresh_actions),
             "blocked_reason": self.blocked_reason,
         }
+        if self.warnings:
+            payload["warnings"] = list(self.warnings)
+        return payload
 
     def to_json(self) -> str:
         """Serialise to a stable JSON string with sorted keys.

--- a/src/specify_cli/charter_runtime/preflight/runner.py
+++ b/src/specify_cli/charter_runtime/preflight/runner.py
@@ -59,6 +59,11 @@ _LAYER_ORDER: tuple[tuple[str, str], ...] = (
 # Passing states — see contracts/charter-preflight-json.md "State semantics".
 _PASS_STATES: frozenset[str] = frozenset({"fresh", "skipped", "built_in_only"})
 
+_FRESH_PROJECT_MISSING_CHARTER_WARNING = (
+    "project charter is not initialized; run `spec-kitty charter generate` "
+    "when this project is ready for charter-governed workflows"
+)
+
 # Refresh-step timeout.  Overridable via env so very slow CI runners can
 # extend the deadline without code changes (risk note in WP03 spec).
 _REFRESH_TIMEOUT_ENV = "SPEC_KITTY_PREFLIGHT_TIMEOUT_SECS"
@@ -87,6 +92,7 @@ def run_charter_preflight(
     repo_root: Path,
     *,
     auto_refresh: bool = False,
+    allow_missing_charter: bool = False,
     strict: bool = False,  # noqa: ARG001 — surfaced for caller symmetry; consumed by CLI exit-code mapping, not by the runner itself.
 ) -> CharterPreflightResult:
     """Compute charter freshness, optionally refresh, return a result.
@@ -97,6 +103,10 @@ def run_charter_preflight(
             checks rather than exceptions.
         auto_refresh: When ``True`` AND the worktree has no uncommitted
             generated artifacts, attempt the safe refresh sequence.
+        allow_missing_charter: Treat a fully absent charter stack as advisory.
+            Read-only/dashboard consumers may enable this for fresh projects;
+            mutation gates leave it disabled so missing governance still fails
+            closed when the workflow requires charter-derived state.
         strict: Accepted for API symmetry with the CLI flag.  The runner
             itself does not change behaviour based on ``strict`` — the CLI
             wrapper translates ``passed=False`` + ``strict=True`` into exit
@@ -109,6 +119,25 @@ def run_charter_preflight(
     """
     freshness = compute_freshness(repo_root)
     checks = _build_checks(freshness)
+
+    if allow_missing_charter and _is_optional_missing_charter_fresh_project(checks):
+        return CharterPreflightResult(
+            passed=True,
+            checks=[
+                CharterPreflightCheck(
+                    name=c.name,
+                    state="skipped",
+                    detail="project charter is not initialized",
+                    remediation=None,
+                )
+                for c in checks
+            ],
+            auto_refresh_applied=False,
+            auto_refresh_actions=[],
+            blocked_reason=None,
+            warnings=[_FRESH_PROJECT_MISSING_CHARTER_WARNING],
+        )
+
     passed = all(c.state in _PASS_STATES for c in checks)
 
     if passed:
@@ -166,6 +195,21 @@ def _build_checks(freshness: CharterFreshness) -> list[CharterPreflightCheck]:
             )
         )
     return result
+
+
+def _is_optional_missing_charter_fresh_project(checks: list[CharterPreflightCheck]) -> bool:
+    """Return True for a never-initialized charter stack.
+
+    Missing project charter is optional in a fresh project.  Treat only the
+    fully absent stack as advisory; partial/generated residue still blocks so
+    stale charter state remains visible.
+    """
+    states = {c.name: c.state for c in checks}
+    return states == {
+        "charter_source": "missing",
+        "synced_bundle": "missing",
+        "synthesized_drg": "missing",
+    }
 
 
 def _default_detail(label: str, state: str, last_change: str | None) -> str:

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -892,7 +892,13 @@ def create_mission(
             "created_at": str(result.meta.get("created_at", "")),
             "created_files": [str(spec_file), str(meta_file), str(tasks_readme)],
             "write_mode": "update_existing_files",
-            "next_step": "Read then update spec_file/meta_file; do not recreate with blind write.",
+            "scaffold_only": True,
+            "requires_agent_authoring": True,
+            "plan_guard": "SPEC_NOT_SUBSTANTIVE_OR_UNCOMMITTED",
+            "next_step": (
+                "Created scaffold only. Run `/spec-kitty.specify <intent>` in your agent "
+                "or edit and commit spec_file before `spec-kitty plan`."
+            ),
             "origin_binding": {
                 "attempted": result.origin_binding_attempted,
                 "succeeded": result.origin_binding_succeeded,
@@ -926,6 +932,10 @@ def create_mission(
         # Issue #846: spec.md is no longer auto-committed at create time.
         # The agent commits it from /spec-kitty.specify after writing substantive content.
         console.print(f"   Meta committed to {result.target_branch}; spec.md scaffold left untracked")
+        console.print(
+            "   [yellow]Scaffold only:[/yellow] run [cyan]/spec-kitty.specify <intent>[/cyan] "
+            "in your agent, or edit and commit spec.md before planning."
+        )
 
 
 @app.command(name="check-prerequisites")

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -746,7 +746,8 @@ def _shared_artifact_guidance(workspace, repo_root: Path, mission_slug: str) -> 
     if workspace.lane_id:
         return [
             "📚 SHARED MISSION ARTIFACTS:",
-            "   Spec, plan, and tasks live in the main repo. Status authority is the coordination branch for modern missions.",
+            f"   Spec, plan, tasks, and status live in main repo: {repo_root}/kitty-specs/{mission_slug}/",
+            "   Status authority syncs through the coordination branch for modern missions.",
             "   Use this lane workspace for code/tests; do not expect shared mission artifacts here",
         ]
 
@@ -1267,7 +1268,7 @@ def implement(
 
             operational_context = build_operational_context_for_claim(
                 repo_root=main_repo_root,
-                feature_dir=_impl_feature_dir,
+                feature_dir=feature_dir,
                 mission_slug=mission_slug,
                 wp_id=normalized_wp_id,
                 actor=_actor,

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -411,34 +411,22 @@ def _agent_command_token(agent_key: str, command: str) -> str:
 def _workflow_lines_for_agent(agent_key: str) -> tuple[str, list[str]]:
     """Return next-step heading and installed workflow commands for a harness."""
     if agent_key in _COMMAND_SKILL_AGENTS:
-        heading = "Build your specification with command skills (in workflow order):"
+        heading = "Build with command skills:"
         commands = [
-            ("charter", "Establish project principles"),
-            ("specify", "Create baseline specification"),
-            ("plan", "Create implementation plan"),
-            ("research", "Run mission-specific Phase 0 research scaffolding"),
-            ("tasks", "Generate work packages"),
-            ("tasks-outline", "Create package outline"),
-            ("tasks-packages", "Generate work packages from outline"),
-            ("tasks-finalize", "Finalize generated work packages"),
-            ("review", "Review prompts and move them to /tasks/done/"),
+            ("specify", "write the spec"),
+            ("plan", "write the plan"),
+            ("tasks", "create work packages"),
         ]
     else:
-        heading = "Build your specification with slash commands (in workflow order):"
+        heading = "Build with slash commands:"
         commands = [
-            ("dashboard", "Open the real-time kanban dashboard"),
-            ("charter", "Establish project principles"),
-            ("specify", "Create baseline specification"),
-            ("plan", "Create implementation plan"),
-            ("research", "Run mission-specific Phase 0 research scaffolding"),
-            ("tasks", "Generate work packages"),
-            ("review", "Review prompts and move them to /tasks/done/"),
-            ("accept", "Run acceptance checks and verify mission complete"),
-            ("merge", "Merge mission into target branch and cleanup worktree"),
+            ("specify", "write the spec"),
+            ("plan", "write the plan"),
+            ("tasks", "create work packages"),
         ]
 
     return heading, [
-        f"   - [cyan]{_agent_command_token(agent_key, command)}[/] - {description}"
+        f"[cyan]{_agent_command_token(agent_key, command)}[/] ({description})"
         for command, description in commands
     ]
 
@@ -618,8 +606,8 @@ def init(  # noqa: C901
         probe_dir = project_path if project_path.exists() else project_path.parent
         if not _is_inside_git_work_tree(probe_dir):
             _console.print(
-                "[yellow]ℹ Target is not a git repository[/yellow] — "
-                "run `git init` here before using `spec-kitty agent ...` commands."
+                "[yellow]Target is not a git repository.[/yellow] "
+                "After init, run `git init` in the target before using `spec-kitty agent ...` commands."
             )
     except VCSNotFoundError:
         # git not available - not an error, just informational
@@ -944,46 +932,48 @@ def init(  # noqa: C901
         _console.print()
         _console.print(security_notice)
 
-    # Boxed "Next steps" section
-    steps_lines = []
-    # FR-005 (#636): When the target is NOT inside a git work tree, prepend
-    # a "Run git init" bullet ABOVE all other next-step items so it is the
-    # first thing the user sees. Recompute against the now-existing
-    # project_path (not the parent) for the post-init check.
-    if not _is_inside_git_work_tree(project_path):
-        steps_lines.append(
-            "○ [yellow]Run [cyan]git init[/cyan][/yellow] - this directory is not yet a git repository"
-        )
+    # Boxed "Next steps" section. Keep first-run guidance short: immediate
+    # setup blocker, first workflow command, then optional tools.
+    steps_lines = [
+        f"Project: [green]{project_path}[/green]",
+        f"Agents: [cyan]{', '.join(selected_agents)}[/cyan]",
+    ]
+    # FR-005 (#636): when target is not inside a git work tree, make git init
+    # a numbered required action. Recompute against the now-existing project_path.
+    inside_git = _is_inside_git_work_tree(project_path)
+    steps_lines.append(
+        "Git: [green]ready[/green]" if inside_git else "Git: [yellow]not initialized[/yellow]"
+    )
+    steps_lines.append("")
     step_num = 1
     if not here:
-        steps_lines.append(f"{step_num}. Go to the project folder: [cyan]cd {project_name}[/cyan]")
+        steps_lines.append(f"{step_num}. Enter the project: [cyan]cd {project_name}[/cyan]")
+        step_num += 1
     else:
-        steps_lines.append(f"{step_num}. You're already in the project directory!")
-    step_num += 1
-
-    steps_lines.append(
-        f"{step_num}. Available missions: [cyan]software-dev[/cyan], [cyan]research[/cyan] "
-        f"(selected per-mission during [cyan]{_agent_command_token(_primary_next_step_agent(selected_agents), 'specify')}[/cyan])"
-    )
-    step_num += 1
+        steps_lines.append(f"{step_num}. Stay in this project directory.")
+        step_num += 1
+    if not inside_git:
+        steps_lines.append(
+            f"{step_num}. [yellow]Required:[/yellow] run [cyan]git init[/cyan] here before agent/worktree commands"
+        )
+        step_num += 1
 
     primary_agent = _primary_next_step_agent(selected_agents)
     workflow_heading, workflow_lines = _workflow_lines_for_agent(primary_agent)
-    steps_lines.append(f"{step_num}. {workflow_heading}")
+    steps_lines.append(f"{step_num}. {workflow_heading} {' -> '.join(workflow_lines)}")
     step_num += 1
 
-    steps_lines.extend(workflow_lines)
-    steps_lines.append("   - [cyan]spec-kitty retrospect summary[/] - Review retrospective status after merge")
-    step_num += 1
-
-    # T003: Canonical post-#555 agent loop path
-    steps_lines.append(f"{step_num}. Run your agent loop (canonical workflow):")
-    steps_lines.append("   [dim]Enter the mission loop:[/dim]")
-    steps_lines.append("     [cyan]spec-kitty next --agent <agent> --mission <slug>[/cyan]")
+    steps_lines.append(
+        f"{step_num}. Run the mission loop: [cyan]spec-kitty next --agent <agent> --mission <slug>[/cyan]"
+    )
     steps_lines.append("")
-    steps_lines.append("   [dim]Your agent will call per-WP actions:[/dim]")
-    steps_lines.append("     [cyan]spec-kitty agent action implement <WP> --agent <name>[/cyan]  [dim](implement a work package)[/dim]")  # noqa: E501
-    steps_lines.append("     [cyan]spec-kitty agent action review    <WP> --agent <name>[/cyan]  [dim](review a work package)[/dim]")  # noqa: E501
+    steps_lines.append("[dim]Optional[/dim]")
+    steps_lines.append(f"- [cyan]{_agent_command_token(primary_agent, 'charter')}[/cyan] - add project governance when needed")
+    steps_lines.append("- [cyan]spec-kitty dashboard[/cyan] - open local project dashboard")
+    steps_lines.append("- [cyan]spec-kitty retrospect summary[/cyan] - review learning status after merge")
+    steps_lines.append(f"- [cyan]{_agent_command_token(primary_agent, 'analyze')}[/cyan] - check artifact alignment")
+    steps_lines.append("")
+    steps_lines.append("[dim]Docs: https://docs.spec-kitty.ai/[/dim]")
 
     steps_panel = Panel("\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1, 2))
     _console.print()
@@ -1047,12 +1037,12 @@ def init(  # noqa: C901
         _console.print(letta_panel)
 
     enhancement_lines = [
-        "Optional commands that you can use for your specs [bright_black](improve quality & confidence)[/bright_black]",
+        "Optional quality checks.",
         "",
         f"○ [cyan]{_agent_command_token(primary_agent, 'analyze')}[/] [bright_black](optional)[/bright_black] - "
         f"Cross-artifact consistency & alignment report (after [cyan]{_agent_command_token(primary_agent, 'tasks')}[/])",
     ]
-    enhancements_panel = Panel("\n".join(enhancement_lines), title="Enhancement Commands", border_style="cyan", padding=(1, 2))
+    enhancements_panel = Panel("\n".join(enhancement_lines), title="Optional Enhancements", border_style="cyan", padding=(1, 2))
     _console.print()
     _console.print(enhancements_panel)
 

--- a/src/specify_cli/cli/commands/lifecycle.py
+++ b/src/specify_cli/cli/commands/lifecycle.py
@@ -7,6 +7,7 @@ agent lifecycle implementations.
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import re
 from pathlib import Path
@@ -18,6 +19,7 @@ from specify_cli.cli.selector_resolution import resolve_selector
 from specify_cli.cli.commands.agent import mission as agent_feature
 from specify_cli.core.paths import locate_project_root
 from specify_cli.workspace.assert_initialized import (
+    SPEC_KITTY_REPO_NOT_INITIALIZED,
     SpecKittyNotInitialized,
     assert_initialized,
 )
@@ -40,7 +42,53 @@ PLAN_WIDEN_QUESTIONS: list[tuple[str, str]] = [
 _console = Console()
 
 
-def _enforce_initialized(*, require_specs: bool = True) -> None:
+def _scaffold_next_action(mission_slug: str) -> str:
+    return (
+        "Open spec_file and replace the scaffold with a complete specification; "
+        f"then run `spec-kitty plan --mission {mission_slug}`."
+    )
+
+
+def _with_specify_scaffold_state(payload: dict[str, object], mission_slug: str) -> dict[str, object]:
+    """Expose that direct ``spec-kitty specify`` only creates a scaffold."""
+    enriched = dict(payload)
+    enriched["scaffold_only"] = True
+    enriched["spec_state"] = "scaffold_only"
+    enriched["next_action"] = _scaffold_next_action(str(enriched.get("mission_slug") or mission_slug))
+    enriched["next_step"] = enriched["next_action"]
+    return enriched
+
+
+def _emit_scaffold_only_guidance(mission_slug: str) -> None:
+    _console.print("[yellow]Scaffold-only:[/yellow] spec.md was created as a scaffold; no complete spec was authored.")
+    _console.print(f"[cyan]Next:[/cyan] {_scaffold_next_action(mission_slug)}")
+
+
+def _create_mission_for_specify_json(slug: str, mission_type: str | None) -> None:
+    """Run mission creation and enrich its single JSON payload for direct specify."""
+    capture = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(capture):
+            agent_feature.create_mission(mission_slug=slug, mission_type=mission_type, json_output=True)
+    except typer.Exit:
+        print(capture.getvalue(), end="")
+        raise
+
+    output = capture.getvalue()
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        print(json.dumps(_with_specify_scaffold_state(payload, slug)))
+        return
+    print(output, end="")
+
+
+def _enforce_initialized(*, require_specs: bool = True, json_output: bool = False) -> None:
     """Fail-loud if the cwd's canonical repo is not a Spec Kitty project (FR-032).
 
     Symmetric with FR-005's no-silent-fallback selector stance: if the
@@ -52,6 +100,16 @@ def _enforce_initialized(*, require_specs: bool = True) -> None:
     try:
         assert_initialized(require_specs=require_specs)
     except SpecKittyNotInitialized as exc:
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "error_code": SPEC_KITTY_REPO_NOT_INITIALIZED,
+                        "error": str(exc),
+                    }
+                )
+            )
+            raise typer.Exit(code=1) from exc
         _console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
 
@@ -71,7 +129,7 @@ def specify(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON result"),
 ) -> None:
     """Create a feature scaffold in kitty-specs/."""
-    _enforce_initialized(require_specs=False)
+    _enforce_initialized(require_specs=False, json_output=json_output)
     slug = _slugify_feature_input(feature)
     resolved_mission_type = mission_type
     if mission_type is not None or mission is not None:
@@ -84,7 +142,11 @@ def specify(
             command_hint="--mission-type <name>",
         )
         resolved_mission_type = resolved.canonical_value
-    agent_feature.create_mission(mission_slug=slug, mission_type=resolved_mission_type, json_output=json_output)
+    if json_output:
+        _create_mission_for_specify_json(slug, resolved_mission_type)
+    else:
+        agent_feature.create_mission(mission_slug=slug, mission_type=resolved_mission_type, json_output=False)
+        _emit_scaffold_only_guidance(slug)
 
     # FR-002: Wire widen-enabled interview for the specify flow.
     # Only run in interactive (non-JSON) mode so agent/script callers are unaffected.
@@ -108,7 +170,7 @@ def plan(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON result"),
 ) -> None:
     """Scaffold plan.md for a feature."""
-    _enforce_initialized()
+    _enforce_initialized(json_output=json_output)
     resolved_mission = None
     if mission is not None or feature is not None:
         resolved = resolve_selector(
@@ -185,7 +247,7 @@ def tasks(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON result"),
 ) -> None:
     """Finalize tasks metadata after task generation."""
-    _enforce_initialized()
+    _enforce_initialized(json_output=json_output)
     resolved_mission = None
     if mission is not None or feature is not None:
         try:

--- a/src/specify_cli/cli/commands/next_cmd.py
+++ b/src/specify_cli/cli/commands/next_cmd.py
@@ -100,19 +100,7 @@ def next_step(
     # has not yet been synthesized (e.g., fresh clones, test envs).
     from pathlib import Path as _Path
 
-    if result is not None:
-        from specify_cli.charter_runtime.preflight.hook import run_preflight_or_abort
-
-        run_preflight_or_abort(_Path(str(repo_root)), consumer="next")
-    else:
-        from specify_cli.charter_runtime.preflight.hook import run_preflight_for_dashboard
-
-        # Query mode: warn-and-continue. The dashboard helper logs at
-        # warning level on failure and returns without raising. We
-        # explicitly ignore the result here because query mode does not
-        # mutate state and the operator is only asking "what is my
-        # mission state?".
-        run_preflight_for_dashboard(_Path(str(repo_root)))
+    _run_charter_preflight_for_next(_Path(str(repo_root)), advancing=result is not None, json_output=json_output)
 
     mission_slug = _resolve_mission_slug(mission, feature)
     _validate_result_and_answer(result, answer, json_output)
@@ -276,6 +264,43 @@ def _maybe_emit_runtime_notice(json_output: bool) -> None:
     # combine stderr into result.output.
     if not json_output:
         maybe_emit_runtime_pkg_notice()
+
+
+def _run_charter_preflight_for_next(repo_root, *, advancing: bool, json_output: bool) -> None:
+    """Run charter preflight without letting advisory text contaminate JSON stdout."""
+    if advancing:
+        from specify_cli.charter_runtime.preflight.hook import run_preflight_or_abort
+
+        if json_output:
+            stderr_buffer = io.StringIO()
+            error_payload: dict[str, str] | None = None
+            with (
+                contextlib.redirect_stdout(sys.stderr),
+                contextlib.redirect_stderr(stderr_buffer),
+            ):
+                try:
+                    run_preflight_or_abort(repo_root, consumer="next")
+                    return
+                except typer.Exit:
+                    message = stderr_buffer.getvalue().strip() or "charter preflight failed"
+                    blocked_reason = message.removeprefix("Error: ").strip()
+                    error_payload = {
+                        "error_code": "CHARTER_PREFLIGHT_FAILED",
+                        "error": message,
+                        "blocked_reason": blocked_reason,
+                    }
+            if error_payload is not None:
+                print(json.dumps(error_payload))
+                raise typer.Exit(1)
+        run_preflight_or_abort(repo_root, consumer="next")
+        return
+
+    from specify_cli.charter_runtime.preflight.hook import run_preflight_for_dashboard
+
+    # Query mode is read-only: warn-and-continue, like dashboard.
+    stdout_redirect = contextlib.redirect_stdout(sys.stderr) if json_output else contextlib.nullcontext()
+    with stdout_redirect:
+        run_preflight_for_dashboard(repo_root)
 
 
 def _resolve_mission_slug(mission: str | None, feature: str | None) -> str:

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -102,6 +102,10 @@ def _transaction_topology_available(identity: _TransactionIdentity, mission_slug
     )
 
 
+def _is_coordination_feature_dir(feature_dir: Path) -> bool:
+    return ".worktrees" in feature_dir.parts
+
+
 def _identity_for_request(request: TransitionRequest) -> _TransactionIdentity:
     raw_feature_dir = request.feature_dir or request.mission_dir
     if raw_feature_dir is None:
@@ -239,6 +243,8 @@ def _read_events_from_transaction_target(
 ) -> list[StatusEvent]:
     """Read target status events without creating worktrees or commits."""
     if not _transaction_topology_available(identity, mission_slug):
+        if _is_coordination_feature_dir(identity.feature_dir):
+            return read_event_log(EventLogReadContract.coordination_worktree(identity.feature_dir))
         return read_event_log(EventLogReadContract.primary_checkout(identity.feature_dir))
     if identity.coordination_branch is None:
         return read_event_log(EventLogReadContract.primary_checkout(identity.feature_dir))
@@ -305,6 +311,8 @@ def _read_contract_from_transaction_target(
 ) -> EventLogReadContract:
     """Resolve the read-only contract for the transaction write target."""
     if not _transaction_topology_available(identity, mission_slug):
+        if _is_coordination_feature_dir(identity.feature_dir):
+            return EventLogReadContract.coordination_worktree(identity.feature_dir)
         return EventLogReadContract.primary_checkout(identity.feature_dir)
     if identity.coordination_branch is None:
         return EventLogReadContract.primary_checkout(identity.feature_dir)

--- a/src/specify_cli/template/manager.py
+++ b/src/specify_cli/template/manager.py
@@ -176,7 +176,7 @@ def get_local_repo_root(override_path: str | None = None) -> Path | None:
         if (override / ".kittify" / "templates" / "command-templates").exists():
             return override
         console.print(
-            f"[yellow]--template-root set to {override}, but src/doctrine/templates/command-templates not found there. Ignoring.[/yellow]"  # noqa: E501
+            f"[yellow]--template-root {override} is not a Spec Kitty checkout/template root; using packaged templates.[/yellow]"  # noqa: E501
         )
 
     # Check environment variable
@@ -189,7 +189,7 @@ def get_local_repo_root(override_path: str | None = None) -> Path | None:
         if (root_path / ".kittify" / "templates" / "command-templates").exists():
             return root_path
         console.print(
-            f"[yellow]SPEC_KITTY_TEMPLATE_ROOT set to {root_path}, but src/doctrine/templates/command-templates not found there. Ignoring.[/yellow]"  # noqa: E501
+            f"[yellow]SPEC_KITTY_TEMPLATE_ROOT {root_path} is not a Spec Kitty checkout/template root; using packaged templates.[/yellow]"  # noqa: E501
         )
 
     # Check package location

--- a/tests/agent/cli/commands/test_charter_cli.py
+++ b/tests/agent/cli/commands/test_charter_cli.py
@@ -258,6 +258,25 @@ def test_context_compact_mode_auto_syncs_missing_extracted_artifacts(tmp_path: P
         assert "Run 'spec-kitty charter sync'" not in second.stdout
 
 
+def test_context_json_stdout_is_single_json_value_for_missing_charter(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with patch("specify_cli.cli.commands.charter.find_repo_root") as mock_find_root:
+        mock_find_root.return_value = repo_root
+
+        result = runner.invoke(app, ["context", "--action", "specify", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["project_charter"]["present"] is False
+    assert result.stdout.strip().startswith("{")
+    assert result.stdout.strip().endswith("}")
+    assert "WARNING" not in result.stdout
+    assert "WARNING" not in result.stderr
+
+
 def test_help_output() -> None:
     result = runner.invoke(app, ["--help"])
 

--- a/tests/charter/test_integration.py
+++ b/tests/charter/test_integration.py
@@ -182,23 +182,25 @@ class TestLoaderFunctions:
     def test_load_governance_config_missing_yaml_returns_empty(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        caplog.clear()
-        config = load_governance_config(tmp_path)
+        with caplog.at_level(logging.INFO, logger="charter.sync"):
+            config = load_governance_config(tmp_path)
 
         assert isinstance(config, GovernanceConfig)
         assert config.testing.min_coverage == 0
         assert config.testing.tdd_required is False
         assert any("governance.yaml not found and charter.md is absent" in record.message for record in caplog.records)
+        assert all(record.levelno < logging.WARNING for record in caplog.records)
 
     def test_load_directives_config_missing_yaml_returns_empty(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        caplog.clear()
-        config = load_directives_config(tmp_path)
+        with caplog.at_level(logging.INFO, logger="charter.sync"):
+            config = load_directives_config(tmp_path)
 
         assert isinstance(config, DirectivesConfig)
         assert len(config.directives) == 0
         assert any("directives.yaml not found and charter.md is absent" in record.message for record in caplog.records)
+        assert all(record.levelno < logging.WARNING for record in caplog.records)
 
     def test_load_governance_config_missing_yaml_auto_syncs_when_charter_present(self, tmp_path: Path) -> None:
         charter_dir = tmp_path / ".kittify" / "charter"

--- a/tests/init/test_init_next_steps.py
+++ b/tests/init/test_init_next_steps.py
@@ -1,8 +1,8 @@
-"""T1.4 — Regression tests: init next-steps output names spec-kitty next.
+"""Regression tests: init next-steps output is concise and actionable.
 
 Verifies:
 - Captured output contains "spec-kitty next"
-- Captured output contains "spec-kitty agent action implement"
+- Non-git targets promote git init as the required next action
 - Captured output does NOT contain "spec-kitty implement WP" (bare top-level CLI)
 - The literal string "Initial commit from Specify template" is absent from src/
 
@@ -58,16 +58,16 @@ def _fake_copy_package(project_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# T1.4: Next-steps output names spec-kitty next + agent action
+# T1.4: Next-steps output names spec-kitty next + first workflow path
 # ---------------------------------------------------------------------------
 
 def test_init_next_steps_names_spec_kitty_next(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """T1.4: init output contains 'spec-kitty next' and 'spec-kitty agent action implement'.
+    """T1.4: init output contains a concise first-run path and mission loop.
 
-    Also asserts the bare top-level CLI invocation 'spec-kitty implement WP' is absent.
+    Also asserts old dense per-WP command catalog entries are absent.
     """
     app, buf = _make_app_with_buf()
 
@@ -88,16 +88,16 @@ def test_init_next_steps_names_spec_kitty_next(
         f"Actual console output:\n{output}"
     )
 
-    # The per-WP implement verb must appear
-    assert "spec-kitty agent action implement" in output, (
-        "Expected 'spec-kitty agent action implement' in init console output, but it was absent.\n"
-        f"Actual console output:\n{output}"
-    )
-
     assert "$spec-kitty.specify" in output, (
         "Codex init next steps must use Codex skill invocation syntax.\n"
         f"Actual console output:\n{output}"
     )
+    assert "$spec-kitty.plan" in output
+    assert "$spec-kitty.tasks" in output
+    assert "Required:" in output
+    assert "git init" in output
+    assert "4. Run the mission loop" in output
+    assert "5." not in output
 
     assert "/spec-kitty.dashboard" not in output, (
         "Codex init next steps must not list slash commands that are not installed as command skills.\n"
@@ -110,6 +110,7 @@ def test_init_next_steps_names_spec_kitty_next(
         "this is the old top-level CLI path and must not appear.\n"
         f"Actual console output:\n{output}"
     )
+    assert "spec-kitty agent action implement" not in output
 
 
 def test_init_letta_next_steps_use_slash_skill_syntax(
@@ -146,8 +147,10 @@ def test_init_vibe_next_steps_list_only_installed_command_skills(
     assert result.exit_code == 0, f"init failed (exit_code={result.exit_code})"
 
     output = buf.getvalue()
-    assert "Build your specification with command skills" in output
-    assert "/spec-kitty.tasks-finalize" in output
+    assert "Build with command skills" in output
+    assert "/spec-kitty.specify" in output
+    assert "/spec-kitty.plan" in output
+    assert "/spec-kitty.tasks" in output
     assert "/spec-kitty.dashboard" not in output
     assert "/spec-kitty.accept" not in output
     assert "/spec-kitty.merge" not in output

--- a/tests/next/test_query_mode_unit.py
+++ b/tests/next/test_query_mode_unit.py
@@ -117,6 +117,42 @@ class TestQueryModeDoesNotAdvance:
         assert result.exit_code == 1
         assert "--agent is required when --result is provided" in result.output
 
+    def test_result_json_preflight_failure_returns_error_document(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fail_preflight(*_args, **_kwargs):
+            print("Error: charter_source missing; run `spec-kitty charter sync`", file=__import__("sys").stderr)
+            raise typer.Exit(1)
+
+        monkeypatch.setattr(
+            "specify_cli.charter_runtime.preflight.hook.run_preflight_or_abort",
+            fail_preflight,
+        )
+        with (
+            patch("specify_cli.cli.commands.next_cmd.locate_project_root", return_value=tmp_path),
+            patch("specify_cli.cli.commands.next_cmd.resolve_selector", return_value=SimpleNamespace(canonical_value="069-test")),
+        ):
+            result = runner.invoke(
+                cli_app,
+                [
+                    "next",
+                    "--mission",
+                    "069-test",
+                    "--agent",
+                    "codex",
+                    "--result",
+                    "success",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["error_code"] == "CHARTER_PREFLIGHT_FAILED"
+        assert "charter_source missing" in payload["blocked_reason"]
+
     def test_answer_requires_result_when_used_without_result(self, tmp_path: Path) -> None:
         with (
             patch("specify_cli.cli.commands.next_cmd.locate_project_root", return_value=tmp_path),
@@ -234,6 +270,42 @@ class TestQueryModeOutput:
 
         data = json.loads(result.output)
         assert data.get("is_query") is True
+
+    def test_json_stdout_is_single_json_value_when_preflight_emits_human_text(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Preflight advisory text belongs on stderr, never in ``next --json`` stdout."""
+        from specify_cli.charter_runtime.preflight.result import CharterPreflightResult
+
+        mock_decision = _make_mock_decision(is_query=True)
+
+        def noisy_preflight(*_args, **_kwargs):
+            print("human charter advisory")
+            return CharterPreflightResult(passed=True, checks=[], warnings=["structured advisory"])
+
+        monkeypatch.setattr(
+            "specify_cli.charter_runtime.preflight.hook.run_preflight_for_dashboard",
+            noisy_preflight,
+        )
+
+        with (
+            patch("specify_cli.cli.commands.next_cmd.locate_project_root", return_value=tmp_path),
+            patch("specify_cli.cli.commands.next_cmd.resolve_selector", return_value=SimpleNamespace(canonical_value="069-test")),
+            patch("specify_cli.next.runtime_bridge.query_current_state", return_value=mock_decision),
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["next", "--agent", "claude", "--mission", "069-test", "--json"],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload.get("is_query") is True
+        assert result.stdout.strip().startswith("{")
+        assert result.stdout.strip().endswith("}")
+        assert "human charter advisory" not in result.stdout
 
     def test_human_output_shows_not_started_preview_step(self, tmp_path: Path) -> None:
         mock_decision = _make_mock_decision(is_query=True, mission_state="not_started", preview_step="discovery")

--- a/tests/specify_cli/charter_preflight/test_runner.py
+++ b/tests/specify_cli/charter_preflight/test_runner.py
@@ -48,7 +48,11 @@ from ._fixtures import (
 def test_fresh_repo_passes(tmp_path: Path) -> None:
     """When charter, bundle, and synthesized DRG are all fresh, preflight passes."""
     make_fresh_repo(tmp_path)
-    result = run_charter_preflight(tmp_path, auto_refresh=False)
+    result = run_charter_preflight(
+        tmp_path,
+        auto_refresh=False,
+        allow_missing_charter=True,
+    )
     assert isinstance(result, CharterPreflightResult)
     assert result.passed is True
     assert result.blocked_reason is None
@@ -76,6 +80,36 @@ def test_built_in_only_passes(tmp_path: Path) -> None:
     assert result.passed is True
     drg = next(c for c in result.checks if c.name == "synthesized_drg")
     assert drg.state == "built_in_only"
+
+
+def test_missing_charter_in_fresh_project_is_advisory_not_blocking(tmp_path: Path) -> None:
+    """A never-initialized charter stack is optional and must not warn-spam callers."""
+    init_git_repo(tmp_path)
+
+    result = run_charter_preflight(
+        tmp_path,
+        auto_refresh=False,
+        allow_missing_charter=True,
+    )
+
+    assert result.passed is True
+    assert result.blocked_reason is None
+    assert [c.state for c in result.checks] == ["skipped", "skipped", "skipped"]
+    assert result.warnings == [
+        "project charter is not initialized; run `spec-kitty charter generate` "
+        "when this project is ready for charter-governed workflows"
+    ]
+
+
+def test_missing_charter_blocks_mutation_gates_by_default(tmp_path: Path) -> None:
+    """Shared runner fails closed unless a read-only/dashboard caller opts in."""
+    init_git_repo(tmp_path)
+
+    result = run_charter_preflight(tmp_path, auto_refresh=False)
+
+    assert result.passed is False
+    assert result.blocked_reason is not None
+    assert [c.state for c in result.checks] == ["missing", "missing", "missing"]
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +300,23 @@ def test_to_dict_and_to_json_shape(tmp_path: Path) -> None:
     # to_json round-trips.
     parsed = json.loads(result.to_json())
     assert parsed == as_dict
+
+
+def test_to_dict_includes_warnings_only_when_present(tmp_path: Path) -> None:
+    """The advisory field is additive only when callers need it."""
+    init_git_repo(tmp_path)
+    result = run_charter_preflight(
+        tmp_path,
+        auto_refresh=False,
+        allow_missing_charter=True,
+    )
+
+    as_dict = result.to_dict()
+
+    assert as_dict["warnings"] == [
+        "project charter is not initialized; run `spec-kitty charter generate` "
+        "when this project is ready for charter-governed workflows"
+    ]
 
 
 def test_check_dataclass_is_frozen() -> None:

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -338,6 +338,9 @@ def test_create_json_output_contains_coordination_branch(tmp_path: Path) -> None
     assert "coordination_branch" in payload
     assert payload["coordination_branch"].startswith("kitty/mission-cli-json-test-")
     assert payload["coordination_branch_created"] is True
+    assert payload["scaffold_only"] is True
+    assert payload["requires_agent_authoring"] is True
+    assert payload["plan_guard"] == "SPEC_NOT_SUBSTANTIVE_OR_UNCOMMITTED"
 
 
 def test_pr_bound_create_json_refuses_with_json_instead_of_prompt_abort(tmp_path: Path) -> None:

--- a/tests/specify_cli/cli/commands/test_init_non_git_message.py
+++ b/tests/specify_cli/cli/commands/test_init_non_git_message.py
@@ -89,6 +89,11 @@ def test_init_in_non_git_dir_emits_actionable_message(
     assert GIT_INIT_HINT.search(output), (
         f"Expected 'git init' guidance in output, got:\n{output}"
     )
+    assert "1. Enter the project:" in output
+    assert "2. Required:" in output
+    assert "Git: not initialized" in output
+    assert "spec-kitty dashboard" in output
+    assert output.index("spec-kitty dashboard") > output.index("Optional")
 
     # Scaffold completed: .kittify/ exists, .git/ was NOT auto-created.
     assert (target / ".kittify").is_dir()
@@ -131,3 +136,4 @@ def test_init_in_existing_git_repo_does_not_emit_non_git_message(
     assert not NOT_A_GIT_REPO.search(output), (
         f"Did not expect 'not a git repository' in output, got:\n{output}"
     )
+    assert "Git: ready" in output

--- a/tests/specify_cli/cli/commands/test_specify_scaffold_state.py
+++ b/tests/specify_cli/cli/commands/test_specify_scaffold_state.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+
+import typer
+from typer.testing import CliRunner
+
+import specify_cli.cli.commands.lifecycle as lifecycle
+from specify_cli.cli.commands.lifecycle import specify
+from specify_cli.workspace.assert_initialized import SpecKittyNotInitialized
+
+
+_app = typer.Typer()
+_app.command()(specify)
+runner = CliRunner()
+
+
+def test_specify_json_exposes_scaffold_only_state(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lifecycle,
+        "_enforce_initialized",
+        lambda *, require_specs=True, json_output=False: None,
+    )
+
+    def fake_create_mission(*, mission_slug: str, mission_type: str | None, json_output: bool) -> None:
+        assert mission_slug == "my-feature"
+        assert mission_type is None
+        assert json_output is True
+        print(
+            json.dumps(
+                {
+                    "result": "success",
+                    "mission_slug": mission_slug,
+                    "spec_file": "/tmp/project/kitty-specs/my-feature/spec.md",
+                    "next_step": "old agent guidance",
+                }
+            )
+        )
+
+    monkeypatch.setattr(lifecycle.agent_feature, "create_mission", fake_create_mission)
+
+    result = runner.invoke(_app, ["my feature", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["scaffold_only"] is True
+    assert payload["spec_state"] == "scaffold_only"
+    assert "complete specification" in payload["next_action"]
+    assert payload["next_step"] == payload["next_action"]
+    assert "spec-kitty plan --mission my-feature" in payload["next_action"]
+
+
+def test_specify_json_uninitialized_error_is_json(monkeypatch, tmp_path) -> None:
+    def fail_initialized(*, require_specs: bool = True) -> None:
+        raise SpecKittyNotInitialized(
+            tmp_path,
+            [tmp_path / ".kittify" / "config.yaml"],
+        )
+
+    monkeypatch.setattr(lifecycle, "assert_initialized", fail_initialized)
+
+    result = runner.invoke(_app, ["my feature", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["error_code"] == "SPEC_KITTY_REPO_NOT_INITIALIZED"
+    assert "Spec Kitty is not initialized" in payload["error"]
+
+
+def test_specify_human_output_explains_scaffold_only_state(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lifecycle,
+        "_enforce_initialized",
+        lambda *, require_specs=True, json_output=False: None,
+    )
+    monkeypatch.setattr(lifecycle, "locate_project_root", lambda: None)
+
+    def fake_create_mission(*, mission_slug: str, mission_type: str | None, json_output: bool) -> None:
+        assert mission_slug == "my-feature"
+        assert mission_type is None
+        assert json_output is False
+        lifecycle._console.print("[green]OK[/green] Mission created: my-feature")
+
+    monkeypatch.setattr(lifecycle.agent_feature, "create_mission", fake_create_mission)
+
+    result = runner.invoke(_app, ["my feature"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "Scaffold-only:" in result.output
+    assert "no complete spec was authored" in result.output
+    assert "spec-kitty plan --mission my-feature" in result.output

--- a/tests/test_dashboard/test_dashboard_preflight.py
+++ b/tests/test_dashboard/test_dashboard_preflight.py
@@ -11,6 +11,7 @@ Verifies the FR-006 caller contract for the dashboard consumer:
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -131,6 +132,26 @@ def test_dashboard_hook_clears_warning_on_success(
     assert read_preflight_warning(tmp_path) is None
 
 
+def test_dashboard_hook_does_not_warning_log_optional_missing_charter(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fresh projects without charter state are advisory, not warning-level spam."""
+    import subprocess
+
+    from specify_cli.charter_preflight import hook as hook_mod
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+
+    with caplog.at_level(logging.WARNING, logger=hook_mod.__name__):
+        result = hook_mod.run_preflight_for_dashboard(tmp_path)
+
+    assert result.passed is True
+    assert result.blocked_reason is None
+    assert result.warnings
+    assert caplog.records == []
+
+
 def test_null_project_config_enabled_still_runs_dashboard_preflight(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -152,7 +173,14 @@ def test_null_project_config_enabled_still_runs_dashboard_preflight(
     result = hook_mod.run_preflight_for_dashboard(tmp_path)
 
     assert result.passed is True
-    assert runner_calls == [{"repo_root": tmp_path, "auto_refresh": False, "strict": False}]
+    assert runner_calls == [
+        {
+            "repo_root": tmp_path,
+            "auto_refresh": False,
+            "allow_missing_charter": True,
+            "strict": False,
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_template/test_manager.py
+++ b/tests/test_template/test_manager.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 
 from specify_cli.template import manager, get_local_repo_root
 from specify_cli.template.manager import copy_specify_base_from_local
@@ -23,6 +25,21 @@ def test_get_local_repo_root_prefers_env(monkeypatch: pytest.MonkeyPatch, tmp_pa
         assert repo_root == tmp_path.resolve()
     finally:
         monkeypatch.delenv("SPEC_KITTY_TEMPLATE_ROOT", raising=False)
+
+
+def test_get_local_repo_root_invalid_env_clarifies_packaged_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = io.StringIO()
+    monkeypatch.setenv("SPEC_KITTY_TEMPLATE_ROOT", str(tmp_path))
+    monkeypatch.setattr(manager, "console", Console(file=output, force_terminal=False, width=240))
+
+    repo_root = get_local_repo_root()
+
+    assert repo_root is None or repo_root.exists()
+    assert "not a Spec Kitty checkout/template root" in output.getvalue()
+    assert "using packaged templates" in output.getvalue()
 
 
 def test_copy_specify_base_from_local_copies_expected_assets(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make scaffold-only `spec-kitty specify` and `agent mission create` states explicit in human and JSON output
- keep JSON command stdout machine-clean for uninitialized repos and charter preflight failures
- treat missing charter as advisory only for read-only/dashboard paths while mutation gates stay fail-closed
- tighten `init` success guidance and template-root warning copy

Fixes #1639
Fixes #1640
Fixes #1641
Fixes #1642

## Verification
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_specify_scaffold_state.py tests/specify_cli/cli/commands/test_specify_widen.py tests/integration/test_fail_loud_uninitialized_repo.py tests/specify_cli/cli/commands/agent/test_mission_create.py::test_create_json_output_contains_coordination_branch`
- `.venv/bin/pytest tests/init/test_init_next_steps.py tests/specify_cli/cli/commands/test_init_non_git_message.py tests/test_template/test_manager.py tests/specify_cli/cli/commands/test_init_vibe.py::test_init_vibe_next_steps_output tests/specify_cli/cli/commands/test_init_pi_letta.py::test_init_pi_letta_installs_command_skills_and_prints_next_steps`
- `.venv/bin/pytest tests/specify_cli/charter_preflight/test_runner.py tests/test_dashboard/test_dashboard_preflight.py tests/next/test_query_mode_unit.py tests/agent/cli/commands/test_charter_cli.py`
- `.venv/bin/ruff check src/charter/sync.py src/specify_cli/charter_runtime/preflight src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/init.py src/specify_cli/cli/commands/lifecycle.py src/specify_cli/cli/commands/next_cmd.py src/specify_cli/template/manager.py tests/agent/cli/commands/test_charter_cli.py tests/init/test_init_next_steps.py tests/next/test_query_mode_unit.py tests/specify_cli/charter_preflight/test_runner.py tests/specify_cli/cli/commands/agent/test_mission_create.py tests/specify_cli/cli/commands/test_init_non_git_message.py tests/specify_cli/cli/commands/test_specify_scaffold_state.py tests/test_dashboard/test_dashboard_preflight.py tests/test_template/test_manager.py`
- `git diff --check`

## Adversarial review notes
- fixed mutation-gate regression risk by requiring explicit `allow_missing_charter=True` only on read-only/dashboard preflight
- fixed `specify --json` uninitialized failures to emit a single JSON error document
- fixed advancing `next --json` charter preflight failures to emit a single JSON error document
- preserved `CharterPreflightResult.to_dict()` shape unless warnings are present
