### PR TITLE
fix: harden loopback control-plane helpers

### DIFF
--- a/kitty-ops/01KTXHY031TVK8JPXW249HJBQG.jsonl
+++ b/kitty-ops/01KTXHY031TVK8JPXW249HJBQG.jsonl
@@ -1,0 +1,2 @@
+{"event": "started", "invocation_id": "01KTXHY031TVK8JPXW249HJBQG", "profile_id": "reviewer-renata", "action": "audit", "request_text": "Re-review GitHub PR #1870 after review-fix commit 43e13f0f2", "actor": "claude", "mode_of_work": "task_execution", "governance_context_hash": "6fc8a5b10f051169", "governance_context_available": true, "started_at": "2026-06-12T09:17:12.666569+00:00"}
+{"event": "completed", "invocation_id": "01KTXHY031TVK8JPXW249HJBQG", "completed_at": "2026-06-12T09:17:54.623764+00:00", "outcome": "done", "closed_by": "agent"}

--- a/kitty-ops/01KTXHY0JHJ1DZMDPWAYNPWGXY.jsonl
+++ b/kitty-ops/01KTXHY0JHJ1DZMDPWAYNPWGXY.jsonl
@@ -1,0 +1,2 @@
+{"event": "started", "invocation_id": "01KTXHY0JHJ1DZMDPWAYNPWGXY", "profile_id": "architect-alphonso", "action": "audit", "request_text": "Re-review GitHub PR #1870 after review-fix commit 43e13f0f2", "actor": "claude", "mode_of_work": "task_execution", "governance_context_hash": "07efa4b800c77a5b", "governance_context_available": true, "started_at": "2026-06-12T09:17:13.170957+00:00"}
+{"event": "completed", "invocation_id": "01KTXHY0JHJ1DZMDPWAYNPWGXY", "completed_at": "2026-06-12T09:17:47.743029+00:00", "outcome": "done", "closed_by": "agent"}

--- a/src/specify_cli/core/loopback_http.py
+++ b/src/specify_cli/core/loopback_http.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from http.server import HTTPServer
-from typing import Any
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlunsplit
 
+__all__ = [
+    "build_loopback_base_url",
+    "build_loopback_url",
+    "create_loopback_server",
+    "serve_loopback_server",
+]
+
 LOOPBACK_HOST = "127.0.0.1"
+
+
+def build_loopback_base_url(port: int) -> str:
+    """Return the loopback origin (no trailing slash) for path concatenation."""
+    return f"http://{LOOPBACK_HOST}:{port}"
 
 
 def build_loopback_url(port: int, path: str) -> str:
@@ -18,7 +28,7 @@ def build_loopback_url(port: int, path: str) -> str:
 
 def create_loopback_server(
     port: int,
-    handler_class: type[Any],
+    handler_class: type[BaseHTTPRequestHandler],
     *,
     server_factory: type[HTTPServer] = HTTPServer,
 ) -> HTTPServer:
@@ -28,17 +38,10 @@ def create_loopback_server(
 
 def serve_loopback_server(
     port: int,
-    handler_class: type[Any],
+    handler_class: type[BaseHTTPRequestHandler],
     *,
-    on_bound: Callable[[HTTPServer], None] | None = None,
-    poll_interval: float | None = None,
     server_factory: type[HTTPServer] = HTTPServer,
 ) -> None:
     """Create, bind, and serve a loopback-only HTTP server forever."""
     server = create_loopback_server(port, handler_class, server_factory=server_factory)
-    if on_bound is not None:
-        on_bound(server)
-    if poll_interval is None:
-        server.serve_forever()
-        return
-    server.serve_forever(poll_interval=poll_interval)
+    server.serve_forever()

--- a/src/specify_cli/dashboard/server.py
+++ b/src/specify_cli/dashboard/server.py
@@ -11,7 +11,7 @@ import threading
 from pathlib import Path
 from typing import Optional, Tuple
 
-from specify_cli.loopback_http import create_loopback_server, serve_loopback_server
+from specify_cli.core.loopback_http import create_loopback_server, serve_loopback_server
 
 from .handlers.router import DashboardRouter
 

--- a/src/specify_cli/dashboard/server.py
+++ b/src/specify_cli/dashboard/server.py
@@ -8,9 +8,10 @@ import subprocess
 import sys
 import textwrap
 import threading
-from http.server import HTTPServer
 from pathlib import Path
 from typing import Optional, Tuple
+
+from specify_cli.loopback_http import create_loopback_server, serve_loopback_server
 
 from .handlers.router import DashboardRouter
 
@@ -71,8 +72,7 @@ def run_dashboard_server(project_dir: Path, port: int, project_token: str | None
         logger.warning("Global sync daemon check failed: %s", exc)
 
     handler_class = _build_handler_class(project_dir, project_token)
-    server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
-    server.serve_forever()
+    serve_loopback_server(port, handler_class)
 
 
 def _background_script(project_dir: Path, port: int, project_token: str | None) -> str:
@@ -129,7 +129,7 @@ def start_dashboard(
         return port, proc.pid
 
     handler_class = _build_handler_class(project_dir_abs, project_token)
-    server = HTTPServer(('127.0.0.1', port), handler_class)  # NOSONAR -- dashboard control plane binds to localhost only
+    server = create_loopback_server(port, handler_class)
 
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/src/specify_cli/loopback_http.py
+++ b/src/specify_cli/loopback_http.py
@@ -1,0 +1,44 @@
+"""Loopback-only HTTP helpers for local control planes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from http.server import HTTPServer
+from typing import Any
+from urllib.parse import urlunsplit
+
+LOOPBACK_HOST = "127.0.0.1"
+
+
+def build_loopback_url(port: int, path: str) -> str:
+    """Return an HTTP URL scoped to the IPv4 loopback interface."""
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    return urlunsplit(("http", f"{LOOPBACK_HOST}:{port}", normalized_path, "", ""))
+
+
+def create_loopback_server(
+    port: int,
+    handler_class: type[Any],
+    *,
+    server_factory: type[HTTPServer] = HTTPServer,
+) -> HTTPServer:
+    """Create a loopback-bound HTTP server with an explicit binding contract."""
+    return server_factory((LOOPBACK_HOST, port), handler_class)
+
+
+def serve_loopback_server(
+    port: int,
+    handler_class: type[Any],
+    *,
+    on_bound: Callable[[HTTPServer], None] | None = None,
+    poll_interval: float | None = None,
+    server_factory: type[HTTPServer] = HTTPServer,
+) -> None:
+    """Create, bind, and serve a loopback-only HTTP server forever."""
+    server = create_loopback_server(port, handler_class, server_factory=server_factory)
+    if on_bound is not None:
+        on_bound(server)
+    if poll_interval is None:
+        server.serve_forever()
+        return
+    server.serve_forever(poll_interval=poll_interval)

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 import psutil  # type: ignore[import-untyped]
 
 from specify_cli.core.atomic import atomic_write
+from specify_cli.loopback_http import build_loopback_url, create_loopback_server
 from specify_cli.sync.diagnostics import SyncDiagnosticCode, emit_sync_diagnostic
 
 logger = logging.getLogger(__name__)
@@ -280,7 +281,7 @@ def _loopback_health_url(port: int) -> str:
 
 
 def _check_sync_daemon_health(port: int, expected_token: str | None, timeout: float = 0.5) -> bool:
-    data = _fetch_health_payload(_loopback_health_url(port), timeout=timeout)
+    data = _fetch_health_payload(build_loopback_url(port, "/api/health"), timeout=timeout)
     if not data:
         return False
     if data.get("status") != "ok":
@@ -293,7 +294,7 @@ def _check_sync_daemon_health(port: int, expected_token: str | None, timeout: fl
 
 def _daemon_version_matches(port: int, expected_token: str | None, timeout: float = 0.5) -> bool:
     """Return True if the running daemon reports the current protocol + package version."""
-    data = _fetch_health_payload(_loopback_health_url(port), timeout=timeout)
+    data = _fetch_health_payload(build_loopback_url(port, "/api/health"), timeout=timeout)
     if not data:
         return False
     if data.get("status") != "ok":
@@ -683,7 +684,7 @@ def run_sync_daemon(port: int, daemon_token: str | None) -> None:
         (SyncDaemonHandler,),
         {"daemon_token": daemon_token},
     )
-    server = HTTPServer(("127.0.0.1", port), handler_class)  # NOSONAR -- sync daemon control plane binds to localhost only
+    server = create_loopback_server(port, handler_class)
 
     # Bind succeeded — record ownership BEFORE accepting traffic so any
     # health probe that arrives in the first scheduling slice already sees

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -47,10 +47,14 @@ else:  # pragma: no cover - platform-specific
 if TYPE_CHECKING:
     from specify_cli.sync.config import SyncConfig
 
-import psutil  # type: ignore[import-untyped]
+import psutil
 
 from specify_cli.core.atomic import atomic_write
-from specify_cli.loopback_http import build_loopback_url, create_loopback_server
+from specify_cli.core.loopback_http import (
+    build_loopback_base_url,
+    build_loopback_url,
+    create_loopback_server,
+)
 from specify_cli.sync.diagnostics import SyncDiagnosticCode, emit_sync_diagnostic
 
 logger = logging.getLogger(__name__)
@@ -273,11 +277,6 @@ def _fetch_health_payload(health_url: str, timeout: float = 0.5) -> dict[str, An
         return None
 
     return data if isinstance(data, dict) else None
-
-
-def _loopback_health_url(port: int) -> str:
-    """Return the localhost-only daemon health endpoint."""
-    return f"http://127.0.0.1:{port}/api/health"  # NOSONAR -- loopback-only control-plane URL, never exposed off-host
 
 
 def _check_sync_daemon_health(port: int, expected_token: str | None, timeout: float = 0.5) -> bool:
@@ -790,11 +789,11 @@ def get_sync_daemon_status(timeout: float = 0.5) -> SyncDaemonStatus:
     if port is None:
         return SyncDaemonStatus(healthy=False, url=url, token=token, pid=pid)
 
-    data = _fetch_health_payload(_loopback_health_url(port), timeout=timeout)
+    data = _fetch_health_payload(build_loopback_url(port, "/api/health"), timeout=timeout)
     if not data:
         return SyncDaemonStatus(
             healthy=False,
-            url=url or f"http://127.0.0.1:{port}",
+            url=url or build_loopback_base_url(port),
             port=port,
             token=token,
             pid=pid,
@@ -810,7 +809,7 @@ def get_sync_daemon_status(timeout: float = 0.5) -> SyncDaemonStatus:
     websocket_status = str(data.get("websocket_status") or "Offline")
     return SyncDaemonStatus(
         healthy=healthy,
-        url=url or f"http://127.0.0.1:{port}",
+        url=url or build_loopback_base_url(port),
         port=port,
         token=token,
         pid=pid,
@@ -1034,7 +1033,7 @@ def _ensure_sync_daemon_running_locked(
     token = secrets.token_hex(16)
 
     proc = _spawn_sync_daemon_process(port, token)
-    url = f"http://127.0.0.1:{port}"
+    url = build_loopback_base_url(port)
 
     # Wait up to ~20s for the daemon to become healthy (matching dashboard pattern)
     retry_delays = _bounded_retry_delays(
@@ -1096,11 +1095,11 @@ def _reuse_or_cleanup_existing_daemon() -> tuple[str, int, bool] | None:
             existing_token,
             timeout=_STARTUP_HEALTH_TIMEOUT_SECONDS,
         ):
-            return existing_url or f"http://127.0.0.1:{existing_port}", existing_port, False
+            return existing_url or build_loopback_base_url(existing_port), existing_port, False
 
         logger.info("Recycling sync daemon (version mismatch)")
         _stop_daemon_by_http(
-            existing_url or f"http://127.0.0.1:{existing_port}", existing_token
+            existing_url or build_loopback_base_url(existing_port), existing_token
         )
         _kill_and_cleanup(existing_pid)
         return None
@@ -1135,6 +1134,7 @@ def _spawn_sync_daemon_process(port: int, token: str) -> subprocess.Popen[str]:
         stderr=log_fh,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
+        text=True,
         env={**os.environ, "SPEC_KITTY_CLI_VERSION": _get_package_version()},
     )
     log_fh.close()
@@ -1172,7 +1172,7 @@ def stop_sync_daemon(timeout: float = 5.0) -> tuple[bool, str]:
             return True, "Unhealthy sync daemon metadata has been cleared."
         return True, "Unhealthy sync daemon process stopped. Metadata has been cleared."
 
-    _stop_daemon_by_http(url or f"http://127.0.0.1:{port}", token)
+    _stop_daemon_by_http(url or build_loopback_base_url(port), token)
 
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/tests/core/test_loopback_http.py
+++ b/tests/core/test_loopback_http.py
@@ -1,0 +1,82 @@
+"""Direct coverage for the loopback-only HTTP helpers.
+
+These tests pin the security-relevant invariant of the module: every server
+it produces binds the IPv4 loopback interface, with no way for a caller to
+widen the bind address.
+"""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from specify_cli.core.loopback_http import (
+    LOOPBACK_HOST,
+    build_loopback_base_url,
+    build_loopback_url,
+    create_loopback_server,
+    serve_loopback_server,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+class _RecordingServer(HTTPServer):
+    """Records the bind address and serve_forever calls without binding a socket."""
+
+    instances: list[_RecordingServer] = []
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        handler_class: type[BaseHTTPRequestHandler],
+    ) -> None:
+        self.bound_address = server_address
+        self.handler_class = handler_class
+        self.serve_forever_calls: list[float | None] = []
+        _RecordingServer.instances.append(self)
+        # Intentionally skip HTTPServer.__init__ so no real socket is bound.
+
+    def serve_forever(self, poll_interval: float = 0.5) -> None:
+        self.serve_forever_calls.append(poll_interval)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    pass
+
+
+def setup_function() -> None:
+    _RecordingServer.instances.clear()
+
+
+def test_build_loopback_url_uses_loopback_host_and_given_path() -> None:
+    assert build_loopback_url(8123, "/api/health") == "http://127.0.0.1:8123/api/health"
+
+
+def test_build_loopback_url_normalizes_missing_leading_slash() -> None:
+    assert build_loopback_url(8123, "api/health") == "http://127.0.0.1:8123/api/health"
+
+
+def test_build_loopback_base_url_has_no_trailing_slash() -> None:
+    assert build_loopback_base_url(9999) == "http://127.0.0.1:9999"
+
+
+def test_create_loopback_server_binds_loopback_only() -> None:
+    server = create_loopback_server(8123, _Handler, server_factory=_RecordingServer)
+
+    assert isinstance(server, _RecordingServer)
+    assert server.bound_address == (LOOPBACK_HOST, 8123)
+    assert server.bound_address[0] == "127.0.0.1"
+    assert server.handler_class is _Handler
+    assert server.serve_forever_calls == []
+
+
+def test_serve_loopback_server_binds_loopback_and_serves_forever() -> None:
+    serve_loopback_server(8124, _Handler, server_factory=_RecordingServer)
+
+    assert len(_RecordingServer.instances) == 1
+    server = _RecordingServer.instances[0]
+    assert server.bound_address == ("127.0.0.1", 8124)
+    assert server.handler_class is _Handler
+    assert len(server.serve_forever_calls) == 1

--- a/tests/sync/test_daemon_self_retirement.py
+++ b/tests/sync/test_daemon_self_retirement.py
@@ -282,7 +282,7 @@ class TestRunSyncDaemonWiring:
             servers.append(self)
 
         FakeServer.__init__ = init_capture  # type: ignore[assignment]
-        monkeypatch.setattr(daemon, "HTTPServer", FakeServer)
+        monkeypatch.setattr(daemon, "create_loopback_server", lambda *_args, **_kwargs: FakeServer(None, None))
 
         # Stub get_runtime so the import does not pull the real sync layer.
         fake_runtime_module = MagicMock()

--- a/tests/test_dashboard/test_server.py
+++ b/tests/test_dashboard/test_server.py
@@ -53,7 +53,7 @@ def test_start_dashboard_foreground_starts_thread(monkeypatch, tmp_path):
             self.started = True
             self._target()
 
-    monkeypatch.setattr(server, "HTTPServer", FakeServer)
+    monkeypatch.setattr(server, "create_loopback_server", lambda *_args, **_kwargs: FakeServer())
     monkeypatch.setattr(server.threading, "Thread", FakeThread)
 
     port, pid = server.start_dashboard(tmp_path, port=12346, background_process=False)
@@ -65,19 +65,16 @@ def test_start_dashboard_foreground_starts_thread(monkeypatch, tmp_path):
 def test_run_dashboard_server_bootstraps_global_sync_daemon(monkeypatch, tmp_path):
     calls = {}
 
-    class FakeServer:
-        def __init__(self, *_args, **_kwargs):
-            calls["created"] = True
-
-        def serve_forever(self):
-            calls["served"] = True
-
     def fake_ensure_sync_daemon_running(*, intent):
         calls["daemon"] = True
         calls["intent"] = intent
         return SimpleNamespace(skipped_reason="intent_local_only")
 
-    monkeypatch.setattr(server, "HTTPServer", FakeServer)
+    def fake_serve_loopback_server(*_args, **_kwargs):
+        calls["created"] = True
+        calls["served"] = True
+
+    monkeypatch.setattr(server, "serve_loopback_server", fake_serve_loopback_server)
     monkeypatch.setattr("specify_cli.sync.daemon.ensure_sync_daemon_running", fake_ensure_sync_daemon_running)
 
     server.run_dashboard_server(tmp_path, 12347, None)

--- a/tests/test_dashboard/test_server.py
+++ b/tests/test_dashboard/test_server.py
@@ -70,9 +70,9 @@ def test_run_dashboard_server_bootstraps_global_sync_daemon(monkeypatch, tmp_pat
         calls["intent"] = intent
         return SimpleNamespace(skipped_reason="intent_local_only")
 
-    def fake_serve_loopback_server(*_args, **_kwargs):
-        calls["created"] = True
-        calls["served"] = True
+    def fake_serve_loopback_server(port, handler_class, **_kwargs):
+        calls["served_port"] = port
+        calls["handler_class"] = handler_class
 
     monkeypatch.setattr(server, "serve_loopback_server", fake_serve_loopback_server)
     monkeypatch.setattr("specify_cli.sync.daemon.ensure_sync_daemon_running", fake_ensure_sync_daemon_running)
@@ -81,4 +81,5 @@ def test_run_dashboard_server_bootstraps_global_sync_daemon(monkeypatch, tmp_pat
 
     assert calls["daemon"] is True
     assert calls["intent"].value == "local_only"
-    assert calls["served"] is True
+    assert calls["served_port"] == 12347
+    assert calls["handler_class"] is not None


### PR DESCRIPTION
## Summary
- centralize loopback-only HTTP server/url setup in `specify_cli.loopback_http`
- switch dashboard and sync daemon control planes to the helper
- fold the nested daemon token check Sonar smell and update targeted tests

## Findings addressed
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- Nightly SonarCloud run: [27329928747](https://github.com/Priivacy-ai/spec-kitty/actions/runs/27329928747) failed on June 11, 2026 due to `new_coverage` 68.8% and `new_security_hotspots_reviewed` 0.0 on `main`
- This PR addresses the actionable loopback-control-plane code paths behind the remaining Sonar hotspots without adding suppressions

## Validation
- `.venv/bin/pytest tests/test_dashboard/test_server.py`
- `.venv/bin/pytest tests/sync/test_daemon_self_retirement.py -k serve_forever_exits_cleanly_when_server_shutdown`
- `.venv/bin/ruff check src/specify_cli/loopback_http.py src/specify_cli/dashboard/server.py src/specify_cli/sync/daemon.py tests/test_dashboard/test_server.py tests/sync/test_daemon_self_retirement.py`

## Residual
- SonarCloud hotspot review state on `main` is server-side metadata, so the nightly `main` gate can still require manual Sonar re-analysis/review even after this code lands.