### PR TITLE
chore: prepare 3.2.0rc36 release

### DIFF
--- a/.kittify/command-skills-manifest.json
+++ b/.kittify/command-skills-manifest.json
@@ -7,7 +7,7 @@
       "content_hash": "0444f42a6f1c7aa3ca4c23e835b34033b08adc12f22c339dab5a0ecfd64f69ba",
       "installed_at": "2026-04-26T06:35:35.802411+00:00",
       "path": ".agents/skills/spec-kitty.analyze/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -16,7 +16,7 @@
       "content_hash": "efdd74fa02b35bf00741dc5fee4187c173e4b1962b3d8c0fa08303a787cb863b",
       "installed_at": "2026-04-26T06:35:35.803991+00:00",
       "path": ".agents/skills/spec-kitty.charter/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -25,7 +25,7 @@
       "content_hash": "4887c9aaae2c5247ea691f0373aab74c4eb344f5a348ee773401ae55a6744f2e",
       "installed_at": "2026-04-26T06:35:35.806276+00:00",
       "path": ".agents/skills/spec-kitty.implement/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -34,7 +34,7 @@
       "content_hash": "f79b8d6ad92db015a6b6f6917aa7df8340cf2af8754daa124878b743134d84e3",
       "installed_at": "2026-04-26T06:35:35.807722+00:00",
       "path": ".agents/skills/spec-kitty.plan/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -43,7 +43,7 @@
       "content_hash": "1e5b293a9acb211becd94f1a2b2b9aee29baf03c805fc0f92ce2efacb2f67896",
       "installed_at": "2026-04-26T06:35:35.808373+00:00",
       "path": ".agents/skills/spec-kitty.research/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -52,7 +52,7 @@
       "content_hash": "4aecf632cfd5017dcfdcdac92be704a260282a3759372d1fd72ed311f8beada7",
       "installed_at": "2026-04-26T06:35:35.808989+00:00",
       "path": ".agents/skills/spec-kitty.review/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -61,7 +61,7 @@
       "content_hash": "e9d6a0ee6f235b15370f3ee02e6c6ba756db781c9055c06045a3289392e6136d",
       "installed_at": "2026-04-26T06:35:35.810336+00:00",
       "path": ".agents/skills/spec-kitty.specify/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -70,7 +70,7 @@
       "content_hash": "e64955df9969d47e026325cd3f73a43a9cfed6b64ad661a5bdd5a1ba5fa02e94",
       "installed_at": "2026-04-26T06:35:35.811817+00:00",
       "path": ".agents/skills/spec-kitty.tasks-finalize/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -79,7 +79,7 @@
       "content_hash": "876f227da1323526e87ce951d6318d9e3796d67b02b6cb4c9ed1c49264e5bab9",
       "installed_at": "2026-04-26T06:35:35.812373+00:00",
       "path": ".agents/skills/spec-kitty.tasks-outline/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -88,7 +88,7 @@
       "content_hash": "aa7b0a5f5620986fcdcfbf405b66c015990f33a5ab62f06c75fd071fe7fac0e4",
       "installed_at": "2026-04-26T06:35:35.813018+00:00",
       "path": ".agents/skills/spec-kitty.tasks-packages/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     },
     {
       "agents": [
@@ -97,7 +97,7 @@
       "content_hash": "994cc8796e9615976dadf495b2b9f95d504ece976ae3103d853d3f2fdb898f2e",
       "installed_at": "2026-04-26T06:35:35.811199+00:00",
       "path": ".agents/skills/spec-kitty.tasks/SKILL.md",
-      "spec_kitty_version": "3.2.0rc35"
+      "spec_kitty_version": "3.2.0rc36"
     }
   ],
   "schema_version": 1

--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc35
+  version: 3.2.0rc36
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc36] - 2026-06-03
+
+### Changed
+
+- Polished 3.2 CLI UX around init next steps, scaffold state, widen guidance,
+  and charter preflight output.
+- Updated agent harness installation guidance and snapshots for Codex, Kiro,
+  Antigravity, and public harness docs.
+- Added execution-state/runtime architecture notes covering mission vs.
+  MissionRun boundaries and context decomposition.
+- Hardened release-candidate CI around charter checks, workflow status
+  coordination, and Next runtime task parsing.
+
 ## [3.2.0rc35] - 2026-06-02
 
 ### Added

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2227,6 +2227,139 @@
   current_target: false
   citation_refs: []
   notes: Index for engineering reflection notes.
+- path: docs/engineering_notes/runtime_and_state_overhaul/01-ticket-capture.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/02-current-state-map.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/03-architecture-context.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/04-doctrine-constraints.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/05-architectural-synthesis.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/06-proposed-domains-and-splits.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/07-existing-pattern-and-domain-extraction.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/08-architecture-phase-1-summary.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/09-context-decomposition-model.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/10-context-needs-capture.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/11-dialectic-and-revised-claims.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/12-actor-mental-model.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/13-dialectic-mission-vs-missionrun.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/14-model-diagrams.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/15-dialectic-on-the-domain-model.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/16-codebase-reassessment-fanout.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/17-consolidated-domain-model.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Internal runtime/state overhaul engineering note.
+- path: docs/engineering_notes/runtime_and_state_overhaul/README.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Index for runtime/state overhaul engineering notes.
+- path: docs/engineering_notes/runtime_and_state_overhaul/SESSION-RECAP.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Runtime/state overhaul session recap.
 - path: docs/engineering_notes/triage/2026-05-25-01KSF9HJ-dir013-sub-issues.md
   tag: internal
   divio_type: none

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc35"
+version = "3.2.0rc36"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc35"
+version = "3.2.0rc36"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- Bump spec-kitty-cli and repo metadata to 3.2.0rc36
- Add 3.2.0rc36 changelog entry
- Align command skill manifest version stamps

## Local verification
- .venv/bin/python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"
- .venv/bin/python scripts/release/validate_release.py --mode tag --tag v3.2.0rc36 --tag-pattern "v*.*.*"
- git diff --check
- .venv/bin/python -m pytest -v --import-mode=importlib tests/release (104 passed, 7 skipped)
- .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*
- .venv/bin/python scripts/release/check_exact_install.py --package spec-kitty-cli --version 3.2.0rc36 --console-script spec-kitty --console-arg=--version
- Wheel content counts: migrations 82/82, doctrine 571/571, bundled skills 51/51
