### PR TITLE
fix(doctor): quarantine retrospective lifecycle rows

### DIFF
--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -40,6 +40,7 @@ from specify_cli.migration.canonicalization import (
 )
 from specify_cli.status import ULID_PATTERN, Lane, StatusEvent
 from specify_cli.status import materialize_snapshot, materialize_to_json
+from specify_cli.status.store import _should_skip_status_event
 
 MIGRATION_SCHEMA_VERSION = "1.0.0"
 CANONICAL_ENVELOPE_SCHEMA_VERSION = "3.0.0"
@@ -1233,7 +1234,7 @@ def _rule_reject_non_status_event(
     row: _Row, _ctx: MigrationContext
 ) -> CanonicalStepResult[_Row]:
     """Rule 1: quarantine rows that carry event_type or event_name (not status events)."""
-    if "event_type" in row or "event_name" in row:
+    if "event_name" in row or _should_skip_status_event(row):
         return CanonicalStepResult(
             state=row,
             actions=("quarantined_non_status_event",),

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -40,7 +40,7 @@ from specify_cli.migration.canonicalization import (
 )
 from specify_cli.status import ULID_PATTERN, Lane, StatusEvent
 from specify_cli.status import materialize_snapshot, materialize_to_json
-from specify_cli.status.store import _should_skip_status_event
+from specify_cli.status.store import is_retrospective_lifecycle_event
 
 MIGRATION_SCHEMA_VERSION = "1.0.0"
 CANONICAL_ENVELOPE_SCHEMA_VERSION = "3.0.0"
@@ -1233,8 +1233,33 @@ _Row = dict[str, Any]
 def _rule_reject_non_status_event(
     row: _Row, _ctx: MigrationContext
 ) -> CanonicalStepResult[_Row]:
-    """Rule 1: quarantine rows that carry event_type or event_name (not status events)."""
-    if "event_name" in row or _should_skip_status_event(row):
+    """Rule 1: route non-lane rows that share status.events.jsonl.
+
+    Two dispositions, each mirroring how the other surfaces treat the row:
+
+    - Retrospective lifecycle rows (``type`` envelope, see
+      :func:`specify_cli.status.store.is_retrospective_lifecycle_event`)
+      are PRESERVED in place: the runtime reader skips them during
+      deserialization but retrospective consumers (``retrospect``,
+      ``retrospective.summary``, the runtime bridge) read them back from
+      status.events.jsonl, so quarantining them would destroy contracted
+      provenance. ``_scan_raw_status_rows`` tolerates them for the same
+      reason.
+    - Rows carrying ``event_type`` or ``event_name`` are QUARANTINED —
+      the same presence check ``_scan_raw_status_rows`` uses to flag
+      typed side-log rows, so repair removes exactly what the dry-run
+      scan reports. The ``event_name`` clause is deliberately broader
+      than the reader's skip set (which only skips ``event_name`` values
+      starting with ``retrospective.``): repair quarantines what the
+      reader would reject loudly.
+    """
+    if is_retrospective_lifecycle_event(row):
+        return CanonicalStepResult(
+            state=row,
+            actions=(),
+            error="preserved_non_lane_event",
+        )
+    if "event_name" in row or "event_type" in row:
         return CanonicalStepResult(
             state=row,
             actions=("quarantined_non_status_event",),
@@ -1477,10 +1502,12 @@ def _canonicalize_status_row(
     optionally transforms the state, and returns a :class:`CanonicalStepResult`.
     Short-circuits on the first error.
 
-    The special quarantine case (non-status events) is handled by
-    ``_rule_reject_non_status_event`` which returns an error; the caller in
-    ``_canonicalize_status_rows`` already treats ``error is not None`` as a
-    quarantine signal for that specific error message.
+    Non-lane rows are handled by ``_rule_reject_non_status_event`` via two
+    sentinel errors translated here: ``quarantined_non_status_event`` becomes
+    ``row=None`` (the caller routes the original line to the quarantine file),
+    and ``preserved_non_lane_event`` returns the original row untouched (the
+    caller keeps it in status.events.jsonl exactly as the runtime reader
+    expects to find it).
     """
     ctx = MigrationContext(
         mission_slug=mission_slug,
@@ -1493,6 +1520,11 @@ def _canonicalize_status_row(
     # (the caller _canonicalize_status_rows checks result.row is None, not result.error)
     if result.error == "quarantined_non_status_event":
         return _CanonicalRowResult(row=None, actions=result.actions, error=None)
+    # Special case: preserved_non_lane_event keeps the original row in the
+    # event log untouched — these rows are contracted data other subsystems
+    # read back, not corruption (see _rule_reject_non_status_event).
+    if result.error == "preserved_non_lane_event":
+        return _CanonicalRowResult(row=dict(data), actions=(), error=None)
     return _CanonicalRowResult.from_pipeline(result)
 
 

--- a/src/specify_cli/status/store.py
+++ b/src/specify_cli/status/store.py
@@ -338,6 +338,10 @@ def read_events_raw(feature_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+# Registration point: any new non-lane lifecycle event that uses the "type"
+# envelope shape MUST be added here, or both read_events and
+# `doctor mission-state --fix` will fail loudly on that mission with
+# "missing required to_lane" (the SNAPSHOT_DRIFT symptom from issue #1782).
 _RETROSPECTIVE_LIFECYCLE_EVENT_TYPES: frozenset[str] = frozenset({
     "RetrospectiveCaptured",
     "RetrospectiveCaptureFailed",
@@ -345,7 +349,19 @@ _RETROSPECTIVE_LIFECYCLE_EVENT_TYPES: frozenset[str] = frozenset({
 })
 
 
-def _should_skip_status_event(obj: dict[str, Any]) -> bool:
+def is_retrospective_lifecycle_event(obj: dict[str, Any]) -> bool:
+    """Return True for retrospective lifecycle rows using the ``type`` envelope.
+
+    These rows are written to status.events.jsonl by design (see
+    contracts/retrospective-events.contract.md) and read back by
+    retrospective consumers; they are descriptive lifecycle events, not
+    lane transitions, and must be skipped in place — never removed.
+    """
+    event_type = obj.get("type")
+    return isinstance(event_type, str) and event_type in _RETROSPECTIVE_LIFECYCLE_EVENT_TYPES
+
+
+def is_non_lane_event(obj: dict[str, Any]) -> bool:
     """Return True for non-lane events that intentionally share the JSONL file."""
     event_name = obj.get("event_name")
     if isinstance(event_name, str) and event_name.startswith("retrospective."):
@@ -354,8 +370,7 @@ def _should_skip_status_event(obj: dict[str, Any]) -> bool:
     # WP03: Skip the three new canonical retrospective lifecycle events which use
     # a "type" field (not "event_name") per contracts/retrospective-events.contract.md.
     # These are descriptive lifecycle events, not lane transitions.
-    event_type = obj.get("type")
-    if isinstance(event_type, str) and event_type in _RETROSPECTIVE_LIFECYCLE_EVENT_TYPES:
+    if is_retrospective_lifecycle_event(obj):
         return True
 
     # Why: Skip mission-level events (DecisionPointOpened,
@@ -402,7 +417,7 @@ def read_events_from_text(feature_dir: Path, content: str) -> list[StatusEvent]:
             raise StoreError(
                 f"Invalid event structure on line {line_number}: expected JSON object"
             )
-        if _should_skip_status_event(obj):
+        if is_non_lane_event(obj):
             continue
 
         try:

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -74,14 +74,17 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
         "work_package_id": "WP01",
     }
     duplicate_row = dict(status_row)
-    typed_row = {
+    retrospective_row = {
         "at": "2026-01-01T00:00:01+00:00",
         "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGS",
-        "event_type": "DecisionPointOpened",
-        "payload": {"decision_point_id": "DP01"},
+        "type": "RetrospectiveCaptured",
+        "payload": {"mission_slug": "042-historical-shape"},
     }
     (mission / "status.events.jsonl").write_text(
-        "\n".join(json.dumps(row, sort_keys=True) for row in (status_row, duplicate_row, typed_row)) + "\n",
+        "\n".join(
+            json.dumps(row, sort_keys=True) for row in (status_row, duplicate_row, retrospective_row)
+        )
+        + "\n",
         encoding="utf-8",
     )
     (mission / "mission-events.jsonl").write_text(
@@ -142,7 +145,7 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
     status_summary = cast(dict[str, object], status["summary"])
     assert status_summary["in_review"] == 1
     quarantine = repo / ".kittify" / "migrations" / "mission-state" / "quarantine" / report.run_id / "042-historical-shape" / "status.events.jsonl"
-    assert "DecisionPointOpened" in quarantine.read_text(encoding="utf-8")
+    assert "RetrospectiveCaptured" in quarantine.read_text(encoding="utf-8")
 
     if not _has_events_5():
         with pytest.raises(MissionStateDryRunError, match="requires spec-kitty-events >= 5.0.0"):

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -74,15 +74,22 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
         "work_package_id": "WP01",
     }
     duplicate_row = dict(status_row)
-    retrospective_row = {
+    typed_row = {
         "at": "2026-01-01T00:00:01+00:00",
         "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGS",
+        "event_type": "DecisionPointOpened",
+        "payload": {"decision_point_id": "DP01"},
+    }
+    retrospective_row = {
+        "at": "2026-01-01T00:00:02+00:00",
+        "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGT",
         "type": "RetrospectiveCaptured",
         "payload": {"mission_slug": "042-historical-shape"},
     }
     (mission / "status.events.jsonl").write_text(
         "\n".join(
-            json.dumps(row, sort_keys=True) for row in (status_row, duplicate_row, retrospective_row)
+            json.dumps(row, sort_keys=True)
+            for row in (status_row, duplicate_row, typed_row, retrospective_row)
         )
         + "\n",
         encoding="utf-8",
@@ -129,7 +136,7 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
         for line in (mission / "status.events.jsonl").read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
-    assert len(rows) == 1
+    assert len(rows) == 2
     row = rows[0]
     assert row["mission_slug"] == "042-historical-shape"
     assert row["mission_id"] == meta["mission_id"]
@@ -140,12 +147,17 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
     assert "feature_slug" not in row
     assert "work_package_id" not in row
     assert "legacy_aggregate_id" not in row
+    # Retrospective lifecycle rows are contracted provenance read back by
+    # retrospective consumers — repair must preserve them untouched.
+    assert rows[1] == retrospective_row
 
     status = _read_json(mission / "status.json")
     status_summary = cast(dict[str, object], status["summary"])
     assert status_summary["in_review"] == 1
     quarantine = repo / ".kittify" / "migrations" / "mission-state" / "quarantine" / report.run_id / "042-historical-shape" / "status.events.jsonl"
-    assert "RetrospectiveCaptured" in quarantine.read_text(encoding="utf-8")
+    quarantine_text = quarantine.read_text(encoding="utf-8")
+    assert "DecisionPointOpened" in quarantine_text
+    assert "RetrospectiveCaptured" not in quarantine_text
 
     if not _has_events_5():
         with pytest.raises(MissionStateDryRunError, match="requires spec-kitty-events >= 5.0.0"):

--- a/tests/next/test_retrospective_terminus_wiring.py
+++ b/tests/next/test_retrospective_terminus_wiring.py
@@ -387,9 +387,9 @@ def test_failure_emit_swallows_emit_failure(tmp_path: Path) -> None:
 
 
 def test_status_reader_skips_retrospective_lifecycle_type_event() -> None:
-    from specify_cli.status.store import _should_skip_status_event
+    from specify_cli.status.store import is_non_lane_event
 
-    assert _should_skip_status_event({"type": "RetrospectiveCaptured"}) is True
+    assert is_non_lane_event({"type": "RetrospectiveCaptured"}) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_canonicalization_rules.py
+++ b/tests/unit/migration/test_canonicalization_rules.py
@@ -90,8 +90,10 @@ def _base_row(**overrides: Any) -> _Row:
         ({"event_type": "some_event", "wp_id": "WP01"}, "quarantined_non_status_event"),
         # happy case — event_name present → quarantine error
         ({"event_name": "custom_event"}, "quarantined_non_status_event"),
-        # happy case — retrospective lifecycle type event → quarantine error
-        ({"type": "RetrospectiveCaptured", "wp_id": "WP01"}, "quarantined_non_status_event"),
+        # retrospective lifecycle type events → preserved in place, never quarantined
+        ({"type": "RetrospectiveCaptured", "wp_id": "WP01"}, "preserved_non_lane_event"),
+        ({"type": "RetrospectiveCaptureFailed"}, "preserved_non_lane_event"),
+        ({"type": "RetrospectiveSkipped"}, "preserved_non_lane_event"),
         # no-op — neither key present → pass-through
         ({"wp_id": "WP01", "to_lane": "done"}, None),
     ],
@@ -101,9 +103,13 @@ def test_rule_reject_non_status_event(
 ) -> None:
     result = _rule_reject_non_status_event(row, _ctx())
     assert isinstance(result, CanonicalStepResult)
-    if expect_error is not None:
+    if expect_error == "quarantined_non_status_event":
         assert result.error == expect_error
         assert result.actions == ("quarantined_non_status_event",)
+    elif expect_error == "preserved_non_lane_event":
+        assert result.error == expect_error
+        assert result.actions == ()
+        assert result.state is row  # preserved untouched
     else:
         assert result.error is None
         assert result.state is row  # exact passthrough

--- a/tests/unit/migration/test_canonicalization_rules.py
+++ b/tests/unit/migration/test_canonicalization_rules.py
@@ -90,6 +90,8 @@ def _base_row(**overrides: Any) -> _Row:
         ({"event_type": "some_event", "wp_id": "WP01"}, "quarantined_non_status_event"),
         # happy case — event_name present → quarantine error
         ({"event_name": "custom_event"}, "quarantined_non_status_event"),
+        # happy case — retrospective lifecycle type event → quarantine error
+        ({"type": "RetrospectiveCaptured", "wp_id": "WP01"}, "quarantined_non_status_event"),
         # no-op — neither key present → pass-through
         ({"wp_id": "WP01", "to_lane": "done"}, None),
     ],


### PR DESCRIPTION
Refs #1782.

Summary:
- quarantine `event_type`/`event_name` side-log rows before lane validation (matching exactly what `_scan_raw_status_rows` flags), keeping the existing quarantine behavior intact
- **preserve** retrospective lifecycle rows (`type: RetrospectiveCaptured/CaptureFailed/Skipped`) in place rather than quarantining them — they are contracted data written by design per `contracts/retrospective-events.contract.md` and read back by `retrospect`, `retrospective.summary`, and the runtime bridge, so removing them on `doctor mission-state --fix` would strip retrospective provenance from healthy missions
- promote `_should_skip_status_event` to the public `is_non_lane_event` / `is_retrospective_lifecycle_event` API on `specify_cli.status.store` (no more private cross-package import)
- add repair and rule regressions covering both dispositions: `DecisionPointOpened` quarantined, `RetrospectiveCaptured` preserved untouched

Note: rebased onto main; the previously bundled CI gating commit was dropped as it landed separately via #1851, and the spec-draft commit was already on main.

Checks:
- `pytest tests/unit/migration/test_canonicalization_rules.py tests/migration/test_mission_state_repair.py tests/next/test_retrospective_terminus_wiring.py` (103 passed)
- `pytest tests/migration tests/unit/migration tests/specify_cli/status tests/status tests/retrospective` (5,550 passed)
- `ruff check` and `mypy` clean