### PR TITLE
docs: add kitty-specs Kanban prompt modals

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -288,6 +288,7 @@ body.tex2jax_ignore > .sk-dashboard {
 .sk-dashboard .status-card.review { border-left-color: var(--lavender); }
 .sk-dashboard .status-card.approved { border-left-color: var(--soft-peach); }
 .sk-dashboard .status-card.completed { border-left-color: var(--grassy-green); }
+.sk-dashboard .status-card.agents { border-left-color: var(--soft-peach); }
 
 .sk-dashboard .status-label {
   font-size: 0.85rem;
@@ -398,6 +399,13 @@ body.tex2jax_ignore > .sk-dashboard {
   margin-bottom: 12px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   border-left: 4px solid;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.sk-dashboard .card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  background: var(--creamy-white);
 }
 
 .sk-dashboard .lane.planned .card { border-left-color: var(--baby-blue); }
@@ -405,6 +413,11 @@ body.tex2jax_ignore > .sk-dashboard {
 .sk-dashboard .lane.for_review .card { border-left-color: var(--lavender); }
 .sk-dashboard .lane.approved .card { border-left-color: var(--soft-peach); }
 .sk-dashboard .lane.done .card { border-left-color: var(--grassy-green); }
+
+.sk-dashboard .card.in-review {
+  border: 2px solid #9b6bb0;
+  border-left-width: 4px;
+}
 
 .sk-dashboard .card-id {
   font-weight: 600;
@@ -421,14 +434,47 @@ body.tex2jax_ignore > .sk-dashboard {
   line-height: 1.4;
 }
 
+.sk-dashboard .card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
 .sk-dashboard .badge {
   display: inline-block;
   padding: 3px 8px;
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 500;
+}
+
+.sk-dashboard .badge.agent {
   background: var(--soft-peach);
   color: #8b5a00;
+}
+
+.sk-dashboard .badge.subtasks {
+  background: var(--lavender);
+  color: #5a3a6e;
+}
+
+.sk-dashboard .badge.model {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.sk-dashboard .agent-identity-section {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.sk-dashboard .agent-identity-label {
+  font-weight: 600;
+  font-size: 0.8em;
+  color: #6b7280;
 }
 
 .sk-dashboard .empty-state {
@@ -436,6 +482,112 @@ body.tex2jax_ignore > .sk-dashboard {
   color: #9ca3af;
   padding: 40px 20px;
   font-style: italic;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.sk-dashboard .modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.sk-dashboard .modal.show {
+  display: flex;
+}
+
+.sk-dashboard .modal.hidden {
+  display: none;
+}
+
+.sk-dashboard .modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.65);
+  backdrop-filter: blur(2px);
+}
+
+.sk-dashboard .modal-content {
+  position: relative;
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 900px;
+  width: min(90%, 900px);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+}
+
+.sk-dashboard .modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.sk-dashboard .modal-title {
+  font-size: 1.35em;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.sk-dashboard .modal-subtitle {
+  font-size: 0.9em;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.sk-dashboard .modal-close {
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  font-size: 1.2em;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.sk-dashboard .modal-close:hover,
+.sk-dashboard .modal-close:focus {
+  color: #1f2937;
+}
+
+.sk-dashboard .modal-body {
+  position: relative;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.sk-dashboard .modal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.sk-dashboard .modal-meta span {
+  background: #f3f4f6;
+  border-radius: 12px;
+  padding: 4px 12px;
+  font-size: 0.85em;
+  color: #4b5563;
+}
+
+.sk-dashboard .modal-content .markdown-content {
+  padding: 0;
+}
+
+.sk-dashboard .modal-content .markdown-content pre {
+  background: #ffffff;
+  color: #111827;
 }
 
 .sk-dashboard .mission-grid {

--- a/scripts/docs/generate_kitty_specs_docs.py
+++ b/scripts/docs/generate_kitty_specs_docs.py
@@ -91,6 +91,66 @@ def parse_task_titles(tasks_md: str) -> dict[str, str]:
     return titles
 
 
+def parse_frontmatter(markdown: str) -> tuple[dict[str, Any], str]:
+    lines = markdown.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, markdown
+    end_index = next((index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"), None)
+    if end_index is None:
+        return {}, markdown
+
+    frontmatter: dict[str, Any] = {}
+    current_key = ""
+    for raw in lines[1:end_index]:
+        if raw.startswith("- ") and current_key:
+            value = raw[2:].strip()
+            frontmatter.setdefault(current_key, []).append(unquote_yaml_scalar(value))
+            continue
+        if ":" not in raw or raw.startswith((" ", "\t")):
+            continue
+        key, value = raw.split(":", 1)
+        current_key = key.strip()
+        value = value.strip()
+        if value == "":
+            frontmatter[current_key] = []
+        elif value == "[]":
+            frontmatter[current_key] = []
+            current_key = ""
+        else:
+            frontmatter[current_key] = unquote_yaml_scalar(value)
+            current_key = ""
+
+    body = "\n".join(lines[end_index + 1 :]).lstrip()
+    return frontmatter, body
+
+
+def unquote_yaml_scalar(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def prompt_file_for_wp(mission: Mission, wp_id: str) -> Path | None:
+    tasks_dir = mission.path / "tasks"
+    if not tasks_dir.exists():
+        return None
+    matches = sorted(tasks_dir.glob(f"{wp_id}*.md"))
+    return matches[0] if matches else None
+
+
+def prompt_title(prompt_file: Path | None, markdown: str, wp_id: str, mission: Mission) -> str:
+    match = re.search(r"^#\s+Work Package Prompt:\s+(.+?)\s*$", markdown, flags=re.MULTILINE)
+    if match:
+        return re.sub(r"\s+", " ", match.group(1)).strip()
+    if prompt_file is not None:
+        return prompt_file.stem
+    return mission.task_titles.get(wp_id, "Work package")
+
+
+def json_script(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False).replace("</", "<\\/")
+
+
 def missions() -> list[Mission]:
     result: list[Mission] = []
     for path in SOURCE.iterdir():
@@ -340,9 +400,31 @@ def stats(mission: Mission) -> dict[str, int | float]:
     return {"total": total, **lane_counts, "weighted_percentage": pct}
 
 
+def active_agents(mission: Mission) -> list[str]:
+    agents: set[str] = set()
+    for wp_id in (mission.status.get("work_packages") or {}):
+        prompt_file = prompt_file_for_wp(mission, wp_id)
+        if prompt_file is None:
+            continue
+        frontmatter, _ = parse_frontmatter(read_text(prompt_file))
+        agent = str(frontmatter.get("agent") or "")
+        if agent:
+            agents.add(agent)
+    return sorted(agents)
+
+
 def status_cards(mission: Mission, compact: bool = False) -> str:
     s = stats(mission)
     label = "Total Work Packages" if compact else "Total Tasks"
+    agents = active_agents(mission) if compact else []
+    agents_card = (
+        f"""  <div class="status-card agents"><div class="status-label">Active Agents</div>
+    <div class="status-value">{len(agents)}</div>
+    <div class="status-detail">{esc(", ".join(agents) if agents else "none")}</div></div>
+"""
+        if compact
+        else ""
+    )
     return f"""
 <div class="status-summary">
   <div class="status-card total"><div class="status-label">{label}</div><div class="status-value">{s['total']}</div>
@@ -354,6 +436,7 @@ def status_cards(mission: Mission, compact: bool = False) -> str:
     <div class="status-detail">{s['weighted_percentage']}% done</div><div class="progress-bar">
       <div class="progress-fill" style="width: {s['weighted_percentage']}%"></div>
     </div></div>
+{agents_card}
 </div>
 """
 
@@ -386,19 +469,34 @@ def overview(mission: Mission) -> str:
 """
 
 
-def lanes(mission: Mission) -> dict[str, list[dict[str, str]]]:
-    result: dict[str, list[dict[str, str]]] = {lane: [] for lane in LANES}
+def lanes(mission: Mission) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {lane: [] for lane in LANES}
     for wp_id, state in sorted((mission.status.get("work_packages") or {}).items()):
-        lane = str(state.get("lane") or "planned")
-        if lane == "in_review":
-            lane = "for_review"
-        if lane not in result:
-            lane = "planned"
-        result[lane].append(
+        raw_lane = str(state.get("lane") or "planned")
+        column_lane = "for_review" if raw_lane == "in_review" else raw_lane
+        if column_lane not in result:
+            column_lane = "planned"
+        prompt_file = prompt_file_for_wp(mission, wp_id)
+        prompt_markdown = read_text(prompt_file) if prompt_file else ""
+        frontmatter, prompt_body = parse_frontmatter(prompt_markdown)
+        subtasks = frontmatter.get("subtasks")
+        if not isinstance(subtasks, list):
+            subtasks = []
+        result[column_lane].append(
             {
                 "id": wp_id,
-                "title": mission.task_titles.get(wp_id, "Work package"),
-                "actor": str(state.get("actor") or ""),
+                "title": prompt_title(prompt_file, prompt_markdown, wp_id, mission),
+                "lane": raw_lane,
+                "subtasks": subtasks,
+                "agent": str(frontmatter.get("agent") or ""),
+                "model": str(frontmatter.get("model") or ""),
+                "agent_profile": str(frontmatter.get("agent_profile") or ""),
+                "role": str(frontmatter.get("role") or ""),
+                "assignee": str(frontmatter.get("assignee") or ""),
+                "phase": str(frontmatter.get("phase") or ""),
+                "prompt_markdown": prompt_body,
+                "prompt_html": markdown_to_html(prompt_body),
+                "prompt_path": prompt_file.relative_to(ROOT).as_posix() if prompt_file else "",
             }
         )
     return result
@@ -406,13 +504,27 @@ def lanes(mission: Mission) -> dict[str, list[dict[str, str]]]:
 
 def kanban(mission: Mission) -> str:
     columns = []
-    for lane, tasks in lanes(mission).items():
+    all_lanes = lanes(mission)
+    tasks_by_id = {task["id"]: task for tasks in all_lanes.values() for task in tasks}
+    for lane, tasks in all_lanes.items():
         cards = []
         for task in tasks:
-            actor = f'<span class="badge agent">{esc(task["actor"])}</span>' if task["actor"] else ""
+            badges = []
+            if task["agent"]:
+                badges.append(f'<span class="badge agent">{esc(task["agent"])}</span>')
+            if task["agent_profile"]:
+                badges.append(f'<span class="badge profile">{esc(task["agent_profile"])}</span>')
+            if task["role"]:
+                badges.append(f'<span class="badge role">{esc(task["role"])}</span>')
+            if task["subtasks"]:
+                count = len(task["subtasks"])
+                badges.append(f'<span class="badge subtasks">{count} subtask{"s" if count != 1 else ""}</span>')
+            card_class = "card in-review" if task["lane"] == "in_review" else "card"
             cards.append(
-                f'<div class="card"><div class="card-id">{esc(task["id"])}</div>'
-                f'<div class="card-title">{esc(task["title"])}</div><div class="card-meta">{actor}</div></div>'
+                f'<div class="{card_class}" role="button" tabindex="0" data-task-id="{esc(task["id"])}">'
+                f'<div class="card-id">{esc(task["id"])}</div>'
+                f'<div class="card-title">{esc(task["title"])}</div>'
+                f'<div class="card-meta">{"".join(badges)}</div></div>'
             )
         body = "".join(cards) if cards else '<div class="empty-state">No tasks</div>'
         columns.append(
@@ -423,6 +535,152 @@ def kanban(mission: Mission) -> str:
 <h2>Kanban Board</h2>
 <div id="kanban-status">{status_cards(mission, compact=True)}</div>
 <div class="kanban-board">{''.join(columns)}</div>
+<div id="prompt-modal" class="modal hidden" aria-hidden="true">
+  <div class="modal-overlay"></div>
+  <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal-header">
+      <div>
+        <div class="modal-title" id="modal-title">Work Package Prompt</div>
+        <div class="modal-subtitle" id="modal-subtitle"></div>
+      </div>
+      <button type="button" class="modal-close" id="modal-close-btn" aria-label="Close prompt viewer">✕</button>
+    </div>
+    <div class="modal-body" id="modal-body">
+      <div class="modal-meta" id="modal-prompt-meta"></div>
+      <div id="modal-prompt-content" class="markdown-content"></div>
+    </div>
+  </div>
+</div>
+<script
+  src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"
+  integrity="sha384-zbcZAIxlvJtNE3Dp5nxLXdXtXyxwOdnILY1TDPVmKFhl4r4nSUG1r8bcFXGVa4Te"
+  crossorigin="anonymous"
+></script>
+<script>
+const KANBAN_TASKS = {json_script(tasks_by_id)};
+
+function escapeHtml(value) {{
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}}
+
+function formatLaneName(lane) {{
+    if (!lane) return '';
+    return lane.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+}}
+
+function showPromptModal(task) {{
+    const modal = document.getElementById('prompt-modal');
+    if (!modal) return;
+
+    const titleEl = document.getElementById('modal-title');
+    const subtitleEl = document.getElementById('modal-subtitle');
+    const metaEl = document.getElementById('modal-prompt-meta');
+    const contentEl = document.getElementById('modal-prompt-content');
+    const modalBody = document.getElementById('modal-body');
+
+    if (titleEl) {{
+        titleEl.textContent = task.title || 'Work Package Prompt';
+    }}
+    if (subtitleEl) {{
+        if (task.id) {{
+            subtitleEl.textContent = task.id;
+            subtitleEl.style.display = 'block';
+        }} else {{
+            subtitleEl.textContent = '';
+            subtitleEl.style.display = 'none';
+        }}
+    }}
+
+    if (metaEl) {{
+        const metaItems = [];
+        if (task.lane) metaItems.push(`<span>Lane: ${{escapeHtml(formatLaneName(task.lane))}}</span>`);
+        if (task.subtasks?.length) {{
+            metaItems.push(`<span>${{task.subtasks.length}} subtask${{task.subtasks.length !== 1 ? 's' : ''}}</span>`);
+        }}
+        if (task.phase) metaItems.push(`<span>Phase: ${{escapeHtml(task.phase)}}</span>`);
+        if (task.prompt_path) metaItems.push(`<span>Source: ${{escapeHtml(task.prompt_path)}}</span>`);
+
+        const identityBadges = [];
+        if (task.agent) identityBadges.push(`<span class="badge agent">${{escapeHtml(task.agent)}}</span>`);
+        if (task.agent_profile) identityBadges.push(`<span class="badge profile">${{escapeHtml(task.agent_profile)}}</span>`);
+        if (task.role) identityBadges.push(`<span class="badge role">${{escapeHtml(task.role)}}</span>`);
+        if (task.model) identityBadges.push(`<span class="badge model">${{escapeHtml(task.model)}}</span>`);
+
+        if (identityBadges.length > 0) {{
+            metaItems.push(`<span class="agent-identity-section"><span class="agent-identity-label">Agent:</span> ${{identityBadges.join(' ')}}</span>`);
+        }}
+
+        if (metaItems.length > 0) {{
+            metaEl.innerHTML = metaItems.join('');
+            metaEl.style.display = 'flex';
+        }} else {{
+            metaEl.innerHTML = '';
+            metaEl.style.display = 'none';
+        }}
+    }}
+
+    if (contentEl) {{
+        if (task.prompt_markdown && window.marked) {{
+            contentEl.innerHTML = marked.parse(task.prompt_markdown);
+        }} else {{
+            contentEl.innerHTML = task.prompt_html || '<div class="empty-state">Prompt content unavailable.</div>';
+        }}
+    }}
+
+    if (modalBody) {{
+        modalBody.scrollTop = 0;
+    }}
+
+    modal.classList.remove('hidden');
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+}}
+
+function hidePromptModal() {{
+    const modal = document.getElementById('prompt-modal');
+    if (!modal) return;
+
+    modal.classList.remove('show');
+    modal.classList.add('hidden');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('modal-open');
+}}
+
+document.querySelectorAll('[data-task-id]').forEach((card) => {{
+    const task = KANBAN_TASKS[card.dataset.taskId];
+    if (!task) return;
+    card.addEventListener('click', () => showPromptModal(task));
+    card.addEventListener('keydown', (event) => {{
+        if (event.key === 'Enter' || event.key === ' ') {{
+            event.preventDefault();
+            showPromptModal(task);
+        }}
+    }});
+}});
+
+const modalOverlay = document.querySelector('#prompt-modal .modal-overlay');
+if (modalOverlay) {{
+    modalOverlay.addEventListener('click', hidePromptModal);
+}}
+const modalCloseButton = document.getElementById('modal-close-btn');
+if (modalCloseButton) {{
+    modalCloseButton.addEventListener('click', hidePromptModal);
+}}
+document.addEventListener('keydown', (event) => {{
+    if (event.key === 'Escape') {{
+        const modal = document.getElementById('prompt-modal');
+        if (modal?.classList.contains('show')) {{
+            hidePromptModal();
+        }}
+    }}
+}});
+</script>
 """
 
 


### PR DESCRIPTION
## Summary
- render kitty-specs Kanban WP cards with local-dashboard modal behavior
- parse WP frontmatter/body for agent badges, subtasks, prompt source, and prompt content
- load the same marked.js version used by the local dashboard and copy dashboard modal/card CSS into the docs skin
- add the local dashboard Active Agents status card on static Kanban pages

## Verification
- python3 -m py_compile scripts/docs/generate_kitty_specs_docs.py
- uv run ruff check scripts/docs/generate_kitty_specs_docs.py scripts/docs/seo_postprocess.py
- python3 scripts/docs/generate_kitty_specs_docs.py
- cd docs && docfx docfx.json
- python3 scripts/docs/seo_postprocess.py
- Playwright: compared local dashboard http://127.0.0.1:9238/ Kanban modal against generated static page at http://127.0.0.1:9332/kitty-specs/p0-test-failure-resolution-1298-1305-01KT1R2G/kanban.html
- Playwright console: no errors on generated static Kanban page