### PR TITLE
fix: suppress localhost-only Sonar HTTP hotspots

### DIFF
--- a/src/specify_cli/dashboard/server.py
+++ b/src/specify_cli/dashboard/server.py
@@ -58,6 +58,11 @@ def _build_handler_class(project_dir: Path, project_token: str | None) -> type[D
     )
 
 
+def _serve_loopback_http_forever(server: HTTPServer) -> None:
+    """Serve the localhost-only dashboard control plane."""
+    server.serve_forever()  # NOSONAR(pythonsecurity:S5332) -- binds to 127.0.0.1 only; no remote transport exposure
+
+
 def run_dashboard_server(project_dir: Path, port: int, project_token: str | None) -> None:
     """Run the dashboard server forever (used by detached child processes)."""
     try:
@@ -72,7 +77,7 @@ def run_dashboard_server(project_dir: Path, port: int, project_token: str | None
 
     handler_class = _build_handler_class(project_dir, project_token)
     server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
-    server.serve_forever()
+    _serve_loopback_http_forever(server)
 
 
 def _background_script(project_dir: Path, port: int, project_token: str | None) -> str:
@@ -129,8 +134,8 @@ def start_dashboard(
         return port, proc.pid
 
     handler_class = _build_handler_class(project_dir_abs, project_token)
-    server = HTTPServer(('127.0.0.1', port), handler_class)
+    server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
 
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread = threading.Thread(target=lambda: _serve_loopback_http_forever(server), daemon=True)
     thread.start()
     return port, None

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -47,7 +47,7 @@ else:  # pragma: no cover - platform-specific
 if TYPE_CHECKING:
     from specify_cli.sync.config import SyncConfig
 
-import psutil  # type: ignore[import-untyped]
+import psutil
 
 from specify_cli.core.atomic import atomic_write
 from specify_cli.sync.diagnostics import SyncDiagnosticCode, emit_sync_diagnostic
@@ -691,10 +691,17 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
 
     tick = _start_self_check_tick(server, my_port=port)
     try:
-        server.serve_forever(poll_interval=DAEMON_SERVE_FOREVER_POLL_SECONDS)
+        _serve_loopback_http_forever(server, poll_interval=DAEMON_SERVE_FOREVER_POLL_SECONDS)
     finally:
         tick.cancel()
         cleanup_owner_record()
+
+
+def _serve_loopback_http_forever(server: HTTPServer, *, poll_interval: float) -> None:
+    """Serve the localhost-only sync daemon control plane."""
+    server.serve_forever(  # NOSONAR(pythonsecurity:S5332) -- binds to 127.0.0.1 only; no remote transport exposure
+        poll_interval=poll_interval
+    )
 
 
 def _background_script(port: int, daemon_token: str | None) -> str:
@@ -1130,6 +1137,7 @@ def _spawn_sync_daemon_process(port: int, token: str) -> subprocess.Popen[str]:
         stderr=log_fh,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
+        text=True,
         env={**os.environ, "SPEC_KITTY_CLI_VERSION": _get_package_version()},
     )
     log_fh.close()


### PR DESCRIPTION
## Summary
- route dashboard and sync-daemon `serve_forever()` calls through localhost-only helpers
- add explicit Sonar suppression rationale for 127.0.0.1 control planes
- clean up adjacent `mypy` nits in `sync/daemon.py` so touched files stay green

## Why suppression is necessary
SonarCloud flagged two `pythonsecurity:S5332` hotspots on loopback-only control planes. These servers bind exclusively to `127.0.0.1` and are intentionally unreachable from remote peers, so TLS would add ceremony without reducing exposure. The suppression is scoped to the exact `serve_forever()` calls and documents that the transport never leaves localhost.

## Validation
- `.venv/bin/pytest tests/test_dashboard/test_server.py tests/sync/test_daemon_self_retirement.py`
- `.venv/bin/ruff check src/specify_cli/dashboard/server.py src/specify_cli/sync/daemon.py`
- `.venv/bin/mypy src/specify_cli/dashboard/server.py src/specify_cli/sync/daemon.py`