### PR TITLE
feat(cli): add universal spec-kitty lint command for agent post-edit hooks

### DIFF
--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -3323,6 +3323,13 @@
   current_target: true
   citation_refs: []
   notes: 3.2 harness setup and usage page.
+- path: docs/how-to/harnesses/setup-lint-hooks.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: harnesses
+  current_target: true
+  citation_refs: []
+  notes: Guide for setting up post-edit lint hooks.
 - path: docs/how-to/harnesses/windsurf.md
   tag: current
   divio_type: how-to

--- a/docs/how-to/harnesses/setup-lint-hooks.md
+++ b/docs/how-to/harnesses/setup-lint-hooks.md
@@ -1,0 +1,94 @@
+---
+title: "Set up Post-Edit Lint Hooks"
+description: "Configure your AI agent harness to automatically run ruff and mypy after every code edit using spec-kitty lint."
+---
+
+# Set up Post-Edit Lint Hooks
+
+One of the most effective ways to reduce review cycles is to catch linting and type errors at the **cheapest point**: immediately after the AI agent makes a change.
+
+Spec Kitty provides a universal wrapper command, `spec-kitty lint`, designed specifically for this purpose. When configured as a "post-edit hook," it feeds violations back to the agent in the same turn, allowing it to self-correct.
+
+## 1. The Universal Wrapper
+
+The `spec-kitty lint <file_path>` command:
+- Runs `ruff check` (linting).
+- Runs `mypy --strict` (type-checking).
+- Summarizes errors in an agent-friendly format.
+- Exits with `1` if errors are found, triggering the agent's auto-fix logic.
+
+## 2. Configuration by Harness
+
+### Claude Code
+Claude Code supports `PostToolUse` hooks in `.claude/settings.json`.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "spec-kitty lint --json"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Aider
+Aider supports the `--lint-cmd` flag. You can set this in your `.aider.conf.yml` or pass it at startup.
+
+```bash
+aider --lint-cmd "spec-kitty lint"
+```
+
+### Cursor
+Cursor (v1.7+) supports hooks in `.cursor/hooks.json`.
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": "spec-kitty lint --json"
+      }
+    ]
+  }
+}
+```
+
+### Windsurf
+Add a natural language rule to your `.windsurfrules` file:
+
+```markdown
+# Linting Guardrail
+After every file edit, you MUST run `spec-kitty lint <file_path>` and fix any reported errors immediately.
+```
+
+## 3. Advanced Usage
+
+### Auto-Fixing
+You can instruct `spec-kitty lint` to attempt to fix errors automatically (via `ruff --fix`) by adding the `--fix` flag:
+
+```bash
+spec-kitty lint <file_path> --fix
+```
+
+### JSON Output
+For tools that can parse structured feedback, use the `--json` flag to get a machine-readable error report:
+
+```bash
+spec-kitty lint <file_path> --json
+```
+
+## Why use hooks?
+
+1. **Faster Merges:** Code arrives at the review gate already clean and type-safe.
+2. **Lower Costs:** Fewer turns spent on trivial "unused import" or "missing type hint" fixes.
+3. **Better Quality:** Enforces project standards (like `mypy --strict`) automatically.

--- a/docs/how-to/harnesses/setup-lint-hooks.md
+++ b/docs/how-to/harnesses/setup-lint-hooks.md
@@ -17,7 +17,20 @@ The `spec-kitty lint <file_path>` command:
 - Summarizes errors in an agent-friendly format.
 - Exits with `1` if errors are found, triggering the agent's auto-fix logic.
 
-## 2. Configuration by Harness
+**Two invocation forms.** When you pass a path explicitly (`spec-kitty lint path/to/file.py`) it lints that file. When you omit the path (`spec-kitty lint --json`, the form wired into harness hooks below) it reads the edited file from the harness's JSON payload on **stdin** — Claude Code delivers `tool_input.file_path`, Cursor delivers `file_path`. A hook that fires without a Python file to lint (for example after a non-edit tool call) is a harmless no-op, never an error that blocks the agent.
+
+## 2. Managed setup (recommended)
+
+Rather than hand-editing harness config, let Spec Kitty manage the hooks for the agents in your `.kittify/config.yaml`:
+
+```bash
+spec-kitty agent config set lint_on_edit true
+spec-kitty agent config sync --sync-hooks
+```
+
+This writes the Claude Code (`PostToolUse`) and Cursor (`afterFileEdit`) hook entries below for every configured agent, idempotently and without disturbing your other hooks/settings. Set `lint_on_edit false` and re-sync to remove them. Only agents listed in `config.yaml` are touched.
+
+## 3. Configuration by Harness (manual)
 
 ### Claude Code
 Claude Code supports `PostToolUse` hooks in `.claude/settings.json`.
@@ -64,14 +77,14 @@ Cursor (v1.7+) supports hooks in `.cursor/hooks.json`.
 ```
 
 ### Windsurf
-Add a natural language rule to your `.windsurfrules` file:
+Windsurf has no programmatic post-edit hook, so `--sync-hooks` does not manage it. Configure it manually by adding a natural-language rule to your `.windsurfrules` file:
 
 ```markdown
 # Linting Guardrail
 After every file edit, you MUST run `spec-kitty lint <file_path>` and fix any reported errors immediately.
 ```
 
-## 3. Advanced Usage
+## 4. Advanced Usage
 
 ### Auto-Fixing
 You can instruct `spec-kitty lint` to attempt to fix errors automatically (via `ruff --fix`) by adding the `--fix` flag:

--- a/docs/how-to/harnesses/toc.yml
+++ b/docs/how-to/harnesses/toc.yml
@@ -1,3 +1,5 @@
+- name: Set up Post-Edit Lint Hooks
+  href: setup-lint-hooks.md
 - name: Claude Code
   href: claude-code.md
 - name: Codex

--- a/docs/reference/agent-subcommands.md
+++ b/docs/reference/agent-subcommands.md
@@ -226,10 +226,11 @@ _Manage project AI agent configuration (add, remove, list agents)_
 
  Currently supported keys:
      auto_commit  - Enable/disable automatic commits by agents (true/false)
+     lint_on_edit - Enable/disable auto-linting feedback loop (true/false)
 
  Examples:
      spec-kitty agent config set auto_commit false
-     spec-kitty agent config set auto_commit true
+     spec-kitty agent config set lint_on_edit true
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    key        TEXT  Configuration key (e.g., auto_commit) [required]       │
@@ -266,6 +267,7 @@ _Manage project AI agent configuration (add, remove, list agents)_
 
  By default, removes orphaned directories (present but not configured).
  Use --create-missing to also create directories for configured agents.
+ Use --sync-hooks to update harness-specific post-edit hooks.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --create-missing                          Create directories for configured  │
@@ -273,6 +275,9 @@ _Manage project AI agent configuration (add, remove, list agents)_
 │ --remove-orphaned    --keep-orphaned      Remove directories for agents not  │
 │                                           in config                          │
 │                                           [default: remove-orphaned]         │
+│ --sync-hooks                              Update AI harness hook             │
+│                                           configurations (Claude, Cursor,    │
+│                                           etc.)                              │
 │ --help                                    Show this message and exit.        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1911,18 +1911,19 @@ _Search tracker issues via the hosted read path_
 
 ## spec-kitty lint
 
-_Run ruff and mypy on a file and report errors._
-
 ```
- Usage: spec-kitty lint [OPTIONS] FILE_PATH
+ Usage: spec-kitty lint [OPTIONS] [FILE_PATH]
 
  Run ruff and mypy on a file and report errors.
 
  This command is designed to be used as a post-edit hook for AI agents,
  providing immediate feedback on linting and type-checking violations.
+ When invoked without a path (the wired hook form), the target file is read
+ from the harness JSON payload on stdin.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    file_path      PATH  File path to lint and type-check [required]         │
+│   file_path      [FILE_PATH]  File to lint/type-check; omit to read the path │
+│                               from a hook stdin payload                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --json          Output in JSON format for AI agents                          │

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1909,6 +1909,28 @@ _Search tracker issues via the hosted read path_
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
+## spec-kitty lint
+
+_Run ruff and mypy on a file and report errors._
+
+```
+ Usage: spec-kitty lint [OPTIONS] FILE_PATH
+
+ Run ruff and mypy on a file and report errors.
+
+ This command is designed to be used as a post-edit hook for AI agents,
+ providing immediate feedback on linting and type-checking violations.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    file_path      PATH  File path to lint and type-check [required]         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json          Output in JSON format for AI agents                          │
+│ --fix           Attempt to automatically fix lint errors                     │
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
 ## spec-kitty materialize
 
 ```

--- a/src/specify_cli/cli/commands/__init__.py
+++ b/src/specify_cli/cli/commands/__init__.py
@@ -166,6 +166,7 @@ def register_commands(app: typer.Typer) -> None:
     from . import intake as intake_module
     from . import invocations_cmd as invocations_cmd_module
     from . import lifecycle as lifecycle_module
+    from . import lint as lint_module
     from . import materialize as materialize_module
     from . import merge as merge_module
     from . import merge_driver as merge_driver_module
@@ -209,6 +210,7 @@ def register_commands(app: typer.Typer) -> None:
     app.command()(lifecycle_module.specify)
     app.command()(lifecycle_module.plan)
     app.command()(lifecycle_module.tasks)
+    app.command(name="lint")(lint_module.lint_command)
     app.command(name="materialize")(materialize_module.materialize)
     app.command()(merge_module.merge)
     app.command(name="merge-driver-event-log", hidden=True)(merge_driver_module.merge_driver_event_log)

--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -564,15 +564,21 @@ def sync_agents(
         help="Create directories for configured agents that are missing",
     ),
     remove_orphaned: bool = typer.Option(
-        True,
+        False,
         "--remove-orphaned/--keep-orphaned",
         help="Remove directories for agents not in config",
+    ),
+    sync_hooks: bool = typer.Option(
+        False,
+        "--sync-hooks",
+        help="Update AI harness hook configurations (Claude, Cursor, etc.)",
     ),
 ):
     """Sync filesystem with config.yaml.
 
     By default, removes orphaned directories (present but not configured).
     Use --create-missing to also create directories for configured agents.
+    Use --sync-hooks to update harness-specific post-edit hooks.
     """
     try:
         repo_root = find_repo_root()
@@ -593,10 +599,128 @@ def sync_agents(
     if create_missing:
         changes_made = _check_or_create_configured_agent_dirs(repo_root, config) or changes_made
 
+    # Sync hooks
+    if sync_hooks:
+        changes_made = _sync_harness_hooks(repo_root, config) or changes_made
+
     if not changes_made:
         console.print("[dim]No changes needed - filesystem matches config[/dim]")
     else:
         console.print("\n[green]✓ Sync complete[/green]")
+
+
+def _sync_harness_hooks(repo_root: Path, config: AgentConfig) -> bool:
+    """Update harness hook configurations based on lint_on_edit setting."""
+    console.print("\n[cyan]Syncing harness hooks...[/cyan]")
+    changes = False
+
+    # Claude Code
+    claude_settings = repo_root / ".claude" / "settings.json"
+    if "claude" in config.available or claude_settings.parent.exists():
+        if _sync_claude_hooks(claude_settings, config.lint_on_edit):
+            changes = True
+
+    # Cursor
+    cursor_hooks = repo_root / ".cursor" / "hooks.json"
+    if "cursor" in config.available or cursor_hooks.parent.exists():
+        if _sync_cursor_hooks(cursor_hooks, config.lint_on_edit):
+            changes = True
+
+    return changes
+
+
+def _sync_claude_hooks(path: Path, enabled: bool) -> bool:
+    import json
+    path.parent.mkdir(parents=True, exist_ok=True)
+    
+    data = {}
+    if path.exists():
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except Exception:
+            pass
+
+    hooks = data.get("hooks", {})
+    post_tool_use = hooks.get("PostToolUse", [])
+    
+    # Check if our lint hook already exists
+    lint_hook_command = "spec-kitty lint --json"
+    existing_hook_idx = -1
+    for i, h_group in enumerate(post_tool_use):
+        if h_group.get("matcher") == "Edit|Write":
+            for hook in h_group.get("hooks", []):
+                if hook.get("command") == lint_hook_command:
+                    existing_hook_idx = i
+                    break
+    
+    changed = False
+    if enabled:
+        if existing_hook_idx == -1:
+            post_tool_use.append({
+                "matcher": "Edit|Write",
+                "hooks": [{"type": "command", "command": lint_hook_command}]
+            })
+            changed = True
+    else:
+        if existing_hook_idx != -1:
+            post_tool_use.pop(existing_hook_idx)
+            changed = True
+            
+    if changed:
+        hooks["PostToolUse"] = post_tool_use
+        data["hooks"] = hooks
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        console.print(f"  [green]✓[/green] {'Updated' if enabled else 'Removed'} Claude Code lint hook")
+    else:
+        console.print("  [dim]• Claude Code hooks already in sync[/dim]")
+        
+    return changed
+
+
+def _sync_cursor_hooks(path: Path, enabled: bool) -> bool:
+    import json
+    path.parent.mkdir(parents=True, exist_ok=True)
+    
+    data = {"version": 1, "hooks": {}}
+    if path.exists():
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except Exception:
+            pass
+
+    hooks = data.get("hooks", {})
+    after_file_edit = hooks.get("afterFileEdit", [])
+    
+    lint_hook_command = "spec-kitty lint --json"
+    existing_hook_idx = -1
+    for i, hook in enumerate(after_file_edit):
+        if hook.get("command") == lint_hook_command:
+            existing_hook_idx = i
+            break
+            
+    changed = False
+    if enabled:
+        if existing_hook_idx == -1:
+            after_file_edit.append({"command": lint_hook_command})
+            changed = True
+    else:
+        if existing_hook_idx != -1:
+            after_file_edit.pop(existing_hook_idx)
+            changed = True
+            
+    if changed:
+        hooks["afterFileEdit"] = after_file_edit
+        data["hooks"] = hooks
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        console.print(f"  [green]✓[/green] {'Updated' if enabled else 'Removed'} Cursor lint hook")
+    else:
+        console.print("  [dim]• Cursor hooks already in sync[/dim]")
+        
+    return changed
 
 
 @app.command(name="set")
@@ -608,10 +732,11 @@ def set_config(
 
     Currently supported keys:
         auto_commit  - Enable/disable automatic commits by agents (true/false)
+        lint_on_edit - Enable/disable auto-linting feedback loop (true/false)
 
     Examples:
         spec-kitty agent config set auto_commit false
-        spec-kitty agent config set auto_commit true
+        spec-kitty agent config set lint_on_edit true
     """
     try:
         repo_root = find_repo_root()
@@ -634,13 +759,26 @@ def set_config(
 
         status_label = "[green]enabled[/green]" if config.auto_commit else "[yellow]disabled[/yellow]"
         console.print(f"[green]✓[/green] auto_commit set to {status_label}")
-        if not config.auto_commit:
-            console.print("[dim]Agents will stage changes but not create commits unless explicitly instructed.[/dim]")
-            console.print("[dim]Per-command flags (--auto-commit/--no-auto-commit) override this setting.[/dim]")
+    elif key == "lint_on_edit":
+        if value.lower() in ("true", "1", "yes", "on"):
+            config.lint_on_edit = True
+        elif value.lower() in ("false", "0", "no", "off"):
+            config.lint_on_edit = False
+        else:
+            console.print(f"[red]Error:[/red] Invalid value for lint_on_edit: '{value}'. Use 'true' or 'false'.")
+            raise typer.Exit(1)
+
+        save_agent_config(repo_root, config)
+
+        status_label = "[green]enabled[/green]" if config.lint_on_edit else "[yellow]disabled[/yellow]"
+        console.print(f"[green]✓[/green] lint_on_edit set to {status_label}")
+        if config.lint_on_edit:
+            console.print("[cyan]Tip:[/cyan] Run 'spec-kitty agent config sync --sync-hooks' to update harness configurations.")
     else:
         console.print(f"[red]Error:[/red] Unknown configuration key: '{key}'")
         console.print("\nSupported keys:")
         console.print("  auto_commit  - Enable/disable automatic commits by agents (true/false)")
+        console.print("  lint_on_edit - Enable/disable auto-linting feedback loop (true/false)")
         raise typer.Exit(1)
 
 

--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import shutil
 from pathlib import Path
 
@@ -18,7 +17,9 @@ from specify_cli.core.agent_config import (
     AgentConfig,
     AgentConfigError,
 )
+from specify_cli.core.utils import write_text_within_directory
 from specify_cli.runtime.agent_commands import get_global_command_dir
+from specify_cli.session_presence.hooks.claude_code_hook import ClaudeCodeHookRegistrar
 from specify_cli.upgrade.migrations.m_0_9_1_complete_lane_migration import (
     AGENT_DIR_TO_KEY,
     CompleteLaneMigration,
@@ -27,10 +28,12 @@ from specify_cli.task_utils import find_repo_root
 
 from .surface_presence import SurfacePresenceIndex
 
-logger = logging.getLogger(__name__)
-
 #: Command wired into harness post-edit hooks when ``lint_on_edit`` is enabled.
+#: It takes no path argument — the edited file is delivered on stdin by the
+#: harness and resolved by ``spec-kitty lint`` (see lint.py).
 LINT_HOOK_COMMAND = "spec-kitty lint --json"
+#: Claude PostToolUse matcher scoping the hook to file-editing tools.
+LINT_HOOK_MATCHER = "Edit|Write"
 
 app = typer.Typer(
     name="config",
@@ -571,7 +574,7 @@ def sync_agents(
         help="Create directories for configured agents that are missing",
     ),
     remove_orphaned: bool = typer.Option(
-        False,
+        True,
         "--remove-orphaned/--keep-orphaned",
         help="Remove directories for agents not in config",
     ),
@@ -616,118 +619,108 @@ def sync_agents(
         console.print("\n[green]✓ Sync complete[/green]")
 
 
-def _load_hook_config(path: Path, default: dict) -> dict:
-    """Load a harness hook-config JSON file, falling back to *default*.
-
-    A missing file yields *default*. A present-but-unreadable/corrupt file is
-    logged and also yields *default* — we never abort the sync on a damaged
-    harness config, but we do not silently mask the problem either.
-    """
-    if not path.exists():
-        return default
-    try:
-        with path.open(encoding="utf-8") as fh:
-            loaded = json.load(fh)
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Could not read hook config %s (%s); using defaults", path, exc)
-        return default
-    return loaded if isinstance(loaded, dict) else default
-
-
-def _write_hook_config(path: Path, data: dict) -> None:
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
+def _parse_bool_value(value: str) -> bool | None:
+    """Parse a CLI boolean string; return None when it is not a valid bool."""
+    lowered = value.lower()
+    if lowered in ("true", "1", "yes", "on"):
+        return True
+    if lowered in ("false", "0", "no", "off"):
+        return False
+    return None
 
 
 def _sync_harness_hooks(repo_root: Path, config: AgentConfig) -> bool:
-    """Update harness hook configurations based on lint_on_edit setting."""
+    """Update harness hook configurations based on lint_on_edit setting.
+
+    config.yaml is the single source of truth: a harness is synced only when
+    its agent key is in ``config.available`` (a stray ``.claude``/``.cursor``
+    directory never triggers a write — see CLAUDE.md agent-config rules).
+    """
     console.print("\n[cyan]Syncing harness hooks...[/cyan]")
     changes = False
 
-    # Claude Code
-    claude_settings = repo_root / ".claude" / "settings.json"
-    if ("claude" in config.available or claude_settings.parent.exists()) and _sync_claude_hooks(
-        claude_settings, config.lint_on_edit
-    ):
+    if "claude" in config.available and _sync_claude_hooks(repo_root, config.lint_on_edit):
         changes = True
 
-    # Cursor
-    cursor_hooks = repo_root / ".cursor" / "hooks.json"
-    if ("cursor" in config.available or cursor_hooks.parent.exists()) and _sync_cursor_hooks(
-        cursor_hooks, config.lint_on_edit
-    ):
+    if "cursor" in config.available and _sync_cursor_hooks(repo_root, config.lint_on_edit):
         changes = True
 
     return changes
 
 
-def _sync_claude_hooks(path: Path, enabled: bool) -> bool:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = _load_hook_config(path, {})
+def _sync_claude_hooks(repo_root: Path, enabled: bool) -> bool:
+    """Register/unregister the lint PostToolUse hook in .claude/settings.json.
 
-    hooks = data.get("hooks", {})
-    post_tool_use = hooks.get("PostToolUse", [])
-
-    # Check if our lint hook already exists
-    existing_hook_idx = -1
-    for i, h_group in enumerate(post_tool_use):
-        if h_group.get("matcher") == "Edit|Write":
-            for hook in h_group.get("hooks", []):
-                if hook.get("command") == LINT_HOOK_COMMAND:
-                    existing_hook_idx = i
-                    break
+    Delegates to the canonical :class:`ClaudeCodeHookRegistrar`, which writes
+    atomically, preserves all unrelated keys/hooks, removes only the lint hook
+    (never sibling hooks), and backs up invalid JSON before rewriting.
+    """
+    registrar = ClaudeCodeHookRegistrar(event_key="PostToolUse")
+    already = registrar.is_registered(repo_root, LINT_HOOK_COMMAND)
 
     changed = False
-    if enabled and existing_hook_idx == -1:
-        post_tool_use.append({
-            "matcher": "Edit|Write",
-            "hooks": [{"type": "command", "command": LINT_HOOK_COMMAND}],
-        })
+    if enabled and not already:
+        registrar.register(repo_root, LINT_HOOK_COMMAND, matcher=LINT_HOOK_MATCHER)
         changed = True
-    elif not enabled and existing_hook_idx != -1:
-        post_tool_use.pop(existing_hook_idx)
+    elif not enabled and already:
+        registrar.unregister(repo_root, LINT_HOOK_COMMAND)
         changed = True
 
     if changed:
-        hooks["PostToolUse"] = post_tool_use
-        data["hooks"] = hooks
-        _write_hook_config(path, data)
         console.print(f"  [green]✓[/green] {'Updated' if enabled else 'Removed'} Claude Code lint hook")
     else:
         console.print("  [dim]• Claude Code hooks already in sync[/dim]")
-
     return changed
 
 
-def _sync_cursor_hooks(path: Path, enabled: bool) -> bool:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = _load_hook_config(path, {"version": 1, "hooks": {}})
+def _load_cursor_hooks(path: Path) -> dict | None:
+    """Load Cursor hooks.json, or ``None`` if it exists but is corrupt.
 
-    hooks = data.get("hooks", {})
+    A corrupt file returns ``None`` so the caller refuses to overwrite it
+    (no silent data loss); a missing file returns the empty default.
+    """
+    if not path.exists():
+        return {"version": 1, "hooks": {}}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        console.print(
+            f"  [yellow]![/yellow] Cursor hooks file is unreadable ({exc}); "
+            "leaving it untouched. Fix or remove it, then re-run."
+        )
+        return None
+    return loaded if isinstance(loaded, dict) else {"version": 1, "hooks": {}}
+
+
+def _sync_cursor_hooks(repo_root: Path, enabled: bool) -> bool:
+    path = repo_root / ".cursor" / "hooks.json"
+    data = _load_cursor_hooks(path)
+    if data is None:
+        return False  # corrupt config: refuse to clobber
+
+    hooks = data.setdefault("hooks", {})
     after_file_edit = hooks.get("afterFileEdit", [])
-
-    existing_hook_idx = -1
-    for i, hook in enumerate(after_file_edit):
-        if hook.get("command") == LINT_HOOK_COMMAND:
-            existing_hook_idx = i
-            break
+    existing_idx = next(
+        (i for i, h in enumerate(after_file_edit) if h.get("command") == LINT_HOOK_COMMAND),
+        -1,
+    )
 
     changed = False
-    if enabled and existing_hook_idx == -1:
+    if enabled and existing_idx == -1:
         after_file_edit.append({"command": LINT_HOOK_COMMAND})
         changed = True
-    elif not enabled and existing_hook_idx != -1:
-        after_file_edit.pop(existing_hook_idx)
+    elif not enabled and existing_idx != -1:
+        after_file_edit.pop(existing_idx)
         changed = True
 
     if changed:
         hooks["afterFileEdit"] = after_file_edit
         data["hooks"] = hooks
-        _write_hook_config(path, data)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_text_within_directory(path, json.dumps(data, indent=2) + "\n", root=path.parent)
         console.print(f"  [green]✓[/green] {'Updated' if enabled else 'Removed'} Cursor lint hook")
     else:
         console.print("  [dim]• Cursor hooks already in sync[/dim]")
-
     return changed
 
 
@@ -755,27 +748,24 @@ def set_config(
     config = _load_config_or_exit(repo_root)
 
     if key == "auto_commit":
-        if value.lower() in ("true", "1", "yes", "on"):
-            config.auto_commit = True
-        elif value.lower() in ("false", "0", "no", "off"):
-            config.auto_commit = False
-        else:
+        parsed = _parse_bool_value(value)
+        if parsed is None:
             console.print(f"[red]Error:[/red] Invalid value for auto_commit: '{value}'. Use 'true' or 'false'.")
             raise typer.Exit(1)
-
+        config.auto_commit = parsed
         save_agent_config(repo_root, config)
 
         status_label = "[green]enabled[/green]" if config.auto_commit else "[yellow]disabled[/yellow]"
         console.print(f"[green]✓[/green] auto_commit set to {status_label}")
+        if not config.auto_commit:
+            console.print("[dim]Agents will stage changes but not create commits unless explicitly instructed.[/dim]")
+            console.print("[dim]Per-command flags (--auto-commit/--no-auto-commit) override this setting.[/dim]")
     elif key == "lint_on_edit":
-        if value.lower() in ("true", "1", "yes", "on"):
-            config.lint_on_edit = True
-        elif value.lower() in ("false", "0", "no", "off"):
-            config.lint_on_edit = False
-        else:
+        parsed = _parse_bool_value(value)
+        if parsed is None:
             console.print(f"[red]Error:[/red] Invalid value for lint_on_edit: '{value}'. Use 'true' or 'false'.")
             raise typer.Exit(1)
-
+        config.lint_on_edit = parsed
         save_agent_config(repo_root, config)
 
         status_label = "[green]enabled[/green]" if config.lint_on_edit else "[yellow]disabled[/yellow]"

--- a/src/specify_cli/cli/commands/agent/config.py
+++ b/src/specify_cli/cli/commands/agent/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import shutil
 from pathlib import Path
 
@@ -24,6 +26,11 @@ from specify_cli.upgrade.migrations.m_0_9_1_complete_lane_migration import (
 from specify_cli.task_utils import find_repo_root
 
 from .surface_presence import SurfacePresenceIndex
+
+logger = logging.getLogger(__name__)
+
+#: Command wired into harness post-edit hooks when ``lint_on_edit`` is enabled.
+LINT_HOOK_COMMAND = "spec-kitty lint --json"
 
 app = typer.Typer(
     name="config",
@@ -609,6 +616,29 @@ def sync_agents(
         console.print("\n[green]✓ Sync complete[/green]")
 
 
+def _load_hook_config(path: Path, default: dict) -> dict:
+    """Load a harness hook-config JSON file, falling back to *default*.
+
+    A missing file yields *default*. A present-but-unreadable/corrupt file is
+    logged and also yields *default* — we never abort the sync on a damaged
+    harness config, but we do not silently mask the problem either.
+    """
+    if not path.exists():
+        return default
+    try:
+        with path.open(encoding="utf-8") as fh:
+            loaded = json.load(fh)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Could not read hook config %s (%s); using defaults", path, exc)
+        return default
+    return loaded if isinstance(loaded, dict) else default
+
+
+def _write_hook_config(path: Path, data: dict) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
 def _sync_harness_hooks(repo_root: Path, config: AgentConfig) -> bool:
     """Update harness hook configurations based on lint_on_edit setting."""
     console.print("\n[cyan]Syncing harness hooks...[/cyan]")
@@ -616,110 +646,88 @@ def _sync_harness_hooks(repo_root: Path, config: AgentConfig) -> bool:
 
     # Claude Code
     claude_settings = repo_root / ".claude" / "settings.json"
-    if "claude" in config.available or claude_settings.parent.exists():
-        if _sync_claude_hooks(claude_settings, config.lint_on_edit):
-            changes = True
+    if ("claude" in config.available or claude_settings.parent.exists()) and _sync_claude_hooks(
+        claude_settings, config.lint_on_edit
+    ):
+        changes = True
 
     # Cursor
     cursor_hooks = repo_root / ".cursor" / "hooks.json"
-    if "cursor" in config.available or cursor_hooks.parent.exists():
-        if _sync_cursor_hooks(cursor_hooks, config.lint_on_edit):
-            changes = True
+    if ("cursor" in config.available or cursor_hooks.parent.exists()) and _sync_cursor_hooks(
+        cursor_hooks, config.lint_on_edit
+    ):
+        changes = True
 
     return changes
 
 
 def _sync_claude_hooks(path: Path, enabled: bool) -> bool:
-    import json
     path.parent.mkdir(parents=True, exist_ok=True)
-    
-    data = {}
-    if path.exists():
-        try:
-            with open(path) as f:
-                data = json.load(f)
-        except Exception:
-            pass
+    data = _load_hook_config(path, {})
 
     hooks = data.get("hooks", {})
     post_tool_use = hooks.get("PostToolUse", [])
-    
+
     # Check if our lint hook already exists
-    lint_hook_command = "spec-kitty lint --json"
     existing_hook_idx = -1
     for i, h_group in enumerate(post_tool_use):
         if h_group.get("matcher") == "Edit|Write":
             for hook in h_group.get("hooks", []):
-                if hook.get("command") == lint_hook_command:
+                if hook.get("command") == LINT_HOOK_COMMAND:
                     existing_hook_idx = i
                     break
-    
+
     changed = False
-    if enabled:
-        if existing_hook_idx == -1:
-            post_tool_use.append({
-                "matcher": "Edit|Write",
-                "hooks": [{"type": "command", "command": lint_hook_command}]
-            })
-            changed = True
-    else:
-        if existing_hook_idx != -1:
-            post_tool_use.pop(existing_hook_idx)
-            changed = True
-            
+    if enabled and existing_hook_idx == -1:
+        post_tool_use.append({
+            "matcher": "Edit|Write",
+            "hooks": [{"type": "command", "command": LINT_HOOK_COMMAND}],
+        })
+        changed = True
+    elif not enabled and existing_hook_idx != -1:
+        post_tool_use.pop(existing_hook_idx)
+        changed = True
+
     if changed:
         hooks["PostToolUse"] = post_tool_use
         data["hooks"] = hooks
-        with open(path, "w") as f:
-            json.dump(data, f, indent=2)
+        _write_hook_config(path, data)
         console.print(f"  [green]✓[/green] {'Updated' if enabled else 'Removed'} Claude Code lint hook")
     else:
         console.print("  [dim]• Claude Code hooks already in sync[/dim]")
-        
+
     return changed
 
 
 def _sync_cursor_hooks(path: Path, enabled: bool) -> bool:
-    import json
     path.parent.mkdir(parents=True, exist_ok=True)
-    
-    data = {"version": 1, "hooks": {}}
-    if path.exists():
-        try:
-            with open(path) as f:
-                data = json.load(f)
-        except Exception:
-            pass
+    data = _load_hook_config(path, {"version": 1, "hooks": {}})
 
     hooks = data.get("hooks", {})
     after_file_edit = hooks.get("afterFileEdit", [])
-    
-    lint_hook_command = "spec-kitty lint --json"
+
     existing_hook_idx = -1
     for i, hook in enumerate(after_file_edit):
-        if hook.get("command") == lint_hook_command:
+        if hook.get("command") == LINT_HOOK_COMMAND:
             existing_hook_idx = i
             break
-            
+
     changed = False
-    if enabled:
-        if existing_hook_idx == -1:
-            after_file_edit.append({"command": lint_hook_command})
-            changed = True
-    else:
-        if existing_hook_idx != -1:
-            after_file_edit.pop(existing_hook_idx)
-            changed = True
-            
+    if enabled and existing_hook_idx == -1:
+        after_file_edit.append({"command": LINT_HOOK_COMMAND})
+        changed = True
+    elif not enabled and existing_hook_idx != -1:
+        after_file_edit.pop(existing_hook_idx)
+        changed = True
+
     if changed:
         hooks["afterFileEdit"] = after_file_edit
         data["hooks"] = hooks
-        with open(path, "w") as f:
-            json.dump(data, f, indent=2)
+        _write_hook_config(path, data)
         console.print(f"  [green]✓[/green] {'Updated' if enabled else 'Removed'} Cursor lint hook")
     else:
         console.print("  [dim]• Cursor hooks already in sync[/dim]")
-        
+
     return changed
 
 

--- a/src/specify_cli/cli/commands/lint.py
+++ b/src/specify_cli/cli/commands/lint.py
@@ -1,16 +1,31 @@
-"""Lint and type-check command implementation."""
+"""Lint and type-check command implementation.
+
+Wraps ``ruff`` and ``mypy`` for a single file and reports the result. The
+command is designed to run as a harness post-edit hook (Claude Code
+``PostToolUse``, Cursor ``afterFileEdit``). Those harnesses do **not** append
+the edited path as an argv; they deliver it as a JSON payload on **stdin**. So
+when no path argument is given, the target is resolved from the stdin payload
+(``tool_input.file_path`` for Claude, ``file_path`` for Cursor/generic). A hook
+that fires without a resolvable Python file is a benign no-op (exit 0), never a
+hard failure that would block the agent's edit.
+"""
 
 from __future__ import annotations
 
 import json
+import re
 import subprocess
+import sys
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
 from specify_cli.cli.helpers import console
 from specify_cli.core.project_resolver import locate_project_root
+
+# mypy's summary lines we never want to surface as "errors".
+_MYPY_SUMMARY_RE = re.compile(r"^(Success:|Found \d+ error)")
 
 
 def _run_ruff(path: Path, project_root: Path, fix: bool) -> list[str]:
@@ -40,7 +55,13 @@ def _run_ruff(path: Path, project_root: Path, fix: bool) -> list[str]:
 def _run_mypy(path: Path, project_root: Path) -> list[str]:
     """Run mypy and return a list of error lines."""
     try:
-        mypy_args = ["mypy", "--strict", "--ignore-missing-imports", "--no-error-summary", str(path)]
+        mypy_args = [
+            "mypy",
+            "--strict",
+            "--ignore-missing-imports",
+            "--no-error-summary",
+            str(path),
+        ]
 
         mypy_proc = subprocess.run(
             mypy_args,
@@ -52,14 +73,61 @@ def _run_mypy(path: Path, project_root: Path) -> list[str]:
         if mypy_proc.returncode != 0:
             raw_output = mypy_proc.stdout.strip() or mypy_proc.stderr.strip()
             if raw_output:
-                return [line for line in raw_output.splitlines() if not line.startswith("Success:") and not line.startswith("Found ")]
+                return [
+                    line
+                    for line in raw_output.splitlines()
+                    if not _MYPY_SUMMARY_RE.match(line)
+                ]
     except FileNotFoundError:
         return ["mypy not found in PATH. Please install it with 'pip install mypy'."]
     return []
 
 
+def _path_from_payload(payload: Any) -> Path | None:
+    """Extract an edited-file path from a harness hook stdin payload.
+
+    Supports Claude Code (``tool_input.file_path``) and Cursor / generic
+    (``file_path``) shapes, plus their ``*_paths`` list variants. Returns the
+    first resolvable path, or ``None`` when the payload carries no file path.
+    """
+    if not isinstance(payload, dict):
+        return None
+    tool_input = payload.get("tool_input")
+    candidates: list[Any] = []
+    if isinstance(tool_input, dict):
+        candidates.append(tool_input.get("file_path"))
+        candidates.extend(tool_input.get("file_paths") or [])
+    candidates.append(payload.get("file_path"))
+    candidates.extend(payload.get("file_paths") or [])
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return Path(candidate)
+    return None
+
+
+def _resolve_target_from_stdin() -> Path | None:
+    """Resolve the target file from a harness hook payload on stdin.
+
+    Returns ``None`` when stdin is a terminal, empty, not JSON, or carries no
+    file path — all of which mean "nothing to lint", a benign hook no-op.
+    """
+    if sys.stdin.isatty():
+        return None
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return _path_from_payload(payload)
+
+
 def lint_command(
-    file_path: Annotated[Path, typer.Argument(help="File path to lint and type-check")],
+    file_path: Annotated[
+        Path | None,
+        typer.Argument(help="File to lint/type-check; omit to read the path from a hook stdin payload"),
+    ] = None,
     json_output: Annotated[bool, typer.Option("--json", help="Output in JSON format for AI agents")] = False,
     fix: Annotated[bool, typer.Option("--fix", help="Attempt to automatically fix lint errors")] = False,
 ) -> None:
@@ -68,7 +136,19 @@ def lint_command(
 
     This command is designed to be used as a post-edit hook for AI agents,
     providing immediate feedback on linting and type-checking violations.
+    When invoked without a path (the wired hook form), the target file is read
+    from the harness JSON payload on stdin.
     """
+    if file_path is None:
+        file_path = _resolve_target_from_stdin()
+    if file_path is None:
+        # Hook fired with no file to lint (e.g. a non-edit tool event): no-op.
+        if json_output:
+            print(json.dumps({"skipped": True, "reason": "No file path provided"}))
+        else:
+            console.print("[dim]Skipping:[/dim] no file path provided.")
+        return
+
     if not file_path.exists():
         if not json_output:
             console.print(f"[red]Error:[/red] File [cyan]{file_path}[/cyan] does not exist.")
@@ -84,18 +164,20 @@ def lint_command(
         return
 
     project_root = locate_project_root() or Path.cwd()
+    # Resolve to an absolute path so ruff/mypy (run with cwd=project_root) find
+    # the file regardless of the caller's working directory.
+    target = file_path.resolve()
 
-    ruff_errors = _run_ruff(file_path, project_root, fix)
-    mypy_errors = _run_mypy(file_path, project_root)
+    ruff_errors = _run_ruff(target, project_root, fix)
+    mypy_errors = _run_mypy(target, project_root)
     all_errors = ruff_errors + mypy_errors
 
     if json_output:
         print(json.dumps({"file": str(file_path), "success": len(all_errors) == 0, "ruff_errors": ruff_errors, "mypy_errors": mypy_errors}, indent=2))
+    elif not all_errors:
+        console.print(f"[green]✓[/green] [cyan]{file_path}[/cyan] passed all checks.")
     else:
-        if not all_errors:
-            console.print(f"[green]✓[/green] [cyan]{file_path}[/cyan] passed all checks.")
-        else:
-            _print_errors(file_path, ruff_errors, mypy_errors)
+        _print_errors(file_path, ruff_errors, mypy_errors)
 
     if all_errors:
         raise typer.Exit(1)

--- a/src/specify_cli/cli/commands/lint.py
+++ b/src/specify_cli/cli/commands/lint.py
@@ -1,0 +1,116 @@
+"""Lint and type-check command implementation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from specify_cli.cli.helpers import console
+from specify_cli.core.project_resolver import locate_project_root
+
+
+def _run_ruff(path: Path, project_root: Path, fix: bool) -> list[str]:
+    """Run ruff and return a list of error lines."""
+    try:
+        ruff_args = ["ruff", "check"]
+        if fix:
+            ruff_args.append("--fix")
+        ruff_args.append(str(path))
+
+        ruff_proc = subprocess.run(
+            ruff_args,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if ruff_proc.returncode != 0:
+            raw_output = ruff_proc.stdout.strip() or ruff_proc.stderr.strip()
+            if raw_output:
+                return raw_output.splitlines()
+    except FileNotFoundError:
+        return ["ruff not found in PATH. Please install it with 'pip install ruff'."]
+    return []
+
+
+def _run_mypy(path: Path, project_root: Path) -> list[str]:
+    """Run mypy and return a list of error lines."""
+    try:
+        mypy_args = ["mypy", "--strict", "--ignore-missing-imports", "--no-error-summary", str(path)]
+
+        mypy_proc = subprocess.run(
+            mypy_args,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if mypy_proc.returncode != 0:
+            raw_output = mypy_proc.stdout.strip() or mypy_proc.stderr.strip()
+            if raw_output:
+                return [line for line in raw_output.splitlines() if not line.startswith("Success:") and not line.startswith("Found ")]
+    except FileNotFoundError:
+        return ["mypy not found in PATH. Please install it with 'pip install mypy'."]
+    return []
+
+
+def lint_command(
+    file_path: Annotated[Path, typer.Argument(help="File path to lint and type-check")],
+    json_output: Annotated[bool, typer.Option("--json", help="Output in JSON format for AI agents")] = False,
+    fix: Annotated[bool, typer.Option("--fix", help="Attempt to automatically fix lint errors")] = False,
+) -> None:
+    """
+    Run ruff and mypy on a file and report errors.
+
+    This command is designed to be used as a post-edit hook for AI agents,
+    providing immediate feedback on linting and type-checking violations.
+    """
+    if not file_path.exists():
+        if not json_output:
+            console.print(f"[red]Error:[/red] File [cyan]{file_path}[/cyan] does not exist.")
+        else:
+            print(json.dumps({"error": f"File {file_path} does not exist"}))
+        raise typer.Exit(1)
+
+    if file_path.suffix != ".py":
+        if not json_output:
+            console.print(f"[dim]Skipping:[/dim] [cyan]{file_path}[/cyan] is not a Python file.")
+        else:
+            print(json.dumps({"skipped": True, "reason": "Not a Python file", "file": str(file_path)}))
+        return
+
+    project_root = locate_project_root() or Path.cwd()
+
+    ruff_errors = _run_ruff(file_path, project_root, fix)
+    mypy_errors = _run_mypy(file_path, project_root)
+    all_errors = ruff_errors + mypy_errors
+
+    if json_output:
+        print(json.dumps({"file": str(file_path), "success": len(all_errors) == 0, "ruff_errors": ruff_errors, "mypy_errors": mypy_errors}, indent=2))
+    else:
+        if not all_errors:
+            console.print(f"[green]✓[/green] [cyan]{file_path}[/cyan] passed all checks.")
+        else:
+            _print_errors(file_path, ruff_errors, mypy_errors)
+
+    if all_errors:
+        raise typer.Exit(1)
+
+
+def _print_errors(file_path: Path, ruff_errors: list[str], mypy_errors: list[str]) -> None:
+    """Print error summary to console."""
+    console.print(f"[red]✗[/red] [cyan]{file_path}[/cyan] failed code quality checks:")
+    if ruff_errors:
+        console.print("\n[bold]Ruff Violations:[/bold]")
+        for err in ruff_errors:
+            console.print(f"  {err}")
+    if mypy_errors:
+        console.print("\n[bold]Mypy Type Errors:[/bold]")
+        for err in mypy_errors:
+            console.print(f"  {err}")
+
+    console.print("\n[yellow]Tip:[/yellow] Fix these errors before proceeding to ensure high code quality.")

--- a/src/specify_cli/core/agent_config.py
+++ b/src/specify_cli/core/agent_config.py
@@ -9,14 +9,13 @@ The configuration is stored in .kittify/config.yaml under the `agents` key
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from ruamel.yaml import YAML
 
 from specify_cli.core.config import AI_CHOICES
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +34,13 @@ class AgentConfig:
             When False, agents may stage changes but MUST NOT create
             commits unless explicitly instructed. Per-command flags
             (--auto-commit/--no-auto-commit) override this setting.
+        lint_on_edit: Whether agents should receive automatic linting
+            and type-checking feedback after editing files.
     """
 
     available: list[str] = field(default_factory=list)
     auto_commit: bool = True
+    lint_on_edit: bool = False
 
 
 def load_agent_config(repo_root: Path) -> AgentConfig:
@@ -71,18 +73,25 @@ def load_agent_config(repo_root: Path) -> AgentConfig:
 
     agents_data = data.get("agents") or data.get("tools") or {}
 
-    # Parse auto_commit setting first so top-level configs still work
-    # when no agents section is present.
+    # Parse settings from either the agents/tools dict or the top level
     auto_commit_raw = None
+    lint_on_edit_raw = None
+
     if isinstance(agents_data, dict):
         auto_commit_raw = agents_data.get("auto_commit")
+        lint_on_edit_raw = agents_data.get("lint_on_edit")
+
     if auto_commit_raw is None:
         auto_commit_raw = data.get("auto_commit")
+    if lint_on_edit_raw is None:
+        lint_on_edit_raw = data.get("lint_on_edit")
+
     auto_commit = auto_commit_raw if isinstance(auto_commit_raw, bool) else True
+    lint_on_edit = lint_on_edit_raw if isinstance(lint_on_edit_raw, bool) else False
 
     if not agents_data:
         logger.info("No agents section in config.yaml")
-        return AgentConfig(auto_commit=auto_commit)
+        return AgentConfig(auto_commit=auto_commit, lint_on_edit=lint_on_edit)
 
     # Parse available agents
     available = agents_data.get("available", [])
@@ -97,7 +106,7 @@ def load_agent_config(repo_root: Path) -> AgentConfig:
         unknown = ", ".join(sorted(invalid_agents))
         raise AgentConfigError(f"Unknown agent key(s) in config.yaml: {unknown}. Valid agents: {valid_agents}")
 
-    return AgentConfig(available=available, auto_commit=auto_commit)
+    return AgentConfig(available=available, auto_commit=auto_commit, lint_on_edit=lint_on_edit)
 
 
 def save_agent_config(repo_root: Path, config: AgentConfig) -> None:
@@ -127,6 +136,7 @@ def save_agent_config(repo_root: Path, config: AgentConfig) -> None:
     data["agents"] = {
         "available": config.available,
         "auto_commit": config.auto_commit,
+        "lint_on_edit": config.lint_on_edit,
     }
 
     # Write back

--- a/src/specify_cli/session_presence/hooks/claude_code_hook.py
+++ b/src/specify_cli/session_presence/hooks/claude_code_hook.py
@@ -143,11 +143,15 @@ class ClaudeCodeHookRegistrar:
             for hook in self._iter_command_hooks(entries)
         )
 
-    def register(self, project_root: Path, command: str) -> None:
+    def register(self, project_root: Path, command: str, matcher: str | None = None) -> None:
         """Add *command* as a hook entry for the configured event (idempotent).
 
         If the command is already registered, returns immediately without
         writing.  Otherwise appends a new entry and writes atomically.
+
+        ``matcher`` (e.g. ``"Edit|Write"``) is included on the entry when given,
+        as required by tool-scoped events such as ``PostToolUse``. Lifecycle
+        events (``SessionStart``/``Stop``) take no matcher and pass ``None``.
         """
         if self.is_registered(project_root, command):
             return
@@ -162,9 +166,10 @@ class ClaudeCodeHookRegistrar:
         if not isinstance(entries, list):
             entries = []
             hooks_section[self._event_key] = entries
-        entries.append(
-            {"hooks": [{"type": "command", "command": command}]}
-        )
+        entry: dict[str, object] = {"hooks": [{"type": "command", "command": command}]}
+        if matcher is not None:
+            entry = {"matcher": matcher, **entry}
+        entries.append(entry)
         self._save(path, data)
 
     def unregister(self, project_root: Path, command: str) -> None:

--- a/tests/agent/cli/commands/test_agent_config.py
+++ b/tests/agent/cli/commands/test_agent_config.py
@@ -330,7 +330,7 @@ class TestSyncCommand:
             claude.mkdir(parents=True)
 
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=mock_project):
-            result = runner.invoke(app, ["sync", "--remove-orphaned"])
+            result = runner.invoke(app, ["sync"])
 
             assert result.exit_code == 0
             assert "Removed orphaned .claude/" in result.stdout
@@ -349,7 +349,7 @@ class TestSyncCommand:
         (prompts / "spec-kitty.example.prompt.md").write_text("# prompt\n")
 
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
-            result = runner.invoke(app, ["sync", "--remove-orphaned"])
+            result = runner.invoke(app, ["sync"])
 
             assert result.exit_code == 0
             assert "Removed orphaned .github/prompts/" in result.stdout
@@ -401,7 +401,7 @@ class TestSyncCommand:
         opencode.mkdir(parents=True)
 
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
-            result = runner.invoke(app, ["sync", "--remove-orphaned"])
+            result = runner.invoke(app, ["sync"])
 
             assert result.exit_code == 0
             assert "No changes needed" in result.stdout

--- a/tests/agent/cli/commands/test_agent_config.py
+++ b/tests/agent/cli/commands/test_agent_config.py
@@ -330,7 +330,7 @@ class TestSyncCommand:
             claude.mkdir(parents=True)
 
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=mock_project):
-            result = runner.invoke(app, ["sync"])
+            result = runner.invoke(app, ["sync", "--remove-orphaned"])
 
             assert result.exit_code == 0
             assert "Removed orphaned .claude/" in result.stdout
@@ -349,7 +349,7 @@ class TestSyncCommand:
         (prompts / "spec-kitty.example.prompt.md").write_text("# prompt\n")
 
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
-            result = runner.invoke(app, ["sync"])
+            result = runner.invoke(app, ["sync", "--remove-orphaned"])
 
             assert result.exit_code == 0
             assert "Removed orphaned .github/prompts/" in result.stdout
@@ -401,7 +401,7 @@ class TestSyncCommand:
         opencode.mkdir(parents=True)
 
         with patch("specify_cli.cli.commands.agent.config.find_repo_root", return_value=tmp_path):
-            result = runner.invoke(app, ["sync"])
+            result = runner.invoke(app, ["sync", "--remove-orphaned"])
 
             assert result.exit_code == 0
             assert "No changes needed" in result.stdout

--- a/tests/specify_cli/cli/commands/test_lint.py
+++ b/tests/specify_cli/cli/commands/test_lint.py
@@ -39,7 +39,7 @@ def test_lint_non_python_file(runner: CliRunner, app: typer.Typer, tmp_path: Pat
     test_file.write_text("hello")
     result = runner.invoke(app, ["lint", str(test_file)])
     assert result.exit_code == 0
-    assert "is not a Python file" in result.output
+    assert "is not a Python file" in " ".join(result.output.split())
 
 @patch("subprocess.run")
 def test_lint_success_mock(mock_run: MagicMock, runner: CliRunner, app: typer.Typer, tmp_path: Path) -> None:
@@ -51,7 +51,7 @@ def test_lint_success_mock(mock_run: MagicMock, runner: CliRunner, app: typer.Ty
 
     result = runner.invoke(app, ["lint", str(test_file)])
     assert result.exit_code == 0
-    assert "passed all checks" in result.output
+    assert "passed all checks" in " ".join(result.output.split())
 
 @patch("subprocess.run")
 def test_lint_json_failure_mock(mock_run: MagicMock, runner: CliRunner, app: typer.Typer, tmp_path: Path) -> None:

--- a/tests/specify_cli/cli/commands/test_lint.py
+++ b/tests/specify_cli/cli/commands/test_lint.py
@@ -1,0 +1,88 @@
+"""Integration tests for the spec-kitty lint command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest import MonkeyPatch
+from typer.testing import CliRunner
+
+import typer
+
+from specify_cli.cli.commands import register_commands
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+@pytest.fixture()
+def app() -> typer.Typer:
+    _app = typer.Typer()
+    register_commands(_app)
+    return _app
+
+def test_lint_file_not_found(runner: CliRunner, app: typer.Typer, tmp_path: Path) -> None:
+    """Ensure we handle missing files gracefully."""
+    result = runner.invoke(app, ["lint", str(tmp_path / "404.py")])
+    assert result.exit_code == 1
+    assert "Error" in result.output
+
+def test_lint_non_python_file(runner: CliRunner, app: typer.Typer, tmp_path: Path) -> None:
+    """Ensure we skip non-python files."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello")
+    result = runner.invoke(app, ["lint", str(test_file)])
+    assert result.exit_code == 0
+    assert "is not a Python file" in result.output
+
+@patch("subprocess.run")
+def test_lint_success_mock(mock_run: MagicMock, runner: CliRunner, app: typer.Typer, tmp_path: Path) -> None:
+    """Verify success path with mocked subprocesses."""
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def foo(): pass")
+
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    result = runner.invoke(app, ["lint", str(test_file)])
+    assert result.exit_code == 0
+    assert "passed all checks" in result.output
+
+@patch("subprocess.run")
+def test_lint_json_failure_mock(mock_run: MagicMock, runner: CliRunner, app: typer.Typer, tmp_path: Path) -> None:
+    """Verify JSON error reporting."""
+    test_file = tmp_path / "test.py"
+    test_file.write_text("bad code")
+
+    mock_run.side_effect = [
+        MagicMock(returncode=1, stdout="ruff error", stderr=""),
+        MagicMock(returncode=1, stdout="mypy error", stderr="")
+    ]
+
+    result = runner.invoke(app, ["lint", str(test_file), "--json"])
+    assert result.exit_code == 1
+
+    data = json.loads(result.output)
+    assert data["success"] is False
+    assert data["ruff_errors"] == ["ruff error"]
+    assert data["mypy_errors"] == ["mypy error"]
+
+def test_lint_config_sync_idempotency(runner: CliRunner, app: typer.Typer, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Verify that sync_hooks handles the Claude settings.json correctly."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".kittify").mkdir()
+    (tmp_path / ".kittify" / "config.yaml").write_text("agents: {available: [claude], lint_on_edit: true}")
+
+    # Run sync
+    result = runner.invoke(app, ["agent", "config", "sync", "--sync-hooks"])
+    assert result.exit_code == 0
+
+    claude_settings = tmp_path / ".claude" / "settings.json"
+    assert claude_settings.exists()
+
+    with open(claude_settings) as f:
+        data = json.load(f)
+        hooks = data["hooks"]["PostToolUse"]
+        assert any(h["matcher"] == "Edit|Write" for h in hooks)

--- a/tests/specify_cli/cli/commands/test_lint.py
+++ b/tests/specify_cli/cli/commands/test_lint.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest import MonkeyPatch
+
+pytestmark = [pytest.mark.integration]
+
 from typer.testing import CliRunner
 
 import typer

--- a/tests/specify_cli/cli/commands/test_lint_hooks.py
+++ b/tests/specify_cli/cli/commands/test_lint_hooks.py
@@ -1,0 +1,243 @@
+"""Tests for the lint stdin-bridge and harness hook-sync remediation (#1858).
+
+Covers the behaviour that the original PR shipped broken or untested:
+- ``spec-kitty lint`` resolving the target file from a harness stdin payload
+  (Claude ``tool_input.file_path`` / Cursor ``file_path``) and from an absolute
+  path so ruff/mypy run from any cwd;
+- the mypy summary-line filter not swallowing real diagnostics;
+- Claude hook sync delegating to the canonical ``ClaudeCodeHookRegistrar``
+  (atomic, sibling-hook-preserving, invalid-JSON-backup);
+- Cursor hook sync refusing to clobber a corrupt config;
+- config.available being the single source of truth for which harness is synced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import register_commands
+from specify_cli.cli.commands.agent import config as config_mod
+from specify_cli.cli.commands.agent.config import (
+    LINT_HOOK_COMMAND,
+    _load_cursor_hooks,
+    _parse_bool_value,
+    _sync_claude_hooks,
+    _sync_cursor_hooks,
+    _sync_harness_hooks,
+)
+from specify_cli.cli.commands.lint import _path_from_payload, _run_mypy
+from specify_cli.core.agent_config import AgentConfig
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def app() -> typer.Typer:
+    _app = typer.Typer()
+    register_commands(_app)
+    return _app
+
+
+# --------------------------------------------------------------------------
+# lint: stdin bridge + path resolution
+# --------------------------------------------------------------------------
+
+
+def test_path_from_payload_claude_shape() -> None:
+    assert _path_from_payload({"tool_input": {"file_path": "/x/a.py"}}) == Path("/x/a.py")
+
+
+def test_path_from_payload_cursor_generic_shape() -> None:
+    assert _path_from_payload({"file_path": "/x/b.py"}) == Path("/x/b.py")
+
+
+def test_path_from_payload_list_variant() -> None:
+    assert _path_from_payload({"tool_input": {"file_paths": ["/x/c.py"]}}) == Path("/x/c.py")
+
+
+def test_path_from_payload_no_path_returns_none() -> None:
+    assert _path_from_payload({"tool_input": {}}) is None
+    assert _path_from_payload({"unrelated": 1}) is None
+    assert _path_from_payload("not-a-dict") is None
+
+
+@patch("subprocess.run")
+def test_lint_reads_path_from_claude_stdin(
+    mock_run: MagicMock, runner: CliRunner, app: typer.Typer, tmp_path: Path
+) -> None:
+    """The wired hook form `lint --json` (no argv) resolves the file from stdin."""
+    target = tmp_path / "edited.py"
+    target.write_text("x = 1\n")
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    payload = json.dumps({"tool_input": {"file_path": str(target)}})
+    result = runner.invoke(app, ["lint", "--json"], input=payload)
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["success"] is True
+
+
+def test_lint_no_path_and_no_stdin_is_noop(runner: CliRunner, app: typer.Typer) -> None:
+    """A hook firing without a file path must be a benign no-op, not an error."""
+    result = runner.invoke(app, ["lint", "--json"], input="")
+    assert result.exit_code == 0
+    assert json.loads(result.output)["skipped"] is True
+
+
+def test_lint_stdin_non_json_is_noop(runner: CliRunner, app: typer.Typer) -> None:
+    result = runner.invoke(app, ["lint", "--json"], input="not json at all")
+    assert result.exit_code == 0
+    assert json.loads(result.output)["skipped"] is True
+
+
+@patch("subprocess.run")
+def test_lint_passes_absolute_path_to_tools(
+    mock_run: MagicMock, runner: CliRunner, app: typer.Typer, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ruff/mypy must receive the resolved absolute path, not the caller-relative one."""
+    target = tmp_path / "rel.py"
+    target.write_text("x = 1\n")
+    monkeypatch.chdir(tmp_path)
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    result = runner.invoke(app, ["lint", "rel.py", "--json"])
+    assert result.exit_code == 0
+    # Every subprocess invocation got the absolute path as its last arg.
+    for call in mock_run.call_args_list:
+        assert call.args[0][-1] == str(target.resolve())
+
+
+@patch("subprocess.run")
+def test_mypy_filter_keeps_real_errors_drops_summary(mock_run: MagicMock, tmp_path: Path) -> None:
+    """A real diagnostic beginning with 'Found' is kept; mypy's summary is dropped."""
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="a.py:1: error: Found a problem here\nFound 1 error in 1 file (checked 1)\n",
+        stderr="",
+    )
+    errors = _run_mypy(tmp_path / "a.py", tmp_path)
+    assert "a.py:1: error: Found a problem here" in errors
+    assert all("Found 1 error" not in line for line in errors)
+
+
+# --------------------------------------------------------------------------
+# Claude hook sync (canonical registrar)
+# --------------------------------------------------------------------------
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_claude_enable_adds_matcher_and_command(tmp_path: Path) -> None:
+    assert _sync_claude_hooks(tmp_path, enabled=True) is True
+    data = _read(tmp_path / ".claude" / "settings.json")
+    entries = data["hooks"]["PostToolUse"]
+    assert any(
+        e.get("matcher") == "Edit|Write"
+        and any(h.get("command") == LINT_HOOK_COMMAND for h in e.get("hooks", []))
+        for e in entries
+    )
+
+
+def test_claude_disable_preserves_sibling_hooks(tmp_path: Path) -> None:
+    """Removing the lint hook must not delete co-located hooks in the same event."""
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "prettier --write"}]},
+                        {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": LINT_HOOK_COMMAND}]},
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert _sync_claude_hooks(tmp_path, enabled=False) is True
+
+    commands = [
+        h.get("command")
+        for e in _read(settings)["hooks"]["PostToolUse"]
+        for h in e.get("hooks", [])
+    ]
+    assert "prettier --write" in commands
+    assert LINT_HOOK_COMMAND not in commands
+
+
+def test_claude_corrupt_settings_backed_up_not_lost(tmp_path: Path) -> None:
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text("{ not valid json", encoding="utf-8")
+
+    assert _sync_claude_hooks(tmp_path, enabled=True) is True
+    # Original corrupt content preserved to a sibling .invalid backup.
+    backups = list(settings.parent.glob("settings.json.invalid*"))
+    assert backups, "corrupt settings must be backed up, not silently discarded"
+    assert _read(settings)["hooks"]["PostToolUse"]  # valid structure written
+
+
+def test_claude_idempotent_enable(tmp_path: Path) -> None:
+    assert _sync_claude_hooks(tmp_path, enabled=True) is True
+    assert _sync_claude_hooks(tmp_path, enabled=True) is False  # no second change
+
+
+# --------------------------------------------------------------------------
+# Cursor hook sync (safe writer)
+# --------------------------------------------------------------------------
+
+
+def test_cursor_enable_then_disable_roundtrip(tmp_path: Path) -> None:
+    assert _sync_cursor_hooks(tmp_path, enabled=True) is True
+    hooks = tmp_path / ".cursor" / "hooks.json"
+    assert any(h["command"] == LINT_HOOK_COMMAND for h in _read(hooks)["hooks"]["afterFileEdit"])
+
+    assert _sync_cursor_hooks(tmp_path, enabled=False) is True
+    assert all(h["command"] != LINT_HOOK_COMMAND for h in _read(hooks)["hooks"]["afterFileEdit"])
+
+
+def test_cursor_corrupt_config_refused(tmp_path: Path) -> None:
+    hooks = tmp_path / ".cursor" / "hooks.json"
+    hooks.parent.mkdir(parents=True)
+    hooks.write_text("}}corrupt", encoding="utf-8")
+
+    assert _load_cursor_hooks(hooks) is None
+    assert _sync_cursor_hooks(tmp_path, enabled=True) is False  # refused
+    assert hooks.read_text(encoding="utf-8") == "}}corrupt"  # untouched
+
+
+# --------------------------------------------------------------------------
+# config.available is the source of truth
+# --------------------------------------------------------------------------
+
+
+def test_sync_skips_unconfigured_cursor_even_if_dir_exists(tmp_path: Path) -> None:
+    (tmp_path / ".cursor").mkdir()  # stray dir, but cursor not configured
+    config = AgentConfig(available=["claude"], lint_on_edit=True)
+
+    with patch.object(config_mod, "_sync_cursor_hooks") as cursor_mock:
+        _sync_harness_hooks(tmp_path, config)
+        cursor_mock.assert_not_called()
+    assert not (tmp_path / ".cursor" / "hooks.json").exists()
+
+
+def test_parse_bool_value() -> None:
+    assert _parse_bool_value("TRUE") is True
+    assert _parse_bool_value("off") is False
+    assert _parse_bool_value("maybe") is None


### PR DESCRIPTION
Implements an optional agent-harness hook that runs ruff and mypy immediately after an AI agent edits a code file. This catches lint regressions at the cheapest point (implementation) and reduces review cycles.

### Features
- **New Command:** `spec-kitty lint <file_path>` wraps ruff and mypy.
- **AI-Friendly:** `--json` output for structured feedback and `--fix` for auto-correction.
- **Universal:** Detailed documentation for Claude Code, Aider, Cursor, and Windsurf integration.

### How it was tested
- Verified against failing Python files (unused imports, missing types) and confirmed they were caught.
- Verified against passing Python files.
- Confirmed JSON output format is correctly structured for agent consumption.

epic #1836