### PR TITLE
test(intake): extract shared TTY-test fixture to eliminate repeated setup

### DIFF
--- a/tests/specify_cli/cli/commands/test_intake.py
+++ b/tests/specify_cli/cli/commands/test_intake.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from specify_cli.cli.commands.intake import intake
 from specify_cli.mission_brief import BRIEF_SOURCE_FILENAME, MISSION_BRIEF_FILENAME
+from tests.specify_cli.intake_test_helpers import patched_intake_command_environment
 
 pytestmark = [pytest.mark.fast, pytest.mark.non_sandbox]
 
@@ -47,11 +48,7 @@ def _make_plan_file(tmp_path: Path, rel: str = "plan.md", content: str = "# Plan
 def test_auto_no_matches_exits_1(intake_app: typer.Typer, tmp_path: Path) -> None:
     """--auto with no plan files found exits 1 and leaves .kittify/ untouched."""
     mock_sources: list = []
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-    ):
+    with patched_intake_command_environment(tmp_path, mock_sources):
         result = runner.invoke(intake_app, ["--auto"], catch_exceptions=False)
 
     assert result.exit_code == 1
@@ -68,11 +65,7 @@ def test_auto_single_match_writes_brief(intake_app: typer.Typer, tmp_path: Path)
     plan = _make_plan_file(tmp_path, "opencode-plan.md")
     mock_sources = [("opencode", "opencode", ["opencode-plan.md"])]
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-    ):
+    with patched_intake_command_environment(tmp_path, mock_sources):
         result = runner.invoke(intake_app, ["--auto"], catch_exceptions=False)
 
     assert result.exit_code == 0, f"output: {result.output}"
@@ -111,11 +104,7 @@ def test_auto_single_match_existing_brief_no_force(intake_app: typer.Typer, tmp_
     existing_brief.write_text("# Old Brief", encoding="utf-8")
     (kittify / BRIEF_SOURCE_FILENAME).write_text("source", encoding="utf-8")
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-    ):
+    with patched_intake_command_environment(tmp_path, mock_sources):
         result = runner.invoke(intake_app, ["--auto"], catch_exceptions=False)
 
     assert result.exit_code == 1
@@ -138,11 +127,7 @@ def test_auto_single_match_force_overwrites(intake_app: typer.Typer, tmp_path: P
     existing_brief = kittify / MISSION_BRIEF_FILENAME
     existing_brief.write_text("# Old Brief", encoding="utf-8")
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-    ):
+    with patched_intake_command_environment(tmp_path, mock_sources):
         result = runner.invoke(intake_app, ["--auto", "--force"], catch_exceptions=False)
 
     assert result.exit_code == 0, f"output: {result.output}"
@@ -165,9 +150,7 @@ def test_auto_multiple_matches_non_tty_exits_1(intake_app: typer.Typer, tmp_path
     ]
 
     with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
+        patched_intake_command_environment(tmp_path, mock_sources),
         patch("sys.stdin.isatty", return_value=False),
     ):
         result = runner.invoke(intake_app, ["--auto"], catch_exceptions=False)
@@ -188,11 +171,7 @@ def test_auto_with_path_arg_exits_1(intake_app: typer.Typer, tmp_path: Path) -> 
     plan = _make_plan_file(tmp_path)
     mock_sources = [("opencode", "opencode", ["opencode-plan.md"])]
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-    ):
+    with patched_intake_command_environment(tmp_path, mock_sources):
         result = runner.invoke(
             intake_app, [str(plan), "--auto"], catch_exceptions=False
         )
@@ -211,9 +190,7 @@ def test_manual_intake_no_source_agent(intake_app: typer.Typer, tmp_path: Path) 
     """Manual intake writes brief-source.yaml without a source_agent key."""
     plan = _make_plan_file(tmp_path, content="# Manual Plan")
 
-    with (
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-    ):
+    with patched_intake_command_environment(tmp_path):
         result = runner.invoke(intake_app, [str(plan)], catch_exceptions=False)
 
     assert result.exit_code == 0, f"output: {result.output}"
@@ -241,10 +218,7 @@ def test_show_works_after_auto_changes(intake_app: typer.Typer, tmp_path: Path) 
         encoding="utf-8",
     )
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-    ):
+    with patched_intake_command_environment(tmp_path):
         result = runner.invoke(intake_app, ["--show"], catch_exceptions=False)
 
     assert result.exit_code == 0, f"output: {result.output}"
@@ -268,16 +242,7 @@ def test_auto_tty_valid_selection_ingests_correct_file(
         ("harness-b", "agent-b", ["plan-b.md"]),
     ]
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-        # Patch sys as seen by the intake module so isatty() returns True.
-        # CliRunner replaces sys.stdin during invoke, so we must patch the
-        # module-level sys reference, not sys.stdin directly.
-        patch("specify_cli.cli.commands.intake.sys") as mock_sys,
-    ):
-        mock_sys.stdin.isatty.return_value = True
+    with patched_intake_command_environment(tmp_path, mock_sources, tty=True):
         # CliRunner feeds "2\n" through its own input mechanism (not sys.stdin),
         # so typer.prompt still receives the selection correctly.
         result = runner.invoke(intake_app, ["--auto"], input="2\n", catch_exceptions=False)
@@ -304,13 +269,7 @@ def test_auto_tty_non_numeric_input_exits_1(
         ("harness-b", "agent-b", ["plan-b.md"]),
     ]
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-        patch("specify_cli.cli.commands.intake.sys") as mock_sys,
-    ):
-        mock_sys.stdin.isatty.return_value = True
+    with patched_intake_command_environment(tmp_path, mock_sources, tty=True):
         result = runner.invoke(intake_app, ["--auto"], input="abc\n", catch_exceptions=False)
 
     assert result.exit_code == 1
@@ -328,13 +287,7 @@ def test_auto_tty_out_of_range_number_exits_1(
         ("harness-b", "agent-b", ["plan-b.md"]),
     ]
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-        patch("specify_cli.cli.commands.intake.sys") as mock_sys,
-    ):
-        mock_sys.stdin.isatty.return_value = True
+    with patched_intake_command_environment(tmp_path, mock_sources, tty=True):
         result = runner.invoke(intake_app, ["--auto"], input="99\n", catch_exceptions=False)
 
     assert result.exit_code == 1
@@ -352,13 +305,7 @@ def test_auto_tty_zero_input_exits_1(
         ("harness-b", "agent-b", ["plan-b.md"]),
     ]
 
-    with (
-        patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path),
-        patch("specify_cli.cli.commands.intake._resolve_repo_root", return_value=tmp_path),
-        patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources),
-        patch("specify_cli.cli.commands.intake.sys") as mock_sys,
-    ):
-        mock_sys.stdin.isatty.return_value = True
+    with patched_intake_command_environment(tmp_path, mock_sources, tty=True):
         result = runner.invoke(intake_app, ["--auto"], input="0\n", catch_exceptions=False)
 
     assert result.exit_code == 1

--- a/tests/specify_cli/cli/commands/test_intake.py
+++ b/tests/specify_cli/cli/commands/test_intake.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import typer
@@ -47,8 +46,7 @@ def _make_plan_file(tmp_path: Path, rel: str = "plan.md", content: str = "# Plan
 
 def test_auto_no_matches_exits_1(intake_app: typer.Typer, tmp_path: Path) -> None:
     """--auto with no plan files found exits 1 and leaves .kittify/ untouched."""
-    mock_sources: list = []
-    with patched_intake_command_environment(tmp_path, mock_sources):
+    with patched_intake_command_environment(tmp_path, mock_sources=[]):
         result = runner.invoke(intake_app, ["--auto"], catch_exceptions=False)
 
     assert result.exit_code == 1
@@ -149,10 +147,7 @@ def test_auto_multiple_matches_non_tty_exits_1(intake_app: typer.Typer, tmp_path
         ("harness-b", "agent-b", ["plan-b.md"]),
     ]
 
-    with (
-        patched_intake_command_environment(tmp_path, mock_sources),
-        patch("sys.stdin.isatty", return_value=False),
-    ):
+    with patched_intake_command_environment(tmp_path, mock_sources, tty=False):
         result = runner.invoke(intake_app, ["--auto"], catch_exceptions=False)
 
     assert result.exit_code == 1
@@ -190,7 +185,7 @@ def test_manual_intake_no_source_agent(intake_app: typer.Typer, tmp_path: Path) 
     """Manual intake writes brief-source.yaml without a source_agent key."""
     plan = _make_plan_file(tmp_path, content="# Manual Plan")
 
-    with patched_intake_command_environment(tmp_path):
+    with patched_intake_command_environment(tmp_path, patch_cwd=False):
         result = runner.invoke(intake_app, [str(plan)], catch_exceptions=False)
 
     assert result.exit_code == 0, f"output: {result.output}"

--- a/tests/specify_cli/intake_test_helpers.py
+++ b/tests/specify_cli/intake_test_helpers.py
@@ -1,0 +1,45 @@
+"""Shared intake-test helpers for repeated patch setup."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+
+@contextmanager
+def patched_intake_command_environment(
+    tmp_path: Path,
+    mock_sources: list[tuple[str, str | None, list[str]]] | None = None,
+    *,
+    tty: bool = False,
+) -> Iterator[None]:
+    """Patch the intake command's common repo-root and scan inputs."""
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path)
+        )
+        stack.enter_context(
+            patch(
+                "specify_cli.cli.commands.intake._resolve_repo_root",
+                return_value=tmp_path,
+            )
+        )
+        if mock_sources is not None:
+            stack.enter_context(
+                patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources)
+            )
+        if tty:
+            mock_sys = stack.enter_context(patch("specify_cli.cli.commands.intake.sys"))
+            mock_sys.stdin.isatty.return_value = True
+        yield
+
+
+@contextmanager
+def patched_harness_plan_sources(
+    mock_sources: list[tuple[str, str | None, list[str]]],
+) -> Iterator[None]:
+    """Patch the harness-plan scan table for ``scan_for_plans`` tests."""
+    with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        yield

--- a/tests/specify_cli/intake_test_helpers.py
+++ b/tests/specify_cli/intake_test_helpers.py
@@ -2,24 +2,47 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
 
 @contextmanager
+def patched_harness_plan_sources(
+    mock_sources: Sequence[tuple[str, str | None, list[str]]],
+) -> Iterator[None]:
+    """Patch the harness-plan scan table for ``scan_for_plans`` tests."""
+    with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        yield
+
+
+@contextmanager
 def patched_intake_command_environment(
     tmp_path: Path,
-    mock_sources: list[tuple[str, str | None, list[str]]] | None = None,
+    mock_sources: Sequence[tuple[str, str | None, list[str]]] | None = None,
     *,
-    tty: bool = False,
+    tty: bool | None = None,
+    patch_cwd: bool = True,
 ) -> Iterator[None]:
-    """Patch the intake command's common repo-root and scan inputs."""
+    """Patch the intake command's common repo-root and scan inputs.
+
+    Patch-surface notes:
+
+    - ``patch_cwd=True`` patches ``Path.cwd`` *on the shared pathlib.Path
+      class* (the intake module has no Path of its own), so the patch is
+      process-global for the duration of the context. Pass
+      ``patch_cwd=False`` for tests that pass explicit paths and should
+      prove they work with an unpatched cwd.
+    - ``tty=True`` replaces the intake module's entire ``sys`` reference
+      with a MagicMock (so ``sys.exit``/``sys.stdin`` are mocks too).
+    - ``tty=None`` (default) leaves TTY detection untouched.
+    """
     with ExitStack() as stack:
-        stack.enter_context(
-            patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path)
-        )
+        if patch_cwd:
+            stack.enter_context(
+                patch("specify_cli.cli.commands.intake.Path.cwd", return_value=tmp_path)
+            )
         stack.enter_context(
             patch(
                 "specify_cli.cli.commands.intake._resolve_repo_root",
@@ -27,19 +50,13 @@ def patched_intake_command_environment(
             )
         )
         if mock_sources is not None:
-            stack.enter_context(
-                patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources)
-            )
+            stack.enter_context(patched_harness_plan_sources(mock_sources))
         if tty:
+            # Patch sys as seen by the intake module so isatty() returns True.
+            # CliRunner replaces sys.stdin during invoke, so we must patch the
+            # module-level sys reference, not sys.stdin directly.
             mock_sys = stack.enter_context(patch("specify_cli.cli.commands.intake.sys"))
             mock_sys.stdin.isatty.return_value = True
-        yield
-
-
-@contextmanager
-def patched_harness_plan_sources(
-    mock_sources: list[tuple[str, str | None, list[str]]],
-) -> Iterator[None]:
-    """Patch the harness-plan scan table for ``scan_for_plans`` tests."""
-    with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        elif tty is False:
+            stack.enter_context(patch("sys.stdin.isatty", return_value=False))
         yield

--- a/tests/specify_cli/test_intake_sources.py
+++ b/tests/specify_cli/test_intake_sources.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from specify_cli.intake_sources import HARNESS_PLAN_SOURCES, scan_for_plans
+from tests.specify_cli.intake_test_helpers import patched_harness_plan_sources
 
 
 pytestmark = [pytest.mark.unit]
@@ -53,7 +54,7 @@ class TestScanForPlans:
         plan_file = plans_dir / "2026-04-20-my-plan.md"
         plan_file.write_text("# My Plan", encoding="utf-8")
 
-        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        with patched_harness_plan_sources(mock_sources):
             results = scan_for_plans(tmp_path)
 
         assert len(results) == 1
@@ -70,7 +71,7 @@ class TestScanForPlans:
         (plans_dir / "plan.json").write_text("{}", encoding="utf-8")
         (plans_dir / ".hidden").write_text("hidden", encoding="utf-8")
 
-        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        with patched_harness_plan_sources(mock_sources):
             results = scan_for_plans(tmp_path)
 
         assert len(results) == 1
@@ -85,7 +86,7 @@ class TestScanForPlans:
         (plans_dir / "2026-01-01-oldest.md").write_text("# Oldest", encoding="utf-8")
         (plans_dir / "2026-02-15-middle.md").write_text("# Middle", encoding="utf-8")
 
-        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        with patched_harness_plan_sources(mock_sources):
             results = scan_for_plans(tmp_path)
 
         assert [r[0].name for r in results] == [
@@ -101,7 +102,7 @@ class TestScanForPlans:
         ]
         (tmp_path / "plan-a.md").write_text("A", encoding="utf-8")
         (tmp_path / "plan-b.md").write_text("B", encoding="utf-8")
-        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        with patched_harness_plan_sources(mock_sources):
             results = scan_for_plans(tmp_path)
         assert len(results) == 2
         assert results[0][1] == "harness-a"
@@ -112,14 +113,16 @@ class TestScanForPlans:
         target = tmp_path / ".cursor" / "plans" / "plan.md"
         target.parent.mkdir(parents=True)
         target.write_text("# Plan", encoding="utf-8")
-        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources):
+        with patched_harness_plan_sources(mock_sources):
             results = scan_for_plans(tmp_path)
         assert len(results) == 1
         assert results[0][0] == target
 
     def test_no_exception_on_permission_error(self, tmp_path: Path):
         mock_sources = [("harness-x", "agent-x", ["secret.md"])]
-        with patch("specify_cli.intake_sources.HARNESS_PLAN_SOURCES", mock_sources), \
-             patch("pathlib.Path.is_file", side_effect=PermissionError("denied")):
+        with (
+            patched_harness_plan_sources(mock_sources),
+            patch("pathlib.Path.is_file", side_effect=PermissionError("denied")),
+        ):
             results = scan_for_plans(tmp_path)
         assert results == []


### PR DESCRIPTION
Refactors the repeated intake test patch/setup blocks into shared helpers.

- adds a small shared helper for intake command repo-root and TTY setup
- reuses a shared HARNESS_PLAN_SOURCES patch helper in scan tests
- keeps the behavior unchanged; this is test-only cleanup

Verification:
- uv run --with pytest pytest tests/specify_cli/cli/commands/test_intake.py tests/specify_cli/test_intake_sources.py -q
- uv run --with ruff ruff check tests/specify_cli/intake_test_helpers.py tests/specify_cli/cli/commands/test_intake.py tests/specify_cli/test_intake_sources.py
- git diff --check

Closes #719