### PR TITLE
Suppress ingress warnings when SaaS sync is disabled

### DIFF
--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -43,6 +43,7 @@ from spec_kitty_events import normalize_event_id as _normalize_event_id
 
 from .clock import LamportClock
 from .config import SyncConfig
+from .feature_flags import is_saas_sync_enabled
 from .queue import OfflineQueue
 from .routing import is_sync_enabled_for_checkout
 
@@ -1622,6 +1623,8 @@ class EventEmitter:
         downstream symptom like "no_team".
         """
         try:
+            if not is_saas_sync_enabled():
+                return "sync_disabled"
             if not is_sync_enabled_for_checkout():
                 return "sync_disabled"
         except Exception:
@@ -1678,11 +1681,11 @@ class EventEmitter:
             )
 
             # Resolve identity, team_slug (may be None), and git metadata.
-            # team_slug=None is now a valid "pending routing" state; the
-            # strict resolver still warns via its structured logger so
-            # operators see the ingress-safety boundary.
+            # When the global SaaS feature flag is disabled, avoid even
+            # touching the direct-ingress Teamspace resolver; feature-disabled
+            # runs should not emit feature-specific warnings.
             identity = self._get_identity()
-            team_slug = self._get_team_slug()
+            team_slug = self._get_team_slug() if is_saas_sync_enabled() else None
             git_meta = self._get_git_metadata()
 
             # Classify the drain blocker (None means ready to ship).

--- a/tests/sync/test_emitter_feature_flag.py
+++ b/tests/sync/test_emitter_feature_flag.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from specify_cli.sync.emitter import EventEmitter
+
+
+class _Clock:
+    node_id = "test-node"
+
+    def tick(self) -> int:
+        return 1
+
+
+def test_saas_flag_disabled_suppresses_direct_ingress_resolution(
+    monkeypatch,
+    caplog,
+) -> None:
+    monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "0")
+    monkeypatch.setattr(
+        EventEmitter,
+        "_get_identity",
+        lambda self: SimpleNamespace(
+            build_id="build-1",
+            project_uuid=uuid4(),
+            project_slug="project-1",
+        ),
+    )
+    monkeypatch.setattr(
+        EventEmitter,
+        "_get_git_metadata",
+        lambda self: SimpleNamespace(
+            git_branch=None,
+            head_commit_sha=None,
+            repo_slug=None,
+        ),
+    )
+    monkeypatch.setattr(EventEmitter, "_validate_event", lambda self, event: True)
+    monkeypatch.setattr("specify_cli.sync.emitter.validate_outbound_payload", lambda event, gate: None)
+
+    def fail_if_team_slug_resolves(self) -> str | None:
+        raise AssertionError("direct-ingress team resolver should stay behind the SaaS feature flag")
+
+    monkeypatch.setattr(EventEmitter, "_get_team_slug", fail_if_team_slug_resolves)
+
+    routed: list[dict] = []
+    monkeypatch.setattr(
+        EventEmitter,
+        "_route_event",
+        lambda self, event: routed.append(event) or True,
+    )
+
+    emitter = EventEmitter(clock=_Clock())
+    event = emitter._emit(
+        event_type="BuildRegistered",
+        aggregate_id="build-1",
+        aggregate_type="Build",
+        payload={},
+    )
+
+    assert event is not None
+    assert routed == [event]
+    assert event["team_slug"] is None
+    assert event["drain_blocked_reason"] == "sync_disabled"
+    assert "direct ingress skipped" not in caplog.text


### PR DESCRIPTION
## Summary
- Gate EventEmitter direct-ingress Teamspace resolution behind SPEC_KITTY_ENABLE_SAAS_SYNC
- Keep local event durability while classifying disabled SaaS sync as sync_disabled
- Add regression coverage proving disabled SaaS sync does not emit direct-ingress warnings

## Verification
- uv run pytest tests/sync/test_client_integration.py::test_ws_token_skipped_when_no_private_team_after_rehydrate tests/sync/test_emitter_feature_flag.py
- uv run ruff check src/specify_cli/sync/emitter.py tests/sync/test_emitter_feature_flag.py

## Notes
- A full spec-kitty init smoke could not run locally because global skill bootstrap fails before init on missing /Users/robert/.agents/skills/spk-admin-upgrade.