### PR TITLE
fix: restore main CI before rc36 release

### DIFF
--- a/src/specify_cli/coordination/workspace.py
+++ b/src/specify_cli/coordination/workspace.py
@@ -175,6 +175,8 @@ class CoordinationWorkspace:
         subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "add", str(path), branch],
             check=True,
+            capture_output=True,
+            text=True,
         )
         return path
 

--- a/tests/cross_cutting/packaging/test_packaging_safety.py
+++ b/tests/cross_cutting/packaging/test_packaging_safety.py
@@ -63,7 +63,14 @@ def test_wheel_contains_only_known_packages(build_artifacts: dict[str, Path]) ->
     """Verify wheel only contains known package directories."""
     wheel_path = build_artifacts["wheel"]
 
-    known_prefixes = ("specify_cli/", "doctrine/", "charter/", "kernel/")
+    known_prefixes = (
+        "specify_cli/",
+        "doctrine/",
+        "charter/",
+        "kernel/",
+        "glossary/",
+        "runtime/",
+    )
 
     with zipfile.ZipFile(wheel_path) as zf:
         all_files = [f for f in zf.namelist() if ".dist-info/" not in f]

--- a/tests/e2e/test_feature_alias_smoke.py
+++ b/tests/e2e/test_feature_alias_smoke.py
@@ -205,7 +205,16 @@ def test_feature_alias_routes_to_mission(tmp_path: Path) -> None:
         )
         create_payload = json.loads(json_line)
         slug = create_payload["mission_slug"]
-        feature_dir = project / "kitty-specs" / slug
+        mission_id = create_payload["mission_id"]
+        mid8 = mission_id[:8]
+
+        from specify_cli.coordination.workspace import CoordinationWorkspace
+
+        primary_feature_dir = project / "kitty-specs" / slug
+        coord_root = CoordinationWorkspace.resolve(project, slug, mid8)
+        feature_dir = coord_root / "kitty-specs" / slug
+        if not feature_dir.exists():
+            shutil.copytree(primary_feature_dir, feature_dir)
         assert feature_dir.exists()
 
         # 2. Seed one WP so the JSON branch is exercised.

--- a/tests/integration/test_quickstart_end_to_end.py
+++ b/tests/integration/test_quickstart_end_to_end.py
@@ -432,10 +432,10 @@ class TestStep4_PackValidatorVocabulary:
         assert f"enhances: {_BUILT_IN_TACTIC_ID}" in msg, msg
         assert f"overrides: {_BUILT_IN_TACTIC_ID}" in msg, msg
 
-    def test_step4b_declared_enhances_suppresses_advisory(
+    def test_step4b_inline_enhances_is_rejected_after_hard_cutover(
         self, tmp_path: Path
     ) -> None:
-        """Declared ``enhances`` against a valid built-in -> advisory gone."""
+        """Inline ``enhances`` is retired; DRG fragment edges own relationships."""
         if not _has_built_in_doctrine():
             pytest.skip("shipped doctrine not on disk in this environment")
 
@@ -448,21 +448,13 @@ class TestStep4_PackValidatorVocabulary:
         )
         result = validate_pack(tmp_path)
 
-        # No same_id_collision advisory for the declared-intent artifact.
-        collision = [
-            a
-            for a in result.advisories
-            if a.artifact_id == _BUILT_IN_TACTIC_ID
-            and a.category == "same_id_collision"
-        ]
-        assert collision == [], (
-            f"Declared `enhances` MUST suppress same_id_collision; "
-            f"saw: {result.advisories}"
-        )
-        # And no schema errors from the partial fields (pack validator's
-        # schema check passes — the advisory pass is the only relevant
-        # gate for this case).
-        assert result.ok is True, result.errors
+        assert result.ok is False
+        assert any(
+            issue.artifact_id == _BUILT_IN_TACTIC_ID
+            and issue.category == "schema_invalid"
+            and "Retired relationship field(s) 'enhances'" in issue.message
+            for issue in result.errors
+        ), result.errors
 
     def test_step4b_unknown_enhances_target_errors(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary
- silence git worktree add stdout during coordination workspace creation so strict JSON commands stay parseable
- update packaging safety allowlist for shipped glossary/runtime packages
- align feature-alias smoke setup with coordination worktree status resolution
- update pack validator test for FR-028 hard cutover rejecting inline enhances

## Verification
- git diff --check
- .venv/bin/python -m pytest -q --import-mode=importlib tests/integration/test_quickstart_end_to_end.py::TestStep4_PackValidatorVocabulary tests/cross_cutting/packaging/test_packaging_safety.py::test_wheel_contains_only_known_packages
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/python -m pytest -q --import-mode=importlib tests/e2e/test_feature_alias_smoke.py::test_feature_alias_routes_to_mission
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/python -m pytest -q --import-mode=importlib tests/e2e/test_charter_epic_golden_path.py::test_charter_epic_golden_path
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python -m pytest -v -m "slow and not windows_ci" --ignore=tests/e2e --ignore=tests/cross_cutting --cov=src/specify_cli --cov=src/charter --cov=src/doctrine --cov-report=xml:out/reports/coverage/coverage-slow.xml --junitxml=out/reports/xunit-reports/xunit-result-slow-local.xml
- SPEC_KITTY_ENABLE_SAAS_SYNC=1 uv run python -m pytest -v tests/e2e/ tests/cross_cutting/ -m "not distribution and not windows_ci" --cov=src/specify_cli --cov=src/charter --cov=src/doctrine --cov-report=xml:out/reports/coverage/coverage-e2e.xml --junitxml=out/reports/xunit-reports/xunit-result-e2e-local.xml
