### PR TITLE
fix: address SonarCloud security and nightly quality findings

### DIFF
--- a/src/mission_runtime/resolution.py
+++ b/src/mission_runtime/resolution.py
@@ -162,35 +162,46 @@ def _resolve_review_wp_id(feature_dir: Path) -> str | None:
     try:
         events = read_events(feature_dir)
 
-        def _is_review_claimed(_wp_id: str) -> bool:
-            for event in reversed(events):
-                if getattr(event, "wp_id", None) == _wp_id:
-                    return bool(
-                        event.to_lane == Lane.IN_REVIEW  # new canonical shape
-                        or (
-                            event.to_lane == Lane.IN_PROGRESS  # legacy shape
-                            and event.review_ref == "action-review-claim"
-                        )
-                    )
-            return False
+        def _is_review_claimed(candidate_wp_id: str) -> bool:
+            latest_event = next(
+                (
+                    event
+                    for event in reversed(events)
+                    if getattr(event, "wp_id", None) == candidate_wp_id
+                ),
+                None,
+            )
+            if latest_event is None:
+                return False
+            return bool(
+                latest_event.to_lane == Lane.IN_REVIEW
+                or (
+                    latest_event.to_lane == Lane.IN_PROGRESS
+                    and latest_event.review_ref == "action-review-claim"
+                )
+            )
 
-        def _candidates() -> list[str]:
-            ids: list[str] = []
-            for wp_file in sorted(tasks_dir.glob("WP*.md")):
-                content = wp_file.read_text(encoding="utf-8-sig")
-                frontmatter, _, _ = split_frontmatter(content)
-                candidate_wp_id = extract_scalar(frontmatter, "work_package_id")
-                if candidate_wp_id:
-                    ids.append(str(candidate_wp_id))
-            return ids
+        candidate_wp_ids = [
+            str(candidate_wp_id)
+            for wp_file in sorted(tasks_dir.glob("WP*.md"))
+            if (
+                candidate_wp_id := extract_scalar(
+                    split_frontmatter(wp_file.read_text(encoding="utf-8-sig"))[0],
+                    "work_package_id",
+                )
+            )
+        ]
 
-        for candidate_wp_id in _candidates():
+        for candidate_wp_id in candidate_wp_ids:
             if get_wp_lane(feature_dir, candidate_wp_id) == Lane.FOR_REVIEW:
                 return candidate_wp_id
 
-        for candidate_wp_id in _candidates():
+        for candidate_wp_id in candidate_wp_ids:
             candidate_lane = get_wp_lane(feature_dir, candidate_wp_id)
-            if candidate_lane in (Lane.IN_PROGRESS, Lane.IN_REVIEW) and _is_review_claimed(candidate_wp_id):
+            if (
+                candidate_lane in (Lane.IN_PROGRESS, Lane.IN_REVIEW)
+                and _is_review_claimed(candidate_wp_id)
+            ):
                 return candidate_wp_id
     except CanonicalStatusNotFoundError as exc:
         raise ActionContextError("CANONICAL_STATUS_NOT_FOUND", str(exc)) from exc

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -146,6 +146,49 @@ _VALID_VERDICTS: frozenset[str] = frozenset(
 )
 
 
+def _issue_matrix_evaluation(
+    feature_dir: Path,
+) -> tuple[object, set[str], list[str], list[str]]:
+    from specify_cli.cli.commands.review._issue_matrix import (
+        IssueMatrixVerdict,
+        validate_issue_matrix,
+    )
+    from specify_cli.tasks.issue_matrix import detect_issue_references
+
+    spec_path = feature_dir / "spec.md"
+    refs = detect_issue_references(spec_path)
+    matrix_path = feature_dir / "issue-matrix.md"
+    result = validate_issue_matrix(matrix_path)
+    referenced_issues = {f"#{ref.number}" for ref in refs}
+    matrix_issues = {row.issue for row in result.rows}
+    for diagnostic in result.diagnostics:
+        match = re.search(r"Row for issue '([^']+)'", diagnostic.get("message", ""))
+        if match:
+            matrix_issues.add(match.group(1))
+    unresolved_in_mission = sorted(
+        row.issue
+        for row in result.rows
+        if row.verdict is IssueMatrixVerdict.IN_MISSION
+        and row.issue in referenced_issues
+    )
+    return result, referenced_issues, sorted(referenced_issues - matrix_issues), unresolved_in_mission
+
+
+def _issue_matrix_diagnostic_lines(result: object) -> tuple[list[str], list[str]]:
+    from specify_cli.cli.commands.review._diagnostics import MissionReviewDiagnostic
+
+    unknown_issues: list[str] = []
+    other_messages: list[str] = []
+    for diagnostic in result.diagnostics:
+        message = diagnostic.get("message", "")
+        if diagnostic.get("diagnostic_code") == str(MissionReviewDiagnostic.ISSUE_MATRIX_VERDICT_UNKNOWN):
+            match = re.search(r"issue '([^']+)'", message)
+            unknown_issues.append(match.group(1) if match else message)
+        else:
+            other_messages.append(message)
+    return unknown_issues, other_messages
+
+
 def _issue_matrix_approval_blocker(
     feature_dir: Path,
     *,
@@ -166,11 +209,6 @@ def _issue_matrix_approval_blocker(
         return None
 
     try:
-        from specify_cli.cli.commands.review._diagnostics import MissionReviewDiagnostic
-        from specify_cli.cli.commands.review._issue_matrix import (
-            IssueMatrixVerdict,
-            validate_issue_matrix,
-        )
         from specify_cli.tasks.issue_matrix import detect_issue_references
 
         refs = detect_issue_references(spec_path)
@@ -194,38 +232,14 @@ def _issue_matrix_approval_blocker(
             "Fill verdicts before approving."
         )
 
-    result = validate_issue_matrix(matrix_path)
-    referenced_issues = {f"#{ref.number}" for ref in refs}
-    matrix_issues = {row.issue for row in result.rows}
-    for diagnostic in result.diagnostics:
-        match = re.search(r"Row for issue '([^']+)'", diagnostic.get("message", ""))
-        if match:
-            matrix_issues.add(match.group(1))
-    missing_issues = sorted(referenced_issues - matrix_issues)
-
-    # `in-mission` is acceptable at per-WP approval but not at mission done:
-    # by the time WPs merge to done, every issue must have a terminal verdict.
-    unresolved_in_mission: list[str] = []
-    if target_lane == Lane.DONE:
-        unresolved_in_mission = sorted(
-            row.issue
-            for row in result.rows
-            if row.verdict is IssueMatrixVerdict.IN_MISSION
-            and row.issue in referenced_issues
-        )
+    result, _, missing_issues, unresolved_in_mission = _issue_matrix_evaluation(feature_dir)
+    if target_lane != Lane.DONE:
+        unresolved_in_mission = []
 
     if result.passed and not missing_issues and not unresolved_in_mission:
         return None
 
-    unknown_issues: list[str] = []
-    other_messages: list[str] = []
-    for diagnostic in result.diagnostics:
-        message = diagnostic.get("message", "")
-        if diagnostic.get("diagnostic_code") == str(MissionReviewDiagnostic.ISSUE_MATRIX_VERDICT_UNKNOWN):
-            match = re.search(r"issue '([^']+)'", message)
-            unknown_issues.append(match.group(1) if match else message)
-        else:
-            other_messages.append(message)
+    unknown_issues, other_messages = _issue_matrix_diagnostic_lines(result)
 
     lines = ["ERROR: issue-matrix.md has unresolved entries. Fill in verdicts before approving."]
     if missing_issues:

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -502,9 +502,9 @@ def _assert_merged_wps_reached_done(
 ) -> None:
     """Fail the merge if merged WPs did not reach ``done`` in the event log."""
     from specify_cli.status import CanonicalStatusNotFoundError
-    from specify_cli.status import lane_reader
     from specify_cli.status import Lane
     from specify_cli.status import StoreError
+    from specify_cli.status import get_wp_lane
     from specify_cli.status import resolve_lane_alias
 
     # Resolve the canonical status surface so reads are on the same side as
@@ -515,7 +515,7 @@ def _assert_merged_wps_reached_done(
     try:
         incomplete: list[str] = []
         for wp_id in wp_ids:
-            raw = lane_reader.get_wp_lane(feature_dir, wp_id)
+            raw = get_wp_lane(feature_dir, wp_id)
             try:
                 lane = Lane(resolve_lane_alias(raw))
             except ValueError:

--- a/src/specify_cli/session_presence/hooks/claude_code_hook.py
+++ b/src/specify_cli/session_presence/hooks/claude_code_hook.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 
 __all__ = ["ClaudeCodeHookRegistrar"]
@@ -62,18 +63,17 @@ class ClaudeCodeHookRegistrar:
             raise ValueError(msg) from exc
         return path
 
-    def _sibling_path(self, path: Path, suffix: str) -> Path:
-        candidate = path.parent / f"{path.name}{suffix}"
-        candidate.relative_to(path.parent)
-        return candidate
-
-    def _invalid_backup_path(self, path: Path) -> Path:
-        backup = self._sibling_path(path, ".invalid")
-        counter = 1
-        while backup.exists():
-            backup = self._sibling_path(path, f".invalid.{counter}")
-            counter += 1
-        return backup
+    def _create_temp_path(self, path: Path, *, suffix: str = "", prefix: str | None = None) -> Path:
+        fd, temp_path = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=path.name if prefix is None else prefix,
+            suffix=suffix,
+            text=True,
+        )
+        os.close(fd)
+        temp = Path(temp_path)
+        temp.relative_to(path.parent)
+        return temp
 
     def _session_start_entries(self, data: dict[str, object]) -> list[object] | None:
         hooks_section = data.get("hooks")
@@ -124,14 +124,18 @@ class ClaudeCodeHookRegistrar:
 
     def _preserve_invalid(self, path: Path, text: str) -> None:
         """Copy invalid settings content to a sibling backup before overwrite."""
-        backup = self._invalid_backup_path(path)
-        backup.write_text(text, encoding="utf-8")
+        backup = self._create_temp_path(path, prefix=f"{path.name}.invalid.")
+        try:
+            backup.write_text(text, encoding="utf-8")
+        except Exception:
+            backup.unlink(missing_ok=True)
+            raise
         _logger.warning("Preserved invalid Claude settings JSON at %s", backup)
 
     def _save(self, path: Path, data: dict[str, object]) -> None:
         """Write *data* as JSON to *path* atomically."""
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._sibling_path(path, ".tmp")
+        tmp = self._create_temp_path(path, suffix=".tmp")
         try:
             tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
             os.replace(tmp, path)

--- a/src/specify_cli/status/wp_state.py
+++ b/src/specify_cli/status/wp_state.py
@@ -401,7 +401,7 @@ class InReviewState(WPState):
             }
         )
 
-    def guard_for(self, target: Lane, ctx: TransitionInputs) -> tuple[bool, str | None]:  # noqa: ARG002 -- FR-012c applies the same guard to every outbound target, so ``target`` is intentionally not branched on
+    def guard_for(self, _target: Lane, ctx: TransitionInputs) -> tuple[bool, str | None]:
         # FR-012c: ALL outbound transitions from in_review require ReviewResult.
         return _check_review_result(ctx)
 

--- a/tests/specify_cli/session_presence/test_claude_code_hook.py
+++ b/tests/specify_cli/session_presence/test_claude_code_hook.py
@@ -35,6 +35,10 @@ def _write_settings(project_root: Path, data: dict[str, Any]) -> None:
     _settings_path(project_root).write_text(json.dumps(data), encoding="utf-8")
 
 
+def _invalid_backups(project_root: Path) -> list[Path]:
+    return sorted(_settings_path(project_root).parent.glob("settings.json.invalid.*"))
+
+
 class TestRegister:
     def test_creates_settings_json_if_absent(self, claude_project: Path) -> None:
         reg = ClaudeCodeHookRegistrar()
@@ -95,7 +99,9 @@ class TestRegister:
         # File should now be valid JSON
         data = _read_settings(claude_project)
         assert "hooks" in data
-        backup = _settings_path(claude_project).with_name("settings.json.invalid")
+        backups = _invalid_backups(claude_project)
+        assert len(backups) == 1
+        backup = backups[0]
         assert backup.read_text(encoding="utf-8") == "NOT JSON"
 
     def test_handles_non_object_json_without_losing_original(
@@ -107,7 +113,9 @@ class TestRegister:
         reg.register(claude_project, _CMD)
         data = _read_settings(claude_project)
         assert "hooks" in data
-        backup = _settings_path(claude_project).with_name("settings.json.invalid")
+        backups = _invalid_backups(claude_project)
+        assert len(backups) == 1
+        backup = backups[0]
         assert backup.read_text(encoding="utf-8") == original
 
     def test_creates_valid_structure_from_empty(self, claude_project: Path) -> None:
@@ -235,5 +243,4 @@ class TestAtomicWrite:
             reg.register(claude_project, _CMD)
 
         # No .tmp file should be left behind
-        tmp_file = settings.with_suffix(".tmp")
-        assert not tmp_file.exists()
+        assert not list(settings.parent.glob("settings.json*.tmp"))


### PR DESCRIPTION
## Summary
- harden Claude Code hook settings writes to use tempfiles inside the validated settings directory, removing the open SonarCloud S2083 code-scanning findings on `src/specify_cli/session_presence/hooks/claude_code_hook.py`
- refactor the new nightly Sonar complexity hotspots in `src/mission_runtime/resolution.py` and `src/specify_cli/cli/commands/agent/tasks.py`
- remove the stale suppression comment in `src/specify_cli/status/wp_state.py` by renaming the intentionally unused parameter
- update hook registrar tests to match tempfile-based backup/temp naming

## Findings investigated
- GitHub Dependabot alerts: none open
- GitHub code scanning alerts: 2 open SonarCloud S2083 alerts on `main`
- SonarCloud issues created from scheduled `CI Quality` run `27187771449` on `main` (2026-06-09):
  - `src/specify_cli/session_presence/hooks/claude_code_hook.py` S2083 path-injection alerts
  - `src/mission_runtime/resolution.py` S3776 complexity
  - `src/specify_cli/cli/commands/agent/tasks.py` S3776 complexity
  - `src/specify_cli/status/wp_state.py` S7632 suppression-comment syntax

## Validation
- `.venv/bin/pytest tests/specify_cli/session_presence/test_claude_code_hook.py -q`
- `.venv/bin/pytest tests/agent/cli/commands/test_tasks_helpers.py -q`
- `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_review_lane_fix.py tests/mission_runtime/test_resolution_target_branch.py -q`
- `.venv/bin/ruff check src/specify_cli/session_presence/hooks/claude_code_hook.py src/mission_runtime/resolution.py src/specify_cli/cli/commands/agent/tasks.py src/specify_cli/status/wp_state.py tests/specify_cli/session_presence/test_claude_code_hook.py`
