### PR TITLE
docs(arch): ADR + research notes for session presence multi-harness architecture

### DIFF
--- a/architecture/3.x/adr/2026-06-07-1-session-presence-multi-harness-architecture.md
+++ b/architecture/3.x/adr/2026-06-07-1-session-presence-multi-harness-architecture.md
@@ -1,0 +1,299 @@
+# Session Presence: Multi-Harness Architecture for Orientation and Upgrade Checking
+
+**Filename:** `2026-06-07-1-session-presence-multi-harness-architecture.md`
+
+**Status:** Proposed
+
+**Date:** 2026-06-07
+
+**Deciders:** Architect Alphonso (profile), Robert Douglass
+
+**Technical Story:** https://github.com/Priivacy-ai/spec-kitty/issues/1760 (Claude Code scoped); this ADR governs the generalised multi-harness design.
+
+---
+
+## Context and Problem Statement
+
+`spec-kitty init` deploys command-skill files into 13 slash-command agent directories and 6 skills-based agent roots (19 harnesses total). After init, no harness has any persistent awareness that spec-kitty exists — there is no always-loaded orientation text, no upgrade check, and no routing rule that directs "hey spec kitty, fix X" to `spec-kitty do`. Competing tools (e.g. gstack) solve this by injecting a section into their harness's persistent instruction file at install time and registering a session-start hook where the harness supports one.
+
+We need a mechanism that, at `spec-kitty init` and `spec-kitty upgrade`, writes orientation content into each configured harness's persistent instruction surface and registers a live session-start hook where the harness supports it.
+
+The implementation must be maintainable across 19 harnesses without 19 separate code paths.
+
+## Decision Drivers
+
+* Every configured harness should gain orientation at init, not just Claude Code.
+* The content (spec-kitty version, two usage patterns, upgrade alert) is harness-agnostic; only the delivery surface differs.
+* Harnesses fall into at most four structural patterns — a shared library keyed on pattern type eliminates per-harness duplication.
+* Where a harness provides no known persistent instruction surface, we must record a research note and emit a `NullWriter` stub — we do not silently skip.
+* Session-start hooks (live command execution) are a separate capability from static text injection; only Claude Code currently exposes one. The architecture must not conflate the two.
+* All writes must be idempotent: running init or upgrade twice produces no duplicate entries.
+
+## Considered Options
+
+* **Option A:** One writer class per harness (19 classes, minimal shared logic)
+* **Option B:** Pattern-grouped shared writers parameterised by harness metadata (3–4 writer classes cover all known harnesses; stubs cover unknowns)
+* **Option C:** Template-only approach — generate static files at init, no runtime upgrade check
+
+## Decision Outcome
+
+**Chosen option: Option B** — pattern-grouped shared writers.
+
+Rationale: The 19 harnesses collapse into four structural patterns (see Component Design). A single `MarkdownRulesWriter` parameterised by `rules_path` and `section_marker` covers 7 harnesses. A single `AgentsMdWriter` covers 3. `ClaudeCodeWriter` extends `MarkdownRulesWriter` and adds hook registration. `SkillsPreambleWriter` handles skills-based harnesses. Option A produces unmaintainable duplication; Option C forfeits the live upgrade signal.
+
+### Consequences
+
+#### Positive
+
+* Adding a new harness requires only a metadata entry in the writer registry, not a new class.
+* Orientation content is authored once and rendered into all harness surfaces by the manager.
+* Claude Code gains a live session-start hook; all other harnesses gain static orientation text; future harnesses with hook support need only a new `HookRegistrar` implementation.
+* Research notes for unknown harnesses are first-class artifacts, not silent omissions.
+
+#### Negative
+
+* `MarkdownRulesWriter` must handle per-harness section-marker and idempotency variations — some harnesses use HTML comments, others use heading markers.
+* The upgrade check cache (`~/.kittify/last-cli-check.json`) is global, not per-project; a user with multiple projects sees a single cached "available version" signal.
+
+#### Neutral
+
+* The `SessionPresenceManager` is a new callsite in `init.py` and the upgrade migration; existing logic is unchanged.
+
+### Confirmation
+
+After implementation: `spec-kitty init` on a fresh project writes orientation into every configured harness directory. `spec-kitty session-start` (Claude Code hook) outputs version + health + two-pattern routing within 200ms and exits 0 on all failure paths. `spec-kitty upgrade` idempotently refreshes orientation content without duplicating sections.
+
+---
+
+## Component Design
+
+### Harness Classification
+
+| Pattern | Harnesses | Mechanism | Session Hook |
+|---|---|---|---|
+| **A — Native hook + rules file** | Claude Code | `.claude/CLAUDE.md` + `.claude/settings.json` `SessionStart` | ✅ |
+| **B — Markdown rules file** | Cursor, Windsurf, GitHub Copilot, Roo, Kiro, Gemini | Harness-specific path (see table below) | ❌ |
+| **C — AGENTS.md ecosystem** | Codex, OpenCode, Google Antigravity | `AGENTS.md` (de-facto cross-tool standard) | ❌ |
+| **D — Skills preamble** | Pi, Letta, Vibe | Inject orientation into shared `AGENTS.md` or skill manifest preamble | ❌ |
+| **E — Unknown / stub** | Qwen, Kilocode, Augment, Amazon Q | `NullWriter` + research note | ❌ |
+
+Pattern B harness paths:
+
+| Harness | Orientation file path |
+|---|---|
+| Cursor | `.cursor/rules/spec-kitty.mdc` |
+| Windsurf | `.windsurfrules` (section append) |
+| GitHub Copilot | `.github/copilot-instructions.md` (section append) |
+| Roo | `.roo/rules/spec-kitty.md` |
+| Kiro | `.kiro/steering/spec-kitty.md` |
+| Gemini | `GEMINI.md` (section append) |
+
+### Module Layout
+
+```
+src/specify_cli/session_presence/
+    __init__.py
+    content.py          # SessionPresenceContent dataclass + render()
+    manager.py          # SessionPresenceManager — orchestrates writers + hooks
+    upgrade_check.py    # UpgradeChecker — cached PyPI version check
+
+    writers/
+        __init__.py
+        base.py             # Writer protocol
+        markdown_rules.py   # MarkdownRulesWriter (Pattern B + A base)
+        agents_md.py        # AgentsMdWriter (Pattern C)
+        claude_code.py      # ClaudeCodeWriter(MarkdownRulesWriter) — adds hook (Pattern A)
+        skills_preamble.py  # SkillsPreambleWriter (Pattern D)
+        null_writer.py      # NullWriter (Pattern E — logs research note, no-ops write)
+        registry.py         # WRITER_REGISTRY: agent_key -> Writer instance
+
+    hooks/
+        __init__.py
+        base.py             # HookRegistrar protocol
+        claude_code_hook.py # Reads/merges/writes .claude/settings.json
+```
+
+### Key Interfaces
+
+```python
+# writers/base.py
+class Writer(Protocol):
+    harness_key: str
+    def can_write(self, project_root: Path) -> bool: ...
+    def has_presence(self, project_root: Path) -> bool: ...
+    def write(self, project_root: Path, content: SessionPresenceContent) -> None: ...
+    def remove(self, project_root: Path) -> None: ...
+
+# hooks/base.py
+class HookRegistrar(Protocol):
+    def register(self, project_root: Path, command: str) -> None: ...
+    def unregister(self, project_root: Path, command: str) -> None: ...
+    def is_registered(self, project_root: Path, command: str) -> bool: ...
+
+# content.py
+@dataclass
+class SessionPresenceContent:
+    version: str
+    project_slug: str
+    health: Literal["healthy", "upgrade-available", "migration-required"]
+    available_version: str | None
+    def render(self) -> str: ...  # canonical markdown, all harnesses
+```
+
+### MarkdownRulesWriter parameterisation
+
+```python
+# writers/markdown_rules.py
+@dataclass
+class MarkdownRulesWriter:
+    harness_key: str
+    rules_path: str          # relative to project_root, e.g. ".cursor/rules/spec-kitty.mdc"
+    append_mode: bool        # True = append section; False = own file
+    section_open: str  = "<!-- spec-kitty:orientation -->"
+    section_close: str = "<!-- /spec-kitty:orientation -->"
+```
+
+`ClaudeCodeWriter` subclasses this with `rules_path=".claude/CLAUDE.md"`, `append_mode=True`, and overrides `write()` to additionally call `claude_code_hook.register()`.
+
+### SessionPresenceManager
+
+```python
+class SessionPresenceManager:
+    def __init__(self, project_root: Path, agent_config: AgentConfig): ...
+
+    def install(self) -> InstallResult:
+        content = self._build_content()
+        for key in agent_config.available:
+            writer = WRITER_REGISTRY.get(key, NullWriter(key))
+            if writer.can_write(project_root) and not writer.has_presence(project_root):
+                writer.write(project_root, content)
+
+    def update(self) -> InstallResult:  # used by upgrade migration
+        content = self._build_content()
+        for key in agent_config.available:
+            writer = WRITER_REGISTRY.get(key, NullWriter(key))
+            if writer.can_write(project_root):
+                writer.write(project_root, content)  # idempotent: replaces section
+```
+
+### UpgradeChecker
+
+```python
+class UpgradeChecker:
+    cache_path: Path = Path.home() / ".kittify" / "last-cli-check.json"
+    ttl_seconds: int = 3600
+
+    def get_available_version(self) -> str | None:
+        # Read cache; return cached value if within TTL
+        # Otherwise spawn background subprocess: uv pip index versions spec-kitty
+        # Return last known value immediately; background process writes cache
+        ...
+```
+
+The background subprocess never blocks `spec-kitty session-start`. The worst case is a one-hour-stale "available version" in the session-start output.
+
+### Callsites
+
+1. `init.py` — after agent directory setup, call `SessionPresenceManager(project_root, agent_config).install()`
+2. Upgrade migrations (see Migration Design below) — `SessionPresenceManager(...).update()` for existing projects
+3. New CLI command `session_start.py` — reads content, emits to stdout (Claude Code hook target)
+
+---
+
+## Migration Design
+
+Session presence is a retro-fit for all existing spec-kitty projects. Two migrations are required, matching the two implementation phases.
+
+### Migration 1 — Claude Code (Phase 1, targets next release after #1760 lands)
+
+**File:** `src/specify_cli/upgrade/migrations/m_<version>_session_presence_claude_code.py` (created as part of #1760)
+
+**`detect(project_path)`:** returns `True` when ALL of:
+- `.kittify/` exists (it is a spec-kitty project)
+- `claude` is in `get_configured_agents(project_path)`
+- `.claude/CLAUDE.md` does not contain `<!-- spec-kitty:orientation -->` **OR** `.claude/settings.json` does not contain `"spec-kitty session-start"` in its `SessionStart` hooks list
+
+**`apply(project_path, dry_run)`:**
+1. Construct `SessionPresenceContent` from installed version + `.kittify/metadata.yaml` health
+2. Instantiate `ClaudeCodeWriter` and call `writer.write(project_root, content)` if `not writer.has_presence(project_root)` — idempotent
+3. Call `ClaudeCodeHookRegistrar().register(project_root, "spec-kitty session-start")` if not already registered — idempotent
+4. Record changes: `"Wrote spec-kitty orientation to .claude/CLAUDE.md"`, `"Registered spec-kitty session-start SessionStart hook"`
+5. Honour `dry_run` — record `"Would write..."` / `"Would register..."` and make no changes
+
+**`migration_id`:** `"3.3.0_session_presence_claude_code"`  
+**`target_version`:** `"3.3.0"` (update to actual release version at merge)  
+**`runs_on_worktrees`:** `False` — session presence is per-checkout, not per-worktree
+
+### Migration 2 — All other harnesses (Phase 2–4, targets release after all Pattern B/C/D writers land)
+
+**File:** `src/specify_cli/upgrade/migrations/m_<version>_session_presence_all_harnesses.py` (created as part of #1761)
+
+**`detect(project_path)`:** returns `True` when ANY configured agent (excluding `claude` — covered by Migration 1) is a known non-NullWriter harness AND does not yet have presence:
+
+```python
+def detect(self, project_path: Path) -> bool:
+    configured = set(get_configured_agents(project_path))
+    for key in configured - {"claude"}:
+        writer = WRITER_REGISTRY.get(key)
+        if writer and not isinstance(writer, NullWriter):
+            if not writer.has_presence(project_root):
+                return True
+    return False
+```
+
+**`apply(project_path, dry_run)`:**
+1. Build `SessionPresenceContent`
+2. For each configured agent key (excluding `claude`): look up writer in `WRITER_REGISTRY`; skip `NullWriter` instances; call `writer.write()` if `not writer.has_presence()` — idempotent
+3. Record one change entry per harness written
+
+**`migration_id`:** `"3.3.0_session_presence_all_harnesses"`  
+**`target_version`:** `"3.3.0"` (update at merge)  
+**`runs_on_worktrees`:** `False`
+
+### Ordering constraint
+
+Migration 2 imports `WRITER_REGISTRY`, which is populated incrementally as Pattern B/C/D writers land. Migration 2 must only be registered after all writers it references exist. The `detect()` guard (`not isinstance(writer, NullWriter)`) ensures the migration is a no-op for any harness whose writer has not yet been implemented — so it is safe to register Migration 2 early as a stub and expand the registry incrementally.
+
+### What upgrades do NOT do
+
+- They do not overwrite user-authored content in the target files. Section markers (`<!-- spec-kitty:orientation -->` ... `<!-- /spec-kitty:orientation -->`) delimit spec-kitty's region; content outside those markers is never touched.
+- They do not create agent directories for agents not in `get_configured_agents()`. Session presence follows the same "respect deletions, never mkdir" rule as all other migrations.
+- They do not run on worktrees — presence is installed once on the main checkout.
+
+## Pros and Cons of the Options
+
+### Option A — One class per harness
+
+**Pros:**
+* Harness-specific edge cases are fully isolated.
+
+**Cons:**
+* 19 classes sharing ~90% logic; adding a 20th harness requires a new class.
+* Content changes (e.g. new usage pattern) require 19 edits.
+
+### Option B — Pattern-grouped shared writers (chosen)
+
+**Pros:**
+* 4 concrete writer classes cover all known harnesses.
+* Adding a harness is a one-line registry entry.
+* Content changes propagate automatically.
+
+**Cons:**
+* Parameterisation adds indirection; must be well-documented.
+
+### Option C — Static template only
+
+**Pros:**
+* No runtime dependencies; fully deterministic at init time.
+
+**Cons:**
+* Version and health are frozen at init; no live upgrade signal.
+* No session-start hook benefit even for Claude Code.
+
+## More Information
+
+* Research notes for Pattern E (unknown harnesses): `architecture/3.x/research/session-presence-harness-gaps.md`
+* Claude Code scoped issue: https://github.com/Priivacy-ai/spec-kitty/issues/1760
+* Multi-harness implementation issue: https://github.com/Priivacy-ai/spec-kitty/issues/1761
+* Agent directory registry: `src/specify_cli/agent_utils/directories.py`
+* Agent skill config: `src/specify_cli/core/config.py` — `AGENT_SKILL_CONFIG`

--- a/architecture/3.x/research/session-presence-harness-gaps.md
+++ b/architecture/3.x/research/session-presence-harness-gaps.md
@@ -1,0 +1,169 @@
+# Research Notes: Session Presence — Harness Capability Gaps
+
+**Status:** Open — items below require investigation before implementation  
+**Owner:** Architect Alphonso  
+**Last updated:** 2026-06-07  
+**Related ADR:** `adr/2026-06-07-1-session-presence-multi-harness-architecture.md`  
+**Related issue:** https://github.com/Priivacy-ai/spec-kitty/issues/1760
+
+---
+
+These harnesses are classified as **Pattern E (Unknown / stub)** in the ADR. Each has a `NullWriter` placeholder in the implementation. Before each harness can be promoted to Pattern B, C, or D, the question below must be answered and the finding recorded here.
+
+When a question is resolved, update the entry: fill in the finding, set status to `resolved`, and open a follow-on issue to implement the writer.
+
+---
+
+## Qwen Code (`qwen`, `.qwen/`)
+
+**Question:** Does Qwen Code read a project-level persistent instruction file analogous to `.cursorrules` or `AGENTS.md`? If so, what is the path and format?
+
+**What we know:**
+- Spec-kitty deploys commands to `.qwen/commands/` (TOML format with `{{args}}` placeholders)
+- Skills root: `.qwen/skills/` (`SKILL_CLASS_NATIVE`)
+- Qwen Code is a CLI agent — it likely has a context/rules file, but the path is undocumented in public sources as of 2026-06-07
+
+**Workaround candidates:**
+- If Qwen reads `AGENTS.md` (common among CLI agents), promote to Pattern C — no new class needed
+- If Qwen has a `.qwenrules` or `.qwen/instructions.md`, promote to Pattern B with `MarkdownRulesWriter`
+
+**Status:** `open`  
+**Research required:** Read Qwen Code CLI docs or source; test with a sample project
+
+---
+
+## Kilocode (`kilocode`, `.kilocode/`)
+
+**Question:** Does Kilocode have a persistent instruction file? Kilocode is architecturally derived from Roo Cline — does it inherit `.kilocode/rules/` or `.clinerules`?
+
+**What we know:**
+- Spec-kitty deploys to `.kilocode/workflows/`
+- Skills root: `.kilocode/skills/` (`SKILL_CLASS_NATIVE`)
+- Roo (the upstream) reads `.roo/rules/*.md` and `.clinerules`
+- Kilocode may read `.kilocode/rules/` by analogy, but this is unverified
+
+**Workaround candidates:**
+- If `.kilocode/rules/` is confirmed, promote to Pattern B — same `MarkdownRulesWriter` as Roo with `rules_path=".kilocode/rules/spec-kitty.md"`
+- If it reads `.clinerules` (shared with Roo), a single `.clinerules` file would need a section for both agents — risky for projects running both
+
+**Status:** `open`  
+**Research required:** Check Kilocode documentation or source for context-file loading
+
+---
+
+## Augment Code (`auggie`, `.augment/`)
+
+**Question:** What is the path and format of Augment Code's workspace-level persistent instructions? The VS Code extension has a "workspace instructions" concept but the file path is unclear.
+
+**What we know:**
+- Spec-kitty deploys to `.augment/commands/`
+- Skills root: `.agents/skills/`, `.augment/skills/` (`SKILL_CLASS_SHARED`)
+- Augment Code (VS Code extension) is documented to support workspace context — the file may be `.augment/instructions.md` or injected via workspace settings
+
+**Workaround candidates:**
+- If `.augment/instructions.md` is confirmed, promote to Pattern B
+- If instructions are only configurable via VS Code workspace settings JSON, static injection is not viable — mark as `no-mechanism` and document
+
+**Status:** `open`  
+**Research required:** Inspect Augment Code VS Code extension settings or VSIX; check for any CLI companion
+
+---
+
+## Amazon Q (`q`, `.amazonq/`)
+
+**Question:** Does Amazon Q Developer read a project-level instruction file from `.amazonq/`? The `.amazonq/prompts/` directory receives spec-kitty command prompts, but it is unclear if Amazon Q reads any file unconditionally at session start.
+
+**What we know:**
+- Spec-kitty deploys to `.amazonq/prompts/`
+- `SKILL_CLASS_WRAPPER` (no skill_roots — Amazon Q uses a wrapper pattern, not native skills)
+- Amazon Q Developer (IDE extension) is documented to support "workspace context" but the mechanism is through the IDE, not a file path
+
+**Workaround candidates:**
+- Amazon Q CLI (`q chat`) may read `AGENTS.md` — if so, promote to Pattern C
+- If context is only available through IDE workspace settings, static injection is not viable
+
+**Status:** `open`  
+**Research required:** Test `q chat` in a directory containing `AGENTS.md`; check if content is included in context
+
+---
+
+## Mistral Vibe (`vibe`, `.agents/skills/`)
+
+**Question:** Does Mistral Vibe read a persistent project-level instruction file? The `.vibe/config.toml` configures skill routing but it is unclear if any file is loaded into the LLM context unconditionally.
+
+**What we know:**
+- Spec-kitty deploys skills to `.agents/skills/` (shared with Codex, Pi, Letta)
+- Config: `.vibe/config.toml`
+- Skills class: `SKILL_CLASS_SHARED`
+
+**Workaround candidates:**
+- If `.vibe/rules.md` or a `system_prompt` field in `.vibe/config.toml` exists, promote to Pattern B/D
+- If Vibe reads `AGENTS.md`, promote to Pattern C — same `AgentsMdWriter` as Codex/OpenCode
+
+**Status:** `open`  
+**Research required:** Read Mistral Vibe documentation; inspect `.vibe/config.toml` schema
+
+---
+
+## Pi (`pi`, `.agents/skills/`, `.pi/skills/`)
+
+**Question:** Does the Pi agent have a persistent instruction/context file that is loaded at session start?
+
+**What we know:**
+- Spec-kitty deploys to `.agents/skills/` and `.pi/skills/`
+- Runtime state in `.pi/` (auth, logs, session state)
+- Skills class: `SKILL_CLASS_SHARED`
+
+**Workaround candidates:**
+- If Pi reads `AGENTS.md`, promote to Pattern C
+- If Pi has a `.pi/instructions.md` or similar, promote to Pattern B
+
+**Status:** `open`  
+**Research required:** Check Pi agent documentation or source
+
+---
+
+## Letta Code (`letta`, `.agents/skills/`)
+
+**Question:** Does Letta Code have a project-level persistent instruction file loaded into agent memory/context at session start?
+
+**What we know:**
+- Spec-kitty deploys to `.agents/skills/`
+- Runtime state in `.letta/` (auth, memory — Letta has persistent memory architecture)
+- Skills class: `SKILL_CLASS_SHARED`
+
+**Workaround candidate:**
+- Letta's memory architecture is agent-side (the agent stores context internally), not file-side. A static file injection may not be the right model — Letta may need a one-time "remember this" injection via the Letta API at project init rather than a file write.
+- This is architecturally different from all other patterns and may warrant its own Pattern F.
+
+**Status:** `open — possible new pattern`  
+**Research required:** Confirm whether Letta reads any file at session start vs relying solely on agent-internal memory; if memory-only, design Pattern F (API injection at init)
+
+---
+
+## Session Hook Gaps (all harnesses except Claude Code)
+
+**Question:** Is there any harness other than Claude Code that exposes a session-start hook (i.e., the ability to run a shell command at the start of each AI session)?
+
+**Known:**
+- Claude Code: `SessionStart` in `.claude/settings.json` ✅
+- All others: no documented hook mechanism as of 2026-06-07
+
+**Impact:** For harnesses without a hook, the upgrade check can only be delivered as static text in the orientation file — e.g., "run `spec-kitty upgrade --cli` to check for updates." This is a soft hint, not a live check.
+
+**Future candidates to monitor:**
+- Cursor: VS Code extension hooks may become available
+- Windsurf: Windsurf IDE may expose session hooks in future versions
+- OpenCode: Open-source; could accept a PR to add hook support
+
+**Status:** `open — monitoring`  
+**Action:** When a new harness gains hook support, implement `HookRegistrar` for it and update the ADR.
+
+---
+
+## How to Resolve an Entry
+
+1. Research the question (docs, source inspection, or live test)
+2. Update the entry: add **Finding**, change **Status** to `resolved` or `no-mechanism`
+3. If resolved with a viable mechanism: open a follow-on issue to implement the writer and update the registry in `src/specify_cli/session_presence/writers/registry.py`
+4. If `no-mechanism`: the `NullWriter` stub remains; document the limitation in user-facing docs


### PR DESCRIPTION
## Summary

- Adds `architecture/3.x/adr/2026-06-07-1-session-presence-multi-harness-architecture.md` — design decision for delivering session presence (orientation text + upgrade check) across all 19 supported harnesses
- Adds `architecture/3.x/research/session-presence-harness-gaps.md` — one entry per Pattern E harness (Qwen, Kilocode, Augment, Amazon Q, Vibe, Letta) with open questions, known facts, and workaround candidates

## What the ADR covers

The 19 harnesses collapse into four patterns:
- **Pattern A** — Claude Code: `SessionStart` hook + `.claude/CLAUDE.md` section
- **Pattern B** — Cursor, Windsurf, Copilot, Roo, Kiro, Gemini: one shared `MarkdownRulesWriter` class parameterised by file path
- **Pattern C** — Codex, OpenCode, Antigravity: `AgentsMdWriter` targeting `AGENTS.md`
- **Pattern D** — Pi, Vibe, Letta: `SkillsPreambleWriter`
- **Pattern E** — 6 harnesses with no confirmed mechanism: `NullWriter` stubs pending research note resolution

No source code is added — this is design-only. Implementation is tracked in:
- Phase 1 (Claude Code): #1760
- All harnesses: #1761

## Test plan

- [ ] ADR reviewed for correctness against known harness capabilities
- [ ] Research note entries verified to accurately reflect what is and isn't known for each Pattern E harness