### PR TITLE
[codex] fix(merge): support planning-artifact research closeout

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -18,7 +18,7 @@ from specify_cli.core.paths import require_explicit_feature as _require_explicit
 from specify_cli.decisions.models import DecisionStatus
 from specify_cli.decisions.store import load_index
 from specify_cli.git.commit_helpers import assert_not_protected_branch
-from specify_cli.mission import MissionError, get_mission_for_feature
+from specify_cli.mission import MissionError, get_deliverables_path, get_mission_for_feature
 from specify_cli.mission_metadata import load_meta, record_acceptance, resolve_mission_identity, write_meta
 from specify_cli.status.lane_reader import CanonicalStatusNotFoundError
 from specify_cli.status.models import Lane
@@ -607,6 +607,19 @@ def _append_skipped_lane_checks(
         )
 
 
+def _is_planning_artifact_only_manifest(lanes_manifest: Any) -> bool:
+    lanes = list(getattr(lanes_manifest, "lanes", []) or [])
+    return bool(lanes) and all(
+        getattr(lane, "lane_id", None) == "lane-planning" for lane in lanes
+    )
+
+
+def _path_prefix_for_mission(mission: Any, feature_dir: Path) -> str | None:
+    if getattr(mission, "domain", None) != "research":
+        return None
+    return get_deliverables_path(feature_dir, mission_slug=feature_dir.name)
+
+
 def _check_lane_gates(
     repo_root: Path,
     feature_dir: Path,
@@ -651,7 +664,10 @@ def _check_lane_gates(
         )
         return
 
-    allowed_branches = {lanes_manifest.mission_branch, lanes_manifest.target_branch}
+    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
+    allowed_branches = {lanes_manifest.target_branch}
+    if not planning_artifact_only:
+        allowed_branches.add(lanes_manifest.mission_branch)
 
     if branch is None or branch not in allowed_branches:
         allowed_label = ", ".join(sorted(branch_name for branch_name in allowed_branches if branch_name))
@@ -662,6 +678,14 @@ def _check_lane_gates(
         _append_skipped_lane_checks(
             skipped_checks,
             reason="current branch is neither mission branch nor target branch",
+            include_matrix_presence=True,
+        )
+        return
+
+    if planning_artifact_only:
+        _append_skipped_lane_checks(
+            skipped_checks,
+            reason="planning_artifact-only missions do not produce acceptance-matrix.json",
             include_matrix_presence=True,
         )
         return
@@ -941,7 +965,12 @@ def collect_feature_summary(
 
     if mission and mission.config.paths:
         try:
-            validate_mission_paths(mission, repo_root, strict=True)
+            validate_mission_paths(
+                mission,
+                repo_root,
+                strict=True,
+                path_prefix=_path_prefix_for_mission(mission, feature_dir),
+            )
         except PathValidationError as exc:
             path_violations.append(exc.result.format_errors() or str(exc))
 

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -5,6 +5,10 @@ the same two-step flow:
 1. Merge each lane branch into the mission branch.
 2. Merge the mission branch into the target branch.
 
+Planning-artifact-only missions are the exception: their artifacts are already
+committed to the target branch, so merge performs closeout bookkeeping directly
+on that target branch without requiring a mission branch.
+
 Recovery semantics (WP01 / 067):
 - MergeState is created at merge start and updated after each WP mark-done.
 - On interruption, rerunning ``merge`` detects the existing state and resumes.
@@ -826,6 +830,38 @@ def _check_mission_branch(
     return False, blocker_payload
 
 
+def _is_planning_artifact_only_manifest(lanes_manifest: object) -> bool:
+    """Return True when every WP is in the canonical planning-artifact lane."""
+
+    from specify_cli.lanes.compute import PLANNING_LANE_ID
+
+    lanes = list(getattr(lanes_manifest, "lanes", []) or [])
+    return bool(lanes) and all(
+        getattr(lane, "lane_id", None) == PLANNING_LANE_ID for lane in lanes
+    )
+
+
+def _enforce_planning_artifact_target_branch(repo_root: Path, target_branch: str) -> None:
+    """Planning-only closeout writes directly to the target branch."""
+
+    retcode, stdout, _stderr = run_command(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    current_branch = stdout.strip() if retcode == 0 else ""
+    if current_branch == target_branch:
+        return
+
+    current_label = current_branch or "detached HEAD"
+    console.print(
+        "[red]Error:[/red] Planning-artifact-only merge must run on "
+        f"target branch {target_branch}, not {current_label}."
+    )
+    raise typer.Exit(1)
+
+
 def _enforce_git_preflight(repo_root: Path, *, json_output: bool) -> None:
     """Run git preflight checks and stop early with deterministic remediation."""
     if not (repo_root / ".git").exists():
@@ -1293,6 +1329,28 @@ def _effective_push_requested(
     return requested_push
 
 
+def _assign_planning_only_mission_number_if_needed(
+    main_repo: Path,
+    feature_dir: Path,
+) -> Path | None:
+    """Assign mission_number directly on target for planning-only closeout."""
+
+    if not needs_number_assignment(feature_dir):
+        return None
+
+    next_number = assign_next_mission_number(
+        main_repo,
+        main_repo / KITTY_SPECS_DIR,
+    )
+    meta = load_meta(feature_dir) or {}
+    meta["mission_number"] = next_number
+    write_meta(feature_dir, meta, validate=False)
+    console.print(
+        f"  [green]✓[/green] Assigned mission_number={next_number} on target branch"
+    )
+    return feature_dir / "meta.json"
+
+
 def _enforce_canonical_status_history(
     *,
     feature_dir: Path,
@@ -1523,6 +1581,7 @@ def _run_lane_based_merge(
     lanes_manifest = require_lanes_json(feature_dir)
     if target_override:
         lanes_manifest.target_branch = target_override
+    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
 
     # -- Resolve canonical mission_id from meta.json (P2 fix: use ULID, not slug) --
     identity = resolve_mission_identity(feature_dir)
@@ -1537,15 +1596,21 @@ def _run_lane_based_merge(
             mission_branch=lanes_manifest.mission_branch,
         )
 
-    branch_ok, branch_blocker = _check_mission_branch(mission_slug, main_repo)
-    if not branch_ok:
-        assert branch_blocker is not None
-        console.print(
-            "[red]Error:[/red] Missing mission branch: "
-            f"{branch_blocker['expected_branch']}. "
-            f"Run: {branch_blocker['remediation']}"
+    if planning_artifact_only:
+        _enforce_planning_artifact_target_branch(
+            main_repo,
+            lanes_manifest.target_branch,
         )
-        raise typer.Exit(1)
+    else:
+        branch_ok, branch_blocker = _check_mission_branch(mission_slug, main_repo)
+        if not branch_ok:
+            assert branch_blocker is not None
+            console.print(
+                "[red]Error:[/red] Missing mission branch: "
+                f"{branch_blocker['expected_branch']}. "
+                f"Run: {branch_blocker['remediation']}"
+            )
+            raise typer.Exit(1)
 
     # -- Acquire global merge lock to serialize concurrent merges --
     # The lock is keyed by a well-known sentinel so that merges of DIFFERENT
@@ -1596,6 +1661,7 @@ def _run_lane_based_merge_locked(
 
     # -- T001: MergeState lifecycle: load or create --
     all_wp_ids = [wp for lane in lanes_manifest.lanes for wp in lane.wp_ids]
+    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
     state = load_state(main_repo, canonical_id)
     is_resume = False
     if state is not None:
@@ -1616,6 +1682,11 @@ def _run_lane_based_merge_locked(
     console.print(f"[bold]Lane-based merge for {mission_slug}[/bold]")
     console.print(f"  Mission branch: {lanes_manifest.mission_branch}")
     console.print(f"  Lanes: {', '.join(ln.lane_id for ln in lanes_manifest.lanes)}")
+    if planning_artifact_only:
+        console.print(
+            "  [dim]Planning-artifact-only mission: target branch already "
+            "contains deliverables; branch merge steps will be skipped.[/dim]"
+        )
 
     policy = load_policy_config(main_repo)
     gate_eval = evaluate_merge_gates(
@@ -1664,6 +1735,12 @@ def _run_lane_based_merge_locked(
             console.print(f"  [dim]Skipping {lane.lane_id} (all WPs already done)[/dim]")
             continue
 
+        if planning_artifact_only and lane.lane_id == PLANNING_LANE_ID:
+            console.print(
+                f"  [green]✓[/green] {lane.lane_id} already on {lanes_manifest.target_branch}"
+            )
+            continue
+
         console.print(f"  [dim]Checking and merging {lane.lane_id}...[/dim]")
         lane_result = merge_lane_to_mission(main_repo, mission_slug, lane.lane_id, lanes_manifest)
         if lane_result.success:
@@ -1697,46 +1774,59 @@ def _run_lane_based_merge_locked(
     except Exception:  # noqa: BLE001 — meta.json may be missing/corrupt for legacy missions
         _baseline_mission_id = None
 
-    # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
-    # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
-    # which serializes ALL merge operations — same-mission and cross-mission.
-    # This guarantees the max+1 scan sees the most recent target state.
-    # WP04/FR-010/FR-011/FR-012: pass merge_state so the idempotency check
-    # (T025) and resume short-circuit (T026) can persist/read the baked flag.
-    _bake_mission_number_into_mission_branch(
-        main_repo=main_repo,
-        mission_slug=mission_slug,
-        mission_branch=lanes_manifest.mission_branch,
-        target_branch=lanes_manifest.target_branch,
-        dry_run=False,
-        merge_state=state,
-    )
-
-    # -- Mission-to-target merge (T010: honor strategy for this step only) --
-    console.print(f"  [dim]Merging mission branch into {lanes_manifest.target_branch}...[/dim]")
-    mission_result = merge_mission_to_target(
-        main_repo,
-        mission_slug,
-        lanes_manifest,
-        strategy=strategy,
-        allow_already_applied=is_resume,
-    )
-    mission_already_applied = getattr(mission_result, "already_applied", False) is True
-    if not mission_result.success:
-        # T005: tolerate already-merged on retry
-        already_merged = any("already" in e.lower() or "up to date" in e.lower() for e in mission_result.errors)
-        if is_resume and already_merged:
-            console.print(f"[dim]{lanes_manifest.mission_branch} already merged into {lanes_manifest.target_branch}[/dim]")
-        else:
-            for error in mission_result.errors:
-                console.print(f"[red]Error:[/red] {error}")
-            raise typer.Exit(1)
+    mission_number_meta_path: Path | None = None
+    mission_already_applied = False
+    if planning_artifact_only:
+        mission_number_meta_path = _assign_planning_only_mission_number_if_needed(
+            main_repo,
+            feature_dir,
+        )
+        console.print(
+            f"  [dim]Skipping mission branch merge; {lanes_manifest.target_branch} "
+            "is the planning artifact branch.[/dim]"
+        )
+        mission_already_applied = True
     else:
-        console.print(f"\n[green]✓[/green] {lanes_manifest.mission_branch} → {lanes_manifest.target_branch}")
-        if mission_already_applied:
-            console.print("  [dim]Mission changes already present on target; continuing bookkeeping.[/dim]")
-        if mission_result.commit:
-            console.print(f"  Commit: {mission_result.commit[:7]}")
+        # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
+        # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
+        # which serializes ALL merge operations — same-mission and cross-mission.
+        # This guarantees the max+1 scan sees the most recent target state.
+        # WP04/FR-010/FR-011/FR-012: pass merge_state so the idempotency check
+        # (T025) and resume short-circuit (T026) can persist/read the baked flag.
+        _bake_mission_number_into_mission_branch(
+            main_repo=main_repo,
+            mission_slug=mission_slug,
+            mission_branch=lanes_manifest.mission_branch,
+            target_branch=lanes_manifest.target_branch,
+            dry_run=False,
+            merge_state=state,
+        )
+
+        # -- Mission-to-target merge (T010: honor strategy for this step only) --
+        console.print(f"  [dim]Merging mission branch into {lanes_manifest.target_branch}...[/dim]")
+        mission_result = merge_mission_to_target(
+            main_repo,
+            mission_slug,
+            lanes_manifest,
+            strategy=strategy,
+            allow_already_applied=is_resume,
+        )
+        mission_already_applied = getattr(mission_result, "already_applied", False) is True
+        if not mission_result.success:
+            # T005: tolerate already-merged on retry
+            already_merged = any("already" in e.lower() or "up to date" in e.lower() for e in mission_result.errors)
+            if is_resume and already_merged:
+                console.print(f"[dim]{lanes_manifest.mission_branch} already merged into {lanes_manifest.target_branch}[/dim]")
+            else:
+                for error in mission_result.errors:
+                    console.print(f"[red]Error:[/red] {error}")
+                raise typer.Exit(1)
+        else:
+            console.print(f"\n[green]✓[/green] {lanes_manifest.mission_branch} → {lanes_manifest.target_branch}")
+            if mission_already_applied:
+                console.print("  [dim]Mission changes already present on target; continuing bookkeeping.[/dim]")
+            if mission_result.commit:
+                console.print(f"  Commit: {mission_result.commit[:7]}")
 
     # -- WP05/T006 FR-013: Post-merge working-tree refresh --
     # Re-sync the primary checkout against HEAD before done-event bookkeeping.
@@ -1852,8 +1942,11 @@ def _run_lane_based_merge_locked(
         feature_dir / _STATUS_EVENTS_FILENAME,
         feature_dir / _STATUS_FILENAME,
     ]
+    if mission_number_meta_path is not None:
+        files_to_commit.append(mission_number_meta_path)
     if baseline_meta_path is not None:
         files_to_commit.append(baseline_meta_path)
+    files_to_commit = list(dict.fromkeys(files_to_commit))
 
     has_bookkeeping_changes = _paths_have_status_changes(main_repo, files_to_commit)
     may_skip_empty_bookkeeping = is_resume or mission_already_applied

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1777,10 +1777,6 @@ def _run_lane_based_merge_locked(
     mission_number_meta_path: Path | None = None
     mission_already_applied = False
     if planning_artifact_only:
-        mission_number_meta_path = _assign_planning_only_mission_number_if_needed(
-            main_repo,
-            feature_dir,
-        )
         console.print(
             f"  [dim]Skipping mission branch merge; {lanes_manifest.target_branch} "
             "is the planning artifact branch.[/dim]"
@@ -1833,6 +1829,12 @@ def _run_lane_based_merge_locked(
     # A path checkout does not remove stale rename sources in sparse-checkout
     # repos; the helper uses a tracked-file hard refresh instead.
     _refresh_primary_checkout_after_merge(main_repo)
+
+    if planning_artifact_only:
+        mission_number_meta_path = _assign_planning_only_mission_number_if_needed(
+            main_repo,
+            feature_dir,
+        )
 
     try:
         baseline_meta_path = _record_baseline_merge_commit(

--- a/src/specify_cli/merge/push_preflight.py
+++ b/src/specify_cli/merge/push_preflight.py
@@ -17,12 +17,7 @@ from pathlib import Path
 from typing import Literal
 
 __all__ = [
-    "TargetBranchSyncState",
     "TargetBranchSyncStatus",
-    "TargetBranchRefreshStatus",
-    "TargetBranchPushSafetyResult",
-    "refresh_target_branch_tracking_ref",
-    "inspect_target_branch_sync",
     "check_push_safety",
 ]
 

--- a/src/specify_cli/mission.py
+++ b/src/specify_cli/mission.py
@@ -618,7 +618,7 @@ def get_deliverables_path(feature_dir: Path, mission_slug: str | None = None) ->
                 return deliverables_path
 
             # Check if this is a research mission - provide default if so
-            mission = meta.get("mission", "software-dev")
+            mission = meta.get("mission_type") or meta.get("mission", "software-dev")
             if mission == "research":
                 # Generate default path using slug from meta or directory name
                 slug = meta.get("slug") or mission_slug or feature_dir.name

--- a/src/specify_cli/validators/paths.py
+++ b/src/specify_cli/validators/paths.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from collections.abc import Iterable
 
 from specify_cli.mission import Mission
@@ -105,11 +105,32 @@ def suggest_directory_creation(missing_paths: Iterable[str]) -> list[str]:
     return suggestions
 
 
+def _prefix_required_path(path_prefix: str | Path | None, relative_path: str) -> str:
+    """Return ``relative_path`` under ``path_prefix`` while preserving dir hints."""
+
+    if not path_prefix:
+        return relative_path
+    candidate = Path(relative_path)
+    if candidate.is_absolute():
+        return relative_path
+
+    prefix = str(path_prefix).strip().strip("/")
+    if not prefix:
+        return relative_path
+
+    relative = relative_path.strip("/")
+    joined = PurePosixPath(prefix) / relative
+    if relative_path.endswith("/"):
+        return joined.as_posix() + "/"
+    return joined.as_posix()
+
+
 def validate_mission_paths(
     mission: Mission,
     project_root: Path,
     *,
     strict: bool = False,
+    path_prefix: str | Path | None = None,
 ) -> PathValidationResult:
     """Validate that project directories follow mission-defined conventions.
 
@@ -117,12 +138,19 @@ def validate_mission_paths(
         mission: Mission containing declared path conventions.
         project_root: Root of the active workspace/worktree.
         strict: When True, raise PathValidationError if paths are missing.
+        path_prefix: Optional project-relative prefix to apply before checking
+            mission-declared paths. Research missions use this to validate
+            configured deliverable directories instead of fixed repository-root
+            directories.
 
     Returns:
         PathValidationResult summarising the state of each required path.
     """
 
-    required_paths = dict(mission.config.paths or {})
+    required_paths = {
+        key: _prefix_required_path(path_prefix, relative_path)
+        for key, relative_path in dict(mission.config.paths or {}).items()
+    }
     result = PathValidationResult(
         mission_name=mission.name,
         required_paths=required_paths,

--- a/tests/e2e/test_charter_epic_golden_path.py
+++ b/tests/e2e/test_charter_epic_golden_path.py
@@ -50,6 +50,7 @@ from typing import Any
 
 import pytest
 
+from specify_cli.invocation.lifecycle import lifecycle_log_path
 from tests.e2e.conftest import (
     REPO_ROOT,
     SourcePollutionBaseline,
@@ -89,9 +90,9 @@ RunCli = Callable[..., subprocess.CompletedProcess[str]]
 #   - "success": bool (often duplicated alongside "result")
 #   - "errors": list  (empty list means success in lint output)
 #
-# `.kittify/events/profile-invocations/*.jsonl` records carry top-level
-# "phase" with values "started"/"completed", plus a "canonical_action_id"
-# that pairs each started record with its completion.
+# `kitty-ops/lifecycle.jsonl` records carry top-level "phase" with values
+# "started"/"completed", plus a "canonical_action_id" that pairs each started
+# record with its completion.
 
 
 # Set WP02_DEBUG_ENVELOPES=1 during local development to dump the
@@ -749,19 +750,16 @@ def _run_next_and_assert_lifecycle(
         payload, test_project_root=project, fr_id="FR-006/FR-007 (next advance)"
     )
 
-    # FR-011/FR-012 / #843: lifecycle records at
-    # `.kittify/events/profile-invocation-lifecycle.jsonl` (single
-    # JSONL file per WP05 contract — see
+    # FR-011/FR-012 / #843: lifecycle records at the canonical Op lifecycle
+    # JSONL file (see
     # `specify_cli.invocation.lifecycle.LIFECYCLE_LOG_RELATIVE_PATH`).
     # WP05 makes a `started` record a HARD requirement for any issued
     # public action.
-    lifecycle_path = (
-        project / ".kittify" / "events" / "profile-invocation-lifecycle.jsonl"
-    )
+    lifecycle_path = lifecycle_log_path(project)
     if not lifecycle_path.is_file():
         raise AssertionError(
             "WP05 / #843 / FR-011: "
-            "`.kittify/events/profile-invocation-lifecycle.jsonl` does not "
+            f"`{lifecycle_path.relative_to(project)}` does not "
             "exist after `next` issued an action. WP05 must write a "
             "`started` lifecycle record at issuance time. If this fires, "
             "the WP05 invocation lifecycle fix has regressed."

--- a/tests/integration/test_documentation_runtime_walk.py
+++ b/tests/integration/test_documentation_runtime_walk.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import pytest
 
+from specify_cli.invocation.writer import EVENTS_DIR
 from specify_cli.next._internal_runtime.engine import _read_snapshot
 from specify_cli.next.runtime_bridge import (
     _check_composed_action_guard,
@@ -43,6 +44,23 @@ from specify_cli.next.runtime_bridge import (
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+
+_NON_INVOCATION_OP_FILES = {
+    "lifecycle.jsonl",
+    "ops-index.jsonl",
+    "propagation-errors.jsonl",
+}
+
+
+def _invocation_trail_files(repo_root: Path) -> list[Path]:
+    invocations_dir = repo_root / EVENTS_DIR
+    return sorted(
+        path
+        for path in invocations_dir.glob("*.jsonl")
+        if path.name not in _NON_INVOCATION_OP_FILES
+    )
+
 
 def _init_min_repo(repo_root: Path) -> None:
     """Initialize a minimal git repo as the test mission's project root."""
@@ -298,8 +316,7 @@ def test_paired_invocation_lifecycle_is_recorded(isolated_repo: Path) -> None:
     """FR-011 + FR-012 + NFR-006: invocation trail records paired started/done.
 
     The composition dispatch routes through ``ProfileInvocationExecutor``
-    which writes JSONL records under
-    ``<repo>/.kittify/events/profile-invocations/<invocation_id>.jsonl``.
+    which writes JSONL records under the canonical Op storage directory.
     Each invocation must have a ``started`` line paired with a
     ``completed`` line whose outcome is ``done`` or ``failed``. The
     recorded ``action`` MUST stay within the documentation-native step
@@ -326,12 +343,12 @@ def test_paired_invocation_lifecycle_is_recorded(isolated_repo: Path) -> None:
         isolated_repo,
     )
 
-    invocations_dir = isolated_repo / ".kittify" / "events" / "profile-invocations"
+    invocations_dir = isolated_repo / EVENTS_DIR
     assert invocations_dir.is_dir(), (
         f"Invocations dir missing: {invocations_dir}. Composition dispatch "
         "did not produce a paired invocation trail."
     )
-    trail_files = sorted(invocations_dir.glob("*.jsonl"))
+    trail_files = _invocation_trail_files(isolated_repo)
     assert trail_files, (
         f"No invocation trail files written under {invocations_dir}. "
         "ProfileInvocationExecutor.invoke was not called from the composed "
@@ -578,7 +595,7 @@ def test_full_advancement_through_six_actions(isolated_repo: Path) -> None:
 
     After the loop finishes the test cross-checks the per-action paired
     invocation trail under
-    ``<repo>/.kittify/events/profile-invocations/`` (T10): every advancing
+    the canonical Op storage directory (T10): every advancing
     action MUST have at least one trail file containing a paired
     ``started`` + ``completed`` record whose ``action`` is the
     documentation-native verb. This is a stricter assertion than the
@@ -656,11 +673,9 @@ def test_full_advancement_through_six_actions(isolated_repo: Path) -> None:
     )
 
     # T10: every advancing action MUST have a paired started/completed
-    # trail record under .kittify/events/profile-invocations/ with the
+    # trail record under the canonical Op storage directory with the
     # documentation-native action name on the started event.
-    invocations_dir = (
-        isolated_repo / ".kittify" / "events" / "profile-invocations"
-    )
+    invocations_dir = isolated_repo / EVENTS_DIR
     assert invocations_dir.is_dir(), (
         f"Invocations dir missing: {invocations_dir}. Composition dispatch "
         "did not produce any paired invocation trails."
@@ -668,7 +683,7 @@ def test_full_advancement_through_six_actions(isolated_repo: Path) -> None:
 
     valid_outcomes = {"done", "failed"}
     paired_actions: set[str] = set()
-    for trail in sorted(invocations_dir.glob("*.jsonl")):
+    for trail in _invocation_trail_files(isolated_repo):
         events: list[dict[str, object]] = []
         for raw in trail.read_text(encoding="utf-8").splitlines():
             line = raw.strip()

--- a/tests/integration/test_merge_lane_planning_data_loss.py
+++ b/tests/integration/test_merge_lane_planning_data_loss.py
@@ -312,6 +312,12 @@ def _file_on_branch(repo: Path, branch: str, relpath: str) -> bool:
     return result.returncode == 0 and relpath in result.stdout.splitlines()
 
 
+def _rel_paths(paths: object, repo: Path) -> set[str]:
+    if paths is None:
+        return set()
+    return {str(Path(path).relative_to(repo)) for path in paths}  # type: ignore[arg-type]
+
+
 @contextlib.contextmanager
 def _real_merge_external_mocks(repo_root: Path):
     """Mock only the side effects that touch state OUTSIDE git.
@@ -358,7 +364,11 @@ def _real_merge_external_mocks(repo_root: Path):
         stale_report.findings = []
         ms[6].return_value = stale_report
         ms[7].return_value = stale_report
-        yield
+        yield {
+            "mark_done": ms[0],
+            "assert_done": ms[1],
+            "safe_commit": ms[2],
+        }
 
 
 class TestPlanningArtifactReachesTarget:
@@ -502,7 +512,7 @@ class TestPlanningArtifactReachesTarget:
         )
         assert missing_branch.returncode != 0
 
-        with _real_merge_external_mocks(tmp_path):
+        with _real_merge_external_mocks(tmp_path) as mocks:
             _run_lane_based_merge(
                 repo_root=tmp_path,
                 mission_slug=slug,
@@ -514,6 +524,21 @@ class TestPlanningArtifactReachesTarget:
             )
 
         assert _file_on_branch(tmp_path, "main", planning_relpath)
+        marked_wps = [call.args[2] for call in mocks["mark_done"].call_args_list]
+        assert marked_wps == ["WP01", "WP02"]
+        mocks["assert_done"].assert_called_once()
+        assert set(mocks["assert_done"].call_args.args[2]) == {"WP01", "WP02"}
+
+        meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert isinstance(meta.get("mission_number"), int)
+        assert meta.get("baseline_merge_commit")
+
+        committed_paths: set[str] = set()
+        for call in mocks["safe_commit"].call_args_list:
+            committed_paths.update(_rel_paths(call.kwargs.get("paths"), tmp_path))
+        assert f"kitty-specs/{slug}/meta.json" in committed_paths
+        assert f"kitty-specs/{slug}/status.events.jsonl" in committed_paths
+        assert f"kitty-specs/{slug}/status.json" in committed_paths
 
     def test_planning_artifact_on_phantom_lane_branch_is_NOT_reached(
         self, tmp_path: Path

--- a/tests/integration/test_merge_lane_planning_data_loss.py
+++ b/tests/integration/test_merge_lane_planning_data_loss.py
@@ -241,16 +241,18 @@ def _write_lanes_manifest(
     """Build a real LanesManifest with a code lane and a planning lane and write it to disk."""
     if mission_branch is None:
         mission_branch = f"kitty/mission-{slug}"
-    lanes: list[ExecutionLane] = [
-        ExecutionLane(
-            lane_id="lane-a",
-            wp_ids=tuple(code_wp_ids),
-            write_scope=("src/foo.py",),
-            predicted_surfaces=("code",),
-            depends_on_lanes=(),
-            parallel_group=0,
+    lanes: list[ExecutionLane] = []
+    if code_wp_ids:
+        lanes.append(
+            ExecutionLane(
+                lane_id="lane-a",
+                wp_ids=tuple(code_wp_ids),
+                write_scope=("src/foo.py",),
+                predicted_surfaces=("code",),
+                depends_on_lanes=(),
+                parallel_group=0,
+            )
         )
-    ]
     if planning_wp_ids:
         lanes.append(
             ExecutionLane(
@@ -461,6 +463,57 @@ class TestPlanningArtifactReachesTarget:
             f"present on main afterward.  This is the silent-data-loss case "
             f"FR-001 forbids."
         )
+
+    def test_planning_artifact_only_merge_does_not_require_mission_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """All-planning research missions close from the target branch without a mission branch."""
+        slug = "real-merge-planning-only-research"
+        _init_git_repo(tmp_path)
+
+        feature_dir = tmp_path / "kitty-specs" / slug
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "tasks").mkdir(parents=True)
+        _write_meta(feature_dir, slug)
+        _write_lanes_manifest(
+            feature_dir,
+            slug,
+            code_wp_ids=[],
+            planning_wp_ids=["WP01", "WP02"],
+        )
+        _git(tmp_path, "add", ".")
+        _git(tmp_path, "commit", "-m", f"chore({slug}): bootstrap planning mission fixture")
+
+        planning_relpath = f"kitty-specs/{slug}/research/decision-A.md"
+        _commit_file(
+            tmp_path,
+            branch="main",
+            relpath=planning_relpath,
+            content="# Decision A\n\nPlanning artifact body.\n",
+            message=f"plan({slug}): commit planning artifact on target",
+        )
+
+        mission_branch = f"kitty/mission-{slug}"
+        missing_branch = subprocess.run(
+            ["git", "-C", str(tmp_path), "rev-parse", "--verify", f"refs/heads/{mission_branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert missing_branch.returncode != 0
+
+        with _real_merge_external_mocks(tmp_path):
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+
+        assert _file_on_branch(tmp_path, "main", planning_relpath)
 
     def test_planning_artifact_on_phantom_lane_branch_is_NOT_reached(
         self, tmp_path: Path

--- a/tests/integration/test_research_runtime_walk.py
+++ b/tests/integration/test_research_runtime_walk.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import pytest
 
+from specify_cli.invocation.writer import EVENTS_DIR
 from specify_cli.next._internal_runtime.engine import _read_snapshot
 from specify_cli.next.runtime_bridge import (
     _check_composed_action_guard,
@@ -42,6 +43,23 @@ from specify_cli.next.runtime_bridge import (
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+
+_NON_INVOCATION_OP_FILES = {
+    "lifecycle.jsonl",
+    "ops-index.jsonl",
+    "propagation-errors.jsonl",
+}
+
+
+def _invocation_trail_files(repo_root: Path) -> list[Path]:
+    invocations_dir = repo_root / EVENTS_DIR
+    return sorted(
+        path
+        for path in invocations_dir.glob("*.jsonl")
+        if path.name not in _NON_INVOCATION_OP_FILES
+    )
+
 
 def _init_min_repo(repo_root: Path) -> None:
     """Initialize a minimal git repo as the test mission's project root."""
@@ -157,8 +175,8 @@ def test_research_advances_one_composed_step(isolated_repo: Path) -> None:
       ``"plan"``. This proves the composed dispatch fired for the
       research mission and the planner moved through the research DAG.
     * (c) The invocation trail under
-      ``.kittify/events/profile-invocations/`` contains paired started +
-      completed lifecycle records (asserted in
+      the canonical Op storage directory contains paired started + completed
+      lifecycle records (asserted in
       :func:`test_paired_invocation_lifecycle_recorded`).
     * (d) No legacy ``runtime_next_step`` was re-entered for the
       composed scoping action — implicitly proven because the snapshot
@@ -228,8 +246,7 @@ def test_paired_invocation_lifecycle_recorded(isolated_repo: Path) -> None:
     """Each composed invocation writes paired started + completed records.
 
     The composition dispatch routes through ``ProfileInvocationExecutor``
-    which writes JSONL records under
-    ``<repo>/.kittify/events/profile-invocations/<invocation_id>.jsonl``.
+    which writes JSONL records under the canonical Op storage directory.
     Each invocation must have at least one ``started`` line; the test also
     confirms recorded ``action`` values stay within the research-native
     step IDs (no software-dev verbs leaking through).
@@ -254,12 +271,12 @@ def test_paired_invocation_lifecycle_recorded(isolated_repo: Path) -> None:
         isolated_repo,
     )
 
-    invocations_dir = isolated_repo / ".kittify" / "events" / "profile-invocations"
+    invocations_dir = isolated_repo / EVENTS_DIR
     assert invocations_dir.is_dir(), (
         f"Invocations dir missing: {invocations_dir}. Composition dispatch "
         "did not produce a paired invocation trail."
     )
-    trail_files = sorted(invocations_dir.glob("*.jsonl"))
+    trail_files = _invocation_trail_files(isolated_repo)
     assert trail_files, (
         f"No invocation trail files written under {invocations_dir}. "
         "ProfileInvocationExecutor.invoke was not called from the composed "

--- a/tests/specify_cli/invocation/test_executor.py
+++ b/tests/specify_cli/invocation/test_executor.py
@@ -19,7 +19,7 @@ from specify_cli.invocation.writer import EVENTS_DIR
 # Fixtures
 # ---------------------------------------------------------------------------
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "profiles"
 

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -481,6 +481,55 @@ def test_collect_feature_summary_allows_main_branch_for_lane_acceptance(tmp_path
     assert any("acceptance-matrix.json" in item for item in summary.recommended_fix_order)
 
 
+def test_collect_feature_summary_allows_planning_artifact_research_without_matrix(
+    tmp_path: Path,
+) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path, "research-planning-only")
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    (repo_root / ".kittify").mkdir(exist_ok=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    deliverables_path = "docs/research/research-planning-only/"
+    meta_path = feature_dir / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["mission_type"] = "research"
+    meta["mission"] = "research"
+    meta["deliverables_path"] = deliverables_path
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    for path_name in ("research", "data", "findings", "reports"):
+        directory = repo_root / deliverables_path / path_name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / ".gitkeep").write_text("", encoding="utf-8")
+
+    write_single_lane_manifest(
+        feature_dir,
+        wp_ids=("WP01",),
+        lane_id="lane-planning",
+        write_scope=(f"{deliverables_path}**",),
+        predicted_surfaces=("planning",),
+    )
+    subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", "Add planning research artifacts"],
+        check=True,
+        capture_output=True,
+    )
+
+    summary = collect_feature_summary(repo_root, "research-planning-only", mutate_matrix=False)
+
+    assert summary.ok is True
+    assert not any("Acceptance matrix" in issue for issue in summary.activity_issues)
+    assert not any(item.check == "acceptance_matrix" for item in summary.blocked_checks)
+    assert not summary.path_violations
+    assert any(
+        item.check == "acceptance_matrix_presence"
+        and "planning_artifact-only" in item.detail
+        for item in summary.skipped_checks
+    )
+
+
 def test_collect_feature_summary_blocks_unrelated_branch_for_lane_acceptance(tmp_path: Path) -> None:
     repo_root, feature_dir = _create_test_feature(tmp_path)
     subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Tuple
 
 import pytest
+import typer
+from typer.testing import CliRunner
 
 from specify_cli.acceptance import (
     AcceptanceError,
@@ -32,6 +34,7 @@ from specify_cli.acceptance import (
 from specify_cli.task_utils import LANES
 from specify_cli.status.models import Lane, StatusEvent
 from specify_cli.status.store import StoreError, append_event
+from specify_cli.cli.commands import accept as accept_module
 
 # Marked for mutmut sandbox skip — see ADR 2026-04-20-1.
 # Reason: subprocess CLI invocation
@@ -493,6 +496,7 @@ def test_collect_feature_summary_allows_planning_artifact_research_without_matri
     deliverables_path = "docs/research/research-planning-only/"
     meta_path = feature_dir / "meta.json"
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["mission_id"] = "01K00000000000000000000000"
     meta["mission_type"] = "research"
     meta["mission"] = "research"
     meta["deliverables_path"] = deliverables_path
@@ -528,6 +532,74 @@ def test_collect_feature_summary_allows_planning_artifact_research_without_matri
         and "planning_artifact-only" in item.detail
         for item in summary.skipped_checks
     )
+
+
+def test_accept_cli_no_commit_json_allows_planning_artifact_research_without_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path, "research-planning-only")
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    (repo_root / ".kittify").mkdir(exist_ok=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    deliverables_path = "docs/research/research-planning-only/"
+    meta_path = feature_dir / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["mission_id"] = "01K00000000000000000000000"
+    meta["mission_type"] = "research"
+    meta["mission"] = "research"
+    meta["deliverables_path"] = deliverables_path
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    for path_name in ("research", "data", "findings", "reports"):
+        directory = repo_root / deliverables_path / path_name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / ".gitkeep").write_text("", encoding="utf-8")
+
+    write_single_lane_manifest(
+        feature_dir,
+        wp_ids=("WP01",),
+        lane_id="lane-planning",
+        write_scope=(f"{deliverables_path}**",),
+        predicted_surfaces=("planning",),
+    )
+    subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", "Add planning research artifacts"],
+        check=True,
+        capture_output=True,
+    )
+
+    cli = typer.Typer()
+    cli.command(name="accept")(accept_module.accept)
+    monkeypatch.setattr(accept_module, "find_repo_root", lambda: repo_root)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--mission",
+            "research-planning-only",
+            "--no-commit",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["summary"]["ok"] is True
+    assert not any(
+        item.get("check") == "acceptance_matrix"
+        for item in payload["summary"]["blocked_checks"]
+    )
+    assert any(
+        item.get("check") == "acceptance_matrix_presence"
+        and "planning_artifact-only" in item.get("detail", "")
+        for item in payload["summary"]["skipped_checks"]
+    )
+    assert not payload["summary"]["path_violations"]
 
 
 def test_collect_feature_summary_blocks_unrelated_branch_for_lane_acceptance(tmp_path: Path) -> None:

--- a/tests/specify_cli/test_doctrine_service_factory.py
+++ b/tests/specify_cli/test_doctrine_service_factory.py
@@ -19,6 +19,8 @@ from specify_cli.doctrine_service_factory import (
     build_activation_aware_doctrine_service,
 )
 
+pytestmark = [pytest.mark.doctrine]
+
 
 def _write_config(repo_root: Path, body: str) -> None:
     kittify = repo_root / ".kittify"

--- a/tests/status/test_agent_status_emit_aggregate_wiring.py
+++ b/tests/status/test_agent_status_emit_aggregate_wiring.py
@@ -23,7 +23,7 @@ from typer.testing import CliRunner
 
 from specify_cli.cli.commands.agent.status import app
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 runner = CliRunner()
 


### PR DESCRIPTION
## Summary

Fixes #1686.

- lets planning_artifact-only lane manifests close from the configured target branch without requiring a mission branch
- skips acceptance-matrix enforcement for planning_artifact-only missions because that execution path does not generate acceptance-matrix.json
- validates research mission path conventions under meta.json deliverables_path instead of fixed repository-root directories
- assigns mission_number directly on the target branch during planning-only closeout, then commits normal merge bookkeeping
- keeps mixed code + planning lane missions on the existing mission-branch merge path

## Validation

- `uv run --extra test python -m pytest tests/specify_cli/test_acceptance_regressions.py tests/research/test_research_deliverables_unit.py tests/lanes/test_compute_planning_artifact.py tests/integration/test_merge_lane_planning_data_loss.py`
- `uv run --extra test python -m pytest tests/agent/test_validators_unit.py tests/research/test_research_workflow_integration.py`
- `uv run --extra lint python -m ruff check src/specify_cli/acceptance/__init__.py src/specify_cli/validators/paths.py src/specify_cli/mission.py src/specify_cli/cli/commands/merge.py tests/specify_cli/test_acceptance_regressions.py tests/integration/test_merge_lane_planning_data_loss.py`
- `git diff --check`
