### PR TITLE
[codex] fix(charter): avoid hollow directive placeholders

### DIFF
--- a/src/charter/compiler.py
+++ b/src/charter/compiler.py
@@ -918,14 +918,20 @@ def _render_directives(
 
     for directive_id in selected_directives:
         directive = doctrine_service.directives.get(directive_id)
-        if directive is None or directive.id != "DIRECTIVE_039":
+        if directive is None:
             lines.append(f"{index}. Apply doctrine directive `{directive_id}` to planning and implementation decisions.")
             index += 1
             continue
 
         lines.append(f"{index}. {directive.title} (`{directive.id}`): {directive.intent.strip()}")
+        if directive.scope:
+            lines.append(f"   - Scope: {directive.scope.strip()}")
+        for procedure in directive.procedures:
+            lines.append(f"   - Procedure: {procedure}")
         for rule in directive.integrity_rules:
-            lines.append(f"   - {rule}")
+            lines.append(f"   - Integrity rule: {rule}")
+        for criterion in directive.validation_criteria:
+            lines.append(f"   - Validation criterion: {criterion}")
         index += 1
 
     risk = interview.answers.get("risk_boundaries")

--- a/src/charter/extractor.py
+++ b/src/charter/extractor.py
@@ -77,6 +77,10 @@ SECTION_MAPPING: dict[str, tuple[str, str]] = {
 #     (e.g. ``pre-commit-hooks`` is not a tactic; ``language-driven-design`` is).
 _DIRECTIVE_CITATION_RE = re.compile(r"\bDIRECTIVE_(\d{3})\b")
 _TACTIC_SLUG_RE = re.compile(r"\b([a-z][a-z0-9]*(?:-[a-z0-9]+){1,4})\b")
+_GENERATED_DIRECTIVE_PLACEHOLDER_RE = re.compile(
+    r"^Apply doctrine directive `(?P<directive_id>[A-Z][A-Z0-9_/-]*)` "
+    r"to planning and implementation decisions\.?$"
+)
 
 
 # WP02: bullet-list pattern used as a fallback inside directive sections that
@@ -154,6 +158,7 @@ class ExtractionResult:
     governance: GovernanceConfig
     directives: DirectivesConfig
     metadata: ExtractionMetadata
+    warnings: list[str]
 
 
 class Extractor:
@@ -193,14 +198,16 @@ class Extractor:
         if not isinstance(content, str):
             raise TypeError(f"content must be str, got {type(content).__name__}")
         sections = self.parser.parse(content)
+        warnings: list[str] = []
         governance = self._extract_governance(sections)
-        directives = self._extract_directives(sections)
+        directives = self._extract_directives(sections, warnings=warnings)
         metadata = self._build_metadata(content, sections)
 
         return ExtractionResult(
             governance=governance,
             directives=directives,
             metadata=metadata,
+            warnings=warnings,
         )
 
     def _extract_governance(self, sections: list[CharterSection]) -> GovernanceConfig:
@@ -624,7 +631,12 @@ class Extractor:
                     return value
         return None
 
-    def _extract_directives(self, sections: list[CharterSection]) -> DirectivesConfig:
+    def _extract_directives(
+        self,
+        sections: list[CharterSection],
+        *,
+        warnings: list[str],
+    ) -> DirectivesConfig:
         """Extract directives from classified sections.
 
         Args:
@@ -665,6 +677,12 @@ class Extractor:
                 items = self._extract_bullet_items(section.content)
 
             for item_text in items:
+                placeholder_directive_id = _generated_directive_placeholder_id(item_text)
+                if placeholder_directive_id:
+                    warnings.append(_generated_directive_placeholder_warning(placeholder_directive_id))
+                    logger.warning(warnings[-1])
+                    continue
+
                 # Detect cross-link catalog citations inside the body so the
                 # downstream resolver can surface the catalog body on demand
                 # (FR-006). The registry callable is injected at __init__
@@ -767,6 +785,22 @@ class Extractor:
                 best_length = len(keyword)
 
         return best_match
+
+
+def _generated_directive_placeholder_id(item_text: str) -> str | None:
+    """Return the catalog directive ID when *item_text* is generated placeholder prose."""
+    match = _GENERATED_DIRECTIVE_PLACEHOLDER_RE.match(item_text.strip())
+    if not match:
+        return None
+    return match.group("directive_id")
+
+
+def _generated_directive_placeholder_warning(directive_id: str) -> str:
+    return (
+        f"Skipped generated placeholder for {directive_id}; "
+        "run `spec-kitty charter generate --force` with current templates so "
+        "directives.yaml does not mint hollow local DIR-NNN policy."
+    )
 
 
 def extract_with_ai(

--- a/src/charter/sync.py
+++ b/src/charter/sync.py
@@ -10,7 +10,7 @@ Provides the main sync() function that orchestrates:
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from ruamel.yaml import YAML
@@ -73,6 +73,7 @@ class SyncResult:
     extraction_mode: str  # "deterministic" | "hybrid"
     error: str | None = None  # Error message if sync failed
     canonical_root: Path | None = None  # NEW (WP02): main-checkout root
+    warnings: list[str] = field(default_factory=list)
 
 
 def ensure_charter_bundle_fresh(repo_root: Path) -> SyncResult | None:
@@ -206,6 +207,7 @@ def sync(
             stale_before=stale,
             files_written=files_written,
             extraction_mode=result.metadata.extraction_mode,
+            warnings=list(result.warnings),
         )
 
     except Exception as e:

--- a/src/specify_cli/cli/commands/charter/generate.py
+++ b/src/specify_cli/cli/commands/charter/generate.py
@@ -316,6 +316,8 @@ def generate(
         if sync_result.error:
             raise RuntimeError(sync_result.error)
 
+        diagnostics = [*compiled.diagnostics, *sync_result.warnings]
+
         files_written = list(bundle_result.files_written)
         for file_name in sync_result.files_written:
             if file_name not in files_written:
@@ -359,7 +361,7 @@ def generate(
                         "references_count": len(compiled.references),
                         "library_files": local_support_files,
                         "files_written": files_written,
-                        "diagnostics": compiled.diagnostics,
+                        "diagnostics": diagnostics,
                     },
                     indent=2,
                 )
@@ -370,9 +372,9 @@ def generate(
         console.print(f"Charter: {charter_path.relative_to(repo_root)}")
         console.print(f"Mission: {compiled.mission}")
         console.print(f"Template set: {compiled.template_set}")
-        if compiled.diagnostics:
+        if diagnostics:
             console.print("Diagnostics:")
-            for line in compiled.diagnostics:
+            for line in diagnostics:
                 console.print(f"  - {line}")
         console.print("Files written:")
         for filename in files_written:

--- a/src/specify_cli/cli/commands/charter/sync.py
+++ b/src/specify_cli/cli/commands/charter/sync.py
@@ -42,6 +42,7 @@ def sync(
                 "files_written": result.files_written,
                 "extraction_mode": result.extraction_mode,
                 "error": result.error,
+                "warnings": result.warnings,
             }
             print(json.dumps(data, indent=2))
             return
@@ -53,6 +54,10 @@ def sync(
         if result.synced:
             console.print("[green]Charter synced successfully[/green]")
             console.print(f"Mode: {result.extraction_mode}")
+            if result.warnings:
+                console.print("\nWarnings:")
+                for warning in result.warnings:
+                    console.print(f"  ! {warning}")
             console.print("\nFiles written:")
             for filename in result.files_written:
                 console.print(f"  ✓ {filename}")

--- a/tests/charter/test_compiler.py
+++ b/tests/charter/test_compiler.py
@@ -96,6 +96,21 @@ def test_compile_charter_renders_lynn_cole_rules_verbatim() -> None:
     assert "Your code will be reviewed by the meanest, most inconsiderate QA agent" in compiled.markdown
 
 
+def test_compile_charter_renders_selected_directive_content() -> None:
+    interview = default_interview(mission="software-dev", profile="minimal")
+    interview = apply_answer_overrides(
+        interview,
+        selected_directives=["DIRECTIVE_003"],
+    )
+
+    compiled = compile_charter(mission="software-dev", interview=interview)
+
+    assert "Apply doctrine directive `DIRECTIVE_003`" not in compiled.markdown
+    assert "Decision Documentation Requirement (`DIRECTIVE_003`)" in compiled.markdown
+    assert "Material technical and governance decisions must be captured" in compiled.markdown
+    assert "Integrity rule: High-impact decisions cannot remain tribal knowledge." in compiled.markdown
+
+
 def test_compile_charter_renders_agent_profile_metadata_when_present() -> None:
     interview = default_interview(mission="software-dev", profile="minimal")
     interview = apply_answer_overrides(interview, agent_profile="reviewer", agent_role="reviewer")

--- a/tests/charter/test_extractor.py
+++ b/tests/charter/test_extractor.py
@@ -136,6 +136,24 @@ class TestDirectivesExtraction:
         assert result.directives.directives[1].id == "DIR-002"
         assert result.directives.directives[2].id == "DIR-003"
 
+    def test_skips_generated_directive_placeholder_with_warning(self, extractor: Extractor) -> None:
+        content = """## Project Directives
+
+1. Apply doctrine directive `DIRECTIVE_003` to planning and implementation decisions.
+2. Hand-authored project rule still syncs normally.
+"""
+        result = extractor.extract(content)
+
+        assert len(result.directives.directives) == 1
+        directive = result.directives.directives[0]
+        assert directive.id == "DIR-001"
+        assert directive.description == "Hand-authored project rule still syncs normally."
+        assert result.warnings == [
+            "Skipped generated placeholder for DIRECTIVE_003; "
+            "run `spec-kitty charter generate --force` with current templates so "
+            "directives.yaml does not mint hollow local DIR-NNN policy."
+        ]
+
 
 class TestMetadataGeneration:
     @pytest.fixture

--- a/tests/charter/test_sync.py
+++ b/tests/charter/test_sync.py
@@ -63,6 +63,39 @@ def test_sync_fresh_charter(tmp_path: Path):
         assert (tmp_path / filename).exists()
 
 
+def test_sync_skips_generated_directive_placeholder_with_warning(tmp_path: Path):
+    """Legacy generated placeholders must not become hollow local policy."""
+    charter_file = tmp_path / "charter.md"
+    charter_file.write_text(
+        """# Project Charter
+
+## Governance Activation
+
+```yaml
+selected_directives: [DIRECTIVE_003]
+```
+
+## Project Directives
+
+1. Apply doctrine directive `DIRECTIVE_003` to planning and implementation decisions.
+""",
+        encoding="utf-8",
+    )
+
+    result = sync(charter_file, tmp_path, force=True)
+
+    assert result.synced is True
+    assert result.error is None
+    assert result.warnings == [
+        "Skipped generated placeholder for DIRECTIVE_003; "
+        "run `spec-kitty charter generate --force` with current templates so "
+        "directives.yaml does not mint hollow local DIR-NNN policy."
+    ]
+    data = YAML().load((tmp_path / "directives.yaml").read_text(encoding="utf-8"))
+    assert data == {"directives": []}
+    assert "DIRECTIVE_003" in (tmp_path / "governance.yaml").read_text(encoding="utf-8")
+
+
 def test_sync_unchanged_charter(tmp_path: Path):
     """Sync with unchanged charter should skip extraction."""
     charter_file = tmp_path / "charter.md"


### PR DESCRIPTION
## Summary

Fixes #1708.

- render selected built-in doctrine directives with title, intent, scope, procedures, integrity rules, and validation criteria instead of generic placeholder prose
- skip legacy generated placeholder rows during charter sync so they do not become hollow local `DIR-NNN` policy
- surface placeholder skips through sync/generate diagnostics and JSON output

## Strict QA

- `uv run --extra test python -m pytest tests/charter/test_compiler.py::test_compile_charter_renders_selected_directive_content tests/charter/test_extractor.py::TestDirectivesExtraction::test_skips_generated_directive_placeholder_with_warning tests/charter/test_sync.py::test_sync_skips_generated_directive_placeholder_with_warning -q --tb=short`
- `uv run --extra test python -m pytest tests/charter/test_compiler.py tests/charter/test_extractor.py tests/charter/test_sync.py tests/specify_cli/cli/commands/test_charter_generate_autotrack.py tests/specify_cli/cli/commands/test_charter.py tests/cli/commands/test_charter_json_error_contract.py -q --tb=short`
- `uv run --extra test python -m pytest tests/charter -q --tb=short`
- `uv run --extra lint python -m ruff check src/charter/compiler.py src/charter/extractor.py src/charter/sync.py src/specify_cli/cli/commands/charter/sync.py src/specify_cli/cli/commands/charter/generate.py tests/charter/test_compiler.py tests/charter/test_extractor.py tests/charter/test_sync.py`
- `git diff --check`