### PR TITLE
fix(ci): skip SaaS consumer compatibility on non-canonical repos

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2617,6 +2617,12 @@ jobs:
       REPO_OWNER: ${{ github.repository_owner }}
       HAS_SAAS_READ_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' }}
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      # Private SaaS evidence is only reachable from the canonical repo. Token
+      # presence alone is not enough of a signal: the canonical repo must fail
+      # loud when the secret is misconfigured, while fork PRs and fork-owned
+      # runs (which can never have the secret) degrade to a skip-with-warning.
+      # The repo name is hardcoded (not vars.*) for in-file auditability and
+      # must track any rename/transfer. See issue #1849.
       IS_CANONICAL_REPO: ${{ github.repository == 'Priivacy-ai/spec-kitty' }}
     steps:
       - name: Check out trusted validation scripts

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2617,6 +2617,7 @@ jobs:
       REPO_OWNER: ${{ github.repository_owner }}
       HAS_SAAS_READ_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' }}
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      IS_CANONICAL_REPO: ${{ github.repository == 'Priivacy-ai/spec-kitty' }}
     steps:
       - name: Check out trusted validation scripts
         uses: actions/checkout@v6
@@ -2654,9 +2655,9 @@ jobs:
           mkdir -p /tmp/spec-kitty-release-contracts
 
           if [ "${HAS_SAAS_READ_TOKEN}" != "true" ]; then
-            if [ "${IS_FORK_PR}" = "true" ]; then
+            if [ "${IS_FORK_PR}" = "true" ] || [ "${IS_CANONICAL_REPO}" != "true" ]; then
               echo "saas_fetched=false" >> "$GITHUB_OUTPUT"
-              echo "::warning::SPEC_KITTY_SAAS_READ_TOKEN is unavailable for fork PRs; skipping private SaaS consumer compatibility evidence."
+              echo "::warning::SPEC_KITTY_SAAS_READ_TOKEN is unavailable for fork PRs or non-canonical repository runs; skipping private SaaS consumer compatibility evidence."
               exit 0
             fi
 

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -100,6 +100,7 @@ def test_ci_quality_consumer_compatibility_reuses_ci_wheel_with_trusted_scripts(
     assert "candidate/.kittify/release/shared-package-compatibility.json" in job_dump
     assert "CROSS_REPO_TOKEN" not in repr(job.get("env", {}))
     assert "IS_FORK_PR" in job["env"]
+    assert "IS_CANONICAL_REPO" in job["env"]
     assert "check_candidate_consumer_compat.py" in job_dump
     assert "check_candidate_consumer_compat.py --help" in job_dump
     assert "MANIFEST_ARGS" in job_dump
@@ -107,6 +108,7 @@ def test_ci_quality_consumer_compatibility_reuses_ci_wheel_with_trusted_scripts(
     fetch_step = next(step for step in job["steps"] if step.get("id") == "fetch_contract")
     assert "CROSS_REPO_TOKEN" in fetch_step["env"]
     assert "saas_fetched=false" in fetch_step["run"]
+    assert "non-canonical repository runs" in fetch_step["run"]
     assert "SPEC_KITTY_SAAS_READ_TOKEN is required" in fetch_step["run"]
 
     validate_step = next(

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -100,7 +100,7 @@ def test_ci_quality_consumer_compatibility_reuses_ci_wheel_with_trusted_scripts(
     assert "candidate/.kittify/release/shared-package-compatibility.json" in job_dump
     assert "CROSS_REPO_TOKEN" not in repr(job.get("env", {}))
     assert "IS_FORK_PR" in job["env"]
-    assert "IS_CANONICAL_REPO" in job["env"]
+    assert job["env"]["IS_CANONICAL_REPO"] == "${{ github.repository == 'Priivacy-ai/spec-kitty' }}"
     assert "check_candidate_consumer_compat.py" in job_dump
     assert "check_candidate_consumer_compat.py --help" in job_dump
     assert "MANIFEST_ARGS" in job_dump
@@ -108,7 +108,7 @@ def test_ci_quality_consumer_compatibility_reuses_ci_wheel_with_trusted_scripts(
     fetch_step = next(step for step in job["steps"] if step.get("id") == "fetch_contract")
     assert "CROSS_REPO_TOKEN" in fetch_step["env"]
     assert "saas_fetched=false" in fetch_step["run"]
-    assert "non-canonical repository runs" in fetch_step["run"]
+    assert '[ "${IS_FORK_PR}" = "true" ] || [ "${IS_CANONICAL_REPO}" != "true" ]' in fetch_step["run"]
     assert "SPEC_KITTY_SAAS_READ_TOKEN is required" in fetch_step["run"]
 
     validate_step = next(


### PR DESCRIPTION
Fixes #1849.

This keeps the canonical repo behavior strict, but skips the SaaS consumer compatibility fetch with a warning when the workflow runs on a fork repository itself and the private read token is unavailable.

Changes:
- add IS_CANONICAL_REPO to the consumer-compatibility job env
- skip-with-warning for fork PRs and non-canonical repository runs when SPEC_KITTY_SAAS_READ_TOKEN is missing
- update the release CI ownership test to cover the new guard

Verification:
- uv run pytest tests/release/test_release_ci_ownership.py -q
- git diff --check