### PR TITLE
Release 3.2.0rc37

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc36
+  version: 3.2.0rc37
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc37] - 2026-06-04
+
+### Added
+
+- Added execution-state domain remediation artifacts, ADRs, and glossary
+  context covering ExecutionContext ownership, command targets, effector
+  actors, mission/MissionRun boundaries, and status aggregate behavior.
+- Added architectural ratchets for execution-context parity, status module
+  boundaries, and raw `kitty-specs/<mission>` path construction.
+
+### Changed
+
+- Routed command and runtime path handling through shared execution-context and
+  feature-directory resolution so raw mission spec paths consistently resolve
+  through the active action context.
+- Refreshed Contextive execution glossary and doctrine skill metadata while
+  removing the retired `spk-integrate-ci` skill from the bundled doctrine pack.
+- Hardened release-candidate CI ownership and release workflow checks around
+  path filters, candidate metadata, and downstream compatibility validation.
+
+### Fixed
+
+- Fixed 3.1.10 acceptance and move-task regressions across transactional
+  coordination, protected branch bypass handling, and clean-tree acceptance
+  fixtures.
+- Suppressed SaaS ingress warnings when SaaS sync is disabled.
+- Addressed low-risk Sonar cleanup findings and mission-review follow-up
+  issues from execution-state domain remediation.
+
 ## [3.2.0rc36] - 2026-06-03
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc36"
+version = "3.2.0rc37"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc36"
+version = "3.2.0rc37"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Release

Prepare `3.2.0rc37` from current `main`.

## Local Evidence

- `uv sync --frozen --all-extras`
- `.venv/bin/python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'`
- `.venv/bin/python -m pytest -q tests/release` → 104 passed, 7 skipped
- `.venv/bin/ruff check scripts/release tests/release src/specify_cli/release`
- `.venv/bin/python -m build`
- `uvx twine check dist/*`
- `.venv/bin/python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version`

## Notes

- `ruff format --check scripts/release tests/release src/specify_cli/release` reports pre-existing formatting drift in release Python files; this release metadata commit does not edit those files.
- Full CLI suite, cross-repo e2e, and deployed-dev canary evidence remain release-candidate hygiene before tagging per `RELEASE_CHECKLIST.md`.
