### PR TITLE
fix: reduce nightly sonar complexity hotspots

### DIFF
--- a/src/mission_runtime/resolution.py
+++ b/src/mission_runtime/resolution.py
@@ -18,9 +18,9 @@ work package, workspace path, and any action-specific commands to run.
 """
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Literal, cast, get_args
+from typing import Any, Literal, cast, get_args
 
 from mission_runtime.context import ExecutionContext
 
@@ -195,12 +195,12 @@ def _resolve_review_wp_id(feature_dir: Path) -> str | None:
 def _review_candidate_wp_ids(
     tasks_dir: Path,
     *,
-    extract_scalar: object,
-    split_frontmatter: object,
+    extract_scalar: Callable[[str, str], str | None],
+    split_frontmatter: Callable[[str], tuple[str, str, str]],
 ) -> list[str]:
     candidate_wp_ids: list[str] = []
     for wp_file in sorted(tasks_dir.glob("WP*.md")):
-        frontmatter, _ = split_frontmatter(wp_file.read_text(encoding="utf-8-sig"))
+        frontmatter = split_frontmatter(wp_file.read_text(encoding="utf-8-sig"))[0]
         candidate_wp_id = extract_scalar(frontmatter, "work_package_id")
         if candidate_wp_id:
             candidate_wp_ids.append(str(candidate_wp_id))
@@ -212,7 +212,7 @@ def _first_wp_in_lane(
     candidate_wp_ids: list[str],
     *,
     target_lane: object,
-    get_wp_lane: object,
+    get_wp_lane: Callable[[Path, str], object],
 ) -> str | None:
     for candidate_wp_id in candidate_wp_ids:
         if get_wp_lane(feature_dir, candidate_wp_id) == target_lane:
@@ -220,7 +220,7 @@ def _first_wp_in_lane(
     return None
 
 
-def _is_review_claimed(events: list[object], candidate_wp_id: str, *, Lane: object) -> bool:
+def _is_review_claimed(events: Sequence[Any], candidate_wp_id: str, *, Lane: Any) -> bool:
     latest_event = next(
         (
             event

--- a/src/mission_runtime/resolution.py
+++ b/src/mission_runtime/resolution.py
@@ -162,46 +162,26 @@ def _resolve_review_wp_id(feature_dir: Path) -> str | None:
     try:
         events = read_events(feature_dir)
 
-        def _is_review_claimed(candidate_wp_id: str) -> bool:
-            latest_event = next(
-                (
-                    event
-                    for event in reversed(events)
-                    if getattr(event, "wp_id", None) == candidate_wp_id
-                ),
-                None,
-            )
-            if latest_event is None:
-                return False
-            return bool(
-                latest_event.to_lane == Lane.IN_REVIEW
-                or (
-                    latest_event.to_lane == Lane.IN_PROGRESS
-                    and latest_event.review_ref == "action-review-claim"
-                )
-            )
+        candidate_wp_ids = _review_candidate_wp_ids(
+            tasks_dir,
+            extract_scalar=extract_scalar,
+            split_frontmatter=split_frontmatter,
+        )
 
-        candidate_wp_ids = [
-            str(candidate_wp_id)
-            for wp_file in sorted(tasks_dir.glob("WP*.md"))
-            if (
-                candidate_wp_id := extract_scalar(
-                    split_frontmatter(wp_file.read_text(encoding="utf-8-sig"))[0],
-                    "work_package_id",
-                )
-            )
-        ]
-
-        for candidate_wp_id in candidate_wp_ids:
-            if get_wp_lane(feature_dir, candidate_wp_id) == Lane.FOR_REVIEW:
-                return candidate_wp_id
+        review_ready_wp_id = _first_wp_in_lane(
+            feature_dir,
+            candidate_wp_ids,
+            target_lane=Lane.FOR_REVIEW,
+            get_wp_lane=get_wp_lane,
+        )
+        if review_ready_wp_id is not None:
+            return review_ready_wp_id
 
         for candidate_wp_id in candidate_wp_ids:
             candidate_lane = get_wp_lane(feature_dir, candidate_wp_id)
-            if (
-                candidate_lane in (Lane.IN_PROGRESS, Lane.IN_REVIEW)
-                and _is_review_claimed(candidate_wp_id)
-            ):
+            if candidate_lane not in (Lane.IN_PROGRESS, Lane.IN_REVIEW):
+                continue
+            if _is_review_claimed(events, candidate_wp_id, Lane=Lane):
                 return candidate_wp_id
     except CanonicalStatusNotFoundError as exc:
         raise ActionContextError("CANONICAL_STATUS_NOT_FOUND", str(exc)) from exc
@@ -210,6 +190,54 @@ def _resolve_review_wp_id(feature_dir: Path) -> str | None:
     except Exception:
         return None
     return None
+
+
+def _review_candidate_wp_ids(
+    tasks_dir: Path,
+    *,
+    extract_scalar: object,
+    split_frontmatter: object,
+) -> list[str]:
+    candidate_wp_ids: list[str] = []
+    for wp_file in sorted(tasks_dir.glob("WP*.md")):
+        frontmatter, _ = split_frontmatter(wp_file.read_text(encoding="utf-8-sig"))
+        candidate_wp_id = extract_scalar(frontmatter, "work_package_id")
+        if candidate_wp_id:
+            candidate_wp_ids.append(str(candidate_wp_id))
+    return candidate_wp_ids
+
+
+def _first_wp_in_lane(
+    feature_dir: Path,
+    candidate_wp_ids: list[str],
+    *,
+    target_lane: object,
+    get_wp_lane: object,
+) -> str | None:
+    for candidate_wp_id in candidate_wp_ids:
+        if get_wp_lane(feature_dir, candidate_wp_id) == target_lane:
+            return candidate_wp_id
+    return None
+
+
+def _is_review_claimed(events: list[object], candidate_wp_id: str, *, Lane: object) -> bool:
+    latest_event = next(
+        (
+            event
+            for event in reversed(events)
+            if getattr(event, "wp_id", None) == candidate_wp_id
+        ),
+        None,
+    )
+    if latest_event is None:
+        return False
+    return bool(
+        latest_event.to_lane == Lane.IN_REVIEW
+        or (
+            latest_event.to_lane == Lane.IN_PROGRESS
+            and latest_event.review_ref == "action-review-claim"
+        )
+    )
 
 
 def _resolve_wp_id(

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -155,23 +155,38 @@ def _issue_matrix_evaluation(
     )
     from specify_cli.tasks.issue_matrix import detect_issue_references
 
-    spec_path = feature_dir / "spec.md"
-    refs = detect_issue_references(spec_path)
-    matrix_path = feature_dir / "issue-matrix.md"
-    result = validate_issue_matrix(matrix_path)
+    refs = detect_issue_references(feature_dir / "spec.md")
+    result = validate_issue_matrix(feature_dir / "issue-matrix.md")
     referenced_issues = {f"#{ref.number}" for ref in refs}
+    matrix_issues = _issue_matrix_row_issues(result)
+    unresolved_in_mission = _issue_matrix_in_mission_rows(
+        result,
+        referenced_issues,
+        IssueMatrixVerdict.IN_MISSION,
+    )
+    missing_issues = sorted(referenced_issues - matrix_issues)
+    return result, referenced_issues, missing_issues, unresolved_in_mission
+
+
+def _issue_matrix_row_issues(result: object) -> set[str]:
     matrix_issues = {row.issue for row in result.rows}
     for diagnostic in result.diagnostics:
         match = re.search(r"Row for issue '([^']+)'", diagnostic.get("message", ""))
         if match:
             matrix_issues.add(match.group(1))
-    unresolved_in_mission = sorted(
+    return matrix_issues
+
+
+def _issue_matrix_in_mission_rows(
+    result: object,
+    referenced_issues: set[str],
+    in_mission_verdict: object,
+) -> list[str]:
+    return sorted(
         row.issue
         for row in result.rows
-        if row.verdict is IssueMatrixVerdict.IN_MISSION
-        and row.issue in referenced_issues
+        if row.verdict is in_mission_verdict and row.issue in referenced_issues
     )
-    return result, referenced_issues, sorted(referenced_issues - matrix_issues), unresolved_in_mission
 
 
 def _issue_matrix_diagnostic_lines(result: object) -> tuple[list[str], list[str]]:

--- a/tests/mission_runtime/test_resolution_target_branch.py
+++ b/tests/mission_runtime/test_resolution_target_branch.py
@@ -30,6 +30,8 @@ import pytest
 from mission_runtime import resolve_action_context
 from specify_cli.coordination.policy import WorkflowMutationPolicy
 from specify_cli.coordination.types import Allowed, GitChangeSet, Refused
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.store import append_event
 
 pytestmark = [pytest.mark.unit, pytest.mark.git_repo]
 
@@ -70,6 +72,39 @@ def _build_mission(repo_root: Path, *, target_branch: str) -> None:
     )
 
 
+def _write_review_wp(feature_dir: Path) -> None:
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "WP01-review.md").write_text(
+        "---\n"
+        "work_package_id: WP01\n"
+        "title: Review target\n"
+        "dependencies: []\n"
+        "execution_mode: planning_artifact\n"
+        "owned_files: []\n"
+        "---\n"
+        "# WP01\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_for_review(feature_dir: Path) -> None:
+    append_event(
+        feature_dir,
+        StatusEvent(
+            event_id="test-WP01-for-review",
+            mission_slug=feature_dir.name,
+            wp_id="WP01",
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.FOR_REVIEW,
+            at="2026-01-01T00:00:00+00:00",
+            actor="test",
+            force=True,
+            execution_mode="worktree",
+        ),
+    )
+
+
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     """Minimal git repo with a mission and a non-protected target branch."""
@@ -95,6 +130,19 @@ def test_resolver_returns_mode_correct_target_branch(repo: Path) -> None:
     ctx = resolve_action_context(repo, action="tasks", feature=_MISSION_SLUG)
 
     assert ctx.target_branch == "feat/execution-state-strangler"
+
+
+def test_review_context_resolves_wp_from_frontmatter(repo: Path) -> None:
+    """Review resolution must use real split_frontmatter's 3-field contract."""
+    _build_mission(repo, target_branch="main")
+    feature_dir = repo / "kitty-specs" / _MISSION_SLUG
+    _write_review_wp(feature_dir)
+    _seed_for_review(feature_dir)
+
+    ctx = resolve_action_context(repo, action="review", feature=_MISSION_SLUG, agent="codex")
+
+    assert ctx.wp_id == "WP01"
+    assert ctx.commands["workflow"].endswith("review WP01 --agent codex")
 
 
 def test_resolver_does_not_invent_branch_for_mainline_target(repo: Path) -> None:


### PR DESCRIPTION
## Summary
- reduce Sonar cognitive complexity in `src/specify_cli/cli/commands/agent/tasks.py`
- reduce Sonar cognitive complexity in `src/mission_runtime/resolution.py`
- leave `src/specify_cli/status/wp_state.py` untouched because the nightly `S7632` finding is already fixed on current `main` and should clear on re-analysis

## Validation
- `.venv/bin/ruff check src/specify_cli/cli/commands/agent/tasks.py src/mission_runtime/resolution.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/agent/cli/commands/test_tasks_helpers.py tests/mission_runtime/test_resolution_target_branch.py -q`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/specify_cli/cli/commands/agent/test_review_lane_fix.py -q`

## Notes
- No suppressions added.
- Open GitHub code-scanning alerts still point at commit `eb39b65ab95d10335a0904b3c73792792ad624b9`; current `main` already contains the temp-file hardening from `#1813`.