### PR TITLE
fix(sonar): address CLI cleanup findings

### DIFF
--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -279,30 +279,33 @@ def _parse_wp_sections_from_tasks_md(tasks_content: str) -> dict[str, str]:
 
 def _parse_requirement_refs_from_tasks_md(tasks_content: str) -> dict[str, list[str]]:
     """Parse requirement references per WP from tasks.md content."""
-    requirement_refs: dict[str, list[str]] = {}
+    return {
+        wp_id: _collect_requirement_refs_for_section(section_content)
+        for wp_id, section_content in _parse_wp_sections_from_tasks_md(tasks_content).items()
+    }
 
-    for wp_id, section_content in _parse_wp_sections_from_tasks_md(tasks_content).items():
-        refs: list[str] = []
-        in_requirement_ref_list = False
-        for line in section_content.splitlines():
-            stripped_line = line.strip()
-            if in_requirement_ref_list:
-                if not stripped_line:
-                    continue
-                if stripped_line.startswith(("-", "*")):
-                    refs.extend(_iter_requirement_refs(stripped_line))
-                    continue
-                in_requirement_ref_list = False
 
-            suffix = _requirement_inline_refs_suffix(line)
-            if suffix is not None:
-                refs.extend(_iter_requirement_refs(suffix))
+def _collect_requirement_refs_for_section(section_content: str) -> list[str]:
+    """Collect deduplicated requirement refs from one WP section."""
+    refs: list[str] = []
+    in_requirement_ref_list = False
+    for line in section_content.splitlines():
+        stripped_line = line.strip()
+        if in_requirement_ref_list:
+            if not stripped_line:
                 continue
-            if _is_requirement_heading(stripped_line):
-                in_requirement_ref_list = True
-        requirement_refs[wp_id] = list(dict.fromkeys(refs))
+            if stripped_line.startswith(("-", "*")):
+                refs.extend(_iter_requirement_refs(stripped_line))
+                continue
+            in_requirement_ref_list = False
 
-    return requirement_refs
+        suffix = _requirement_inline_refs_suffix(line)
+        if suffix is not None:
+            refs.extend(_iter_requirement_refs(suffix))
+            continue
+        if _is_requirement_heading(stripped_line):
+            in_requirement_ref_list = True
+    return list(dict.fromkeys(refs))
 
 
 def _iter_requirement_refs(text: str) -> list[str]:

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -76,6 +76,7 @@ SETUP_PLAN_COMMAND_NAME = "spec-kitty agent mission setup-plan"
 FINALIZE_TASKS_COMMAND_NAME = "spec-kitty agent mission finalize-tasks"
 INVALID_WP_OWNED_FILES_KITTY_SPECS = "INVALID_WP_OWNED_FILES_KITTY_SPECS"
 PROJECT_ROOT_NOT_FOUND = "Could not locate project root"
+PROJECT_ROOT_NOT_FOUND_MESSAGE = f"{PROJECT_ROOT_NOT_FOUND}. Run from within spec-kitty repository."
 
 
 def _extract_wp_ids_from_task_files(wp_files: list[Path]) -> list[str]:
@@ -86,6 +87,108 @@ def _extract_wp_ids_from_task_files(wp_files: list[Path]) -> list[str]:
         if wp_id_match:
             wp_ids.add(wp_id_match.group(1))
     return sorted(wp_ids)
+
+
+def _emit_console_or_json_error(*, json_output: bool, message: str) -> None:
+    """Emit a command error consistently across human and JSON modes."""
+    if json_output:
+        _emit_json({"error": message})
+    else:
+        console.print(f"[red]Error:[/red] {message}")
+
+
+def _emit_check_prerequisites_detection_error(
+    *,
+    repo_root: Path,
+    detection_error: ValueError,
+    feature: str | None,
+    json_output: bool,
+    paths_only: bool,
+    include_tasks: bool,
+) -> None:
+    """Emit the existing feature-detection payload for prerequisite checks."""
+    command_args: list[str] = []
+    if json_output:
+        command_args.append("--json")
+    if paths_only:
+        command_args.append("--paths-only")
+    if include_tasks:
+        command_args.append("--include-tasks")
+
+    payload = _build_setup_plan_detection_error(
+        repo_root,
+        str(detection_error),
+        feature,
+        error_code="FEATURE_CONTEXT_UNRESOLVED",
+        command_name="check-prerequisites",
+        command_args=command_args,
+    )
+    if json_output:
+        _emit_json(payload)
+        return
+
+    console.print(f"[red]Error:[/red] {payload['error']}")
+    for slug in cast(list[str], payload.get("available_missions", []))[:10]:
+        console.print(f"  - {slug}")
+    if "example_command" in payload:
+        console.print(f"  {payload['example_command']}")
+
+
+def _paths_only_payload(validation_result: dict[str, object]) -> dict[str, object]:
+    """Build the legacy paths-only payload shape for prerequisite checks."""
+    paths_payload = dict(cast(dict[str, object], validation_result["paths"]))
+    paths_payload["artifact_files"] = validation_result.get("artifact_files", {})
+    paths_payload["artifact_dirs"] = validation_result.get("artifact_dirs", {})
+    paths_payload["available_docs"] = validation_result.get("available_docs", [])
+    paths_payload["FEATURE_DIR"] = paths_payload.get("feature_dir", "")
+    paths_payload["SPEC_FILE"] = paths_payload.get("spec_file", "")
+    paths_payload["PLAN_FILE"] = paths_payload.get("plan_file", "")
+    paths_payload["TASKS_FILE"] = paths_payload.get("tasks_file", "")
+    paths_payload["FEATURE_SPEC"] = paths_payload.get("spec_file", "")
+    paths_payload["IMPL_PLAN"] = paths_payload.get("plan_file", "")
+    paths_payload["TASKS"] = paths_payload.get("tasks_file", "")
+    feature_dir_value = str(paths_payload.get("feature_dir", ""))
+    paths_payload["SPECS_DIR"] = str(Path(feature_dir_value).parent) if feature_dir_value else ""
+    return paths_payload
+
+
+def _emit_check_prerequisites_result(
+    *,
+    validation_result: dict[str, object],
+    feature_dir: Path,
+    json_output: bool,
+    paths_only: bool,
+    target_branch: str,
+    current_branch: str,
+) -> None:
+    """Emit prerequisite-check output in JSON or human form."""
+    if json_output:
+        payload = (
+            _paths_only_payload(validation_result)
+            if paths_only
+            else dict(validation_result)
+        )
+        _emit_json(
+            _inject_branch_contract(
+                payload,
+                target_branch=target_branch,
+                current_branch=current_branch,
+            )
+        )
+        return
+
+    if validation_result["valid"]:
+        console.print("[green]✓[/green] Prerequisites check passed")
+        console.print(f"   Mission: {feature_dir.name}")
+    else:
+        console.print("[red]✗[/red] Prerequisites check failed")
+        for error in cast(list[str], validation_result["errors"]):
+            console.print(f"   • {error}")
+
+    for warning in cast(list[str], validation_result["warnings"]):
+        if warning == validation_result["warnings"][0]:
+            console.print("\n[yellow]Warnings:[/yellow]")
+        console.print(f"   • {warning}")
 
 
 def _collect_finalize_artifacts(
@@ -351,6 +454,23 @@ def _enforce_analysis_report_write_preflight(repo_root: Path, *, json_output: bo
     if not is_git_repo(repo_root):
         return
 
+    dirty_paths = _git_dirty_paths(repo_root)
+    if dirty_paths:
+        payload = {
+            "success": False,
+            "error_code": "DIRTY_WORKTREE",
+            "error": "Refusing to record analysis report with pre-existing dirty working tree.",
+            "dirty_paths": dirty_paths,
+            "remediation": ["Commit or stash existing changes, then rerun /spec-kitty.analyze."],
+        }
+        if json_output:
+            _emit_json(payload)
+        else:
+            console.print(f"[red]Error:[/red] {payload['error']}")
+            for path in dirty_paths:
+                console.print(f"  - {path}")
+        raise typer.Exit(1)
+
     # Use the CWD git toplevel (the actual worktree) for the branch check so
     # that running from a coord/lane worktree on a mission branch is allowed.
     # repo_root is always the main repo root (locate_project_root() follows
@@ -381,23 +501,6 @@ def _enforce_analysis_report_write_preflight(repo_root: Path, *, json_output: bo
         else:
             console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from None
-
-    dirty_paths = _git_dirty_paths(repo_root)
-    if dirty_paths:
-        payload = {
-            "success": False,
-            "error_code": "DIRTY_WORKTREE",
-            "error": "Refusing to record analysis report with pre-existing dirty working tree.",
-            "dirty_paths": dirty_paths,
-            "remediation": ["Commit or stash existing changes, then rerun /spec-kitty.analyze."],
-        }
-        if json_output:
-            _emit_json(payload)
-        else:
-            console.print(f"[red]Error:[/red] {payload['error']}")
-            for path in dirty_paths:
-                console.print(f"  - {path}")
-        raise typer.Exit(1)
 
 
 def _show_branch_context(
@@ -1055,11 +1158,10 @@ def check_prerequisites(
 
         repo_root = locate_project_root()
         if repo_root is None:
-            error_msg = "Could not locate project root. Run from within spec-kitty repository."
-            if json_output:
-                _emit_json({"error": error_msg})
-            else:
-                console.print(f"[red]Error:[/red] {error_msg}")
+            _emit_console_or_json_error(
+                json_output=json_output,
+                message=PROJECT_ROOT_NOT_FOUND_MESSAGE,
+            )
             raise typer.Exit(1) from None
 
         _enforce_git_preflight(
@@ -1077,80 +1179,27 @@ def check_prerequisites(
                 explicit_feature=feature,
             )
         except ValueError as detection_error:
-            command_args: list[str] = []
-            if json_output:
-                command_args.append("--json")
-            if paths_only:
-                command_args.append("--paths-only")
-            if include_tasks:
-                command_args.append("--include-tasks")
-
-            payload = _build_setup_plan_detection_error(
-                repo_root,
-                str(detection_error),
-                feature,
-                error_code="FEATURE_CONTEXT_UNRESOLVED",
-                command_name="check-prerequisites",
-                command_args=command_args,
+            _emit_check_prerequisites_detection_error(
+                repo_root=repo_root,
+                detection_error=detection_error,
+                feature=feature,
+                json_output=json_output,
+                paths_only=paths_only,
+                include_tasks=include_tasks,
             )
-            if json_output:
-                _emit_json(payload)
-            else:
-                console.print(f"[red]Error:[/red] {payload['error']}")
-                for slug in cast(list[str], payload.get("available_missions", []))[:10]:
-                    console.print(f"  - {slug}")
-                if "example_command" in payload:
-                    console.print(f"  {payload['example_command']}")
             raise typer.Exit(1) from None
 
         validation_result = validate_feature_structure(feature_dir, check_tasks=include_tasks)
         target_branch = _resolve_feature_target_branch(feature_dir, repo_root)
         current_branch = get_current_branch(repo_root) or target_branch
-
-        if json_output:
-            if paths_only:
-                paths_payload = dict(validation_result["paths"])
-                paths_payload["artifact_files"] = validation_result.get("artifact_files", {})
-                paths_payload["artifact_dirs"] = validation_result.get("artifact_dirs", {})
-                paths_payload["available_docs"] = validation_result.get("available_docs", [])
-                paths_payload["FEATURE_DIR"] = paths_payload.get("feature_dir", "")
-                paths_payload["SPEC_FILE"] = paths_payload.get("spec_file", "")
-                paths_payload["PLAN_FILE"] = paths_payload.get("plan_file", "")
-                paths_payload["TASKS_FILE"] = paths_payload.get("tasks_file", "")
-                paths_payload["FEATURE_SPEC"] = paths_payload.get("spec_file", "")
-                paths_payload["IMPL_PLAN"] = paths_payload.get("plan_file", "")
-                paths_payload["TASKS"] = paths_payload.get("tasks_file", "")
-                feature_dir_value = str(paths_payload.get("feature_dir", ""))
-                paths_payload["SPECS_DIR"] = str(Path(feature_dir_value).parent) if feature_dir_value else ""
-                _emit_json(
-                    _inject_branch_contract(
-                        paths_payload,
-                        target_branch=target_branch,
-                        current_branch=current_branch,
-                    )
-                )
-            else:
-                result_payload = dict(validation_result)
-                _emit_json(
-                    _inject_branch_contract(
-                        result_payload,
-                        target_branch=target_branch,
-                        current_branch=current_branch,
-                    )
-                )
-        else:
-            if validation_result["valid"]:
-                console.print("[green]✓[/green] Prerequisites check passed")
-                console.print(f"   Mission: {feature_dir.name}")
-            else:
-                console.print("[red]✗[/red] Prerequisites check failed")
-                for error in validation_result["errors"]:
-                    console.print(f"   • {error}")
-
-            if validation_result["warnings"]:
-                console.print("\n[yellow]Warnings:[/yellow]")
-                for warning in validation_result["warnings"]:
-                    console.print(f"   • {warning}")
+        _emit_check_prerequisites_result(
+            validation_result=validation_result,
+            feature_dir=feature_dir,
+            json_output=json_output,
+            paths_only=paths_only,
+            target_branch=target_branch,
+            current_branch=current_branch,
+        )
 
     except typer.Exit:
         raise

--- a/src/specify_cli/cli/commands/charter/sync.py
+++ b/src/specify_cli/cli/commands/charter/sync.py
@@ -16,6 +16,40 @@ import specify_cli.cli.commands.charter as _charter_pkg
 __all__ = ["sync"]
 
 
+def _sync_json_payload(result: object) -> dict[str, object]:
+    """Return stable JSON output for ``charter sync``."""
+    return {
+        "result": "success" if result.synced else "noop",
+        "success": result.synced,
+        "stale_before": result.stale_before,
+        "files_written": result.files_written,
+        "extraction_mode": result.extraction_mode,
+        "error": result.error,
+        "warnings": result.warnings,
+    }
+
+
+def _emit_sync_human_result(result: object) -> None:
+    """Render the non-JSON ``charter sync`` result."""
+    if result.error:
+        console.print(f"[red]Error:[/red] {result.error}")
+        raise typer.Exit(code=1)
+
+    if not result.synced:
+        console.print("[blue]Charter already in sync[/blue] (use --force to re-extract)")
+        return
+
+    console.print("[green]Charter synced successfully[/green]")
+    console.print(f"Mode: {result.extraction_mode}")
+    if result.warnings:
+        console.print("\nWarnings:")
+        for warning in result.warnings:
+            console.print(f"  ! {warning}")
+    console.print("\nFiles written:")
+    for filename in result.files_written:
+        console.print(f"  ✓ {filename}")
+
+
 @charter_app.command()
 def sync(
     force: bool = typer.Option(False, "--force", "-f", help="Force sync even if not stale"),
@@ -35,34 +69,10 @@ def sync(
             if result.error:
                 _emit_error(console, json_output=True, message=str(result.error))
                 raise typer.Exit(code=1)
-            data = {
-                "result": "success" if result.synced else "noop",
-                "success": result.synced,
-                "stale_before": result.stale_before,
-                "files_written": result.files_written,
-                "extraction_mode": result.extraction_mode,
-                "error": result.error,
-                "warnings": result.warnings,
-            }
-            print(json.dumps(data, indent=2))
+            print(json.dumps(_sync_json_payload(result), indent=2))
             return
 
-        if result.error:
-            console.print(f"[red]Error:[/red] {result.error}")
-            raise typer.Exit(code=1)
-
-        if result.synced:
-            console.print("[green]Charter synced successfully[/green]")
-            console.print(f"Mode: {result.extraction_mode}")
-            if result.warnings:
-                console.print("\nWarnings:")
-                for warning in result.warnings:
-                    console.print(f"  ! {warning}")
-            console.print("\nFiles written:")
-            for filename in result.files_written:
-                console.print(f"  ✓ {filename}")
-        else:
-            console.print("[blue]Charter already in sync[/blue] (use --force to re-extract)")
+        _emit_sync_human_result(result)
 
     except typer.Exit:
         raise

--- a/src/specify_cli/cli/commands/do_cmd.py
+++ b/src/specify_cli/cli/commands/do_cmd.py
@@ -134,7 +134,7 @@ def do(
     # so completion write failures cannot masquerade as successful JSON.
     try:
         executor.complete_invocation(payload.invocation_id, outcome="done")
-    except (InvocationError, InvocationWriteError) as e:
+    except InvocationError as e:
         typer.echo(
             json.dumps({"error": "write_failed", "message": str(e)}), err=True
         )

--- a/src/specify_cli/cli/commands/profiles_cmd.py
+++ b/src/specify_cli/cli/commands/profiles_cmd.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 
 app = typer.Typer(name="profiles", help="Manage and list agent profiles.")
 console = Console()
+_KITTIFY_DIR = ".kittify"
+_PROFILE_ID_LABEL = "Profile ID"
+_EMPTY_VALUE = "[dim]—[/dim]"
 
 
 def _activated_agent_profiles(repo_root: Path) -> frozenset[str] | None:
@@ -28,7 +31,7 @@ def _activated_agent_profiles(repo_root: Path) -> frozenset[str] | None:
     backward-compat). ``frozenset()`` → explicit empty (nothing activated).
     Non-empty frozenset → explicit set of activated IDs.
     """
-    if not (repo_root / ".kittify" / "config.yaml").exists():
+    if not (repo_root / _KITTIFY_DIR / "config.yaml").exists():
         return None
 
     from charter.pack_context import PackContext
@@ -78,7 +81,7 @@ def _profile_catalog(
     """
     from charter.profiles import AgentProfileRepository
 
-    legacy_dir = repo_root / ".kittify" / "profiles"
+    legacy_dir = repo_root / _KITTIFY_DIR / "profiles"
     legacy_repo = AgentProfileRepository(
         project_dir=legacy_dir if legacy_dir.exists() else None
     )
@@ -96,7 +99,7 @@ def _profile_catalog(
     # Overlay charter doctrine project/org profiles that the legacy invocation
     # registry cannot see. Built-ins stay controlled by ProfileRegistry so
     # existing tests/monkeypatches keep their pre-activation behavior.
-    project_doctrine_profiles = repo_root / ".kittify" / "doctrine" / "agent_profiles"
+    project_doctrine_profiles = repo_root / _KITTIFY_DIR / "doctrine" / "agent_profiles"
     from doctrine.drg.org_pack_config import resolve_org_roots
 
     org_roots = [root for root in resolve_org_roots(repo_root) if root.exists()]
@@ -196,7 +199,7 @@ def _render_list(descriptors: list[dict[str, Any]], *, json_output: bool) -> Non
         typer.echo(json.dumps(descriptors, indent=2))
         return
     table = Table(title="Agent Profiles")
-    table.add_column("Profile ID", no_wrap=True, overflow="fold")
+    table.add_column(_PROFILE_ID_LABEL, no_wrap=True, overflow="fold")
     table.add_column("Friendly Name")
     table.add_column("Role")
     table.add_column("Source")
@@ -211,7 +214,7 @@ def _render_list_annotated(descriptors: list[dict[str, Any]], *, json_output: bo
         typer.echo(json.dumps(descriptors, indent=2))
         return
     table = Table(title="Agent Profiles")
-    table.add_column("Profile ID", no_wrap=True, overflow="fold")
+    table.add_column(_PROFILE_ID_LABEL, no_wrap=True, overflow="fold")
     table.add_column("Friendly Name")
     table.add_column("Role")
     table.add_column("Source")
@@ -390,29 +393,29 @@ def _render_profile_human(payload: dict[str, Any]) -> None:
     table = Table(title=f"Agent Profile: {payload['profile_id']}", show_lines=True)
     table.add_column("Field", style="bold cyan", no_wrap=True)
     table.add_column("Value", style="white")
-    table.add_row("Profile ID", str(payload["profile_id"]))
+    table.add_row(_PROFILE_ID_LABEL, str(payload["profile_id"]))
     table.add_row("Name", str(payload["name"]))
     table.add_row("Role", str(payload["role"]))
     table.add_row("Source layer", str(payload["source_layer"]))
-    table.add_row("Initialization", str(payload["initialization_declaration"]) or "[dim]—[/dim]")
+    table.add_row("Initialization", str(payload["initialization_declaration"]) or _EMPTY_VALUE)
 
     spec = payload["specialization"]
-    table.add_row("Primary focus", spec["primary_focus"] or "[dim]—[/dim]")
-    table.add_row("Secondary awareness", spec["secondary_awareness"] or "[dim]—[/dim]")
-    table.add_row("Avoidance boundary", spec["avoidance_boundary"] or "[dim]—[/dim]")
-    table.add_row("Success definition", spec["success_definition"] or "[dim]—[/dim]")
+    table.add_row("Primary focus", spec["primary_focus"] or _EMPTY_VALUE)
+    table.add_row("Secondary awareness", spec["secondary_awareness"] or _EMPTY_VALUE)
+    table.add_row("Avoidance boundary", spec["avoidance_boundary"] or _EMPTY_VALUE)
+    table.add_row("Success definition", spec["success_definition"] or _EMPTY_VALUE)
 
     collab = payload["collaboration"]
-    table.add_row("Handoff to", ", ".join(collab["handoff_to"]) or "[dim]—[/dim]")
-    table.add_row("Handoff from", ", ".join(collab["handoff_from"]) or "[dim]—[/dim]")
-    table.add_row("Works with", ", ".join(collab["works_with"]) or "[dim]—[/dim]")
-    table.add_row("Canonical verbs", ", ".join(collab["canonical_verbs"]) or "[dim]—[/dim]")
+    table.add_row("Handoff to", ", ".join(collab["handoff_to"]) or _EMPTY_VALUE)
+    table.add_row("Handoff from", ", ".join(collab["handoff_from"]) or _EMPTY_VALUE)
+    table.add_row("Works with", ", ".join(collab["works_with"]) or _EMPTY_VALUE)
+    table.add_row("Canonical verbs", ", ".join(collab["canonical_verbs"]) or _EMPTY_VALUE)
 
     modes = ", ".join(m["mode"] for m in payload["mode_defaults"])
-    table.add_row("Mode defaults", modes or "[dim]—[/dim]")
+    table.add_row("Mode defaults", modes or _EMPTY_VALUE)
     directives = ", ".join(r["code"] for r in payload["directive_references"])
-    table.add_row("Directive refs", directives or "[dim]—[/dim]")
+    table.add_row("Directive refs", directives or _EMPTY_VALUE)
     tactics = ", ".join(r["id"] for r in payload["tactic_references"])
-    table.add_row("Tactic refs", tactics or "[dim]—[/dim]")
+    table.add_row("Tactic refs", tactics or _EMPTY_VALUE)
 
     console.print(table)

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -488,24 +488,8 @@ def _is_completed_op_record_exception(
     worktree_root: Path,
     normalized_files: Sequence[str],
 ) -> bool:
-    if len(normalized_files) != 1:
-        return False
-
-    op_path = Path(normalized_files[0])
-    if op_path.is_absolute() or len(op_path.parts) != 2:
-        return False
-    if op_path.parts[0] != "kitty-ops":
-        return False
-
-    filename = op_path.parts[1]
-    if not filename.endswith(".jsonl"):
-        return False
-    op_id = filename.removesuffix(".jsonl")
-    if op_id in {"ops-index", "lifecycle", "propagation-errors"}:
-        return False
-
-    ulid_alphabet = set("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
-    if len(op_id) != 26 or not all(char in ulid_alphabet for char in op_id):
+    op_id, op_path = _completed_op_exception_target(normalized_files)
+    if op_id is None or op_path is None:
         return False
 
     record_path = worktree_root / op_path
@@ -528,6 +512,33 @@ def _is_completed_op_record_exception(
         ):
             return True
     return False
+
+
+def _completed_op_exception_target(
+    normalized_files: Sequence[str],
+) -> tuple[str | None, Path | None]:
+    """Return the op id/path pair when ``normalized_files`` is an op record."""
+    if len(normalized_files) != 1:
+        return None, None
+
+    op_path = Path(normalized_files[0])
+    if op_path.is_absolute() or len(op_path.parts) != 2 or op_path.parts[0] != "kitty-ops":
+        return None, None
+
+    filename = op_path.parts[1]
+    if not filename.endswith(".jsonl"):
+        return None, None
+
+    op_id = filename.removesuffix(".jsonl")
+    if op_id in {"ops-index", "lifecycle", "propagation-errors"} or not _is_ulid(op_id):
+        return None, None
+    return op_id, op_path
+
+
+def _is_ulid(value: str) -> bool:
+    """Return whether ``value`` is a canonical 26-char Crockford ULID."""
+    ulid_alphabet = set("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+    return len(value) == 26 and all(char in ulid_alphabet for char in value)
 
 
 def assert_staging_area_matches_expected(

--- a/src/specify_cli/readiness/coordinator.py
+++ b/src/specify_cli/readiness/coordinator.py
@@ -33,7 +33,7 @@ from specify_cli.cli.commands._auth_recovery import (  # noqa: F401
 )
 
 _READINESS_CTX_KEY = "readiness"
-_PROTOCOL_OUTPUT_SUBCOMMANDS = frozenset({"next"})
+_PROTOCOL_OUTPUT_SUBCOMMANDS = frozenset({"do", "next"})
 
 
 class OutputPolicy(StrEnum):

--- a/src/specify_cli/status/aggregate.py
+++ b/src/specify_cli/status/aggregate.py
@@ -28,12 +28,12 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
 
 if TYPE_CHECKING:
-    pass
+    from specify_cli.status import TransitionRequest
 
 _logger = logging.getLogger(__name__)
 
@@ -421,40 +421,24 @@ class MissionStatus:
         )
         from specify_cli.status import emit as status_emit
 
-        # Derive from_lane from the same target the transactional writer will
-        # use. For declared coordination branches without a materialized
-        # worktree, this reads the branch ref rather than stale primary files.
-        from_lane_enum, current_actor = read_current_wp_state_transactional(
-            feature_dir=self.read_dir,
-            mission_slug=self.mission_slug,
-            wp_id=request.wp_id or "",
-            repo_root=self.repo_root,
-        )
-        if str(from_lane_enum) == "uninitialized":
-            from_lane_enum = Lane.PLANNED
-        to_lane_str = request.to_lane or ""
-        from_lane_str = str(from_lane_enum)
-
         from specify_cli.status.transitions import resolve_lane_alias
 
+        from_lane_str, current_actor = self._resolve_current_lane(
+            request=request,
+            read_current_wp_state_transactional=read_current_wp_state_transactional,
+            lane_planned=Lane.PLANNED,
+        )
+        to_lane_str = request.to_lane or ""
         resolved_to_lane = resolve_lane_alias(to_lane_str)
-        workspace_context = request.workspace_context
-        if workspace_context is None:
-            context_root = request.repo_root if request.repo_root is not None else self.read_dir
-            workspace_context = f"{request.execution_mode}:{context_root}"
-
-        subtasks_complete = request.subtasks_complete
-        implementation_evidence_present = request.implementation_evidence_present
-        if subtasks_complete is None and from_lane_str == Lane.IN_PROGRESS and resolved_to_lane == Lane.FOR_REVIEW:
-            subtasks_complete = status_emit._infer_subtasks_complete(self.read_dir, request.wp_id or "")
-        if (
-            implementation_evidence_present is None
-            and from_lane_str == Lane.IN_PROGRESS
-            and resolved_to_lane == Lane.FOR_REVIEW
-        ):
-            implementation_evidence_present = status_emit._infer_implementation_evidence(
-                self.read_dir, request.wp_id or ""
-            )
+        workspace_context = self._resolve_workspace_context(request)
+        subtasks_complete, implementation_evidence_present = self._resolve_review_gate_inputs(
+            request=request,
+            from_lane_str=from_lane_str,
+            resolved_to_lane=resolved_to_lane,
+            status_emit=status_emit,
+            lane_in_progress=Lane.IN_PROGRESS,
+            lane_for_review=Lane.FOR_REVIEW,
+        )
 
         if status_emit._legacy_alias_collapses_to_current_lane(
             to_lane_str,
@@ -499,6 +483,53 @@ class MissionStatus:
             mission_slug=self.mission_slug,
         )
         return emit_status_transition_transactional(enriched)
+
+    def _resolve_current_lane(
+        self,
+        *,
+        request: TransitionRequest,
+        read_current_wp_state_transactional: Any,
+        lane_planned: Any,
+    ) -> tuple[str, str | None]:
+        """Resolve the lane/current actor from the transactional authority."""
+        from_lane_enum, current_actor = read_current_wp_state_transactional(
+            feature_dir=self.read_dir,
+            mission_slug=self.mission_slug,
+            wp_id=request.wp_id or "",
+            repo_root=self.repo_root,
+        )
+        if str(from_lane_enum) == "uninitialized":
+            from_lane_enum = lane_planned
+        return str(from_lane_enum), current_actor
+
+    def _resolve_workspace_context(self, request: TransitionRequest) -> str:
+        """Return the workspace context string used by transition guards."""
+        if request.workspace_context is not None:
+            return request.workspace_context
+        context_root = request.repo_root if request.repo_root is not None else self.read_dir
+        return f"{request.execution_mode}:{context_root}"
+
+    def _resolve_review_gate_inputs(
+        self,
+        *,
+        request: TransitionRequest,
+        from_lane_str: str,
+        resolved_to_lane: str,
+        status_emit: Any,
+        lane_in_progress: Any,
+        lane_for_review: Any,
+    ) -> tuple[bool | None, bool | None]:
+        """Infer review gate inputs only for in-progress -> for-review transitions."""
+        subtasks_complete = request.subtasks_complete
+        implementation_evidence_present = request.implementation_evidence_present
+        entering_review = from_lane_str == lane_in_progress and resolved_to_lane == lane_for_review
+        if entering_review and subtasks_complete is None:
+            subtasks_complete = status_emit._infer_subtasks_complete(self.read_dir, request.wp_id or "")
+        if entering_review and implementation_evidence_present is None:
+            implementation_evidence_present = status_emit._infer_implementation_evidence(
+                self.read_dir, request.wp_id or ""
+            )
+        return subtasks_complete, implementation_evidence_present
 
     def save(self, *, operation: str) -> CommitReceipt:  # noqa: F821
         """Persist staged transitions via ``BookkeepingTransaction``.

--- a/tests/status/test_agent_status_emit_aggregate_wiring.py
+++ b/tests/status/test_agent_status_emit_aggregate_wiring.py
@@ -304,6 +304,111 @@ def test_emit_json_output_contract_is_preserved(tmp_path: Path) -> None:
     )
 
 
+def test_transition_helper_maps_uninitialized_lane_to_planned(tmp_path: Path) -> None:
+    """Aggregate helper normalizes transactional bootstrap reads to planned."""
+    from specify_cli.status import TransitionRequest
+    from specify_cli.status.aggregate import MissionStatus
+    from specify_cli.status.models import Lane
+
+    ms = MissionStatus(
+        mission_slug="017-helper-lane",
+        mission_id=None,
+        mid8="",
+        topology="legacy",
+        read_dir=tmp_path,
+        repo_root=tmp_path,
+    )
+    request = TransitionRequest(
+        wp_id="WP01",
+        to_lane="claimed",
+        actor="codex",
+        feature_dir=tmp_path,
+        mission_slug=ms.mission_slug,
+    )
+
+    from_lane, current_actor = ms._resolve_current_lane(
+        request=request,
+        read_current_wp_state_transactional=lambda **_: ("uninitialized", "codex"),
+        lane_planned=Lane.PLANNED,
+    )
+
+    assert from_lane == "planned"
+    assert current_actor == "codex"
+
+
+def test_transition_helper_prefers_explicit_workspace_context(tmp_path: Path) -> None:
+    """Aggregate helper must not overwrite caller-provided workspace context."""
+    from specify_cli.status import TransitionRequest
+    from specify_cli.status.aggregate import MissionStatus
+
+    ms = MissionStatus(
+        mission_slug="017-helper-workspace-context",
+        mission_id=None,
+        mid8="",
+        topology="legacy",
+        read_dir=tmp_path,
+        repo_root=tmp_path,
+    )
+    request = TransitionRequest(
+        wp_id="WP01",
+        to_lane="claimed",
+        actor="codex",
+        feature_dir=tmp_path,
+        mission_slug=ms.mission_slug,
+        workspace_context="explicit-context",
+    )
+
+    assert ms._resolve_workspace_context(request) == "explicit-context"
+
+
+def test_transition_helper_infers_missing_review_gate_inputs(tmp_path: Path) -> None:
+    """Aggregate helper infers both review-gate booleans on enter-review."""
+    from specify_cli.status import TransitionRequest
+    from specify_cli.status.aggregate import MissionStatus
+    from specify_cli.status.models import Lane
+
+    ms = MissionStatus(
+        mission_slug="017-helper-review-gates",
+        mission_id=None,
+        mid8="",
+        topology="legacy",
+        read_dir=tmp_path,
+        repo_root=tmp_path,
+    )
+    request = TransitionRequest(
+        wp_id="WP07",
+        to_lane="for_review",
+        actor="codex",
+        feature_dir=tmp_path,
+        mission_slug=ms.mission_slug,
+    )
+
+    class _StatusEmit:
+        @staticmethod
+        def _infer_subtasks_complete(read_dir: Path, wp_id: str) -> bool:
+            assert read_dir == tmp_path
+            assert wp_id == "WP07"
+            return True
+
+        @staticmethod
+        def _infer_implementation_evidence(read_dir: Path, wp_id: str) -> bool:
+            assert read_dir == tmp_path
+            assert wp_id == "WP07"
+            return True
+
+    subtasks_complete, implementation_evidence_present = ms._resolve_review_gate_inputs(
+        request=request,
+        from_lane_str=str(Lane.IN_PROGRESS),
+        resolved_to_lane=str(Lane.FOR_REVIEW),
+        status_emit=_StatusEmit,
+        lane_in_progress=Lane.IN_PROGRESS,
+        lane_for_review=Lane.FOR_REVIEW,
+    )
+
+    assert subtasks_complete is True
+    assert implementation_evidence_present is True
+
+
 @patch("specify_cli.cli.commands.agent.status.locate_project_root")
 @patch("specify_cli.cli.commands.agent.status._find_mission_slug")
 def test_emit_reaches_transition_when_coord_declared_before_worktree_materialized(

--- a/tests/unit/status/test_mission_status_aggregate.py
+++ b/tests/unit/status/test_mission_status_aggregate.py
@@ -432,6 +432,108 @@ class TestStatusFacadeExports:
 
 
 class TestTransitionHappyPath:
+    def test_resolve_current_lane_maps_uninitialized_to_planned(self, tmp_path: Path) -> None:
+        """Uninitialized transactional reads should validate from planned."""
+        from specify_cli.status import TransitionRequest
+        from specify_cli.status.aggregate import MissionStatus
+        from specify_cli.status.models import Lane
+
+        ms = MissionStatus(
+            mission_slug="034-lane-fallback",
+            mission_id=None,
+            mid8="",
+            topology="legacy",
+            read_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+        request = TransitionRequest(
+            wp_id="WP01",
+            to_lane="claimed",
+            actor="claude",
+            feature_dir=tmp_path,
+            mission_slug=ms.mission_slug,
+        )
+
+        from_lane, current_actor = ms._resolve_current_lane(
+            request=request,
+            read_current_wp_state_transactional=lambda **_: ("uninitialized", "claude"),
+            lane_planned=Lane.PLANNED,
+        )
+
+        assert from_lane == "planned"
+        assert current_actor == "claude"
+
+    def test_resolve_workspace_context_prefers_request_value(self, tmp_path: Path) -> None:
+        """Explicit workspace context must bypass aggregate inference."""
+        from specify_cli.status import TransitionRequest
+        from specify_cli.status.aggregate import MissionStatus
+
+        ms = MissionStatus(
+            mission_slug="034-workspace-context",
+            mission_id=None,
+            mid8="",
+            topology="legacy",
+            read_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+        request = TransitionRequest(
+            wp_id="WP01",
+            to_lane="claimed",
+            actor="claude",
+            feature_dir=tmp_path,
+            mission_slug=ms.mission_slug,
+            workspace_context="explicit-context",
+        )
+
+        assert ms._resolve_workspace_context(request) == "explicit-context"
+
+    def test_resolve_review_gate_inputs_infers_missing_review_guards(self, tmp_path: Path) -> None:
+        """Entering review infers both guard inputs when omitted."""
+        from specify_cli.status import TransitionRequest
+        from specify_cli.status.aggregate import MissionStatus
+        from specify_cli.status.models import Lane
+
+        ms = MissionStatus(
+            mission_slug="034-review-gate-inputs",
+            mission_id=None,
+            mid8="",
+            topology="legacy",
+            read_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+        request = TransitionRequest(
+            wp_id="WP07",
+            to_lane="for_review",
+            actor="claude",
+            feature_dir=tmp_path,
+            mission_slug=ms.mission_slug,
+        )
+
+        class _StatusEmit:
+            @staticmethod
+            def _infer_subtasks_complete(read_dir: Path, wp_id: str) -> bool:
+                assert read_dir == tmp_path
+                assert wp_id == "WP07"
+                return True
+
+            @staticmethod
+            def _infer_implementation_evidence(read_dir: Path, wp_id: str) -> bool:
+                assert read_dir == tmp_path
+                assert wp_id == "WP07"
+                return True
+
+        subtasks_complete, implementation_evidence_present = ms._resolve_review_gate_inputs(
+            request=request,
+            from_lane_str=str(Lane.IN_PROGRESS),
+            resolved_to_lane=str(Lane.FOR_REVIEW),
+            status_emit=_StatusEmit,
+            lane_in_progress=Lane.IN_PROGRESS,
+            lane_for_review=Lane.FOR_REVIEW,
+        )
+
+        assert subtasks_complete is True
+        assert implementation_evidence_present is True
+
     def test_transition_validates_then_applies(self, tmp_path: Path) -> None:
         """transition() rejects illegal transitions before calling BookkeepingTransaction."""
         slug = "034-transition-test"


### PR DESCRIPTION
## Summary
- refactor the new nightly Sonar hot spots in `runtime_bridge.py`, `mission.py`, `commit_helpers.py`, and `status/aggregate.py` to cut cognitive complexity without changing behavior
- hoist repeated literals in `profiles_cmd.py`, simplify `charter sync` rendering, and remove the redundant `InvocationWriteError` catch in `do_cmd.py`
- preserve clean JSON for `spec-kitty do --json` by suppressing the readiness auth banner on the protocol-style `do` surface, and make `record-analysis` report dirty-worktree blockers before protected-branch blockers

## Validation
- `.venv/bin/ruff check src/runtime/next/runtime_bridge.py src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/charter/sync.py src/specify_cli/cli/commands/do_cmd.py src/specify_cli/cli/commands/profiles_cmd.py src/specify_cli/git/commit_helpers.py src/specify_cli/readiness/coordinator.py src/specify_cli/status/aggregate.py`
- `.venv/bin/python -m pytest tests/specify_cli/next/test_runtime_bridge.py tests/next/test_runtime_bridge_unit.py tests/tasks/test_planning_workflow_integration.py tests/agent/test_agent_feature.py tests/specify_cli/test_analysis_report.py tests/specify_cli/invocation/cli/test_profiles.py tests/specify_cli/invocation/cli/test_profiles_activation.py tests/specify_cli/invocation/cli/test_do.py tests/unit/git/test_commit_helpers_backstop.py tests/specify_cli/git/test_commit_helpers.py tests/unit/status/test_mission_status_aggregate.py -q`

## Notes
- GitHub security alerts: none open
- GitHub code-scanning alerts: none open
- Previous scheduled `CI Quality` run on `main` from 2026-06-06 (`27054458415`) reached SonarCloud and failed the quality gate; the actionable nightly set was 10 open code issues created at `2026-06-06T06:36:29+0000`
