### PR TITLE
Limit agent upgrade check to once per session

### DIFF
--- a/src/specify_cli/agent_upgrade_prompt.py
+++ b/src/specify_cli/agent_upgrade_prompt.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 AGENT_UPGRADE_CHECK_BLOCK = """## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/analyze.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/analyze.prompt.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/charter.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/charter.prompt.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/implement.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/implement.prompt.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/plan.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/plan.prompt.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/research.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/research.prompt.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/review.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/review.prompt.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-finalize.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-finalize.prompt.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-outline.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-outline.prompt.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-packages.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-packages.prompt.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks.prompt.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/analyze.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/analyze.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/charter.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/charter.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/implement.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/implement.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/plan.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/plan.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -300,7 +303,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/research.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/research.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/review.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/review.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-finalize.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-finalize.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -84,6 +87,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -123,7 +159,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-outline.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-outline.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -130,8 +133,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-packages.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-packages.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -151,7 +154,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/analyze.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/analyze.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/charter.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/charter.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/implement.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/implement.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/plan.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/plan.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -300,7 +303,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/research.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/research.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/review.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/review.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-finalize.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-finalize.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -84,6 +87,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -123,7 +159,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-outline.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-outline.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -130,8 +133,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-packages.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-packages.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -151,7 +154,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks.toml
@@ -4,7 +4,10 @@ prompt = """
 <!-- spec-kitty-command-version: 3.1.2a3 -->
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/analyze.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/analyze.md
@@ -5,7 +5,10 @@ description: Cross-artifact consistency and quality analysis
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/charter.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/charter.md
@@ -5,7 +5,10 @@ description: Interview and compile a project charter
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/implement.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/implement.md
@@ -5,7 +5,10 @@ description: Execute a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/plan.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/plan.md
@@ -5,7 +5,10 @@ description: Create an implementation plan
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -301,7 +304,7 @@ If the mission is not a bulk edit<!-- glossary:glossary:bulk-edit -->, skip this
    - Phase 1: Generate data-model.md, contracts/, quickstart.md based on confirmed intent; when applicable, capture entities/value objects, invariants, state transitions, and externally visible events in the design artifacts
    - Re-evaluate Charter Check post-design, asking the user to resolve new gaps before proceeding
 
-6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern Map if present).
+6. **STOP and report**: This command ends after Phase 1 planning. Report branch, IMPL_PLAN path, and generated artifacts (including the Implementation Concern<!-- glossary:glossary:implementation-concern --> Map if present).
 
    **⚠️ CRITICAL: DO NOT proceed to task generation!** The user must explicitly run `/spec-kitty.tasks` to translate implementation concerns from `plan.md` into executable work packages. Your job is COMPLETE after reporting the planning artifacts.
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/research.md
@@ -5,7 +5,10 @@ description: Generate research documents for the current mission
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/review.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/review.md
@@ -5,7 +5,10 @@ description: Review a work package implementation
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
@@ -5,7 +5,10 @@ description: Create a mission specification
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-finalize.md
@@ -5,7 +5,10 @@ description: Validate dependencies, finalize WP metadata, and commit all task ar
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -85,6 +88,39 @@ do **not** run finalization. Report the blocking fields
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
 
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane<!-- glossary:glossary:lane --> and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope<!-- glossary:glossary:scope -->: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
+
 ### 2. Run Finalization Command
 
 Only after validate-only exits successfully, run the mutating finalization
@@ -124,7 +160,7 @@ Provide a concise outcome summary:
 - Path to `tasks.md`
 - Work package<!-- glossary:glossary:work-package --> count and per-package subtask tallies
 - Parallelization highlights
-- MVP scope<!-- glossary:glossary:scope --> recommendation
+- MVP scope recommendation
 - Finalization status (dependencies parsed, X WP files updated, committed to target branch)
 - Next suggested command (e.g., `/spec-kitty.analyze` or `/spec-kitty.implement`)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-outline.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-outline.md
@@ -5,7 +5,10 @@ description: Create a work package manifest
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -131,8 +134,8 @@ Group subtasks into work packages (IDs `WP01`, `WP02`, ...):
 
 ### 4a. Cite plan concern refs for each WP
 
-For each work package, record which implementation concern(s) from `plan.md` it
-addresses by populating `plan_concern_refs` in `wps.yaml`.
+For each work package, record which implementation concern<!-- glossary:glossary:implementation-concern -->(s) from `plan.md` it
+addresses by populating `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` in `wps.yaml`.
 
 - If the WP covers exactly one concern: `plan_concern_refs: [IC-01]`
 - If the WP spans multiple concerns: `plan_concern_refs: [IC-01, IC-03]`

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-packages.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-packages.md
@@ -5,7 +5,10 @@ description: Materialize work package files
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -152,7 +155,7 @@ model: ""          # filled in Step 4a — model identifier (e.g., claude-sonnet
 ---
 ```
 
-**IMPORTANT — `plan_concern_refs` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
+**IMPORTANT — `plan_concern_refs<!-- glossary:glossary:plan_concern_refs -->` lives in `wps.yaml` only.** Do NOT copy `plan_concern_refs` into WP prompt frontmatter. `WPMetadata` uses `extra="forbid"`, so any WP prompt file with `plan_concern_refs` in its frontmatter will cause `finalize-tasks --validate-only` to raise a `ValidationError`.
 
 Body sections (in order):
 0. `## ⚡ Do This First: Load Agent Profile` — **REQUIRED. Must be the first section after the H1 title, before Objective.** Instructs the implementing agent to load the assigned profile via `/ad-hoc-profile-load` before reading anything else. Use this exact structure, substituting frontmatter values:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks.md
@@ -5,7 +5,10 @@ description: Translate implementation concerns into work packages
 
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/accept.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/accept.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/charter.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/implement.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/research.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/research.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/review.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-finalize.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -84,6 +87,39 @@ do **not** run finalization. Report the blocking fields
 `unmapped_functional_requirements`), then fix mappings with
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
+
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
 
 ### 2. Run Finalization Command
 

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-outline.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-outline.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks-packages.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/accept.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/accept.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/charter.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/implement.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/research.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/research.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/review.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-finalize.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json
@@ -84,6 +87,39 @@ do **not** run finalization. Report the blocking fields
 `unmapped_functional_requirements`), then fix mappings with
 `spec-kitty agent tasks map-requirements --mission <mission-slug> --json` or by
 updating WP `requirement_refs`.
+
+### 1b. Ownership Overlap — domain-focused / refactor missions
+
+If validate-only fails with `"error": "Ownership validation failed"` and
+`ownership_errors` listing overlapping `owned_files`:
+
+**Ownership collisions are EXPECTED for domain-focused and refactor-oriented
+missions** (cross-cutting strangler work, repo-wide migrations, boundary
+enforcement) where many work packages legitimately edit the same files. This is
+not a defect in the slicing. Handle it as follows:
+
+1. **Linearize shared surfaces (execution safety).** Work packages that touch the
+   same files MUST be made dependent/linear (via `Depends on WPxx`) so they
+   execute sequentially in one lane and **share a single worktree** (or run
+   direct-to-branch). Limited parallelism is acceptable and expected for these
+   missions — do not force artificial parallelism. Note: linearization protects
+   the *worktree* from concurrent edits; it does **not** by itself satisfy
+   ownership validation (see step 3).
+2. **Declare cross-cutting WPs codebase-wide (the exemption).** A WP that is
+   expected to overlap broadly should carry `scope: codebase-wide` in its
+   frontmatter; the ownership validator exempts codebase-wide WPs from overlap
+   and authoritative-surface checks. Keep the genuinely-targeted WPs (single test
+   file, single module) narrow and mutually disjoint.
+3. **`codebase-wide` is the ONLY exemption.** Two *narrow* WPs that claim the same
+   files **always** fail ownership validation — regardless of whether they sit in
+   different lanes or are linked in a dependency hierarchy. Dependency/lane
+   structure never bypasses the overlap check. If WPs legitimately share a
+   surface, mark the broadly-overlapping one `scope: codebase-wide`; otherwise
+   re-slice so the narrow WPs are disjoint.
+
+Do **not** fabricate disjoint `owned_files` that misrepresent which WP edits
+which files solely to pass validation — linearize and/or declare codebase-wide
+instead.
 
 ### 2. Run Finalization Command
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-outline.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-outline.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks-packages.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
@@ -5,7 +5,10 @@ user-invocable: true
 ---
 ## Startup Upgrade Check
 
-Before continuing, run:
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
 
 ```bash
 spec-kitty upgrade --agent-check --json

--- a/tests/specify_cli/skills/test_command_renderer.py
+++ b/tests/specify_cli/skills/test_command_renderer.py
@@ -173,6 +173,7 @@ def test_render_includes_agent_upgrade_check() -> None:
     skill = render(_all_templates()[0], "codex", _TEST_VERSION)
 
     assert skill.body.startswith("## Startup Upgrade Check")
+    assert "at most once per active agent session" in skill.body
     assert "spec-kitty upgrade --agent-check --json" in skill.body
     assert "spec-kitty upgrade --agent-choice" in skill.body
 

--- a/tests/test_template/test_asset_generator.py
+++ b/tests/test_template/test_asset_generator.py
@@ -74,6 +74,7 @@ def test_render_command_template_injects_claude_upgrade_check(tmp_path: Path) ->
 
     assert "<!-- spec-kitty-command-version:" in output
     assert "## Startup Upgrade Check" in output
+    assert "at most once per active agent session" in output
     assert "spec-kitty upgrade --agent-check --json" in output
     assert output.index("<!-- spec-kitty-command-version:") < output.index("## Startup Upgrade Check")
     assert output.index("## Startup Upgrade Check") < output.index("Run echo hi")
@@ -98,6 +99,7 @@ def test_render_command_template_injects_upgrade_check_for_all_command_agents(
 
     searchable = tomllib.loads(output)["prompt"] if config["ext"] == "toml" else output
     assert "## Startup Upgrade Check" in searchable
+    assert "at most once per active agent session" in searchable
     assert "spec-kitty upgrade --agent-check --json" in searchable
     assert "Run echo hi" in searchable
 


### PR DESCRIPTION
## Summary
- update injected agent upgrade-check prompt to run at most once per active agent session
- tell later Spec Kitty command workflows to reuse the remembered result and avoid repeated upgrade-check announcements
- add render assertions so generated command/skill surfaces keep the once-per-session instruction

## Tests
- .venv/bin/pytest tests/specify_cli/skills/test_command_renderer.py::test_render_includes_agent_upgrade_check tests/test_template/test_asset_generator.py::test_render_command_template_injects_claude_upgrade_check tests/test_template/test_asset_generator.py::test_render_command_template_injects_upgrade_check_for_all_command_agents
- .venv/bin/ruff check src/specify_cli/agent_upgrade_prompt.py tests/specify_cli/skills/test_command_renderer.py tests/test_template/test_asset_generator.py