### PR TITLE
chore(ops): publish governed review Op records for PRs #1869/#1870

### DIFF
--- a/kitty-ops/01KTXB9DFB1SA8XYTB3NP4GQ52.jsonl
+++ b/kitty-ops/01KTXB9DFB1SA8XYTB3NP4GQ52.jsonl
@@ -1,0 +1,2 @@
+{"event": "started", "invocation_id": "01KTXB9DFB1SA8XYTB3NP4GQ52", "profile_id": "architect-alphonso", "action": "audit", "request_text": "Review GitHub PR #1869 (suppress localhost-only Sonar HTTP hotspots) and report findings", "actor": "claude", "mode_of_work": "task_execution", "governance_context_hash": "07efa4b800c77a5b", "governance_context_available": true, "started_at": "2026-06-12T07:21:07.177675+00:00"}
+{"event": "completed", "invocation_id": "01KTXB9DFB1SA8XYTB3NP4GQ52", "completed_at": "2026-06-12T07:22:41.613462+00:00", "outcome": "done", "closed_by": "agent"}

--- a/kitty-ops/01KTXB9DGHN984CREZS5JJPC3C.jsonl
+++ b/kitty-ops/01KTXB9DGHN984CREZS5JJPC3C.jsonl
@@ -1,0 +1,2 @@
+{"event": "started", "invocation_id": "01KTXB9DGHN984CREZS5JJPC3C", "profile_id": "reviewer-renata", "action": "audit", "request_text": "Review GitHub PR #1869 (suppress localhost-only Sonar HTTP hotspots) and report findings", "actor": "claude", "mode_of_work": "task_execution", "governance_context_hash": "6fc8a5b10f051169", "governance_context_available": true, "started_at": "2026-06-12T07:21:07.180552+00:00"}
+{"event": "completed", "invocation_id": "01KTXB9DGHN984CREZS5JJPC3C", "completed_at": "2026-06-12T07:23:02.953675+00:00", "outcome": "done", "closed_by": "agent"}

--- a/kitty-ops/01KTXBBAR63Q3VP3EKWWHE7BSC.jsonl
+++ b/kitty-ops/01KTXBBAR63Q3VP3EKWWHE7BSC.jsonl
@@ -1,0 +1,2 @@
+{"event": "started", "invocation_id": "01KTXBBAR63Q3VP3EKWWHE7BSC", "profile_id": "architect-alphonso", "action": "audit", "request_text": "Review GitHub PR #1870 (harden loopback control-plane helpers) and report findings", "actor": "claude", "mode_of_work": "task_execution", "governance_context_hash": "07efa4b800c77a5b", "governance_context_available": true, "started_at": "2026-06-12T07:22:09.561615+00:00"}
+{"event": "completed", "invocation_id": "01KTXBBAR63Q3VP3EKWWHE7BSC", "completed_at": "2026-06-12T07:24:06.477653+00:00", "outcome": "done", "closed_by": "agent"}

--- a/kitty-ops/01KTXBBCHP9EH08GA9WE6DJ9A7.jsonl
+++ b/kitty-ops/01KTXBBCHP9EH08GA9WE6DJ9A7.jsonl
@@ -1,0 +1,2 @@
+{"event": "started", "invocation_id": "01KTXBBCHP9EH08GA9WE6DJ9A7", "profile_id": "reviewer-renata", "action": "audit", "request_text": "Review GitHub PR #1870 (harden loopback control-plane helpers) and report findings", "actor": "claude", "mode_of_work": "task_execution", "governance_context_hash": "6fc8a5b10f051169", "governance_context_available": true, "started_at": "2026-06-12T07:22:11.533094+00:00"}
+{"event": "completed", "invocation_id": "01KTXBBCHP9EH08GA9WE6DJ9A7", "completed_at": "2026-06-12T07:25:14.179973+00:00", "outcome": "done", "closed_by": "agent"}


### PR DESCRIPTION
Publishes the four kitty-ops ledger records from the first-round dual-profile reviews (Reviewer Renata + Architect Alphonso) of #1869 and #1870, run via `spec-kitty do`. The re-review Op records already landed with #1870's squash merge; these four complete the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)