### PR TITLE
Release 3.2.0rc39

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.3.0
+  version: 3.2.0rc39
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-05-19T12:44:58.404394+00:00'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.0] - 2026-06-07
+## [3.2.0rc39] - 2026-06-07
 
 ### ✨ Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.3.0"
+version = "3.2.0rc39"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/upgrade/migrations/m_3_3_0_session_presence_all_harnesses.py
+++ b/src/specify_cli/upgrade/migrations/m_3_3_0_session_presence_all_harnesses.py
@@ -50,7 +50,7 @@ class SessionPresenceAllHarnessesMigration(BaseMigration):
         "Write session presence orientation to each configured non-Claude harness "
         "(only agents listed in .kittify/config.yaml are processed)"
     )
-    target_version = "3.3.0"
+    target_version = "3.2.0rc39"
     runs_on_worktrees = False
 
     # ------------------------------------------------------------------

--- a/src/specify_cli/upgrade/migrations/m_3_3_0_session_presence_claude_code.py
+++ b/src/specify_cli/upgrade/migrations/m_3_3_0_session_presence_claude_code.py
@@ -19,7 +19,7 @@ class SessionPresenceClaudeCodeMigration(BaseMigration):
 
     migration_id = "3_3_0_session_presence_claude_code"
     description = "Write session presence orientation to .claude/CLAUDE.md and register SessionStart hook for existing Claude Code projects"
-    target_version = "3.3.0"
+    target_version = "3.2.0rc39"
     runs_on_worktrees = False
 
     def detect(self, project_path: Path) -> bool:

--- a/tests/specify_cli/upgrade/migrations/test_session_presence_upgrade_smoke.py
+++ b/tests/specify_cli/upgrade/migrations/test_session_presence_upgrade_smoke.py
@@ -101,7 +101,7 @@ class TestUpgradeSmoke:
             ),
         ):
             mock_checker_cls.return_value.get_available_version.return_value = None
-            result = runner.upgrade("3.3.0", dry_run=False, include_worktrees=False)
+            result = runner.upgrade("3.2.0rc39", dry_run=False, include_worktrees=False)
 
         assert result.success, f"Upgrade failed with errors: {result.errors}"
         assert result.errors == []
@@ -109,7 +109,7 @@ class TestUpgradeSmoke:
     def test_upgrade_dry_run_runs_without_errors(self, full_project: Path) -> None:
         """MigrationRunner.upgrade(dry_run=True) runs without errors."""
         runner = MigrationRunner(full_project)
-        result = runner.upgrade("3.3.0", dry_run=True, include_worktrees=False)
+        result = runner.upgrade("3.2.0rc39", dry_run=True, include_worktrees=False)
         assert result.success, f"Dry-run upgrade failed: {result.errors}"
         assert result.errors == []
 
@@ -127,8 +127,8 @@ class TestUpgradeSmoke:
             ),
         ):
             mock_checker_cls.return_value.get_available_version.return_value = None
-            result1 = runner.upgrade("3.3.0", dry_run=False, include_worktrees=False)
-            result2 = runner.upgrade("3.3.0", dry_run=False, include_worktrees=False)
+            result1 = runner.upgrade("3.2.0rc39", dry_run=False, include_worktrees=False)
+            result2 = runner.upgrade("3.2.0rc39", dry_run=False, include_worktrees=False)
 
         assert result1.success, f"First upgrade failed: {result1.errors}"
         assert result2.success, f"Second upgrade failed: {result2.errors}"
@@ -157,7 +157,7 @@ class TestUpgradeSmoke:
             ),
         ):
             mock_checker_cls.return_value.get_available_version.return_value = None
-            runner.upgrade("3.3.0", dry_run=False, include_worktrees=False)
+            runner.upgrade("3.2.0rc39", dry_run=False, include_worktrees=False)
 
         claude_md = full_project / ".claude" / "CLAUDE.md"
         assert claude_md.exists(), "CLAUDE.md should have been created by Phase 1"
@@ -179,7 +179,7 @@ class TestUpgradeSmoke:
             ),
         ):
             mock_checker_cls.return_value.get_available_version.return_value = None
-            runner.upgrade("3.3.0", dry_run=False, include_worktrees=False)
+            runner.upgrade("3.2.0rc39", dry_run=False, include_worktrees=False)
 
         rules_file = full_project / ".cursor" / "rules" / "spec-kitty.mdc"
         assert rules_file.exists(), "cursor rules file should have been created"

--- a/uv.lock
+++ b/uv.lock
@@ -2068,7 +2068,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.3.0"
+version = "3.2.0rc39"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Prepare the next 3.2.0 release candidate: `3.2.0rc39`.

## Changes

- Set package, metadata, lockfile, and changelog version to `3.2.0rc39`.
- Retarget session-presence upgrade migrations from the stable placeholder `3.3.0` to `3.2.0rc39` so the RC applies them.

## Local release checks

- `uv sync --frozen --all-extras`
- `python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'`
- `python scripts/release/validate_release.py --mode tag --tag v3.2.0rc39 --tag-pattern 'v*.*.*'`
- `.venv/bin/pytest -q tests/release`
- `.venv/bin/pytest -q tests/specify_cli/upgrade/migrations/test_session_presence_upgrade_smoke.py tests/specify_cli/upgrade/migrations/test_m_session_presence_claude_code.py tests/specify_cli/upgrade/migrations/test_m_session_presence_all_harnesses.py tests/release/test_validate_release.py`
- `.venv/bin/ruff check src/specify_cli/upgrade/migrations/m_3_3_0_session_presence_claude_code.py src/specify_cli/upgrade/migrations/m_3_3_0_session_presence_all_harnesses.py tests/specify_cli/upgrade/migrations/test_session_presence_upgrade_smoke.py tests/release/test_validate_release.py`
- `.venv/bin/python -m build`
- `.venv/bin/python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version`
- `.venv/bin/python scripts/release/check_shared_package_drift.py --saas-pyproject <spec-kitty-saas origin/main pyproject>`
- `.venv/bin/python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract <spec-kitty-saas origin/main consumer contract>`
- `.venv/bin/twine check dist/*`
