### PR TITLE
ci: normalize all-contributors output

### DIFF
--- a/.github/workflows/all-contributors-normalize.yml
+++ b/.github/workflows/all-contributors-normalize.yml
@@ -1,0 +1,81 @@
+name: Normalize All Contributors
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - '.all-contributorsrc'
+      - 'CONTRIBUTORS.md'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/sync_all_contributors.py'
+      - '.github/workflows/all-contributors-normalize.yml'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  normalize:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out base tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: tooling
+
+      - name: Check out pull request branch
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: pr
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tooling/package-lock.json
+
+      - name: Install contributor tooling
+        working-directory: tooling
+        run: npm ci --ignore-scripts
+
+      - name: Validate contributor config target
+        working-directory: pr
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const config = JSON.parse(fs.readFileSync('.all-contributorsrc', 'utf8'));
+          const files = config.files || [];
+          if (JSON.stringify(files) !== JSON.stringify(['CONTRIBUTORS.md'])) {
+            throw new Error(`Unexpected all-contributors files target: ${JSON.stringify(files)}`);
+          }
+          NODE
+
+      - name: Regenerate contributors output
+        working-directory: pr
+        run: ../tooling/node_modules/.bin/all-contributors generate --config .all-contributorsrc
+
+      - name: Commit normalized contributors output
+        working-directory: pr
+        run: |
+          if git diff --quiet -- CONTRIBUTORS.md; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CONTRIBUTORS.md
+          git commit -m "docs: normalize contributors output"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+
+      - name: Verify contributors output is normalized
+        working-directory: pr
+        run: git diff --exit-code -- CONTRIBUTORS.md

--- a/.github/workflows/all-contributors-normalize.yml
+++ b/.github/workflows/all-contributors-normalize.yml
@@ -7,9 +7,6 @@ on:
     paths:
       - '.all-contributorsrc'
       - 'CONTRIBUTORS.md'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'scripts/sync_all_contributors.py'
       - '.github/workflows/all-contributors-normalize.yml'
 
 permissions:


### PR DESCRIPTION
Adds a PR-targeted contributor normalization workflow so all-contributors bot updates are regenerated with the repo-pinned toolchain automatically.

Behavior:
- runs on contributor metadata/output changes
- uses `pull_request_target` so `[skip ci]` allcontributors commits still trigger it
- guards to same-repo PRs only
- installs tooling from the base branch, not PR-owned package files
- validates `.all-contributorsrc` only targets `CONTRIBUTORS.md` before generating
- commits normalized `CONTRIBUTORS.md` back to the PR branch when needed

Validation run locally:
- YAML parsed successfully
- `.all-contributorsrc` target validation passed
- `./node_modules/.bin/all-contributors generate --config .all-contributorsrc && git diff --exit-code -- CONTRIBUTORS.md` passed