### PR TITLE
fix(merge): finalize planning-artifact research closeout (supersedes #1723)

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -607,13 +607,6 @@ def _append_skipped_lane_checks(
         )
 
 
-def _is_planning_artifact_only_manifest(lanes_manifest: Any) -> bool:
-    lanes = list(getattr(lanes_manifest, "lanes", []) or [])
-    return bool(lanes) and all(
-        getattr(lane, "lane_id", None) == "lane-planning" for lane in lanes
-    )
-
-
 def _path_prefix_for_mission(mission: Any, feature_dir: Path) -> str | None:
     if getattr(mission, "domain", None) != "research":
         return None
@@ -631,6 +624,7 @@ def _check_lane_gates(
     mutate_matrix: bool = True,
 ) -> None:
     """Enforce lane-based acceptance gates and acceptance matrix."""
+    from specify_cli.lanes.compute import is_planning_artifact_only
     from specify_cli.lanes.persistence import CorruptLanesError, read_lanes_json
 
     try:
@@ -664,7 +658,7 @@ def _check_lane_gates(
         )
         return
 
-    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
+    planning_artifact_only = is_planning_artifact_only(lanes_manifest)
     allowed_branches = {lanes_manifest.target_branch}
     if not planning_artifact_only:
         allowed_branches.add(lanes_manifest.mission_branch)

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -18,7 +18,7 @@ from specify_cli.core.paths import require_explicit_feature as _require_explicit
 from specify_cli.decisions.models import DecisionStatus
 from specify_cli.decisions.store import load_index
 from specify_cli.git.commit_helpers import assert_not_protected_branch
-from specify_cli.mission import MissionError, get_mission_for_feature
+from specify_cli.mission import MissionError, get_deliverables_path, get_mission_for_feature
 from specify_cli.mission_metadata import load_meta, record_acceptance, resolve_mission_identity, write_meta
 from specify_cli.status.lane_reader import CanonicalStatusNotFoundError
 from specify_cli.status.models import Lane
@@ -607,6 +607,19 @@ def _append_skipped_lane_checks(
         )
 
 
+def _is_planning_artifact_only_manifest(lanes_manifest: Any) -> bool:
+    lanes = list(getattr(lanes_manifest, "lanes", []) or [])
+    return bool(lanes) and all(
+        getattr(lane, "lane_id", None) == "lane-planning" for lane in lanes
+    )
+
+
+def _path_prefix_for_mission(mission: Any, feature_dir: Path) -> str | None:
+    if getattr(mission, "domain", None) != "research":
+        return None
+    return get_deliverables_path(feature_dir, mission_slug=feature_dir.name)
+
+
 def _check_lane_gates(
     repo_root: Path,
     feature_dir: Path,
@@ -651,7 +664,10 @@ def _check_lane_gates(
         )
         return
 
-    allowed_branches = {lanes_manifest.mission_branch, lanes_manifest.target_branch}
+    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
+    allowed_branches = {lanes_manifest.target_branch}
+    if not planning_artifact_only:
+        allowed_branches.add(lanes_manifest.mission_branch)
 
     if branch is None or branch not in allowed_branches:
         allowed_label = ", ".join(sorted(branch_name for branch_name in allowed_branches if branch_name))
@@ -662,6 +678,14 @@ def _check_lane_gates(
         _append_skipped_lane_checks(
             skipped_checks,
             reason="current branch is neither mission branch nor target branch",
+            include_matrix_presence=True,
+        )
+        return
+
+    if planning_artifact_only:
+        _append_skipped_lane_checks(
+            skipped_checks,
+            reason="planning_artifact-only missions do not produce acceptance-matrix.json",
             include_matrix_presence=True,
         )
         return
@@ -941,7 +965,12 @@ def collect_feature_summary(
 
     if mission and mission.config.paths:
         try:
-            validate_mission_paths(mission, repo_root, strict=True)
+            validate_mission_paths(
+                mission,
+                repo_root,
+                strict=True,
+                path_prefix=_path_prefix_for_mission(mission, feature_dir),
+            )
         except PathValidationError as exc:
             path_violations.append(exc.result.format_errors() or str(exc))
 

--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -860,8 +860,8 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
 
         lanes_manifest = None
         lane = None
-        from specify_cli.lanes.compute import PLANNING_LANE_ID
-        if resolved_workspace.lane_id != PLANNING_LANE_ID:
+        from specify_cli.lanes.compute import is_planning_lane
+        if not is_planning_lane(resolved_workspace):
             lanes_manifest = require_lanes_json(feature_dir)
             lane = lanes_manifest.lane_for_wp(wp_id)
             if lane is None:
@@ -892,7 +892,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         # LanesManifest that uses it as the mission_branch so the worktree
         # allocator branches from the explicit base instead of auto-detecting.
         active_lanes_manifest = lanes_manifest
-        if base is not None and resolved_workspace.lane_id != PLANNING_LANE_ID:
+        if base is not None and not is_planning_lane(resolved_workspace):
             _validate_base_ref(repo_root, base)
             # Shallow-patch the manifest's mission_branch so
             # allocate_lane_worktree branches from the explicit ref.

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -5,6 +5,10 @@ the same two-step flow:
 1. Merge each lane branch into the mission branch.
 2. Merge the mission branch into the target branch.
 
+Planning-artifact-only missions are the exception: their artifacts are already
+committed to the target branch, so merge performs closeout bookkeeping directly
+on that target branch without requiring a mission branch.
+
 Recovery semantics (WP01 / 067):
 - MergeState is created at merge start and updated after each WP mark-done.
 - On interruption, rerunning ``merge`` detects the existing state and resumes.
@@ -825,6 +829,38 @@ def _check_mission_branch(
     return False, blocker_payload
 
 
+def _is_planning_artifact_only_manifest(lanes_manifest: object) -> bool:
+    """Return True when every WP is in the canonical planning-artifact lane."""
+
+    from specify_cli.lanes.compute import PLANNING_LANE_ID
+
+    lanes = list(getattr(lanes_manifest, "lanes", []) or [])
+    return bool(lanes) and all(
+        getattr(lane, "lane_id", None) == PLANNING_LANE_ID for lane in lanes
+    )
+
+
+def _enforce_planning_artifact_target_branch(repo_root: Path, target_branch: str) -> None:
+    """Planning-only closeout writes directly to the target branch."""
+
+    retcode, stdout, _stderr = run_command(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    current_branch = stdout.strip() if retcode == 0 else ""
+    if current_branch == target_branch:
+        return
+
+    current_label = current_branch or "detached HEAD"
+    console.print(
+        "[red]Error:[/red] Planning-artifact-only merge must run on "
+        f"target branch {target_branch}, not {current_label}."
+    )
+    raise typer.Exit(1)
+
+
 def _enforce_git_preflight(repo_root: Path, *, json_output: bool) -> None:
     """Run git preflight checks and stop early with deterministic remediation."""
     if not (repo_root / ".git").exists():
@@ -1292,6 +1328,28 @@ def _effective_push_requested(
     return requested_push
 
 
+def _assign_planning_only_mission_number_if_needed(
+    main_repo: Path,
+    feature_dir: Path,
+) -> Path | None:
+    """Assign mission_number directly on target for planning-only closeout."""
+
+    if not needs_number_assignment(feature_dir):
+        return None
+
+    next_number = assign_next_mission_number(
+        main_repo,
+        main_repo / KITTY_SPECS_DIR,
+    )
+    meta = load_meta(feature_dir) or {}
+    meta["mission_number"] = next_number
+    write_meta(feature_dir, meta, validate=False)
+    console.print(
+        f"  [green]✓[/green] Assigned mission_number={next_number} on target branch"
+    )
+    return feature_dir / "meta.json"
+
+
 def _enforce_canonical_status_history(
     *,
     feature_dir: Path,
@@ -1525,6 +1583,7 @@ def _run_lane_based_merge(
     lanes_manifest = require_lanes_json(feature_dir)
     if target_override:
         lanes_manifest.target_branch = target_override
+    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
 
     # -- Resolve canonical mission_id from meta.json (P2 fix: use ULID, not slug) --
     identity = resolve_mission_identity(feature_dir)
@@ -1539,15 +1598,21 @@ def _run_lane_based_merge(
             mission_branch=lanes_manifest.mission_branch,
         )
 
-    branch_ok, branch_blocker = _check_mission_branch(mission_slug, main_repo)
-    if not branch_ok:
-        assert branch_blocker is not None
-        console.print(
-            "[red]Error:[/red] Missing mission branch: "
-            f"{branch_blocker['expected_branch']}. "
-            f"Run: {branch_blocker['remediation']}"
+    if planning_artifact_only:
+        _enforce_planning_artifact_target_branch(
+            main_repo,
+            lanes_manifest.target_branch,
         )
-        raise typer.Exit(1)
+    else:
+        branch_ok, branch_blocker = _check_mission_branch(mission_slug, main_repo)
+        if not branch_ok:
+            assert branch_blocker is not None
+            console.print(
+                "[red]Error:[/red] Missing mission branch: "
+                f"{branch_blocker['expected_branch']}. "
+                f"Run: {branch_blocker['remediation']}"
+            )
+            raise typer.Exit(1)
 
     # -- Acquire global merge lock to serialize concurrent merges --
     # The lock is keyed by a well-known sentinel so that merges of DIFFERENT
@@ -1605,6 +1670,7 @@ def _run_lane_based_merge_locked(
         wp_ids=all_wp_ids,
     )
 
+    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
     state = load_state(main_repo, canonical_id)
     is_resume = False
     if state is not None:
@@ -1625,6 +1691,11 @@ def _run_lane_based_merge_locked(
     console.print(f"[bold]Lane-based merge for {mission_slug}[/bold]")
     console.print(f"  Mission branch: {lanes_manifest.mission_branch}")
     console.print(f"  Lanes: {', '.join(ln.lane_id for ln in lanes_manifest.lanes)}")
+    if planning_artifact_only:
+        console.print(
+            "  [dim]Planning-artifact-only mission: target branch already "
+            "contains deliverables; branch merge steps will be skipped.[/dim]"
+        )
 
     policy = load_policy_config(main_repo)
     gate_eval = evaluate_merge_gates(
@@ -1666,6 +1737,12 @@ def _run_lane_based_merge_locked(
             console.print(f"  [dim]Skipping {lane.lane_id} (all WPs already done)[/dim]")
             continue
 
+        if planning_artifact_only and lane.lane_id == PLANNING_LANE_ID:
+            console.print(
+                f"  [green]✓[/green] {lane.lane_id} already on {lanes_manifest.target_branch}"
+            )
+            continue
+
         console.print(f"  [dim]Checking and merging {lane.lane_id}...[/dim]")
         lane_result = merge_lane_to_mission(main_repo, mission_slug, lane.lane_id, lanes_manifest)
         if lane_result.success:
@@ -1699,46 +1776,59 @@ def _run_lane_based_merge_locked(
     except Exception:  # noqa: BLE001 — meta.json may be missing/corrupt for legacy missions
         _baseline_mission_id = None
 
-    # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
-    # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
-    # which serializes ALL merge operations — same-mission and cross-mission.
-    # This guarantees the max+1 scan sees the most recent target state.
-    # WP04/FR-010/FR-011/FR-012: pass merge_state so the idempotency check
-    # (T025) and resume short-circuit (T026) can persist/read the baked flag.
-    _bake_mission_number_into_mission_branch(
-        main_repo=main_repo,
-        mission_slug=mission_slug,
-        mission_branch=lanes_manifest.mission_branch,
-        target_branch=lanes_manifest.target_branch,
-        dry_run=False,
-        merge_state=state,
-    )
-
-    # -- Mission-to-target merge (T010: honor strategy for this step only) --
-    console.print(f"  [dim]Merging mission branch into {lanes_manifest.target_branch}...[/dim]")
-    mission_result = merge_mission_to_target(
-        main_repo,
-        mission_slug,
-        lanes_manifest,
-        strategy=strategy,
-        allow_already_applied=is_resume,
-    )
-    mission_already_applied = getattr(mission_result, "already_applied", False) is True
-    if not mission_result.success:
-        # T005: tolerate already-merged on retry
-        already_merged = any("already" in e.lower() or "up to date" in e.lower() for e in mission_result.errors)
-        if is_resume and already_merged:
-            console.print(f"[dim]{lanes_manifest.mission_branch} already merged into {lanes_manifest.target_branch}[/dim]")
-        else:
-            for error in mission_result.errors:
-                console.print(f"[red]Error:[/red] {error}")
-            raise typer.Exit(1)
+    mission_number_meta_path: Path | None = None
+    mission_already_applied = False
+    if planning_artifact_only:
+        mission_number_meta_path = _assign_planning_only_mission_number_if_needed(
+            main_repo,
+            feature_dir,
+        )
+        console.print(
+            f"  [dim]Skipping mission branch merge; {lanes_manifest.target_branch} "
+            "is the planning artifact branch.[/dim]"
+        )
+        mission_already_applied = True
     else:
-        console.print(f"\n[green]✓[/green] {lanes_manifest.mission_branch} → {lanes_manifest.target_branch}")
-        if mission_already_applied:
-            console.print("  [dim]Mission changes already present on target; continuing bookkeeping.[/dim]")
-        if mission_result.commit:
-            console.print(f"  Commit: {mission_result.commit[:7]}")
+        # -- WP10/T053/T055: assign dense integer mission_number on mission branch --
+        # Inside the global merge lock (acquire_merge_lock("__global_merge__"))
+        # which serializes ALL merge operations — same-mission and cross-mission.
+        # This guarantees the max+1 scan sees the most recent target state.
+        # WP04/FR-010/FR-011/FR-012: pass merge_state so the idempotency check
+        # (T025) and resume short-circuit (T026) can persist/read the baked flag.
+        _bake_mission_number_into_mission_branch(
+            main_repo=main_repo,
+            mission_slug=mission_slug,
+            mission_branch=lanes_manifest.mission_branch,
+            target_branch=lanes_manifest.target_branch,
+            dry_run=False,
+            merge_state=state,
+        )
+
+        # -- Mission-to-target merge (T010: honor strategy for this step only) --
+        console.print(f"  [dim]Merging mission branch into {lanes_manifest.target_branch}...[/dim]")
+        mission_result = merge_mission_to_target(
+            main_repo,
+            mission_slug,
+            lanes_manifest,
+            strategy=strategy,
+            allow_already_applied=is_resume,
+        )
+        mission_already_applied = getattr(mission_result, "already_applied", False) is True
+        if not mission_result.success:
+            # T005: tolerate already-merged on retry
+            already_merged = any("already" in e.lower() or "up to date" in e.lower() for e in mission_result.errors)
+            if is_resume and already_merged:
+                console.print(f"[dim]{lanes_manifest.mission_branch} already merged into {lanes_manifest.target_branch}[/dim]")
+            else:
+                for error in mission_result.errors:
+                    console.print(f"[red]Error:[/red] {error}")
+                raise typer.Exit(1)
+        else:
+            console.print(f"\n[green]✓[/green] {lanes_manifest.mission_branch} → {lanes_manifest.target_branch}")
+            if mission_already_applied:
+                console.print("  [dim]Mission changes already present on target; continuing bookkeeping.[/dim]")
+            if mission_result.commit:
+                console.print(f"  Commit: {mission_result.commit[:7]}")
 
     # -- WP05/T006 FR-013: Post-merge working-tree refresh --
     # Re-sync the primary checkout against HEAD before done-event bookkeeping.
@@ -1854,8 +1944,11 @@ def _run_lane_based_merge_locked(
         feature_dir / _STATUS_EVENTS_FILENAME,
         feature_dir / _STATUS_FILENAME,
     ]
+    if mission_number_meta_path is not None:
+        files_to_commit.append(mission_number_meta_path)
     if baseline_meta_path is not None:
         files_to_commit.append(baseline_meta_path)
+    files_to_commit = list(dict.fromkeys(files_to_commit))
 
     has_bookkeeping_changes = _paths_have_status_changes(main_repo, files_to_commit)
     may_skip_empty_bookkeeping = is_resume or mission_already_applied

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1899,6 +1899,14 @@ def _run_lane_based_merge_locked(
         }
         if baseline_meta_path is not None:
             expected_paths.add(str(baseline_meta_path.relative_to(main_repo)))
+        # Planning-only closeout dirties meta.json to bake in mission_number.
+        # That path is committed by the immediately-following safe_commit, so it
+        # is an expected divergence here. Without this, a legacy planning-only
+        # mission (no mission_id → _record_baseline_merge_commit returns None,
+        # leaving baseline_meta_path None) trips the invariant and fails the
+        # merge. Mirrors the baseline_meta_path branch above.
+        if mission_number_meta_path is not None:
+            expected_paths.add(str(mission_number_meta_path.relative_to(main_repo)))
         offending_lines, _skipped_untracked = _classify_porcelain_lines(
             (_out_status or "").splitlines(),
             expected_paths,

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -114,6 +114,35 @@ class BaselineMergeCommitError(RuntimeError):
     """
 
 
+def _raw_porcelain_status(repo_root: Path) -> tuple[int, str]:
+    """Return ``(returncode, raw_stdout)`` for ``git status --porcelain``.
+
+    Reads stdout RAW (not via ``run_command``) so the leading status column of
+    each porcelain line is preserved. Porcelain v1 emits ``XY<space>PATH`` (a
+    fixed 3-char prefix); for a tracked file that is modified-but-not-staged X
+    is a space (``" M path"``). ``run_command``'s whole-output ``.strip()`` would
+    remove the leading space of the *first* line only, shifting its columns so
+    ``_classify_porcelain_lines`` rejects it (``line[2] != " "``) and silently
+    drops the first divergent path. The post-merge working-tree invariant MUST
+    see every divergent line, so it reads porcelain via this helper instead.
+
+    Mirrors the raw-read pattern documented in
+    :func:`specify_cli.cli.commands.implement._feature_dir_status_entries`.
+    """
+    import subprocess as _subprocess
+
+    result = _subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return result.returncode, result.stdout
+
+
 def _classify_porcelain_lines(
     lines: list[str],
     expected_paths: set[str],
@@ -1886,12 +1915,13 @@ def _run_lane_based_merge_locked(
     # (sparse-checkout, a stale lock, a filter driver) silently dropped paths
     # during the merge and must stop the flow before the housekeeping commit
     # papers over it.
-    _ret_status, _out_status, _err_status = run_command(
-        ["git", "status", "--porcelain"],
-        capture=True,
-        check_return=False,
-        cwd=main_repo,
-    )
+    #
+    # Read porcelain RAW (not via run_command): run_command strips the whole
+    # output, which removes the leading status column of the FIRST porcelain
+    # line, so _classify_porcelain_lines would silently skip the first divergent
+    # path (e.g. meta.json, which sorts first inside kitty-specs/<slug>/). The
+    # invariant must be blind to nothing, so we splitlines() the raw stdout.
+    _ret_status, _out_status = _raw_porcelain_status(main_repo)
     if _ret_status == 0:
         expected_paths = {
             f"kitty-specs/{mission_slug}/{_STATUS_EVENTS_FILENAME}",
@@ -1936,8 +1966,8 @@ def _run_lane_based_merge_locked(
             raise typer.Exit(1)
     else:
         console.print(
-            f"[yellow]Warning:[/yellow] post-merge invariant check skipped: "
-            f"git status failed ({(_err_status or '').strip()})"
+            "[yellow]Warning:[/yellow] post-merge invariant check skipped: "
+            f"git status --porcelain returned {_ret_status}"
         )
 
     # -- T012: FR-019 — Persist done events to git BEFORE any worktree removal --

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -829,17 +829,6 @@ def _check_mission_branch(
     return False, blocker_payload
 
 
-def _is_planning_artifact_only_manifest(lanes_manifest: object) -> bool:
-    """Return True when every WP is in the canonical planning-artifact lane."""
-
-    from specify_cli.lanes.compute import PLANNING_LANE_ID
-
-    lanes = list(getattr(lanes_manifest, "lanes", []) or [])
-    return bool(lanes) and all(
-        getattr(lane, "lane_id", None) == PLANNING_LANE_ID for lane in lanes
-    )
-
-
 def _enforce_planning_artifact_target_branch(repo_root: Path, target_branch: str) -> None:
     """Planning-only closeout writes directly to the target branch."""
 
@@ -1580,10 +1569,12 @@ def _run_lane_based_merge(
         mission_id=_preflight_mission_id or mission_slug,
     )
 
+    from specify_cli.lanes.compute import is_planning_artifact_only
+
     lanes_manifest = require_lanes_json(feature_dir)
     if target_override:
         lanes_manifest.target_branch = target_override
-    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
+    planning_artifact_only = is_planning_artifact_only(lanes_manifest)
 
     # -- Resolve canonical mission_id from meta.json (P2 fix: use ULID, not slug) --
     identity = resolve_mission_identity(feature_dir)
@@ -1656,7 +1647,7 @@ def _run_lane_based_merge_locked(
 ) -> None:
     """Inner merge flow, called with the global merge lock held."""
     from specify_cli.lanes.branch_naming import lane_branch_name
-    from specify_cli.lanes.compute import PLANNING_LANE_ID
+    from specify_cli.lanes.compute import is_planning_artifact_only, is_planning_lane
     from specify_cli.lanes.merge import merge_lane_to_mission, merge_mission_to_target
     from specify_cli.policy.config import load_policy_config
     from specify_cli.policy.merge_gates import evaluate_merge_gates
@@ -1670,7 +1661,7 @@ def _run_lane_based_merge_locked(
         wp_ids=all_wp_ids,
     )
 
-    planning_artifact_only = _is_planning_artifact_only_manifest(lanes_manifest)
+    planning_artifact_only = is_planning_artifact_only(lanes_manifest)
     state = load_state(main_repo, canonical_id)
     is_resume = False
     if state is not None:
@@ -1737,7 +1728,7 @@ def _run_lane_based_merge_locked(
             console.print(f"  [dim]Skipping {lane.lane_id} (all WPs already done)[/dim]")
             continue
 
-        if planning_artifact_only and lane.lane_id == PLANNING_LANE_ID:
+        if planning_artifact_only and is_planning_lane(lane):
             console.print(
                 f"  [green]✓[/green] {lane.lane_id} already on {lanes_manifest.target_branch}"
             )
@@ -2060,7 +2051,7 @@ def _run_lane_based_merge_locked(
             # deleting it would attempt `git branch -D main` — destroying the
             # persistent target branch.  Planning lanes never have a dedicated
             # lane branch to clean up.
-            if lane.lane_id == PLANNING_LANE_ID:
+            if is_planning_lane(lane):
                 continue
             branch_name = lane_branch_name(mission_slug, lane.lane_id)
             # T005: check if branch exists before attempting deletion

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -1779,10 +1779,6 @@ def _run_lane_based_merge_locked(
     mission_number_meta_path: Path | None = None
     mission_already_applied = False
     if planning_artifact_only:
-        mission_number_meta_path = _assign_planning_only_mission_number_if_needed(
-            main_repo,
-            feature_dir,
-        )
         console.print(
             f"  [dim]Skipping mission branch merge; {lanes_manifest.target_branch} "
             "is the planning artifact branch.[/dim]"
@@ -1835,6 +1831,12 @@ def _run_lane_based_merge_locked(
     # A path checkout does not remove stale rename sources in sparse-checkout
     # repos; the helper uses a tracked-file hard refresh instead.
     _refresh_primary_checkout_after_merge(main_repo)
+
+    if planning_artifact_only:
+        mission_number_meta_path = _assign_planning_only_mission_number_if_needed(
+            main_repo,
+            feature_dir,
+        )
 
     try:
         baseline_meta_path = _record_baseline_merge_commit(

--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -642,14 +642,10 @@ def _load_lanes_manifest(feature_dir: Path) -> Any | None:
 
 def _delete_lane_branches(repo_root: Path, mission_slug: str, lanes_manifest: Any) -> None:
     from specify_cli.lanes.branch_naming import lane_branch_name
-
-    try:
-        from specify_cli.lanes.merge import PLANNING_LANE_ID
-    except ImportError:
-        PLANNING_LANE_ID = "lane-planning"  # historical fallback
+    from specify_cli.lanes.compute import is_planning_lane
 
     for lane in lanes_manifest.lanes:
-        if lane.lane_id == PLANNING_LANE_ID:
+        if is_planning_lane(lane):
             continue
         branch_name = lane_branch_name(mission_slug, lane.lane_id)
         _force_delete_branch_if_exists(repo_root, branch_name)

--- a/src/specify_cli/lanes/compute.py
+++ b/src/specify_cli/lanes/compute.py
@@ -39,6 +39,10 @@ def is_planning_lane(lane: object) -> bool:
     only the body of this predicate (and :func:`is_planning_artifact_only`) needs
     to change — call sites must keep asking the lane/manifest semantic question
     rather than comparing against the constant or a string literal directly.
+
+    # TODO(#1666): when planning-ness becomes charter/mission-type-derived, this
+    # predicate's BACKING (and possibly its signature → context-aware) changes
+    # here; callers must keep asking the semantic question via this seam.
     """
     return getattr(lane, "lane_id", None) == PLANNING_LANE_ID
 

--- a/src/specify_cli/lanes/compute.py
+++ b/src/specify_cli/lanes/compute.py
@@ -28,6 +28,33 @@ from specify_cli.ownership.validation import _globs_overlap
 PLANNING_LANE_ID = "lane-planning"
 
 
+def is_planning_lane(lane: object) -> bool:
+    """Return True when *lane* is the canonical planning-artifact lane.
+
+    This is the single seam where "what counts as a planning lane" is decided.
+    Today the backing is the static ``PLANNING_LANE_ID`` constant; that constant
+    is intentionally an internal implementation detail of this predicate. The
+    classification is expected to become charter / mission-type-derived and
+    surfaced via the shared context objects (domain epic #1666); when that lands
+    only the body of this predicate (and :func:`is_planning_artifact_only`) needs
+    to change — call sites must keep asking the lane/manifest semantic question
+    rather than comparing against the constant or a string literal directly.
+    """
+    return getattr(lane, "lane_id", None) == PLANNING_LANE_ID
+
+
+def is_planning_artifact_only(lanes_manifest: object) -> bool:
+    """Return True when every lane in *lanes_manifest* is a planning lane.
+
+    A planning-artifact-only mission has no code lanes; its closeout writes
+    directly to the target branch without a mission branch. See
+    :func:`is_planning_lane` for the forward-compatibility note on the backing
+    of this classification (#1666).
+    """
+    lanes = list(getattr(lanes_manifest, "lanes", None) or [])
+    return bool(lanes) and all(is_planning_lane(lane) for lane in lanes)
+
+
 class LaneComputationError(Exception):
     """Raised when lane computation cannot produce a valid lane assignment.
 

--- a/src/specify_cli/lanes/lifecycle_sync.py
+++ b/src/specify_cli/lanes/lifecycle_sync.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 
 from specify_cli.lanes.auto_rebase import AutoRebaseReport, attempt_auto_rebase
 from specify_cli.lanes.branch_naming import lane_branch_name
+from specify_cli.lanes.compute import is_planning_lane
 from specify_cli.lanes.models import ExecutionLane
 from specify_cli.lanes.persistence import CorruptLanesError, read_lanes_json
 
@@ -141,7 +142,7 @@ def sync_lane_after_coordination_commit(
         return None
 
     lane = lanes_manifest.lane_for_wp(wp_id)
-    if lane is None or lane.lane_id == "lane-planning":
+    if lane is None or is_planning_lane(lane):
         return None
 
     lane_branch = _resolve_lane_branch(

--- a/src/specify_cli/merge/push_preflight.py
+++ b/src/specify_cli/merge/push_preflight.py
@@ -17,12 +17,7 @@ from pathlib import Path
 from typing import Literal
 
 __all__ = [
-    "TargetBranchSyncState",
     "TargetBranchSyncStatus",
-    "TargetBranchRefreshStatus",
-    "TargetBranchPushSafetyResult",
-    "refresh_target_branch_tracking_ref",
-    "inspect_target_branch_sync",
     "check_push_safety",
 ]
 

--- a/src/specify_cli/mission.py
+++ b/src/specify_cli/mission.py
@@ -618,7 +618,7 @@ def get_deliverables_path(feature_dir: Path, mission_slug: str | None = None) ->
                 return deliverables_path
 
             # Check if this is a research mission - provide default if so
-            mission = meta.get("mission", "software-dev")
+            mission = meta.get("mission_type") or meta.get("mission", "software-dev")
             if mission == "research":
                 # Generate default path using slug from meta or directory name
                 slug = meta.get("slug") or mission_slug or feature_dir.name

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -361,12 +361,46 @@ def _build_merge_preflight(
     return _MergePreflightResult(target_branch=resolved_target, errors=errors)
 
 
+def _execute_planning_only_merge(
+    main_repo_root: Path,
+    mission_slug: str,
+    target_branch: str,
+    *,
+    strategy: object,
+    push: bool,
+    delete_branch: bool,
+    remove_worktree: bool,
+) -> None:
+    """Run the hardened CLI closeout path while preserving JSON-only stdout."""
+    import typer
+
+    from specify_cli.cli.commands import merge as merge_command
+
+    try:
+        with merge_command.console.capture():
+            merge_command._run_lane_based_merge(
+                repo_root=main_repo_root,
+                mission_slug=mission_slug,
+                push=push,
+                delete_branch=delete_branch,
+                remove_worktree=remove_worktree,
+                target_override=target_branch,
+                strategy=strategy,
+                assume_yes=True,
+            )
+    except typer.Exit as exc:
+        raise RuntimeError(
+            f"Planning-artifact closeout failed with exit code {exc.exit_code}"
+        ) from exc
+
+
 def _execute_lane_merge(
     main_repo_root: Path,
     mission_dir: Path,
     mission_slug: str,
     target_branch: str,
     *,
+    strategy: str,
     push: bool,
     delete_branch: bool,
     remove_worktree: bool,
@@ -375,14 +409,28 @@ def _execute_lane_merge(
     from specify_cli.cli.commands.merge import _mark_wp_merged_done
     from specify_cli.core.git_ops import has_remote, run_command
     from specify_cli.lanes.branch_naming import lane_branch_name
-    from specify_cli.lanes.compute import is_planning_lane
+    from specify_cli.lanes.compute import is_planning_artifact_only, is_planning_lane
     from specify_cli.lanes.merge import merge_lane_to_mission, merge_mission_to_target
     from specify_cli.lanes.persistence import require_lanes_json
+    from specify_cli.merge.config import MergeStrategy
     from specify_cli.policy.config import load_policy_config
     from specify_cli.policy.merge_gates import evaluate_merge_gates
 
     lanes_manifest = require_lanes_json(mission_dir)
     lanes_manifest.target_branch = target_branch
+    merge_strategy = MergeStrategy(strategy)
+
+    if is_planning_artifact_only(lanes_manifest):
+        _execute_planning_only_merge(
+            main_repo_root,
+            mission_slug,
+            target_branch,
+            strategy=merge_strategy,
+            push=push,
+            delete_branch=delete_branch,
+            remove_worktree=remove_worktree,
+        )
+        return
 
     policy = load_policy_config(main_repo_root)
     all_wp_ids = [wp for lane in lanes_manifest.lanes for wp in lane.wp_ids]
@@ -402,7 +450,12 @@ def _execute_lane_merge(
         if not lane_result.success:
             raise RuntimeError("; ".join(lane_result.errors) or f"Lane {lane.lane_id} merge failed.")
 
-    mission_result = merge_mission_to_target(main_repo_root, mission_slug, lanes_manifest)
+    mission_result = merge_mission_to_target(
+        main_repo_root,
+        mission_slug,
+        lanes_manifest,
+        strategy=merge_strategy,
+    )
     if not mission_result.success:
         raise RuntimeError("; ".join(mission_result.errors) or "Mission merge failed.")
 
@@ -1212,6 +1265,7 @@ def merge_mission(
             mission_dir,
             mission,
             preflight.target_branch,
+            strategy=strategy,
             push=push,
             delete_branch=True,
             remove_worktree=True,

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -375,7 +375,7 @@ def _execute_lane_merge(
     from specify_cli.cli.commands.merge import _mark_wp_merged_done
     from specify_cli.core.git_ops import has_remote, run_command
     from specify_cli.lanes.branch_naming import lane_branch_name
-    from specify_cli.lanes.compute import PLANNING_LANE_ID
+    from specify_cli.lanes.compute import is_planning_lane
     from specify_cli.lanes.merge import merge_lane_to_mission, merge_mission_to_target
     from specify_cli.lanes.persistence import require_lanes_json
     from specify_cli.policy.config import load_policy_config
@@ -425,7 +425,7 @@ def _execute_lane_merge(
 
     if delete_branch:
         for lane in lanes_manifest.lanes:
-            if lane.lane_id == PLANNING_LANE_ID:
+            if is_planning_lane(lane):
                 continue
             run_command(
                 [

--- a/src/specify_cli/validators/paths.py
+++ b/src/specify_cli/validators/paths.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from collections.abc import Iterable
 
 from specify_cli.mission import Mission
@@ -105,11 +105,32 @@ def suggest_directory_creation(missing_paths: Iterable[str]) -> list[str]:
     return suggestions
 
 
+def _prefix_required_path(path_prefix: str | Path | None, relative_path: str) -> str:
+    """Return ``relative_path`` under ``path_prefix`` while preserving dir hints."""
+
+    if not path_prefix:
+        return relative_path
+    candidate = Path(relative_path)
+    if candidate.is_absolute():
+        return relative_path
+
+    prefix = str(path_prefix).strip().strip("/")
+    if not prefix:
+        return relative_path
+
+    relative = relative_path.strip("/")
+    joined = PurePosixPath(prefix) / relative
+    if relative_path.endswith("/"):
+        return joined.as_posix() + "/"
+    return joined.as_posix()
+
+
 def validate_mission_paths(
     mission: Mission,
     project_root: Path,
     *,
     strict: bool = False,
+    path_prefix: str | Path | None = None,
 ) -> PathValidationResult:
     """Validate that project directories follow mission-defined conventions.
 
@@ -117,12 +138,19 @@ def validate_mission_paths(
         mission: Mission containing declared path conventions.
         project_root: Root of the active workspace/worktree.
         strict: When True, raise PathValidationError if paths are missing.
+        path_prefix: Optional project-relative prefix to apply before checking
+            mission-declared paths. Research missions use this to validate
+            configured deliverable directories instead of fixed repository-root
+            directories.
 
     Returns:
         PathValidationResult summarising the state of each required path.
     """
 
-    required_paths = dict(mission.config.paths or {})
+    required_paths = {
+        key: _prefix_required_path(path_prefix, relative_path)
+        for key, relative_path in dict(mission.config.paths or {}).items()
+    }
     result = PathValidationResult(
         mission_name=mission.name,
         required_paths=required_paths,

--- a/src/specify_cli/workspace/context.py
+++ b/src/specify_cli/workspace/context.py
@@ -683,7 +683,7 @@ def resolve_workspace_for_wp(
 
     feature_dir = _resolve_feature_dir(repo_root, mission_slug)
     from specify_cli.lanes.branch_naming import lane_branch_name
-    from specify_cli.lanes.compute import PLANNING_LANE_ID
+    from specify_cli.lanes.compute import PLANNING_LANE_ID, is_planning_lane
     from specify_cli.lanes.persistence import require_lanes_json
 
     lanes_manifest = require_lanes_json(feature_dir)
@@ -692,7 +692,7 @@ def resolve_workspace_for_wp(
         raise ValueError(f"{wp_id} resolved to execution_mode={execution_mode.value!r} but is not assigned to any lane in {feature_dir / 'lanes.json'}")
 
     # lane-planning resolves to the main repository checkout, not a .worktrees/ path.
-    if lane.lane_id == PLANNING_LANE_ID:
+    if is_planning_lane(lane):
         target_branch = lanes_manifest.target_branch
         return ResolvedWorkspace(
             mission_slug=mission_slug,

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -1298,7 +1298,7 @@ class TestMergeMission:
             ),
             patch(
                 "specify_cli.orchestrator_api.commands._execute_lane_merge",
-            ),
+            ) as execute_merge,
         ):
             result = runner.invoke(
                 app,
@@ -1320,6 +1320,8 @@ class TestMergeMission:
         assert data["data"]["merged"] is True
         assert data["data"]["target_branch"] == "main"
         assert data["data"]["strategy"] == "merge"
+        execute_merge.assert_called_once()
+        assert execute_merge.call_args.kwargs["strategy"] == "merge"
 
     def test_rebase_strategy_success(self, tmp_path):
         repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")
@@ -1340,7 +1342,7 @@ class TestMergeMission:
             ),
             patch(
                 "specify_cli.orchestrator_api.commands._execute_lane_merge",
-            ),
+            ) as execute_merge,
         ):
             result = runner.invoke(
                 app,
@@ -1359,6 +1361,79 @@ class TestMergeMission:
         data = json.loads(result.output)
         assert data["success"] is True
         assert data["data"]["strategy"] == "rebase"
+        execute_merge.assert_called_once()
+        assert execute_merge.call_args.kwargs["strategy"] == "rebase"
+
+    def test_planning_only_merge_uses_hardened_closeout_without_stdout_noise(
+        self,
+        tmp_path,
+    ):
+        repo_root, mission_dir = _make_mission(tmp_path, "research-planning-only")
+        mission_slug = "research-planning-only"
+        meta_path = mission_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["mission_number"] = 99
+        meta["mission_type"] = "research"
+        meta_path.write_text(json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        lane = MagicMock()
+        lane.lane_id = "lane-planning"
+        lane.wp_ids = ["WP01", "WP02"]
+        manifest = MagicMock()
+        manifest.target_branch = "main"
+        manifest.mission_branch = f"kitty/mission-{mission_slug}"
+        manifest.lanes = [lane]
+
+        mock_preflight = MagicMock()
+        mock_preflight.target_branch = "main"
+        mock_preflight.errors = []
+
+        def noisy_hardened_merge(**_kwargs):
+            from specify_cli.cli.commands import merge as merge_command
+
+            merge_command.console.print("this must not reach orchestrator stdout")
+
+        with (
+            patch(
+                "specify_cli.orchestrator_api.commands._get_main_repo_root",
+                return_value=repo_root,
+            ),
+            patch(
+                "specify_cli.orchestrator_api.commands._build_merge_preflight",
+                return_value=mock_preflight,
+            ),
+            patch(
+                "specify_cli.lanes.persistence.require_lanes_json",
+                return_value=manifest,
+            ),
+            patch(
+                "specify_cli.cli.commands.merge._run_lane_based_merge",
+                side_effect=noisy_hardened_merge,
+            ) as hardened_merge,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "merge-mission",
+                    "--mission",
+                    mission_slug,
+                    "--target",
+                    "main",
+                    "--strategy",
+                    "squash",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "this must not reach" not in result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["merged"] is True
+        assert data["data"]["strategy"] == "squash"
+        hardened_merge.assert_called_once()
+        assert hardened_merge.call_args.kwargs["target_override"] == "main"
+        assert hardened_merge.call_args.kwargs["strategy"].value == "squash"
+        assert hardened_merge.call_args.kwargs["assume_yes"] is True
 
     def test_unsupported_strategy_rejected(self, tmp_path):
         repo_root, mission_dir = _make_mission(tmp_path, "099-test-mission")

--- a/tests/e2e/test_charter_epic_golden_path.py
+++ b/tests/e2e/test_charter_epic_golden_path.py
@@ -50,6 +50,7 @@ from typing import Any
 
 import pytest
 
+from specify_cli.invocation.lifecycle import lifecycle_log_path
 from tests.e2e.conftest import (
     REPO_ROOT,
     SourcePollutionBaseline,
@@ -89,9 +90,9 @@ RunCli = Callable[..., subprocess.CompletedProcess[str]]
 #   - "success": bool (often duplicated alongside "result")
 #   - "errors": list  (empty list means success in lint output)
 #
-# `.kittify/events/profile-invocations/*.jsonl` records carry top-level
-# "phase" with values "started"/"completed", plus a "canonical_action_id"
-# that pairs each started record with its completion.
+# `kitty-ops/lifecycle.jsonl` records carry top-level "phase" with values
+# "started"/"completed", plus a "canonical_action_id" that pairs each started
+# record with its completion.
 
 
 # Set WP02_DEBUG_ENVELOPES=1 during local development to dump the
@@ -749,19 +750,16 @@ def _run_next_and_assert_lifecycle(
         payload, test_project_root=project, fr_id="FR-006/FR-007 (next advance)"
     )
 
-    # FR-011/FR-012 / #843: lifecycle records at
-    # `.kittify/events/profile-invocation-lifecycle.jsonl` (single
-    # JSONL file per WP05 contract — see
+    # FR-011/FR-012 / #843: lifecycle records at the canonical Op lifecycle
+    # JSONL file (see
     # `specify_cli.invocation.lifecycle.LIFECYCLE_LOG_RELATIVE_PATH`).
     # WP05 makes a `started` record a HARD requirement for any issued
     # public action.
-    lifecycle_path = (
-        project / ".kittify" / "events" / "profile-invocation-lifecycle.jsonl"
-    )
+    lifecycle_path = lifecycle_log_path(project)
     if not lifecycle_path.is_file():
         raise AssertionError(
             "WP05 / #843 / FR-011: "
-            "`.kittify/events/profile-invocation-lifecycle.jsonl` does not "
+            f"`{lifecycle_path.relative_to(project)}` does not "
             "exist after `next` issued an action. WP05 must write a "
             "`started` lifecycle record at issuance time. If this fires, "
             "the WP05 invocation lifecycle fix has regressed."

--- a/tests/integration/sparse_checkout/test_merge_refresh_and_invariant.py
+++ b/tests/integration/sparse_checkout/test_merge_refresh_and_invariant.py
@@ -18,6 +18,7 @@ verify the two git subprocess calls (``git reset --hard HEAD`` and
 
 from __future__ import annotations
 
+import contextlib
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -90,13 +91,15 @@ class TestPostMergeRefreshAndInvariant:
             if "reset" in cmd and "--hard" in cmd and "HEAD" in cmd:
                 call_log.append("hard_refresh")
                 return (0, "", "")
-            if "status" in cmd and "--porcelain" in cmd:
-                call_log.append("status_check")
-                # Clean working tree — no offending lines.
-                return (0, "", "")
             if "merge-base" in cmd:
                 return (0, "abc123\n", "")
             return (0, "", "")
+
+        def fake_raw_porcelain(repo_root):  # noqa: ANN001
+            call_log.append("status_check")
+            # Clean working tree — no offending lines. The post-merge invariant
+            # reads porcelain RAW via _raw_porcelain_status.
+            return (0, "")
 
         def fake_safe_commit(**kwargs):  # noqa: ANN001
             call_log.append("safe_commit")
@@ -105,7 +108,15 @@ class TestPostMergeRefreshAndInvariant:
         def fake_mark_wp_merged_done(*args, **kwargs):  # noqa: ANN001
             call_log.append("mark_done")
 
-        with (
+        stale_report = MagicMock()
+        stale_report.findings = []
+        gate_eval = MagicMock()
+        gate_eval.overall_pass = True
+        gate_eval.gates = []
+        policy = MagicMock()
+        policy.merge_gates = []
+
+        patches = [
             patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
             patch("specify_cli.cli.commands.merge.load_state", return_value=None),
             patch("specify_cli.cli.commands.merge.save_state"),
@@ -116,29 +127,20 @@ class TestPostMergeRefreshAndInvariant:
             patch("specify_cli.lanes.merge.merge_mission_to_target", return_value=mission_result),
             patch("specify_cli.cli.commands.merge._mark_wp_merged_done", side_effect=fake_mark_wp_merged_done),
             patch("specify_cli.cli.commands.merge.safe_commit", side_effect=fake_safe_commit),
-            patch("specify_cli.post_merge.stale_assertions.run_check") as mock_run_check,
-            patch("specify_cli.policy.merge_gates.evaluate_merge_gates") as mock_gates,
-            patch("specify_cli.policy.config.load_policy_config") as mock_policy,
+            patch("specify_cli.post_merge.stale_assertions.run_check", return_value=stale_report),
+            patch("specify_cli.policy.merge_gates.evaluate_merge_gates", return_value=gate_eval),
+            patch("specify_cli.policy.config.load_policy_config", return_value=policy),
             patch("specify_cli.cli.commands.merge.run_command", side_effect=fake_run_command),
+            patch("specify_cli.cli.commands.merge._raw_porcelain_status", side_effect=fake_raw_porcelain),
             patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
             patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
             patch("specify_cli.cli.commands.merge.clear_state"),
             patch("specify_cli.merge.state.MergeState"),
             patch("specify_cli.cli.commands.merge._bake_mission_number_into_mission_branch"),
-        ):
-            stale_report = MagicMock()
-            stale_report.findings = []
-            mock_run_check.return_value = stale_report
-
-            gate_eval = MagicMock()
-            gate_eval.overall_pass = True
-            gate_eval.gates = []
-            mock_gates.return_value = gate_eval
-
-            policy = MagicMock()
-            policy.merge_gates = []
-            mock_policy.return_value = policy
-
+        ]
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             _run_lane_based_merge(
                 repo_root=tmp_path,
                 mission_slug=slug,
@@ -191,20 +193,31 @@ class TestPostMergeRefreshAndInvariant:
             if "reset" in cmd and "--hard" in cmd and "HEAD" in cmd:
                 call_log.append("hard_refresh")
                 return (0, "", "")
-            if "status" in cmd and "--porcelain" in cmd:
-                call_log.append("status_check")
-                # Simulate an offending diverging path that is NOT one of the
-                # two expected status files. This must trigger the invariant.
-                return (0, " M src/unexpected_file.py\n", "")
             if "merge-base" in cmd:
                 return (0, "abc123\n", "")
             return (0, "", "")
+
+        def fake_raw_porcelain(repo_root):  # noqa: ANN001
+            call_log.append("status_check")
+            # Simulate an offending diverging path that is NOT one of the two
+            # expected status files. This must trigger the invariant. The
+            # post-merge invariant reads porcelain RAW via _raw_porcelain_status
+            # so the leading status column is preserved.
+            return (0, " M src/unexpected_file.py\n")
 
         def fake_safe_commit(**kwargs):  # noqa: ANN001
             call_log.append("safe_commit")
             return True
 
-        with (
+        stale_report = MagicMock()
+        stale_report.findings = []
+        gate_eval = MagicMock()
+        gate_eval.overall_pass = True
+        gate_eval.gates = []
+        policy = MagicMock()
+        policy.merge_gates = []
+
+        patches = [
             patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
             patch("specify_cli.cli.commands.merge.load_state", return_value=None),
             patch("specify_cli.cli.commands.merge.save_state"),
@@ -215,29 +228,20 @@ class TestPostMergeRefreshAndInvariant:
             patch("specify_cli.lanes.merge.merge_mission_to_target", return_value=mission_result),
             patch("specify_cli.cli.commands.merge._mark_wp_merged_done"),
             patch("specify_cli.cli.commands.merge.safe_commit", side_effect=fake_safe_commit),
-            patch("specify_cli.post_merge.stale_assertions.run_check") as mock_run_check,
-            patch("specify_cli.policy.merge_gates.evaluate_merge_gates") as mock_gates,
-            patch("specify_cli.policy.config.load_policy_config") as mock_policy,
+            patch("specify_cli.post_merge.stale_assertions.run_check", return_value=stale_report),
+            patch("specify_cli.policy.merge_gates.evaluate_merge_gates", return_value=gate_eval),
+            patch("specify_cli.policy.config.load_policy_config", return_value=policy),
             patch("specify_cli.cli.commands.merge.run_command", side_effect=fake_run_command),
+            patch("specify_cli.cli.commands.merge._raw_porcelain_status", side_effect=fake_raw_porcelain),
             patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
             patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
             patch("specify_cli.cli.commands.merge.clear_state"),
             patch("specify_cli.merge.state.MergeState"),
             patch("specify_cli.cli.commands.merge._bake_mission_number_into_mission_branch"),
-        ):
-            stale_report = MagicMock()
-            stale_report.findings = []
-            mock_run_check.return_value = stale_report
-
-            gate_eval = MagicMock()
-            gate_eval.overall_pass = True
-            gate_eval.gates = []
-            mock_gates.return_value = gate_eval
-
-            policy = MagicMock()
-            policy.merge_gates = []
-            mock_policy.return_value = policy
-
+        ]
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             with pytest.raises(typer.Exit):
                 _run_lane_based_merge(
                     repo_root=tmp_path,

--- a/tests/integration/test_documentation_runtime_walk.py
+++ b/tests/integration/test_documentation_runtime_walk.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import pytest
 
+from specify_cli.invocation.writer import EVENTS_DIR
 from specify_cli.next._internal_runtime.engine import _read_snapshot
 from specify_cli.next.runtime_bridge import (
     _check_composed_action_guard,
@@ -43,6 +44,23 @@ from specify_cli.next.runtime_bridge import (
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+
+_NON_INVOCATION_OP_FILES = {
+    "lifecycle.jsonl",
+    "ops-index.jsonl",
+    "propagation-errors.jsonl",
+}
+
+
+def _invocation_trail_files(repo_root: Path) -> list[Path]:
+    invocations_dir = repo_root / EVENTS_DIR
+    return sorted(
+        path
+        for path in invocations_dir.glob("*.jsonl")
+        if path.name not in _NON_INVOCATION_OP_FILES
+    )
+
 
 def _init_min_repo(repo_root: Path) -> None:
     """Initialize a minimal git repo as the test mission's project root."""
@@ -298,8 +316,7 @@ def test_paired_invocation_lifecycle_is_recorded(isolated_repo: Path) -> None:
     """FR-011 + FR-012 + NFR-006: invocation trail records paired started/done.
 
     The composition dispatch routes through ``ProfileInvocationExecutor``
-    which writes JSONL records under
-    ``<repo>/.kittify/events/profile-invocations/<invocation_id>.jsonl``.
+    which writes JSONL records under the canonical Op storage directory.
     Each invocation must have a ``started`` line paired with a
     ``completed`` line whose outcome is ``done`` or ``failed``. The
     recorded ``action`` MUST stay within the documentation-native step
@@ -326,12 +343,12 @@ def test_paired_invocation_lifecycle_is_recorded(isolated_repo: Path) -> None:
         isolated_repo,
     )
 
-    invocations_dir = isolated_repo / ".kittify" / "events" / "profile-invocations"
+    invocations_dir = isolated_repo / EVENTS_DIR
     assert invocations_dir.is_dir(), (
         f"Invocations dir missing: {invocations_dir}. Composition dispatch "
         "did not produce a paired invocation trail."
     )
-    trail_files = sorted(invocations_dir.glob("*.jsonl"))
+    trail_files = _invocation_trail_files(isolated_repo)
     assert trail_files, (
         f"No invocation trail files written under {invocations_dir}. "
         "ProfileInvocationExecutor.invoke was not called from the composed "
@@ -578,7 +595,7 @@ def test_full_advancement_through_six_actions(isolated_repo: Path) -> None:
 
     After the loop finishes the test cross-checks the per-action paired
     invocation trail under
-    ``<repo>/.kittify/events/profile-invocations/`` (T10): every advancing
+    the canonical Op storage directory (T10): every advancing
     action MUST have at least one trail file containing a paired
     ``started`` + ``completed`` record whose ``action`` is the
     documentation-native verb. This is a stricter assertion than the
@@ -656,11 +673,9 @@ def test_full_advancement_through_six_actions(isolated_repo: Path) -> None:
     )
 
     # T10: every advancing action MUST have a paired started/completed
-    # trail record under .kittify/events/profile-invocations/ with the
+    # trail record under the canonical Op storage directory with the
     # documentation-native action name on the started event.
-    invocations_dir = (
-        isolated_repo / ".kittify" / "events" / "profile-invocations"
-    )
+    invocations_dir = isolated_repo / EVENTS_DIR
     assert invocations_dir.is_dir(), (
         f"Invocations dir missing: {invocations_dir}. Composition dispatch "
         "did not produce any paired invocation trails."
@@ -668,7 +683,7 @@ def test_full_advancement_through_six_actions(isolated_repo: Path) -> None:
 
     valid_outcomes = {"done", "failed"}
     paired_actions: set[str] = set()
-    for trail in sorted(invocations_dir.glob("*.jsonl")):
+    for trail in _invocation_trail_files(isolated_repo):
         events: list[dict[str, object]] = []
         for raw in trail.read_text(encoding="utf-8").splitlines():
             line = raw.strip()

--- a/tests/integration/test_merge_lane_planning_data_loss.py
+++ b/tests/integration/test_merge_lane_planning_data_loss.py
@@ -312,6 +312,12 @@ def _file_on_branch(repo: Path, branch: str, relpath: str) -> bool:
     return result.returncode == 0 and relpath in result.stdout.splitlines()
 
 
+def _rel_paths(paths: object, repo: Path) -> set[str]:
+    if paths is None:
+        return set()
+    return {str(Path(path).relative_to(repo)) for path in paths}  # type: ignore[arg-type]
+
+
 @contextlib.contextmanager
 def _real_merge_external_mocks(repo_root: Path):
     """Mock only the side effects that touch state OUTSIDE git.
@@ -358,7 +364,11 @@ def _real_merge_external_mocks(repo_root: Path):
         stale_report.findings = []
         ms[6].return_value = stale_report
         ms[7].return_value = stale_report
-        yield
+        yield {
+            "mark_done": ms[0],
+            "assert_done": ms[1],
+            "safe_commit": ms[2],
+        }
 
 
 class TestPlanningArtifactReachesTarget:
@@ -502,7 +512,7 @@ class TestPlanningArtifactReachesTarget:
         )
         assert missing_branch.returncode != 0
 
-        with _real_merge_external_mocks(tmp_path):
+        with _real_merge_external_mocks(tmp_path) as mocks:
             _run_lane_based_merge(
                 repo_root=tmp_path,
                 mission_slug=slug,
@@ -514,6 +524,21 @@ class TestPlanningArtifactReachesTarget:
             )
 
         assert _file_on_branch(tmp_path, "main", planning_relpath)
+        marked_wps = [call.args[2] for call in mocks["mark_done"].call_args_list]
+        assert marked_wps == ["WP01", "WP02"]
+        mocks["assert_done"].assert_called_once()
+        assert set(mocks["assert_done"].call_args.args[2]) == {"WP01", "WP02"}
+
+        meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert isinstance(meta.get("mission_number"), int)
+        assert meta.get("baseline_merge_commit")
+
+        committed_paths: set[str] = set()
+        for call in mocks["safe_commit"].call_args_list:
+            committed_paths.update(_rel_paths(call.kwargs.get("paths"), tmp_path))
+        assert f"kitty-specs/{slug}/meta.json" in committed_paths
+        assert f"kitty-specs/{slug}/status.events.jsonl" in committed_paths
+        assert f"kitty-specs/{slug}/status.json" in committed_paths
 
     def test_planning_artifact_on_phantom_lane_branch_is_NOT_reached(
         self, tmp_path: Path

--- a/tests/integration/test_merge_lane_planning_data_loss.py
+++ b/tests/integration/test_merge_lane_planning_data_loss.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 
 from specify_cli.cli.commands.merge import _run_lane_based_merge
 from specify_cli.lanes.models import ExecutionLane, LanesManifest
@@ -374,24 +375,28 @@ def _real_merge_external_mocks(repo_root: Path):
 @contextlib.contextmanager
 def _real_invariant_external_mocks(repo_root: Path):
     """Like :func:`_real_merge_external_mocks` but runs the REAL post-merge
-    working-tree invariant (``_classify_porcelain_lines`` is NOT mocked).
+    working-tree invariant (``_classify_porcelain_lines`` is NOT mocked) AND
+    the REAL raw porcelain read.
 
-    This is the F2 regression surface: it proves the post-merge working-tree
-    invariant tolerates the ``meta.json`` dirtied by planning-only
-    mission_number assignment.  ``safe_commit`` stays mocked so we can inspect
-    the committed path set without driving a real commit onto the (protected)
-    target branch.
+    This is the F2 / porcelain-hole regression surface. It proves two things:
+
+    1. The post-merge working-tree invariant tolerates the ``meta.json`` dirtied
+       by planning-only mission_number assignment when it is in ``expected_paths``
+       (F2) — and that this tolerance is genuinely load-bearing now that the
+       invariant reads RAW porcelain (``meta.json`` sorts first inside
+       ``kitty-specs/<slug>/`` and its intact ``" M ..."`` line is classifiable).
+    2. An UNEXPECTED divergent tracked file that sorts FIRST is caught — the
+       raw-porcelain read no longer silently drops the first line.
+
+    ``safe_commit`` stays mocked so we can inspect the committed path set without
+    driving a real commit onto the (protected) target branch.
 
     ``_refresh_primary_checkout_after_merge`` is mocked to a no-op so a
-    deliberately-dirtied tracked sentinel file survives to the invariant.  This
-    matters because :func:`specify_cli.core.git_ops.run_command` strips the
-    ``git status --porcelain`` output, which removes the leading status
-    column of the *first* porcelain line only.  ``meta.json`` sorts first inside
-    ``kitty-specs/<slug>/``, so without an earlier-sorting dirty entry its
-    ``" M ..."`` line would be stripped to ``"M ..."`` and skipped as malformed
-    by ``_classify_porcelain_lines`` -- masking the very defect under test.  A
-    sentinel that sorts before ``meta.json`` keeps ``meta.json``'s line
-    well-formed so the invariant genuinely classifies it.
+    deliberately-dirtied tracked file survives to the invariant.  The invariant
+    now reads ``git status --porcelain`` via a RAW capture (not via
+    :func:`specify_cli.core.git_ops.run_command`, whose whole-output ``.strip()``
+    would remove the leading status column of the *first* porcelain line only),
+    so the first dirty line — whatever sorts first — is classified correctly.
     """
     patches = [
         patch("specify_cli.cli.commands.merge._mark_wp_merged_done"),
@@ -432,6 +437,55 @@ def _real_invariant_external_mocks(repo_root: Path):
         }
 
 
+def _bootstrap_legacy_planning_only_mission(
+    repo: Path, slug: str, *, baseline_merge_commit: str | None = "0" * 40
+) -> Path:
+    """Bootstrap a LEGACY planning-only mission (meta.json WITHOUT mission_id).
+
+    ``mission_number`` is null (needs assignment) and, by default, a
+    ``baseline_merge_commit`` is already present so ``_record_baseline_merge_commit``
+    returns ``None`` (legacy mission) — the exact pre-conditions under which
+    ``meta.json`` is dirtied by ``_assign_planning_only_mission_number_if_needed``
+    and reaches the post-merge invariant. Returns the feature_dir.
+    """
+    feature_dir = repo / "kitty-specs" / slug
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks").mkdir(parents=True)
+
+    meta: dict[str, object] = {
+        "mission_slug": slug,
+        "mission_number": None,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "purpose_tldr": "legacy planning-only invariant pin",
+        "purpose_context": "post-merge invariant must classify the dirtied meta.json",
+    }
+    if baseline_merge_commit is not None:
+        meta["baseline_merge_commit"] = baseline_merge_commit
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    _write_lanes_manifest(
+        feature_dir,
+        slug,
+        code_wp_ids=[],
+        planning_wp_ids=["WP01"],
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", f"chore({slug}): bootstrap legacy planning mission")
+
+    planning_relpath = f"kitty-specs/{slug}/research/decision-A.md"
+    _commit_file(
+        repo,
+        branch="main",
+        relpath=planning_relpath,
+        content="# Decision A\n\nPlanning artifact body.\n",
+        message=f"plan({slug}): commit planning artifact on target",
+    )
+    return feature_dir
+
+
 class TestLegacyPlanningOnlyMetaInvariant:
     """F2: a LEGACY planning-only mission (meta.json WITHOUT mission_id) that
     needs a mission_number assigned must NOT trip the real post-merge
@@ -444,6 +498,13 @@ class TestLegacyPlanningOnlyMetaInvariant:
     a pre-existing baseline), and ``meta.json`` is classified by the real
     post-merge invariant, the dirtied ``meta.json`` becomes an offending line →
     ``typer.Exit(1)``, failing the merge.
+
+    This is the REAL scenario: ``meta.json`` sorts FIRST in the dirty set inside
+    ``kitty-specs/<slug>/`` and — because the invariant now reads RAW porcelain —
+    its intact ``" M ..."`` line is genuinely classifiable. The F2 fix
+    (``meta.json`` ∈ ``expected_paths``) is therefore load-bearing rather than
+    synthetic: the load-bearing variant below proves that without that
+    membership the invariant flags ``meta.json`` and fails the merge.
     """
 
     def test_legacy_planning_only_meta_json_does_not_trip_invariant(
@@ -451,62 +512,12 @@ class TestLegacyPlanningOnlyMetaInvariant:
     ) -> None:
         slug = "legacy-planning-only-meta-invariant"
         _init_git_repo(tmp_path)
-
-        feature_dir = tmp_path / "kitty-specs" / slug
-        feature_dir.mkdir(parents=True)
-        (feature_dir / "tasks").mkdir(parents=True)
-
-        # LEGACY mission: meta.json WITHOUT mission_id, mission_number null
-        # (needs assignment), and a baseline_merge_commit already present so
-        # _record_baseline_merge_commit returns None — the exact trigger for
-        # the F2 defect.
-        meta = {
-            "mission_slug": slug,
-            "mission_number": None,
-            "mission_type": "software-dev",
-            "target_branch": "main",
-            "baseline_merge_commit": "0" * 40,
-            "purpose_tldr": "F2 legacy planning-only meta invariant pin",
-            "purpose_context": "post-merge invariant must tolerate dirtied meta.json",
-        }
-        (feature_dir / "meta.json").write_text(
-            json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
-
-        # Sentinel tracked file that sorts BEFORE meta.json inside the mission
-        # dir ("a" < "m"). Dirtied at fixture time and kept dirty because the
-        # primary-checkout refresh is mocked to a no-op for this test — this
-        # ensures meta.json is NOT the first porcelain line (so run_command's
-        # .strip() does not mask meta.json's status column). See the context
-        # manager docstring for the full rationale.
-        sentinel_rel = f"kitty-specs/{slug}/aaa-sentinel.md"
-        (feature_dir / "aaa-sentinel.md").write_text("sentinel v1\n", encoding="utf-8")
-
-        _write_lanes_manifest(
-            feature_dir,
-            slug,
-            code_wp_ids=[],
-            planning_wp_ids=["WP01"],
-        )
-        _git(tmp_path, "add", ".")
-        _git(tmp_path, "commit", "-m", f"chore({slug}): bootstrap legacy planning mission")
-
-        planning_relpath = f"kitty-specs/{slug}/research/decision-A.md"
-        _commit_file(
-            tmp_path,
-            branch="main",
-            relpath=planning_relpath,
-            content="# Decision A\n\nPlanning artifact body.\n",
-            message=f"plan({slug}): commit planning artifact on target",
-        )
-
-        # Dirty the sentinel (tracked modification) so it precedes meta.json
-        # in `git status --porcelain` output.
-        (feature_dir / "aaa-sentinel.md").write_text("sentinel v2\n", encoding="utf-8")
+        feature_dir = _bootstrap_legacy_planning_only_mission(tmp_path, slug)
 
         with _real_invariant_external_mocks(tmp_path) as mocks:
-            # Must NOT raise typer.Exit — the real post-merge invariant runs and
-            # must tolerate the dirtied meta.json (the F2 fix).
+            # Must NOT raise typer.Exit — the real post-merge invariant runs
+            # against RAW porcelain and must tolerate the dirtied meta.json
+            # (the F2 fix: meta.json ∈ expected_paths).
             _run_lane_based_merge(
                 repo_root=tmp_path,
                 mission_slug=slug,
@@ -518,7 +529,7 @@ class TestLegacyPlanningOnlyMetaInvariant:
             )
 
         # mission_number was assigned (dirtying meta.json), confirming the
-        # invariant ran against a genuinely-dirty meta.json.
+        # invariant ran against a genuinely-dirty meta.json that sorts first.
         post_meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
         assert isinstance(post_meta.get("mission_number"), int), (
             "fixture precondition: mission_number must have been assigned so "
@@ -534,9 +545,114 @@ class TestLegacyPlanningOnlyMetaInvariant:
             "F2 regression: planning-only mission_number meta.json was not "
             "committed after merge."
         )
-        # Sanity: the sentinel was the vehicle for a well-formed meta.json
-        # porcelain line; it is not part of the committed bookkeeping set.
-        assert sentinel_rel not in committed_paths
+
+    def test_meta_json_membership_is_load_bearing(self, tmp_path: Path) -> None:
+        """Prove the F2 fix is load-bearing: if ``meta.json`` were NOT in
+        ``expected_paths``, the real invariant (reading RAW porcelain) flags the
+        dirtied ``meta.json`` first line and fails the merge with ``typer.Exit``.
+
+        We simulate the pre-fix state by patching ``_classify_porcelain_lines``
+        to receive an ``expected_paths`` set with the mission_number meta.json
+        path stripped out — i.e. exactly the membership the F2 fix adds. The
+        real raw-porcelain read still runs, so this proves that meta.json's
+        intact ``" M ..."`` line genuinely reaches classification.
+        """
+        import specify_cli.cli.commands.merge as merge_mod
+
+        slug = "legacy-planning-only-meta-loadbearing"
+        _init_git_repo(tmp_path)
+        feature_dir = _bootstrap_legacy_planning_only_mission(tmp_path, slug)
+        meta_rel = f"kitty-specs/{slug}/meta.json"
+
+        real_classify = merge_mod._classify_porcelain_lines
+
+        def classify_without_meta_membership(
+            lines: list[str], expected_paths: set[str]
+        ) -> tuple[list[str], int]:
+            # Drop the F2 membership to recreate the pre-fix expected_paths.
+            return real_classify(lines, expected_paths - {meta_rel})
+
+        with (
+            _real_invariant_external_mocks(tmp_path),
+            patch.object(
+                merge_mod,
+                "_classify_porcelain_lines",
+                side_effect=classify_without_meta_membership,
+            ),
+            pytest.raises(typer.Exit),
+        ):
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+
+        # The dirtied meta.json was genuinely the file that tripped the
+        # invariant (its intact " M " line reached classification).
+        post_meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert isinstance(post_meta.get("mission_number"), int)
+
+
+class TestPostMergePorcelainHole:
+    """Porcelain-hole regression: an UNEXPECTED divergent tracked file that
+    sorts FIRST must be CAUGHT by the post-merge working-tree invariant.
+
+    Pre-fix the invariant read porcelain via ``run_command`` whose whole-output
+    ``.strip()`` removed the leading status column of the FIRST line, so the
+    first divergent path was silently dropped by ``_classify_porcelain_lines``
+    (``len(line) < 4 or line[2] != " "``) and the invariant did NOT raise.
+
+    This test drives the REAL invariant with REAL porcelain — neither the
+    porcelain read nor ``_classify_porcelain_lines`` is mocked. After the
+    raw-read fix the first line survives intact and the invariant raises
+    ``typer.Exit``.
+    """
+
+    def test_unexpected_first_sorting_tracked_file_is_caught(
+        self, tmp_path: Path
+    ) -> None:
+        slug = "post-merge-porcelain-hole"
+        _init_git_repo(tmp_path)
+        _bootstrap_legacy_planning_only_mission(tmp_path, slug)
+
+        # An UNEXPECTED tracked file that sorts FIRST inside kitty-specs/<slug>/
+        # ("aaa-..." < "meta.json"). It is committed (tracked) and then dirtied
+        # so it diverges from HEAD. It is NOT in expected_paths, so the invariant
+        # MUST flag it — but ONLY if its first porcelain line is read intact.
+        unexpected_rel = f"kitty-specs/{slug}/aaa-unexpected.md"
+        _commit_file(
+            tmp_path,
+            branch="main",
+            relpath=unexpected_rel,
+            content="unexpected v1\n",
+            message=f"chore({slug}): add unexpected tracked file",
+        )
+        (tmp_path / unexpected_rel).write_text("unexpected v2\n", encoding="utf-8")
+
+        with _real_invariant_external_mocks(tmp_path), pytest.raises(typer.Exit):
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+
+        # Sanity: the unexpected file is genuinely dirty (it diverges from HEAD),
+        # proving the invariant raised because it classified this first line.
+        status = subprocess.run(
+            ["git", "-C", str(tmp_path), "status", "--porcelain", "--", unexpected_rel],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert unexpected_rel in status.stdout
 
 
 def _write_wp_file(feature_dir: Path, wp_id: str, *, agent: str = "researcher-ryan") -> None:

--- a/tests/integration/test_merge_lane_planning_data_loss.py
+++ b/tests/integration/test_merge_lane_planning_data_loss.py
@@ -241,16 +241,18 @@ def _write_lanes_manifest(
     """Build a real LanesManifest with a code lane and a planning lane and write it to disk."""
     if mission_branch is None:
         mission_branch = f"kitty/mission-{slug}"
-    lanes: list[ExecutionLane] = [
-        ExecutionLane(
-            lane_id="lane-a",
-            wp_ids=tuple(code_wp_ids),
-            write_scope=("src/foo.py",),
-            predicted_surfaces=("code",),
-            depends_on_lanes=(),
-            parallel_group=0,
+    lanes: list[ExecutionLane] = []
+    if code_wp_ids:
+        lanes.append(
+            ExecutionLane(
+                lane_id="lane-a",
+                wp_ids=tuple(code_wp_ids),
+                write_scope=("src/foo.py",),
+                predicted_surfaces=("code",),
+                depends_on_lanes=(),
+                parallel_group=0,
+            )
         )
-    ]
     if planning_wp_ids:
         lanes.append(
             ExecutionLane(
@@ -461,6 +463,57 @@ class TestPlanningArtifactReachesTarget:
             f"present on main afterward.  This is the silent-data-loss case "
             f"FR-001 forbids."
         )
+
+    def test_planning_artifact_only_merge_does_not_require_mission_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """All-planning research missions close from the target branch without a mission branch."""
+        slug = "real-merge-planning-only-research"
+        _init_git_repo(tmp_path)
+
+        feature_dir = tmp_path / "kitty-specs" / slug
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "tasks").mkdir(parents=True)
+        _write_meta(feature_dir, slug)
+        _write_lanes_manifest(
+            feature_dir,
+            slug,
+            code_wp_ids=[],
+            planning_wp_ids=["WP01", "WP02"],
+        )
+        _git(tmp_path, "add", ".")
+        _git(tmp_path, "commit", "-m", f"chore({slug}): bootstrap planning mission fixture")
+
+        planning_relpath = f"kitty-specs/{slug}/research/decision-A.md"
+        _commit_file(
+            tmp_path,
+            branch="main",
+            relpath=planning_relpath,
+            content="# Decision A\n\nPlanning artifact body.\n",
+            message=f"plan({slug}): commit planning artifact on target",
+        )
+
+        mission_branch = f"kitty/mission-{slug}"
+        missing_branch = subprocess.run(
+            ["git", "-C", str(tmp_path), "rev-parse", "--verify", f"refs/heads/{mission_branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert missing_branch.returncode != 0
+
+        with _real_merge_external_mocks(tmp_path):
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+
+        assert _file_on_branch(tmp_path, "main", planning_relpath)
 
     def test_planning_artifact_on_phantom_lane_branch_is_NOT_reached(
         self, tmp_path: Path

--- a/tests/integration/test_merge_lane_planning_data_loss.py
+++ b/tests/integration/test_merge_lane_planning_data_loss.py
@@ -371,6 +371,357 @@ def _real_merge_external_mocks(repo_root: Path):
         }
 
 
+@contextlib.contextmanager
+def _real_invariant_external_mocks(repo_root: Path):
+    """Like :func:`_real_merge_external_mocks` but runs the REAL post-merge
+    working-tree invariant (``_classify_porcelain_lines`` is NOT mocked).
+
+    This is the F2 regression surface: it proves the post-merge working-tree
+    invariant tolerates the ``meta.json`` dirtied by planning-only
+    mission_number assignment.  ``safe_commit`` stays mocked so we can inspect
+    the committed path set without driving a real commit onto the (protected)
+    target branch.
+
+    ``_refresh_primary_checkout_after_merge`` is mocked to a no-op so a
+    deliberately-dirtied tracked sentinel file survives to the invariant.  This
+    matters because :func:`specify_cli.core.git_ops.run_command` strips the
+    ``git status --porcelain`` output, which removes the leading status
+    column of the *first* porcelain line only.  ``meta.json`` sorts first inside
+    ``kitty-specs/<slug>/``, so without an earlier-sorting dirty entry its
+    ``" M ..."`` line would be stripped to ``"M ..."`` and skipped as malformed
+    by ``_classify_porcelain_lines`` -- masking the very defect under test.  A
+    sentinel that sorts before ``meta.json`` keeps ``meta.json``'s line
+    well-formed so the invariant genuinely classifies it.
+    """
+    patches = [
+        patch("specify_cli.cli.commands.merge._mark_wp_merged_done"),
+        patch("specify_cli.cli.commands.merge._assert_merged_wps_reached_done"),
+        patch("specify_cli.cli.commands.merge.safe_commit"),
+        patch("specify_cli.cli.commands.merge.trigger_feature_dossier_sync_if_enabled"),
+        patch("specify_cli.cli.commands.merge.emit_mission_closed"),
+        patch("specify_cli.cli.commands.merge._emit_merge_diff_summary"),
+        patch("specify_cli.post_merge.stale_assertions.run_check"),
+        patch("specify_cli.cli.commands.merge.run_check"),
+        patch("specify_cli.cli.commands.merge.require_no_sparse_checkout"),
+        patch("specify_cli.cli.commands.merge._enforce_git_preflight"),
+        patch("specify_cli.policy.merge_gates.evaluate_merge_gates"),
+        patch("specify_cli.policy.config.load_policy_config"),
+        patch("specify_cli.cli.commands.merge._bake_mission_number_into_mission_branch", return_value=None),
+        patch("specify_cli.cli.commands.merge._refresh_primary_checkout_after_merge"),
+        # NOTE: _classify_porcelain_lines is intentionally NOT mocked here —
+        # the real post-merge working-tree invariant must run so the F2 fix
+        # (meta.json in expected_paths) is exercised.
+    ]
+    with contextlib.ExitStack() as stack:
+        ms = [stack.enter_context(p) for p in patches]
+        gate_eval = MagicMock()
+        gate_eval.overall_pass = True
+        gate_eval.gates = []
+        ms[10].return_value = gate_eval
+        policy = MagicMock()
+        policy.merge_gates = []
+        ms[11].return_value = policy
+        stale_report = MagicMock()
+        stale_report.findings = []
+        ms[6].return_value = stale_report
+        ms[7].return_value = stale_report
+        yield {
+            "mark_done": ms[0],
+            "assert_done": ms[1],
+            "safe_commit": ms[2],
+        }
+
+
+class TestLegacyPlanningOnlyMetaInvariant:
+    """F2: a LEGACY planning-only mission (meta.json WITHOUT mission_id) that
+    needs a mission_number assigned must NOT trip the real post-merge
+    working-tree invariant.
+
+    Defect: ``_assign_planning_only_mission_number_if_needed`` dirties
+    ``meta.json`` and returns its path into ``mission_number_meta_path``, which
+    is appended to ``files_to_commit`` but was NEVER added to ``expected_paths``.
+    When ``_record_baseline_merge_commit`` returns ``None`` (legacy mission with
+    a pre-existing baseline), and ``meta.json`` is classified by the real
+    post-merge invariant, the dirtied ``meta.json`` becomes an offending line →
+    ``typer.Exit(1)``, failing the merge.
+    """
+
+    def test_legacy_planning_only_meta_json_does_not_trip_invariant(
+        self, tmp_path: Path
+    ) -> None:
+        slug = "legacy-planning-only-meta-invariant"
+        _init_git_repo(tmp_path)
+
+        feature_dir = tmp_path / "kitty-specs" / slug
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "tasks").mkdir(parents=True)
+
+        # LEGACY mission: meta.json WITHOUT mission_id, mission_number null
+        # (needs assignment), and a baseline_merge_commit already present so
+        # _record_baseline_merge_commit returns None — the exact trigger for
+        # the F2 defect.
+        meta = {
+            "mission_slug": slug,
+            "mission_number": None,
+            "mission_type": "software-dev",
+            "target_branch": "main",
+            "baseline_merge_commit": "0" * 40,
+            "purpose_tldr": "F2 legacy planning-only meta invariant pin",
+            "purpose_context": "post-merge invariant must tolerate dirtied meta.json",
+        }
+        (feature_dir / "meta.json").write_text(
+            json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+        # Sentinel tracked file that sorts BEFORE meta.json inside the mission
+        # dir ("a" < "m"). Dirtied at fixture time and kept dirty because the
+        # primary-checkout refresh is mocked to a no-op for this test — this
+        # ensures meta.json is NOT the first porcelain line (so run_command's
+        # .strip() does not mask meta.json's status column). See the context
+        # manager docstring for the full rationale.
+        sentinel_rel = f"kitty-specs/{slug}/aaa-sentinel.md"
+        (feature_dir / "aaa-sentinel.md").write_text("sentinel v1\n", encoding="utf-8")
+
+        _write_lanes_manifest(
+            feature_dir,
+            slug,
+            code_wp_ids=[],
+            planning_wp_ids=["WP01"],
+        )
+        _git(tmp_path, "add", ".")
+        _git(tmp_path, "commit", "-m", f"chore({slug}): bootstrap legacy planning mission")
+
+        planning_relpath = f"kitty-specs/{slug}/research/decision-A.md"
+        _commit_file(
+            tmp_path,
+            branch="main",
+            relpath=planning_relpath,
+            content="# Decision A\n\nPlanning artifact body.\n",
+            message=f"plan({slug}): commit planning artifact on target",
+        )
+
+        # Dirty the sentinel (tracked modification) so it precedes meta.json
+        # in `git status --porcelain` output.
+        (feature_dir / "aaa-sentinel.md").write_text("sentinel v2\n", encoding="utf-8")
+
+        with _real_invariant_external_mocks(tmp_path) as mocks:
+            # Must NOT raise typer.Exit — the real post-merge invariant runs and
+            # must tolerate the dirtied meta.json (the F2 fix).
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+
+        # mission_number was assigned (dirtying meta.json), confirming the
+        # invariant ran against a genuinely-dirty meta.json.
+        post_meta = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+        assert isinstance(post_meta.get("mission_number"), int), (
+            "fixture precondition: mission_number must have been assigned so "
+            "meta.json is dirty when the invariant runs"
+        )
+
+        # The dirtied meta.json must be in the committed path set (F2 fix:
+        # it is added to both files_to_commit AND expected_paths).
+        committed_paths: set[str] = set()
+        for call in mocks["safe_commit"].call_args_list:
+            committed_paths.update(_rel_paths(call.kwargs.get("paths"), tmp_path))
+        assert f"kitty-specs/{slug}/meta.json" in committed_paths, (
+            "F2 regression: planning-only mission_number meta.json was not "
+            "committed after merge."
+        )
+        # Sanity: the sentinel was the vehicle for a well-formed meta.json
+        # porcelain line; it is not part of the committed bookkeeping set.
+        assert sentinel_rel not in committed_paths
+
+
+def _write_wp_file(feature_dir: Path, wp_id: str, *, agent: str = "researcher-ryan") -> None:
+    """Write a minimal WP prompt file with an ``agent`` so _mark_wp_merged_done
+    can synthesize done evidence from an approved lane state."""
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{wp_id}.md").write_text(
+        f"---\nwork_package_id: {wp_id}\ntitle: {wp_id} planning\n"
+        f"agent: {agent}\ndependencies: []\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_wp_approved(feature_dir: Path, mission_slug: str, wp_id: str) -> None:
+    """Drive a WP to ``approved`` via the real status-emit pipeline."""
+    from specify_cli.status.emit import emit_status_transition
+    from specify_cli.status.models import ReviewResult, TransitionRequest
+
+    for to_lane in ("claimed", "in_progress", "for_review", "in_review"):
+        emit_status_transition(
+            TransitionRequest(
+                feature_dir=feature_dir,
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                to_lane=to_lane,
+                actor="seed",
+            )
+        )
+    emit_status_transition(
+        TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug=mission_slug,
+            wp_id=wp_id,
+            to_lane="approved",
+            actor="seed",
+            evidence={
+                "review": {
+                    "reviewer": "reviewer-renata",
+                    "verdict": "approved",
+                    "reference": f"review-{wp_id}",
+                }
+            },
+            review_result=ReviewResult(
+                reviewer="reviewer-renata",
+                verdict="approved",
+                reference=f"review-{wp_id}",
+            ),
+        )
+    )
+
+
+@contextlib.contextmanager
+def _real_persistence_external_mocks(repo_root: Path):
+    """Mock only genuinely external side-effects (dossier sync, SaaS/mission-
+    closed emit, diff summary, stale-assertion network check) while running the
+    REAL ``_mark_wp_merged_done`` and ``_assert_merged_wps_reached_done`` so the
+    done-marking persistence is actually exercised.
+
+    ``safe_commit`` and the post-merge invariant (``_classify_porcelain_lines``)
+    are mocked: the done events are persisted to ``feature_dir/status.events.jsonl``
+    by the real status-emit pipeline *before* any commit, so persistence is
+    provable without driving a commit onto the protected target branch. The
+    real-invariant path is covered separately by
+    ``TestLegacyPlanningOnlyMetaInvariant`` (F2).
+    """
+    patches = [
+        patch("specify_cli.cli.commands.merge.safe_commit"),
+        patch("specify_cli.cli.commands.merge.trigger_feature_dossier_sync_if_enabled"),
+        patch("specify_cli.cli.commands.merge.emit_mission_closed"),
+        patch("specify_cli.cli.commands.merge._emit_merge_diff_summary"),
+        patch("specify_cli.post_merge.stale_assertions.run_check"),
+        patch("specify_cli.cli.commands.merge.run_check"),
+        patch("specify_cli.cli.commands.merge.require_no_sparse_checkout"),
+        patch("specify_cli.cli.commands.merge._enforce_git_preflight"),
+        patch("specify_cli.policy.merge_gates.evaluate_merge_gates"),
+        patch("specify_cli.policy.config.load_policy_config"),
+        patch("specify_cli.cli.commands.merge._bake_mission_number_into_mission_branch", return_value=None),
+        patch("specify_cli.cli.commands.merge._classify_porcelain_lines", return_value=([], 0)),
+        # NOTE: _mark_wp_merged_done and _assert_merged_wps_reached_done are
+        # intentionally NOT mocked — the real done-marking persistence runs.
+    ]
+    with contextlib.ExitStack() as stack:
+        ms = [stack.enter_context(p) for p in patches]
+        gate_eval = MagicMock()
+        gate_eval.overall_pass = True
+        gate_eval.gates = []
+        ms[8].return_value = gate_eval
+        policy = MagicMock()
+        policy.merge_gates = []
+        ms[9].return_value = policy
+        stale_report = MagicMock()
+        stale_report.findings = []
+        ms[4].return_value = stale_report
+        ms[5].return_value = stale_report
+        yield {"safe_commit": ms[0]}
+
+
+class TestPlanningOnlyDoneMarkingPersists:
+    """F1: planning-only closeout must REALLY mark each WP done and persist the
+    transition, not just call mocked side-effects.
+
+    The previous planning-only merge test mocked ``_mark_wp_merged_done`` /
+    ``_assert_merged_wps_reached_done`` and only asserted they were called — the
+    "WP reaches done and persists" guarantee was unproven. This test runs the
+    real done-marking pipeline and reads the persisted events back.
+
+    NOTE: the fixture leaves ``coordination_branch`` ABSENT (the primary-checkout
+    surface). The ``coordination_branch``-set variant is deliberately deferred to
+    https://github.com/Priivacy-ai/spec-kitty/issues/1726.
+    """
+
+    def test_planning_only_done_events_are_persisted_and_readable(
+        self, tmp_path: Path
+    ) -> None:
+        from specify_cli.status.models import Lane
+        from specify_cli.status.reducer import reduce
+        from specify_cli.status.store import read_events
+
+        slug = "real-merge-planning-only-done-persist"
+        _init_git_repo(tmp_path)
+
+        feature_dir = tmp_path / "kitty-specs" / slug
+        feature_dir.mkdir(parents=True)
+        _write_meta(feature_dir, slug)
+        _write_lanes_manifest(
+            feature_dir,
+            slug,
+            code_wp_ids=[],
+            planning_wp_ids=["WP01", "WP02"],
+        )
+        for wp_id in ("WP01", "WP02"):
+            _write_wp_file(feature_dir, wp_id)
+            _seed_wp_approved(feature_dir, slug, wp_id)
+
+        # Pre-condition: WPs are approved (not yet done) in the persisted log.
+        pre = reduce(read_events(feature_dir))
+        assert pre.work_packages["WP01"]["lane"] == Lane.APPROVED.value
+        assert pre.work_packages["WP02"]["lane"] == Lane.APPROVED.value
+        # coordination_branch must be absent for this primary-checkout case.
+        assert "coordination_branch" not in json.loads(
+            (feature_dir / "meta.json").read_text(encoding="utf-8")
+        )
+
+        _git(tmp_path, "add", ".")
+        _git(tmp_path, "commit", "-m", f"chore({slug}): bootstrap approved planning mission")
+
+        planning_relpath = f"kitty-specs/{slug}/research/decision-A.md"
+        _commit_file(
+            tmp_path,
+            branch="main",
+            relpath=planning_relpath,
+            content="# Decision A\n\nPlanning artifact body.\n",
+            message=f"plan({slug}): commit planning artifact on target",
+        )
+
+        with _real_persistence_external_mocks(tmp_path):
+            _run_lane_based_merge(
+                repo_root=tmp_path,
+                mission_slug=slug,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+
+        # The real done-marking pipeline must have persisted a done transition
+        # for every WP, readable back from the canonical event log.
+        post = reduce(read_events(feature_dir))
+        assert post.work_packages["WP01"]["lane"] == Lane.DONE.value, (
+            "F1 regression: WP01 did not reach done in the persisted event log."
+        )
+        assert post.work_packages["WP02"]["lane"] == Lane.DONE.value, (
+            "F1 regression: WP02 did not reach done in the persisted event log."
+        )
+        # And the done transitions are concretely present in the JSONL log.
+        done_events = [e for e in read_events(feature_dir) if e.to_lane == Lane.DONE]
+        done_wps = {e.wp_id for e in done_events}
+        assert done_wps == {"WP01", "WP02"}, (
+            f"F1 regression: expected persisted done transitions for WP01/WP02, "
+            f"got {done_wps!r}."
+        )
+
+
 class TestPlanningArtifactReachesTarget:
     """FR-001 load-bearing: planning-artifact files MUST end up on the target
     branch after ``_run_lane_based_merge`` runs against real git.
@@ -477,7 +828,18 @@ class TestPlanningArtifactReachesTarget:
     def test_planning_artifact_only_merge_does_not_require_mission_branch(
         self, tmp_path: Path
     ) -> None:
-        """All-planning research missions close from the target branch without a mission branch."""
+        """All-planning research missions close from the target branch without a mission branch.
+
+        This test pins the call-contract (mark-done invoked per WP, assert-done
+        invoked once) by mocking the persistence helpers. The *persistence*
+        guarantee — that the done transition is actually written and readable
+        back — is proven separately by
+        ``TestPlanningOnlyDoneMarkingPersists`` (F1), which runs the real
+        ``_mark_wp_merged_done`` / ``_assert_merged_wps_reached_done`` for the
+        primary-checkout (``coordination_branch``-absent) surface. The
+        ``coordination_branch``-set variant is deferred to
+        https://github.com/Priivacy-ai/spec-kitty/issues/1726.
+        """
         slug = "real-merge-planning-only-research"
         _init_git_repo(tmp_path)
 

--- a/tests/integration/test_post_merge_unrelated_untracked.py
+++ b/tests/integration/test_post_merge_unrelated_untracked.py
@@ -145,6 +145,12 @@ class TestMergeToleratesUntrackedFiles:
                 return (0, "?? .worktrees/scratch/\n?? tmp.txt\n", "")
             return (0, "", "")
 
+        # The post-merge invariant reads porcelain RAW (not via run_command,
+        # whose whole-output .strip() would corrupt the first line). Inject the
+        # raw stdout the invariant classifies via _raw_porcelain_status.
+        def fake_raw_porcelain(repo_root):  # noqa: ANN001
+            return (0, "?? .worktrees/scratch/\n?? tmp.txt\n")
+
         patches = [
             patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
             patch("specify_cli.cli.commands.merge.load_state", return_value=None),
@@ -160,6 +166,7 @@ class TestMergeToleratesUntrackedFiles:
             patch("specify_cli.policy.merge_gates.evaluate_merge_gates"),
             patch("specify_cli.policy.config.load_policy_config"),
             patch("specify_cli.cli.commands.merge.run_command", side_effect=fake_run_command),
+            patch("specify_cli.cli.commands.merge._raw_porcelain_status", side_effect=fake_raw_porcelain),
             patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
             patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
             patch("specify_cli.cli.commands.merge.clear_state"),
@@ -220,6 +227,12 @@ class TestMergeToleratesUntrackedFiles:
                 return (0, "?? .worktrees/\n M src/operator_change.py\n", "")
             return (0, "", "")
 
+        # The post-merge invariant reads porcelain RAW (not via run_command).
+        # Inject the same mixed status via _raw_porcelain_status so the tracked
+        # modification reaches classification and trips the invariant.
+        def fake_raw_porcelain(repo_root):  # noqa: ANN001
+            return (0, "?? .worktrees/\n M src/operator_change.py\n")
+
         patches = [
             patch("specify_cli.cli.commands.merge.require_lanes_json", return_value=manifest),
             patch("specify_cli.cli.commands.merge.load_state", return_value=None),
@@ -235,6 +248,7 @@ class TestMergeToleratesUntrackedFiles:
             patch("specify_cli.policy.merge_gates.evaluate_merge_gates"),
             patch("specify_cli.policy.config.load_policy_config"),
             patch("specify_cli.cli.commands.merge.run_command", side_effect=fake_run_command),
+            patch("specify_cli.cli.commands.merge._raw_porcelain_status", side_effect=fake_raw_porcelain),
             patch("specify_cli.cli.commands.merge.has_remote", return_value=False),
             patch("specify_cli.cli.commands.merge.cleanup_merge_workspace"),
             patch("specify_cli.cli.commands.merge.clear_state"),

--- a/tests/integration/test_research_runtime_walk.py
+++ b/tests/integration/test_research_runtime_walk.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import pytest
 
+from specify_cli.invocation.writer import EVENTS_DIR
 from specify_cli.next._internal_runtime.engine import _read_snapshot
 from specify_cli.next.runtime_bridge import (
     _check_composed_action_guard,
@@ -42,6 +43,23 @@ from specify_cli.next.runtime_bridge import (
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+
+_NON_INVOCATION_OP_FILES = {
+    "lifecycle.jsonl",
+    "ops-index.jsonl",
+    "propagation-errors.jsonl",
+}
+
+
+def _invocation_trail_files(repo_root: Path) -> list[Path]:
+    invocations_dir = repo_root / EVENTS_DIR
+    return sorted(
+        path
+        for path in invocations_dir.glob("*.jsonl")
+        if path.name not in _NON_INVOCATION_OP_FILES
+    )
+
 
 def _init_min_repo(repo_root: Path) -> None:
     """Initialize a minimal git repo as the test mission's project root."""
@@ -157,8 +175,8 @@ def test_research_advances_one_composed_step(isolated_repo: Path) -> None:
       ``"plan"``. This proves the composed dispatch fired for the
       research mission and the planner moved through the research DAG.
     * (c) The invocation trail under
-      ``.kittify/events/profile-invocations/`` contains paired started +
-      completed lifecycle records (asserted in
+      the canonical Op storage directory contains paired started + completed
+      lifecycle records (asserted in
       :func:`test_paired_invocation_lifecycle_recorded`).
     * (d) No legacy ``runtime_next_step`` was re-entered for the
       composed scoping action — implicitly proven because the snapshot
@@ -228,8 +246,7 @@ def test_paired_invocation_lifecycle_recorded(isolated_repo: Path) -> None:
     """Each composed invocation writes paired started + completed records.
 
     The composition dispatch routes through ``ProfileInvocationExecutor``
-    which writes JSONL records under
-    ``<repo>/.kittify/events/profile-invocations/<invocation_id>.jsonl``.
+    which writes JSONL records under the canonical Op storage directory.
     Each invocation must have at least one ``started`` line; the test also
     confirms recorded ``action`` values stay within the research-native
     step IDs (no software-dev verbs leaking through).
@@ -254,12 +271,12 @@ def test_paired_invocation_lifecycle_recorded(isolated_repo: Path) -> None:
         isolated_repo,
     )
 
-    invocations_dir = isolated_repo / ".kittify" / "events" / "profile-invocations"
+    invocations_dir = isolated_repo / EVENTS_DIR
     assert invocations_dir.is_dir(), (
         f"Invocations dir missing: {invocations_dir}. Composition dispatch "
         "did not produce a paired invocation trail."
     )
-    trail_files = sorted(invocations_dir.glob("*.jsonl"))
+    trail_files = _invocation_trail_files(isolated_repo)
     assert trail_files, (
         f"No invocation trail files written under {invocations_dir}. "
         "ProfileInvocationExecutor.invoke was not called from the composed "

--- a/tests/lanes/test_planning_lane_predicate.py
+++ b/tests/lanes/test_planning_lane_predicate.py
@@ -1,0 +1,55 @@
+"""Unit tests for the single planning-lane classifier seam.
+
+These pin the shared predicates ``is_planning_lane`` / ``is_planning_artifact_only``
+in :mod:`specify_cli.lanes.compute`. They are the one place lane classification
+lives so the backing of "what counts as a planning lane" can later be swapped to a
+charter / mission-type-derived surface (#1666) as a localized change.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from specify_cli.lanes.compute import (
+    PLANNING_LANE_ID,
+    is_planning_artifact_only,
+    is_planning_lane,
+)
+
+
+def _lane(lane_id: str | None) -> SimpleNamespace:
+    return SimpleNamespace(lane_id=lane_id)
+
+
+def _manifest(*lane_ids: str | None) -> SimpleNamespace:
+    return SimpleNamespace(lanes=[_lane(lid) for lid in lane_ids])
+
+
+class TestIsPlanningLane:
+    def test_planning_lane_id_is_planning(self) -> None:
+        assert is_planning_lane(_lane(PLANNING_LANE_ID)) is True
+
+    def test_code_lane_is_not_planning(self) -> None:
+        assert is_planning_lane(_lane("lane-a")) is False
+
+    def test_missing_lane_id_is_not_planning(self) -> None:
+        assert is_planning_lane(_lane(None)) is False
+        assert is_planning_lane(SimpleNamespace()) is False
+
+
+class TestIsPlanningArtifactOnly:
+    def test_planning_only_manifest_is_true(self) -> None:
+        assert is_planning_artifact_only(_manifest(PLANNING_LANE_ID)) is True
+
+    def test_mixed_planning_and_code_is_false(self) -> None:
+        assert is_planning_artifact_only(_manifest(PLANNING_LANE_ID, "lane-a")) is False
+
+    def test_code_only_manifest_is_false(self) -> None:
+        assert is_planning_artifact_only(_manifest("lane-a", "lane-b")) is False
+
+    def test_empty_lanes_is_false(self) -> None:
+        assert is_planning_artifact_only(_manifest()) is False
+        assert is_planning_artifact_only(SimpleNamespace(lanes=None)) is False
+
+    def test_missing_lane_id_is_false(self) -> None:
+        assert is_planning_artifact_only(_manifest(None)) is False

--- a/tests/lanes/test_planning_lane_predicate.py
+++ b/tests/lanes/test_planning_lane_predicate.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from specify_cli.lanes.compute import (
     PLANNING_LANE_ID,
     is_planning_artifact_only,
     is_planning_lane,
 )
+
+pytestmark = pytest.mark.fast
 
 
 def _lane(lane_id: str | None) -> SimpleNamespace:

--- a/tests/specify_cli/invocation/test_executor.py
+++ b/tests/specify_cli/invocation/test_executor.py
@@ -19,7 +19,7 @@ from specify_cli.invocation.writer import EVENTS_DIR
 # Fixtures
 # ---------------------------------------------------------------------------
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "profiles"
 

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -481,6 +481,55 @@ def test_collect_feature_summary_allows_main_branch_for_lane_acceptance(tmp_path
     assert any("acceptance-matrix.json" in item for item in summary.recommended_fix_order)
 
 
+def test_collect_feature_summary_allows_planning_artifact_research_without_matrix(
+    tmp_path: Path,
+) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path, "research-planning-only")
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    (repo_root / ".kittify").mkdir(exist_ok=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    deliverables_path = "docs/research/research-planning-only/"
+    meta_path = feature_dir / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["mission_type"] = "research"
+    meta["mission"] = "research"
+    meta["deliverables_path"] = deliverables_path
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    for path_name in ("research", "data", "findings", "reports"):
+        directory = repo_root / deliverables_path / path_name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / ".gitkeep").write_text("", encoding="utf-8")
+
+    write_single_lane_manifest(
+        feature_dir,
+        wp_ids=("WP01",),
+        lane_id="lane-planning",
+        write_scope=(f"{deliverables_path}**",),
+        predicted_surfaces=("planning",),
+    )
+    subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", "Add planning research artifacts"],
+        check=True,
+        capture_output=True,
+    )
+
+    summary = collect_feature_summary(repo_root, "research-planning-only", mutate_matrix=False)
+
+    assert summary.ok is True
+    assert not any("Acceptance matrix" in issue for issue in summary.activity_issues)
+    assert not any(item.check == "acceptance_matrix" for item in summary.blocked_checks)
+    assert not summary.path_violations
+    assert any(
+        item.check == "acceptance_matrix_presence"
+        and "planning_artifact-only" in item.detail
+        for item in summary.skipped_checks
+    )
+
+
 def test_collect_feature_summary_blocks_unrelated_branch_for_lane_acceptance(tmp_path: Path) -> None:
     repo_root, feature_dir = _create_test_feature(tmp_path)
     subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Tuple
 
 import pytest
+import typer
+from typer.testing import CliRunner
 
 from specify_cli.acceptance import (
     AcceptanceError,
@@ -32,6 +34,7 @@ from specify_cli.acceptance import (
 from specify_cli.task_utils import LANES
 from specify_cli.status.models import Lane, StatusEvent
 from specify_cli.status.store import StoreError, append_event
+from specify_cli.cli.commands import accept as accept_module
 
 # Marked for mutmut sandbox skip — see ADR 2026-04-20-1.
 # Reason: subprocess CLI invocation
@@ -493,6 +496,7 @@ def test_collect_feature_summary_allows_planning_artifact_research_without_matri
     deliverables_path = "docs/research/research-planning-only/"
     meta_path = feature_dir / "meta.json"
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["mission_id"] = "01K00000000000000000000000"
     meta["mission_type"] = "research"
     meta["mission"] = "research"
     meta["deliverables_path"] = deliverables_path
@@ -528,6 +532,74 @@ def test_collect_feature_summary_allows_planning_artifact_research_without_matri
         and "planning_artifact-only" in item.detail
         for item in summary.skipped_checks
     )
+
+
+def test_accept_cli_no_commit_json_allows_planning_artifact_research_without_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root, feature_dir = _create_test_feature(tmp_path, "research-planning-only")
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "main"], check=True, capture_output=True)
+    (repo_root / ".kittify").mkdir(exist_ok=True)
+
+    from tests.lane_test_utils import write_single_lane_manifest
+
+    deliverables_path = "docs/research/research-planning-only/"
+    meta_path = feature_dir / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["mission_id"] = "01K00000000000000000000000"
+    meta["mission_type"] = "research"
+    meta["mission"] = "research"
+    meta["deliverables_path"] = deliverables_path
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    for path_name in ("research", "data", "findings", "reports"):
+        directory = repo_root / deliverables_path / path_name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / ".gitkeep").write_text("", encoding="utf-8")
+
+    write_single_lane_manifest(
+        feature_dir,
+        wp_ids=("WP01",),
+        lane_id="lane-planning",
+        write_scope=(f"{deliverables_path}**",),
+        predicted_surfaces=("planning",),
+    )
+    subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", "Add planning research artifacts"],
+        check=True,
+        capture_output=True,
+    )
+
+    cli = typer.Typer()
+    cli.command(name="accept")(accept_module.accept)
+    monkeypatch.setattr(accept_module, "find_repo_root", lambda: repo_root)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--mission",
+            "research-planning-only",
+            "--no-commit",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["summary"]["ok"] is True
+    assert not any(
+        item.get("check") == "acceptance_matrix"
+        for item in payload["summary"]["blocked_checks"]
+    )
+    assert any(
+        item.get("check") == "acceptance_matrix_presence"
+        and "planning_artifact-only" in item.get("detail", "")
+        for item in payload["summary"]["skipped_checks"]
+    )
+    assert not payload["summary"]["path_violations"]
 
 
 def test_collect_feature_summary_blocks_unrelated_branch_for_lane_acceptance(tmp_path: Path) -> None:

--- a/tests/specify_cli/test_doctrine_service_factory.py
+++ b/tests/specify_cli/test_doctrine_service_factory.py
@@ -19,6 +19,8 @@ from specify_cli.doctrine_service_factory import (
     build_activation_aware_doctrine_service,
 )
 
+pytestmark = [pytest.mark.doctrine]
+
 
 def _write_config(repo_root: Path, body: str) -> None:
     kittify = repo_root / ".kittify"

--- a/tests/status/test_agent_status_emit_aggregate_wiring.py
+++ b/tests/status/test_agent_status_emit_aggregate_wiring.py
@@ -23,7 +23,7 @@ from typer.testing import CliRunner
 
 from specify_cli.cli.commands.agent.status import app
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 runner = CliRunner()
 


### PR DESCRIPTION
## Summary

Finalizes the planning-artifact research closeout fix for #1686. This PR **supersedes #1723** by @lynncoleart — it preserves her original commits and fix verbatim at the base of the branch, then layers a reviewed scope increase on top (adversarial review under the `reviewer-renata` / `architect-alphonso` / `python-pedro` profiles, ATDD/TDD throughout).

Once this lands, **#1723 can be closed in favor of this PR**.

Closes #1686
Refs #1666 #1726 #1673 #1672

## What's preserved from #1723 (Lynn Cole)

The two base commits are unchanged and retain Lynn's authorship:
- `76cfbbd` `fix(merge): support planning artifact research closeout`
- `4f08468` `test: tighten planning research closeout qa`

Her fix lets research / planning-artifact-only missions accept and merge from the target branch: skip mission-branch baking, skip the acceptance-matrix requirement for planning-only lanes, route research deliverables under the correct path prefix, and repair the `get_deliverables_path` mission-type key-name bug.

## Scope increase (this PR, on top of Lynn's work)

Driven by an adversarial review that validated Lynn's point fix and surfaced four follow-ups:

**1. 🐞 `meta.json` excluded from the post-merge `expected_paths` (real, load-bearing).**
`_assign_planning_only_mission_number_if_needed` writes `meta.json` and adds it to `files_to_commit`, but it was missing from `expected_paths`, so the post-merge working-tree invariant could flag it. Now added (mirrors the `baseline_meta_path` branch).

**2. 🐞 Post-merge invariant was blind to its first divergent path (recurring porcelain-truncation class).**
`run_command` `.strip()`s the whole `git status --porcelain` output, dropping the leading status column of the *first* line; `_classify_porcelain_lines` then silently skipped it. Because `meta.json` sorts first in the planning-only dirty set, the invariant never actually saw it — which made #1 above only *appear* synthetic. Fixed with a contained raw-porcelain read at the invariant (no change to `run_command`'s global behavior). With the raw read, #1's `expected_paths` membership becomes genuinely load-bearing, and a new regression proves an unexpected first-sorting file is no longer silently skipped.

**3. 🧪 Real done-marking persistence.**
The planning-only merge test mocked `_mark_wp_merged_done` / `_assert_merged_wps_reached_done`. A strengthened test now runs them for real and asserts done events persist and read back (`reduce(read_events(...))` shows WPs at `done`). The `coordination_branch`-set surface variant is deliberately deferred to #1726.

**4. ♻️ Single forward-compatible planning-lane classifier seam.**
The duplicated `_is_planning_artifact_only_manifest` (one constant-based, one hardcoding `"lane-planning"`) is collapsed into one predicate pair (`is_planning_lane` / `is_planning_artifact_only`) in `lanes/compute.py`. All remaining raw `PLANNING_LANE_ID` / `"lane-planning"` classification sites across `merge.py`, `acceptance`, `workspace/context.py`, `implement.py`, `orchestrator_api/commands.py`, `lifecycle_sync.py`, and `mission_type.py` (incl. a dead `lanes.merge` import) are routed through the seam. The constant is now the single internal backing point, so when lanes become charter/mission-type-derived (#1666) the swap is localized — marked with `# TODO(#1666)`.

## Related tickets / evidence

The review also corroborated three of @kentonium3's follow-up observations as symptoms of the broader execution-state / surface-identity class (out of scope for a point fix):
- #1726 — merge done-marking write/read surface fork (split off, with the `coordination_branch` regression as acceptance criteria)
- #1673 — gate boundaries must observe the worktree branch, not the `find_repo_root`-normalized main checkout
- #1672 — parity-ratchet scenario for real done-marking from a lane CWD

## Proof

```
ruff check (changed src) ............ All checks passed!
pytest tests/integration/test_merge_lane_planning_data_loss.py \
       tests/specify_cli/test_acceptance_regressions.py \
       tests/lanes/test_planning_lane_predicate.py \
       tests/integration/test_post_merge_unrelated_untracked.py \
       tests/integration/sparse_checkout/test_merge_refresh_and_invariant.py
  => 65 passed
```

All production changes were authored test-first (RED→GREEN verified for #1, #2, #4; #3 is a non-vacuity-checked persistence test). Diff is limited to the 11 source + 11 test files in the diffstat; no charter/doctrine-sync byproducts are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
