### PR TITLE
docs: publish kitty-specs dashboard section

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Build documentation
         run: |
+          python3 scripts/docs/generate_kitty_specs_docs.py
           cd docs
           docfx docfx.json
           cd ..

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,6 +2,7 @@
 _site/
 obj/
 .docfx/
+kitty-specs/
 
 # Temporary files
 *.tmp

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -20,3 +20,493 @@
 .sk-separator {
   opacity: 0.6;
 }
+
+.sk-dashboard {
+  --baby-blue: #A7C7E7;
+  --grassy-green: #7BB661;
+  --lavender: #C9A0DC;
+  --sunny-yellow: #FFF275;
+  --soft-peach: #FFD8B1;
+  --light-gray: #E8E8E8;
+  --creamy-white: #FFFDF7;
+  --dark-text: #2c3e50;
+  --medium-text: #546e7a;
+  background: var(--baby-blue);
+  color: var(--dark-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  min-height: calc(100vh - 160px);
+  margin: -1rem -1rem 2rem;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.12);
+}
+
+body.tex2jax_ignore:has(> .sk-dashboard) {
+  margin: 0;
+  background: #A7C7E7;
+}
+
+body.tex2jax_ignore > .sk-dashboard {
+  margin: 0;
+  border-radius: 0;
+  min-height: 100vh;
+  box-shadow: none;
+}
+
+.sk-dashboard * {
+  box-sizing: border-box;
+}
+
+.sk-dashboard .header {
+  background: var(--creamy-white);
+  padding: 20px 30px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 3px solid var(--sunny-yellow);
+  gap: 20px;
+}
+
+.sk-dashboard .header-left,
+.sk-dashboard .header-right {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.sk-dashboard .header-logo-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  height: 60px;
+  background: white;
+  border-radius: 14px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  border: 2px solid rgba(123, 182, 97, 0.25);
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+
+.sk-dashboard .header-logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.sk-dashboard .header h1 {
+  font-size: 1.8rem;
+  color: var(--grassy-green);
+  margin: 0;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.sk-dashboard .header-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sk-dashboard .tree-view {
+  font-size: 0.75rem;
+  color: var(--medium-text);
+  font-family: Monaco, Menlo, Consolas, monospace;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 6px 10px;
+  border-radius: 6px;
+  white-space: pre;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.sk-dashboard .feature-selector {
+  min-width: 300px;
+}
+
+.sk-dashboard .feature-selector label {
+  display: block;
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-bottom: 5px;
+  font-weight: 500;
+}
+
+.sk-dashboard .feature-selector select {
+  width: 100%;
+  padding: 10px 15px;
+  border: 2px solid var(--lavender);
+  border-radius: 8px;
+  font-size: 1rem;
+  background: var(--creamy-white);
+  color: var(--dark-text);
+}
+
+.sk-dashboard .docs-site-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(123, 182, 97, 0.35);
+  background: rgba(123, 182, 97, 0.12);
+  color: var(--grassy-green);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.sk-dashboard .container {
+  display: flex;
+  min-height: 760px;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sk-dashboard .sidebar {
+  width: 250px;
+  flex-shrink: 0;
+  background: var(--creamy-white);
+  padding: 40px 0 20px;
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  border-right: 2px solid var(--light-gray);
+}
+
+.sk-dashboard .sidebar-item {
+  padding: 12px 30px;
+  width: 100%;
+  background: none;
+  border: none;
+  border-left: 4px solid transparent;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--dark-text);
+  text-align: left;
+  font: inherit;
+  text-decoration: none;
+}
+
+.sk-dashboard .sidebar-item:hover {
+  background: rgba(201, 160, 220, 0.15);
+  color: var(--grassy-green);
+}
+
+.sk-dashboard .sidebar-item.active {
+  background: rgba(123, 182, 97, 0.1);
+  border-left-color: var(--grassy-green);
+  color: var(--grassy-green);
+  font-weight: 600;
+}
+
+.sk-dashboard .sidebar-item.disabled {
+  opacity: 0.4;
+}
+
+.sk-dashboard .main-content {
+  flex: 1;
+  padding: 30px;
+  overflow-x: auto;
+}
+
+.sk-dashboard .content-card {
+  background: var(--creamy-white);
+  border-radius: 12px;
+  padding: 30px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+  border-top: 3px solid var(--sunny-yellow);
+}
+
+.sk-dashboard .content-card h2 {
+  color: var(--grassy-green);
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--soft-peach);
+}
+
+.sk-dashboard .markdown-content {
+  line-height: 1.6;
+  color: #374151;
+}
+
+.sk-dashboard .markdown-content h3,
+.sk-dashboard .markdown-content h4 {
+  margin-top: 24px;
+  margin-bottom: 12px;
+  color: #1f2937;
+}
+
+.sk-dashboard .markdown-content p,
+.sk-dashboard .markdown-content ul {
+  margin-bottom: 12px;
+}
+
+.sk-dashboard .markdown-content code {
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: Monaco, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+.sk-dashboard .sk-source-link {
+  color: var(--grassy-green);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  cursor: help;
+}
+
+.sk-dashboard .markdown-content pre {
+  background: #ffffff;
+  color: #111827;
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 16px 0;
+}
+
+.sk-dashboard .status-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 15px;
+  margin-bottom: 25px;
+}
+
+.sk-dashboard .status-card {
+  background: linear-gradient(135deg, var(--creamy-white) 0%, #fafaf8 100%);
+  padding: 20px;
+  border-radius: 8px;
+  border-left: 4px solid;
+}
+
+.sk-dashboard .status-card.total { border-left-color: var(--baby-blue); }
+.sk-dashboard .status-card.progress { border-left-color: var(--sunny-yellow); }
+.sk-dashboard .status-card.review { border-left-color: var(--lavender); }
+.sk-dashboard .status-card.approved { border-left-color: var(--soft-peach); }
+.sk-dashboard .status-card.completed { border-left-color: var(--grassy-green); }
+
+.sk-dashboard .status-label {
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.sk-dashboard .status-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1f2937;
+  line-height: 1;
+}
+
+.sk-dashboard .status-detail {
+  font-size: 0.85rem;
+  color: #9ca3af;
+  margin-top: 6px;
+}
+
+.sk-dashboard .progress-bar {
+  width: 100%;
+  height: 6px;
+  background: #e5e7eb;
+  border-radius: 3px;
+  margin-top: 10px;
+  overflow: hidden;
+}
+
+.sk-dashboard .progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--grassy-green) 0%, #5a9647 100%);
+}
+
+.sk-dashboard .artifacts-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.sk-dashboard .artifact-row {
+  padding: 10px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--dark-text);
+}
+
+.sk-dashboard .artifact-row.available {
+  background: #ecfdf5;
+  border-left: 3px solid #10b981;
+}
+
+.sk-dashboard .artifact-row.missing {
+  background: #fef2f2;
+  border-left: 3px solid #ef4444;
+}
+
+.sk-dashboard .kanban-board {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(190px, 1fr));
+  gap: 20px;
+}
+
+.sk-dashboard .lane {
+  background: var(--creamy-white);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  min-height: 400px;
+  border-top: 3px solid;
+}
+
+.sk-dashboard .lane-header {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sk-dashboard .lane-header .count {
+  font-size: 0.8rem;
+  background: rgba(0, 0, 0, 0.08);
+  padding: 4px 10px;
+  border-radius: 12px;
+}
+
+.sk-dashboard .lane.planned { border-top-color: var(--baby-blue); }
+.sk-dashboard .lane.planned .lane-header { border-color: var(--baby-blue); color: var(--baby-blue); }
+.sk-dashboard .lane.doing { border-top-color: var(--sunny-yellow); }
+.sk-dashboard .lane.doing .lane-header { border-color: var(--sunny-yellow); color: #d4a800; }
+.sk-dashboard .lane.for_review { border-top-color: var(--lavender); }
+.sk-dashboard .lane.for_review .lane-header { border-color: var(--lavender); color: var(--lavender); }
+.sk-dashboard .lane.approved { border-top-color: var(--soft-peach); }
+.sk-dashboard .lane.approved .lane-header { border-color: var(--soft-peach); color: #c07b2a; }
+.sk-dashboard .lane.done { border-top-color: var(--grassy-green); }
+.sk-dashboard .lane.done .lane-header { border-color: var(--grassy-green); color: var(--grassy-green); }
+
+.sk-dashboard .card {
+  background: white;
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  border-left: 4px solid;
+}
+
+.sk-dashboard .lane.planned .card { border-left-color: var(--baby-blue); }
+.sk-dashboard .lane.doing .card { border-left-color: var(--sunny-yellow); }
+.sk-dashboard .lane.for_review .card { border-left-color: var(--lavender); }
+.sk-dashboard .lane.approved .card { border-left-color: var(--soft-peach); }
+.sk-dashboard .lane.done .card { border-left-color: var(--grassy-green); }
+
+.sk-dashboard .card-id {
+  font-weight: 600;
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin-bottom: 5px;
+}
+
+.sk-dashboard .card-title {
+  font-size: 1.05rem;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: #1f2937;
+  line-height: 1.4;
+}
+
+.sk-dashboard .badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--soft-peach);
+  color: #8b5a00;
+}
+
+.sk-dashboard .empty-state {
+  text-align: center;
+  color: #9ca3af;
+  padding: 40px 20px;
+  font-style: italic;
+}
+
+.sk-dashboard .mission-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 15px;
+}
+
+.sk-dashboard .mission-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: white;
+  border-left: 4px solid var(--grassy-green);
+  border-radius: 8px;
+  padding: 16px;
+  color: var(--dark-text);
+  text-decoration: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.sk-dashboard .mission-card strong {
+  color: #1f2937;
+}
+
+.sk-dashboard .mission-card span {
+  color: #6b7280;
+}
+
+.sk-dashboard .mission-card em,
+.sk-dashboard .mission-number {
+  color: var(--grassy-green);
+  font-size: 0.85rem;
+  font-style: normal;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .sk-dashboard {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .sk-dashboard .header,
+  .sk-dashboard .header-left,
+  .sk-dashboard .container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sk-dashboard .feature-selector,
+  .sk-dashboard .sidebar {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .sk-dashboard .sidebar {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding: 10px 0;
+  }
+
+  .sk-dashboard .sidebar-item {
+    padding: 10px 14px;
+  }
+
+  .sk-dashboard .main-content {
+    padding: 16px;
+  }
+
+  .sk-dashboard .kanban-board {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -55,6 +55,8 @@
           "CNAME",
           ".nojekyll",
           "llms.txt",
+          "kitty-specs/**/*.html",
+          "kitty-specs/toc.yml",
           "1x/*.html",
           "2x/*.html"
         ]

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -14,6 +14,8 @@
       href: 3x/
 - name: Migration to 3.2
   href: migration/
+- name: Mission Runs
+  href: kitty-specs/index.html
 - name: Historical Archive
   items:
     - name: Archive Overview

--- a/scripts/docs/generate_kitty_specs_docs.py
+++ b/scripts/docs/generate_kitty_specs_docs.py
@@ -1,0 +1,516 @@
+"""Generate dashboard-style DocFX pages from kitty-specs."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "kitty-specs"
+DEST = ROOT / "docs" / "kitty-specs"
+
+LANES = ["planned", "doing", "for_review", "approved", "done"]
+LANE_LABELS = {
+    "planned": "📋 Planned",
+    "doing": "🚀 Doing",
+    "for_review": "👀 For Review",
+    "approved": "👍 Approved",
+    "done": "✅ Done",
+}
+ARTIFACTS = [
+    ("overview", "Overview", "📊", None),
+    ("spec", "Specification", "📄", "spec.md"),
+    ("plan", "Implementation Plan", "🏗️", "plan.md"),
+    ("tasks", "Task List", "📋", "tasks.md"),
+    ("kanban", "Kanban Board", "🎯", None),
+    ("research", "Research", "🔬", "research.md"),
+    ("contracts", "Contracts", "📜", "contracts"),
+    ("checklists", "Checklists", "✅", "checklists"),
+    ("quickstart", "Quickstart Guide", "🚀", "quickstart.md"),
+    ("data-model", "Data Model", "💾", "data-model.md"),
+]
+
+
+@dataclass(frozen=True)
+class Mission:
+    slug: str
+    name: str
+    meta: dict[str, Any]
+    status: dict[str, Any]
+    path: Path
+    task_titles: dict[str, str]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def mission_name(path: Path, meta: dict[str, Any]) -> str:
+    return (
+        meta.get("friendly_name")
+        or meta.get("name")
+        or meta.get("mission_slug")
+        or meta.get("slug")
+        or path.name
+    )
+
+
+def sort_key(mission: Mission) -> tuple[int, str]:
+    number = mission.meta.get("mission_number")
+    try:
+        return (-int(number), mission.name.lower())
+    except (TypeError, ValueError):
+        created = str(mission.meta.get("created_at") or "")
+        return (0, f"{created} {mission.name}".lower())
+
+
+def parse_task_titles(tasks_md: str) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    for line in tasks_md.splitlines():
+        match = re.match(r"^#{2,4}\s+(?:Work Package\s+)?(WP\d+)\s*:?\s*(.+?)\s*$", line)
+        if match:
+            titles[match.group(1)] = re.sub(r"\s+", " ", match.group(2)).strip()
+    return titles
+
+
+def missions() -> list[Mission]:
+    result: list[Mission] = []
+    for path in SOURCE.iterdir():
+        if not path.is_dir():
+            continue
+        meta = read_json(path / "meta.json")
+        status = read_json(path / "status.json")
+        if not meta and not status and not (path / "spec.md").exists():
+            continue
+        result.append(
+            Mission(
+                slug=path.name,
+                name=mission_name(path, meta),
+                meta=meta,
+                status=status,
+                path=path,
+                task_titles=parse_task_titles(read_text(path / "tasks.md")),
+            )
+        )
+    return sorted(result, key=sort_key)
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def inline_md(text: str) -> str:
+    value = esc(text)
+    value = re.sub(r"`([^`]+)`", r"<code>\1</code>", value)
+    value = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", value)
+    value = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", value)
+    value = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        r'<span class="sk-source-link" title="\2">\1</span>',
+        value,
+    )
+    return value
+
+
+def markdown_to_html(markdown: str) -> str:
+    lines = markdown.splitlines()
+    blocks: list[str] = []
+    paragraph: list[str] = []
+    list_items: list[str] = []
+    in_code = False
+    code_lang = ""
+    code_lines: list[str] = []
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph
+        if paragraph:
+            blocks.append(f"<p>{inline_md(' '.join(paragraph).strip())}</p>")
+            paragraph = []
+
+    def flush_list() -> None:
+        nonlocal list_items
+        if list_items:
+            blocks.append("<ul>" + "".join(f"<li>{item}</li>" for item in list_items) + "</ul>")
+            list_items = []
+
+    for raw in lines:
+        line = raw.rstrip()
+        if line.startswith("```"):
+            if in_code:
+                blocks.append(
+                    f'<pre><code class="language-{esc(code_lang)}">{esc(chr(10).join(code_lines))}</code></pre>'
+                )
+                in_code = False
+                code_lang = ""
+                code_lines = []
+            else:
+                flush_paragraph()
+                flush_list()
+                in_code = True
+                code_lang = line[3:].strip()
+            continue
+        if in_code:
+            code_lines.append(line)
+            continue
+        if not line.strip():
+            flush_paragraph()
+            flush_list()
+            continue
+        heading = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if heading:
+            flush_paragraph()
+            flush_list()
+            level = min(len(heading.group(1)) + 1, 6)
+            blocks.append(f"<h{level}>{inline_md(heading.group(2))}</h{level}>")
+            continue
+        if re.match(r"^-{3,}$", line):
+            flush_paragraph()
+            flush_list()
+            blocks.append("<hr>")
+            continue
+        bullet = re.match(r"^\s*[-*]\s+(.+)$", line)
+        task = re.match(r"^\s*[-*]\s+\[([ xX])\]\s+(.+)$", line)
+        if task:
+            flush_paragraph()
+            checked = task.group(1).lower() == "x"
+            label = "✅" if checked else "□"
+            list_items.append(f"{label} {inline_md(task.group(2))}")
+            continue
+        if bullet:
+            flush_paragraph()
+            list_items.append(inline_md(bullet.group(1)))
+            continue
+        paragraph.append(line.strip())
+    flush_paragraph()
+    flush_list()
+    return "\n".join(blocks)
+
+
+def artifact_exists(mission: Mission, key: str, source: str | None) -> bool:
+    if key == "overview":
+        return True
+    if key == "kanban":
+        return bool(mission.status.get("work_packages"))
+    if not source:
+        return False
+    return (mission.path / source).exists()
+
+
+def artifact_href(mission: Mission, key: str) -> str:
+    if key == "overview":
+        return "index.html"
+    return f"{key}.html"
+
+
+def dashboard_header(mission_list: list[Mission], active: Mission | None) -> str:
+    options = []
+    for mission in mission_list:
+        selected = " selected" if active and mission.slug == active.slug else ""
+        option_href = f"../{mission.slug}/index.html" if active else f"{mission.slug}/index.html"
+        options.append(
+            f'<option value="{esc(option_href)}"{selected}>{esc(mission.name)}</option>'
+        )
+    select = "\n".join(options)
+    name = active.name if active else "All mission runs"
+    return f"""
+<div class="sk-dashboard">
+  <div class="header">
+    <div class="header-left">
+      <div class="header-logo-wrapper">
+        <img src="/assets/images/logo_small.webp" alt="Spec Kitty logo" class="header-logo">
+      </div>
+      <div class="header-info">
+        <h1>Spec Kitty</h1>
+        <pre class="tree-view">└─ kitty-specs
+   └─ {esc(name)}</pre>
+      </div>
+      <div class="feature-selector">
+        <label for="feature-select">Mission Run:</label>
+        <select id="feature-select" onchange="if (this.value) location.href=this.value">
+          {select}
+        </select>
+      </div>
+    </div>
+    <div class="header-right">
+      <a class="docs-site-link" href="/">📚 Docs ↗</a>
+    </div>
+  </div>
+"""
+
+
+def sidebar(mission: Mission, active_key: str) -> str:
+    items = []
+    for key, label, icon, source in ARTIFACTS:
+        exists = artifact_exists(mission, key, source)
+        active = " active" if key == active_key else ""
+        disabled = "" if exists else " disabled"
+        if exists:
+            items.append(
+                f'<a class="sidebar-item{active}" href="{esc(artifact_href(mission, key))}" title="{esc(label)}">'
+                f'{icon} <span class="sidebar-label">{esc(label)}</span></a>'
+            )
+        else:
+            items.append(
+                f'<span class="sidebar-item{disabled}" title="{esc(label)}">'
+                f'{icon} <span class="sidebar-label">{esc(label)}</span></span>'
+            )
+    return "\n".join(items)
+
+
+def stats(mission: Mission) -> dict[str, int | float]:
+    summary = mission.status.get("summary") or {}
+    wps = mission.status.get("work_packages") or {}
+    lane_counts = {lane: 0 for lane in LANES}
+    for wp in wps.values():
+        lane = str(wp.get("lane") or "planned")
+        if lane == "in_review":
+            lane = "for_review"
+        if lane in lane_counts:
+            lane_counts[lane] += 1
+    for key, value in summary.items():
+        normalized = "for_review" if key == "in_review" else key
+        if normalized in lane_counts and not wps:
+            try:
+                lane_counts[normalized] += int(value)
+            except (TypeError, ValueError):
+                pass
+    total = sum(lane_counts.values())
+    done = lane_counts["done"]
+    pct = round(done / total * 100) if total else 0
+    return {"total": total, **lane_counts, "weighted_percentage": pct}
+
+
+def status_cards(mission: Mission, compact: bool = False) -> str:
+    s = stats(mission)
+    label = "Total Work Packages" if compact else "Total Tasks"
+    return f"""
+<div class="status-summary">
+  <div class="status-card total"><div class="status-label">{label}</div><div class="status-value">{s['total']}</div><div class="status-detail">{s['planned']} planned</div></div>
+  <div class="status-card progress"><div class="status-label">In Progress</div><div class="status-value">{s['doing']}</div></div>
+  <div class="status-card review"><div class="status-label">Review</div><div class="status-value">{s['for_review']}</div></div>
+  <div class="status-card approved"><div class="status-label">Approved</div><div class="status-value">{s['approved']}</div></div>
+  <div class="status-card completed"><div class="status-label">Completed</div><div class="status-value">{s['done']}</div><div class="status-detail">{s['weighted_percentage']}% done</div><div class="progress-bar"><div class="progress-fill" style="width: {s['weighted_percentage']}%"></div></div></div>
+</div>
+"""
+
+
+def overview(mission: Mission) -> str:
+    purpose_tldr = mission.meta.get("purpose_tldr") or "View and track all artifacts for this mission run."
+    purpose_context = mission.meta.get("purpose_context") or mission.meta.get("source_description") or ""
+    artifact_rows = []
+    for key, label, icon, source in ARTIFACTS[1:]:
+        exists = artifact_exists(mission, key, source)
+        cls = "available" if exists else "missing"
+        text = "✅ Available" if exists else "❌ Not created"
+        artifact_rows.append(
+            f'<a class="artifact-row {cls}" href="{esc(artifact_href(mission, key))}">{icon} {esc(label)}: {text}</a>'
+            if exists
+            else f'<div class="artifact-row {cls}">{icon} {esc(label)}: {text}</div>'
+        )
+    return f"""
+<h2>Mission Run Overview</h2>
+<div class="overview-header">
+  <h3>Mission Run: {esc(mission.name)}</h3>
+  <p class="overview-tldr">{esc(purpose_tldr)}</p>
+  <p class="overview-context">{esc(purpose_context)}</p>
+</div>
+{status_cards(mission)}
+<h3 class="artifacts-heading">Available Artifacts</h3>
+<div class="artifacts-grid">
+  {''.join(artifact_rows)}
+</div>
+"""
+
+
+def lanes(mission: Mission) -> dict[str, list[dict[str, str]]]:
+    result: dict[str, list[dict[str, str]]] = {lane: [] for lane in LANES}
+    for wp_id, state in sorted((mission.status.get("work_packages") or {}).items()):
+        lane = str(state.get("lane") or "planned")
+        if lane == "in_review":
+            lane = "for_review"
+        if lane not in result:
+            lane = "planned"
+        result[lane].append(
+            {
+                "id": wp_id,
+                "title": mission.task_titles.get(wp_id, "Work package"),
+                "actor": str(state.get("actor") or ""),
+            }
+        )
+    return result
+
+
+def kanban(mission: Mission) -> str:
+    columns = []
+    for lane, tasks in lanes(mission).items():
+        cards = []
+        for task in tasks:
+            actor = f'<span class="badge agent">{esc(task["actor"])}</span>' if task["actor"] else ""
+            cards.append(
+                f'<div class="card"><div class="card-id">{esc(task["id"])}</div>'
+                f'<div class="card-title">{esc(task["title"])}</div><div class="card-meta">{actor}</div></div>'
+            )
+        body = "".join(cards) if cards else '<div class="empty-state">No tasks</div>'
+        columns.append(
+            f'<div class="lane {lane}"><div class="lane-header"><span>{LANE_LABELS[lane]}</span>'
+            f'<span class="count">{len(tasks)}</span></div><div>{body}</div></div>'
+        )
+    return f"""
+<h2>Kanban Board</h2>
+<div id="kanban-status">{status_cards(mission, compact=True)}</div>
+<div class="kanban-board">{''.join(columns)}</div>
+"""
+
+
+def collection_html(mission: Mission, folder: str) -> str:
+    base = mission.path / folder
+    if not base.exists():
+        return '<div class="empty-state">No files</div>'
+    parts = []
+    for file_path in sorted(base.rglob("*")):
+        if not file_path.is_file():
+            continue
+        rel = file_path.relative_to(base).as_posix()
+        parts.append(f"<h3>{esc(rel)}</h3>")
+        parts.append(markdown_to_html(read_text(file_path)))
+    return "\n".join(parts) if parts else '<div class="empty-state">No files</div>'
+
+
+def artifact_body(mission: Mission, key: str, source: str | None) -> str:
+    if key == "overview":
+        return overview(mission)
+    if key == "kanban":
+        return kanban(mission)
+    if source in {"contracts", "checklists"}:
+        return f"<h2>{esc(source.title())}</h2>\n{collection_html(mission, source)}"
+    text = read_text(mission.path / source) if source else ""
+    if not text:
+        return '<div class="empty-state">Artifact not created</div>'
+    return markdown_to_html(text)
+
+
+def html_document(title: str, description: str, body: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{esc(title)} | Spec Kitty Documentation</title>
+  <meta name="description" content="{esc(description)}">
+  <link rel="icon" href="/assets/images/logo_small.webp">
+  <link rel="stylesheet" href="/assets/css/custom.css">
+</head>
+<body class="tex2jax_ignore">
+{body}
+</body>
+</html>
+"""
+
+
+def page(mission_list: list[Mission], mission: Mission, key: str, label: str, source: str | None) -> str:
+    desc = mission.meta.get("purpose_tldr") or mission.meta.get("source_description") or f"{label} for {mission.name}."
+    body = artifact_body(mission, key, source)
+    dashboard = (
+        dashboard_header(mission_list, mission)
+        + f"""
+  <div class="container">
+    <div class="sidebar">
+      {sidebar(mission, key)}
+    </div>
+    <div class="main-content">
+      <div class="content-card markdown-content">
+        {body}
+      </div>
+    </div>
+  </div>
+</div>
+"""
+    )
+    return html_document(f"{label} | {mission.name}", str(desc).replace("\n", " ")[:260], dashboard)
+
+
+def index_page(mission_list: list[Mission]) -> str:
+    cards = []
+    for mission in mission_list:
+        s = stats(mission)
+        desc = mission.meta.get("purpose_tldr") or mission.meta.get("source_description") or ""
+        cards.append(
+            f'<a class="mission-card" href="{esc(mission.slug)}/index.html">'
+            f'<span class="mission-number">{esc(mission.meta.get("mission_number") or "mission")}</span>'
+            f'<strong>{esc(mission.name)}</strong>'
+            f'<span>{esc(str(desc)[:220])}</span>'
+            f'<em>{s["total"]} work packages · {s["weighted_percentage"]}% done</em>'
+            f'</a>'
+        )
+    dashboard = (
+        dashboard_header(mission_list, None)
+        + f"""
+  <div class="container">
+    <div class="sidebar">
+      <a class="sidebar-item active" href="./">📊 <span class="sidebar-label">All Mission Runs</span></a>
+    </div>
+    <div class="main-content">
+      <div class="content-card">
+        <h2>Mission Runs</h2>
+        <p class="overview-context">Static mirror of the local Spec Kitty dashboard. Every mission and artifact has a stable URL for sharing, indexing, and AI answer engines.</p>
+        <div class="mission-grid">{''.join(cards)}</div>
+      </div>
+    </div>
+  </div>
+</div>
+"""
+    )
+    return html_document(
+        "Mission Runs",
+        "Static Spec Kitty mission dashboard generated from kitty-specs with permanent links for every mission artifact.",
+        dashboard,
+    )
+
+
+def write_toc(mission_list: list[Mission]) -> None:
+    lines = ["- name: Mission Runs", "  href: index.html", "  items:"]
+    for mission in mission_list:
+        lines.append(f"    - name: {json.dumps(mission.name, ensure_ascii=False)}")
+        lines.append(f"      href: {mission.slug}/index.html")
+    DEST.joinpath("toc.yml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    if DEST.exists():
+        shutil.rmtree(DEST)
+    DEST.mkdir(parents=True)
+    mission_list = missions()
+    DEST.joinpath("index.html").write_text(index_page(mission_list), encoding="utf-8")
+    write_toc(mission_list)
+    for mission in mission_list:
+        mission_dir = DEST / mission.slug
+        mission_dir.mkdir()
+        for key, label, _icon, source in ARTIFACTS:
+            if not artifact_exists(mission, key, source):
+                continue
+            name = "index.html" if key == "overview" else f"{key}.html"
+            mission_dir.joinpath(name).write_text(
+                page(mission_list, mission, key, label, source),
+                encoding="utf-8",
+            )
+    print(f"Generated {len(mission_list)} mission dashboards in {DEST}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docs/seo_postprocess.py
+++ b/scripts/docs/seo_postprocess.py
@@ -104,6 +104,81 @@ def breadcrumb_items(page: Page, base_url: str) -> list[dict[str, object]]:
     return crumbs
 
 
+def kitty_specs_json_ld(page: Page, base_url: str) -> list[dict[str, object]]:
+    rel = page.relative_path.replace("\\", "/")
+    if not rel.startswith("kitty-specs/"):
+        return []
+
+    docs_url = normalize_base_url(base_url)
+    if rel == "kitty-specs/index.html":
+        return [
+            {
+                "@context": "https://schema.org",
+                "@type": "CollectionPage",
+                "name": "Spec Kitty Mission Runs",
+                "description": page.description,
+                "url": page.url,
+                "isPartOf": {"@type": "WebSite", "name": "Spec Kitty Documentation", "url": docs_url},
+                "about": [
+                    "Spec Kitty mission runs",
+                    "spec-driven development",
+                    "AI coding agents",
+                    "work packages",
+                ],
+            },
+            {
+                "@context": "https://schema.org",
+                "@type": "ItemList",
+                "name": "Spec Kitty mission run index",
+                "url": page.url,
+                "itemListOrder": "https://schema.org/ItemListOrderDescending",
+            },
+        ]
+
+    parts = rel.split("/")
+    mission_slug = parts[1] if len(parts) > 1 else ""
+    artifact = parts[-1].removesuffix(".html")
+    if artifact == "index":
+        artifact = "overview"
+    artifact_name = artifact.replace("-", " ").title()
+    return [
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": page.title,
+            "description": page.description,
+            "url": page.url,
+            "inLanguage": "en",
+            "isPartOf": {"@type": "WebSite", "name": "Spec Kitty Documentation", "url": docs_url},
+            "about": [
+                "Spec Kitty mission run",
+                mission_slug,
+                artifact_name,
+                "spec-driven development",
+                "AI coding agents",
+            ],
+            "mainEntity": {
+                "@type": "CreativeWork",
+                "name": page.title,
+                "description": page.description,
+                "identifier": mission_slug,
+                "url": page.url,
+                "genre": "Software specification artifact",
+                "isPartOf": {
+                    "@type": "CreativeWorkSeries",
+                    "name": "Spec Kitty mission run artifacts",
+                    "url": canonical_url(base_url, f"kitty-specs/{mission_slug}/index.html"),
+                },
+            },
+            "publisher": {
+                "@type": "Organization",
+                "name": "Spec Kitty",
+                "url": "https://github.com/Priivacy-ai/spec-kitty",
+            },
+        }
+    ]
+
+
 def seo_block(page: Page, base_url: str, image_path: str) -> str:
     image_url = normalize_base_url(base_url) + quote(image_path.lstrip("/"), safe="/.-_~")
     json_ld = [
@@ -132,6 +207,7 @@ def seo_block(page: Page, base_url: str, image_path: str) -> str:
             "itemListElement": breadcrumb_items(page, base_url),
         },
     ]
+    json_ld.extend(kitty_specs_json_ld(page, base_url))
     escaped_title = html.escape(page.title, quote=True)
     escaped_desc = html.escape(page.description, quote=True)
     escaped_url = html.escape(page.url, quote=True)


### PR DESCRIPTION
## Summary\n- generate a static docs/kitty-specs dashboard section from the repository kitty-specs directory\n- add standalone dashboard-style pages for mission overview, artifacts, and kanban with permanent URLs\n- wire DocFX Pages CI to generate the section before build\n- add sitemap/canonical/JSON-LD coverage for mission run pages and artifacts\n\n## Verification\n- python3 scripts/docs/generate_kitty_specs_docs.py\n- cd docs && docfx docfx.json\n- python3 scripts/docs/seo_postprocess.py\n- Playwright screenshots for /kitty-specs/, a mission overview, kanban, and mobile\n\n## Publish\nMerging to main triggers .github/workflows/docs-pages.yml and publishes to GitHub Pages for https://docs.spec-kitty.ai/.