### PR TITLE
[codex] fix(merge): diagnose malformed review artifacts

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1598,6 +1598,13 @@ def _run_lane_based_merge_locked(
 
     # -- T001: MergeState lifecycle: load or create --
     all_wp_ids = [wp for lane in lanes_manifest.lanes for wp in lane.wp_ids]
+    _enforce_review_artifact_consistency(
+        repo_root=main_repo,
+        feature_dir=feature_dir,
+        mission_slug=mission_slug,
+        wp_ids=all_wp_ids,
+    )
+
     state = load_state(main_repo, canonical_id)
     is_resume = False
     if state is not None:
@@ -1633,13 +1640,6 @@ def _run_lane_based_merge_locked(
     if not gate_eval.overall_pass:
         console.print("\n[red]Error:[/red] Merge gates failed.")
         raise typer.Exit(1)
-
-    _enforce_review_artifact_consistency(
-        repo_root=main_repo,
-        feature_dir=feature_dir,
-        mission_slug=mission_slug,
-        wp_ids=all_wp_ids,
-    )
 
     # -- Bootstrap-only canonical history guard (issue #1069) --
     # Refuse to merge missions whose status.events.jsonl contains

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -2310,6 +2310,16 @@ def merge(
                     console.print(
                         f"    branch_or_work_package: {diagnostic['branch_or_work_package']}"
                     )
+                    console.print(
+                        f"    violated_invariant: {diagnostic['violated_invariant']}"
+                    )
+                    console.print(
+                        f"    latest_review_cycle_path: {diagnostic['latest_review_cycle_path']}"
+                    )
+                    if "latest_review_cycle_verdict" in diagnostic:
+                        console.print(
+                            f"    latest_review_cycle_verdict: {diagnostic['latest_review_cycle_verdict']}"
+                        )
                     if "schema_error" in diagnostic:
                         console.print(f"    schema_error: {diagnostic['schema_error']}")
                     remediation = diagnostic.get("remediation", [])

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -63,9 +63,8 @@ from specify_cli.mission_metadata import load_meta, resolve_mission_identity, wr
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace, get_merge_runtime_dir
 from specify_cli.post_merge.review_artifact_consistency import (
     REJECTED_REVIEW_ARTIFACT_CONFLICT,
-    REJECTED_REVIEW_ARTIFACT_REMEDIATION,
-    format_review_artifact_conflict,
-    review_artifact_conflict_diagnostic,
+    format_review_artifact_finding,
+    review_artifact_finding_diagnostic,
     run_review_artifact_consistency_preflight,
 )
 from specify_cli.post_merge.stale_assertions import StaleAssertionReport, run_check
@@ -1352,17 +1351,14 @@ def _enforce_review_artifact_consistency(
         return
     findings = list(preflight.findings)
 
-    console.print(
-        "[red]Error:[/red] Review artifact consistency gate failed. "
-        "Approved/done work packages cannot have a latest rejected review artifact."
-    )
+    console.print("[red]Error:[/red] Review artifact consistency gate failed.")
     for finding in findings:
-        diagnostic = review_artifact_conflict_diagnostic(
+        diagnostic = review_artifact_finding_diagnostic(
             finding,
             repo_root=repo_root,
         )
         console.print(
-            f"  - {format_review_artifact_conflict(finding, repo_root=repo_root)}"
+            f"  - {format_review_artifact_finding(finding, repo_root=repo_root)}"
         )
         console.print(f"    diagnostic_code: {diagnostic['diagnostic_code']}")
         console.print(
@@ -1374,10 +1370,16 @@ def _enforce_review_artifact_consistency(
         console.print(
             f"    latest_review_cycle_path: {diagnostic['latest_review_cycle_path']}"
         )
-        console.print(
-            f"    latest_review_cycle_verdict: {diagnostic['latest_review_cycle_verdict']}"
-        )
-        for line in REJECTED_REVIEW_ARTIFACT_REMEDIATION:
+        if "latest_review_cycle_verdict" in diagnostic:
+            console.print(
+                f"    latest_review_cycle_verdict: {diagnostic['latest_review_cycle_verdict']}"
+            )
+        if "schema_error" in diagnostic:
+            console.print(f"    schema_error: {diagnostic['schema_error']}")
+        remediation = diagnostic.get("remediation", [])
+        if not isinstance(remediation, list):
+            remediation = [str(remediation)]
+        for line in remediation:
             console.print(f"    remediation: {line}")
     console.print(
         f"  Mission: {mission_slug}"
@@ -2275,6 +2277,11 @@ def merge(
                 repo_root=main_repo_for_diag,
             )
             if json_output:
+                diagnostic_code = (
+                    diagnostics[0]["diagnostic_code"]
+                    if diagnostics
+                    else REJECTED_REVIEW_ARTIFACT_CONFLICT
+                )
                 print(
                     json.dumps(
                         {
@@ -2283,26 +2290,32 @@ def merge(
                             "target_branch": resolved_target_branch,
                             "blocked": True,
                             "blockers": diagnostics,
-                            "diagnostic_code": REJECTED_REVIEW_ARTIFACT_CONFLICT,
+                            "diagnostic_code": diagnostic_code,
                         }
                     )
                 )
             else:
-                console.print(
-                    "[red]Error:[/red] Review artifact consistency gate failed. "
-                    "Approved/done work packages cannot have a latest rejected review artifact."
-                )
+                console.print("[red]Error:[/red] Review artifact consistency gate failed.")
                 for finding in review_artifact_preflight.findings:
-                    console.print(
-                        f"  - {format_review_artifact_conflict(finding, repo_root=main_repo_for_diag)}"
+                    diagnostic = review_artifact_finding_diagnostic(
+                        finding,
+                        repo_root=main_repo_for_diag,
                     )
                     console.print(
-                        f"    diagnostic_code: {REJECTED_REVIEW_ARTIFACT_CONFLICT}"
+                        f"  - {format_review_artifact_finding(finding, repo_root=main_repo_for_diag)}"
                     )
                     console.print(
-                        f"    branch_or_work_package: {finding.wp_id}"
+                        f"    diagnostic_code: {diagnostic['diagnostic_code']}"
                     )
-                    for line in REJECTED_REVIEW_ARTIFACT_REMEDIATION:
+                    console.print(
+                        f"    branch_or_work_package: {diagnostic['branch_or_work_package']}"
+                    )
+                    if "schema_error" in diagnostic:
+                        console.print(f"    schema_error: {diagnostic['schema_error']}")
+                    remediation = diagnostic.get("remediation", [])
+                    if not isinstance(remediation, list):
+                        remediation = [str(remediation)]
+                    for line in remediation:
                         console.print(f"    remediation: {line}")
                 console.print(f"  Mission: {resolved_feature}")
             raise typer.Exit(1)

--- a/src/specify_cli/cli/commands/review/_lane_gate.py
+++ b/src/specify_cli/cli/commands/review/_lane_gate.py
@@ -12,9 +12,10 @@ from typing import cast
 from rich.console import Console
 
 from specify_cli.post_merge.review_artifact_consistency import (
+    REVIEW_ARTIFACT_SCHEMA_INVALID,
     find_rejected_review_artifact_conflicts,
-    format_review_artifact_conflict,
-    review_artifact_conflict_diagnostic,
+    format_review_artifact_finding,
+    review_artifact_finding_diagnostic,
 )
 from specify_cli.status.reducer import materialize
 
@@ -53,16 +54,16 @@ def check_wp_lanes(
     review_artifact_conflicts = find_rejected_review_artifact_conflicts(feature_dir)
     if review_artifact_conflicts:
         console.print(
-            "  [red]✗[/red]  Review artifact consistency: latest rejected artifact "
-            "exists for terminal WP(s)"
+            "  [red]✗[/red]  Review artifact consistency: blocking latest review "
+            "artifact exists for terminal WP(s)"
         )
         for conflict in review_artifact_conflicts:
-            diagnostic = review_artifact_conflict_diagnostic(
+            diagnostic = review_artifact_finding_diagnostic(
                 conflict,
                 repo_root=repo_root,
             )
             console.print(
-                f"       {format_review_artifact_conflict(conflict, repo_root=repo_root)}"
+                f"       {format_review_artifact_finding(conflict, repo_root=repo_root)}"
             )
             console.print(f"       diagnostic_code: {diagnostic['diagnostic_code']}")
             console.print(
@@ -71,28 +72,39 @@ def check_wp_lanes(
             console.print(
                 f"       violated_invariant: {diagnostic['violated_invariant']}"
             )
+            if "schema_error" in diagnostic:
+                console.print(f"       schema_error: {diagnostic['schema_error']}")
             for line in cast(list[str], diagnostic["remediation"]):
                 console.print(f"       remediation: {line}")
+            finding_type = (
+                "review_artifact_schema_invalid"
+                if diagnostic["diagnostic_code"] == REVIEW_ARTIFACT_SCHEMA_INVALID
+                else "rejected_review_artifact"
+            )
+            finding: dict[str, str] = {
+                "type": finding_type,
+                "wp_id": conflict.wp_id,
+                "lane": conflict.lane,
+                "artifact_path": str(conflict.artifact_path),
+                "diagnostic_code": str(diagnostic["diagnostic_code"]),
+                "branch_or_work_package": str(
+                    diagnostic["branch_or_work_package"]
+                ),
+                "violated_invariant": str(diagnostic["violated_invariant"]),
+                "remediation": "; ".join(
+                    str(line) for line in cast(list[str], diagnostic["remediation"])
+                ),
+            }
+            if "latest_review_cycle_verdict" in diagnostic:
+                finding["latest_review_cycle_verdict"] = str(
+                    diagnostic["latest_review_cycle_verdict"]
+                )
+            if "schema_error" in diagnostic:
+                finding["schema_error"] = str(diagnostic["schema_error"])
             findings.append(
-                {
-                    "type": "rejected_review_artifact",
-                    "wp_id": conflict.wp_id,
-                    "lane": conflict.lane,
-                    "artifact_path": str(conflict.artifact_path),
-                    "diagnostic_code": str(diagnostic["diagnostic_code"]),
-                    "branch_or_work_package": str(
-                        diagnostic["branch_or_work_package"]
-                    ),
-                    "violated_invariant": str(diagnostic["violated_invariant"]),
-                    "remediation": "; ".join(
-                        str(line) for line in cast(list[str], diagnostic["remediation"])
-                    ),
-                    "latest_review_cycle_verdict": str(
-                        diagnostic["latest_review_cycle_verdict"]
-                    ),
-                }
+                finding
             )
     else:
         console.print(
-            "  [green]✓[/green]  Review artifact consistency: no terminal WP has a latest rejected artifact"
+            "  [green]✓[/green]  Review artifact consistency: no terminal WP has a blocking latest review artifact"
         )

--- a/src/specify_cli/cli/commands/review/_report.py
+++ b/src/specify_cli/cli/commands/review/_report.py
@@ -20,6 +20,7 @@ _HARD_FAILURE_FINDING_TYPES = frozenset(
     {
         "wp_not_done",
         "rejected_review_artifact",
+        "review_artifact_schema_invalid",
         "ble001_suppression",
         "issue_matrix_violation",
         "dead_code_baseline_missing",
@@ -71,6 +72,18 @@ def _format_finding_line(finding: dict[str, str]) -> str | None:
             "branch_or_work_package="
             f"`{finding.get('branch_or_work_package', 'unknown')}`, "
             f"violated_invariant=`{finding.get('violated_invariant', 'unknown')}`, "
+            f"remediation=`{finding.get('remediation', 'unknown')}`"
+        )
+    if finding_type == "review_artifact_schema_invalid":
+        return (
+            f"- **review_artifact_schema_invalid** `{finding['wp_id']}`: lane is "
+            f"`{finding.get('lane', 'unknown')}`, latest artifact is "
+            f"`{finding.get('artifact_path', 'unknown')}`; "
+            f"diagnostic_code=`{finding.get('diagnostic_code', 'unknown')}`, "
+            "branch_or_work_package="
+            f"`{finding.get('branch_or_work_package', 'unknown')}`, "
+            f"violated_invariant=`{finding.get('violated_invariant', 'unknown')}`, "
+            f"schema_error=`{finding.get('schema_error', 'unknown')}`, "
             f"remediation=`{finding.get('remediation', 'unknown')}`"
         )
     if finding_type == "issue_matrix_violation":

--- a/src/specify_cli/post_merge/review_artifact_consistency.py
+++ b/src/specify_cli/post_merge/review_artifact_consistency.py
@@ -84,6 +84,24 @@ def _latest_review_artifact_path(artifact_dir: Path) -> Path | None:
     return candidates[-1]
 
 
+def _schema_error_message(exc: ValueError, artifact_path: Path) -> str:
+    """Strip machine-local paths from parser errors; path is reported separately."""
+    message = str(exc)
+    prefixes = (
+        f"Missing or invalid field in review artifact {artifact_path}: ",
+        f"Failed to parse YAML frontmatter in {artifact_path}: ",
+        f"Cannot read review artifact file {artifact_path}: ",
+        f"Review artifact file has no YAML frontmatter: {artifact_path}",
+        f"Review artifact file has no closing '---' delimiter: {artifact_path}",
+        f"YAML frontmatter in {artifact_path} is not a mapping",
+    )
+    for prefix in prefixes:
+        if message.startswith(prefix):
+            stripped = message[len(prefix) :].strip()
+            return stripped or message.replace(str(artifact_path), "").strip(": ")
+    return message.replace(str(artifact_path), "<review artifact>")
+
+
 def find_rejected_review_artifact_conflicts(
     feature_dir: Path,
     wp_ids: list[str] | None = None,
@@ -110,7 +128,7 @@ def find_rejected_review_artifact_conflicts(
                         wp_id=wp_id,
                         lane=lane,
                         artifact_path=latest_path,
-                        schema_error=str(exc),
+                        schema_error=_schema_error_message(exc, latest_path),
                     )
                 )
                 break

--- a/src/specify_cli/post_merge/review_artifact_consistency.py
+++ b/src/specify_cli/post_merge/review_artifact_consistency.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+import re
 
 from specify_cli.review.artifacts import rejected_review_artifact_for_terminal_lane
 from specify_cli.status import materialize
@@ -17,6 +18,13 @@ REJECTED_REVIEW_ARTIFACT_REMEDIATION = [
     "Run another review cycle that writes an approved review-cycle artifact.",
     "Or move the WP out of approved/done before merge.",
 ]
+REVIEW_ARTIFACT_SCHEMA_INVALID = "REVIEW_ARTIFACT_SCHEMA_INVALID"
+REVIEW_ARTIFACT_SCHEMA_INVARIANT = "review_cycle_frontmatter_must_match_schema"
+REVIEW_ARTIFACT_SCHEMA_REMEDIATION = [
+    "Repair or regenerate the review-cycle artifact frontmatter.",
+    "Ensure affected_files is a list of mappings with path keys.",
+    "Retry merge after the artifact parses cleanly.",
+]
 
 
 @dataclass(frozen=True)
@@ -28,6 +36,19 @@ class RejectedReviewArtifactFinding:
     artifact_path: Path
     cycle_number: int
     verdict: str
+
+
+@dataclass(frozen=True)
+class ReviewArtifactSchemaFinding:
+    """A WP whose latest review artifact cannot be parsed as schema-valid frontmatter."""
+
+    wp_id: str
+    lane: str
+    artifact_path: Path
+    schema_error: str
+
+
+ReviewArtifactFinding = RejectedReviewArtifactFinding | ReviewArtifactSchemaFinding
 
 
 def _artifact_dirs_for_wp(feature_dir: Path, wp_id: str) -> list[Path]:
@@ -50,14 +71,27 @@ def _artifact_dirs_for_wp(feature_dir: Path, wp_id: str) -> list[Path]:
     return candidates
 
 
+def _review_cycle_number(path: Path) -> int:
+    match = re.search(r"review-cycle-(\d+)\.md$", path.name)
+    return int(match.group(1)) if match else 0
+
+
+def _latest_review_artifact_path(artifact_dir: Path) -> Path | None:
+    candidates = list(artifact_dir.glob("review-cycle-*.md"))
+    if not candidates:
+        return None
+    candidates.sort(key=_review_cycle_number)
+    return candidates[-1]
+
+
 def find_rejected_review_artifact_conflicts(
     feature_dir: Path,
     wp_ids: list[str] | None = None,
-) -> list[RejectedReviewArtifactFinding]:
-    """Return approved/done WPs whose latest review artifact is rejected."""
+) -> list[ReviewArtifactFinding]:
+    """Return review artifact findings that block merge readiness."""
     snapshot = materialize(feature_dir)
     selected_wp_ids = wp_ids or sorted(snapshot.work_packages)
-    findings: list[RejectedReviewArtifactFinding] = []
+    findings: list[ReviewArtifactFinding] = []
 
     for wp_id in selected_wp_ids:
         state = snapshot.work_packages.get(wp_id)
@@ -65,7 +99,21 @@ def find_rejected_review_artifact_conflicts(
             continue
         lane = str(state.get("lane", ""))
         for artifact_dir in _artifact_dirs_for_wp(feature_dir, wp_id):
-            rejected = rejected_review_artifact_for_terminal_lane(artifact_dir, lane)
+            latest_path = _latest_review_artifact_path(artifact_dir)
+            if latest_path is None:
+                continue
+            try:
+                rejected = rejected_review_artifact_for_terminal_lane(artifact_dir, lane)
+            except ValueError as exc:
+                findings.append(
+                    ReviewArtifactSchemaFinding(
+                        wp_id=wp_id,
+                        lane=lane,
+                        artifact_path=latest_path,
+                        schema_error=str(exc),
+                    )
+                )
+                break
             if rejected is None:
                 continue
             findings.append(
@@ -98,6 +146,25 @@ def format_review_artifact_conflict(
     )
 
 
+def format_review_artifact_finding(
+    finding: ReviewArtifactFinding,
+    *,
+    repo_root: Path | None = None,
+) -> str:
+    """Render one review artifact finding with stable path context."""
+    if isinstance(finding, RejectedReviewArtifactFinding):
+        return format_review_artifact_conflict(finding, repo_root=repo_root)
+
+    path = finding.artifact_path
+    if repo_root is not None:
+        with suppress(ValueError):
+            path = path.relative_to(repo_root)
+    return (
+        f"{finding.wp_id} has malformed latest review artifact {path}: "
+        f"{finding.schema_error}"
+    )
+
+
 def review_artifact_conflict_diagnostic(
     finding: RejectedReviewArtifactFinding,
     *,
@@ -120,6 +187,38 @@ def review_artifact_conflict_diagnostic(
     }
 
 
+def review_artifact_schema_diagnostic(
+    finding: ReviewArtifactSchemaFinding,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    """Return the stable diagnostic payload for a malformed review artifact."""
+    path = finding.artifact_path
+    if repo_root is not None:
+        with suppress(ValueError):
+            path = path.relative_to(repo_root)
+    return {
+        "diagnostic_code": REVIEW_ARTIFACT_SCHEMA_INVALID,
+        "branch_or_work_package": finding.wp_id,
+        "violated_invariant": REVIEW_ARTIFACT_SCHEMA_INVARIANT,
+        "remediation": REVIEW_ARTIFACT_SCHEMA_REMEDIATION,
+        "lane": finding.lane,
+        "latest_review_cycle_path": str(path),
+        "schema_error": finding.schema_error,
+    }
+
+
+def review_artifact_finding_diagnostic(
+    finding: ReviewArtifactFinding,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    """Return the stable diagnostic payload for any review artifact finding."""
+    if isinstance(finding, RejectedReviewArtifactFinding):
+        return review_artifact_conflict_diagnostic(finding, repo_root=repo_root)
+    return review_artifact_schema_diagnostic(finding, repo_root=repo_root)
+
+
 @dataclass(frozen=True)
 class ReviewArtifactPreflightResult:
     """Structured result of the review-artifact consistency preflight.
@@ -128,7 +227,7 @@ class ReviewArtifactPreflightResult:
     ``merge --dry-run`` preview surface (renders diagnostics and exits non-zero).
     """
 
-    findings: tuple[RejectedReviewArtifactFinding, ...]
+    findings: tuple[ReviewArtifactFinding, ...]
 
     @property
     def passed(self) -> bool:
@@ -141,7 +240,7 @@ class ReviewArtifactPreflightResult:
     ) -> list[dict[str, object]]:
         """Return the stable diagnostic payloads, one per finding."""
         return [
-            review_artifact_conflict_diagnostic(finding, repo_root=repo_root)
+            review_artifact_finding_diagnostic(finding, repo_root=repo_root)
             for finding in self.findings
         ]
 

--- a/src/specify_cli/review/artifacts.py
+++ b/src/specify_cli/review/artifacts.py
@@ -49,9 +49,23 @@ class AffectedFile:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AffectedFile:
         """Deserialize from dict."""
+        if not isinstance(data, dict):
+            raise ValueError(
+                "affected_files entries must be mappings with a 'path' key"
+            )
+        path = data.get("path")
+        if not isinstance(path, str) or not path:
+            raise ValueError(
+                "affected_files entries must include a non-empty string 'path'"
+            )
+        line_range = data.get("line_range")
+        if line_range is not None and not isinstance(line_range, str):
+            raise ValueError(
+                "affected_files entry 'line_range' must be a string when present"
+            )
         return cls(
-            path=data["path"],
-            line_range=data.get("line_range"),
+            path=path,
+            line_range=line_range,
         )
 
 

--- a/src/specify_cli/review/artifacts.py
+++ b/src/specify_cli/review/artifacts.py
@@ -21,6 +21,7 @@ from typing import Any
 from ruamel.yaml import YAML
 
 TERMINAL_REVIEW_LANES = frozenset({"approved", "done"})
+REVIEW_ARTIFACT_VERDICTS = frozenset({"approved", "rejected"})
 
 
 def _make_yaml() -> YAML:
@@ -113,19 +114,51 @@ class ReviewCycleArtifact:
     @classmethod
     def from_dict(cls, data: dict[str, Any], body: str = "") -> ReviewCycleArtifact:
         """Deserialize from frontmatter dict and optional body string."""
+        cycle_number = data.get("cycle_number")
+        if isinstance(cycle_number, bool):
+            raise ValueError("cycle_number must be a positive integer")
+        try:
+            parsed_cycle_number = int(cycle_number)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("cycle_number must be a positive integer") from exc
+        if parsed_cycle_number < 1:
+            raise ValueError("cycle_number must be a positive integer")
+
+        wp_id = data.get("wp_id")
+        if not isinstance(wp_id, str) or not wp_id:
+            raise ValueError("wp_id must be a non-empty string")
+        mission_slug = data.get("mission_slug")
+        if not isinstance(mission_slug, str) or not mission_slug:
+            raise ValueError("mission_slug must be a non-empty string")
+        reviewer_agent = data.get("reviewer_agent")
+        if not isinstance(reviewer_agent, str) or not reviewer_agent:
+            raise ValueError("reviewer_agent must be a non-empty string")
+        verdict = data.get("verdict")
+        if not isinstance(verdict, str) or verdict not in REVIEW_ARTIFACT_VERDICTS:
+            raise ValueError("verdict must be one of: approved, rejected")
+        reviewed_at = data.get("reviewed_at")
+        if not isinstance(reviewed_at, str) or not reviewed_at:
+            raise ValueError("reviewed_at must be a non-empty string")
+        affected_files_data = data.get("affected_files", [])
+        if not isinstance(affected_files_data, list):
+            raise ValueError("affected_files must be a list")
+        reproduction_command = data.get("reproduction_command")
+        if reproduction_command is not None and not isinstance(reproduction_command, str):
+            raise ValueError("reproduction_command must be a string when present")
+
         affected_files = [
             AffectedFile.from_dict(af)
-            for af in data.get("affected_files", [])
+            for af in affected_files_data
         ]
         return cls(
-            cycle_number=int(data["cycle_number"]),
-            wp_id=data["wp_id"],
-            mission_slug=data["mission_slug"],
-            reviewer_agent=data["reviewer_agent"],
-            verdict=data["verdict"],
-            reviewed_at=data["reviewed_at"],
+            cycle_number=parsed_cycle_number,
+            wp_id=wp_id,
+            mission_slug=mission_slug,
+            reviewer_agent=reviewer_agent,
+            verdict=verdict,
+            reviewed_at=reviewed_at,
             affected_files=affected_files,
-            reproduction_command=data.get("reproduction_command"),
+            reproduction_command=reproduction_command,
             body=body,
         )
 

--- a/tests/post_merge/test_review_artifact_consistency.py
+++ b/tests/post_merge/test_review_artifact_consistency.py
@@ -9,9 +9,12 @@ import typer
 
 from specify_cli.cli.commands.merge import _enforce_review_artifact_consistency
 from specify_cli.post_merge.review_artifact_consistency import (
+    REVIEW_ARTIFACT_SCHEMA_INVALID,
     find_rejected_review_artifact_conflicts,
     format_review_artifact_conflict,
+    format_review_artifact_finding,
     review_artifact_conflict_diagnostic,
+    review_artifact_finding_diagnostic,
 )
 from specify_cli.review.artifacts import ReviewCycleArtifact
 from specify_cli.status.models import Lane
@@ -42,6 +45,31 @@ def _write_review_artifact(
     )
     path = artifact_dir / f"review-cycle-{cycle_number}.md"
     artifact.write(path)
+    return path
+
+
+def _write_malformed_review_artifact(
+    artifact_dir: Path,
+    *,
+    cycle_number: int = 1,
+) -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / f"review-cycle-{cycle_number}.md"
+    path.write_text(
+        "---\n"
+        "affected_files:\n"
+        "  - src/foo.py\n"
+        "cycle_number: 1\n"
+        "mission_slug: release-320-workflow-reliability-01KQKV85\n"
+        "reviewed_at: '2026-05-03T12:00:00+00:00'\n"
+        "reviewer_agent: reviewer-renata\n"
+        "verdict: approved\n"
+        "wp_id: WP01\n"
+        "---\n"
+        "\n"
+        "# Review\n",
+        encoding="utf-8",
+    )
     return path
 
 
@@ -159,3 +187,75 @@ def test_merge_review_artifact_consistency_gate_blocks_done_signoff(
     ) in output
     assert "latest_review_cycle_verdict: rejected" in output
     assert "remediation:" in output
+
+
+def test_malformed_review_artifact_frontmatter_becomes_schema_diagnostic(
+    tmp_path: Path,
+) -> None:
+    mission = create_mission_fixture(tmp_path)
+    write_work_package(mission, WorkPackageSpec(lane="approved"))
+    append_status_event(
+        mission,
+        from_lane=Lane.FOR_REVIEW,
+        to_lane=Lane.APPROVED,
+        event_id="01KQKV85APPROVED000000002",
+    )
+    artifact_dir = mission.tasks_dir / "WP01-regression-harness"
+    malformed = _write_malformed_review_artifact(artifact_dir)
+
+    findings = find_rejected_review_artifact_conflicts(
+        mission.mission_dir,
+        wp_ids=["WP01"],
+    )
+
+    assert len(findings) == 1
+    diagnostic = review_artifact_finding_diagnostic(
+        findings[0],
+        repo_root=mission.repo_root,
+    )
+    assert diagnostic["diagnostic_code"] == REVIEW_ARTIFACT_SCHEMA_INVALID
+    assert diagnostic["branch_or_work_package"] == "WP01"
+    assert (
+        diagnostic["violated_invariant"]
+        == "review_cycle_frontmatter_must_match_schema"
+    )
+    assert diagnostic["latest_review_cycle_path"] == str(
+        malformed.relative_to(mission.repo_root)
+    )
+    assert "affected_files entries must be mappings" in diagnostic["schema_error"]
+    assert "affected_files entries must be mappings" in format_review_artifact_finding(
+        findings[0],
+        repo_root=mission.repo_root,
+    )
+
+
+def test_merge_review_artifact_consistency_gate_blocks_malformed_artifact(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mission = create_mission_fixture(tmp_path)
+    write_work_package(mission, WorkPackageSpec(lane="done"))
+    append_status_event(
+        mission,
+        from_lane=Lane.APPROVED,
+        to_lane=Lane.DONE,
+        event_id="01KQKV85DONE00000000002",
+    )
+    artifact_dir = mission.tasks_dir / "WP01-regression-harness"
+    _write_malformed_review_artifact(artifact_dir)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _enforce_review_artifact_consistency(
+            repo_root=mission.repo_root,
+            feature_dir=mission.mission_dir,
+            mission_slug=mission.mission_slug,
+            wp_ids=["WP01"],
+        )
+
+    assert exc_info.value.exit_code == 1
+    output = capsys.readouterr().out
+    assert "diagnostic_code: REVIEW_ARTIFACT_SCHEMA_INVALID" in output
+    assert "branch_or_work_package: WP01" in output
+    assert "violated_invariant: review_cycle_frontmatter_must_match_schema" in output
+    assert "schema_error:" in output
+    assert "Traceback" not in output

--- a/tests/post_merge/test_review_artifact_consistency.py
+++ b/tests/post_merge/test_review_artifact_consistency.py
@@ -73,6 +73,26 @@ def _write_malformed_review_artifact(
     return path
 
 
+def _write_review_artifact_with_invalid_verdict(artifact_dir: Path) -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / "review-cycle-1.md"
+    path.write_text(
+        "---\n"
+        "affected_files: []\n"
+        "cycle_number: 1\n"
+        "mission_slug: release-320-workflow-reliability-01KQKV85\n"
+        "reviewed_at: '2026-05-03T12:00:00+00:00'\n"
+        "reviewer_agent: reviewer-renata\n"
+        "verdict: changes_requested\n"
+        "wp_id: WP01\n"
+        "---\n"
+        "\n"
+        "# Review\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_latest_rejected_review_artifact_conflicts_with_approved_wp(
     tmp_path: Path,
 ) -> None:
@@ -227,6 +247,37 @@ def test_malformed_review_artifact_frontmatter_becomes_schema_diagnostic(
         findings[0],
         repo_root=mission.repo_root,
     )
+
+
+def test_invalid_top_level_review_artifact_field_becomes_schema_diagnostic(
+    tmp_path: Path,
+) -> None:
+    mission = create_mission_fixture(tmp_path)
+    write_work_package(mission, WorkPackageSpec(lane="approved"))
+    append_status_event(
+        mission,
+        from_lane=Lane.FOR_REVIEW,
+        to_lane=Lane.APPROVED,
+        event_id="01KQKV85APPROVED000000003",
+    )
+    artifact_dir = mission.tasks_dir / "WP01-regression-harness"
+    malformed = _write_review_artifact_with_invalid_verdict(artifact_dir)
+
+    findings = find_rejected_review_artifact_conflicts(
+        mission.mission_dir,
+        wp_ids=["WP01"],
+    )
+
+    assert len(findings) == 1
+    diagnostic = review_artifact_finding_diagnostic(
+        findings[0],
+        repo_root=mission.repo_root,
+    )
+    assert diagnostic["diagnostic_code"] == REVIEW_ARTIFACT_SCHEMA_INVALID
+    assert diagnostic["latest_review_cycle_path"] == str(
+        malformed.relative_to(mission.repo_root)
+    )
+    assert diagnostic["schema_error"] == "verdict must be one of: approved, rejected"
 
 
 def test_merge_review_artifact_consistency_gate_blocks_malformed_artifact(

--- a/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
+++ b/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -382,6 +383,47 @@ def test_dry_run_human_emits_review_artifact_schema_invalid(
         "violated_invariant: review_cycle_frontmatter_must_match_schema" in output
     )
     assert f"latest_review_cycle_path: {review_path_text}" in unwrapped_output
-    assert "schema_error: Missing or invalid field in review artifact" in output
+    assert "schema_error: affected_files entries must be mappings" in output
     assert "affected_files entries must be mappings" in unwrapped_output
     assert "Traceback" not in output
+
+
+def test_real_merge_schema_preflight_does_not_write_merge_state(
+    tmp_path: Path,
+) -> None:
+    """Schema-invalid review artifacts must fail before merge-state mutation."""
+    import typer
+
+    from specify_cli.cli.commands.merge import _run_lane_based_merge_locked
+    from specify_cli.merge.state import get_state_path
+
+    mission = create_mission_fixture(tmp_path)
+    write_work_package(mission, WorkPackageSpec(lane="approved"))
+    append_status_event(
+        mission,
+        from_lane=Lane.FOR_REVIEW,
+        to_lane=Lane.APPROVED,
+        event_id="01KRKTT5APPROVED00000008",
+    )
+    artifact_dir = mission.tasks_dir / "WP01-regression-harness"
+    _write_malformed_review_artifact(artifact_dir)
+    lanes_manifest = SimpleNamespace(
+        lanes=[SimpleNamespace(lane_id="lane-a", wp_ids=["WP01"])],
+        mission_branch=f"kitty/mission-{mission.mission_slug}",
+        target_branch="main",
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _run_lane_based_merge_locked(
+            mission.repo_root,
+            mission.mission_slug,
+            mission.mission_id,
+            mission.mission_dir,
+            lanes_manifest,
+            push=False,
+            delete_branch=False,
+            remove_worktree=False,
+        )
+
+    assert exc_info.value.exit_code == 1
+    assert not get_state_path(mission.repo_root, mission.mission_id).exists()

--- a/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
+++ b/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
@@ -21,6 +21,7 @@ import pytest
 
 from specify_cli.post_merge.review_artifact_consistency import (
     REJECTED_REVIEW_ARTIFACT_CONFLICT,
+    REVIEW_ARTIFACT_SCHEMA_INVALID,
     ReviewArtifactPreflightResult,
     run_review_artifact_consistency_preflight,
 )
@@ -55,6 +56,78 @@ def _write_review_artifact(
     path = artifact_dir / f"review-cycle-{cycle_number}.md"
     artifact.write(path)
     return path
+
+
+def _write_malformed_review_artifact(artifact_dir: Path) -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / "review-cycle-1.md"
+    path.write_text(
+        "---\n"
+        "affected_files:\n"
+        "  - src/foo.py\n"
+        "cycle_number: 1\n"
+        "mission_slug: release-320-workflow-reliability-01KQKV85\n"
+        "reviewed_at: '2026-05-14T12:00:00+00:00'\n"
+        "reviewer_agent: reviewer-renata\n"
+        "verdict: approved\n"
+        "wp_id: WP01\n"
+        "---\n"
+        "\n"
+        "# Review\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_lanes_json(mission: object) -> None:
+    lanes_json = mission.mission_dir / "lanes.json"
+    lanes_json.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "mission_slug": mission.mission_slug,
+                "mission_id": mission.mission_id,
+                "mission_branch": f"kitty/mission-{mission.mission_slug}",
+                "target_branch": "main",
+                "lanes": [
+                    {
+                        "lane_id": "lane-a",
+                        "wp_ids": ["WP01"],
+                        "write_scope": [],
+                        "predicted_surfaces": [],
+                        "depends_on_lanes": [],
+                        "parallel_group": 0,
+                    }
+                ],
+                "computed_at": "2026-05-14T12:00:00+00:00",
+                "computed_from": "dependency_graph+ownership",
+                "planning_artifact_wps": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _patch_dry_run_git_boundaries(monkeypatch: pytest.MonkeyPatch, mission: object) -> None:
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.merge._enforce_git_preflight", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.merge.find_repo_root", lambda: mission.repo_root
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.merge.get_main_repo_root",
+        lambda _repo: mission.repo_root,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.merge._validate_target_branch",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.merge._resolve_target_branch",
+        lambda *a, **kw: ("main", "cli"),
+    )
 
 
 def test_preflight_detects_rejected_review_artifact_on_approved_wp(
@@ -148,33 +221,7 @@ def test_dry_run_emits_rejected_review_artifact_conflict(
         mission_slug=mission.mission_slug,
     )
 
-    lanes_json = mission.mission_dir / "lanes.json"
-    lanes_json.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "mission_slug": mission.mission_slug,
-                "mission_id": mission.mission_id,
-                "mission_branch": f"kitty/mission-{mission.mission_slug}",
-                "target_branch": "main",
-                "lanes": [
-                    {
-                        "lane_id": "lane-a",
-                        "wp_ids": ["WP01"],
-                        "write_scope": [],
-                        "predicted_surfaces": [],
-                        "depends_on_lanes": [],
-                        "parallel_group": 0,
-                    }
-                ],
-                "computed_at": "2026-05-14T12:00:00+00:00",
-                "computed_from": "dependency_graph+ownership",
-                "planning_artifact_wps": [],
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    _write_lanes_json(mission)
 
     monkeypatch.chdir(mission.repo_root)
 
@@ -183,24 +230,7 @@ def test_dry_run_emits_rejected_review_artifact_conflict(
     runner = CliRunner()
 
     # Avoid the git preflight, which would fail in a non-git tmp dir.
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge._enforce_git_preflight", lambda *a, **kw: None
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge.find_repo_root", lambda: mission.repo_root
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge.get_main_repo_root",
-        lambda _repo: mission.repo_root,
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge._validate_target_branch",
-        lambda *a, **kw: None,
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge._resolve_target_branch",
-        lambda *a, **kw: ("main", "cli"),
-    )
+    _patch_dry_run_git_boundaries(monkeypatch, mission)
 
     result = runner.invoke(
         app,
@@ -216,6 +246,55 @@ def test_dry_run_emits_rejected_review_artifact_conflict(
     assert payload["blockers"]
     assert payload["blockers"][0]["diagnostic_code"] == REJECTED_REVIEW_ARTIFACT_CONFLICT
     assert payload["blockers"][0]["branch_or_work_package"] == "WP01"
+
+
+def test_dry_run_emits_review_artifact_schema_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``merge --dry-run --json`` reports malformed review-cycle frontmatter."""
+    import typer
+    from typer.testing import CliRunner
+
+    from specify_cli.cli.commands.merge import merge
+
+    mission = create_mission_fixture(tmp_path)
+    write_work_package(mission, WorkPackageSpec(lane="approved"))
+    append_status_event(
+        mission,
+        from_lane=Lane.FOR_REVIEW,
+        to_lane=Lane.APPROVED,
+        event_id="01KRKTT5APPROVED00000006",
+    )
+    artifact_dir = mission.tasks_dir / "WP01-regression-harness"
+    _write_malformed_review_artifact(artifact_dir)
+    _write_lanes_json(mission)
+
+    monkeypatch.chdir(mission.repo_root)
+
+    app = typer.Typer()
+    app.command()(merge)
+    runner = CliRunner()
+
+    _patch_dry_run_git_boundaries(monkeypatch, mission)
+
+    result = runner.invoke(
+        app,
+        ["--mission", mission.mission_slug, "--dry-run", "--json"],
+    )
+
+    assert result.exit_code == 1, (
+        f"Expected exit 1, got {result.exit_code}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["blocked"] is True
+    assert payload["diagnostic_code"] == REVIEW_ARTIFACT_SCHEMA_INVALID
+    assert payload["blockers"][0]["diagnostic_code"] == REVIEW_ARTIFACT_SCHEMA_INVALID
+    assert payload["blockers"][0]["branch_or_work_package"] == "WP01"
+    assert (
+        payload["blockers"][0]["violated_invariant"]
+        == "review_cycle_frontmatter_must_match_schema"
+    )
+    assert "affected_files entries must be mappings" in payload["blockers"][0]["schema_error"]
 
 
 def test_dry_run_human_emits_rejected_review_artifact_conflict(
@@ -243,33 +322,7 @@ def test_dry_run_human_emits_rejected_review_artifact_conflict(
         mission_slug=mission.mission_slug,
     )
 
-    lanes_json = mission.mission_dir / "lanes.json"
-    lanes_json.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "mission_slug": mission.mission_slug,
-                "mission_id": mission.mission_id,
-                "mission_branch": f"kitty/mission-{mission.mission_slug}",
-                "target_branch": "main",
-                "lanes": [
-                    {
-                        "lane_id": "lane-a",
-                        "wp_ids": ["WP01"],
-                        "write_scope": [],
-                        "predicted_surfaces": [],
-                        "depends_on_lanes": [],
-                        "parallel_group": 0,
-                    }
-                ],
-                "computed_at": "2026-05-14T12:00:00+00:00",
-                "computed_from": "dependency_graph+ownership",
-                "planning_artifact_wps": [],
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    _write_lanes_json(mission)
 
     monkeypatch.chdir(mission.repo_root)
 
@@ -277,24 +330,7 @@ def test_dry_run_human_emits_rejected_review_artifact_conflict(
     app.command()(merge)
     runner = CliRunner()
 
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge._enforce_git_preflight", lambda *a, **kw: None
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge.find_repo_root", lambda: mission.repo_root
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge.get_main_repo_root",
-        lambda _repo: mission.repo_root,
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge._validate_target_branch",
-        lambda *a, **kw: None,
-    )
-    monkeypatch.setattr(
-        "specify_cli.cli.commands.merge._resolve_target_branch",
-        lambda *a, **kw: ("main", "cli"),
-    )
+    _patch_dry_run_git_boundaries(monkeypatch, mission)
 
     result = runner.invoke(app, ["--mission", mission.mission_slug, "--dry-run"])
 

--- a/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
+++ b/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
@@ -9,6 +9,7 @@ readiness signal. These tests lock the new behavior:
 * The shared preflight helper detects the same conflict the real gate detects.
 * Dry-run surfaces ``REJECTED_REVIEW_ARTIFACT_CONFLICT`` in JSON output.
 * Dry-run surfaces ``REJECTED_REVIEW_ARTIFACT_CONFLICT`` in human output.
+* Dry-run surfaces malformed review-cycle schema diagnostics in human output.
 * Dry-run success path is unchanged on a clean mission.
 """
 
@@ -338,3 +339,49 @@ def test_dry_run_human_emits_rejected_review_artifact_conflict(
     output = result.stdout
     assert REJECTED_REVIEW_ARTIFACT_CONFLICT in output
     assert "WP01" in output
+
+
+def test_dry_run_human_emits_review_artifact_schema_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``merge --dry-run`` prints labelled schema diagnostics without a traceback."""
+    import typer
+    from typer.testing import CliRunner
+
+    from specify_cli.cli.commands.merge import merge
+
+    mission = create_mission_fixture(tmp_path)
+    write_work_package(mission, WorkPackageSpec(lane="approved"))
+    append_status_event(
+        mission,
+        from_lane=Lane.FOR_REVIEW,
+        to_lane=Lane.APPROVED,
+        event_id="01KRKTT5APPROVED00000007",
+    )
+    artifact_dir = mission.tasks_dir / "WP01-regression-harness"
+    review_path = _write_malformed_review_artifact(artifact_dir)
+    _write_lanes_json(mission)
+
+    monkeypatch.chdir(mission.repo_root)
+
+    app = typer.Typer()
+    app.command()(merge)
+    runner = CliRunner()
+
+    _patch_dry_run_git_boundaries(monkeypatch, mission)
+
+    result = runner.invoke(app, ["--mission", mission.mission_slug, "--dry-run"])
+
+    assert result.exit_code == 1
+    output = result.stdout
+    unwrapped_output = output.replace("\n", "")
+    review_path_text = str(review_path.relative_to(mission.repo_root))
+    assert REVIEW_ARTIFACT_SCHEMA_INVALID in output
+    assert "branch_or_work_package: WP01" in output
+    assert (
+        "violated_invariant: review_cycle_frontmatter_must_match_schema" in output
+    )
+    assert f"latest_review_cycle_path: {review_path_text}" in unwrapped_output
+    assert "schema_error: Missing or invalid field in review artifact" in output
+    assert "affected_files entries must be mappings" in unwrapped_output
+    assert "Traceback" not in output

--- a/tests/specify_cli/cli/commands/test_review.py
+++ b/tests/specify_cli/cli/commands/test_review.py
@@ -105,6 +105,29 @@ def _setup_fixture(
     return repo_root, feature_dir
 
 
+def _write_malformed_review_artifact(feature_dir: Path, wp_id: str) -> Path:
+    """Write a review-cycle artifact with legacy string affected_files entries."""
+    artifact_dir = feature_dir / "tasks" / f"{wp_id}-regression-harness"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / "review-cycle-1.md"
+    artifact_path.write_text(
+        "---\n"
+        "affected_files:\n"
+        "  - src/foo.py\n"
+        "cycle_number: 1\n"
+        f"mission_slug: {_MISSION_SLUG}\n"
+        "reviewed_at: '2026-06-05T12:00:00+00:00'\n"
+        "reviewer_agent: reviewer-renata\n"
+        "verdict: approved\n"
+        f"wp_id: {wp_id}\n"
+        "---\n"
+        "\n"
+        "# Review\n",
+        encoding="utf-8",
+    )
+    return artifact_path
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -183,6 +206,44 @@ def test_review_fails_when_wp_not_done(tmp_path: Path, monkeypatch: pytest.Monke
     assert "verdict: fail" in content
     # WP01 must appear in findings
     assert "WP01" in content
+
+
+def test_review_fails_with_schema_diagnostic_for_malformed_review_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Review lane gate must not crash on schema-invalid review-cycle frontmatter."""
+    repo_root, feature_dir = _setup_fixture(
+        tmp_path,
+        {"WP01": "done"},
+        baseline_merge_commit="0000000000000000000000000000000000000000",
+    )
+    _write_malformed_review_artifact(feature_dir, "WP01")
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.find_repo_root",
+        lambda: repo_root,
+    )
+    _mock_resolved = _make_mock_resolved(feature_dir)
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.review.resolve_mission_handle",
+        lambda handle, repo_root: _mock_resolved,
+    )
+
+    app = _build_cli_app()
+    runner = CliRunner()
+    result = runner.invoke(app, ["--mission", _MISSION_SLUG, "--mode", "lightweight"])
+
+    assert result.exit_code == 1, result.output
+    assert "diagnostic_code: REVIEW_ARTIFACT_SCHEMA_INVALID" in result.output
+    assert "affected_files entries must be mappings" in result.output.replace("\n", "")
+    assert "Traceback" not in result.output
+
+    report_text = (feature_dir / "mission-review-report.md").read_text(encoding="utf-8")
+    assert "verdict: fail" in report_text
+    assert "review_artifact_schema_invalid" in report_text
+    assert "REVIEW_ARTIFACT_SCHEMA_INVALID" in report_text
 
 
 def test_review_report_frontmatter_structure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #1705.

- converts malformed review-cycle frontmatter into a stable `REVIEW_ARTIFACT_SCHEMA_INVALID` diagnostic instead of letting parser errors bubble out of merge
- validates `affected_files` entries so string entries like `['src/foo.py']` produce a targeted schema error
- shares the schema-invalid finding through the existing review-artifact preflight so real merge and `merge --dry-run --json` report the same blocker
- keeps existing rejected-review artifact diagnostics intact

## Validation

- `uv run --extra test python -m pytest tests/review/test_artifacts.py tests/post_merge/test_review_artifact_consistency.py tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py`
- `uv run --extra lint python -m ruff check src/specify_cli/review/artifacts.py src/specify_cli/post_merge/review_artifact_consistency.py src/specify_cli/cli/commands/merge.py tests/post_merge/test_review_artifact_consistency.py tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py`
- `git diff --check`
