### PR TITLE
fix(retrospect): accept legacy schema version scalars

### DIFF
--- a/src/specify_cli/retrospective/reader.py
+++ b/src/specify_cli/retrospective/reader.py
@@ -7,6 +7,7 @@ corrupt-YAML, and schema-invalid cases without catching broad exceptions.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from pydantic import ValidationError
 from ruamel.yaml import YAML
@@ -110,8 +111,10 @@ _PROPOSAL_CATEGORIES = frozenset({"glossary", "drg", "doctrine", "tooling", "pro
 _EVIDENCE_KINDS = frozenset({"file", "event_range", "external"})
 _FINDINGS_STATUSES = frozenset({"has_findings", "ran_no_findings"})
 
+YamlMapping = dict[str, Any]
 
-def _load_yaml_mapping(path: Path) -> dict:
+
+def _load_yaml_mapping(path: Path) -> YamlMapping:
     raw_text = path.read_text(encoding="utf-8")
     yaml = YAML(typ="safe")
     try:
@@ -124,7 +127,7 @@ def _load_yaml_mapping(path: Path) -> dict:
     return data
 
 
-def _coerce_legacy_schema_versions(data: dict) -> dict:
+def _coerce_legacy_schema_versions(data: YamlMapping) -> YamlMapping:
     """Accept legacy YAML scalar versions while keeping the model schema strict."""
     normalized = dict(data)
 
@@ -144,13 +147,13 @@ def _coerce_legacy_schema_versions(data: dict) -> dict:
     return normalized
 
 
-def _validate_keys(raw: dict, allowed: frozenset[str], *, label: str) -> None:
+def _validate_keys(raw: YamlMapping, allowed: frozenset[str], *, label: str) -> None:
     extra = sorted(set(raw) - allowed)
     if extra:
         raise ValueError(f"{label} has unsupported field(s): {', '.join(extra)}")
 
 
-def _validate_mapping(raw: object, *, label: str) -> dict:
+def _validate_mapping(raw: object, *, label: str) -> YamlMapping:
     if not isinstance(raw, dict):
         raise ValueError(f"{label} must be a mapping")
     return raw
@@ -208,7 +211,7 @@ def _validate_gen_proposal(raw: object, *, label: str) -> None:
     _validate_string_list(proposal.get("evidence_refs", []), label=f"{label}.evidence_refs")
 
 
-def _validate_gen_header(data: dict) -> None:
+def _validate_gen_header(data: YamlMapping) -> None:
     _validate_keys(data, _GEN_TOP_LEVEL_KEYS, label="record")
     missing = sorted(_GEN_REQUIRED_KEYS - set(data))
     if missing:
@@ -219,7 +222,7 @@ def _validate_gen_header(data: dict) -> None:
         raise ValueError("findings_status must be has_findings or ran_no_findings")
 
 
-def _validate_gen_mapping(data: dict) -> None:
+def _validate_gen_mapping(data: YamlMapping) -> None:
     _validate_gen_header(data)
 
     _validate_gen_actor(data.get("created_by"), label="created_by")
@@ -240,7 +243,7 @@ def _validate_gen_mapping(data: dict) -> None:
         _validate_gen_provenance(item, label=f"provenance_history[{idx}]")
 
 
-def _gen_record_from_mapping(data: dict) -> GenRetrospectiveRecord:
+def _gen_record_from_mapping(data: YamlMapping) -> GenRetrospectiveRecord:
     def _actor(raw: object) -> GenActor:
         if not isinstance(raw, dict):
             raw = {}
@@ -260,7 +263,7 @@ def _gen_record_from_mapping(data: dict) -> GenRetrospectiveRecord:
             command=raw.get("command"),
         )
 
-    def _evidence_ref(raw: dict) -> GenEvidenceRef:
+    def _evidence_ref(raw: YamlMapping) -> GenEvidenceRef:
         return GenEvidenceRef(
             id=raw["id"],
             kind=raw["kind"],
@@ -269,7 +272,7 @@ def _gen_record_from_mapping(data: dict) -> GenRetrospectiveRecord:
             url=raw.get("url"),
         )
 
-    def _finding(raw: dict) -> GenFinding:
+    def _finding(raw: YamlMapping) -> GenFinding:
         return GenFinding(
             id=raw["id"],
             category=raw["category"],
@@ -278,7 +281,7 @@ def _gen_record_from_mapping(data: dict) -> GenRetrospectiveRecord:
             details=raw.get("details"),
         )
 
-    def _proposal(raw: dict) -> GenProposal:
+    def _proposal(raw: YamlMapping) -> GenProposal:
         return GenProposal(
             id=raw["id"],
             category=raw["category"],

--- a/src/specify_cli/retrospective/reader.py
+++ b/src/specify_cli/retrospective/reader.py
@@ -124,6 +124,26 @@ def _load_yaml_mapping(path: Path) -> dict:
     return data
 
 
+def _coerce_legacy_schema_versions(data: dict) -> dict:
+    """Accept legacy YAML scalar versions while keeping the model schema strict."""
+    normalized = dict(data)
+
+    schema_version = normalized.get("schema_version")
+    if type(schema_version) is int:
+        normalized["schema_version"] = str(schema_version)
+
+    provenance = normalized.get("provenance")
+    if isinstance(provenance, dict):
+        provenance_schema_version = provenance.get("schema_version")
+        if type(provenance_schema_version) is int:
+            normalized["provenance"] = {
+                **provenance,
+                "schema_version": str(provenance_schema_version),
+            }
+
+    return normalized
+
+
 def _validate_keys(raw: dict, allowed: frozenset[str], *, label: str) -> None:
     extra = sorted(set(raw) - allowed)
     if extra:
@@ -329,7 +349,7 @@ def read_record(path: Path, *, verify_evidence: bool = False) -> RetrospectiveRe
 
     # Schema validation via Pydantic.
     try:
-        record = RetrospectiveRecord.model_validate(data)
+        record = RetrospectiveRecord.model_validate(_coerce_legacy_schema_versions(data))
     except ValidationError as exc:
         raise SchemaError(
             f"Schema validation failed for {path}:\n{exc}"

--- a/tests/retrospective/test_reader_tolerance.py
+++ b/tests/retrospective/test_reader_tolerance.py
@@ -133,6 +133,23 @@ def test_legacy_integer_schema_version_reads_correctly(tmp_path: Path) -> None:
     assert record.provenance.schema_version == "1"
 
 
+@pytest.mark.parametrize(
+    "mutated_yaml",
+    [
+        VALID_YAML.replace('schema_version: "1"', "schema_version: true", 1),
+        VALID_YAML.replace('schema_version: "1"', "schema_version: 2", 1),
+        VALID_YAML.replace('  schema_version: "1"', "  schema_version: 2"),
+    ],
+)
+def test_legacy_schema_version_coercion_stays_narrow(tmp_path: Path, mutated_yaml: str) -> None:
+    """Only legacy integer 1 scalars are tolerated."""
+    bad = tmp_path / "retrospective.yaml"
+    bad.write_text(mutated_yaml, encoding="utf-8")
+
+    with pytest.raises(SchemaError):
+        read_record(bad)
+
+
 def _valid_generator_yaml() -> str:
     return f"""\
 schema_version: 1

--- a/tests/retrospective/test_reader_tolerance.py
+++ b/tests/retrospective/test_reader_tolerance.py
@@ -120,6 +120,19 @@ def test_valid_yaml_reads_correctly(tmp_path: Path) -> None:
     assert record.schema_version == "1"
 
 
+def test_legacy_integer_schema_version_reads_correctly(tmp_path: Path) -> None:
+    """Older Pydantic-shape records with schema_version: 1 remain readable."""
+    legacy_yaml = VALID_YAML.replace('schema_version: "1"', "schema_version: 1")
+    good = tmp_path / "retrospective.yaml"
+    good.write_text(legacy_yaml, encoding="utf-8")
+
+    record = read_record(good)
+
+    assert record.status == "completed"
+    assert record.schema_version == "1"
+    assert record.provenance.schema_version == "1"
+
+
 def _valid_generator_yaml() -> str:
     return f"""\
 schema_version: 1

--- a/tests/retrospective/test_summary_tolerance.py
+++ b/tests/retrospective/test_summary_tolerance.py
@@ -417,6 +417,19 @@ class TestToleranceCategories:
         assert snapshot.malformed == []
         assert snapshot.not_helpful_top[0].urn == "retrospective:not_helpful:process"
 
+    def test_legacy_integer_schema_version_record_is_not_malformed(self, tmp_path: Path) -> None:
+        missions_root = tmp_path / ".kittify" / "missions"
+        missions_root.mkdir(parents=True)
+        mission_dir = missions_root / MISSION_ID_2
+        mission_dir.mkdir()
+        legacy_yaml = _make_brief_yaml().replace('schema_version: "1"', "schema_version: 1")
+        (mission_dir / "retrospective.yaml").write_text(legacy_yaml, encoding="utf-8")
+
+        snapshot = build_summary(project_path=tmp_path)
+
+        assert snapshot.completed_count == 1
+        assert snapshot.malformed == []
+
     def test_malformed_entries_have_path_and_reason(self, tmp_path: Path) -> None:
         project = _build_corpus(tmp_path)
         snapshot = build_summary(project_path=project)


### PR DESCRIPTION
## Summary
- Coerce legacy integer `schema_version` scalars at the retrospective reader boundary before Pydantic validation
- Covers both top-level `schema_version: 1` and nested `provenance.schema_version: 1` on old Pydantic-shape records
- Add reader and summary reducer regressions so old records are counted as completed instead of malformed

Fixes #1751

## Validation
- `uv run pytest tests/retrospective/test_reader_tolerance.py tests/retrospective/test_summary_tolerance.py tests/retrospective/test_summary_cli.py tests/cli/commands/test_retrospect.py tests/specify_cli/retrospect -q`
- `uv run pytest tests/retrospective -q`
- `uv run ruff check src/specify_cli/retrospective/reader.py tests/retrospective/test_reader_tolerance.py tests/retrospective/test_summary_tolerance.py`
- `git diff --check`