### PR TITLE
fix(sonar): address actionable parser and transaction findings

### DIFF
--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -278,10 +278,27 @@ def _parse_wp_sections_from_tasks_md(tasks_content: str) -> dict[str, str]:
 def _parse_requirement_refs_from_tasks_md(tasks_content: str) -> dict[str, list[str]]:
     """Parse requirement references per WP from tasks.md content."""
     requirement_refs: dict[str, list[str]] = {}
+    requirement_heading_pattern = re.compile(
+        r"^#{1,4}\s*\*?\*?Requirements?\s*(?:Refs)?\*?\*?\s*$",
+        re.IGNORECASE,
+    )
 
     for wp_id, section_content in _parse_wp_sections_from_tasks_md(tasks_content).items():
         refs: list[str] = []
+        in_requirement_ref_list = False
         for line in section_content.splitlines():
+            stripped_line = line.strip()
+            if in_requirement_ref_list:
+                if not stripped_line:
+                    continue
+                if stripped_line.startswith(("-", "*")):
+                    refs.extend(
+                        ref_id.upper()
+                        for ref_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", stripped_line, re.IGNORECASE)
+                    )
+                    continue
+                in_requirement_ref_list = False
+
             lower_line = line.lower()
             if "requirement" not in lower_line:
                 continue
@@ -291,6 +308,9 @@ def _parse_requirement_refs_from_tasks_md(tasks_content: str) -> dict[str, list[
                     ref_id.upper()
                     for ref_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", suffix, re.IGNORECASE)
                 )
+                continue
+            if requirement_heading_pattern.match(stripped_line):
+                in_requirement_ref_list = True
         requirement_refs[wp_id] = list(dict.fromkeys(refs))
 
     return requirement_refs

--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -282,17 +282,14 @@ def _parse_requirement_refs_from_tasks_md(tasks_content: str) -> dict[str, list[
     for wp_id, section_content in _parse_wp_sections_from_tasks_md(tasks_content).items():
         refs: list[str] = []
         for line in section_content.splitlines():
-            if "Requirement" not in line and "requirement" not in line:
+            lower_line = line.lower()
+            if "requirement" not in lower_line:
                 continue
-            ref_line_match = re.search(
-                r"\*?\*?Requirements?\s*(?:Refs)?\*?\*?\s*:\s*(.+)",
-                line,
-                re.IGNORECASE,
-            )
-            if ref_line_match:
+            prefix, separator, suffix = line.partition(":")
+            if separator and "requirement" in prefix.lower():
                 refs.extend(
                     ref_id.upper()
-                    for ref_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", ref_line_match.group(1), re.IGNORECASE)
+                    for ref_id in re.findall(r"\b(?:FR|NFR|C)-\d+\b", suffix, re.IGNORECASE)
                 )
         requirement_refs[wp_id] = list(dict.fromkeys(refs))
 

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -669,6 +669,8 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
     ) -> BookkeepingTransaction:
         safe_mission_slug = _validate_safe_segment("mission_slug", mission_slug)
         safe_mid8 = _validate_safe_segment("mid8", mid8)
+        effective_destination_ref = destination_ref
+        effective_normalized_ref = normalised_ref
 
         # Resolve the worktree.  Two paths exist (WP08 T035–T036, SC-11):
         #
@@ -704,13 +706,13 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
                 raise
             # Override caller-supplied destination_ref with the actual
             # lane branch so policy + HEAD assertion both see truth.
-            normalised_ref = _normalize_ref(lane_branch)
-            destination_ref = normalised_ref
+            effective_normalized_ref = _normalize_ref(lane_branch)
+            effective_destination_ref = effective_normalized_ref
             _emit_legacy_warning_once(repo_root, mission_id, safe_mission_slug)
         else:
             coord_branch = CoordinationWorkspace.branch_name(safe_mission_slug, safe_mid8)
             caller_change_set = GitChangeSet(
-                destination_ref=destination_ref,
+                destination_ref=effective_destination_ref,
                 repo_root=repo_root,
                 worktree_root=repo_root,
                 paths=(),
@@ -729,7 +731,7 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
                 )
                 allow_coord_resolution_to_report_missing_branch = (
                     caller_verdict.error_code == "DESTINATION_REF_NOT_FOUND"
-                    and destination_ref == coord_branch
+                    and effective_destination_ref == coord_branch
                 )
                 if not (
                     can_recover_to_coord_branch
@@ -749,8 +751,8 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
             # Status events must be committed to the coordination branch,
             # not the caller-supplied destination (which may be "main").
             # Mirror the legacy path's destination_ref override (lines above).
-            normalised_ref = _normalize_ref(coord_branch)
-            destination_ref = normalised_ref
+            effective_normalized_ref = _normalize_ref(coord_branch)
+            effective_destination_ref = effective_normalized_ref
 
         # 3. Compute the feature_dir + status files INSIDE the resolved
         # worktree.  Both paths (coord and legacy lane) host the
@@ -768,7 +770,7 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
         # This still happens before any bookkeeping write; the lock is
         # already held only to serialize first-time coord worktree setup.
         change_set = GitChangeSet(
-            destination_ref=destination_ref,
+            destination_ref=effective_destination_ref,
             repo_root=repo_root,
             worktree_root=worktree_root,
             paths=(events_path, snapshot_path),
@@ -796,7 +798,7 @@ class BookkeepingTransaction(AbstractContextManager["BookkeepingTransaction"]):
             mission_id=mission_id,
             mission_slug=mission_slug,
             mid8=mid8,
-            destination_ref=normalised_ref,
+            destination_ref=effective_normalized_ref,
             operation=operation,
             worktree_root=worktree_root,
             feature_dir=feature_dir,

--- a/tests/next/test_runtime_bridge_unit.py
+++ b/tests/next/test_runtime_bridge_unit.py
@@ -721,6 +721,19 @@ class TestTasksMarkdownParsing:
             "WP01": ["FR-001", "NFR-002"]
         }
 
+    def test_parse_requirement_refs_supports_heading_bullet_format(self) -> None:
+        from specify_cli.next.runtime_bridge import _parse_requirement_refs_from_tasks_md
+
+        tasks_md = (
+            "## Work Package WP01: Build parser\n"
+            "### Requirement Refs\n"
+            "- FR-001, nfr-002\n"
+        )
+
+        assert _parse_requirement_refs_from_tasks_md(tasks_md) == {
+            "WP01": ["FR-001", "NFR-002"]
+        }
+
     def test_parse_requirement_refs_completes_under_budget_on_adversarial_input(self) -> None:
         from specify_cli.next.runtime_bridge import _parse_requirement_refs_from_tasks_md
 

--- a/tests/specify_cli/next/test_runtime_bridge.py
+++ b/tests/specify_cli/next/test_runtime_bridge.py
@@ -237,6 +237,40 @@ def test_should_advance_implement_one_canceled(feature_dir: Path) -> None:
     assert _should_advance_wp_step("implement", feature_dir) is True
 
 
+def test_parse_requirement_refs_handles_markdown_label_without_regex_backtracking() -> None:
+    """Requirement refs parser accepts bold markdown labels and dedupes refs."""
+    from specify_cli.next.runtime_bridge import _parse_requirement_refs_from_tasks_md
+
+    tasks_md = """
+## Work Package WP01
+**Requirement Refs**: FR-001, nfr-002, FR-001
+Ignored line
+
+## Work Package WP02
+Requirement Refs: C-003, FR-004
+""".strip()
+
+    assert _parse_requirement_refs_from_tasks_md(tasks_md) == {
+        "WP01": ["FR-001", "NFR-002"],
+        "WP02": ["C-003", "FR-004"],
+    }
+
+
+def test_parse_requirement_refs_ignores_non_reference_lines() -> None:
+    """Only colon-delimited requirement labels should contribute refs."""
+    from specify_cli.next.runtime_bridge import _parse_requirement_refs_from_tasks_md
+
+    tasks_md = """
+## Work Package WP01
+Requirement notes only
+- requirement refs live elsewhere
+### Requirement Refs
+- FR-999
+""".strip()
+
+    assert _parse_requirement_refs_from_tasks_md(tasks_md) == {"WP01": []}
+
+
 def test_should_advance_review_all_approved(feature_dir: Path) -> None:
     """review step advances when all WPs are approved."""
     tasks = feature_dir / "tasks"

--- a/tests/specify_cli/next/test_runtime_bridge.py
+++ b/tests/specify_cli/next/test_runtime_bridge.py
@@ -256,19 +256,20 @@ Requirement Refs: C-003, FR-004
     }
 
 
-def test_parse_requirement_refs_ignores_non_reference_lines() -> None:
-    """Only colon-delimited requirement labels should contribute refs."""
+def test_parse_requirement_refs_supports_heading_and_bullet_list_format() -> None:
+    """Requirement refs parser accepts the documented heading + bullet form."""
     from specify_cli.next.runtime_bridge import _parse_requirement_refs_from_tasks_md
 
     tasks_md = """
 ## Work Package WP01
-Requirement notes only
-- requirement refs live elsewhere
 ### Requirement Refs
 - FR-999
+- nfr-001
 """.strip()
 
-    assert _parse_requirement_refs_from_tasks_md(tasks_md) == {"WP01": []}
+    assert _parse_requirement_refs_from_tasks_md(tasks_md) == {
+        "WP01": ["FR-999", "NFR-001"],
+    }
 
 
 def test_should_advance_review_all_approved(feature_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- remove the Sonar reliability/bug-style reassignment smell in `BookkeepingTransaction._acquire_locked` by splitting effective destination refs from input params
- replace the requirement-ref regex in `runtime_bridge` with bounded line parsing to avoid the regex hotspot / backtracking warning
- add focused regression tests for requirement-ref parsing variants

## Findings investigated
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud nightly `main` run `26936068885`: gate failed on `new_reliability_rating`, `new_coverage`, and `new_security_hotspots_reviewed`
- Actionable code fixes in this PR: the open Sonar bug in `src/specify_cli/coordination/transaction.py` and the regex hotspot in `src/runtime/next/runtime_bridge.py`
- Remaining Sonar hotspots still `TO_REVIEW`: two localhost-only `http` control-plane findings (`dashboard/server.py`, `sync/daemon.py`). Those are safe-by-design loopback endpoints and likely need Sonar review/rationale rather than a behavioral code change.

## Validation
- `.venv/bin/pytest tests/specify_cli/next/test_runtime_bridge.py -q`
- `.venv/bin/pytest tests/specify_cli/coordination/test_transaction.py -q`
- `.venv/bin/ruff check src/specify_cli/coordination/transaction.py src/runtime/next/runtime_bridge.py tests/specify_cli/next/test_runtime_bridge.py`
