### PR TITLE
fix(upgrade): record not-applicable migrations once (#1872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **Upgrade no longer re-records not-applicable migrations (issue #1872):** a migration whose `detect()`
+  is `False` was re-appended as a `skipped` / "Not applicable" `MigrationRecord` on every `spec-kitty upgrade`
+  run over the same version range, growing `applied_migrations` without bound and — for worktrees, after
+  #1857 — bumping `last_upgraded_at` on no-op runs. `ProjectMetadata.record_migration()` is now idempotent
+  (an identical `(id, result)` record is not re-appended) and the worktree upgrade path only marks metadata
+  dirty when a new record was actually written, restoring stable `last_upgraded_at` for no-op re-runs. A
+  genuine `failed → success` transition still records the new result.
 - **Coordination & Merge stabilization (mission 131; closes #1826, #1861 Part 1, residuals of #1833/#1814/#1736/#1735):**
   merge-pipeline ref advances now resync any worktree checked out on the advanced branch (shared
   `git/ref_advance.py` helper with a no-raw-`update-ref` architectural ratchet), refusing loudly — never

--- a/src/specify_cli/upgrade/metadata.py
+++ b/src/specify_cli/upgrade/metadata.py
@@ -189,14 +189,32 @@ class ProjectMetadata:
         """
         return any(m.id == migration_id and m.result == "success" for m in self.applied_migrations)
 
-    def record_migration(self, migration_id: str, result: str, notes: str | None = None) -> None:
+    def record_migration(self, migration_id: str, result: str, notes: str | None = None) -> bool:
         """Record a migration application.
+
+        Recording is idempotent: if an identical ``(migration_id, result)``
+        record already exists, this is a no-op. Without this, a migration whose
+        ``detect()`` is ``False`` is re-recorded as ``skipped`` / "Not
+        applicable" on *every* upgrade run over the same version range, growing
+        ``applied_migrations`` without bound and churning timestamps (issue
+        #1872). A genuine result transition (e.g. a previously ``failed``
+        migration that now succeeds) carries a different ``result`` and is
+        still appended.
 
         Args:
             migration_id: The ID of the migration
             result: The result ("success", "skipped", "failed")
             notes: Optional notes about the migration
+
+        Returns:
+            ``True`` if a new record was appended; ``False`` if an identical
+            record already existed and the call was a no-op.
         """
+        if any(
+            m.id == migration_id and m.result == result
+            for m in self.applied_migrations
+        ):
+            return False
         self.applied_migrations.append(
             MigrationRecord(
                 id=migration_id,
@@ -205,3 +223,4 @@ class ProjectMetadata:
                 notes=notes,
             )
         )
+        return True

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -319,14 +319,16 @@ class MigrationRunner:
                     continue
 
                 if not migration.detect(worktree):
-                    if not dry_run:
-                        self._record_migration_result(
-                            wt_metadata,
-                            wt_kittify,
-                            migration.migration_id,
-                            "skipped",
-                            "Not applicable",
-                        )
+                    # Only mark dirty when a NEW record was written; an
+                    # already-recorded "skipped" migration is a no-op and must
+                    # not bump last_upgraded_at on every re-run (issue #1872).
+                    if not dry_run and self._record_migration_result(
+                        wt_metadata,
+                        wt_kittify,
+                        migration.migration_id,
+                        "skipped",
+                        "Not applicable",
+                    ):
                         worktree_metadata_dirty = True
                     continue
 
@@ -340,14 +342,13 @@ class MigrationRunner:
                 migration_result = migration.apply(worktree, dry_run=dry_run)
 
                 if migration_result.success:
-                    if not dry_run:
-                        self._record_migration_result(
-                            wt_metadata,
-                            wt_kittify,
-                            migration.migration_id,
-                            "success",
-                            "; ".join(migration_result.changes_made) if migration_result.changes_made else None,
-                        )
+                    if not dry_run and self._record_migration_result(
+                        wt_metadata,
+                        wt_kittify,
+                        migration.migration_id,
+                        "success",
+                        "; ".join(migration_result.changes_made) if migration_result.changes_made else None,
+                    ):
                         worktree_metadata_dirty = True
                     result["warnings"].extend([f"Worktree {worktree.name}: {w}" for w in migration_result.warnings])
                 else:
@@ -407,10 +408,18 @@ class MigrationRunner:
         migration_id: str,
         result: str,
         notes: str | None = None,
-    ) -> None:
-        """Persist each migration record immediately for crash/failure recovery."""
-        metadata.record_migration(migration_id, result, notes)
-        metadata.save(metadata_dir)
+    ) -> bool:
+        """Persist each migration record immediately for crash/failure recovery.
+
+        Returns ``True`` when a new record was written. An idempotent no-op
+        (the record already existed) returns ``False`` and skips the save, so
+        callers can avoid bumping ``last_upgraded_at`` on a re-run that recorded
+        nothing new (issue #1872 / #1838).
+        """
+        recorded = metadata.record_migration(migration_id, result, notes)
+        if recorded:
+            metadata.save(metadata_dir)
+        return recorded
 
     @staticmethod
     def _stamp_schema_version(kittify_dir: Path, schema_version: int) -> None:

--- a/tests/upgrade/test_runner_status_classification.py
+++ b/tests/upgrade/test_runner_status_classification.py
@@ -252,3 +252,96 @@ def test_upgrade_persists_successful_migrations_before_later_failure(
     assert metadata is not None
     assert metadata.has_migration(first.migration_id)
     assert any(record.id == second.migration_id and record.result == "failed" for record in metadata.applied_migrations)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1872: not-applicable ("skipped") migrations must be recorded once,
+# not re-appended on every upgrade run over the same version range.
+# ---------------------------------------------------------------------------
+
+
+def test_record_migration_is_idempotent_for_identical_records() -> None:
+    """Recording the same (id, result) twice is a no-op (issue #1872)."""
+    metadata = ProjectMetadata(version="1.0.0", initialized_at=datetime.now())
+
+    first = metadata.record_migration("9.9.9_not_needed", "skipped", "Not applicable")
+    second = metadata.record_migration("9.9.9_not_needed", "skipped", "Not applicable")
+
+    assert first is True
+    assert second is False
+    assert len([m for m in metadata.applied_migrations if m.id == "9.9.9_not_needed"]) == 1
+
+
+def test_record_migration_appends_on_result_transition() -> None:
+    """A genuine failed -> success transition still appends (issue #1872)."""
+    metadata = ProjectMetadata(version="1.0.0", initialized_at=datetime.now())
+
+    assert metadata.record_migration("10.0.0_x", "failed", "boom") is True
+    assert metadata.record_migration("10.0.0_x", "success", "fixed") is True
+
+    results = [m.result for m in metadata.applied_migrations if m.id == "10.0.0_x"]
+    assert results == ["failed", "success"]
+    assert metadata.has_migration("10.0.0_x") is True
+
+
+def test_repeated_not_needed_upgrade_does_not_grow_applied_migrations(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Re-running an upgrade with a not-applicable migration records it once."""
+    project_path = _setup_project(tmp_path)
+    migration = _NotNeededMigration()
+
+    def _run() -> None:
+        runner = MigrationRunner(project_path)
+        monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+            lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+        )
+        runner.upgrade("9.9.9", include_worktrees=False)
+
+    _run()
+    _run()
+
+    metadata = ProjectMetadata.load(project_path / ".kittify")
+    assert metadata is not None
+    skipped = [m for m in metadata.applied_migrations if m.id == migration.migration_id]
+    assert len(skipped) == 1
+    assert skipped[0].result == "skipped"
+
+
+def test_worktree_skipped_migration_keeps_last_upgraded_at_stable_on_rerun(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A no-op skipped re-run must not bump the worktree's last_upgraded_at (issue #1872)."""
+    project_path = _setup_project(tmp_path)
+    worktree = project_path / ".worktrees" / "001-feature-lane-a"
+    (worktree / ".kittify").mkdir(parents=True)
+    ProjectMetadata(version="1.0.0", initialized_at=datetime.now()).save(worktree / ".kittify")
+    migration = _NotNeededMigration()
+
+    def _run() -> None:
+        runner = MigrationRunner(project_path)
+        monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+            lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+        )
+        runner.upgrade("9.9.9", include_worktrees=True)
+
+    _run()
+    wt_kittify = worktree / ".kittify"
+    after_first = ProjectMetadata.load(wt_kittify)
+    assert after_first is not None
+    stamp_first = after_first.last_upgraded_at
+
+    _run()
+    after_second = ProjectMetadata.load(wt_kittify)
+    assert after_second is not None
+
+    # Exactly one skipped record, and the timestamp did not move on the no-op re-run.
+    skipped = [m for m in after_second.applied_migrations if m.id == migration.migration_id]
+    assert len(skipped) == 1
+    assert after_second.last_upgraded_at == stamp_first


### PR DESCRIPTION
## Summary

Fixes **#1872**: `spec-kitty upgrade` re-recorded not-applicable migrations as `skipped` / "Not applicable" on **every** run over the same version range, growing `applied_migrations` without bound and — for worktrees, after #1857 — bumping `last_upgraded_at` on no-op runs.

## Root cause

`ProjectMetadata.has_migration()` returns `True` only for records with `result == "success"`. A migration whose `detect()` is `False` therefore never short-circuits, falls into the not-applicable branch (`upgrade/runner.py`), and appends a fresh `skipped` `MigrationRecord` on each run.

## Fix

- `ProjectMetadata.record_migration()` is now **idempotent** — an identical `(migration_id, result)` record is not re-appended — and returns whether a new record was written. A genuine `failed → success` transition carries a different `result` and is still appended.
- `_record_migration_result()` propagates that boolean and only `save()`s when a record was actually added.
- The worktree upgrade path marks `worktree_metadata_dirty` (and so moves `last_upgraded_at`) **only when a new record was written**, restoring #1857/#1838's "no-op upgrade keeps the timestamp stable" invariant for the skipped case.

The main-project path's existing `last_upgraded_at`-on-success behavior is intentionally left unchanged (out of scope for #1872); only the unbounded-growth aspect applies there and is fixed by the idempotent record.

## Tests

New regression tests in `tests/upgrade/test_runner_status_classification.py`:
- `record_migration` idempotency for identical records;
- `failed → success` still appends;
- repeated not-applicable upgrade runs append the skipped record **once**;
- worktree `last_upgraded_at` stays stable across a no-op skipped re-run.

`ruff` + `mypy` clean on changed files; full `tests/upgrade/` + `tests/specify_cli/upgrade/` suites green (676 passed).

---

Opened as **draft**; will mark ready once CI is green.
