### PR TITLE
Fix charter Sonar findings

### DIFF
--- a/src/charter/activation_engine.py
+++ b/src/charter/activation_engine.py
@@ -192,7 +192,7 @@ def plan_activation(
     available_ids: Iterable[str],
     config_data: Mapping[str, Any],
     default_ids: Iterable[str] = (),
-    cascade_scope: Any = None,  # noqa: ANN401, ARG001 - WP11 CascadeScope; threaded, not consumed here
+    cascade_scope: Any = None,  # noqa: ANN401
 ) -> ActivationPlan:
     """Compute the post-state for activating *artifact_id* — purely (FR-011/012).
 
@@ -238,6 +238,9 @@ def plan_activation(
         If ``config_data[yaml_key]`` is present but not a list (malformed
         config, fail-closed).
     """
+    # Preserve the typed cascade contract at this seam even though this pure
+    # planner does not branch on it yet.
+    _ = cascade_scope
     # FR-011/012/NFR-003: validate BEFORE computing any post-state.
     if artifact_id not in set(available_ids):
         raise UnknownActivationIdError(kind, artifact_id)
@@ -278,7 +281,7 @@ def plan_deactivation(
     *,
     yaml_key: str,
     config_data: Mapping[str, Any],
-    cascade_scope: Any = None,  # noqa: ANN401, ARG001 - WP11 CascadeScope; threaded, not consumed here
+    cascade_scope: Any = None,  # noqa: ANN401
 ) -> ActivationPlan:
     """Compute the post-state for deactivating *artifact_id* — purely.
 
@@ -313,6 +316,9 @@ def plan_deactivation(
     ValueError
         If ``config_data[yaml_key]`` is present but not a list.
     """
+    # Preserve the typed cascade contract at this seam even though this pure
+    # planner does not branch on it yet.
+    _ = cascade_scope
     current = _current_list(config_data, yaml_key)
     if current is None:
         raise NoActivationRestrictionsError(kind)

--- a/src/charter/cascade.py
+++ b/src/charter/cascade.py
@@ -136,7 +136,7 @@ class CascadeScope:
     kinds: frozenset[ArtifactKind] = field(default_factory=frozenset)
 
     #: The literal CLI token for the all-kind shorthand.
-    ALL_TOKEN: ClassVar[str] = "all"  # noqa: S105 - CLI scope token, not a secret
+    ALL_TOKEN: ClassVar[str] = "all"  # noqa: S105
 
     def __post_init__(self) -> None:
         if self.is_all and self.kinds:

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -67,6 +67,7 @@ NO_POLICY_SUMMARY_MESSAGE = "  - No explicit policy summary section found in cha
 REFERENCE_DOCS_HEADER = "Reference Docs:"
 NONE_LABEL = "(none)"
 KITTIFY_DIRNAME = ".kittify"
+CHARTER_FILENAME = "charter.md"
 MISSING_REFERENCES_MESSAGE = "  - No references manifest found."
 
 _MIN_EFFECTIVE_DEPTH = 2   # minimum depth for bootstrap context (full summary + references)
@@ -174,7 +175,7 @@ def build_charter_context(
     canonical_root = sync_result.canonical_root if sync_result and sync_result.canonical_root else repo_root
 
     normalized = action.strip().lower()
-    charter_path = canonical_root / KITTIFY_DIRNAME / "charter" / "charter.md"
+    charter_path = canonical_root / KITTIFY_DIRNAME / "charter" / CHARTER_FILENAME
     references_path = canonical_root / KITTIFY_DIRNAME / "charter" / "references.yaml"
 
     def _augment(text: str) -> str:
@@ -314,7 +315,7 @@ def build_charter_context_include(
 
     if kind == "section":
         canonical_root = _bundle_root_for_json(repo_root)
-        charter_path = canonical_root / KITTIFY_DIRNAME / "charter" / "charter.md"
+        charter_path = canonical_root / KITTIFY_DIRNAME / "charter" / CHARTER_FILENAME
         if not charter_path.exists():
             raise ValueError("No charter.md found for section selector.")
         charter_content = charter_path.read_text(encoding="utf-8")
@@ -2601,7 +2602,7 @@ def _render_compact_governance(
         augmented_blocks.append(reference_block)
 
     if action:
-        charter_path = repo_root / KITTIFY_DIRNAME / "charter" / "charter.md"
+        charter_path = repo_root / KITTIFY_DIRNAME / "charter" / CHARTER_FILENAME
         if charter_path.exists():
             try:
                 charter_content = charter_path.read_text(encoding="utf-8")
@@ -2631,7 +2632,7 @@ def _render_compact_governance(
     # via the WP06 wiring) honour the same NFR-001 contract.
     section_block_str = ""
     if action:
-        charter_path = repo_root / KITTIFY_DIRNAME / "charter" / "charter.md"
+        charter_path = repo_root / KITTIFY_DIRNAME / "charter" / CHARTER_FILENAME
         if charter_path.exists():
             try:
                 charter_content = charter_path.read_text(encoding="utf-8")
@@ -2805,7 +2806,7 @@ def _project_charter_json_block(repo_root: Path) -> dict[str, object]:
     """Describe the project-local charter loaded by the context renderer."""
     bundle_root = _bundle_root_for_json(repo_root)
     charter_dir = bundle_root / KITTIFY_DIRNAME / "charter"
-    charter_path = charter_dir / "charter.md"
+    charter_path = charter_dir / CHARTER_FILENAME
     metadata_path = charter_dir / "metadata.yaml"
 
     block: dict[str, object] = {


### PR DESCRIPTION
## Summary
- consume the threaded `cascade_scope` params instead of using malformed inline suppression comments
- normalize the `CascadeScope.ALL_TOKEN` Bandit suppression to clean `ruff`/Sonar syntax
- extract a shared `CHARTER_FILENAME` constant to remove repeated `"charter.md"` literals in charter context helpers

## Validation
- `.venv/bin/ruff check src/charter/activation_engine.py src/charter/cascade.py src/charter/context.py`
- `.venv/bin/pytest tests/charter/test_pack_manager_catalog.py tests/charter/test_context_profile.py tests/charter/test_worktree_charter_via_canonical_root.py`

## Findings addressed
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud: actionable maintainability issues on `main`; this PR addresses recent charter-layer findings in `activation_engine.py`, `cascade.py`, and `context.py`