### PR TITLE
Improve README search positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
 <div align="center">
-    <img src="https://github.com/Priivacy-ai/spec-kitty/raw/main/media/logo_small.webp" alt="Spec Kitty Logo"/>
+    <img src="https://github.com/Priivacy-ai/spec-kitty/raw/main/media/logo_small.webp" alt="Spec Kitty logo"/>
     <h1>Spec Kitty</h1>
-    <p><strong>Spec-driven development for AI coding agents.</strong></p>
+    <p><strong>Spec-driven development for AI coding agents, multi-agent workflows, and governed software factories.</strong></p>
 </div>
 
-Spec Kitty is an open-source CLI for turning product intent into a repeatable agent workflow:
+Spec Kitty is an open-source CLI for turning product intent into a repo-native AI coding workflow:
 
 ```text
 spec -> plan -> tasks -> next -> review -> accept -> merge
 ```
 
-It keeps the important context in your repository, creates work packages that agents can execute, and uses git worktrees so implementation work can happen without constantly switching branches.
+Use it to build a governed software factory around Claude Code, Codex, Cursor, Gemini, GitHub Copilot, Windsurf, OpenCode, and other AI coding agents. Spec Kitty keeps specs, plans, work packages, acceptance criteria, review state, and merge decisions in your repository, then gives agents isolated git worktrees so implementation can happen in parallel without branch chaos.
 
 [![PyPI version](https://img.shields.io/pypi/v/spec-kitty-cli?style=flat-square&logo=pypi)](https://pypi.org/project/spec-kitty-cli/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat-square)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue?style=flat-square)](https://www.python.org/downloads/)
+
+## Software Factory, Not a Black Box
+
+Spec Kitty is for teams building software factories: repeatable inputs, clear work-package boundaries, isolated execution, visible progress, and review gates. It can support dark software factories and autonomous coding experiments, but it is deliberately not a lights-out black box by default. Humans define intent, architecture, and acceptance criteria; agents implement inside traceable worktrees; reviewers accept, reject, or merge with an audit trail.
+
+The goal is not more prompt text. The goal is a durable operating system for agentic coding where the repository remains the source of truth.
 
 ## Is It For You?
 
 Use Spec Kitty when:
 
 - AI coding sessions are losing requirements, decisions, or acceptance criteria.
-- You want specs, plans, tasks, reviews, and merge state stored in the repo.
-- Multiple agents or developers need clear work package boundaries.
+- You want specs, plans, tasks, reviews, and merge state stored in Git.
+- Multiple agents or developers need clear work-package boundaries.
+- You are running parallel Claude Code, Codex, Cursor, Copilot, Gemini, or Windsurf work and need git worktree isolation.
+- You are moving from vibe coding to a repeatable spec-driven development workflow.
 - You want a local workflow first, with optional hosted tracker and sync integrations later.
 
 It is probably overkill for one-off edits, tiny scripts, or teams that do not use Git.
@@ -34,12 +42,21 @@ It is probably overkill for one-off edits, tiny scripts, or teams that do not us
 | Start from intent | Guided `specify`, `plan`, and `tasks` workflows |
 | Keep agents aligned | Repository-native mission artifacts under `kitty-specs/` |
 | Split implementation | Work packages with lifecycle lanes such as `planned`, `in_progress`, `for_review`, `approved`, and `done` |
-| Avoid branch chaos | Isolated git worktrees under `.worktrees/` |
+| Run agents in parallel | Isolated git worktrees under `.worktrees/` |
+| Keep quality visible | Review, accept, merge, and retrospective gates |
 | See progress | Optional local kanban dashboard with `spec-kitty dashboard` |
-| Integrate agents | Slash commands or skills for common AI coding tools |
+| Integrate agents | Slash commands or skills for Claude Code, Codex, Cursor, Gemini, Copilot, Windsurf, OpenCode, and more |
 | Learn from missions | Every completed mission generates a retrospective by default. Tune via `.kittify/config.yaml#retrospective` or charter; see [how-to](docs/how-to/use-retrospective-learning.md). |
 
-## Governance layer
+## Common Use Cases
+
+- Replace ad hoc vibe coding with spec-driven development.
+- Turn GitHub issues, product requirements, or bug reports into executable work packages.
+- Coordinate multiple AI coding agents without losing context between sessions.
+- Keep architecture decisions, constraints, and acceptance criteria close to the code.
+- Build a governed software factory that can scale toward more autonomy without hiding review, test, or merge decisions.
+
+## Governed Agent Workflow
 
 Spec Kitty keeps runtime governance in the repo instead of treating it as
 agent-only prompt text. The trail model in [docs/trail-model.md](docs/trail-model.md)
@@ -47,6 +64,12 @@ describes how `spec-kitty advise`, `spec-kitty ask`, and `spec-kitty do` map
 operator intent to runtime behavior, while
 [docs/host-surface-parity.md](docs/host-surface-parity.md) tracks parity across
 CLI, slash-command, and hosted surfaces.
+
+Three primary commands drive this layer:
+
+- `spec-kitty advise` - surfaces relevant doctrine, guidelines, and warnings for the current context
+- `spec-kitty ask` - queries the knowledge base for specific guidance
+- `spec-kitty do` - executes governed actions, ensuring compliance with the trail model
 
 ## Quick Start
 
@@ -76,7 +99,7 @@ cd my-project
 spec-kitty verify-setup
 ```
 
-Replace `claude` with your agent key when needed. Common choices include `codex`, `cursor`, `gemini`, `copilot`, `opencode`, `qwen`, `windsurf`, `kiro`, `vibe`, `pi`, and `letta`.
+Replace `claude` with your agent key when needed. Common choices include `codex`, `cursor`, `gemini`, `copilot`, `opencode`, `qwen`, `windsurf`, `kiro`, `vibe`, `pi`, and `letta`. See [Supported Agents](docs/reference/supported-agents.md) for the current list.
 
 Open your AI coding agent in the project and run the core workflow:
 
@@ -109,22 +132,6 @@ autonomous facilitator), not by `merge`. Once it exists, use
 staged proposals (dry-run by default — pass `--apply` to mutate).
 
 For the full walkthrough, see [Your First Feature](docs/tutorials/your-first-feature.md).
-
-## Governance layer
-
-Spec Kitty includes a governance layer that advises, queries, and acts on your project's
-architectural conventions. Three primary commands drive this layer:
-
-- `spec-kitty advise` — surfaces relevant doctrine, guidelines, and warnings for the current context
-- `spec-kitty ask` — queries the knowledge base for specific guidance
-- `spec-kitty do` — executes governed actions, ensuring compliance with the trail model
-
-The governance layer is anchored by two key reference documents:
-
-- [Trail model](docs/trail-model.md) — defines how spec-kitty traces mission provenance and
-  decision history through the project lifecycle
-- [Host surface parity](docs/host-surface-parity.md) — describes the contract between
-  spec-kitty and the host project's agent integration surfaces
 
 ## Everyday Commands
 
@@ -159,12 +166,28 @@ Deeper topics:
 - [External Orchestrator Runbook](docs/how-to/run-external-orchestrator.md)
 - [Hosted Sync Workspaces](docs/how-to/sync-workspaces.md)
 
-Hosted auth, sync, and tracker flows remain opt-in today. Internal /
-pre-launch operators dogfooding the hidden hosted-readiness mode behind
-`SPEC_KITTY_ENABLE_SAAS_SYNC=1` should read
-[Internal Hosted-Readiness (Pre-Launch)](docs/how-to/internal-hosted-readiness.md).
-The launch-day behavior that will replace today's defaults is staged
-under [Launch-Readiness Behavior (Coming Soon)](docs/explanation/launch-readiness-future.md).
+Hosted auth, sync, and tracker flows remain opt-in. For setup details, see
+[Hosted Sync Workspaces](docs/how-to/sync-workspaces.md), [Internal
+Hosted-Readiness](docs/how-to/internal-hosted-readiness.md), and
+[Launch-Readiness Behavior](docs/explanation/launch-readiness-future.md).
+
+## FAQ
+
+### Is Spec Kitty for dark software factories?
+
+Spec Kitty can be used as part of a dark software factory or autonomous coding pipeline, but its default model is governed and human-in-loop. It keeps specs, work packages, agent actions, review decisions, and merge state visible in the repository.
+
+### Which AI coding agents does Spec Kitty support?
+
+Spec Kitty supports common AI coding agents and coding harnesses including Claude Code, Codex, Cursor, Gemini, GitHub Copilot, OpenCode, Qwen, Windsurf, Kiro, Vibe, Pi, and Letta. See [Supported Agents](docs/reference/supported-agents.md).
+
+### How is Spec Kitty different from prompt templates or Spec Kit?
+
+Spec Kitty is inspired by spec-driven development workflows, but adds repo-native mission state, work-package lanes, git worktree isolation, a local dashboard, governance commands, and an explicit `next -> review -> accept -> merge` runtime loop.
+
+### Does Spec Kitty require a SaaS service?
+
+No. Spec Kitty is local-first and stores its core artifacts in your repo. Hosted tracker and sync integrations are optional.
 
 ## Development
 
@@ -185,37 +208,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 ## Identity-Boundary CI Gate
 
-The `drift-detector` required check runs
-`tests/sync/test_diagnose.py::TestCanonicalRegistryRecognition` on every PR
-against `main`. It catches drift between the canonical registries in this
-repo and the consumer-recognition contract that
-`spec-kitty-end-to-end-testing#41` closed over an 8-RC peeling cycle
-(rc14 → rc22). Workflow file:
-[`.github/workflows/drift-detector.yml`](.github/workflows/drift-detector.yml).
-
-This is one of three coordinated CI gates tracked under
-[`#1247`](https://github.com/Priivacy-ai/spec-kitty/issues/1247):
-
-- `drift-detector` here (this repo).
-- `cross-repo-harness-tests` in [`spec-kitty-events`](https://github.com/Priivacy-ai/spec-kitty-events) — workflow `.github/workflows/cross-repo-harness-tests.yml`.
-- `identity-boundary-canary` in [`spec-kitty-saas`](https://github.com/Priivacy-ai/spec-kitty-saas) — workflow `.github/workflows/canary-gate.yml`.
-
-This repo's drift-detector pins no external SHA — it only runs an in-repo
-test. The sibling repos' workflows pin a specific commit of
-`Priivacy-ai/spec-kitty-end-to-end-testing`; see each sibling's README
-"Identity-Boundary CI Gate" section for the SHA-bump procedure.
-
-**Admin action required (one-time per repo)**: after this gate merges, a
-repo admin must register the check as required on `main`:
-
-1. Open https://github.com/Priivacy-ai/spec-kitty/settings/branches.
-2. Edit the rule for `main`.
-3. Under "Require status checks to pass before merging", add the exact
-   name `drift-detector`.
-4. Save.
-
-Until that step is done, the workflow still runs on every PR but its
-red status does not block merge.
+The `drift-detector` required check protects the shared identity-boundary
+contract across Spec Kitty repos. Contributor and admin details live in
+[Identity-Boundary CI Gate](docs/development/identity-boundary-ci-gate.md).
 
 ## Support
 

--- a/docs/development/identity-boundary-ci-gate.md
+++ b/docs/development/identity-boundary-ci-gate.md
@@ -1,0 +1,35 @@
+# Identity-Boundary CI Gate
+
+The `drift-detector` required check runs
+`tests/sync/test_diagnose.py::TestCanonicalRegistryRecognition` on every PR
+against `main`. It catches drift between the canonical registries in this
+repo and the consumer-recognition contract that
+`spec-kitty-end-to-end-testing#41` closed over an 8-RC peeling cycle
+(rc14 -> rc22). Workflow file:
+[`.github/workflows/drift-detector.yml`](../../.github/workflows/drift-detector.yml).
+
+This is one of three coordinated CI gates tracked under
+[`#1247`](https://github.com/Priivacy-ai/spec-kitty/issues/1247):
+
+- `drift-detector` here (this repo).
+- `cross-repo-harness-tests` in [`spec-kitty-events`](https://github.com/Priivacy-ai/spec-kitty-events) - workflow `.github/workflows/cross-repo-harness-tests.yml`.
+- `identity-boundary-canary` in [`spec-kitty-saas`](https://github.com/Priivacy-ai/spec-kitty-saas) - workflow `.github/workflows/canary-gate.yml`.
+
+This repo's drift-detector pins no external SHA. It only runs an in-repo
+test. The sibling repos' workflows pin a specific commit of
+`Priivacy-ai/spec-kitty-end-to-end-testing`; see each sibling's README
+`Identity-Boundary CI Gate` section for the SHA-bump procedure.
+
+## Admin Action
+
+After this gate merges, a repo admin must register the check as required on
+`main`:
+
+1. Open https://github.com/Priivacy-ai/spec-kitty/settings/branches.
+1. Edit the rule for `main`.
+1. Under "Require status checks to pass before merging", add the exact name
+   `drift-detector`.
+1. Save.
+
+Until that step is done, the workflow still runs on every PR but its red
+status does not block merge.


### PR DESCRIPTION
## Summary
- Reposition README intro around spec-driven development, AI coding agents, software factories, and dark software factory differentiation
- Add use cases and FAQ for GitHub/Google search intent around Claude Code, Codex, Cursor, Copilot, Gemini, worktrees, review gates, and vibe coding
- Move detailed Identity-Boundary CI Gate admin notes into docs/development while keeping a short README pointer

## Validation
- git diff --check

## Notes
- Repository description/topics still need to be updated in GitHub settings; they are not represented in this PR.