### PR TITLE
fix(sonar): address CLI cleanup findings

### DIFF
--- a/src/specify_cli/cli/commands/charter/sync.py
+++ b/src/specify_cli/cli/commands/charter/sync.py
@@ -16,6 +16,38 @@ import specify_cli.cli.commands.charter as _charter_pkg
 __all__ = ["sync"]
 
 
+def _sync_result_payload(result: object) -> dict[str, object]:
+    return {
+        "result": "success" if result.synced else "noop",
+        "success": result.synced,
+        "stale_before": result.stale_before,
+        "files_written": result.files_written,
+        "extraction_mode": result.extraction_mode,
+        "error": result.error,
+        "warnings": result.warnings,
+    }
+
+
+def _render_sync_result(result: object) -> None:
+    if result.error:
+        console.print(f"[red]Error:[/red] {result.error}")
+        raise typer.Exit(code=1)
+
+    if not result.synced:
+        console.print("[blue]Charter already in sync[/blue] (use --force to re-extract)")
+        return
+
+    console.print("[green]Charter synced successfully[/green]")
+    console.print(f"Mode: {result.extraction_mode}")
+    if result.warnings:
+        console.print("\nWarnings:")
+        for warning in result.warnings:
+            console.print(f"  ! {warning}")
+    console.print("\nFiles written:")
+    for filename in result.files_written:
+        console.print(f"  ✓ {filename}")
+
+
 @charter_app.command()
 def sync(
     force: bool = typer.Option(False, "--force", "-f", help="Force sync even if not stale"),
@@ -35,34 +67,10 @@ def sync(
             if result.error:
                 _emit_error(console, json_output=True, message=str(result.error))
                 raise typer.Exit(code=1)
-            data = {
-                "result": "success" if result.synced else "noop",
-                "success": result.synced,
-                "stale_before": result.stale_before,
-                "files_written": result.files_written,
-                "extraction_mode": result.extraction_mode,
-                "error": result.error,
-                "warnings": result.warnings,
-            }
-            print(json.dumps(data, indent=2))
+            print(json.dumps(_sync_result_payload(result), indent=2))
             return
 
-        if result.error:
-            console.print(f"[red]Error:[/red] {result.error}")
-            raise typer.Exit(code=1)
-
-        if result.synced:
-            console.print("[green]Charter synced successfully[/green]")
-            console.print(f"Mode: {result.extraction_mode}")
-            if result.warnings:
-                console.print("\nWarnings:")
-                for warning in result.warnings:
-                    console.print(f"  ! {warning}")
-            console.print("\nFiles written:")
-            for filename in result.files_written:
-                console.print(f"  ✓ {filename}")
-        else:
-            console.print("[blue]Charter already in sync[/blue] (use --force to re-extract)")
+        _render_sync_result(result)
 
     except typer.Exit:
         raise

--- a/src/specify_cli/cli/commands/profiles_cmd.py
+++ b/src/specify_cli/cli/commands/profiles_cmd.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
 app = typer.Typer(name="profiles", help="Manage and list agent profiles.")
 console = Console()
 
+KITTIFY_DIRNAME = ".kittify"
+PROFILE_ID_COLUMN = "Profile ID"
+EMPTY_VALUE = "[dim]—[/dim]"
+
 
 def _activated_agent_profiles(repo_root: Path) -> frozenset[str] | None:
     """Return the three-state ``activated_agent_profiles`` set for ``repo_root``.
@@ -28,7 +32,7 @@ def _activated_agent_profiles(repo_root: Path) -> frozenset[str] | None:
     backward-compat). ``frozenset()`` → explicit empty (nothing activated).
     Non-empty frozenset → explicit set of activated IDs.
     """
-    if not (repo_root / ".kittify" / "config.yaml").exists():
+    if not (repo_root / KITTIFY_DIRNAME / "config.yaml").exists():
         return None
 
     from charter.pack_context import PackContext
@@ -78,7 +82,7 @@ def _profile_catalog(
     """
     from charter.profiles import AgentProfileRepository
 
-    legacy_dir = repo_root / ".kittify" / "profiles"
+    legacy_dir = repo_root / KITTIFY_DIRNAME / "profiles"
     legacy_repo = AgentProfileRepository(
         project_dir=legacy_dir if legacy_dir.exists() else None
     )
@@ -96,7 +100,7 @@ def _profile_catalog(
     # Overlay charter doctrine project/org profiles that the legacy invocation
     # registry cannot see. Built-ins stay controlled by ProfileRegistry so
     # existing tests/monkeypatches keep their pre-activation behavior.
-    project_doctrine_profiles = repo_root / ".kittify" / "doctrine" / "agent_profiles"
+    project_doctrine_profiles = repo_root / KITTIFY_DIRNAME / "doctrine" / "agent_profiles"
     from doctrine.drg.org_pack_config import resolve_org_roots
 
     org_roots = [root for root in resolve_org_roots(repo_root) if root.exists()]
@@ -196,7 +200,7 @@ def _render_list(descriptors: list[dict[str, Any]], *, json_output: bool) -> Non
         typer.echo(json.dumps(descriptors, indent=2))
         return
     table = Table(title="Agent Profiles")
-    table.add_column("Profile ID", no_wrap=True, overflow="fold")
+    table.add_column(PROFILE_ID_COLUMN, no_wrap=True, overflow="fold")
     table.add_column("Friendly Name")
     table.add_column("Role")
     table.add_column("Source")
@@ -211,7 +215,7 @@ def _render_list_annotated(descriptors: list[dict[str, Any]], *, json_output: bo
         typer.echo(json.dumps(descriptors, indent=2))
         return
     table = Table(title="Agent Profiles")
-    table.add_column("Profile ID", no_wrap=True, overflow="fold")
+    table.add_column(PROFILE_ID_COLUMN, no_wrap=True, overflow="fold")
     table.add_column("Friendly Name")
     table.add_column("Role")
     table.add_column("Source")
@@ -394,25 +398,25 @@ def _render_profile_human(payload: dict[str, Any]) -> None:
     table.add_row("Name", str(payload["name"]))
     table.add_row("Role", str(payload["role"]))
     table.add_row("Source layer", str(payload["source_layer"]))
-    table.add_row("Initialization", str(payload["initialization_declaration"]) or "[dim]—[/dim]")
+    table.add_row("Initialization", str(payload["initialization_declaration"]) or EMPTY_VALUE)
 
     spec = payload["specialization"]
-    table.add_row("Primary focus", spec["primary_focus"] or "[dim]—[/dim]")
-    table.add_row("Secondary awareness", spec["secondary_awareness"] or "[dim]—[/dim]")
-    table.add_row("Avoidance boundary", spec["avoidance_boundary"] or "[dim]—[/dim]")
-    table.add_row("Success definition", spec["success_definition"] or "[dim]—[/dim]")
+    table.add_row("Primary focus", spec["primary_focus"] or EMPTY_VALUE)
+    table.add_row("Secondary awareness", spec["secondary_awareness"] or EMPTY_VALUE)
+    table.add_row("Avoidance boundary", spec["avoidance_boundary"] or EMPTY_VALUE)
+    table.add_row("Success definition", spec["success_definition"] or EMPTY_VALUE)
 
     collab = payload["collaboration"]
-    table.add_row("Handoff to", ", ".join(collab["handoff_to"]) or "[dim]—[/dim]")
-    table.add_row("Handoff from", ", ".join(collab["handoff_from"]) or "[dim]—[/dim]")
-    table.add_row("Works with", ", ".join(collab["works_with"]) or "[dim]—[/dim]")
-    table.add_row("Canonical verbs", ", ".join(collab["canonical_verbs"]) or "[dim]—[/dim]")
+    table.add_row("Handoff to", ", ".join(collab["handoff_to"]) or EMPTY_VALUE)
+    table.add_row("Handoff from", ", ".join(collab["handoff_from"]) or EMPTY_VALUE)
+    table.add_row("Works with", ", ".join(collab["works_with"]) or EMPTY_VALUE)
+    table.add_row("Canonical verbs", ", ".join(collab["canonical_verbs"]) or EMPTY_VALUE)
 
     modes = ", ".join(m["mode"] for m in payload["mode_defaults"])
-    table.add_row("Mode defaults", modes or "[dim]—[/dim]")
+    table.add_row("Mode defaults", modes or EMPTY_VALUE)
     directives = ", ".join(r["code"] for r in payload["directive_references"])
-    table.add_row("Directive refs", directives or "[dim]—[/dim]")
+    table.add_row("Directive refs", directives or EMPTY_VALUE)
     tactics = ", ".join(r["id"] for r in payload["tactic_references"])
-    table.add_row("Tactic refs", tactics or "[dim]—[/dim]")
+    table.add_row("Tactic refs", tactics or EMPTY_VALUE)
 
     console.print(table)

--- a/src/specify_cli/status/aggregate.py
+++ b/src/specify_cli/status/aggregate.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Literal
 from specify_cli.core.constants import KITTY_SPECS_DIR
 
 if TYPE_CHECKING:
-    pass
+    from specify_cli.status import StatusEvent, TransitionRequest
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- refactor the new nightly Sonar hot spots in `runtime_bridge.py`, `mission.py`, `commit_helpers.py`, and `status/aggregate.py` to cut cognitive complexity without changing behavior
- hoist repeated literals in `profiles_cmd.py`, simplify `charter sync` rendering, and remove the redundant `InvocationWriteError` catch in `do_cmd.py`
- preserve clean JSON for `spec-kitty do --json` by suppressing the readiness auth banner on the protocol-style `do` surface, and make `record-analysis` report dirty-worktree blockers before protected-branch blockers

## Validation
- `.venv/bin/ruff check src/runtime/next/runtime_bridge.py src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/charter/sync.py src/specify_cli/cli/commands/do_cmd.py src/specify_cli/cli/commands/profiles_cmd.py src/specify_cli/git/commit_helpers.py src/specify_cli/readiness/coordinator.py src/specify_cli/status/aggregate.py`
- `.venv/bin/python -m pytest tests/specify_cli/next/test_runtime_bridge.py tests/next/test_runtime_bridge_unit.py tests/tasks/test_planning_workflow_integration.py tests/agent/test_agent_feature.py tests/specify_cli/test_analysis_report.py tests/specify_cli/invocation/cli/test_profiles.py tests/specify_cli/invocation/cli/test_profiles_activation.py tests/specify_cli/invocation/cli/test_do.py tests/unit/git/test_commit_helpers_backstop.py tests/specify_cli/git/test_commit_helpers.py tests/unit/status/test_mission_status_aggregate.py -q`

## Notes
- GitHub security alerts: none open
- GitHub code-scanning alerts: none open
- Previous scheduled `CI Quality` run on `main` from 2026-06-06 (`27054458415`) reached SonarCloud and failed the quality gate; the actionable nightly set was 10 open code issues created at `2026-06-06T06:36:29+0000`
