### PR TITLE
fix(release): use dispatch inputs in job gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
   downstream-consumer-verify:
     name: Verify downstream consumer compatibility
     needs: build-release
-    if: ${{ env.SKIP_DOWNSTREAM != 'true' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_downstream != true }}
     runs-on: ubuntu-latest
     env:
       REPO_OWNER: ${{ github.repository_owner }}
@@ -342,7 +342,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: [build-release, downstream-consumer-verify]
-    if: ${{ always() && needs.build-release.result == 'success' && (needs.downstream-consumer-verify.result == 'success' || env.SKIP_DOWNSTREAM == 'true') }}
+    if: ${{ always() && needs.build-release.result == 'success' && (needs.downstream-consumer-verify.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_downstream == true)) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -156,13 +156,17 @@ def test_release_manual_dispatch_can_skip_downstream_with_explicit_waiver() -> N
 
     assert inputs["tag"]["required"] is True
     assert inputs["skip_downstream"]["required"] is True
-    assert jobs["downstream-consumer-verify"]["if"] == "${{ env.SKIP_DOWNSTREAM != 'true' }}"
+    assert (
+        jobs["downstream-consumer-verify"]["if"]
+        == "${{ github.event_name != 'workflow_dispatch' || inputs.skip_downstream != true }}"
+    )
 
     publish_if = jobs["publish-pypi"]["if"]
     assert "always()" in publish_if
     assert "needs.build-release.result == 'success'" in publish_if
     assert "needs.downstream-consumer-verify.result == 'success'" in publish_if
-    assert "env.SKIP_DOWNSTREAM == 'true'" in publish_if
+    assert "github.event_name == 'workflow_dispatch'" in publish_if
+    assert "inputs.skip_downstream == true" in publish_if
 
 
 def test_release_verifies_pypi_exact_install_after_publish() -> None:


### PR DESCRIPTION
## Summary
- replace job-level release gates that referenced global env with dispatch input expressions GitHub Actions can parse
- keep the manual downstream waiver path for v3.2.0rc37 publishing
- update release workflow ownership coverage

## Tests
- uv run python -m pytest -q tests/release/test_release_ci_ownership.py tests/integration/test_release_gate_downstream_consumer.py