### PR TITLE
Persist analyze reports before implementation

### DIFF
--- a/docs/reference/agent-subcommands.md
+++ b/docs/reference/agent-subcommands.md
@@ -489,6 +489,8 @@ _Mission lifecycle commands for AI agents_
 │ create               Create new mission directory structure in the project   │
 │                      root checkout.                                          │
 │ check-prerequisites  Validate mission structure and prerequisites.           │
+│ record-analysis      Persist `/spec-kitty.analyze` output as                │
+│                      `analysis-report.md`.                                  │
 │ setup-plan           Scaffold implementation plan template in the project    │
 │                      root checkout.                                          │
 │ accept               Perform mission acceptance workflow.                    │
@@ -606,6 +608,24 @@ _Mission lifecycle commands for AI agents_
 │                                             (e.g., 'already-confirmed' to    │
 │                                             bypass the prompt)               │
 │ --help                                      Show this message and exit.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## spec-kitty agent mission record-analysis
+
+```
+ Usage: spec-kitty agent mission record-analysis [OPTIONS]
+
+ Persist `/spec-kitty.analyze` output as `analysis-report.md`.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --mission           TEXT  Mission slug (e.g., '020-my-mission')              │
+│ --input-file        TEXT  Markdown report path, or '-' to read report from   │
+│                           stdin                                              │
+│                           [default: -]                                       │
+│ --agent             TEXT  Agent name that produced the analysis report       │
+│ --json                    Output JSON format                                 │
+│ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -286,10 +286,11 @@ Syntax format in this reference:
 
 **What it does**:
 - Reads spec, plan, tasks, and charter (if present).
-- Produces a read-only analysis report of gaps and conflicts.
+- Produces and persists an analysis report of gaps and conflicts.
+- Records source artifact hashes so implementation can reject stale analysis.
 
 **Creates/updates**:
-- `kitty-specs/<feature>/analysis.md`
+- `kitty-specs/<feature>/analysis-report.md`
 
 **Related**: `/spec-kitty.tasks`, `/spec-kitty.implement`
 

--- a/src/doctrine/missions/mission-steps/software-dev/analyze/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/analyze/prompt.md
@@ -17,7 +17,7 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ## Operating Constraints
 
-**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+**NON-REMEDIATING**: Do **not** modify `spec.md`, `plan.md`, `tasks.md`, WP files, source code, or any remediation target. The only permitted file mutation is persisting this command's report to `kitty-specs/<mission>/analysis-report.md` via `spec-kitty agent mission record-analysis`. Offer an optional remediation plan only after the report is persisted (user must explicitly approve before any follow-up editing commands would be invoked manually).
 
 **Charter Authority**: The project charter (`/charter/charter.md`) is **non-negotiable** within this analysis scope. Charter conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit charter update outside `/analyze`.
 
@@ -122,7 +122,7 @@ Use this heuristic to prioritize findings:
 
 ### 6. Produce Compact Analysis Report
 
-Output a Markdown report (no file writes) with the following structure:
+Draft a Markdown report with the following structure:
 
 ## Specification Analysis Report
 
@@ -150,7 +150,23 @@ Output a Markdown report (no file writes) with the following structure:
 - Duplication Count
 - Critical Issues Count
 
-### 7. Provide Next Actions
+### 7. Persist Report Artifact
+
+Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running:
+
+```bash
+spec-kitty agent mission record-analysis --mission <mission-slug> --input-file <path-to-temp-report.md> --json
+```
+
+If your host supports piping reliable multiline stdin, this equivalent form is acceptable:
+
+```bash
+spec-kitty agent mission record-analysis --mission <mission-slug> --input-file - --json
+```
+
+Treat persistence failure as command failure. The command is not complete until the JSON response reports success and names `analysis-report.md`.
+
+### 8. Provide Next Actions
 
 At end of report, output a concise Next Actions block:
 
@@ -158,7 +174,7 @@ At end of report, output a concise Next Actions block:
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
 - Provide explicit command suggestions: e.g., "Run /spec-kitty.specify with refinement", "Run /plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
-### 8. Offer Remediation
+### 9. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
 
@@ -173,7 +189,7 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 
 ### Analysis Guidelines
 
-- **NEVER modify files** (this is read-only analysis)
+- **NEVER modify source/planning files** other than the required `analysis-report.md` persistence step
 - **NEVER hallucinate missing sections** (if absent, report them accurately)
 - **Prioritize charter violations** (these are always CRITICAL)
 - **Use examples over exhaustive rules** (cite specific instances, not generic patterns)

--- a/src/doctrine/missions/mission-steps/software-dev/analyze/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/analyze/prompt.md
@@ -152,7 +152,7 @@ Draft a Markdown report with the following structure:
 
 ### 7. Persist Report Artifact
 
-Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running:
+Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running the recorder with a temp report file outside the repository checkout:
 
 ```bash
 spec-kitty agent mission record-analysis --mission <mission-slug> --input-file <path-to-temp-report.md> --json
@@ -176,7 +176,7 @@ At end of report, output a concise Next Actions block:
 
 ### 9. Offer Remediation
 
-Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+Ask the user: "Should all of these findings be addressed before moving on to implementation? I can suggest concrete remediation edits for the findings you want to resolve." (Do NOT apply edits automatically.)
 
 ## Operating Principles
 

--- a/src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md
@@ -576,9 +576,12 @@ After reporting, ask the user directly:
 
 > **Should I use the `/spec-kitty-implement-review` skill to fully implement all WPs until completion?**
 > This will dispatch implementing and reviewing agents for every WP, handle rejection cycles, and merge all lanes when done.
+>
+> Optional quality control gate before implementation: run `/spec-kitty.analyze` first to persist an `analysis-report.md` and review spec/plan/task consistency before any WP implementation starts.
 
 - If the user says **yes**: invoke the `spec-kitty-implement-review` skill with the mission slug. The user may also specify which agents to use for implementation and review (e.g., "yes, use sonnet for implementing and opus for reviewing").
 - If the user says **no** or wants to do it manually: end here and let them run `/spec-kitty.implement` at their own pace.
+- If the user wants the optional quality gate first: run `/spec-kitty.analyze --mission <mission-slug>` and wait for the user's decision on whether to address findings before invoking implementation.
 - If the user asks for a subset (e.g., "just WP01 and WP02 for now"): invoke the skill with that scope.
 
 This handoff is the natural transition from planning to execution. Do NOT skip the question — always offer it explicitly so the user can choose their execution strategy.

--- a/src/doctrine/missions/software-dev/expected-artifacts.yaml
+++ b/src/doctrine/missions/software-dev/expected-artifacts.yaml
@@ -39,9 +39,10 @@ required_by_step:
       blocking: true
 
   implement:
-    # Implementation step requires code changes tracked via git
-    # Filesystem artifacts not blocking (tracked via git)
-    []
+    - artifact_key: "evidence.analysis-report"
+      artifact_class: "evidence"
+      path_pattern: "analysis-report.md"
+      blocking: true
 
   review:
     # Review step checks code quality and completeness

--- a/src/specify_cli/analysis_report.py
+++ b/src/specify_cli/analysis_report.py
@@ -1,0 +1,286 @@
+"""Durable `/spec-kitty.analyze` report persistence and freshness checks."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from specify_cli.core.atomic import atomic_write
+from specify_cli.frontmatter import FrontmatterError, FrontmatterManager
+from specify_cli.mission_metadata import resolve_mission_identity
+
+ANALYSIS_REPORT_FILENAME = "analysis-report.md"
+ANALYSIS_REPORT_ARTIFACT_TYPE = "spec-kitty.analysis-report"
+ANALYSIS_REPORT_COMMAND = "/spec-kitty.analyze"
+_HASH_INPUTS = ("spec.md", "plan.md", "tasks.md")
+
+
+@dataclass(frozen=True)
+class AnalysisReportResult:
+    """Result of writing an analysis report artifact."""
+
+    path: Path
+    mission_slug: str
+    mission_id: str | None
+    input_artifacts: dict[str, dict[str, str | None]]
+    verdict: str
+    issue_counts: dict[str, int | None]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": str(self.path),
+            "mission_slug": self.mission_slug,
+            "mission_id": self.mission_id,
+            "input_artifacts": self.input_artifacts,
+            "verdict": self.verdict,
+            "issue_counts": self.issue_counts,
+            "stale": False,
+        }
+
+
+@dataclass(frozen=True)
+class AnalysisFreshness:
+    """Freshness status for `analysis-report.md`."""
+
+    ok: bool
+    path: Path
+    stale: bool
+    missing: bool
+    reason: str | None
+    mismatches: dict[str, dict[str, str | None]]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "path": str(self.path),
+            "stale": self.stale,
+            "missing": self.missing,
+            "reason": self.reason,
+            "mismatches": self.mismatches,
+        }
+
+
+class AnalysisReportError(RuntimeError):
+    """Raised when the analysis report cannot be written or validated."""
+
+
+def _yaml() -> YAML:
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.width = 4096
+    return yaml
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()  # noqa: TID251 - file-integrity hash for artifact freshness
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact_hash_entry(path: Path) -> dict[str, str | None]:
+    if not path.exists():
+        return {"path": str(path), "sha256": None}
+    return {"path": str(path), "sha256": _sha256_file(path)}
+
+
+def _charter_path(repo_root: Path) -> Path | None:
+    for candidate in (
+        repo_root / ".kittify" / "charter" / "charter.md",
+        repo_root / "charter" / "charter.md",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def collect_input_artifact_hashes(feature_dir: Path, repo_root: Path) -> dict[str, dict[str, str | None]]:
+    """Return current hashes for analyzer source artifacts."""
+
+    inputs = {
+        name: _artifact_hash_entry(feature_dir / name)
+        for name in _HASH_INPUTS
+    }
+    charter = _charter_path(repo_root)
+    inputs["charter"] = {"path": str(charter) if charter else None, "sha256": _sha256_file(charter) if charter else None}
+    return inputs
+
+
+def _count_from_patterns(body: str, severity: str) -> int | None:
+    patterns = (
+        rf"{severity}\s+Issues?\s+Count\s*[:|]\s*(\d+)",
+        rf"{severity}\s+Issues?\s*[:|]\s*(\d+)",
+        rf"{severity}\s*[:|]\s*(\d+)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, body, flags=re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def infer_issue_counts(body: str) -> dict[str, int | None]:
+    """Infer issue counts from common analyze report wording."""
+
+    counts = {
+        key: _count_from_patterns(body, key)
+        for key in ("critical", "high", "medium", "low")
+    }
+    if all(value is None for value in counts.values()):
+        for key in counts:
+            pattern = rf"\b{key.upper()}\b"
+            matches = re.findall(pattern, body)
+            if matches:
+                counts[key] = len(matches)
+    return counts
+
+
+def infer_verdict(body: str, counts: dict[str, int | None]) -> str:
+    """Infer a coarse report verdict for gates and JSON output."""
+
+    upper = body.upper()
+    if "READY FOR IMPLEMENTATION" in upper or "PASS" in upper:
+        return "ready"
+    if "BLOCK" in upper or "CRITICAL" in upper and (counts.get("critical") or 0) > 0:
+        return "blocked"
+    if (counts.get("critical") or 0) > 0 or (counts.get("high") or 0) > 0:
+        return "blocked"
+    return "unknown"
+
+
+def _frontmatter_text(frontmatter: dict[str, Any]) -> str:
+    stream = io.StringIO()
+    yaml = _yaml()
+    yaml.dump(frontmatter, stream)
+    return stream.getvalue()
+
+
+def write_analysis_report(
+    *,
+    feature_dir: Path,
+    repo_root: Path,
+    body: str,
+    analyzer_agent: str | None = None,
+) -> AnalysisReportResult:
+    """Persist `analysis-report.md` with source-artifact hashes."""
+
+    for required in _HASH_INPUTS:
+        required_path = feature_dir / required
+        if not required_path.exists():
+            raise AnalysisReportError(f"Required artifact missing: {required_path}")
+
+    identity = resolve_mission_identity(feature_dir)
+    input_artifacts = collect_input_artifact_hashes(feature_dir, repo_root)
+    issue_counts = infer_issue_counts(body)
+    verdict = infer_verdict(body, issue_counts)
+    frontmatter: dict[str, Any] = {
+        "schema_version": 1,
+        "artifact_type": ANALYSIS_REPORT_ARTIFACT_TYPE,
+        "command": ANALYSIS_REPORT_COMMAND,
+        "mission_slug": identity.mission_slug,
+        "mission_id": identity.mission_id,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "analyzer_agent": analyzer_agent or "unknown",
+        "input_artifacts": input_artifacts,
+        "verdict": verdict,
+        "issue_counts": issue_counts,
+    }
+    normalized_body = body if body.endswith("\n") else body + "\n"
+    content = f"---\n{_frontmatter_text(frontmatter)}---\n\n{normalized_body}"
+    path = feature_dir / ANALYSIS_REPORT_FILENAME
+    atomic_write(path, content)
+    return AnalysisReportResult(
+        path=path,
+        mission_slug=identity.mission_slug,
+        mission_id=identity.mission_id,
+        input_artifacts=input_artifacts,
+        verdict=verdict,
+        issue_counts=issue_counts,
+    )
+
+
+def check_analysis_report_current(feature_dir: Path, repo_root: Path) -> AnalysisFreshness:
+    """Return whether `analysis-report.md` exists and matches current inputs."""
+
+    path = feature_dir / ANALYSIS_REPORT_FILENAME
+    if not path.exists():
+        return AnalysisFreshness(
+            ok=False,
+            path=path,
+            stale=False,
+            missing=True,
+            reason="missing_analysis_report",
+            mismatches={},
+        )
+
+    try:
+        frontmatter, _body = FrontmatterManager().read(path)
+    except FrontmatterError as exc:
+        return AnalysisFreshness(
+            ok=False,
+            path=path,
+            stale=True,
+            missing=False,
+            reason=f"invalid_analysis_report_frontmatter: {exc}",
+            mismatches={},
+        )
+
+    if frontmatter.get("artifact_type") != ANALYSIS_REPORT_ARTIFACT_TYPE:
+        return AnalysisFreshness(
+            ok=False,
+            path=path,
+            stale=True,
+            missing=False,
+            reason="invalid_analysis_report_artifact_type",
+            mismatches={},
+        )
+
+    saved_inputs = frontmatter.get("input_artifacts")
+    if not isinstance(saved_inputs, dict):
+        return AnalysisFreshness(
+            ok=False,
+            path=path,
+            stale=True,
+            missing=False,
+            reason="missing_input_artifacts",
+            mismatches={},
+        )
+
+    current = collect_input_artifact_hashes(feature_dir, repo_root)
+    mismatches: dict[str, dict[str, str | None]] = {}
+    for key in (*_HASH_INPUTS, "charter"):
+        saved_entry = saved_inputs.get(key)
+        saved_hash = saved_entry.get("sha256") if isinstance(saved_entry, dict) else None
+        current_hash = current.get(key, {}).get("sha256")
+        if saved_hash != current_hash:
+            mismatches[key] = {
+                "saved_sha256": saved_hash,
+                "current_sha256": current_hash,
+            }
+
+    if mismatches:
+        return AnalysisFreshness(
+            ok=False,
+            path=path,
+            stale=True,
+            missing=False,
+            reason="stale_analysis_report",
+            mismatches=mismatches,
+        )
+
+    return AnalysisFreshness(
+        ok=True,
+        path=path,
+        stale=False,
+        missing=False,
+        reason=None,
+        mismatches={},
+    )

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -1080,6 +1080,98 @@ def check_prerequisites(
         raise typer.Exit(1) from None
 
 
+@app.command(name="record-analysis")
+def record_analysis(
+    feature: Annotated[str | None, typer.Option("--mission", help="Mission slug (e.g., '020-my-mission')")] = None,
+    input_file: Annotated[
+        str,
+        typer.Option("--input-file", help="Markdown report path, or '-' to read report from stdin"),
+    ] = "-",
+    analyzer_agent: Annotated[
+        str | None,
+        typer.Option("--agent", help="Agent name that produced the analysis report"),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output JSON format")] = False,
+) -> None:
+    """Persist `/spec-kitty.analyze` output as `analysis-report.md`."""
+    try:
+        repo_root = locate_project_root()
+        if repo_root is None:
+            error_msg = "Could not locate project root"
+            if json_output:
+                _emit_json({"error": error_msg, "success": False})
+            else:
+                console.print(f"[red]Error:[/red] {error_msg}")
+            raise typer.Exit(1)
+        repo_root = get_main_repo_root(repo_root)
+
+        try:
+            feature_dir = _find_feature_directory(
+                repo_root,
+                Path.cwd().resolve(),
+                explicit_feature=feature,
+            )
+        except ValueError as detection_error:
+            payload = _build_setup_plan_detection_error(
+                repo_root,
+                str(detection_error),
+                feature,
+                error_code="FEATURE_CONTEXT_UNRESOLVED",
+                command_name="record-analysis",
+                command_args=["--json"] if json_output else [],
+            )
+            if json_output:
+                _emit_json(payload)
+            else:
+                console.print(f"[red]Error:[/red] {payload['error']}")
+            raise typer.Exit(1) from None
+
+        body = sys.stdin.read() if input_file == "-" else Path(input_file).read_text(encoding="utf-8")
+        if not body.strip():
+            error_msg = "Analysis report body is empty"
+            if json_output:
+                _emit_json({"error": error_msg, "success": False})
+            else:
+                console.print(f"[red]Error:[/red] {error_msg}")
+            raise typer.Exit(1)
+
+        from specify_cli.analysis_report import write_analysis_report
+
+        result = write_analysis_report(
+            feature_dir=feature_dir,
+            repo_root=repo_root,
+            body=body,
+            analyzer_agent=analyzer_agent,
+        )
+
+        with contextlib.suppress(Exception):
+            from specify_cli.sync.dossier_pipeline import (
+                trigger_feature_dossier_sync_if_enabled,
+            )
+
+            trigger_feature_dossier_sync_if_enabled(
+                feature_dir,
+                result.mission_slug,
+                repo_root,
+            )
+
+        payload = {"success": True, "result": "success", **result.to_dict()}
+        if json_output:
+            _emit_json(payload)
+        else:
+            rel = result.path.relative_to(repo_root) if result.path.is_relative_to(repo_root) else result.path
+            console.print(f"[green]✓[/green] Analysis report persisted: {rel}")
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if json_output:
+            _emit_json({"error": str(e), "success": False})
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+
 @app.command(name="setup-plan")
 def setup_plan(
     feature: Annotated[str | None, typer.Option("--mission", help="Mission slug (e.g., '020-my-mission')")] = None,

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -37,7 +37,7 @@ from specify_cli.core.paths import get_main_repo_root, locate_project_root
 from specify_cli.core.paths import (
     get_feature_target_branch,
 )
-from specify_cli.git import safe_commit
+from specify_cli.git import ProtectedBranchCommitError, assert_not_protected_branch, safe_commit
 from specify_cli.core.worktree import (
     validate_feature_structure,
 )
@@ -316,6 +316,69 @@ def _enforce_git_preflight(
         for cmd in cast(list[str], payload.get("remediation", [])):
             console.print(f"  - Run: {cmd}")
     raise typer.Exit(1)
+
+
+def _git_dirty_paths(repo_root: Path) -> list[str]:
+    """Return dirty paths from `git status --porcelain`, or an empty list outside git."""
+    if not is_git_repo(repo_root):
+        return []
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError:
+        return []
+    if result.returncode != 0:
+        raise RuntimeError((result.stderr or "git status failed").strip())
+    dirty: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        dirty.append(line[3:].strip() if len(line) > 3 else line.strip())
+    return dirty
+
+
+def _enforce_analysis_report_write_preflight(repo_root: Path, *, json_output: bool) -> None:
+    """Fail before `record-analysis` mutates a mission artifact in unsafe git state."""
+    if not is_git_repo(repo_root):
+        return
+
+    try:
+        assert_not_protected_branch(repo_root, operation="record analysis report")
+    except ProtectedBranchCommitError as exc:
+        payload = {
+            "success": False,
+            "error_code": "PROTECTED_BRANCH_REFUSED",
+            "error": str(exc),
+        }
+        if json_output:
+            _emit_json(payload)
+        else:
+            console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    dirty_paths = _git_dirty_paths(repo_root)
+    if dirty_paths:
+        payload = {
+            "success": False,
+            "error_code": "DIRTY_WORKTREE",
+            "error": "Refusing to record analysis report with pre-existing dirty working tree.",
+            "dirty_paths": dirty_paths,
+            "remediation": ["Commit or stash existing changes, then rerun /spec-kitty.analyze."],
+        }
+        if json_output:
+            _emit_json(payload)
+        else:
+            console.print(f"[red]Error:[/red] {payload['error']}")
+            for path in dirty_paths:
+                console.print(f"  - {path}")
+        raise typer.Exit(1)
 
 
 def _show_branch_context(
@@ -1104,6 +1167,7 @@ def record_analysis(
                 console.print(f"[red]Error:[/red] {error_msg}")
             raise typer.Exit(1)
         repo_root = get_main_repo_root(repo_root)
+        _enforce_analysis_report_write_preflight(repo_root, json_output=json_output)
 
         try:
             feature_dir = _find_feature_directory(

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -984,6 +984,26 @@ def _auto_claim_failure_message(preview: object | None) -> str:
     return "No planned work packages found. Specify a WP ID explicitly."
 
 
+def _require_current_analysis_report(feature_dir: Path, repo_root: Path, mission_slug: str) -> None:
+    """Block implementation until `/spec-kitty.analyze` is persisted and fresh."""
+    from specify_cli.analysis_report import check_analysis_report_current
+
+    analysis_freshness = check_analysis_report_current(feature_dir, repo_root)
+    if analysis_freshness.ok:
+        return
+    print("Error: analysis_report_required: /spec-kitty.analyze must be run before implementation.")
+    if analysis_freshness.missing:
+        print(f"  Missing: {analysis_freshness.path}")
+    elif analysis_freshness.reason:
+        print(f"  Reason: {analysis_freshness.reason}")
+    if analysis_freshness.mismatches:
+        print("  Stale inputs:")
+        for artifact_name in sorted(analysis_freshness.mismatches):
+            print(f"    - {artifact_name}")
+    print(f"  Run: /spec-kitty.analyze --mission {mission_slug}")
+    raise typer.Exit(1)
+
+
 @app.command(name="implement")
 def implement(
     wp_id: Annotated[str | None, typer.Argument(help="Work package ID (e.g., WP01, wp01, WP01-slug) - auto-detects first planned if omitted")] = None,
@@ -1073,6 +1093,8 @@ def implement(
         # Ensure planning repo is on the target branch before we start
         # (needed for auto-commits and status tracking inside this command)
         main_repo_root, target_branch = _ensure_target_branch_checked_out(repo_root, mission_slug)
+        feature_dir = resolve_feature_dir_for_mission(main_repo_root, mission_slug)
+        _require_current_analysis_report(feature_dir, main_repo_root, mission_slug)
 
         # Determine which WP to implement
         if wp_id:

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1093,8 +1093,6 @@ def implement(
         # Ensure planning repo is on the target branch before we start
         # (needed for auto-commits and status tracking inside this command)
         main_repo_root, target_branch = _ensure_target_branch_checked_out(repo_root, mission_slug)
-        feature_dir = resolve_feature_dir_for_mission(main_repo_root, mission_slug)
-        _require_current_analysis_report(feature_dir, main_repo_root, mission_slug)
 
         # Determine which WP to implement
         if wp_id:
@@ -1145,6 +1143,60 @@ def implement(
                     f"resolution={_resolution_cmd!r}"
                 )
 
+        wp_meta, _ = read_wp_frontmatter(wp.path)
+
+        from specify_cli.status.reducer import reduce as _dep_reduce_events
+        from specify_cli.status.store import read_events as _dep_read_events
+        from specify_cli.status.transitions import resolve_lane_alias as _dep_resolve_alias
+
+        _dependency_feature_dir = _canonical_status_feature_dir(main_repo_root, mission_slug)
+        _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
+        _dependency_lanes = {
+            _wp_id: _state.get("lane", Lane.PLANNED)
+            for _wp_id, _state in _dependency_snapshot.work_packages.items()
+        }
+        if normalized_wp_id not in _dependency_snapshot.work_packages:
+            print(f"Error: {_missing_canonical_status_message(normalized_wp_id, mission_slug)}")
+            raise typer.Exit(1)
+
+        # Only gate the not-yet-started claim transition. Re-invoking implement on
+        # a WP that is already in_progress/for_review/.../approved (resume, prompt
+        # redisplay, fix-cycle) must not be rejected just because a dependency
+        # later regressed out of approved/done — the lifecycle treats those
+        # re-invocations as no-op resumes, not new claims.
+        try:
+            _self_lane = Lane(_dep_resolve_alias(str(_dependency_lanes.get(normalized_wp_id, Lane.PLANNED))))
+        except ValueError:
+            _self_lane = Lane.PLANNED
+        if _self_lane in (Lane.PLANNED, Lane.CLAIMED):
+            _dependency_readiness = dependency_readiness_for_wp(
+                normalized_wp_id,
+                wp_meta.dependencies,
+                _dependency_lanes,
+            )
+            if not _dependency_readiness.satisfied:
+                blocked = ", ".join(_dependency_readiness.unsatisfied)
+                print(
+                    f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
+                    "all dependencies must be approved or done before implementation can start"
+                )
+                raise typer.Exit(1)
+
+        feature_dir = resolve_feature_dir_for_mission(main_repo_root, mission_slug)
+        has_feedback, review_feedback_ref, review_feedback_file, review_feedback_source = _resolve_review_feedback_context(
+            feature_dir=feature_dir,
+            repo_root=main_repo_root,
+            wp_id=normalized_wp_id,
+            wp_frontmatter=getattr(wp, "frontmatter", "") or "",
+        )
+
+        if review_feedback_source == "canonical" and review_feedback_file is None:
+            print(f"Error: {normalized_wp_id} review feedback artifact is missing or unreadable: {review_feedback_ref}")
+            print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
+            raise typer.Exit(1)
+
+        _require_current_analysis_report(feature_dir, main_repo_root, mission_slug)
+
         workspace = resolve_workspace_for_wp(main_repo_root, mission_slug, normalized_wp_id)
         workspace_path = workspace.worktree_path
         status_execution_mode = "direct_repo" if workspace.resolution_kind == "repo_root" else "worktree"
@@ -1181,48 +1233,6 @@ def implement(
                 print(f"Error: implement completed but no workspace could be resolved for {normalized_wp_id}.")
                 raise typer.Exit(1)
 
-        # Load work package
-        try:
-            wp = locate_work_package(repo_root, mission_slug, normalized_wp_id)
-            wp_meta, _ = read_wp_frontmatter(wp.path)
-        except RuntimeError as e:
-            if _is_missing_canonical_status_error(e):
-                raise RuntimeError(_missing_canonical_status_message(normalized_wp_id, mission_slug)) from e
-            raise
-
-        from specify_cli.status.reducer import reduce as _dep_reduce_events
-        from specify_cli.status.store import read_events as _dep_read_events
-        from specify_cli.status.transitions import resolve_lane_alias as _dep_resolve_alias
-
-        _dependency_feature_dir = _canonical_status_feature_dir(main_repo_root, mission_slug)
-        _dependency_snapshot = _dep_reduce_events(_dep_read_events(_dependency_feature_dir))
-        _dependency_lanes = {
-            _wp_id: _state.get("lane", Lane.PLANNED)
-            for _wp_id, _state in _dependency_snapshot.work_packages.items()
-        }
-        # Only gate the not-yet-started claim transition. Re-invoking implement on
-        # a WP that is already in_progress/for_review/.../approved (resume, prompt
-        # redisplay, fix-cycle) must not be rejected just because a dependency
-        # later regressed out of approved/done — the lifecycle treats those
-        # re-invocations as no-op resumes, not new claims.
-        try:
-            _self_lane = Lane(_dep_resolve_alias(str(_dependency_lanes.get(normalized_wp_id, Lane.PLANNED))))
-        except ValueError:
-            _self_lane = Lane.PLANNED
-        if _self_lane in (Lane.PLANNED, Lane.CLAIMED):
-            _dependency_readiness = dependency_readiness_for_wp(
-                normalized_wp_id,
-                wp_meta.dependencies,
-                _dependency_lanes,
-            )
-            if not _dependency_readiness.satisfied:
-                blocked = ", ".join(_dependency_readiness.unsatisfied)
-                print(
-                    f"Error: dependencies_not_satisfied: {normalized_wp_id} depends on {blocked}; "
-                    "all dependencies must be approved or done before implementation can start"
-                )
-                raise typer.Exit(1)
-
         subtask_ids = [str(item) for item in wp_meta.subtasks if isinstance(item, str)]
         subtask_cmd = " ".join(subtask_ids) if subtask_ids else "<subtask-ids>"
 
@@ -1244,20 +1254,8 @@ def implement(
             raise RuntimeError(_missing_canonical_status_message(normalized_wp_id, mission_slug, _wf_feature_dir))
         current_lane = _wf_get_wp_lane(_wf_feature_dir, normalized_wp_id)
         needs_agent_assignment = _wp_agent_assignment.tool == "unknown"
-        feature_dir = resolve_feature_dir_for_mission(main_repo_root, mission_slug)
         wp_slug = wp.path.stem
-        has_feedback, review_feedback_ref, review_feedback_file, review_feedback_source = _resolve_review_feedback_context(
-            feature_dir=feature_dir,
-            repo_root=main_repo_root,
-            wp_id=normalized_wp_id,
-            wp_frontmatter=wp.frontmatter,
-        )
         fix_mode_active = _has_prior_rejection(feature_dir, wp_slug, normalized_wp_id)
-
-        if review_feedback_source == "canonical" and review_feedback_file is None:
-            print(f"Error: {normalized_wp_id} review feedback artifact is missing or unreadable: {review_feedback_ref}")
-            print("Re-run move-task with --review-feedback-file so the fix cycle can attach the canonical review artifact.")
-            raise typer.Exit(1)
 
         if current_lane != Lane.IN_PROGRESS or needs_agent_assignment or agent:
             # Require --agent parameter to track who is working

--- a/src/specify_cli/dossier/indexer.py
+++ b/src/specify_cli/dossier/indexer.py
@@ -245,6 +245,8 @@ class Indexer:
         # Evidence artifacts (check before policy/input, as names may overlap)
         if name in ["research.md"]:
             return "evidence"
+        if name == "analysis-report.md":
+            return "evidence"
         if "test" in name or name.startswith("test_"):
             return "evidence"
         if "gap-analysis" in name:

--- a/src/specify_cli/missions/software-dev/expected-artifacts.yaml
+++ b/src/specify_cli/missions/software-dev/expected-artifacts.yaml
@@ -39,9 +39,10 @@ required_by_step:
       blocking: true
 
   implement:
-    # Implementation step requires code changes tracked via git
-    # Filesystem artifacts not blocking (tracked via git)
-    []
+    - artifact_key: "evidence.analysis-report"
+      artifact_class: "evidence"
+      path_pattern: "analysis-report.md"
+      blocking: true
 
   review:
     # Review step checks code quality and completeness

--- a/src/specify_cli/sync/body_upload.py
+++ b/src/specify_cli/sync/body_upload.py
@@ -35,6 +35,7 @@ _TOP_LEVEL_ARTIFACTS: frozenset[str] = frozenset(
         "spec.md",
         "plan.md",
         "tasks.md",
+        "analysis-report.md",
         "research.md",
         "quickstart.md",
         "data-model.md",

--- a/tests/dossier/test_indexer.py
+++ b/tests/dossier/test_indexer.py
@@ -153,6 +153,15 @@ class TestArtifactClassification:
         artifact_class = indexer._classify_artifact(gap_file, None)
         assert artifact_class == "evidence"
 
+    def test_classify_analysis_report_as_evidence(self, tmp_path):
+        """Classify analysis-report.md as evidence."""
+        report_file = tmp_path / "analysis-report.md"
+        report_file.write_text("# Analysis Report")
+
+        indexer = Indexer(ManifestRegistry())
+        artifact_class = indexer._classify_artifact(report_file, None)
+        assert artifact_class == "evidence"
+
     def test_classify_test_file_as_evidence(self, tmp_path):
         """Classify test_*.py files as evidence."""
         test_file = tmp_path / "test_something.py"

--- a/tests/dossier/test_manifest.py
+++ b/tests/dossier/test_manifest.py
@@ -411,6 +411,16 @@ class TestManifestIntegration:
         assert len(research) > 0
         assert research[0].path_pattern == "research.md"
 
+    def test_software_dev_implement_requires_analysis_report(self):
+        """software-dev manifest requires analysis-report.md before implement."""
+        manifest = ManifestRegistry.load_manifest("software-dev")
+        assert manifest is not None
+        specs = ManifestRegistry.get_required_artifacts(manifest, "implement")
+        report = [s for s in specs if s.artifact_key == "evidence.analysis-report"]
+        assert len(report) > 0
+        assert report[0].blocking is True
+        assert report[0].path_pattern == "analysis-report.md"
+
     def test_research_manifest_scoping_step_requires_spec(self):
         """research manifest requires spec.md at scoping step."""
         manifest = ManifestRegistry.load_manifest("research")

--- a/tests/integration/test_rejection_cycle.py
+++ b/tests/integration/test_rejection_cycle.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from specify_cli.analysis_report import write_analysis_report
 from specify_cli.cli.commands.agent import workflow
 from specify_cli.frontmatter import write_frontmatter
 from specify_cli.lanes.models import ExecutionLane, LanesManifest
@@ -456,7 +457,15 @@ def workflow_cli_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[
         ),
     )
     (feature_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
+    (feature_dir / "spec.md").write_text("# Spec\n\nFR-001.\n", encoding="utf-8")
+    (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
     _write_cli_wp(tasks_dir / "WP01-test-task.md")
+    write_analysis_report(
+        feature_dir=feature_dir,
+        repo_root=repo,
+        body="# Analysis\n\nCritical Issues Count: 0\nHigh Issues Count: 0\nPASS\n",
+        analyzer_agent="test",
+    )
 
     workspace = repo / ".worktrees" / f"{mission_slug}-lane-a"
     workspace.mkdir(parents=True)

--- a/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py
@@ -20,6 +20,7 @@ from typer.testing import CliRunner
 from tests.lane_test_utils import lane_worktree_path, write_single_lane_manifest
 
 from specify_cli.cli.commands.agent import workflow
+from specify_cli.analysis_report import write_analysis_report
 from specify_cli.frontmatter import write_frontmatter
 from specify_cli.status.models import StatusEvent, Lane
 from specify_cli.status.store import append_event, read_events
@@ -76,6 +77,20 @@ def _write_wp_file(path: Path, wp_id: str, lane: str) -> None:
     write_frontmatter(path, frontmatter, body)
 
 
+def _write_current_analysis_report(feature_dir: Path, repo_root: Path) -> None:
+    """Write a current analysis report for implement success-path fixtures."""
+    (feature_dir / "spec.md").write_text("# Spec\n\nFR-001.\n", encoding="utf-8")
+    (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    if not (feature_dir / "tasks.md").exists():
+        (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+    write_analysis_report(
+        feature_dir=feature_dir,
+        repo_root=repo_root,
+        body="# Analysis\n\nCritical Issues Count: 0\nHigh Issues Count: 0\nPASS\n",
+        analyzer_agent="test",
+    )
+
+
 @pytest.fixture()
 def workflow_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     repo_root = tmp_path
@@ -117,6 +132,7 @@ class TestImplementBodyNoteLaneFree:
         _write_wp_file(wp_path, "WP01", lane="planned")
         # Seed canonical state so implement doesn't hard-fail
         _seed_wp_lane(feature_dir, "WP01", "planned")
+        _write_current_analysis_report(feature_dir, workflow_repo)
 
         workspace = lane_worktree_path(workflow_repo, mission_slug)
         workspace.mkdir(parents=True)
@@ -147,6 +163,7 @@ class TestImplementBodyNoteLaneFree:
         _write_wp_file(wp_path, "WP01", lane="doing")
         # Seed canonical state as in_progress (= doing)
         _seed_wp_lane(feature_dir, "WP01", "doing", actor="test-agent")
+        _write_current_analysis_report(feature_dir, workflow_repo)
 
         workspace = lane_worktree_path(workflow_repo, mission_slug)
         workspace.mkdir(parents=True)
@@ -268,6 +285,7 @@ class TestImplementHardFailNoCanonical:
         _write_wp_file(wp_path, "WP01", lane="planned")
         # Seed canonical state
         _seed_wp_lane(feature_dir, "WP01", "planned")
+        _write_current_analysis_report(feature_dir, workflow_repo)
 
         workspace = lane_worktree_path(workflow_repo, mission_slug)
         workspace.mkdir(parents=True)
@@ -293,6 +311,7 @@ class TestImplementHardFailNoCanonical:
         (feature_dir / "tasks.md").write_text("## WP01 Test\n\n- [x] T001 Placeholder task\n", encoding="utf-8")
         _write_wp_file(tasks_dir / "WP01-test.md", "WP01", lane="planned")
         _seed_wp_lane(feature_dir, "WP01", "planned")
+        _write_current_analysis_report(feature_dir, workflow_repo)
 
         workspace = lane_worktree_path(workflow_repo, mission_slug)
         workspace.mkdir(parents=True)
@@ -432,6 +451,7 @@ class TestPlanningArtifactWorkflowPrompt:
             encoding="utf-8",
         )
         _seed_wp_lane(feature_dir, "WP02", "planned")
+        _write_current_analysis_report(feature_dir, workflow_repo)
 
         result = CliRunner().invoke(
             workflow.app,
@@ -473,6 +493,7 @@ class TestPlanningArtifactWorkflowPrompt:
             encoding="utf-8",
         )
         _seed_wp_lane(feature_dir, "WP02", "planned")
+        _write_current_analysis_report(feature_dir, workflow_repo)
 
         result = CliRunner().invoke(
             workflow.app,
@@ -573,6 +594,7 @@ class TestImplementDependencyGate:
         self._scaffold_dependent_pair(feature_dir)
         # WP01 is only in_progress (not approved/done); WP02 stays planned.
         _seed_wp_lane(feature_dir, "WP01", "in_progress")
+        _seed_wp_lane(feature_dir, "WP02", "planned")
         # Workspace already resolves so creation is skipped and the gate is reached.
         lane_worktree_path(workflow_repo, mission_slug).mkdir(parents=True)
 
@@ -596,6 +618,7 @@ class TestImplementDependencyGate:
         # WP01 reverted to in_progress (unsatisfied); WP02 was already started.
         _seed_wp_lane(feature_dir, "WP01", "in_progress")
         _seed_wp_lane(feature_dir, "WP02", "in_progress", actor="test-agent")
+        _write_current_analysis_report(feature_dir, workflow_repo)
         lane_worktree_path(workflow_repo, mission_slug).mkdir(parents=True)
 
         result = CliRunner().invoke(

--- a/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
+++ b/tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py
@@ -13,6 +13,8 @@ from typer.testing import CliRunner
 from specify_cli.cli.commands.agent.mission import app
 from specify_cli.cli.commands.agent import workflow
 from specify_cli.merge.config import MergeStrategy
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.store import append_event
 
 pytestmark = pytest.mark.fast
 
@@ -25,6 +27,44 @@ def _workspace(exists: bool) -> SimpleNamespace:
         worktree_path=Path("/tmp/spec-kitty-test-worktree"),
         resolution_kind="repo_root",
     )
+
+
+def _scaffold_implement_mission(repo_root: Path, mission_slug: str, wp_id: str = "WP01") -> Path:
+    feature_dir = repo_root / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("# Spec\n", encoding="utf-8")
+    (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (feature_dir / "tasks.md").write_text(f"## {wp_id}\n", encoding="utf-8")
+    wp_path = tasks_dir / f"{wp_id}-test.md"
+    wp_path.write_text(
+        "---\n"
+        f"work_package_id: {wp_id}\n"
+        "subtasks: [T001]\n"
+        "title: Test WP\n"
+        "dependencies: []\n"
+        "execution_mode: code_change\n"
+        "owned_files:\n  - src/**\n"
+        "authoritative_surface: src/\n"
+        "---\n"
+        "# Test WP\n",
+        encoding="utf-8",
+    )
+    append_event(
+        feature_dir,
+        StatusEvent(
+            event_id=f"test-{wp_id}-planned",
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.PLANNED,
+            at="2026-01-01T00:00:00+00:00",
+            actor="test",
+            force=True,
+            execution_mode="worktree",
+        ),
+    )
+    return wp_path
 
 
 @patch("specify_cli.cli.commands.agent.mission.top_level_accept")
@@ -121,6 +161,7 @@ def test_agent_mission_merge_passes_explicit_wrapper_defaults(
 @patch("specify_cli.cli.commands.agent.workflow.top_level_implement")
 @patch("specify_cli.cli.commands.agent.workflow.resolve_workspace_for_wp")
 @patch("specify_cli.cli.commands.agent.workflow.locate_work_package")
+@patch("specify_cli.cli.commands.agent.workflow._require_current_analysis_report")
 @patch("specify_cli.cli.commands.agent.workflow._ensure_target_branch_checked_out")
 @patch("specify_cli.cli.commands.agent.workflow.get_main_repo_root")
 @patch("specify_cli.cli.commands.agent.workflow.locate_project_root")
@@ -130,6 +171,7 @@ def test_agent_action_implement_passes_acknowledge_default_false(
     mock_locate_project_root: MagicMock,
     mock_get_main_repo_root: MagicMock,
     mock_ensure_target_branch_checked_out: MagicMock,
+    mock_require_current_analysis_report: MagicMock,
     mock_locate_work_package: MagicMock,
     mock_resolve_workspace_for_wp: MagicMock,
     mock_top_level_implement: MagicMock,
@@ -141,7 +183,9 @@ def test_agent_action_implement_passes_acknowledge_default_false(
     mock_locate_project_root.return_value = tmp_path
     mock_get_main_repo_root.return_value = tmp_path
     mock_ensure_target_branch_checked_out.return_value = (tmp_path, "main")
-    mock_locate_work_package.return_value = SimpleNamespace(path=tmp_path / "wp01.md")
+    wp_path = _scaffold_implement_mission(tmp_path, "demo-mission")
+    mock_locate_work_package.return_value = SimpleNamespace(path=wp_path)
+    mock_require_current_analysis_report.return_value = None
     mock_resolve_workspace_for_wp.return_value = _workspace(exists=False)
     mock_top_level_implement.side_effect = RuntimeError("stop after delegation")
 
@@ -162,6 +206,7 @@ def test_agent_action_implement_passes_acknowledge_default_false(
 @patch("specify_cli.cli.commands.agent.workflow.top_level_implement")
 @patch("specify_cli.cli.commands.agent.workflow.resolve_workspace_for_wp")
 @patch("specify_cli.cli.commands.agent.workflow.locate_work_package")
+@patch("specify_cli.cli.commands.agent.workflow._require_current_analysis_report")
 @patch("specify_cli.cli.commands.agent.workflow._ensure_target_branch_checked_out")
 @patch("specify_cli.cli.commands.agent.workflow.get_main_repo_root")
 @patch("specify_cli.cli.commands.agent.workflow.locate_project_root")
@@ -171,6 +216,7 @@ def test_agent_action_implement_passes_acknowledge_true_when_requested(
     mock_locate_project_root: MagicMock,
     mock_get_main_repo_root: MagicMock,
     mock_ensure_target_branch_checked_out: MagicMock,
+    mock_require_current_analysis_report: MagicMock,
     mock_locate_work_package: MagicMock,
     mock_resolve_workspace_for_wp: MagicMock,
     mock_top_level_implement: MagicMock,
@@ -182,7 +228,9 @@ def test_agent_action_implement_passes_acknowledge_true_when_requested(
     mock_locate_project_root.return_value = tmp_path
     mock_get_main_repo_root.return_value = tmp_path
     mock_ensure_target_branch_checked_out.return_value = (tmp_path, "main")
-    mock_locate_work_package.return_value = SimpleNamespace(path=tmp_path / "wp01.md")
+    wp_path = _scaffold_implement_mission(tmp_path, "demo-mission")
+    mock_locate_work_package.return_value = SimpleNamespace(path=wp_path)
+    mock_require_current_analysis_report.return_value = None
     mock_resolve_workspace_for_wp.return_value = _workspace(exists=False)
     mock_top_level_implement.side_effect = RuntimeError("stop after delegation")
 

--- a/tests/specify_cli/events/test_sanitizer.py
+++ b/tests/specify_cli/events/test_sanitizer.py
@@ -64,11 +64,11 @@ def test_all_pii_fields_stripped_together() -> None:
     """All five PII fields are removed when present simultaneously."""
     envelope = {
         "event_type": "TestEvent",
-        "machine_name": "roberts-mbp",
-        "hostname": "roberts-mbp.local",
-        "workspace_path": "/Users/robert/project",
-        "developer_name": "Robert",
-        "developer_email": "robert@example.com",
+        "machine_name": "dev-mbp",
+        "hostname": "dev-mbp.local",
+        "workspace_path": "/Users/tester/project",
+        "developer_name": "Test User",
+        "developer_email": "tester@example.com",
         "node_id": "keep-this",
     }
     result = sanitize_event_for_log(envelope)
@@ -281,11 +281,11 @@ def test_pii_and_timestamps_stripped_together() -> None:
     # canonical-producer-exempt: #1198 -- sanitizer unit test must exercise raw envelope input.
     envelope = {
         "event_type": "DecisionInputRequested",
-        "machine_name": "roberts-mbp",
+        "machine_name": "dev-mbp",
         "session_started_at": "2026-06-01T07:00:00Z",
         "session_ended_at": "2026-06-01T07:01:00Z",
         "payload": {
-            "workspace_path": "/Users/robert/project",
+            "workspace_path": "/Users/tester/project",
             "question": "Which strategy?",
         },
     }

--- a/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
@@ -47,7 +47,7 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ## Operating Constraints
 
-**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+**NON-REMEDIATING**: Do **not** modify `spec.md`, `plan.md`, `tasks.md`, WP files, source code, or any remediation target. The only permitted file mutation is persisting this command's report to `kitty-specs/<mission>/analysis-report.md` via `spec-kitty agent mission record-analysis`. Offer an optional remediation plan only after the report is persisted (user must explicitly approve before any follow-up editing commands would be invoked manually).
 
 **Charter Authority**: The project charter (`/charter/charter.md`) is **non-negotiable** within this analysis scope. Charter conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit charter update outside `/analyze`.
 
@@ -152,7 +152,7 @@ Use this heuristic to prioritize findings:
 
 ### 6. Produce Compact Analysis Report
 
-Output a Markdown report (no file writes) with the following structure:
+Draft a Markdown report with the following structure:
 
 ## Specification Analysis Report
 
@@ -180,7 +180,23 @@ Output a Markdown report (no file writes) with the following structure:
 - Duplication Count
 - Critical Issues Count
 
-### 7. Provide Next Actions
+### 7. Persist Report Artifact
+
+Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running:
+
+```bash
+spec-kitty agent mission record-analysis --mission <mission-slug> --input-file <path-to-temp-report.md> --json
+```
+
+If your host supports piping reliable multiline stdin, this equivalent form is acceptable:
+
+```bash
+spec-kitty agent mission record-analysis --mission <mission-slug> --input-file - --json
+```
+
+Treat persistence failure as command failure. The command is not complete until the JSON response reports success and names `analysis-report.md`.
+
+### 8. Provide Next Actions
 
 At end of report, output a concise Next Actions block:
 
@@ -188,7 +204,7 @@ At end of report, output a concise Next Actions block:
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
 - Provide explicit command suggestions: e.g., "Run /spec-kitty.specify with refinement", "Run /plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
-### 8. Offer Remediation
+### 9. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
 
@@ -203,7 +219,7 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 
 ### Analysis Guidelines
 
-- **NEVER modify files** (this is read-only analysis)
+- **NEVER modify source/planning files** other than the required `analysis-report.md` persistence step
 - **NEVER hallucinate missing sections** (if absent, report them accurately)
 - **Prioritize charter violations** (these are always CRITICAL)
 - **Use examples over exhaustive rules** (cite specific instances, not generic patterns)

--- a/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
@@ -182,7 +182,7 @@ Draft a Markdown report with the following structure:
 
 ### 7. Persist Report Artifact
 
-Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running:
+Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running the recorder with a temp report file outside the repository checkout:
 
 ```bash
 spec-kitty agent mission record-analysis --mission <mission-slug> --input-file <path-to-temp-report.md> --json
@@ -206,7 +206,7 @@ At end of report, output a concise Next Actions block:
 
 ### 9. Offer Remediation
 
-Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+Ask the user: "Should all of these findings be addressed before moving on to implementation? I can suggest concrete remediation edits for the findings you want to resolve." (Do NOT apply edits automatically.)
 
 ## Operating Principles
 

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
@@ -594,9 +594,12 @@ After reporting, ask the user directly:
 
 > **Should I use the `/spec-kitty-implement-review` skill to fully implement all WPs until completion?**
 > This will dispatch implementing and reviewing agents for every WP, handle rejection cycles, and merge all lanes when done.
+>
+> Optional quality control gate before implementation: run `/spec-kitty.analyze` first to persist an `analysis-report.md` and review spec/plan/task consistency before any WP implementation starts.
 
 - If the user says **yes**: invoke the `spec-kitty-implement-review` skill with the mission slug. The user may also specify which agents to use for implementation and review (e.g., "yes, use sonnet for implementing and opus for reviewing").
 - If the user says **no** or wants to do it manually: end here and let them run `/spec-kitty.implement` at their own pace.
+- If the user wants the optional quality gate first: run `/spec-kitty.analyze --mission <mission-slug>` and wait for the user's decision on whether to address findings before invoking implementation.
 - If the user asks for a subset (e.g., "just WP01 and WP02 for now"): invoke the skill with that scope.
 
 This handoff is the natural transition from planning to execution. Do NOT skip the question — always offer it explicitly so the user can choose their execution strategy.

--- a/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
@@ -47,7 +47,7 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ## Operating Constraints
 
-**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+**NON-REMEDIATING**: Do **not** modify `spec.md`, `plan.md`, `tasks.md`, WP files, source code, or any remediation target. The only permitted file mutation is persisting this command's report to `kitty-specs/<mission>/analysis-report.md` via `spec-kitty agent mission record-analysis`. Offer an optional remediation plan only after the report is persisted (user must explicitly approve before any follow-up editing commands would be invoked manually).
 
 **Charter Authority**: The project charter (`/charter/charter.md`) is **non-negotiable** within this analysis scope. Charter conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit charter update outside `/analyze`.
 
@@ -152,7 +152,7 @@ Use this heuristic to prioritize findings:
 
 ### 6. Produce Compact Analysis Report
 
-Output a Markdown report (no file writes) with the following structure:
+Draft a Markdown report with the following structure:
 
 ## Specification Analysis Report
 
@@ -180,7 +180,23 @@ Output a Markdown report (no file writes) with the following structure:
 - Duplication Count
 - Critical Issues Count
 
-### 7. Provide Next Actions
+### 7. Persist Report Artifact
+
+Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running:
+
+```bash
+spec-kitty agent mission record-analysis --mission <mission-slug> --input-file <path-to-temp-report.md> --json
+```
+
+If your host supports piping reliable multiline stdin, this equivalent form is acceptable:
+
+```bash
+spec-kitty agent mission record-analysis --mission <mission-slug> --input-file - --json
+```
+
+Treat persistence failure as command failure. The command is not complete until the JSON response reports success and names `analysis-report.md`.
+
+### 8. Provide Next Actions
 
 At end of report, output a concise Next Actions block:
 
@@ -188,7 +204,7 @@ At end of report, output a concise Next Actions block:
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
 - Provide explicit command suggestions: e.g., "Run /spec-kitty.specify with refinement", "Run /plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
-### 8. Offer Remediation
+### 9. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
 
@@ -203,7 +219,7 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 
 ### Analysis Guidelines
 
-- **NEVER modify files** (this is read-only analysis)
+- **NEVER modify source/planning files** other than the required `analysis-report.md` persistence step
 - **NEVER hallucinate missing sections** (if absent, report them accurately)
 - **Prioritize charter violations** (these are always CRITICAL)
 - **Use examples over exhaustive rules** (cite specific instances, not generic patterns)

--- a/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
@@ -182,7 +182,7 @@ Draft a Markdown report with the following structure:
 
 ### 7. Persist Report Artifact
 
-Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running:
+Save the Markdown report body to `kitty-specs/<mission>/analysis-report.md` by running the recorder with a temp report file outside the repository checkout:
 
 ```bash
 spec-kitty agent mission record-analysis --mission <mission-slug> --input-file <path-to-temp-report.md> --json
@@ -206,7 +206,7 @@ At end of report, output a concise Next Actions block:
 
 ### 9. Offer Remediation
 
-Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+Ask the user: "Should all of these findings be addressed before moving on to implementation? I can suggest concrete remediation edits for the findings you want to resolve." (Do NOT apply edits automatically.)
 
 ## Operating Principles
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
@@ -594,9 +594,12 @@ After reporting, ask the user directly:
 
 > **Should I use the `/spec-kitty-implement-review` skill to fully implement all WPs until completion?**
 > This will dispatch implementing and reviewing agents for every WP, handle rejection cycles, and merge all lanes when done.
+>
+> Optional quality control gate before implementation: run `/spec-kitty.analyze` first to persist an `analysis-report.md` and review spec/plan/task consistency before any WP implementation starts.
 
 - If the user says **yes**: invoke the `spec-kitty-implement-review` skill with the mission slug. The user may also specify which agents to use for implementation and review (e.g., "yes, use sonnet for implementing and opus for reviewing").
 - If the user says **no** or wants to do it manually: end here and let them run `/spec-kitty.implement` at their own pace.
+- If the user wants the optional quality gate first: run `/spec-kitty.analyze --mission <mission-slug>` and wait for the user's decision on whether to address findings before invoking implementation.
 - If the user asks for a subset (e.g., "just WP01 and WP02 for now"): invoke the skill with that scope.
 
 This handoff is the natural transition from planning to execution. Do NOT skip the question — always offer it explicitly so the user can choose their execution strategy.

--- a/tests/specify_cli/test_analysis_report.py
+++ b/tests/specify_cli/test_analysis_report.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from specify_cli.analysis_report import (
+    ANALYSIS_REPORT_FILENAME,
+    check_analysis_report_current,
+    write_analysis_report,
+)
+from specify_cli.cli.commands.agent.mission import app as mission_app
+from specify_cli.cli.commands.agent.workflow import _require_current_analysis_report
+from specify_cli.frontmatter import FrontmatterManager
+
+
+def _write_required_artifacts(feature_dir):
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text("# Spec\n\nFR-001.\n", encoding="utf-8")
+    (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+
+
+def test_write_analysis_report_records_input_hashes(tmp_path):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+
+    result = write_analysis_report(
+        feature_dir=feature_dir,
+        repo_root=repo_root,
+        body="# Specification Analysis Report\n\nCritical Issues Count: 0\nHigh Issues Count: 0\nPASS\n",
+        analyzer_agent="codex",
+    )
+
+    assert result.path == feature_dir / ANALYSIS_REPORT_FILENAME
+    frontmatter, body = FrontmatterManager().read(result.path)
+    assert frontmatter["artifact_type"] == "spec-kitty.analysis-report"
+    assert frontmatter["command"] == "/spec-kitty.analyze"
+    assert frontmatter["analyzer_agent"] == "codex"
+    assert frontmatter["input_artifacts"]["spec.md"]["sha256"]
+    assert frontmatter["verdict"] == "ready"
+    assert "# Specification Analysis Report" in body
+
+
+def test_analysis_report_freshness_detects_stale_inputs(tmp_path):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+    write_analysis_report(
+        feature_dir=feature_dir,
+        repo_root=repo_root,
+        body="# Report\n\nPASS\n",
+    )
+
+    assert check_analysis_report_current(feature_dir, repo_root).ok is True
+
+    (feature_dir / "tasks.md").write_text("# Tasks\n\nChanged.\n", encoding="utf-8")
+    freshness = check_analysis_report_current(feature_dir, repo_root)
+    assert freshness.ok is False
+    assert freshness.reason == "stale_analysis_report"
+    assert "tasks.md" in freshness.mismatches
+
+
+def test_implement_gate_blocks_missing_analysis_report(tmp_path, capsys):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+
+    with pytest.raises(typer.Exit):
+        _require_current_analysis_report(feature_dir, repo_root, "sample-01KS")
+
+    out = capsys.readouterr().out
+    assert "analysis_report_required" in out
+    assert "/spec-kitty.analyze --mission sample-01KS" in out
+
+
+def test_implement_gate_allows_current_analysis_report(tmp_path):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+    write_analysis_report(
+        feature_dir=feature_dir,
+        repo_root=repo_root,
+        body="# Report\n\nPASS\n",
+    )
+
+    _require_current_analysis_report(feature_dir, repo_root, "sample-01KS")
+
+
+def test_record_analysis_command_persists_report(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+    input_file = tmp_path / "analysis.md"
+    input_file.write_text("# Analysis\n\nCritical Issues Count: 0\nPASS\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.agent.mission.locate_project_root",
+        lambda: repo_root,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.agent.mission.get_main_repo_root",
+        lambda path: path,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.agent.mission.resolve_mission_handle",
+        lambda _handle, _repo_root: SimpleNamespace(feature_dir=feature_dir),
+    )
+    emitted: dict[str, object] = {}
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.agent.mission._emit_json",
+        lambda payload: emitted.update(payload),
+    )
+
+    result = CliRunner().invoke(
+        mission_app,
+        [
+            "record-analysis",
+            "--mission",
+            feature_dir.name,
+            "--input-file",
+            str(input_file),
+            "--agent",
+            "codex",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert emitted["success"] is True
+    report_path = feature_dir / ANALYSIS_REPORT_FILENAME
+    assert emitted["path"] == str(report_path)
+    frontmatter, body = FrontmatterManager().read(report_path)
+    assert frontmatter["analyzer_agent"] == "codex"
+    assert frontmatter["input_artifacts"]["tasks.md"]["sha256"]
+    assert "# Analysis" in body

--- a/tests/specify_cli/test_analysis_report.py
+++ b/tests/specify_cli/test_analysis_report.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 
 import pytest
 import typer
 from typer.testing import CliRunner
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 from specify_cli.analysis_report import (
     ANALYSIS_REPORT_FILENAME,
@@ -21,6 +25,16 @@ def _write_required_artifacts(feature_dir):
     (feature_dir / "spec.md").write_text("# Spec\n\nFR-001.\n", encoding="utf-8")
     (feature_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
     (feature_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+
+
+def _init_committed_git_project(repo_root: Path, *, branch: str = "feature") -> None:
+    (repo_root / ".kittify").mkdir(exist_ok=True)
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+    subprocess.run(["git", "branch", "-M", branch], cwd=repo_root, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo_root, check=True, capture_output=True)
 
 
 def test_write_analysis_report_records_input_hashes(tmp_path):
@@ -137,3 +151,51 @@ def test_record_analysis_command_persists_report(tmp_path, monkeypatch):
     assert frontmatter["analyzer_agent"] == "codex"
     assert frontmatter["input_artifacts"]["tasks.md"]["sha256"]
     assert "# Analysis" in body
+
+
+def test_record_analysis_refuses_dirty_worktree_before_write(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+    _init_committed_git_project(repo_root, branch="feature")
+    (repo_root / "dirty.txt").write_text("uncommitted\n", encoding="utf-8")
+    input_file = tmp_path.parent / f"{tmp_path.name}-analysis.md"
+    input_file.write_text("# Analysis\n\nPASS\n", encoding="utf-8")
+
+    monkeypatch.setattr("specify_cli.cli.commands.agent.mission.locate_project_root", lambda: repo_root)
+    monkeypatch.setattr("specify_cli.cli.commands.agent.mission.get_main_repo_root", lambda path: path)
+    emitted: dict[str, object] = {}
+    monkeypatch.setattr("specify_cli.cli.commands.agent.mission._emit_json", lambda payload: emitted.update(payload))
+
+    result = CliRunner().invoke(
+        mission_app,
+        ["record-analysis", "--mission", feature_dir.name, "--input-file", str(input_file), "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert emitted["error_code"] == "DIRTY_WORKTREE"
+    assert not (feature_dir / ANALYSIS_REPORT_FILENAME).exists()
+
+
+def test_record_analysis_refuses_protected_branch_before_write(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    feature_dir = repo_root / "kitty-specs" / "sample-01KS"
+    _write_required_artifacts(feature_dir)
+    _init_committed_git_project(repo_root, branch="main")
+    input_file = tmp_path.parent / f"{tmp_path.name}-analysis.md"
+    input_file.write_text("# Analysis\n\nPASS\n", encoding="utf-8")
+
+    monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
+    monkeypatch.setattr("specify_cli.cli.commands.agent.mission.locate_project_root", lambda: repo_root)
+    monkeypatch.setattr("specify_cli.cli.commands.agent.mission.get_main_repo_root", lambda path: path)
+    emitted: dict[str, object] = {}
+    monkeypatch.setattr("specify_cli.cli.commands.agent.mission._emit_json", lambda payload: emitted.update(payload))
+
+    result = CliRunner().invoke(
+        mission_app,
+        ["record-analysis", "--mission", feature_dir.name, "--input-file", str(input_file), "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert emitted["error_code"] == "PROTECTED_BRANCH_REFUSED"
+    assert not (feature_dir / ANALYSIS_REPORT_FILENAME).exists()

--- a/tests/specify_cli/test_command_template_cleanliness.py
+++ b/tests/specify_cli/test_command_template_cleanliness.py
@@ -27,21 +27,12 @@ import pytest
 # Template discovery
 # ---------------------------------------------------------------------------
 
-# All 9 prompt-driven command templates
-
 pytestmark = [pytest.mark.unit]
 
-PROMPT_DRIVEN: list[str] = [
-    "specify",
-    "plan",
-    "tasks",
-    "tasks-outline",
-    "tasks-packages",
-    "checklist",
-    "analyze",
-    "research",
-    "charter",
-]
+from specify_cli.shims.registry import PROMPT_DRIVEN_COMMANDS
+
+# All full prompt-driven command templates.
+PROMPT_DRIVEN: list[str] = sorted(PROMPT_DRIVEN_COMMANDS)
 
 # Planning-workflow templates that MUST use "repository root checkout" terminology.
 # These are commands that explicitly direct agents on where to perform work.
@@ -56,14 +47,13 @@ PLANNING_WORKFLOW_TEMPLATES: list[str] = [
     "research",
 ]
 
-# Resolve the templates directory relative to the installed package source
-_TEMPLATES_DIR = (
+_PROMPT_STEPS_DIR = (
     Path(__file__).parent.parent.parent
     / "src"
-    / "specify_cli"
+    / "doctrine"
     / "missions"
+    / "mission-steps"
     / "software-dev"
-    / "command-templates"
 )
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
@@ -82,7 +72,7 @@ _FORBIDDEN_HOME_LITERAL = "/Users/" + "robe" + "rt/"
 
 def _template_content(command: str) -> str:
     """Read and return the content of a command template file."""
-    return (_TEMPLATES_DIR / f"{command}.md").read_text(encoding="utf-8")
+    return (_PROMPT_STEPS_DIR / command / "prompt.md").read_text(encoding="utf-8")
 
 
 def _active_codebase_files() -> list[Path]:
@@ -112,8 +102,8 @@ def _active_codebase_files() -> list[Path]:
 @pytest.mark.parametrize("command", PROMPT_DRIVEN)
 def test_template_exists(command: str) -> None:
     """Every prompt-driven command must have a template file."""
-    f = _TEMPLATES_DIR / f"{command}.md"
-    assert f.exists(), f"{command}.md not found in command-templates dir: {_TEMPLATES_DIR}"
+    f = _PROMPT_STEPS_DIR / command / "prompt.md"
+    assert f.exists(), f"{command}/prompt.md not found in mission steps dir: {_PROMPT_STEPS_DIR}"
 
 
 @pytest.mark.parametrize("command", PROMPT_DRIVEN)
@@ -385,6 +375,22 @@ def test_tasks_template_map_requirements_has_mission() -> None:
         assert "--mission" in line, (
             f"tasks.md map-requirements --batch line missing '--mission': {line.strip()!r}"
         )
+
+
+def test_analyze_template_persists_analysis_report() -> None:
+    """analyze.md must persist durable proof before implementation."""
+    content = (
+        _REPO_ROOT
+        / "src"
+        / "doctrine"
+        / "missions"
+        / "mission-steps"
+        / "software-dev"
+        / "analyze"
+        / "prompt.md"
+    ).read_text(encoding="utf-8")
+    assert "analysis-report.md" in content
+    assert "spec-kitty agent mission record-analysis --mission" in content
 
 
 def test_tasks_template_has_ownership_guidance() -> None:

--- a/tests/specify_cli/test_command_template_cleanliness.py
+++ b/tests/specify_cli/test_command_template_cleanliness.py
@@ -391,6 +391,15 @@ def test_analyze_template_persists_analysis_report() -> None:
     ).read_text(encoding="utf-8")
     assert "analysis-report.md" in content
     assert "spec-kitty agent mission record-analysis --mission" in content
+    assert "Should all of these findings be addressed before moving on to implementation?" in content
+
+
+def test_tasks_template_offers_optional_analyze_quality_gate() -> None:
+    """tasks.md must offer analyze as optional QC before implement-review."""
+    content = _template_content("tasks")
+    assert "/spec-kitty-implement-review" in content
+    assert "Optional quality control gate before implementation" in content
+    assert "/spec-kitty.analyze" in content
 
 
 def test_tasks_template_has_ownership_guidance() -> None:

--- a/tests/sync/test_body_upload.py
+++ b/tests/sync/test_body_upload.py
@@ -68,6 +68,9 @@ class TestSurfaceFiltering:
     def test_tasks_md_accepted(self) -> None:
         assert _is_supported_surface("tasks.md") is True
 
+    def test_analysis_report_md_accepted(self) -> None:
+        assert _is_supported_surface("analysis-report.md") is True
+
     def test_research_md_accepted(self) -> None:
         assert _is_supported_surface("research.md") is True
 

--- a/tests/unit/status/test_mission_status_aggregate.py
+++ b/tests/unit/status/test_mission_status_aggregate.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `spec-kitty agent mission record-analysis` to persist `analysis-report.md` with source artifact hashes and verdict metadata
- update `/spec-kitty.analyze` prompt/snapshots so analyze must persist the report artifact before completion and ask whether findings should be addressed before implementation
- gate `agent action implement` on a present, current analysis report after earlier lifecycle/canonical/dependency preflights, before workspace/status mutation
- reject `record-analysis` before mutation on protected branches or pre-existing dirty worktrees
- update `/spec-kitty.tasks` handoff text to offer `/spec-kitty.analyze` as an optional quality-control gate before `/spec-kitty-implement-review`
- sync/index/report manifests now treat the report as evidence; docs/reference and prompt cleanliness tests updated

Closes #1696

## Tests
- `.venv/bin/python -m pytest tests/specify_cli/test_analysis_report.py tests/specify_cli/cli/commands/agent/test_workflow.py tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py tests/specify_cli/skills/test_command_renderer.py tests/sync/test_body_upload.py tests/dossier/test_indexer.py tests/dossier/test_manifest.py tests/specify_cli/test_command_template_cleanliness.py tests/specify_cli/events/test_sanitizer.py -q` (396 passed)
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 PYTHONPATH=. .venv/bin/python scripts/docs/check_docs_freshness.py --ci --report freshness.json --link-check none` (exit 0, warning only for pre-existing mission help drift)
- `.venv/bin/ruff check src/specify_cli/analysis_report.py src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/agent/workflow.py src/specify_cli/sync/body_upload.py src/specify_cli/dossier/indexer.py tests/specify_cli/test_analysis_report.py tests/specify_cli/cli/commands/agent/test_workflow_canonical_cleanup.py tests/specify_cli/cli/commands/agent/test_wrapper_delegation.py tests/sync/test_body_upload.py tests/dossier/test_indexer.py tests/dossier/test_manifest.py tests/specify_cli/test_command_template_cleanliness.py tests/specify_cli/events/test_sanitizer.py`
- `git diff --check`