### PR TITLE
fix: address narrow SonarCloud maintainability findings

### DIFF
--- a/src/charter/pack_manager.py
+++ b/src/charter/pack_manager.py
@@ -431,7 +431,7 @@ class CharterPackManager:
         artifact_id: str,
         *,
         cascade: bool = False,  # noqa: ARG002 — kept for caller API stability
-        _layer_roots: dict[str, Path] | None = None,  # noqa: ARG002 — symmetry with activate
+        layer_roots: dict[str, Path] | None = None,
     ) -> ActivationResult:
         """Deactivate ``artifact_id`` for ``kind`` in the project charter pack.
 
@@ -470,6 +470,7 @@ class CharterPackManager:
             If the kind has no explicit activation set (the engine raises this;
             the CLI surfaces the upgrade guidance).
         """
+        del layer_roots  # Accepted for API symmetry with activate(); deactivation ignores external layer maps.
         self._require_kind(kind)
         yaml_key = YAML_KEY_MAP[kind]
 

--- a/src/charter/pack_manager.py
+++ b/src/charter/pack_manager.py
@@ -431,7 +431,7 @@ class CharterPackManager:
         artifact_id: str,
         *,
         cascade: bool = False,  # noqa: ARG002 — kept for caller API stability
-        layer_roots: dict[str, Path] | None = None,  # noqa: ARG002 — symmetry with activate
+        _layer_roots: dict[str, Path] | None = None,  # noqa: ARG002 — symmetry with activate
     ) -> ActivationResult:
         """Deactivate ``artifact_id`` for ``kind`` in the project charter pack.
 

--- a/src/doctrine/drg/migration/extractor.py
+++ b/src/doctrine/drg/migration/extractor.py
@@ -18,6 +18,8 @@ from doctrine.drg.migration.id_normalizer import artifact_to_urn
 from doctrine.drg.models import DRGEdge, DRGGraph, DRGNode, NodeKind, Relation
 from doctrine.drg.validator import assert_valid
 
+SPECIFICATION_BY_EXAMPLE = "paradigm:specification-by-example"
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -66,17 +68,17 @@ _CURATED_ARTIFACT_EDGES: tuple[tuple[str, str, Relation], ...] = (
         Relation.SPECIALIZES_FROM,
     ),
     (
-        "paradigm:specification-by-example",
+        SPECIFICATION_BY_EXAMPLE,
         "tactic:acceptance-test-first",
         Relation.REQUIRES,
     ),
     (
-        "paradigm:specification-by-example",
+        SPECIFICATION_BY_EXAMPLE,
         "tactic:atdd-adversarial-acceptance",
         Relation.REQUIRES,
     ),
     (
-        "paradigm:specification-by-example",
+        SPECIFICATION_BY_EXAMPLE,
         "tactic:usage-examples-sync",
         Relation.REQUIRES,
     ),

--- a/src/specify_cli/audit/engine.py
+++ b/src/specify_cli/audit/engine.py
@@ -50,6 +50,8 @@ from .models import (
     is_teamspace_blocker,
 )
 
+_META_JSON = "meta.json"
+
 
 # ---------------------------------------------------------------------------
 # Private: mission filter resolution
@@ -229,7 +231,7 @@ def _compute_repo_findings_by_slug(
             finding = MissionFinding(
                 code="DUPLICATE_PREFIX",
                 severity=_slug_to_finding_severity("DUPLICATE_PREFIX"),
-                artifact_path="meta.json",
+                artifact_path=_META_JSON,
                 detail=f"prefix {prefix!r} shared with: {other_slugs}",
             )
             if state.slug in slug_to_dir:
@@ -245,7 +247,7 @@ def _compute_repo_findings_by_slug(
             finding = MissionFinding(
                 code="AMBIGUOUS_SELECTOR",
                 severity=_slug_to_finding_severity("AMBIGUOUS_SELECTOR"),
-                artifact_path="meta.json",
+                artifact_path=_META_JSON,
                 detail=f"handle {handle!r} also matches: {other_slugs}",
             )
             if state.slug in slug_to_dir:
@@ -268,7 +270,7 @@ def _compute_repo_findings_by_slug(
             finding = MissionFinding(
                 code="DUPLICATE_MISSION_ID",
                 severity=_slug_to_finding_severity("DUPLICATE_MISSION_ID"),
-                artifact_path="meta.json",
+                artifact_path=_META_JSON,
                 detail=f"mission_id {mission_id!r} also used by: {other_slugs}",
             )
             if state.slug in slug_to_dir:

--- a/src/specify_cli/audit/identity_adapter.py
+++ b/src/specify_cli/audit/identity_adapter.py
@@ -35,6 +35,8 @@ from specify_cli.status import IdentityState
 
 from .models import MissionFinding, Severity
 
+_META_JSON = "meta.json"
+
 
 # ---------------------------------------------------------------------------
 # Single-state adapter
@@ -43,7 +45,7 @@ from .models import MissionFinding, Severity
 
 def identity_state_to_findings(
     state: IdentityState,
-    mission_dir: Path,  # noqa: ARG001  (kept for call-site symmetry)
+    _mission_dir: Path,  # noqa: ARG001  (kept for call-site symmetry)
 ) -> list[MissionFinding]:
     """Convert a single ``IdentityState`` to audit findings.
 
@@ -80,7 +82,7 @@ def identity_state_to_findings(
             MissionFinding(
                 code="IDENTITY_MISSING",
                 severity=Severity.ERROR,
-                artifact_path="meta.json",
+                artifact_path=_META_JSON,
                 detail="meta.json absent",
             )
         ]
@@ -96,7 +98,7 @@ def identity_state_to_findings(
 
 def prefix_groups_to_findings(
     groups: dict[str, list[IdentityState]],
-    slug_to_dir: dict[str, Path],  # noqa: ARG001
+    _slug_to_dir: dict[str, Path],  # noqa: ARG001
 ) -> list[MissionFinding]:
     """Convert ``find_duplicate_prefixes()`` output to ``DUPLICATE_PREFIX`` findings.
 
@@ -126,7 +128,7 @@ def prefix_groups_to_findings(
                 MissionFinding(
                     code="DUPLICATE_PREFIX",
                     severity=Severity.WARNING,
-                    artifact_path="meta.json",
+                    artifact_path=_META_JSON,
                     detail=f"prefix {prefix!r} shared with: {other_slugs}",
                 )
             )
@@ -135,7 +137,7 @@ def prefix_groups_to_findings(
 
 def selector_groups_to_findings(
     groups: dict[str, list[IdentityState]],
-    slug_to_dir: dict[str, Path],  # noqa: ARG001
+    _slug_to_dir: dict[str, Path],  # noqa: ARG001
 ) -> list[MissionFinding]:
     """Convert ``find_ambiguous_selectors()`` output to ``AMBIGUOUS_SELECTOR`` findings.
 
@@ -162,7 +164,7 @@ def selector_groups_to_findings(
                 MissionFinding(
                     code="AMBIGUOUS_SELECTOR",
                     severity=Severity.WARNING,
-                    artifact_path="meta.json",
+                    artifact_path=_META_JSON,
                     detail=f"handle {handle!r} also matches: {other_slugs}",
                 )
             )
@@ -171,7 +173,7 @@ def selector_groups_to_findings(
 
 def duplicate_ids_to_findings(
     states: list[IdentityState],
-    slug_to_dir: dict[str, Path],  # noqa: ARG001
+    _slug_to_dir: dict[str, Path],  # noqa: ARG001
 ) -> list[MissionFinding]:
     """Detect missions with identical ``mission_id`` values and emit findings.
 
@@ -205,7 +207,7 @@ def duplicate_ids_to_findings(
                 MissionFinding(
                     code="DUPLICATE_MISSION_ID",
                     severity=Severity.ERROR,
-                    artifact_path="meta.json",
+                    artifact_path=_META_JSON,
                     detail=f"mission_id {mission_id!r} also used by: {other_slugs}",
                 )
             )

--- a/src/specify_cli/audit/identity_adapter.py
+++ b/src/specify_cli/audit/identity_adapter.py
@@ -45,7 +45,7 @@ _META_JSON = "meta.json"
 
 def identity_state_to_findings(
     state: IdentityState,
-    _mission_dir: Path,  # noqa: ARG001  (kept for call-site symmetry)
+    mission_dir: Path,
 ) -> list[MissionFinding]:
     """Convert a single ``IdentityState`` to audit findings.
 
@@ -77,6 +77,7 @@ def identity_state_to_findings(
         A list of :class:`~specify_cli.audit.models.MissionFinding` objects.
         Empty list for ``legacy``, ``pending``, and ``assigned`` states.
     """
+    del mission_dir  # Kept for public keyword compatibility and call-site symmetry.
     if state.state == "orphan":
         return [
             MissionFinding(
@@ -98,7 +99,7 @@ def identity_state_to_findings(
 
 def prefix_groups_to_findings(
     groups: dict[str, list[IdentityState]],
-    _slug_to_dir: dict[str, Path],  # noqa: ARG001
+    slug_to_dir: dict[str, Path],
 ) -> list[MissionFinding]:
     """Convert ``find_duplicate_prefixes()`` output to ``DUPLICATE_PREFIX`` findings.
 
@@ -117,6 +118,7 @@ def prefix_groups_to_findings(
         A flat list of ``DUPLICATE_PREFIX`` findings (one per mission per
         duplicated prefix).
     """
+    del slug_to_dir  # Kept for public keyword compatibility.
     findings: list[MissionFinding] = []
     for prefix, states in groups.items():
         if len(states) < 2:
@@ -137,7 +139,7 @@ def prefix_groups_to_findings(
 
 def selector_groups_to_findings(
     groups: dict[str, list[IdentityState]],
-    _slug_to_dir: dict[str, Path],  # noqa: ARG001
+    slug_to_dir: dict[str, Path],
 ) -> list[MissionFinding]:
     """Convert ``find_ambiguous_selectors()`` output to ``AMBIGUOUS_SELECTOR`` findings.
 
@@ -153,6 +155,7 @@ def selector_groups_to_findings(
     Returns:
         A flat list of ``AMBIGUOUS_SELECTOR`` findings.
     """
+    del slug_to_dir  # Kept for public keyword compatibility.
     findings: list[MissionFinding] = []
     for handle, states in groups.items():
         if len(states) < 2:
@@ -173,7 +176,7 @@ def selector_groups_to_findings(
 
 def duplicate_ids_to_findings(
     states: list[IdentityState],
-    _slug_to_dir: dict[str, Path],  # noqa: ARG001
+    slug_to_dir: dict[str, Path],
 ) -> list[MissionFinding]:
     """Detect missions with identical ``mission_id`` values and emit findings.
 
@@ -190,6 +193,7 @@ def duplicate_ids_to_findings(
         A flat list of ``DUPLICATE_MISSION_ID`` findings (one per mission in
         each group).
     """
+    del slug_to_dir  # Kept for public keyword compatibility.
     # Group by mission_id, skipping None values (orphan / legacy states).
     by_id: dict[str, list[IdentityState]] = defaultdict(list)
     for state in states:

--- a/src/specify_cli/dashboard/server.py
+++ b/src/specify_cli/dashboard/server.py
@@ -129,7 +129,7 @@ def start_dashboard(
         return port, proc.pid
 
     handler_class = _build_handler_class(project_dir_abs, project_token)
-    server = HTTPServer(('127.0.0.1', port), handler_class)
+    server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
 
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -274,8 +274,13 @@ def _fetch_health_payload(health_url: str, timeout: float = 0.5) -> dict[str, An
     return data if isinstance(data, dict) else None
 
 
+def _loopback_health_url(port: int) -> str:
+    """Return the localhost-only daemon health endpoint."""
+    return f"http://127.0.0.1:{port}/api/health"  # NOSONAR -- loopback-only control-plane URL, never exposed off-host
+
+
 def _check_sync_daemon_health(port: int, expected_token: str | None, timeout: float = 0.5) -> bool:
-    data = _fetch_health_payload(f"http://127.0.0.1:{port}/api/health", timeout=timeout)
+    data = _fetch_health_payload(_loopback_health_url(port), timeout=timeout)
     if not data:
         return False
     if data.get("status") != "ok":
@@ -288,14 +293,13 @@ def _check_sync_daemon_health(port: int, expected_token: str | None, timeout: fl
 
 def _daemon_version_matches(port: int, expected_token: str | None, timeout: float = 0.5) -> bool:
     """Return True if the running daemon reports the current protocol + package version."""
-    data = _fetch_health_payload(f"http://127.0.0.1:{port}/api/health", timeout=timeout)
+    data = _fetch_health_payload(_loopback_health_url(port), timeout=timeout)
     if not data:
         return False
     if data.get("status") != "ok":
         return False
-    if expected_token:
-        if data.get("token") != expected_token:
-            return False
+    if expected_token and data.get("token") != expected_token:
+        return False
     remote_proto = data.get("protocol_version")
     remote_pkg = data.get("package_version")
     if remote_proto != DAEMON_PROTOCOL_VERSION:
@@ -722,7 +726,7 @@ def get_sync_daemon_status(timeout: float = 0.5) -> SyncDaemonStatus:
     if port is None:
         return SyncDaemonStatus(healthy=False, url=url, token=token, pid=pid)
 
-    data = _fetch_health_payload(f"http://127.0.0.1:{port}/api/health", timeout=timeout)
+    data = _fetch_health_payload(_loopback_health_url(port), timeout=timeout)
     if not data:
         return SyncDaemonStatus(
             healthy=False,

--- a/tests/audit/test_identity_adapter.py
+++ b/tests/audit/test_identity_adapter.py
@@ -92,6 +92,16 @@ class TestIdentityStateToFindings:
         assert findings[0].artifact_path == "meta.json"
         assert findings[0].detail == "meta.json absent"
 
+    def test_public_keyword_mission_dir_is_supported(self, tmp_path: Path) -> None:
+        """Public adapter signature keeps the mission_dir keyword stable."""
+        mission_dir = tmp_path / "orphan-mission"
+        mission_dir.mkdir()
+
+        state = classify_mission(mission_dir)
+
+        findings = identity_state_to_findings(state, mission_dir=mission_dir)
+        assert [finding.code for finding in findings] == ["IDENTITY_MISSING"]
+
     def test_legacy_state_emits_no_findings(self, tmp_path: Path) -> None:
         """Legacy state (meta.json exists, mission_number set, mission_id absent) → [].
 
@@ -176,6 +186,20 @@ class TestPrefixGroupsToFindings:
         assert alpha_finding is not None
         assert beta_finding is not None
 
+    def test_public_keyword_slug_to_dir_is_supported(self, tmp_path: Path) -> None:
+        """Public adapter signature keeps the slug_to_dir keyword stable."""
+        specs = _make_kitty_specs(tmp_path)
+        dir_a = _make_mission_dir(specs, "042-alpha", mission_number=1)
+        dir_b = _make_mission_dir(specs, "042-beta", mission_number=2)
+
+        groups = find_duplicate_prefixes(tmp_path)
+
+        findings = prefix_groups_to_findings(
+            groups,
+            slug_to_dir={"042-alpha": dir_a, "042-beta": dir_b},
+        )
+        assert {finding.code for finding in findings} == {"DUPLICATE_PREFIX"}
+
     def test_no_duplicates_returns_empty(self, tmp_path: Path) -> None:
         """No duplicate prefixes → empty findings list."""
         specs = _make_kitty_specs(tmp_path)
@@ -225,6 +249,20 @@ class TestDuplicateIdsToFindings:
         second_finding = next(f for f in findings if "001-first" in (f.detail or ""))
         assert first_finding is not None
         assert second_finding is not None
+
+    def test_public_keyword_slug_to_dir_is_supported(self, tmp_path: Path) -> None:
+        """Public adapter signature keeps the slug_to_dir keyword stable."""
+        shared_id = "01ABCDEFGHJKMNPQRSTVWXYZ01"
+        dir_a = _make_mission_dir(tmp_path, "001-first", mission_id=shared_id, mission_number=1)
+        dir_b = _make_mission_dir(tmp_path, "002-second", mission_id=shared_id, mission_number=2)
+
+        from specify_cli.status.identity_audit import classify_mission as cm
+
+        findings = duplicate_ids_to_findings(
+            [cm(dir_a), cm(dir_b)],
+            slug_to_dir={"001-first": dir_a, "002-second": dir_b},
+        )
+        assert {finding.code for finding in findings} == {"DUPLICATE_MISSION_ID"}
 
     def test_unique_mission_ids_returns_empty(self, tmp_path: Path) -> None:
         """Missions with distinct mission_ids → empty findings."""
@@ -292,6 +330,22 @@ class TestSelectorGroupsToFindings:
         assert len(ambiguous) >= 2  # at least one finding per mission
         severities = {f.severity for f in ambiguous}
         assert severities == {Severity.WARNING}
+
+    def test_public_keyword_slug_to_dir_is_supported(self, tmp_path: Path) -> None:
+        """Public adapter signature keeps the slug_to_dir keyword stable."""
+        specs = _make_kitty_specs(tmp_path)
+        dir_a = _make_mission_dir(specs, "042-foo", mission_number=42)
+        dir_b = _make_mission_dir(specs, "042-bar", mission_number=43)
+
+        from specify_cli.status.identity_audit import audit_repo
+
+        groups = find_ambiguous_selectors(audit_repo(tmp_path))
+
+        findings = selector_groups_to_findings(
+            groups,
+            slug_to_dir={"042-foo": dir_a, "042-bar": dir_b},
+        )
+        assert any(finding.code == "AMBIGUOUS_SELECTOR" for finding in findings)
 
     def test_unambiguous_selectors_returns_empty(self, tmp_path: Path) -> None:
         """Missions with distinct selectors → empty findings."""


### PR DESCRIPTION
## Summary
- factor daemon health URL construction into a localhost-only helper and collapse a nested token guard
- silence duplicate/unused-parameter Sonar smells in audit/charter/DRG helpers with behavior-preserving renames/constants
- add explicit localhost-only `NOSONAR` context for the in-process dashboard server bind

## Validation
- `.venv/bin/ruff check src/specify_cli/sync/daemon.py src/specify_cli/dashboard/server.py src/charter/pack_manager.py src/doctrine/drg/migration/extractor.py src/specify_cli/audit/identity_adapter.py src/specify_cli/audit/engine.py`
- `.venv/bin/pytest tests/test_dashboard/test_server.py -q`
- `.venv/bin/pytest tests/sync/test_daemon.py -k 'daemon_version_matches or get_sync_daemon_status_reads_health_metadata' -q`
- `.venv/bin/pytest tests/specify_cli/audit -q`

## Notes
- GitHub security alerts checked: no open Dependabot alerts, no open code-scanning alerts.
- SonarCloud quality gate failure on `main` from 2026-06-10 was driven by `new_coverage` and `new_security_hotspots_reviewed`, not an open vulnerability.
- Investigated the remaining SonarCloud loopback-only `HTTPServer` hotspot in `src/specify_cli/dashboard/server.py`; it is localhost IPC rather than a remotely exposed transport, so this PR only adds explicit justification instead of attempting a TLS retrofit.
