### PR TITLE
fix(#1753): wire codebase-wide ownership scope end-to-end + finalize-tooling stabilization + testing doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,18 @@ src/doctrine/missions/mission-steps/{mission_type}/{step_id}/prompt.md  (SOURCE)
 
 ---
 
+## ⚠️ CRITICAL: Use Canonical Sources, Never Improvise
+
+**Always use the canonical templates, skills, commands, and code surfaces rather than improvising or using older artefacts as examples.**
+
+- Spec/plan/tasks templates come from `src/doctrine/missions/<type>/templates/` (resolved through the charter/doctrine chain) — never copy structure from an older mission in `kitty-specs/`.
+- Workflows run through the documented `spec-kitty` CLI commands and the published skills — do not hand-roll equivalents or reconstruct paths the resolver should provide.
+- When a canonical command, template, or code surface appears missing or broken, **trace the source and file an upstream gap** — do not silently work around it with an improvised substitute.
+
+**Why:** older missions and ad-hoc artefacts drift from the canonical structure; copying them propagates the drift. The doctrine templates are the single source of truth.
+
+---
+
 ## ⚠️ CRITICAL: Git Workflow — No Direct Pushes to origin/main
 
 **All changes to origin/main MUST go through pull requests. Direct pushes are prohibited.**
@@ -175,6 +187,8 @@ PWHEADLESS=1 pytest tests/   # headless (prevents browser windows)
 ## Code Style
 
 Python 3.11+. Follow standard conventions. Any changes to `__init__.py` require a version bump in `pyproject.toml` and a `CHANGELOG.md` entry.
+
+**New code MUST pass `ruff` and `mypy` with zero issues and zero warnings. Do NOT disable, suppress, or relax checks (no blanket `# noqa`, `# type: ignore`, or per-file ignore additions) to achieve this — fix the code instead.** Narrowly-scoped, individually-justified suppressions are allowed only when the check is genuinely wrong about correct code, and must carry an inline rationale.
 
 ## Recent Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,8 @@ Python 3.11+. Follow standard conventions. Any changes to `__init__.py` require 
 
 **New code MUST pass `ruff` and `mypy` with zero issues and zero warnings. Do NOT disable, suppress, or relax checks (no blanket `# noqa`, `# type: ignore`, or per-file ignore additions) to achieve this — fix the code instead.** Narrowly-scoped, individually-justified suppressions are allowed only when the check is genuinely wrong about correct code, and must carry an inline rationale.
 
+**Pre-push: run the terminology guard when touching `src/doctrine/` or user-facing prose.** Some repo-wide gates run only in CI's `integration-tests-core-misc` job, NOT in the `fast-tests-*` suites — so a forbidden-term regression passes local doctrine runs and only fails at CI. Before pushing doctrine/prose changes, run `pytest tests/architectural/test_no_legacy_terminology.py` (≈0.1 s); it enforces the Terminology Canon (e.g. canonical `status commit` not `ceremony`; `Mission` not `feature`). The full `tests/architectural/` suite is the complete safety net.
+
 ## Recent Changes
 
 - **068**: `src/specify_cli/post_merge/` (AST-based stale-assertion analyzer), `agent tests` CLI subgroup, `agent/release.py prep` subcommand, FR-019 safe_commit fix in `_run_lane_based_merge`, FR-021 `scan_recovery_state` + `implement --base`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- `WPMetadata` now accepts the `scope` frontmatter key (e.g. `scope: codebase-wide`)
+  that `OwnershipManifest`/ownership validation already consume. Previously the
+  strict (`extra="forbid"`) parser rejected it, so `finalize-tasks` could not
+  declare cross-cutting/refactor work packages codebase-wide and failed ownership
+  validation on legitimately overlapping `owned_files` (#1753).
+
+### 📝 Docs
+
+- AGENTS.md: added "Use Canonical Sources, Never Improvise" guidance and a
+  ruff/mypy-clean (no disabled checks) code-style rule.
+- `tasks-finalize` doctrine prompt: documented ownership-overlap handling for
+  domain/refactor missions (linearize shared surfaces; declare codebase-wide).
+
 ## [3.2.0rc38] - 2026-06-06
 
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
-- `WPMetadata` now accepts the `scope` frontmatter key (e.g. `scope: codebase-wide`)
-  that `OwnershipManifest`/ownership validation already consume. Previously the
-  strict (`extra="forbid"`) parser rejected it, so `finalize-tasks` could not
-  declare cross-cutting/refactor work packages codebase-wide and failed ownership
-  validation on legitimately overlapping `owned_files` (#1753).
+- Work packages can now declare `scope: codebase-wide` so cross-cutting/refactor
+  WPs are exempt from `owned_files` overlap validation, end-to-end through
+  `finalize-tasks` (#1753). Two coupled defects were fixed: (1) the strict
+  (`extra="forbid"`) `WPMetadata` parser rejected the `scope` key at parse time,
+  and (2) `OwnershipManifest.from_frontmatter` hard-coded `scope = None` on its
+  `WPMetadata` branch — the exact path `finalize-tasks` uses — silently dropping
+  the exemption even when the key parsed. The adapter now propagates `scope`, and
+  acceptance tests assert that narrow WPs claiming the same files still fail
+  regardless of lane/dependency structure, while a codebase-wide WP is exempt.
+  Also removed redundant `@overload` stubs on `from_frontmatter` that tripped
+  strict mypy (`overload-cannot-match`).
 
 ### 📝 Docs
 

--- a/src/doctrine/agent_profiles/built-in/python-pedro.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/python-pedro.agent.yaml
@@ -28,7 +28,7 @@ context-sources:
     - "025"
     - "030"
   tactics:
-    - test-ceremony-as-design-smell
+    - test-scaffolding-as-design-smell
   additional:
     - coding-standards
     - test-strategy
@@ -169,7 +169,7 @@ directive-references:
     rationale: Tests define the contract before production code — TDD red-green-refactor is the default implementation rhythm
 
 tactic-references:
-  - id: test-ceremony-as-design-smell
+  - id: test-scaffolding-as-design-smell
     rationale: >
       Write code whose behavior is testable without infrastructure. If a unit test
       would need real files, git, or several mocks to run, invert the dependency and

--- a/src/doctrine/agent_profiles/built-in/python-pedro.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/python-pedro.agent.yaml
@@ -27,6 +27,8 @@ context-sources:
     - "024"
     - "025"
     - "030"
+  tactics:
+    - test-ceremony-as-design-smell
   additional:
     - coding-standards
     - test-strategy
@@ -165,3 +167,10 @@ directive-references:
   - code: "034"
     name: Test-First Development
     rationale: Tests define the contract before production code — TDD red-green-refactor is the default implementation rhythm
+
+tactic-references:
+  - id: test-ceremony-as-design-smell
+    rationale: >
+      Write code whose behavior is testable without infrastructure. If a unit test
+      would need real files, git, or several mocks to run, invert the dependency and
+      extract a pure seam before adding the test, rather than expanding the mock setup.

--- a/src/doctrine/agent_profiles/built-in/randy-reducer.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/randy-reducer.agent.yaml
@@ -33,7 +33,7 @@ context-sources:
     - semantic-compression-dead-weight-elimination
     - semantic-compression-semantic-consolidation
     - semantic-compression-equivalence-verification
-    - test-ceremony-as-design-smell
+    - test-scaffolding-as-design-smell
   additional:
     - semantic-compression-paradigm
     - characterization-tests
@@ -155,5 +155,5 @@ tactic-references:
     rationale: Collapse split business-rule paths into one canonical owner
   - id: semantic-compression-equivalence-verification
     rationale: Prove the smaller implementation still preserves the behavioral envelope
-  - id: test-ceremony-as-design-smell
+  - id: test-scaffolding-as-design-smell
     rationale: Heavy test setup signals duplicated, IO-coupled code paths and a missing seam — extract one pure boundary and collapse the variants.

--- a/src/doctrine/agent_profiles/built-in/randy-reducer.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/randy-reducer.agent.yaml
@@ -33,6 +33,7 @@ context-sources:
     - semantic-compression-dead-weight-elimination
     - semantic-compression-semantic-consolidation
     - semantic-compression-equivalence-verification
+    - test-ceremony-as-design-smell
   additional:
     - semantic-compression-paradigm
     - characterization-tests
@@ -154,3 +155,5 @@ tactic-references:
     rationale: Collapse split business-rule paths into one canonical owner
   - id: semantic-compression-equivalence-verification
     rationale: Prove the smaller implementation still preserves the behavioral envelope
+  - id: test-ceremony-as-design-smell
+    rationale: Heavy test setup signals duplicated, IO-coupled code paths and a missing seam — extract one pure boundary and collapse the variants.

--- a/src/doctrine/agent_profiles/built-in/reviewer-renata.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/reviewer-renata.agent.yaml
@@ -29,7 +29,7 @@ context-sources:
     - code-review-incremental
     - language-driven-design
     - reverse-speccing
-    - test-ceremony-as-design-smell
+    - test-scaffolding-as-design-smell
   additional:
     - behaviour-driven-development-paradigm
     - review-checklist
@@ -162,7 +162,7 @@ tactic-references:
     rationale: >
       Verify that every behavior covered in scope has a passing executable scenario
       before approving the WP. Scenarios not yet wired to step definitions block approval.
-  - id: test-ceremony-as-design-smell
+  - id: test-scaffolding-as-design-smell
     rationale: >
       Treat heavy test setup or many infrastructure mocks in a diff as a design
       smell to flag, not accept — request a pure boundary/seam instead of more doubles.

--- a/src/doctrine/agent_profiles/built-in/reviewer-renata.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/reviewer-renata.agent.yaml
@@ -29,6 +29,7 @@ context-sources:
     - code-review-incremental
     - language-driven-design
     - reverse-speccing
+    - test-ceremony-as-design-smell
   additional:
     - behaviour-driven-development-paradigm
     - review-checklist
@@ -161,3 +162,7 @@ tactic-references:
     rationale: >
       Verify that every behavior covered in scope has a passing executable scenario
       before approving the WP. Scenarios not yet wired to step definitions block approval.
+  - id: test-ceremony-as-design-smell
+    rationale: >
+      Treat heavy test setup or many infrastructure mocks in a diff as a design
+      smell to flag, not accept — request a pure boundary/seam instead of more doubles.

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -580,9 +580,6 @@ nodes:
 - urn: tactic:test-boundaries-by-responsibility
   kind: tactic
   label: Test Boundaries by Functional Responsibility
-- urn: tactic:test-ceremony-as-design-smell
-  kind: tactic
-  label: Test Setup Ceremony as a Design Smell
 - urn: tactic:test-minimisation
   kind: tactic
   label: Test Minimisation
@@ -592,6 +589,9 @@ nodes:
 - urn: tactic:test-readability-clarity-check
   kind: tactic
   label: Test Readability and Clarity Check
+- urn: tactic:test-scaffolding-as-design-smell
+  kind: tactic
+  label: Test Setup Scaffolding as a Design Smell
 - urn: tactic:test-to-system-reconstruction
   kind: tactic
   label: Test-to-System Reconstruction
@@ -1305,7 +1305,7 @@ edges:
   target: directive:DIRECTIVE_030
   relation: requires
 - source: agent_profile:python-pedro
-  target: tactic:test-ceremony-as-design-smell
+  target: tactic:test-scaffolding-as-design-smell
   relation: requires
   reason: Write code whose behavior is testable without infrastructure. If a unit test would need real files, git, or several mocks to run, invert the dependency and extract a pure seam before adding the test, rather than expanding the mock setup.
 - source: agent_profile:randy-reducer
@@ -1345,7 +1345,7 @@ edges:
   relation: requires
   reason: Collapse split business-rule paths into one canonical owner
 - source: agent_profile:randy-reducer
-  target: tactic:test-ceremony-as-design-smell
+  target: tactic:test-scaffolding-as-design-smell
   relation: requires
   reason: Heavy test setup signals duplicated, IO-coupled code paths and a missing seam — extract one pure boundary and collapse the variants.
 - source: agent_profile:researcher-robbie
@@ -1389,13 +1389,13 @@ edges:
   relation: requires
   reason: Validate that tests serve as executable specifications by reconstructing system understanding from test code alone
 - source: agent_profile:reviewer-renata
-  target: tactic:test-ceremony-as-design-smell
-  relation: requires
-  reason: Treat heavy test setup or many infrastructure mocks in a diff as a design smell to flag, not accept — request a pure boundary/seam instead of more doubles.
-- source: agent_profile:reviewer-renata
   target: tactic:test-readability-clarity-check
   relation: requires
   reason: 'Apply the dual-perspective reconstruction check during review: read only the test suite and attempt to reconstruct system behavior, then compare against the specification. Tests that fail reconstruction are documentation gaps.'
+- source: agent_profile:reviewer-renata
+  target: tactic:test-scaffolding-as-design-smell
+  relation: requires
+  reason: Treat heavy test setup or many infrastructure mocks in a diff as a design smell to flag, not accept — request a pure boundary/seam instead of more doubles.
 - source: directive:DIRECTIVE_001
   target: tactic:paula-patterns-architecture-scout-review
   relation: requires
@@ -2468,18 +2468,6 @@ edges:
   target: tactic:tdd-red-green-refactor
   relation: suggests
   when: Driving implementation inside the boundaries defined by this tactic
-- source: tactic:test-ceremony-as-design-smell
-  target: styleguide:test-desiderata-and-boundaries
-  relation: suggests
-  when: The styleguide this tactic operationalizes — desiderata as trade-offs and infrastructure-as-shared-state as the anti-pattern this tactic detects
-- source: tactic:test-ceremony-as-design-smell
-  target: tactic:function-over-form-testing
-  relation: suggests
-  when: Use to keep the extracted seam's tests asserting behavior, not structure, so they stay structure-insensitive
-- source: tactic:test-ceremony-as-design-smell
-  target: tactic:test-boundaries-by-responsibility
-  relation: suggests
-  when: Use to decide what belongs inside the extracted seam versus what is stubbed at the boundary
 - source: tactic:test-minimisation
   target: directive:DIRECTIVE_030
   relation: suggests
@@ -2496,6 +2484,18 @@ edges:
   target: tactic:test-boundaries-by-responsibility
   relation: suggests
   when: After identifying coverage gaps, use this tactic to determine the correct level at which to add missing tests
+- source: tactic:test-scaffolding-as-design-smell
+  target: styleguide:test-desiderata-and-boundaries
+  relation: suggests
+  when: The styleguide this tactic operationalizes — desiderata as trade-offs and infrastructure-as-shared-state as the anti-pattern this tactic detects
+- source: tactic:test-scaffolding-as-design-smell
+  target: tactic:function-over-form-testing
+  relation: suggests
+  when: Use to keep the extracted seam's tests asserting behavior, not structure, so they stay structure-insensitive
+- source: tactic:test-scaffolding-as-design-smell
+  target: tactic:test-boundaries-by-responsibility
+  relation: suggests
+  when: Use to decide what belongs inside the extracted seam versus what is stubbed at the boundary
 - source: tactic:test-to-system-reconstruction
   target: directive:DIRECTIVE_034
   relation: suggests

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -277,6 +277,9 @@ nodes:
 - urn: styleguide:reasons-canvas-writing
   kind: styleguide
   label: REASONS Canvas Writing Styleguide
+- urn: styleguide:test-desiderata-and-boundaries
+  kind: styleguide
+  label: Test Desiderata and Clear Test Boundaries
 - urn: styleguide:testing-principles
   kind: styleguide
   label: Testing Principles Styleguide
@@ -577,6 +580,9 @@ nodes:
 - urn: tactic:test-boundaries-by-responsibility
   kind: tactic
   label: Test Boundaries by Functional Responsibility
+- urn: tactic:test-ceremony-as-design-smell
+  kind: tactic
+  label: Test Setup Ceremony as a Design Smell
 - urn: tactic:test-minimisation
   kind: tactic
   label: Test Minimisation
@@ -1298,6 +1304,10 @@ edges:
 - source: agent_profile:python-pedro
   target: directive:DIRECTIVE_030
   relation: requires
+- source: agent_profile:python-pedro
+  target: tactic:test-ceremony-as-design-smell
+  relation: requires
+  reason: Write code whose behavior is testable without infrastructure. If a unit test would need real files, git, or several mocks to run, invert the dependency and extract a pure seam before adding the test, rather than expanding the mock setup.
 - source: agent_profile:randy-reducer
   target: directive:DIRECTIVE_001
   relation: requires
@@ -1334,6 +1344,10 @@ edges:
   target: tactic:semantic-compression-semantic-consolidation
   relation: requires
   reason: Collapse split business-rule paths into one canonical owner
+- source: agent_profile:randy-reducer
+  target: tactic:test-ceremony-as-design-smell
+  relation: requires
+  reason: Heavy test setup signals duplicated, IO-coupled code paths and a missing seam — extract one pure boundary and collapse the variants.
 - source: agent_profile:researcher-robbie
   target: directive:DIRECTIVE_003
   relation: requires
@@ -1374,6 +1388,10 @@ edges:
   target: tactic:reverse-speccing
   relation: requires
   reason: Validate that tests serve as executable specifications by reconstructing system understanding from test code alone
+- source: agent_profile:reviewer-renata
+  target: tactic:test-ceremony-as-design-smell
+  relation: requires
+  reason: Treat heavy test setup or many infrastructure mocks in a diff as a design smell to flag, not accept — request a pure boundary/seam instead of more doubles.
 - source: agent_profile:reviewer-renata
   target: tactic:test-readability-clarity-check
   relation: requires
@@ -2450,6 +2468,18 @@ edges:
   target: tactic:tdd-red-green-refactor
   relation: suggests
   when: Driving implementation inside the boundaries defined by this tactic
+- source: tactic:test-ceremony-as-design-smell
+  target: styleguide:test-desiderata-and-boundaries
+  relation: suggests
+  when: The styleguide this tactic operationalizes — desiderata as trade-offs and infrastructure-as-shared-state as the anti-pattern this tactic detects
+- source: tactic:test-ceremony-as-design-smell
+  target: tactic:function-over-form-testing
+  relation: suggests
+  when: Use to keep the extracted seam's tests asserting behavior, not structure, so they stay structure-insensitive
+- source: tactic:test-ceremony-as-design-smell
+  target: tactic:test-boundaries-by-responsibility
+  relation: suggests
+  when: Use to decide what belongs inside the extracted seam versus what is stubbed at the boundary
 - source: tactic:test-minimisation
   target: directive:DIRECTIVE_030
   relation: suggests

--- a/src/doctrine/missions/mission-steps/software-dev/tasks-finalize/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/tasks-finalize/prompt.md
@@ -51,6 +51,37 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces.** Work packages that touch the same files MUST be
+   made dependent/linear (via `Depends on WPxx`) so they execute sequentially in
+   one lane and **share a single worktree** (or run direct-to-branch). Limited
+   parallelism is acceptable and expected for these missions — do not force
+   artificial parallelism.
+2. **Declare cross-cutting WPs codebase-wide.** A WP that is expected to overlap
+   broadly should carry `scope: codebase-wide` in its frontmatter; the ownership
+   validator exempts codebase-wide WPs from overlap and authoritative-surface
+   checks. Keep the genuinely-targeted WPs (single test file, single module)
+   narrow and mutually disjoint.
+3. **Tooling note (known gap):** the `WPMetadata` parser currently rejects the
+   `scope` frontmatter key (`extra="forbid"`), so `scope: codebase-wide` may fail
+   to finalize on affected CLI versions. When this blocks a legitimate refactor
+   mission, file/track the upstream gap and proceed direct-to-branch with the
+   shared-surface WPs linearized, rather than improvising disjoint ownership that
+   misrepresents the work.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization

--- a/src/doctrine/missions/mission-steps/software-dev/tasks-finalize/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/tasks-finalize/prompt.md
@@ -61,22 +61,24 @@ missions** (cross-cutting strangler work, repo-wide migrations, boundary
 enforcement) where many work packages legitimately edit the same files. This is
 not a defect in the slicing. Handle it as follows:
 
-1. **Linearize shared surfaces.** Work packages that touch the same files MUST be
-   made dependent/linear (via `Depends on WPxx`) so they execute sequentially in
-   one lane and **share a single worktree** (or run direct-to-branch). Limited
-   parallelism is acceptable and expected for these missions — do not force
-   artificial parallelism.
-2. **Declare cross-cutting WPs codebase-wide.** A WP that is expected to overlap
-   broadly should carry `scope: codebase-wide` in its frontmatter; the ownership
-   validator exempts codebase-wide WPs from overlap and authoritative-surface
-   checks. Keep the genuinely-targeted WPs (single test file, single module)
-   narrow and mutually disjoint.
-3. **Tooling note (known gap):** the `WPMetadata` parser currently rejects the
-   `scope` frontmatter key (`extra="forbid"`), so `scope: codebase-wide` may fail
-   to finalize on affected CLI versions. When this blocks a legitimate refactor
-   mission, file/track the upstream gap and proceed direct-to-branch with the
-   shared-surface WPs linearized, rather than improvising disjoint ownership that
-   misrepresents the work.
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
 
 Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
 which files solely to pass validation — linearize and/or declare codebase-wide

--- a/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
+++ b/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
@@ -130,5 +130,6 @@ references:
   - "src/doctrine/styleguides/built-in/mutation-aware-test-design.styleguide.yaml"
   - "src/doctrine/tactics/built-in/testing/test-boundaries-by-responsibility.tactic.yaml"
   - "src/doctrine/tactics/built-in/testing/function-over-form-testing.tactic.yaml"
+  - "src/doctrine/tactics/built-in/testing/test-ceremony-as-design-smell.tactic.yaml"
   - "src/doctrine/directives/built-in/030-test-and-typecheck-quality-gate.directive.yaml"
   - "src/doctrine/directives/built-in/034-test-first-development.directive.yaml"

--- a/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
+++ b/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
@@ -130,6 +130,5 @@ references:
   - "src/doctrine/styleguides/built-in/mutation-aware-test-design.styleguide.yaml"
   - "src/doctrine/tactics/built-in/testing/test-boundaries-by-responsibility.tactic.yaml"
   - "src/doctrine/tactics/built-in/testing/function-over-form-testing.tactic.yaml"
-  - "src/doctrine/tactics/built-in/testing/test-ceremony-as-design-smell.tactic.yaml"
   - "src/doctrine/directives/built-in/030-test-and-typecheck-quality-gate.directive.yaml"
   - "src/doctrine/directives/built-in/034-test-first-development.directive.yaml"

--- a/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
+++ b/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
@@ -34,7 +34,7 @@ principles:
   - "Boundary by responsibility, not by layer: include exactly the components responsible for the behavior under test; everything else is outside the boundary."
   - "Stub infrastructure at the boundary: external services, data access, and IO (filesystem, database, clock, network, randomness, git) live OUTSIDE the boundary and are replaced by test doubles or pure inputs."
   - "Assert observable outcomes, not mechanisms: test the behavior crossing the boundary, not internal call counts or field values, to stay structure-insensitive."
-  - "If a unit test needs heavy infrastructure ceremony to run, the boundary is wrong: extract a pure seam that takes domain inputs so the behavior is testable without IO."
+  - "If a unit test needs heavy infrastructure scaffolding to run, the boundary is wrong: extract a pure seam that takes domain inputs so the behavior is testable without IO."
 
 patterns:
   - name: Draw the boundary by functional responsibility
@@ -51,7 +51,7 @@ patterns:
           _write_mission_dir(tmp_path)                  # real files
           with patch("...locate_project_root"), \
                patch("...safe_commit"), patch("...run_command"), \
-               patch("...bootstrap_canonical_state"):    # infra ceremony
+               patch("...bootstrap_canonical_state"):    # infra scaffolding
               finalize_tasks(feature="m", validate_only=True)
           # assertion buried behind subprocess/JSON parsing
     good_example: |
@@ -84,7 +84,7 @@ anti_patterns:
       state. Two consequences follow: (1) surfaces can disagree about the same
       on-disk state (read/write forks, staleness); (2) tests cannot exercise the
       logic without standing up the infrastructure or mocking many seams. The
-      mock/stub ceremony in tests is a symptom, not the disease — the cure is an
+      mock/stub scaffolding in tests is a symptom, not the disease — the cure is an
       owning boundary (a port / aggregate / pure resolver) the logic routes
       through, which the test then drives with simple inputs.
     bad_example: |

--- a/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
+++ b/src/doctrine/styleguides/built-in/test-desiderata-and-boundaries.styleguide.yaml
@@ -1,0 +1,134 @@
+schema_version: "1.0"
+id: test-desiderata-and-boundaries
+title: Test Desiderata and Clear Test Boundaries
+scope: testing
+applies_to_languages: []
+
+# Sources (traceable adoption):
+#   - Kent Beck, "Test Desiderata" — https://testdesiderata.com/
+#   - Stijn Dejongh, "Define Test Boundaries" —
+#     https://patterns.sddevelopment.be/practices/define_test_boundaries/
+# Complements the broader `testing-principles` styleguide; this artifact focuses
+# on (a) the desiderata as properties to trade off deliberately and (b) drawing
+# the test boundary by functional responsibility so infrastructure is stubbed at
+# a real seam rather than mocked ad hoc.
+
+principles:
+  # — Kent Beck's twelve test desiderata: properties to OPTIMIZE via deliberate
+  #   trade-offs, not to maximize all at once. Conflicts are often a design smell
+  #   resolvable by better boundaries/composability, not an inherent limit.
+  - "Desiderata are trade-offs: choose which properties a given test optimizes; do not pretend one test maximizes all twelve at once."
+  - "Isolated: a test returns the same result regardless of the order tests run in — no shared mutable state, no order dependence."
+  - "Composable: dimensions of variability can be tested separately and combined, so coverage grows without combinatorial test counts."
+  - "Deterministic: if nothing changes, the result does not change — no reliance on clocks, randomness, network, or ambient filesystem state."
+  - "Fast: a test runs quickly enough to run after every small change without friction."
+  - "Writable: a test is cheap to write relative to the code it covers; expensive setup is a signal the boundary is wrong."
+  - "Readable: a test communicates the motivation and scenario to a future reader without spelunking the production code."
+  - "Behavioral: a test is sensitive to changes in the behavior of the code under test."
+  - "Structure-insensitive: a test does not change its result when internal structure is refactored without behavior change."
+  - "Automated: a test runs without human intervention."
+  - "Specific: when a test fails, the cause is obvious from the failure alone."
+  - "Predictive: when all tests pass, the code is fit for production."
+  - "Inspiring: passing the suite inspires confidence to ship."
+  # — Clear Test Boundaries (Define Test Boundaries):
+  - "Boundary by responsibility, not by layer: include exactly the components responsible for the behavior under test; everything else is outside the boundary."
+  - "Stub infrastructure at the boundary: external services, data access, and IO (filesystem, database, clock, network, randomness, git) live OUTSIDE the boundary and are replaced by test doubles or pure inputs."
+  - "Assert observable outcomes, not mechanisms: test the behavior crossing the boundary, not internal call counts or field values, to stay structure-insensitive."
+  - "If a unit test needs heavy infrastructure ceremony to run, the boundary is wrong: extract a pure seam that takes domain inputs so the behavior is testable without IO."
+
+patterns:
+  - name: Draw the boundary by functional responsibility
+    description: >
+      Pick the behavior to validate, identify the components responsible for it,
+      and place the test boundary around exactly those. Replace infrastructure
+      (IO, data access, external services) with simple inputs or doubles at the
+      boundary. This keeps tests Fast, Isolated, Writable, and
+      Structure-insensitive (Define Test Boundaries; Beck's desiderata).
+    bad_example: |
+      # The unit reaches the filesystem + git directly, so the "unit" test must
+      # build a real mission on disk and mock every infrastructure seam.
+      def test_overlap_rejected(tmp_path):
+          _write_mission_dir(tmp_path)                  # real files
+          with patch("...locate_project_root"), \
+               patch("...safe_commit"), patch("...run_command"), \
+               patch("...bootstrap_canonical_state"):    # infra ceremony
+              finalize_tasks(feature="m", validate_only=True)
+          # assertion buried behind subprocess/JSON parsing
+    good_example: |
+      # A pure seam takes domain inputs; the behavior is validated with plain
+      # stubs — no files, no git, no command mocking. The IO stays outside.
+      def test_overlap_rejected():
+          manifests = build_wp_manifests({
+              "WP01": wp(owned=["src/foo/**"]),
+              "WP02": wp(owned=["src/foo/**"]),   # overlapping, narrow
+          })
+          assert not validate_ownership(manifests).passed
+
+  - name: Resolve desiderata tension by design, not by accepting brittleness
+    description: >
+      When two desiderata appear to conflict (e.g. Predictive vs Fast,
+      Behavioral vs Structure-insensitive), prefer a design change — a clearer
+      boundary, a pure function, composition — over a brittle test. A pure seam
+      at the boundary usually recovers Fast + Isolated + Specific simultaneously.
+    good_example: |
+      # Behavioral AND structure-insensitive: assert the outcome that crosses the
+      # boundary, regardless of which internal helper produced it.
+      assert resolve_action_context(repo, "m", "WP01").target_branch == expected
+
+anti_patterns:
+  - name: Infrastructure as untyped shared mutable state
+    description: >
+      When production code reads and writes infrastructure (the filesystem,
+      database, git) DIRECTLY from many surfaces instead of through an owning
+      application boundary, that infrastructure becomes un-owned shared mutable
+      state. Two consequences follow: (1) surfaces can disagree about the same
+      on-disk state (read/write forks, staleness); (2) tests cannot exercise the
+      logic without standing up the infrastructure or mocking many seams. The
+      mock/stub ceremony in tests is a symptom, not the disease — the cure is an
+      owning boundary (a port / aggregate / pure resolver) the logic routes
+      through, which the test then drives with simple inputs.
+    bad_example: |
+      # Direct, scattered filesystem access — every caller re-reads/re-writes
+      # mission state, and every test must reconstruct that state on disk.
+      feature_dir = main_repo_root / "kitty-specs" / mission_slug
+      events = (feature_dir / "status.events.jsonl").read_text()
+      ...
+      (feature_dir / "status.events.jsonl").write_text(updated)   # another surface
+    good_example: |
+      # One owning boundary mediates the state; logic and tests depend on it,
+      # not on the filesystem. The IO lives in one place behind the seam.
+      status = MissionStatus.load(repo_root, mission_slug)   # owns read+write
+      status.transition(wp_id="WP01", to_lane="in_progress")
+      # tests drive MissionStatus / build_wp_manifests with stub inputs — no files
+
+  - name: Over-mocking to compensate for a missing boundary
+    description: >
+      Patching five infrastructure functions to test one behavior means the test
+      is fighting the absence of a seam. Mock only at true system boundaries; if
+      you must mock more, extract the boundary instead. Heavy mocking also makes
+      tests pass when the real integration is broken (loss of Predictive).
+    bad_example: |
+      with patch("a.locate_project_root"), patch("a.safe_commit"), \
+           patch("a.run_command"), patch("a.bootstrap_canonical_state"), \
+           patch("a.validate_ownership"):
+          run_command_under_test()   # nothing real is exercised
+    good_example: |
+      # Extract the decision into a pure function; mock nothing.
+      result = decide(domain_inputs)
+      assert result == expected
+
+quality_test: >
+  Can the behavior under test be validated with plain in-memory inputs and at
+  most one mock at a true system boundary? If the test needs real files, a git
+  repo, or several patched infrastructure functions, the boundary is in the
+  wrong place — extract a pure seam before adding the test.
+
+references:
+  - "https://testdesiderata.com/"
+  - "https://patterns.sddevelopment.be/practices/define_test_boundaries/"
+  - "src/doctrine/styleguides/built-in/testing-principles.styleguide.yaml"
+  - "src/doctrine/styleguides/built-in/mutation-aware-test-design.styleguide.yaml"
+  - "src/doctrine/tactics/built-in/testing/test-boundaries-by-responsibility.tactic.yaml"
+  - "src/doctrine/tactics/built-in/testing/function-over-form-testing.tactic.yaml"
+  - "src/doctrine/directives/built-in/030-test-and-typecheck-quality-gate.directive.yaml"
+  - "src/doctrine/directives/built-in/034-test-first-development.directive.yaml"

--- a/src/doctrine/tactics/built-in/testing/test-ceremony-as-design-smell.tactic.yaml
+++ b/src/doctrine/tactics/built-in/testing/test-ceremony-as-design-smell.tactic.yaml
@@ -1,0 +1,70 @@
+schema_version: "1.0"
+id: test-ceremony-as-design-smell
+name: Test Setup Ceremony as a Design Smell
+purpose: >
+  Read the cost and shape of test setup as a signal about production design.
+  When a unit test needs real infrastructure (files, git, database, network,
+  clock) or many mocks/patches to run, that ceremony is evidence of a missing
+  boundary in the code under test — the unit reaches infrastructure directly
+  instead of depending on a pure seam. The remedy is to extract the behavior
+  under test as a function of domain inputs, then test it directly. The mock
+  ceremony is the symptom; the missing boundary is the disease.
+steps:
+  - title: Notice the ceremony
+    description: >
+      Before accepting an expensive test, quantify the setup: how many
+      infrastructure functions are mocked/patched, and how much real on-disk or
+      external state must be constructed. A unit test that patches several
+      infrastructure seams or writes real fixtures to disk is a signal, not a
+      norm.
+    examples:
+      - "A single command test mocks locate_project_root, safe_commit, run_command, bootstrap, and the validator, then writes a real mission directory to tmp_path."
+  - title: Locate the coupling
+    description: >
+      Find the exact production lines where the behavior under test reaches
+      infrastructure directly (filesystem read/write, git, network, time,
+      randomness) rather than receiving the data it needs as an argument.
+    examples:
+      - "finalize logic reads kitty-specs/<mission>/* and commits via git inside the same function that decides ownership overlap."
+  - title: Name the behavior as a function of domain inputs
+    description: >
+      State the behavior under test as pure inputs to outputs, independent of
+      where the inputs came from. This is the seam to extract.
+    examples:
+      - "Given a set of work-package frontmatters, decide whether ownership overlaps — independent of how the frontmatter was read."
+  - title: Extract the pure seam
+    description: >
+      Move infrastructure to the caller/boundary; the behavior takes domain
+      objects and returns a result. Production routes through the seam; the seam
+      itself does no IO.
+    examples:
+      - "build_wp_manifests(frontmatters) -> manifests, then validate_ownership(manifests); the filesystem read stays in the command, outside the decision."
+  - title: Re-test through the seam, keep one thin boundary test
+    description: >
+      Test the behavior through the seam with plain stub inputs (no mocks). Keep
+      exactly one thin integration test that exercises the real boundary
+      (wiring + IO) so predictive coverage at the edge is not lost.
+  - title: Verify the desiderata recovered
+    description: >
+      Confirm the new tests are Fast, Isolated, Specific, and
+      Structure-insensitive, and that the heavy mock ceremony is gone. If a test
+      still needs broad infrastructure, the boundary is still in the wrong place.
+failure_modes:
+  - "Symptom-fighting: adding more mocks/patches to make the expensive test pass instead of extracting the missing boundary."
+  - "Over-extraction: creating a seam that carries no behavior, trading a real test for an indirection."
+  - "Dropping the boundary test entirely: losing predictive coverage that the real IO wiring works."
+  - "Mocking collaborators inside the functional slice: testing doubles instead of the logic the test claims to cover."
+  - "Reading ceremony as inevitable for 'integration-y' code: most command logic has a pure decision core that can be lifted out."
+references:
+  - name: Test Boundaries by Functional Responsibility
+    type: tactic
+    id: test-boundaries-by-responsibility
+    when: Use to decide what belongs inside the extracted seam versus what is stubbed at the boundary
+  - name: Function Over Form Testing
+    type: tactic
+    id: function-over-form-testing
+    when: Use to keep the extracted seam's tests asserting behavior, not structure, so they stay structure-insensitive
+  - name: Test Desiderata and Clear Test Boundaries
+    type: styleguide
+    id: test-desiderata-and-boundaries
+    when: The styleguide this tactic operationalizes — desiderata as trade-offs and infrastructure-as-shared-state as the anti-pattern this tactic detects

--- a/src/doctrine/tactics/built-in/testing/test-scaffolding-as-design-smell.tactic.yaml
+++ b/src/doctrine/tactics/built-in/testing/test-scaffolding-as-design-smell.tactic.yaml
@@ -1,16 +1,16 @@
 schema_version: "1.0"
-id: test-ceremony-as-design-smell
-name: Test Setup Ceremony as a Design Smell
+id: test-scaffolding-as-design-smell
+name: Test Setup Scaffolding as a Design Smell
 purpose: >
   Read the cost and shape of test setup as a signal about production design.
   When a unit test needs real infrastructure (files, git, database, network,
-  clock) or many mocks/patches to run, that ceremony is evidence of a missing
+  clock) or many mocks/patches to run, that scaffolding is evidence of a missing
   boundary in the code under test — the unit reaches infrastructure directly
   instead of depending on a pure seam. The remedy is to extract the behavior
   under test as a function of domain inputs, then test it directly. The mock
-  ceremony is the symptom; the missing boundary is the disease.
+  scaffolding is the symptom; the missing boundary is the disease.
 steps:
-  - title: Notice the ceremony
+  - title: Notice the scaffolding
     description: >
       Before accepting an expensive test, quantify the setup: how many
       infrastructure functions are mocked/patched, and how much real on-disk or
@@ -47,14 +47,14 @@ steps:
   - title: Verify the desiderata recovered
     description: >
       Confirm the new tests are Fast, Isolated, Specific, and
-      Structure-insensitive, and that the heavy mock ceremony is gone. If a test
+      Structure-insensitive, and that the heavy mock scaffolding is gone. If a test
       still needs broad infrastructure, the boundary is still in the wrong place.
 failure_modes:
   - "Symptom-fighting: adding more mocks/patches to make the expensive test pass instead of extracting the missing boundary."
   - "Over-extraction: creating a seam that carries no behavior, trading a real test for an indirection."
   - "Dropping the boundary test entirely: losing predictive coverage that the real IO wiring works."
   - "Mocking collaborators inside the functional slice: testing doubles instead of the logic the test claims to cover."
-  - "Reading ceremony as inevitable for 'integration-y' code: most command logic has a pure decision core that can be lifted out."
+  - "Reading scaffolding as inevitable for 'integration-y' code: most command logic has a pure decision core that can be lifted out."
 references:
   - name: Test Boundaries by Functional Responsibility
     type: tactic

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -46,7 +46,7 @@ from specify_cli.mission import get_mission_type
 from specify_cli.doc_analysis.doc_state import GeneratorConfig
 from specify_cli.ownership import infer_ownership, validate_ownership
 from specify_cli.ownership.audit_targets import validate_audit_coverage
-from specify_cli.ownership.validation import validate_glob_matches
+from specify_cli.ownership.validation import build_wp_manifests, validate_glob_matches
 from specify_cli.core.wps_manifest import (
     load_wps_manifest,
     check_concern_refs_coverage,
@@ -2581,9 +2581,7 @@ def finalize_tasks(
         # in memory but does NOT write to disk.  Re-reading from disk would miss
         # the inferred ownership fields, silently skipping ownership/lane
         # validation.  We therefore use the in-memory state when available.
-        from specify_cli.ownership.models import OwnershipManifest
-
-        wp_manifests: dict[str, OwnershipManifest] = {}
+        wp_frontmatters: dict[str, WPMetadata] = {}
         wp_bodies: dict[str, str] = {}
         for wp_file in wp_files:
             wp_id_match = re.match(r"^(WP\d{2})(?:[-_.]|$)", wp_file.name)
@@ -2597,8 +2595,9 @@ def finalize_tasks(
                 else:
                     fm_meta, wp_body = read_wp_frontmatter(wp_file)
                 wp_bodies[wp_id] = wp_body
-                if fm_meta.execution_mode and fm_meta.owned_files:
-                    wp_manifests[wp_id] = OwnershipManifest.from_frontmatter(fm_meta)
+                wp_frontmatters[wp_id] = fm_meta
+
+        wp_manifests = build_wp_manifests(wp_frontmatters)
 
         if wp_manifests:
             ownership_result = validate_ownership(wp_manifests)

--- a/src/specify_cli/migration/__init__.py
+++ b/src/specify_cli/migration/__init__.py
@@ -4,6 +4,8 @@ Provides schema version gate (WP11), one-shot migration steps (WP12), and
 the state rebuild + atomic runner (WP13).
 """
 
+from typing import TYPE_CHECKING
+
 # WP11: schema version gate
 from .schema_version import (
     REQUIRED_SCHEMA_VERSION,
@@ -29,9 +31,15 @@ from .normalize_mission_lifecycle import (
 from .strip_frontmatter import StripResult, strip_mutable_fields
 from .rewrite_shims import RewriteResult, rewrite_agent_shims
 
-# WP13: state rebuild and atomic runner
-from .rebuild_state import RebuildResult, rebuild_event_log
+# WP13: atomic runner. ``RebuildResult`` / ``rebuild_event_log`` live in the
+# deprecated ``rebuild_state`` module (superseded by
+# ``mission_state.repair_repo``) and are re-exported lazily via ``__getattr__``
+# below, so importing this package does not emit the module's import-time
+# DeprecationWarning for unrelated consumers.
 from .runner import MigrationReport, run_migration
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .rebuild_state import RebuildResult, rebuild_event_log
 
 __all__ = [
     # schema version (WP11)
@@ -64,3 +72,20 @@ __all__ = [
     "MigrationReport",
     "run_migration",
 ]
+
+_DEPRECATED_REBUILD_EXPORTS = frozenset({"RebuildResult", "rebuild_event_log"})
+
+
+def __getattr__(name: str) -> object:
+    """Lazily re-export deprecated ``rebuild_state`` symbols (PEP 562).
+
+    Deferring the import keeps ``from specify_cli.migration import
+    rebuild_event_log`` working while ensuring the ``rebuild_state`` module's
+    import-time ``DeprecationWarning`` fires only when a symbol is actually
+    accessed — not for every importer of this package.
+    """
+    if name in _DEPRECATED_REBUILD_EXPORTS:
+        from . import rebuild_state
+
+        return getattr(rebuild_state, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/specify_cli/migration/normalize_mission_lifecycle.py
+++ b/src/specify_cli/migration/normalize_mission_lifecycle.py
@@ -17,7 +17,6 @@ from specify_cli.migration.backfill_identity import (
     backfill_wp_ids,
     trigger_feature_dossier_sync_if_enabled,
 )
-from specify_cli.migration.rebuild_state import rebuild_event_log
 from specify_cli.status.lifecycle import derive_mission_lifecycle, generate_lifecycle_json
 from specify_cli.status.progress import generate_progress_json
 from specify_cli.status.views import write_derived_views
@@ -144,6 +143,14 @@ def _normalize_event_log(
     if dry_run:
         result.actions.append("Would rebuild status.events.jsonl from legacy mission state")
         return True
+
+    # Imported lazily: rebuild_event_log lives in the deprecated rebuild_state
+    # module (superseded by mission_state.repair_repo for new code) and emits a
+    # DeprecationWarning at import time. This legacy lifecycle-normalization path
+    # legitimately still needs the per-feature rebuild, so we defer the import to
+    # the point of use rather than firing the warning for every importer of this
+    # module (e.g. unrelated planning/test paths via compat.planner).
+    from specify_cli.migration.rebuild_state import rebuild_event_log
 
     rebuild = rebuild_event_log(feature_dir, result.slug, wp_id_map={})
     if rebuild.errors:

--- a/src/specify_cli/ownership/models.py
+++ b/src/specify_cli/ownership/models.py
@@ -73,19 +73,22 @@ class OwnershipManifest:
         from specify_cli.status.wp_metadata import WPMetadata
 
         if isinstance(data, WPMetadata):
-            raw_mode = data.execution_mode
-            if raw_mode is None:
+            # Normalize to a dict and fall through to the single extraction path.
+            # Two contracts must be preserved through the normalization:
+            #   1. KeyError (not the ValueError that ``ExecutionMode(None)`` would
+            #      raise via the dict path) when execution_mode is None — guarded
+            #      explicitly here before normalizing.
+            #   2. ``authoritative_surface`` defaults to "" (not None), so coerce
+            #      with ``or ""`` rather than letting ``dict.get(k, "")`` return a
+            #      present-but-None value.
+            if data.execution_mode is None:
                 raise KeyError("execution_mode")
-            execution_mode = ExecutionMode(raw_mode)
-            owned_files = tuple(data.owned_files) if data.owned_files else ()
-            authoritative_surface = data.authoritative_surface or ""
-            scope = data.scope  # carry codebase-wide scope through the adapter
-            return cls(
-                execution_mode=execution_mode,
-                owned_files=owned_files,
-                authoritative_surface=authoritative_surface,
-                scope=scope,
-            )
+            data = {
+                "execution_mode": data.execution_mode,
+                "owned_files": data.owned_files,
+                "authoritative_surface": data.authoritative_surface or "",
+                "scope": data.scope,
+            }
 
         raw_mode = data["execution_mode"]
         execution_mode = ExecutionMode(raw_mode)

--- a/src/specify_cli/ownership/models.py
+++ b/src/specify_cli/ownership/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from specify_cli.status.wp_metadata import WPMetadata
@@ -54,14 +54,6 @@ class OwnershipManifest:
         """Return True if this WP has codebase-wide scope."""
         return self.scope == SCOPE_CODEBASE_WIDE
 
-    @overload
-    @classmethod
-    def from_frontmatter(cls, data: WPMetadata) -> OwnershipManifest: ...
-
-    @overload
-    @classmethod
-    def from_frontmatter(cls, data: dict[str, Any]) -> OwnershipManifest: ...
-
     @classmethod
     def from_frontmatter(cls, data: dict[str, Any] | WPMetadata) -> OwnershipManifest:
         """Construct an OwnershipManifest from parsed frontmatter data.
@@ -87,7 +79,7 @@ class OwnershipManifest:
             execution_mode = ExecutionMode(raw_mode)
             owned_files = tuple(data.owned_files) if data.owned_files else ()
             authoritative_surface = data.authoritative_surface or ""
-            scope = None  # WPMetadata doesn't carry scope field
+            scope = data.scope  # carry codebase-wide scope through the adapter
             return cls(
                 execution_mode=execution_mode,
                 owned_files=owned_files,

--- a/src/specify_cli/ownership/validation.py
+++ b/src/specify_cli/ownership/validation.py
@@ -14,14 +14,20 @@ from __future__ import annotations
 from specify_cli.core.constants import KITTY_SPECS_DIR
 import fnmatch
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from itertools import combinations
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from specify_cli.ownership.models import ExecutionMode, OwnershipManifest
 
+if TYPE_CHECKING:
+    from specify_cli.status.wp_metadata import WPMetadata
+
 __all__ = [
     "ValidationResult",
+    "build_wp_manifests",
     "validate_no_overlap",
     "validate_authoritative_surface",
     "validate_execution_mode_consistency",
@@ -226,6 +232,32 @@ def validate_all(manifests: dict[str, OwnershipManifest]) -> ValidationResult:
         result.warnings.extend(f"{wp_id}: {w}" for w in mode_warnings)
 
     return result
+
+
+def build_wp_manifests(
+    frontmatters: Mapping[str, WPMetadata],
+) -> dict[str, OwnershipManifest]:
+    """Build ownership manifests from WP frontmatter, ready for validation.
+
+    This is the pure, filesystem-free seam between WP frontmatter and ownership
+    validation. WPs that do not declare ownership (no ``execution_mode`` or empty
+    ``owned_files``) are skipped, mirroring finalize-tasks. Because
+    :meth:`OwnershipManifest.from_frontmatter` carries the ``scope`` field
+    through (including ``codebase-wide``), callers can exercise the full
+    overlap/exemption decision with plain ``WPMetadata`` stubs — no temp files,
+    no finalize-command mocking.
+
+    Args:
+        frontmatters: Mapping of WP ID to its parsed ``WPMetadata``.
+
+    Returns:
+        Mapping of WP ID to ``OwnershipManifest`` for WPs that declare ownership.
+    """
+    manifests: dict[str, OwnershipManifest] = {}
+    for wp_id, fm in frontmatters.items():
+        if fm.execution_mode and fm.owned_files:
+            manifests[wp_id] = OwnershipManifest.from_frontmatter(fm)
+    return manifests
 
 
 # Public alias used by __init__.py

--- a/src/specify_cli/status/wp_metadata.py
+++ b/src/specify_cli/status/wp_metadata.py
@@ -220,6 +220,14 @@ class WPMetadata(BaseModel):
     execution_mode: str | None = None
     owned_files: list[str] = Field(default_factory=list)
     authoritative_surface: str | None = None
+    scope: str | None = Field(
+        default=None,
+        description=(
+            'Ownership scope. "codebase-wide" marks a cross-cutting/refactor WP that '
+            "is exempt from owned_files overlap and authoritative-surface checks "
+            "(see specify_cli.ownership.validation). None = narrow/default."
+        ),
+    )
     task_type: str | None = None
 
     # ── Optional: workflow metadata ────────────────────────────

--- a/tests/doctrine/test_shipped_profiles.py
+++ b/tests/doctrine/test_shipped_profiles.py
@@ -415,6 +415,7 @@ class TestShippedProfilesContextSources:
                     "code-review-incremental",
                     "language-driven-design",
                     "reverse-speccing",
+                    "test-ceremony-as-design-smell",
                 ],
             ),
         ],

--- a/tests/doctrine/test_shipped_profiles.py
+++ b/tests/doctrine/test_shipped_profiles.py
@@ -415,7 +415,7 @@ class TestShippedProfilesContextSources:
                     "code-review-incremental",
                     "language-driven-design",
                     "reverse-speccing",
-                    "test-ceremony-as-design-smell",
+                    "test-scaffolding-as-design-smell",
                 ],
             ),
         ],

--- a/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
+++ b/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
@@ -1130,3 +1130,153 @@ class TestTypedFrontmatterMigration:
         assert len(received_args) >= 1, "OwnershipManifest.from_frontmatter was never called"
         for arg in received_args:
             assert isinstance(arg, WPMetadata), f"Expected WPMetadata instance, got {type(arg).__name__}"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: ownership overlap fails regardless of lane / dependency hierarchy
+#
+# Invariant under test (#1753 follow-up): the ONLY way two WPs may claim the
+# same code is by declaring the broadly-overlapping one `scope: codebase-wide`.
+# Being in different lanes (independent) OR linked in a dependency hierarchy
+# (linearized into one lane) does NOT exempt narrow WPs from the overlap check.
+# ---------------------------------------------------------------------------
+
+
+def _write_overlap_feature(
+    tmp_path: Path,
+    wps: list[tuple[str, list[str], str, list[str], str | None]],
+    tasks_md: str,
+    mission_slug: str = "060-test-feature",
+) -> None:
+    """Write a feature whose WP files carry explicit (overlapping) ownership.
+
+    Each WP tuple is ``(wp_id, owned_files, authoritative_surface, deps, scope)``.
+    All ownership fields are explicit so finalize does not infer/clobber them.
+    """
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text(
+        "---\ntitle: Test Feature\n---\n\n## Requirements\n\n- FR-001: First requirement\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks.md").write_text(tasks_md, encoding="utf-8")
+    (feature_dir / "meta.json").write_text(
+        json.dumps({"mission_slug": mission_slug}), encoding="utf-8"
+    )
+    for wp_id, owned, surface, deps, scope in wps:
+        lines = [
+            "---",
+            f'work_package_id: "{wp_id}"',
+            f'title: "Test {wp_id}"',
+            "requirement_refs:",
+            "  - FR-001",
+            "execution_mode: code_change",
+            "owned_files:",
+            *[f"  - {p}" for p in owned],
+            f'authoritative_surface: "{surface}"',
+        ]
+        if deps:
+            lines.append("dependencies:")
+            lines.extend(f"  - {d}" for d in deps)
+        else:
+            lines.append("dependencies: []")
+        if scope is not None:
+            lines.append(f'scope: "{scope}"')
+        lines.extend(["---", "", f"# {wp_id}", ""])
+        (tasks_dir / f"{wp_id}-test.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _run_finalize_validate_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    mission_slug: str = "060-test-feature",
+) -> list[dict[str, object]]:
+    """Run finalize-tasks --validate-only with the REAL ownership validator."""
+    patches = _common_patches(tmp_path, mission_slug)
+    del patches[f"{MODULE}.validate_ownership"]  # exercise the real validator
+    patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
+        return_value=_make_bootstrap_result()
+    )
+    from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+    started = [patch(target, value) for target, value in patches.items()]
+    for p in started:
+        p.start()
+    try:
+        finalize_tasks(feature=mission_slug, json_output=True, validate_only=True)
+    except (typer.Exit, SystemExit):
+        pass
+    finally:
+        for p in started:
+            p.stop()
+
+    results: list[dict[str, object]] = []
+    for line in capsys.readouterr().out.strip().splitlines():
+        try:
+            results.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return results
+
+
+class TestOwnershipOverlapAcceptance:
+    """Overlap fails for narrow WPs regardless of lane/dependency structure."""
+
+    def test_independent_wps_overlap_fails(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two independent (different-lane) narrow WPs on the same files fail."""
+        _write_overlap_feature(
+            tmp_path,
+            wps=[
+                ("WP01", ["src/foo/**"], "src/foo/", [], None),
+                ("WP02", ["src/foo/**"], "src/foo/", [], None),
+            ],
+            tasks_md="# Tasks\n\n## WP01\n\nNo dependencies.\n\n## WP02\n\nNo dependencies.\n",
+        )
+        results = _run_finalize_validate_only(tmp_path, capsys)
+        failures = [r for r in results if r.get("error") == "Ownership validation failed"]
+        assert failures, f"expected ownership failure, got {results}"
+        errors = failures[0]["ownership_errors"]
+        assert isinstance(errors, list)
+        assert any("WP01" in e and "WP02" in e for e in errors)
+
+    def test_dependent_wps_overlap_still_fails(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """WP02→WP01 dependency (one lane) does NOT exempt narrow overlap."""
+        _write_overlap_feature(
+            tmp_path,
+            wps=[
+                ("WP01", ["src/foo/**"], "src/foo/", [], None),
+                ("WP02", ["src/foo/**"], "src/foo/", ["WP01"], None),
+            ],
+            tasks_md="# Tasks\n\n## WP01\n\nNo dependencies.\n\n## WP02\n\nDepends on WP01.\n",
+        )
+        results = _run_finalize_validate_only(tmp_path, capsys)
+        failures = [r for r in results if r.get("error") == "Ownership validation failed"]
+        assert failures, (
+            "a dependency hierarchy must NOT exempt overlapping narrow WPs; "
+            f"got {results}"
+        )
+
+    def test_codebase_wide_is_the_only_exemption(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A codebase-wide WP overlapping a narrow WP passes (end-to-end #1753)."""
+        _write_overlap_feature(
+            tmp_path,
+            wps=[
+                ("WP01", ["src/**"], "src/", [], "codebase-wide"),
+                ("WP02", ["src/foo/bar.py"], "src/foo/bar.py", ["WP01"], None),
+            ],
+            tasks_md="# Tasks\n\n## WP01\n\nNo dependencies.\n\n## WP02\n\nDepends on WP01.\n",
+        )
+        results = _run_finalize_validate_only(tmp_path, capsys)
+        assert not [
+            r for r in results if r.get("error") == "Ownership validation failed"
+        ], f"codebase-wide WP must be exempt from overlap; got {results}"
+        assert any(
+            r.get("result") == "validation_passed" for r in results
+        ), f"expected validation_passed; got {results}"

--- a/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
+++ b/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
@@ -160,6 +160,7 @@ class TestFinalizeTasksCallsBootstrap:
             tmp_path / "kitty-specs" / mission_slug,
             mission_slug,
             dry_run=False,
+            allow_protected_branch_in_test_mode=True,
         )
 
 
@@ -768,10 +769,16 @@ class TestFinalizeScaffoldsAcceptanceMatrix:
         feature_dir = _setup_feature(tmp_path, mission_slug)
         captured_files: list[Path] = []
 
-        def _bootstrap_side_effect(feature_path: Path, slug: str, dry_run: bool) -> BootstrapResult:
+        def _bootstrap_side_effect(
+            feature_path: Path,
+            slug: str,
+            dry_run: bool,
+            allow_protected_branch_in_test_mode: bool = False,
+        ) -> BootstrapResult:
             assert feature_path == feature_dir
             assert slug == mission_slug
             assert dry_run is False
+            assert allow_protected_branch_in_test_mode is True
             (feature_path / "status.events.jsonl").write_text('{"event":"seeded"}\n', encoding="utf-8")
             (feature_path / "status.json").write_text("{}", encoding="utf-8")
             return _make_bootstrap_result()

--- a/tests/specify_cli/ownership/test_models.py
+++ b/tests/specify_cli/ownership/test_models.py
@@ -139,6 +139,35 @@ class TestOwnershipManifestFromWPMetadata:
         assert m.owned_files == ("src/foo/**",)
         assert m.authoritative_surface == "src/foo/"
 
+    def test_carries_scope_from_wp_metadata(self) -> None:
+        """#1753: the WPMetadata branch must propagate codebase-wide scope.
+
+        finalize-tasks builds manifests from WPMetadata instances (see
+        read_wp_frontmatter), so dropping scope here silently defeats the
+        codebase-wide overlap exemption on the exact path finalize uses.
+        """
+        meta = WPMetadata(
+            work_package_id="WP04",
+            title="T",
+            execution_mode="code_change",
+            owned_files=["src/**"],
+            authoritative_surface="src/",
+            scope="codebase-wide",
+        )
+        m = OwnershipManifest.from_frontmatter(meta)
+        assert m.scope == "codebase-wide"
+        assert m.is_codebase_wide is True
+
+    def test_narrow_wp_metadata_scope_is_none(self) -> None:
+        meta = WPMetadata(
+            work_package_id="WP01",
+            title="T",
+            execution_mode="code_change",
+            owned_files=["src/foo/**"],
+            authoritative_surface="src/foo/",
+        )
+        assert OwnershipManifest.from_frontmatter(meta).scope is None
+
     def test_wp_metadata_missing_owned_files_defaults_empty(self) -> None:
         meta = WPMetadata(
             work_package_id="WP01",

--- a/tests/specify_cli/ownership/test_validation.py
+++ b/tests/specify_cli/ownership/test_validation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from specify_cli.ownership.models import ExecutionMode, OwnershipManifest
 from specify_cli.ownership.validation import (
     ValidationResult,
+    build_wp_manifests,
     validate_all,
     validate_authoritative_surface,
     validate_execution_mode_consistency,
@@ -16,6 +17,7 @@ from specify_cli.ownership.validation import (
     validate_no_overlap,
     validate_ownership,
 )
+from specify_cli.status.wp_metadata import WPMetadata
 
 
 pytestmark = [pytest.mark.unit]
@@ -301,3 +303,79 @@ class TestValidateGlobMatches:
         assert len(warnings) == 2
         assert warnings[0].startswith("WP01")
         assert warnings[1].startswith("WP02")
+
+
+# ---------------------------------------------------------------------------
+# #1753 follow-up: ownership overlap decided logically from WPMetadata stubs.
+#
+# These prove the invariant WITHOUT real WP files or finalize-command ceremony:
+# build_wp_manifests + validate_ownership is the pure seam finalize-tasks uses.
+# Invariant: scope=codebase-wide is the ONLY exemption; lane/dependency
+# structure (modelled via the `dependencies` field) never exempts an overlap.
+# ---------------------------------------------------------------------------
+
+
+def _wp(
+    wp_id: str,
+    owned: tuple[str, ...],
+    surface: str,
+    *,
+    scope: str | None = None,
+    deps: tuple[str, ...] = (),
+) -> WPMetadata:
+    """Minimal WPMetadata stub with explicit ownership (no files involved)."""
+    return WPMetadata(
+        work_package_id=wp_id,
+        execution_mode="code_change",
+        owned_files=list(owned),
+        authoritative_surface=surface,
+        scope=scope,
+        dependencies=list(deps),
+    )
+
+
+class TestBuildWpManifestsOverlap:
+    """The validator is exercised logically from WPMetadata stubs."""
+
+    def test_independent_wps_overlap_fails(self) -> None:
+        """Two independent (different-lane) narrow WPs on the same files fail."""
+        result = validate_ownership(
+            build_wp_manifests(
+                {
+                    "WP01": _wp("WP01", ("src/foo/**",), "src/foo/"),
+                    "WP02": _wp("WP02", ("src/foo/**",), "src/foo/"),
+                }
+            )
+        )
+        assert not result.passed
+        assert any("WP01" in e and "WP02" in e for e in result.errors)
+
+    def test_dependency_hierarchy_does_not_exempt(self) -> None:
+        """WP02 → WP01 dependency (one lane) does NOT exempt narrow overlap."""
+        result = validate_ownership(
+            build_wp_manifests(
+                {
+                    "WP01": _wp("WP01", ("src/foo/**",), "src/foo/"),
+                    "WP02": _wp("WP02", ("src/foo/**",), "src/foo/", deps=("WP01",)),
+                }
+            )
+        )
+        assert not result.passed
+
+    def test_codebase_wide_is_the_only_exemption(self) -> None:
+        """A codebase-wide WP overlapping a narrow WP passes (scope carried)."""
+        result = validate_ownership(
+            build_wp_manifests(
+                {
+                    "WP01": _wp("WP01", ("src/**",), "src/", scope="codebase-wide"),
+                    "WP02": _wp(
+                        "WP02", ("src/foo/bar.py",), "src/foo/bar.py", deps=("WP01",)
+                    ),
+                }
+            )
+        )
+        assert result.passed
+
+    def test_wp_without_ownership_is_skipped(self) -> None:
+        """WPs without execution_mode/owned_files are not manifested."""
+        assert build_wp_manifests({"WP01": WPMetadata(work_package_id="WP01")}) == {}

--- a/tests/specify_cli/ownership/test_validation.py
+++ b/tests/specify_cli/ownership/test_validation.py
@@ -308,7 +308,7 @@ class TestValidateGlobMatches:
 # ---------------------------------------------------------------------------
 # #1753 follow-up: ownership overlap decided logically from WPMetadata stubs.
 #
-# These prove the invariant WITHOUT real WP files or finalize-command ceremony:
+# These prove the invariant WITHOUT real WP files or finalize-command scaffolding:
 # build_wp_manifests + validate_ownership is the pure seam finalize-tasks uses.
 # Invariant: scope=codebase-wide is the ONLY exemption; lane/dependency
 # structure (modelled via the `dependencies` field) never exempts an overlap.

--- a/tests/specify_cli/status/test_wp_metadata.py
+++ b/tests/specify_cli/status/test_wp_metadata.py
@@ -21,6 +21,43 @@ pytestmark = pytest.mark.non_sandbox
 
 
 # ─────────────────────────────────────────────────────────────
+# #1753: codebase-wide scope round-trips through the strict parser
+# ─────────────────────────────────────────────────────────────
+
+
+class TestWPMetadataScope:
+    """`scope: codebase-wide` must parse (the ownership module reads it)."""
+
+    def test_scope_codebase_wide_accepted(self) -> None:
+        meta = WPMetadata(work_package_id="WP04", scope="codebase-wide")
+        assert meta.scope == "codebase-wide"
+
+    def test_scope_defaults_to_none(self) -> None:
+        assert WPMetadata(work_package_id="WP01").scope is None
+
+    def test_scope_exempts_overlap_via_ownership_manifest(self) -> None:
+        """A codebase-wide WP is exempt from owned_files overlap (#1753)."""
+        from specify_cli.ownership.models import OwnershipManifest
+        from specify_cli.ownership.validation import validate_no_overlap
+
+        wide = OwnershipManifest.from_frontmatter(
+            {
+                "execution_mode": "code_change",
+                "scope": "codebase-wide",
+                "owned_files": ["src/**"],
+            }
+        )
+        narrow = OwnershipManifest.from_frontmatter(
+            {
+                "execution_mode": "code_change",
+                "owned_files": ["src/mission_runtime/context.py"],
+                "authoritative_surface": "src/mission_runtime/context.py",
+            }
+        )
+        assert validate_no_overlap({"WP04": wide, "WP03": narrow}) == []
+
+
+# ─────────────────────────────────────────────────────────────
 # T012: WPMetadata unit tests
 # ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why
`finalize-tasks` could not let cross-cutting / refactor missions declare a work package `scope: codebase-wide`, even though the ownership validator already exempts such WPs. The exemption was **half-wired**: the strict `WPMetadata` parser rejected the `scope` key, and `OwnershipManifest.from_frontmatter` hard-coded `scope = None` on the exact branch `finalize-tasks` uses — so the flag either failed to parse or was silently dropped. Net effect: domain-focused / refactor missions (where WPs legitimately edit overlapping files) could not be finalized. This PR closes that, and stabilizes the surrounding finalize tooling for upcoming refactor work.

## For whom
- Operators/maintainers running domain or refactor missions (repo-wide migrations, boundary enforcement, strangler work).
- Agent profiles — new testing doctrine is wired to `python-pedro`, `randy-reducer`, `reviewer-renata`.

## What
- **#1753 fix (Closes #1753):** add `scope` to `WPMetadata`; propagate it through `OwnershipManifest.from_frontmatter` (and collapse its two duplicated branches into one — the parallel-maintenance hazard that hid the drop); drop redundant `@overload` stubs (strict-mypy clean).
- **Testability seam:** extract `build_wp_manifests()` — the pure `WPMetadata → OwnershipManifest` boundary — so the ownership invariant is testable with plain stubs (no temp files, no finalize mocking). Logical + acceptance tests prove: narrow overlaps fail regardless of lane/dependency structure; `codebase-wide` is the only exemption.
- **Boyscout:** fix a stale `bootstrap_canonical_state` mock signature that was failing 2 finalize tests on `main`.
- **Deprecation hygiene:** stop the eager import of the deprecated `rebuild_state` module (PEP 562 lazy `__getattr__` + point-of-use import) so its import-time `DeprecationWarning` no longer pollutes unrelated paths. Deliberately **not** swapped to `repair_repo` (not a per-feature drop-in) — tracked as #1754.
- **Doctrine:** new `test-desiderata-and-boundaries` styleguide (Kent Beck's desiderata + Stijn Dejongh's Clear Test Boundaries) and `test-ceremony-as-design-smell` tactic (test setup ceremony as a code-design smell), wired to the three profiles + DRG; `tasks-finalize` prompt documents refactor-mission ownership overlap; AGENTS.md gains a "use canonical sources" rule and a ruff/mypy-clean (no disabled checks) rule.
- **Filed follow-ups:** #1754 (legacy migration → `repair_repo`), #1755 (DRG generator/freshness DX + incomplete profile-edge derivation).

## Where reviewers should focus
1. **`ownership/models.py` `from_frontmatter` collapse** — the behavior-preserving claim. Two contracts must hold: `execution_mode is None` raises `KeyError` (not the `ValueError` `ExecutionMode(None)` would raise via the dict path), and `authoritative_surface` defaults to `""`. Both are guarded + pinned by tests.
2. **`migration/__init__.py` PEP 562 lazy re-export** — that `from specify_cli.migration import rebuild_event_log` still works and the warning fires only on access, not on package import.
3. **The decision to NOT migrate the legacy callers to `repair_repo`** (#1754) — confirm you agree this belongs in a separate, fixture-backed change.
4. **Doctrine/DRG** — `graph.yaml` is regenerated from sources (not hand-edited); the diff is exactly the new nodes/edges.

## Quality signal
Four-lens adversarial review (Reviewer Renata + Debugger Debbie on opus; Paula Patterns + Architect Alphonso on sonnet), each loading its spec-kitty profile: Renata SHIP, Debbie NO-REGRESSION (8 falsified break-attempts), Paula SOUND. Alphonso caught one missed profile snapshot test — fixed in the final commit. Full suite green; `ruff` + `mypy --strict` clean on touched code; no checks disabled.

**Known non-blocking follow-up:** `scope` is human-authored only — `backfill_ownership` does not infer/preserve it (Paula's whack-a-field finding). Latent (requires manual operator action to bite); recommend folding into #1754 or a small dedicated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)