### PR TITLE
docs: add MCP worktree guidance for Windows agents

### DIFF
--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2822,6 +2822,13 @@
   current_target: true
   citation_refs: []
   notes: How-to; provisional current — confirm in WP08 IA review.
+- path: docs/how-to/worktrees-with-mcp-agents.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: C
+  current_target: true
+  citation_refs: []
+  notes: How-to; provisional current — confirm in WP08 IA review.
 - path: docs/index.md
   tag: current
   divio_type: none

--- a/docs/how-to/implement-work-package.md
+++ b/docs/how-to/implement-work-package.md
@@ -85,6 +85,7 @@ spec-kitty agent tasks move-task WP01 --to for_review --note "Ready for review: 
 ## See Also
 
 - [Generate Tasks](generate-tasks.md) - Required before implementation
+- [Keep MCP Agents in the Worktree](worktrees-with-mcp-agents.md) - Keep editor sessions attached to the active worktree
 - [Handle Dependencies](handle-dependencies.md) - How dependencies shape execution lanes
 - [Review a Work Package](review-work-package.md) - Next step after implementation
 

--- a/docs/how-to/install-windows.md
+++ b/docs/how-to/install-windows.md
@@ -153,6 +153,7 @@ Plain `python` may resolve to a Microsoft Store stub on a fresh install; `py` al
 
 - [Initialize a project](non-interactive-init.md)
 - [Upgrade the CLI](upgrade-cli.md)
+- [Keep MCP Agents in the Worktree](worktrees-with-mcp-agents.md)
 - [macOS install guide](install-macos.md)
 - [Linux install guide](install-linux.md)
 - [Pip vs pipx vs uv — which to choose](../explanation/pip-vs-pipx-vs-uv.md)

--- a/docs/how-to/toc.yml
+++ b/docs/how-to/toc.yml
@@ -32,6 +32,8 @@
   href: use-wps-yaml-manifest.md
 - name: Implement a Work Package
   href: implement-work-package.md
+- name: Keep MCP Agents in the Worktree
+  href: worktrees-with-mcp-agents.md
 - name: Review Work Packages
   href: review-work-package.md
 - name: Run an Autonomous Mission

--- a/docs/how-to/worktrees-with-mcp-agents.md
+++ b/docs/how-to/worktrees-with-mcp-agents.md
@@ -3,7 +3,6 @@ title: "How to Keep MCP Agents in the Worktree"
 description: "Keep MCP-backed editors and agents pointed at the active Spec Kitty worktree instead of the repository root."
 type: how-to
 audience: end-users
-os: windows
 ---
 
 # How to Keep MCP Agents in the Worktree
@@ -14,7 +13,7 @@ This is a workspace configuration issue, not a Spec Kitty workflow bug. Spec Kit
 
 ## What Goes Wrong
 
-During implementation, `spec-kitty` changes into an execution worktree under `.worktrees/`.
+For code-change work packages, `spec-kitty` creates an execution worktree under `.worktrees/` and prints its path; your shell, editor, and MCP server must follow it.
 If your MCP-backed editor keeps its own repository root, it can keep editing files in the main checkout while Spec Kitty thinks you are inside the worktree.
 
 That mismatch is the whole problem:

--- a/docs/how-to/worktrees-with-mcp-agents.md
+++ b/docs/how-to/worktrees-with-mcp-agents.md
@@ -1,0 +1,55 @@
+---
+title: "How to Keep MCP Agents in the Worktree"
+description: "Keep MCP-backed editors and agents pointed at the active Spec Kitty worktree instead of the repository root."
+type: how-to
+audience: end-users
+os: windows
+---
+
+# How to Keep MCP Agents in the Worktree
+
+Use this guide when an MCP-backed editor or agent keeps opening the repository root instead of the active Spec Kitty worktree.
+
+This is a workspace configuration issue, not a Spec Kitty workflow bug. Spec Kitty creates the worktree for implementation, but the MCP server or editor still has to follow that new workspace root.
+
+## What Goes Wrong
+
+During implementation, `spec-kitty` changes into an execution worktree under `.worktrees/`.
+If your MCP-backed editor keeps its own repository root, it can keep editing files in the main checkout while Spec Kitty thinks you are inside the worktree.
+
+That mismatch is the whole problem:
+
+- Spec Kitty is operating in the worktree
+- the editor or MCP agent is still attached to the repository root
+- edits land in the wrong place
+
+## Recommended Pattern
+
+1. Start implementation with `spec-kitty agent action implement WP01 --agent <name>`.
+2. Use the path printed by the command as the workspace root in your editor.
+3. Restart the MCP server or agent after switching into that worktree.
+4. Keep one editor session per worktree.
+
+If you are using tools such as Serena MCP or OpenCode, the same rule applies: open the worktree path as the workspace, not the repository root.
+
+## If the Agent Still Points at the Root
+
+If the agent keeps finding files in the root checkout:
+
+1. Close the MCP-backed editor or agent session.
+2. Reopen it from inside the worktree directory.
+3. Confirm the shell and file tree now point at the worktree path.
+
+If that still does not stick, treat the current session as attached to the wrong root and start a fresh one in the worktree.
+
+## Good Habits
+
+- Do not keep the root checkout and the active worktree open in the same MCP session.
+- Treat the printed worktree path as authoritative for implementation.
+- Use a separate session for each active worktree.
+
+## See Also
+
+- [Implement a Work Package](implement-work-package.md)
+- [Git Worktrees Explained](../explanation/git-worktrees.md)
+- [Parallel Development](parallel-development.md)


### PR DESCRIPTION
Adds a short how-to for keeping MCP-backed editors and agents attached to the active Spec Kitty worktree instead of the repository root.

- new guide: docs/how-to/worktrees-with-mcp-agents.md
- linked from the how-to toc, Windows install guide, and implement-work-package guide
- docs-only change; no behavior change

Verification:
- uv run --with pytest --with pytestarch pytest tests/architectural/test_docs_cli_reference_parity.py -q
- git diff --check

Closes #631