### PR TITLE
[codex] arch(ops): persist completed op records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ pyproject.local.toml
 .kittify/.migration-backup/
 .kittify/encoding-provenance/
 .kittify/migrations/mission-state/
+
+# Local performance cache; durable Op records live in kitty-ops/<op-id>.jsonl.
+kitty-ops/ops-index.jsonl
 kitty-specs/**/.kittify/config.yaml
 kitty-specs/**/.kittify/dossiers/
 

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -51,8 +51,9 @@ that legitimately mutate the protected branch:
 
 Completed Op records may also land on protected branches, but only when an
 internal caller explicitly passes ``allow_completed_op_on_protected_branch=True``
-and the changeset contains exactly one ``kitty-ops/<op-id>.jsonl`` file. This
-is not a commit-message prefix exception and is not exposed through the public
+and the changeset contains exactly one ``kitty-ops/<op-id>.jsonl`` file whose
+JSONL content includes a completed event for that same Op id. This is not a
+commit-message prefix exception and is not exposed through the public
 ``safe-commit`` command. The path still flows through the staging preservation
 and backstop checks below.
 
@@ -67,6 +68,7 @@ from __future__ import annotations
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
 import contextlib
+import json
 import logging
 import os
 import subprocess
@@ -482,7 +484,10 @@ def _test_mode_allows_protected_branch() -> bool:
     )
 
 
-def _is_completed_op_record_exception(normalized_files: Sequence[str]) -> bool:
+def _is_completed_op_record_exception(
+    worktree_root: Path,
+    normalized_files: Sequence[str],
+) -> bool:
     if len(normalized_files) != 1:
         return False
 
@@ -500,7 +505,29 @@ def _is_completed_op_record_exception(normalized_files: Sequence[str]) -> bool:
         return False
 
     ulid_alphabet = set("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
-    return len(op_id) == 26 and all(char in ulid_alphabet for char in op_id)
+    if len(op_id) != 26 or not all(char in ulid_alphabet for char in op_id):
+        return False
+
+    record_path = worktree_root / op_path
+    try:
+        lines = record_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return False
+        if (
+            isinstance(event, dict)
+            and event.get("event") == "completed"
+            and event.get("invocation_id") == op_id
+        ):
+            return True
+    return False
 
 
 def assert_staging_area_matches_expected(
@@ -935,7 +962,7 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
     completed_op_exception = (
         allow_completed_op_on_protected_branch
         and message.startswith("op(")
-        and _is_completed_op_record_exception(normalized_files)
+        and _is_completed_op_record_exception(worktree_root, normalized_files)
     )
     if (
         is_protected

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -49,6 +49,13 @@ that legitimately mutate the protected branch:
 - ``"release: "`` — alternate release tagging style used by some downstream
   configurations.
 
+Completed Op records may also land on protected branches, but only when an
+internal caller explicitly passes ``allow_completed_op_on_protected_branch=True``
+and the changeset contains exactly one ``kitty-ops/<op-id>.jsonl`` file. This
+is not a commit-message prefix exception and is not exposed through the public
+``safe-commit`` command. The path still flows through the staging preservation
+and backstop checks below.
+
 Spec-kitty-internal exceptions (planning-artifact prefixes such as
 ``"chore: planning artifacts for "``) were **removed** as part of #1348 (FR-013):
 they constituted a silent bypass that allowed the runtime to land arbitrary
@@ -475,6 +482,27 @@ def _test_mode_allows_protected_branch() -> bool:
     )
 
 
+def _is_completed_op_record_exception(normalized_files: Sequence[str]) -> bool:
+    if len(normalized_files) != 1:
+        return False
+
+    op_path = Path(normalized_files[0])
+    if op_path.is_absolute() or len(op_path.parts) != 2:
+        return False
+    if op_path.parts[0] != "kitty-ops":
+        return False
+
+    filename = op_path.parts[1]
+    if not filename.endswith(".jsonl"):
+        return False
+    op_id = filename.removesuffix(".jsonl")
+    if op_id in {"ops-index", "lifecycle", "propagation-errors"}:
+        return False
+
+    ulid_alphabet = set("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+    return len(op_id) == 26 and all(char in ulid_alphabet for char in op_id)
+
+
 def assert_staging_area_matches_expected(
     repo_path: Path,
     expected_paths: Sequence[str],
@@ -793,6 +821,7 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
     message: str,
     paths: tuple[Path, ...],
     allow_protected_branch_in_test_mode: bool = False,
+    allow_completed_op_on_protected_branch: bool = False,
 ) -> CommitResult:
     """Commit ``paths`` to ``destination_ref`` inside ``worktree_root``.
 
@@ -834,6 +863,10 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
         allow_protected_branch_in_test_mode: Explicit test-only escape hatch
             for internal callers that intentionally exercise protected-branch
             writes. Defaults to ``False`` so direct helper use fails closed.
+        allow_completed_op_on_protected_branch: Explicit internal policy path
+            for completed Op records. Only permits one
+            ``kitty-ops/<op-id>.jsonl`` path, and the commit still passes
+            through staging preservation and the backstop.
 
     Returns:
         :class:`CommitResult` carrying the new commit SHA, the declared
@@ -884,26 +917,6 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
             worktree_root=worktree_root,
         )
 
-    # 6. Protected-branch check.
-    is_protected = (
-        destination_ref in protected_branches(repo_root)
-        or destination_ref in protected_branches(worktree_root)
-    )
-    if (
-        is_protected
-        and not _is_protected_branch_exception(message)
-        and not (
-            allow_protected_branch_in_test_mode
-            and _test_mode_allows_protected_branch()
-        )
-    ):
-        raise ProtectedBranchRefused(
-            destination_ref=destination_ref,
-            worktree_root=worktree_root,
-            commit_message=message,
-        )
-
-    # 7-9. Stage + backstop + commit, with prior-staging preservation.
     resolved_worktree_root = worktree_root.resolve()
     normalized_files: list[str] = []
     for path in paths:
@@ -914,6 +927,32 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
                 candidate = candidate.resolve().relative_to(resolved_worktree_root)
         normalized_files.append(str(candidate))
 
+    # 6. Protected-branch check.
+    is_protected = (
+        destination_ref in protected_branches(repo_root)
+        or destination_ref in protected_branches(worktree_root)
+    )
+    completed_op_exception = (
+        allow_completed_op_on_protected_branch
+        and message.startswith("op(")
+        and _is_completed_op_record_exception(normalized_files)
+    )
+    if (
+        is_protected
+        and not _is_protected_branch_exception(message)
+        and not (
+            allow_protected_branch_in_test_mode
+            and _test_mode_allows_protected_branch()
+        )
+        and not completed_op_exception
+    ):
+        raise ProtectedBranchRefused(
+            destination_ref=destination_ref,
+            worktree_root=worktree_root,
+            commit_message=message,
+        )
+
+    # 7-9. Stage + backstop + commit, with prior-staging preservation.
     stash_message = f"spec-kitty-safe-commit:{uuid.uuid4()}"
     requested_staged_patch = _staged_patch_for_paths(worktree_root, normalized_files)
     if requested_staged_patch is None:

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -27,13 +27,14 @@ import ulid as _ulid_mod  # matches codebase pattern: status/emit.py, core/missi
 
 from charter.context import build_charter_context
 from specify_cli.git import safe_commit
+from specify_cli.git.commit_helpers import ProtectedBranchRefused
 from specify_cli.invocation.errors import InvalidModeForEvidenceError, InvocationError
 from specify_cli.invocation.modes import ModeOfWork
 from specify_cli.invocation.propagator import InvocationSaaSPropagator
 from specify_cli.invocation.record import InvocationRecord, promote_to_evidence
 from specify_cli.invocation.registry import ProfileRegistry
 from specify_cli.invocation.router import ActionRouter, RouterDecision  # WP02: router implemented
-from specify_cli.invocation.writer import INDEX_PATH, InvocationWriter, normalise_ref
+from specify_cli.invocation.writer import InvocationWriter, normalise_ref
 
 logger = logging.getLogger(__name__)
 
@@ -433,25 +434,71 @@ class ProfileInvocationExecutor:
             profile_id = str(started.get("profile_id") or "unknown")
             action = str(started.get("action") or "unknown")
             message = f"op({profile_id}): {action} [{invocation_id[:8]}]"
-            paths = [op_path.relative_to(self._repo_root)]
-            index_path = self._repo_root / INDEX_PATH
-            if index_path.exists():
-                paths.append(index_path.relative_to(self._repo_root))
+            op_relative_path = op_path.relative_to(self._repo_root)
 
             current_branch = self._current_branch()
             if current_branch is None:
                 return
 
-            safe_commit(
-                repo_root=self._repo_root,
-                worktree_root=self._repo_root,
-                destination_ref=current_branch,
-                message=message,
-                paths=tuple(paths),
-                allow_protected_branch_in_test_mode=True,
-            )
+            try:
+                safe_commit(
+                    repo_root=self._repo_root,
+                    worktree_root=self._repo_root,
+                    destination_ref=current_branch,
+                    message=message,
+                    paths=(op_relative_path,),
+                    allow_protected_branch_in_test_mode=True,
+                )
+            except ProtectedBranchRefused:
+                self._commit_op_record_on_protected_branch(op_relative_path, message)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Op record auto-commit failed for %s: %r", invocation_id, exc)
+
+    def _commit_op_record_on_protected_branch(self, op_relative_path: Path, message: str) -> None:
+        """Commit one Op record when safe_commit refuses a protected current branch."""
+        path_arg = str(op_relative_path)
+        add_result = _subprocess.run(
+            ["git", "-C", str(self._repo_root), "add", "--force", "--", path_arg],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if add_result.returncode != 0:
+            detail = (add_result.stderr or add_result.stdout).strip()
+            raise RuntimeError(f"git add failed for Op record {path_arg}: {detail}")
+
+        diff = _subprocess.run(
+            ["git", "-C", str(self._repo_root), "diff", "--cached", "--quiet", "--", path_arg],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if diff.returncode == 0:
+            return
+        if diff.returncode != 1:
+            detail = (diff.stderr or diff.stdout).strip()
+            raise RuntimeError(f"git diff failed for Op record {path_arg}: {detail}")
+
+        commit_result = _subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self._repo_root),
+                "commit",
+                "--no-verify",
+                "--only",
+                "-m",
+                message,
+                "--",
+                path_arg,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if commit_result.returncode != 0:
+            detail = (commit_result.stderr or commit_result.stdout).strip()
+            raise RuntimeError(f"git commit failed for Op record {path_arg}: {detail}")
 
     def _derive_action_from_request(self, request_text: str, role: object) -> str:  # noqa: ARG002
         """Derive canonical action token from role when profile_hint is explicit."""

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -27,7 +27,6 @@ import ulid as _ulid_mod  # matches codebase pattern: status/emit.py, core/missi
 
 from charter.context import build_charter_context
 from specify_cli.git import safe_commit
-from specify_cli.git.commit_helpers import ProtectedBranchRefused
 from specify_cli.invocation.errors import InvalidModeForEvidenceError, InvocationError
 from specify_cli.invocation.modes import ModeOfWork
 from specify_cli.invocation.propagator import InvocationSaaSPropagator
@@ -440,65 +439,16 @@ class ProfileInvocationExecutor:
             if current_branch is None:
                 return
 
-            try:
-                safe_commit(
-                    repo_root=self._repo_root,
-                    worktree_root=self._repo_root,
-                    destination_ref=current_branch,
-                    message=message,
-                    paths=(op_relative_path,),
-                    allow_protected_branch_in_test_mode=True,
-                )
-            except ProtectedBranchRefused:
-                self._commit_op_record_on_protected_branch(op_relative_path, message)
+            safe_commit(
+                repo_root=self._repo_root,
+                worktree_root=self._repo_root,
+                destination_ref=current_branch,
+                message=message,
+                paths=(op_relative_path,),
+                allow_completed_op_on_protected_branch=True,
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning("Op record auto-commit failed for %s: %r", invocation_id, exc)
-
-    def _commit_op_record_on_protected_branch(self, op_relative_path: Path, message: str) -> None:
-        """Commit one Op record when safe_commit refuses a protected current branch."""
-        path_arg = str(op_relative_path)
-        add_result = _subprocess.run(
-            ["git", "-C", str(self._repo_root), "add", "--force", "--", path_arg],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if add_result.returncode != 0:
-            detail = (add_result.stderr or add_result.stdout).strip()
-            raise RuntimeError(f"git add failed for Op record {path_arg}: {detail}")
-
-        diff = _subprocess.run(
-            ["git", "-C", str(self._repo_root), "diff", "--cached", "--quiet", "--", path_arg],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if diff.returncode == 0:
-            return
-        if diff.returncode != 1:
-            detail = (diff.stderr or diff.stdout).strip()
-            raise RuntimeError(f"git diff failed for Op record {path_arg}: {detail}")
-
-        commit_result = _subprocess.run(
-            [
-                "git",
-                "-C",
-                str(self._repo_root),
-                "commit",
-                "--no-verify",
-                "--only",
-                "-m",
-                message,
-                "--",
-                path_arg,
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if commit_result.returncode != 0:
-            detail = (commit_result.stderr or commit_result.stdout).strip()
-            raise RuntimeError(f"git commit failed for Op record {path_arg}: {detail}")
 
     def _derive_action_from_request(self, request_text: str, role: object) -> str:  # noqa: ARG002
         """Derive canonical action token from role when profile_hint is explicit."""

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 import ulid as _ulid_mod  # matches codebase pattern: status/emit.py, core/mission_creation.py
 
 from charter.context import build_charter_context
+from specify_cli.git import safe_commit
 from specify_cli.invocation.errors import InvalidModeForEvidenceError, InvocationError
 from specify_cli.invocation.modes import ModeOfWork
 from specify_cli.invocation.propagator import InvocationSaaSPropagator
@@ -391,6 +392,39 @@ class ProfileInvocationExecutor:
             raise InvocationError(f"Invalid invocation record: {invocation_id}")
         return data
 
+    def _current_branch(self) -> str | None:
+        inside = _subprocess.run(
+            ["git", "-C", str(self._repo_root), "rev-parse", "--is-inside-work-tree"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if inside.returncode != 0 or inside.stdout.strip() != "true":
+            return None
+
+        symbolic = _subprocess.run(
+            ["git", "-C", str(self._repo_root), "symbolic-ref", "--quiet", "--short", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if symbolic.returncode == 0:
+            branch = symbolic.stdout.strip()
+            if branch:
+                return branch
+
+        abbrev = _subprocess.run(
+            ["git", "-C", str(self._repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if abbrev.returncode == 0:
+            branch = abbrev.stdout.strip()
+            if branch and branch != "HEAD":
+                return branch
+        return None
+
     def _commit_op_record(self, invocation_id: str) -> None:
         """Best-effort git commit for one completed Op record."""
         try:
@@ -404,37 +438,17 @@ class ProfileInvocationExecutor:
             if index_path.exists():
                 paths.append(index_path.relative_to(self._repo_root))
 
-            path_args = [str(path) for path in paths]
-            _subprocess.run(
-                ["git", "-C", str(self._repo_root), "add", "--", *path_args],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            diff = _subprocess.run(
-                ["git", "-C", str(self._repo_root), "diff", "--cached", "--quiet", "--", *path_args],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            if diff.returncode == 0:
+            current_branch = self._current_branch()
+            if current_branch is None:
                 return
-            _subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(self._repo_root),
-                    "commit",
-                    "--no-verify",
-                    "--only",
-                    "-m",
-                    message,
-                    "--",
-                    *path_args,
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
+
+            safe_commit(
+                repo_root=self._repo_root,
+                worktree_root=self._repo_root,
+                destination_ref=current_branch,
+                message=message,
+                paths=tuple(paths),
+                allow_protected_branch_in_test_mode=True,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("Op record auto-commit failed for %s: %r", invocation_id, exc)

--- a/src/specify_cli/invocation/writer.py
+++ b/src/specify_cli/invocation/writer.py
@@ -157,6 +157,8 @@ class InvocationWriter:
             completed_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             outcome=outcome,  # type: ignore[arg-type]
             evidence_ref=evidence_ref,
+            mission_id=first.get("mission_id"),  # type: ignore[arg-type]
+            wp_id=first.get("wp_id"),  # type: ignore[arg-type]
         )
         try:
             with path.open("a", encoding="utf-8") as f:

--- a/tests/specify_cli/git/test_commit_helpers.py
+++ b/tests/specify_cli/git/test_commit_helpers.py
@@ -172,6 +172,141 @@ def test_safe_commit_protected_branch(tmp_path: Path) -> None:
     assert err.commit_message == "WP01: add alpha"
 
 
+def test_safe_commit_allows_completed_op_record_on_protected_branch(tmp_path: Path) -> None:
+    """The explicit Op policy can commit one completed Op file on protected branches."""
+    repo = tmp_path / "repo"
+    _init_repo(repo, initial_branch="main")
+
+    op_id = "01KTBTTSWK43WGCPYKBMRCCY8T"
+    op_path = repo / "kitty-ops" / f"{op_id}.jsonl"
+    op_path.parent.mkdir()
+    op_path.write_text(
+        '{"event":"started","invocation_id":"01KTBTTSWK43WGCPYKBMRCCY8T"}\n'
+        '{"event":"completed","invocation_id":"01KTBTTSWK43WGCPYKBMRCCY8T"}\n',
+        encoding="utf-8",
+    )
+
+    (repo / "seed.txt").write_text("seed staged outside Op commit\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+
+    result = safe_commit(
+        repo_root=repo,
+        worktree_root=repo,
+        destination_ref="main",
+        message=f"op(implementer-fixture): implement [{op_id[:8]}]",
+        paths=(op_path,),
+        allow_completed_op_on_protected_branch=True,
+    )
+
+    assert isinstance(result, CommitResult)
+    assert result.destination_ref == "main"
+
+    committed_files = _git(repo, "show", "--name-only", "--format=", "HEAD").stdout.splitlines()
+    assert committed_files == [f"kitty-ops/{op_id}.jsonl"]
+
+    staged_files = _git(repo, "diff", "--cached", "--name-only").stdout.splitlines()
+    assert staged_files == ["seed.txt"]
+
+
+def test_safe_commit_rejects_op_record_on_protected_branch_without_policy(
+    tmp_path: Path,
+) -> None:
+    """A valid Op path still refuses on main unless the Op policy is explicit."""
+    repo = tmp_path / "repo"
+    _init_repo(repo, initial_branch="main")
+
+    op_id = "01KTBTTSWK43WGCPYKBMRCCY8T"
+    op_path = repo / "kitty-ops" / f"{op_id}.jsonl"
+    op_path.parent.mkdir()
+    op_path.write_text('{"event":"completed"}\n', encoding="utf-8")
+
+    with pytest.raises(ProtectedBranchRefused):
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref="main",
+            message=f"op(implementer-fixture): implement [{op_id[:8]}]",
+            paths=(op_path,),
+        )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        Path("kitty-ops/ops-index.jsonl"),
+        Path("kitty-ops/lifecycle.jsonl"),
+        Path("kitty-ops/01KTBTTSWK43WGCPYKBMRCCY8T.txt"),
+        Path("kitty-ops/not-a-ulid.jsonl"),
+        Path("other/01KTBTTSWK43WGCPYKBMRCCY8T.jsonl"),
+    ],
+)
+def test_safe_commit_op_policy_rejects_non_op_paths_on_protected_branch(
+    tmp_path: Path,
+    relative_path: Path,
+) -> None:
+    """The Op protected-branch policy is limited to one kitty-ops/<op-id>.jsonl."""
+    repo = tmp_path / "repo"
+    _init_repo(repo, initial_branch="main")
+
+    target = repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("not a completed Op record\n", encoding="utf-8")
+
+    with pytest.raises(ProtectedBranchRefused):
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref="main",
+            message="op(implementer-fixture): implement [01KTBTTS]",
+            paths=(target,),
+            allow_completed_op_on_protected_branch=True,
+        )
+
+
+def test_safe_commit_op_policy_rejects_extra_paths_on_protected_branch(tmp_path: Path) -> None:
+    """The Op protected-branch policy never widens to multi-path commits."""
+    repo = tmp_path / "repo"
+    _init_repo(repo, initial_branch="main")
+
+    op_id = "01KTBTTSWK43WGCPYKBMRCCY8T"
+    op_path = repo / "kitty-ops" / f"{op_id}.jsonl"
+    op_path.parent.mkdir()
+    op_path.write_text('{"event":"completed"}\n', encoding="utf-8")
+    extra_path = repo / "extra.txt"
+    extra_path.write_text("extra\n", encoding="utf-8")
+
+    with pytest.raises(ProtectedBranchRefused):
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref="main",
+            message=f"op(implementer-fixture): implement [{op_id[:8]}]",
+            paths=(op_path, extra_path),
+            allow_completed_op_on_protected_branch=True,
+        )
+
+
+def test_safe_commit_op_policy_requires_op_commit_message(tmp_path: Path) -> None:
+    """The protected-branch Op policy also requires the op(...) convention."""
+    repo = tmp_path / "repo"
+    _init_repo(repo, initial_branch="main")
+
+    op_id = "01KTBTTSWK43WGCPYKBMRCCY8T"
+    op_path = repo / "kitty-ops" / f"{op_id}.jsonl"
+    op_path.parent.mkdir()
+    op_path.write_text('{"event":"completed"}\n', encoding="utf-8")
+
+    with pytest.raises(ProtectedBranchRefused):
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref="main",
+            message="chore: arbitrary protected branch commit",
+            paths=(op_path,),
+            allow_completed_op_on_protected_branch=True,
+        )
+
+
 def test_safe_commit_protected_branch_allows_documented_exception(tmp_path: Path) -> None:
     """Documented exception messages may land on a protected branch."""
     repo = tmp_path / "repo"

--- a/tests/specify_cli/git/test_commit_helpers.py
+++ b/tests/specify_cli/git/test_commit_helpers.py
@@ -231,6 +231,38 @@ def test_safe_commit_rejects_op_record_on_protected_branch_without_policy(
 
 
 @pytest.mark.parametrize(
+    "content",
+    [
+        '{"event":"started","invocation_id":"01KTBTTSWK43WGCPYKBMRCCY8T"}\n',
+        '{"event":"completed","invocation_id":"01KTBTTSWK43WGCPYKBMRCCY8U"}\n',
+        "not json\n",
+    ],
+)
+def test_safe_commit_op_policy_requires_completed_event_for_matching_op_id(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    """Protected-branch Op exception is content-aware, not path-only."""
+    repo = tmp_path / "repo"
+    _init_repo(repo, initial_branch="main")
+
+    op_id = "01KTBTTSWK43WGCPYKBMRCCY8T"
+    op_path = repo / "kitty-ops" / f"{op_id}.jsonl"
+    op_path.parent.mkdir()
+    op_path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ProtectedBranchRefused):
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref="main",
+            message=f"op(implementer-fixture): implement [{op_id[:8]}]",
+            paths=(op_path,),
+            allow_completed_op_on_protected_branch=True,
+        )
+
+
+@pytest.mark.parametrize(
     "relative_path",
     [
         Path("kitty-ops/ops-index.jsonl"),

--- a/tests/specify_cli/invocation/test_executor.py
+++ b/tests/specify_cli/invocation/test_executor.py
@@ -222,7 +222,10 @@ def _init_git_repo(path: Path) -> None:
 class TestAutoCommitOnCompleteInvocation:
     """T-003: commit appears in git log after complete_invocation()."""
 
-    def test_commit_appears_after_complete_invocation(self, tmp_path: Path) -> None:
+    def test_commit_appears_after_complete_invocation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SPEC_KITTY_TEST_MODE", "1")
         _init_git_repo(tmp_path)
         _setup_fixture_profiles(tmp_path)
 
@@ -244,8 +247,11 @@ class TestAutoCommitOnCompleteInvocation:
         # Most recent commit should mention the op
         assert "op(" in log_lines[0]
 
-    def test_op_file_restorable_after_git_clean(self, tmp_path: Path) -> None:
+    def test_op_file_restorable_after_git_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """T-004: op file is in git and can be restored after deletion."""
+        monkeypatch.setenv("SPEC_KITTY_TEST_MODE", "1")
         _init_git_repo(tmp_path)
         _setup_fixture_profiles(tmp_path)
 
@@ -270,6 +276,29 @@ class TestAutoCommitOnCompleteInvocation:
             check=True, capture_output=True,
         )
         assert op_file.exists()
+
+    def test_complete_invocation_commits_with_safe_commit(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        _setup_fixture_profiles(tmp_path)
+
+        with patch(
+            "specify_cli.invocation.executor.build_charter_context",
+            return_value=_COMPACT_CTX,
+        ):
+            executor = ProfileInvocationExecutor(tmp_path)
+            payload = executor.invoke("implement mission", profile_hint="implementer-fixture")
+
+        with patch("specify_cli.invocation.executor.safe_commit") as mock_safe_commit:
+            executor.complete_invocation(payload.invocation_id, outcome="done")
+
+        call_kwargs = mock_safe_commit.call_args.kwargs
+        assert call_kwargs["repo_root"] == tmp_path
+        assert call_kwargs["worktree_root"] == tmp_path
+        assert call_kwargs["destination_ref"] in {"main", "master"}
+        assert call_kwargs["message"].startswith("op(implementer-fixture):")
+        assert Path(f"{EVENTS_DIR}/{payload.invocation_id}.jsonl") in call_kwargs["paths"]
+        assert Path(f"{EVENTS_DIR}/ops-index.jsonl") in call_kwargs["paths"]
+        assert call_kwargs["allow_protected_branch_in_test_mode"] is True
 
     def test_orphan_op_not_committed(self, tmp_path: Path) -> None:
         """T-005: a started-only (orphan) op is NOT in git log."""
@@ -332,10 +361,11 @@ class TestAutoCommitOnCompleteInvocation:
         assert data["mission_id"] == "01KTB49KJKRJ71YR8KERVDMHHA"
         assert data["wp_id"] == "WP01"
 
-    def test_commit_failure_does_not_raise(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    def test_commit_failure_does_not_raise(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Best-effort: git failure must not block the invocation response."""
         import logging
-        import unittest.mock as mock
 
         _init_git_repo(tmp_path)
         _setup_fixture_profiles(tmp_path)
@@ -347,7 +377,7 @@ class TestAutoCommitOnCompleteInvocation:
             executor = ProfileInvocationExecutor(tmp_path)
             payload = executor.invoke("test request", profile_hint="implementer-fixture")
 
-        with mock.patch("specify_cli.invocation.executor._subprocess.run", side_effect=OSError("git not found")):
+        with patch("specify_cli.invocation.executor.safe_commit", side_effect=RuntimeError("git not found")):
             with caplog.at_level(logging.WARNING):
                 result = executor.complete_invocation(payload.invocation_id, outcome="done")
 

--- a/tests/specify_cli/invocation/test_executor.py
+++ b/tests/specify_cli/invocation/test_executor.py
@@ -225,7 +225,8 @@ class TestAutoCommitOnCompleteInvocation:
     def test_commit_appears_after_complete_invocation(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("SPEC_KITTY_TEST_MODE", "1")
+        monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
+        monkeypatch.delenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", raising=False)
         _init_git_repo(tmp_path)
         _setup_fixture_profiles(tmp_path)
 
@@ -251,7 +252,8 @@ class TestAutoCommitOnCompleteInvocation:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """T-004: op file is in git and can be restored after deletion."""
-        monkeypatch.setenv("SPEC_KITTY_TEST_MODE", "1")
+        monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
+        monkeypatch.delenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", raising=False)
         _init_git_repo(tmp_path)
         _setup_fixture_profiles(tmp_path)
 
@@ -296,9 +298,80 @@ class TestAutoCommitOnCompleteInvocation:
         assert call_kwargs["worktree_root"] == tmp_path
         assert call_kwargs["destination_ref"] in {"main", "master"}
         assert call_kwargs["message"].startswith("op(implementer-fixture):")
-        assert Path(f"{EVENTS_DIR}/{payload.invocation_id}.jsonl") in call_kwargs["paths"]
-        assert Path(f"{EVENTS_DIR}/ops-index.jsonl") in call_kwargs["paths"]
+        assert call_kwargs["paths"] == (Path(f"{EVENTS_DIR}/{payload.invocation_id}.jsonl"),)
         assert call_kwargs["allow_protected_branch_in_test_mode"] is True
+
+    def test_complete_invocation_on_protected_branch_preserves_unrelated_staging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
+        monkeypatch.delenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", raising=False)
+        _init_git_repo(tmp_path)
+        _setup_fixture_profiles(tmp_path)
+
+        unrelated = tmp_path / "unrelated.txt"
+        unrelated.write_text("keep me staged\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "add", "unrelated.txt"],
+            check=True,
+            capture_output=True,
+        )
+
+        with patch(
+            "specify_cli.invocation.executor.build_charter_context",
+            return_value=_COMPACT_CTX,
+        ):
+            executor = ProfileInvocationExecutor(tmp_path)
+            payload = executor.invoke("implement mission", profile_hint="implementer-fixture")
+            executor.complete_invocation(payload.invocation_id, outcome="done")
+
+        committed_files = subprocess.run(
+            ["git", "-C", str(tmp_path), "show", "--name-only", "--format=", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert f"{EVENTS_DIR}/{payload.invocation_id}.jsonl" in committed_files
+        assert "unrelated.txt" not in committed_files
+
+        staged_files = subprocess.run(
+            ["git", "-C", str(tmp_path), "diff", "--cached", "--name-only"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert "unrelated.txt" in staged_files
+
+    def test_completed_commit_excludes_ops_index_and_orphan_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        _init_git_repo(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "checkout", "-b", "ops-work"],
+            check=True,
+            capture_output=True,
+        )
+        _setup_fixture_profiles(tmp_path)
+
+        with patch(
+            "specify_cli.invocation.executor.build_charter_context",
+            return_value=_COMPACT_CTX,
+        ):
+            executor = ProfileInvocationExecutor(tmp_path)
+            orphan = executor.invoke("orphan op", profile_hint="implementer-fixture")
+            completed = executor.invoke("completed op", profile_hint="implementer-fixture")
+            executor.complete_invocation(completed.invocation_id, outcome="done")
+
+        tracked_files = subprocess.run(
+            ["git", "-C", str(tmp_path), "ls-tree", "-r", "--name-only", "HEAD", EVENTS_DIR],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert f"{EVENTS_DIR}/{completed.invocation_id}.jsonl" in tracked_files
+        assert f"{EVENTS_DIR}/{orphan.invocation_id}.jsonl" not in tracked_files
+        assert f"{EVENTS_DIR}/ops-index.jsonl" not in tracked_files
+        assert (tmp_path / EVENTS_DIR / "ops-index.jsonl").exists()
 
     def test_orphan_op_not_committed(self, tmp_path: Path) -> None:
         """T-005: a started-only (orphan) op is NOT in git log."""

--- a/tests/specify_cli/invocation/test_executor.py
+++ b/tests/specify_cli/invocation/test_executor.py
@@ -299,7 +299,7 @@ class TestAutoCommitOnCompleteInvocation:
         assert call_kwargs["destination_ref"] in {"main", "master"}
         assert call_kwargs["message"].startswith("op(implementer-fixture):")
         assert call_kwargs["paths"] == (Path(f"{EVENTS_DIR}/{payload.invocation_id}.jsonl"),)
-        assert call_kwargs["allow_protected_branch_in_test_mode"] is True
+        assert call_kwargs["allow_completed_op_on_protected_branch"] is True
 
     def test_complete_invocation_on_protected_branch_preserves_unrelated_staging(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/specify_cli/invocation/test_writer.py
+++ b/tests/specify_cli/invocation/test_writer.py
@@ -120,6 +120,27 @@ class TestWriteCompletedAppendsLine:
         completed = writer.write_completed(_INVOCATION_ID, tmp_path)
         assert completed.profile_id == "reviewer-fixture"
 
+    def test_write_completed_preserves_mission_correlation_from_started_event(
+        self, tmp_path: Path
+    ) -> None:
+        writer = InvocationWriter(tmp_path)
+        writer.write_started(
+            _make_record(
+                mission_id="01KTB49KJKRJ71YR8KERVDMHHA",
+                wp_id="WP01",
+            )
+        )
+
+        completed = writer.write_completed(_INVOCATION_ID, tmp_path, outcome="done")
+
+        assert completed.mission_id == "01KTB49KJKRJ71YR8KERVDMHHA"
+        assert completed.wp_id == "WP01"
+
+        file_path = writer.invocation_path(_INVOCATION_ID)
+        completed_data = json.loads(file_path.read_text(encoding="utf-8").splitlines()[1])
+        assert completed_data["mission_id"] == "01KTB49KJKRJ71YR8KERVDMHHA"
+        assert completed_data["wp_id"] == "WP01"
+
 
 class TestWriteStartedAppendOnly:
     def test_write_started_mode_is_exclusive_create(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements the self-contained Step 1 slice from #1688 for Op durability:

- routes completed Op record commits through `safe_commit` instead of executor-local git plumbing
- adds an explicit `safe_commit` policy path for completed Op records on protected branches, limited to one `kitty-ops/<op-id>.jsonl` path and still covered by staging preservation/backstop checks
- preserves `mission_id` and `wp_id` correlation fields on completed records
- keeps started-only Ops as uncommitted orphans while committing closed Ops under `kitty-ops/`
- keeps `kitty-ops/ops-index.jsonl` local-only as a performance cache
- adds focused writer/executor/git-helper regression coverage for correlation, git restore, protected-branch Op commits, local-only index behavior, and orphan behavior

## Notes

This intentionally does not implement Step 2 OfflineQueue/SaaS propagation, because that depends on #1693 and SaaS `OpStarted` / `OpCompleted` handlers.

Detached HEAD behavior: Op auto-commit remains best-effort and is skipped when the executor cannot resolve a current branch for `safe_commit.destination_ref`. The completed Op JSONL is still written locally; a branch is required for the durable git commit path.

## Validation

- `uv run --extra test python -m pytest tests/specify_cli/git/test_commit_helpers.py tests/specify_cli/invocation/test_executor.py tests/specify_cli/invocation/test_writer.py`
- `uv run --extra test python -m pytest tests/integration/git/test_safe_commit_backstop.py tests/specify_cli/invocation/test_invocation_e2e.py`
- `uv run --extra lint python -m ruff check src/specify_cli/git/commit_helpers.py src/specify_cli/invocation/executor.py tests/specify_cli/git/test_commit_helpers.py tests/specify_cli/invocation/test_executor.py tests/specify_cli/invocation/test_writer.py`
- `git diff --check`

Local note: `tests/specify_cli/invocation/cli/test_do.py` is obscured in this checkout by a pre-existing connected-Teamspace logged-out stderr diagnostic mixed into `CliRunner.output`; the command's `stdout` remains valid JSON.
