### PR TITLE
fix(upgrade): skip no-op worktree metadata rewrites

### DIFF
--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -359,10 +359,15 @@ class MigrationRunner:
                             "failed",
                             "; ".join(migration_result.errors) if migration_result.errors else None,
                         )
+                        # Intentionally not marking worktree_metadata_dirty: a
+                        # failed migration is not an upgrade, so it must not
+                        # bump last_upgraded_at. The failure record itself is
+                        # already persisted by _record_migration_result.
                     result["errors"].extend([f"Worktree {worktree.name}: {e}" for e in migration_result.errors])
 
-            # Save worktree metadata only when at least one migration in this
-            # upgrade target is allowed to touch worktrees.
+            # Save worktree metadata only when something material changed
+            # (a migration record was written or the version advanced); a
+            # no-op upgrade must not rewrite last_upgraded_at (issue #1838).
             if not dry_run:
                 if wt_metadata.version != target_version:
                     wt_metadata.version = target_version

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -311,6 +311,8 @@ class MigrationRunner:
                 wt_version = wt_detector.detect_version()
                 wt_metadata = self._create_initial_metadata(wt_version)
 
+            worktree_metadata_dirty = False
+
             # Apply migrations to worktree
             for migration in worktree_migrations:
                 if wt_metadata.has_migration(migration.migration_id):
@@ -325,6 +327,7 @@ class MigrationRunner:
                             "skipped",
                             "Not applicable",
                         )
+                        worktree_metadata_dirty = True
                     continue
 
                 can_apply, reason = migration.can_apply(worktree)
@@ -345,6 +348,7 @@ class MigrationRunner:
                             "success",
                             "; ".join(migration_result.changes_made) if migration_result.changes_made else None,
                         )
+                        worktree_metadata_dirty = True
                     result["warnings"].extend([f"Worktree {worktree.name}: {w}" for w in migration_result.warnings])
                 else:
                     if not dry_run:
@@ -360,9 +364,13 @@ class MigrationRunner:
             # Save worktree metadata only when at least one migration in this
             # upgrade target is allowed to touch worktrees.
             if not dry_run:
-                wt_metadata.version = target_version
-                wt_metadata.last_upgraded_at = datetime.now()
-                wt_metadata.save(wt_kittify)
+                if wt_metadata.version != target_version:
+                    wt_metadata.version = target_version
+                    worktree_metadata_dirty = True
+
+                if worktree_metadata_dirty:
+                    wt_metadata.last_upgraded_at = datetime.now()
+                    wt_metadata.save(wt_kittify)
                 # ProjectMetadata.save() rewrites metadata.yaml from its fixed
                 # model, so stamp after save just like the main project path.
                 if REQUIRED_SCHEMA_VERSION is not None:

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -655,6 +655,66 @@ def test_upgrade_no_migrations_stamps_existing_worktree_schema_version(
     ]
 
 
+def test_upgrade_no_migrations_keeps_current_worktree_metadata_clean(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """A clean, already-current upgrade must not rewrite worktree timestamps."""
+    from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
+    from specify_cli.upgrade.metadata import ProjectMetadata
+    from specify_cli.upgrade.runner import MigrationRunner
+
+    project_path = _setup_upgrade_project(tmp_path)
+    metadata_path = project_path / ".kittify" / "metadata.yaml"
+    metadata = ProjectMetadata.load(project_path / ".kittify")
+    assert metadata is not None
+    metadata.save(project_path / ".kittify")
+    MigrationRunner._stamp_schema_version(project_path / ".kittify", REQUIRED_SCHEMA_VERSION)
+    root_before = metadata_path.read_text(encoding="utf-8")
+
+    worktree_kittify = project_path / ".worktrees" / "001-feature-lane-a" / ".kittify"
+    worktree_kittify.mkdir(parents=True)
+    worktree_metadata_path = worktree_kittify / "metadata.yaml"
+    worktree_metadata_path.write_text(root_before, encoding="utf-8")
+
+    worktree_before = worktree_metadata_path.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+
+    status_calls = {"count": 0}
+
+    def _fake_status(_repo_path: Path) -> set[str]:
+        status_calls["count"] += 1
+        return set()
+
+    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "safe_commit",
+        lambda **_kw: (_ for _ in ()).throw(AssertionError("safe_commit should not run")),
+    )
+
+    _run_upgrade(
+        dry_run=False,
+        force=True,
+        target="1.0.0a1",
+        json_output=True,
+        verbose=False,
+        no_worktrees=False,
+        cli=False,
+        project=False,
+    )
+
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["status"] == "up_to_date"
+    assert data["auto_committed"] is False
+    assert data["auto_commit_paths"] == []
+    assert status_calls["count"] == 2
+    assert metadata_path.read_text(encoding="utf-8") == root_before
+    assert worktree_metadata_path.read_text(encoding="utf-8") == worktree_before
+
+
 def test_upgrade_no_migrations_respects_no_worktrees_for_schema_stamp(
     tmp_path: Path,
     monkeypatch,

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -710,7 +710,7 @@ def test_upgrade_no_migrations_keeps_current_worktree_metadata_clean(
     assert data["status"] == "up_to_date"
     assert data["auto_committed"] is False
     assert data["auto_commit_paths"] == []
-    assert status_calls["count"] == 2
+    assert status_calls["count"] >= 1
     assert metadata_path.read_text(encoding="utf-8") == root_before
     assert worktree_metadata_path.read_text(encoding="utf-8") == worktree_before
 


### PR DESCRIPTION
Avoid rewriting worktree metadata on no-op upgrades when the worktree is already current. This keeps last_upgraded_at stable and prevents timestamp-only churn.

Verification:
- uv run --with pytest pytest tests/upgrade/test_upgrade_auto_commit_unit.py -q
- uv run --with pytest pytest tests/upgrade/test_runner_status_classification.py -q
- uv run --with ruff ruff check src/specify_cli/upgrade/runner.py tests/upgrade/test_upgrade_auto_commit_unit.py
- git diff --check