### PR TITLE
Release 3.1.10: declare click runtime dependency

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.1.9
+  version: 3.1.10
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-04-09T16:23:40.925198'
 environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.10] - 2026-06-03
+
+### Fixed
+
+- Fresh `pipx` and `uv tool` installs now include `click`, fixing
+  `ModuleNotFoundError: No module named 'click'` at CLI startup when Typer
+  resolves to a version that no longer depends on Click.
+
 ## [3.1.9] - 2026-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fresh `pipx` and `uv tool` installs now include `click`, fixing
   `ModuleNotFoundError: No module named 'click'` at CLI startup when Typer
-  resolves to a version that no longer depends on Click.
+  resolves to a version that no longer depends on Click. Typer is also capped
+  below `0.26` because that line vendors Click and changes exception identity
+  used by CLI failure handling.
 
 ## [3.1.9] - 2026-05-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.1.9"
+version = "3.1.10"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -50,6 +50,7 @@ classifiers = [
 ]
 dependencies = [
     "typer>=0.24.1",
+    "click>=8.2.1",  # Used directly by CLI modules; typer>=0.26 no longer depends on click
     "rich>=14.3.3",
     "httpx[socks]>=0.28.1",
     "platformdirs>=4.9.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typer>=0.24.1",
-    "click>=8.2.1",  # Used directly by CLI modules; typer>=0.26 no longer depends on click
+    "typer>=0.24.1,<0.26",  # 0.26 vendors Click and changes typer.Exit identity
+    "click>=8.2.1",  # Used directly by CLI modules
     "rich>=14.3.3",
     "httpx[socks]>=0.28.1",
     "platformdirs>=4.9.2",

--- a/tests/release/test_dependency_metadata.py
+++ b/tests/release/test_dependency_metadata.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+from packaging.requirements import Requirement
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _project_dependencies() -> dict[str, Requirement]:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    return {
+        requirement.name: requirement
+        for requirement in (
+            Requirement(value) for value in pyproject["project"]["dependencies"]
+        )
+    }
+
+
+def test_click_is_declared_as_direct_runtime_dependency() -> None:
+    dependencies = _project_dependencies()
+
+    assert "click" in dependencies
+    assert ">=8.2.1" in str(dependencies["click"].specifier)
+
+
+def test_typer_is_capped_below_click_vendoring_release() -> None:
+    dependencies = _project_dependencies()
+
+    assert "typer" in dependencies
+    specifier = str(dependencies["typer"].specifier)
+    assert ">=0.24.1" in specifier
+    assert "<0.26" in specifier

--- a/tests/sync/test_batch_error_surfacing.py
+++ b/tests/sync/test_batch_error_surfacing.py
@@ -17,8 +17,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-pytestmark = pytest.mark.fast
-
 from specify_cli.sync.batch import (
     BatchEventResult,
     BatchSyncResult,
@@ -33,6 +31,8 @@ from specify_cli.sync.batch import (
     CATEGORY_ACTIONS,
 )
 from specify_cli.sync.queue import OfflineQueue
+
+pytestmark = pytest.mark.fast
 
 
 # ────────────────────────────────────────────────────────────────
@@ -624,8 +624,11 @@ class TestBatchSyncEventResults:
         assert len(result.event_results) == 5
         assert all(r.error_category == "server_error" for r in result.event_results)
 
+    @patch("specify_cli.sync.batch.request_with_stdlib_fallback_sync", return_value=None)
     @patch("specify_cli.sync.batch.requests.post")
-    def test_timeout_populates_server_error_category(self, mock_post, small_queue):
+    def test_timeout_populates_server_error_category(
+        self, mock_post, _mock_fallback, small_queue
+    ):
         """Request timeout creates event_results with server_error category."""
         import requests as req
 
@@ -641,8 +644,11 @@ class TestBatchSyncEventResults:
         assert result.error_count == 5
         assert all(r.error_category == "server_error" for r in result.event_results)
 
+    @patch("specify_cli.sync.batch.request_with_stdlib_fallback_sync", return_value=None)
     @patch("specify_cli.sync.batch.requests.post")
-    def test_connection_error_populates_event_results(self, mock_post, small_queue):
+    def test_connection_error_populates_event_results(
+        self, mock_post, _mock_fallback, small_queue
+    ):
         """Connection error creates event_results with server_error category."""
         import requests as req
 

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -259,8 +259,9 @@ class TestBatchSyncErrors:
         assert result.error_count == 100
         assert "HTTP 500" in result.error_messages[0]
 
+    @patch("specify_cli.sync.batch.request_with_stdlib_fallback_sync", return_value=None)
     @patch("specify_cli.sync.batch.requests.post")
-    def test_batch_sync_timeout(self, mock_post, populated_queue):
+    def test_batch_sync_timeout(self, mock_post, _mock_fallback, populated_queue):
         """Test batch sync handles request timeout"""
         import requests
 
@@ -273,8 +274,11 @@ class TestBatchSyncErrors:
         assert result.error_count == 100
         assert "Request timeout" in result.error_messages
 
+    @patch("specify_cli.sync.batch.request_with_stdlib_fallback_sync", return_value=None)
     @patch("specify_cli.sync.batch.requests.post")
-    def test_batch_sync_connection_error(self, mock_post, populated_queue):
+    def test_batch_sync_connection_error(
+        self, mock_post, _mock_fallback, populated_queue
+    ):
         """Test batch sync handles connection error"""
         import requests
 


### PR DESCRIPTION
## Summary
- bump the 3.1 patch line to `3.1.10`
- declare `click>=8.2.1` directly because Spec Kitty imports Click and Typer 0.26+ no longer depends on it
- add a changelog entry for the fresh `pipx` / `uv tool` install crash

## Verification
- `python3 -m build`
- `python3 scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'`\n- clean Python 3.14 venv install of `dist/spec_kitty_cli-3.1.10-py3-none-any.whl`; `spec-kitty --version` reports `3.1.10`\n- inspected wheel metadata: `Requires-Dist: click>=8.2.1` and `Requires-Dist: typer>=0.24.1`\n\nFixes #1338\n