### PR TITLE
Speed up core-misc CI shards

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -163,11 +163,13 @@ jobs:
             orchestrator_api:
               - 'src/specify_cli/orchestrator_api/**'
             core_misc:
+              - '.github/workflows/ci-quality.yml'
               - 'src/kernel/**'
               - 'src/doctrine/**'
               - 'src/specify_cli/core/**'
               - 'src/specify_cli/doctrine_synthesizer/**'
               - 'src/specify_cli/saas/**'
+              - 'tests/architectural/**'
               - 'tests/kernel/**'
               - 'tests/doctrine/**'
               - 'tests/doctrine_synthesizer/**'
@@ -175,12 +177,12 @@ jobs:
               - 'tests/core/**'
               - 'tests/contract/**'
               - 'tests/init/**'
-              - 'tests/e2e/**'
               - 'tests/integration/**'
               - 'tests/dossier/**'
               - 'tests/git_ops/**'
               - 'tests/tasks/**'
             e2e:
+              - '.github/workflows/ci-quality.yml'
               - 'tests/e2e/**'
               - 'tests/cross_cutting/**'
             charter:
@@ -1172,7 +1174,11 @@ jobs:
             --ignore=tests/runtime \
             --ignore=tests/charter \
             --ignore=tests/agent \
+            --ignore=tests/e2e \
+            --ignore=tests/cross_cutting \
             -m "fast and not windows_ci" -q --tb=short \
+            -n auto --dist loadfile \
+            --durations=50 \
             --cov=src/specify_cli \
             --cov-report=xml:out/reports/coverage/coverage-fast-core-misc.xml
       - name: "Upload fast-core-misc coverage"
@@ -1183,19 +1189,90 @@ jobs:
           path: out/reports/
 
   # ---------------------------------------------------------------------------
-  # integration-tests-core-misc: architectural + git_repo tests for execution
-  # context parity. Runs after fast-tests-core-misc passes.
+  # integration-tests-core-misc: catch-all architectural/git_repo/integration
+  # tests split by directory family so one slow bucket cannot dominate PR CI.
   # Triggered by core_misc or execution_context path filters. Execution-context
   # only changes run the parity gate instead of the full catch-all integration
   # suite so status/runtime edits do not inherit unrelated core-misc debt.
   # ---------------------------------------------------------------------------
   integration-tests-core-misc:
+    name: integration-tests-core-misc (${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: [changes, fast-tests-core-misc]
     if: >-
       always() &&
       (needs.changes.outputs.core_misc == 'true' || needs.changes.outputs.execution_context == 'true') &&
-      needs.fast-tests-core-misc.result != 'failure'
+      needs.fast-tests-core-misc.result != 'failure' &&
+      (
+        github.event_name != 'pull_request' ||
+        (
+          github.event.pull_request.draft == false &&
+          !startsWith(github.event.pull_request.title, 'WIP') &&
+          !startsWith(github.event.pull_request.title, '[WIP]')
+        ) ||
+        contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+        contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: architectural
+            paths: >-
+              tests/adversarial
+              tests/architectural
+              tests/architecture
+              tests/lint
+            ignore_args: ''
+          - shard: integration
+            paths: tests/integration
+            ignore_args: ''
+          - shard: specify-cli-heavy
+            paths: >-
+              tests/specify_cli/migration
+              tests/specify_cli/invocation
+              tests/specify_cli/test_charter_activate_cli.py
+            ignore_args: ''
+          - shard: specify-cli-rest
+            paths: tests/specify_cli
+            ignore_args: >-
+              --ignore=tests/specify_cli/migration
+              --ignore=tests/specify_cli/invocation
+              --ignore=tests/specify_cli/test_charter_activate_cli.py
+              --ignore=tests/specify_cli/status
+              --ignore=tests/specify_cli/next
+          - shard: auth-audit-git
+            paths: >-
+              tests/auth
+              tests/audit
+              tests/git_ops
+              tests/git
+              tests/cli_gate
+            ignore_args: ''
+          - shard: misc
+            paths: >-
+              tests/calibration
+              tests/concurrency
+              tests/contract
+              tests/core
+              tests/cross_branch
+              tests/docs
+              tests/doctor
+              tests/init
+              tests/migration
+              tests/mission_runtime
+              tests/packaging
+              tests/policy
+              tests/readiness
+              tests/regression
+              tests/regressions
+              tests/research
+              tests/retrospective
+              tests/saas
+              tests/stress
+              tests/tasks
+              tests/unit
+            ignore_args: ''
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.1.0
@@ -1206,44 +1283,37 @@ jobs:
       - name: "Run integration tests — core misc"
         run: |
           if [ "${{ needs.changes.outputs.core_misc }}" != "true" ] && [ "${{ needs.changes.outputs.execution_context }}" = "true" ]; then
+            if [ "${{ matrix.shard }}" != "architectural" ]; then
+              echo "Skipping ${{ matrix.shard }} for execution-context-only change."
+              exit 0
+            fi
+
             uv run python -m pytest \
               tests/architectural/test_execution_context_parity.py \
               -q --tb=short \
+              -n auto --dist loadfile \
+              --durations=50 \
               --cov=src/specify_cli \
-              --cov-report=xml:out/reports/coverage/coverage-integration-core-misc.xml
+              --cov-report=xml:out/reports/coverage/coverage-integration-core-misc-${{ matrix.shard }}.xml
             exit $?
           fi
 
           uv run python -m pytest \
-            --ignore=tests/doctrine \
-            --ignore=tests/kernel \
-            --ignore=tests/status \
-            --ignore=tests/specify_cli/status \
-            --ignore=tests/sync \
-            --ignore=tests/merge \
-            --ignore=tests/missions \
-            --ignore=tests/post_merge \
-            --ignore=tests/release \
-            --ignore=tests/review \
-            --ignore=tests/next \
-            --ignore=tests/specify_cli/next \
-            --ignore=tests/lanes \
-            --ignore=tests/test_dashboard \
-            --ignore=tests/upgrade \
-            --ignore=tests/cli \
-            --ignore=tests/runtime \
-            --ignore=tests/charter \
-            --ignore=tests/agent \
+            ${{ matrix.paths }} \
+            ${{ matrix.ignore_args }} \
             -m 'not windows_ci and (git_repo or integration or architectural)' \
             -q --tb=short \
+            -n auto --dist loadfile \
+            --durations=50 \
             --cov=src/specify_cli \
-            --cov-report=xml:out/reports/coverage/coverage-integration-core-misc.xml
+            --cov-report=xml:out/reports/coverage/coverage-integration-core-misc-${{ matrix.shard }}.xml
       - name: "Upload integration-core-misc coverage"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: integration-test-core-misc-reports
+          name: integration-test-core-misc-${{ matrix.shard }}-reports
           path: out/reports/
+          if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
   # fast-tests-charter: charter package, depends on doctrine.
@@ -1832,6 +1902,7 @@ jobs:
             -m "slow and not windows_ci" \
             --ignore=tests/e2e \
             --ignore=tests/cross_cutting \
+            --durations=50 \
             --cov=src/specify_cli --cov=src/charter --cov=src/doctrine \
             --cov-report=xml:out/reports/coverage/coverage-slow.xml \
             --junitxml=out/reports/xunit-reports/xunit-result-slow-${{ github.run_id }}.xml \
@@ -1892,28 +1963,27 @@ jobs:
   # ---------------------------------------------------------------------------
   e2e-cross-cutting:
     runs-on: ubuntu-latest
-    needs:
-      - changes
-      - fast-tests-doctrine
-      - fast-tests-sync
-      - fast-tests-merge
-      - fast-tests-missions
-      - fast-tests-post-merge
-      - fast-tests-release
-      - fast-tests-status
-      - fast-tests-review
-      - fast-tests-next
-      - fast-tests-lanes
-      - fast-tests-dashboard
-      - fast-tests-upgrade
-      - fast-tests-cli
-      - fast-tests-core-misc
-      - fast-tests-charter
-      - fast-tests-agent
+    needs: [changes]
     if: |
       always() && (
         github.event_name == 'push' ||
-        (github.event_name == 'pull_request' && needs.changes.outputs.e2e == 'true') ||
+        (
+          github.event_name == 'pull_request' &&
+          (
+            needs.changes.outputs.e2e == 'true' ||
+            needs.changes.outputs.core_misc == 'true' ||
+            needs.changes.outputs.execution_context == 'true'
+          ) &&
+          (
+            (
+              github.event.pull_request.draft == false &&
+              !startsWith(github.event.pull_request.title, 'WIP') &&
+              !startsWith(github.event.pull_request.title, '[WIP]')
+            ) ||
+            contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+            contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+          )
+        ) ||
         (github.event_name == 'workflow_dispatch' && (inputs.run_extended || inputs.run_all))
       )
     timeout-minutes: 40
@@ -1941,6 +2011,7 @@ jobs:
             -v \
             tests/e2e/ tests/cross_cutting/ \
             -m "not distribution and not windows_ci" \
+            --durations=50 \
             --cov=src/specify_cli --cov=src/charter --cov=src/doctrine \
             --cov-report=xml:out/reports/coverage/coverage-e2e.xml \
             --junitxml=out/reports/xunit-reports/xunit-result-e2e-${{ github.run_id }}.xml
@@ -2730,6 +2801,7 @@ jobs:
       - fast-tests-charter
       - fast-tests-agent
       - integration-tests-doctrine
+      - integration-tests-charter
       - integration-tests-sync
       - integration-tests-merge
       - integration-tests-missions
@@ -2744,6 +2816,7 @@ jobs:
       - integration-tests-cli
       - integration-tests-agent
       - integration-tests-core-misc
+      - e2e-cross-cutting
       - restart-daemon-nfr-timing
       - build-wheel
       - clean-install-verification
@@ -2793,6 +2866,7 @@ jobs:
             "${{ needs.integration-tests-cli.result }}" \
             "${{ needs.integration-tests-agent.result }}" \
             "${{ needs.integration-tests-core-misc.result }}" \
+            "${{ needs.e2e-cross-cutting.result }}" \
             "${{ needs.restart-daemon-nfr-timing.result }}" \
             "${{ needs.build-wheel.result }}" \
             "${{ needs.clean-install-verification.result }}" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ test = [
     "pytest-asyncio>=0.21.0",  # Required for async tests
     "pytest-cov>=4.1.0",  # Required by CI coverage flags
     "pytest-timeout>=2.2.0",  # Required by mutmut pytest_add_cli_args --timeout flag
+    "pytest-xdist>=3.8.0",  # Parallelize large CI shards with --dist loadfile
     "respx>=0.21.1",  # HTTPX mocking for auth transport tests (feature 080)
     "diff-cover>=10.0.0",  # Enforce changed-line coverage in CI
     "chardet>=3.0.4,<6",  # Pin chardet below 6.x to avoid requests compatibility warning

--- a/tests/architectural/test_ci_quality_path_filters.py
+++ b/tests/architectural/test_ci_quality_path_filters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -29,6 +31,27 @@ def _job_run_script(job_name: str, step_name: str) -> str:
         if step.get("name") == step_name
     )
     return str(step["run"])
+
+
+def _job(job_name: str) -> dict[str, object]:
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    return dict(data["jobs"][job_name])
+
+
+def _collect_nodes(args: list[str]) -> set[str]:
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-qq", *args],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.startswith("tests/") and "::" in line
+    }
 
 
 def test_missions_filter_includes_missions_package_and_tests() -> None:
@@ -104,4 +127,176 @@ def test_execution_context_only_core_misc_runs_focused_parity_gate() -> None:
     assert 'needs.changes.outputs.core_misc }}" != "true"' in run_script
     assert 'needs.changes.outputs.execution_context }}" = "true"' in run_script
     assert "tests/architectural/test_execution_context_parity.py" in run_script
-    assert "coverage-integration-core-misc.xml" in run_script
+    assert "coverage-integration-core-misc-${{ matrix.shard }}.xml" in run_script
+
+
+def test_core_misc_integration_is_sharded_and_parallelized() -> None:
+    """The slow core-misc integration bucket must stay split and parallel."""
+    job = _job("integration-tests-core-misc")
+    matrix = job["strategy"]["matrix"]["include"]  # type: ignore[index]
+    shard_names = {entry["shard"] for entry in matrix}
+
+    assert shard_names == {
+        "architectural",
+        "integration",
+        "specify-cli-heavy",
+        "specify-cli-rest",
+        "auth-audit-git",
+        "misc",
+    }
+
+    run_script = _job_run_script(
+        "integration-tests-core-misc",
+        "Run integration tests — core misc",
+    )
+    assert "-n auto --dist loadfile" in run_script
+    assert "--durations=50" in run_script
+
+
+def test_ci_quality_guards_trigger_core_misc_validation() -> None:
+    """CI workflow and architectural guard edits must run the validating shard."""
+    core_misc_filter = set(_path_filters()["core_misc"])
+    assert ".github/workflows/ci-quality.yml" in core_misc_filter
+    assert "tests/architectural/**" in core_misc_filter
+
+
+def test_core_misc_shards_plus_e2e_owner_cover_legacy_selection() -> None:
+    """The shard split must not drop tests covered by the legacy catch-all job."""
+    marker = "-m"
+    marker_expr = "not windows_ci and (git_repo or integration or architectural)"
+    legacy_nodes = _collect_nodes(
+        [
+            "--ignore=tests/doctrine",
+            "--ignore=tests/kernel",
+            "--ignore=tests/status",
+            "--ignore=tests/specify_cli/status",
+            "--ignore=tests/sync",
+            "--ignore=tests/merge",
+            "--ignore=tests/missions",
+            "--ignore=tests/post_merge",
+            "--ignore=tests/release",
+            "--ignore=tests/review",
+            "--ignore=tests/next",
+            "--ignore=tests/specify_cli/next",
+            "--ignore=tests/lanes",
+            "--ignore=tests/test_dashboard",
+            "--ignore=tests/upgrade",
+            "--ignore=tests/cli",
+            "--ignore=tests/runtime",
+            "--ignore=tests/charter",
+            "--ignore=tests/agent",
+            marker,
+            marker_expr,
+        ]
+    )
+
+    shard_commands = [
+        ["tests/adversarial", "tests/architectural", "tests/architecture", "tests/lint"],
+        ["tests/integration"],
+        [
+            "tests/specify_cli/migration",
+            "tests/specify_cli/invocation",
+            "tests/specify_cli/test_charter_activate_cli.py",
+        ],
+        [
+            "tests/specify_cli",
+            "--ignore=tests/specify_cli/migration",
+            "--ignore=tests/specify_cli/invocation",
+            "--ignore=tests/specify_cli/test_charter_activate_cli.py",
+            "--ignore=tests/specify_cli/status",
+            "--ignore=tests/specify_cli/next",
+        ],
+        ["tests/auth", "tests/audit", "tests/git_ops", "tests/git", "tests/cli_gate"],
+        [
+            "tests/calibration",
+            "tests/concurrency",
+            "tests/contract",
+            "tests/core",
+            "tests/cross_branch",
+            "tests/docs",
+            "tests/doctor",
+            "tests/init",
+            "tests/migration",
+            "tests/mission_runtime",
+            "tests/packaging",
+            "tests/policy",
+            "tests/readiness",
+            "tests/regression",
+            "tests/regressions",
+            "tests/research",
+            "tests/retrospective",
+            "tests/saas",
+            "tests/stress",
+            "tests/tasks",
+            "tests/unit",
+        ],
+    ]
+    new_nodes: set[str] = set()
+    for command in shard_commands:
+        new_nodes.update(_collect_nodes([*command, marker, marker_expr]))
+    new_nodes.update(
+        _collect_nodes(
+            [
+                "tests/e2e",
+                "tests/cross_cutting",
+                "-m",
+                "not distribution and not windows_ci",
+            ]
+        )
+    )
+
+    missing = sorted(legacy_nodes - new_nodes)
+    assert not missing, "Shard split dropped legacy core-misc tests:\n" + "\n".join(
+        missing[:20]
+    )
+
+
+def test_core_misc_excludes_e2e_and_cross_cutting_suites() -> None:
+    """E2E and cross-cutting suites belong to e2e-cross-cutting, not core-misc."""
+    path_filters = _path_filters()
+    assert "tests/e2e/**" not in path_filters["core_misc"]
+    assert "tests/cross_cutting/**" not in path_filters["core_misc"]
+    assert "tests/e2e/**" in path_filters["e2e"]
+    assert "tests/cross_cutting/**" in path_filters["e2e"]
+
+    fast_run = _job_run_script("fast-tests-core-misc", "Run fast tests — core misc")
+    assert "--ignore=tests/e2e" in fast_run
+    assert "--ignore=tests/cross_cutting" in fast_run
+
+    job = _job("integration-tests-core-misc")
+    matrix = job["strategy"]["matrix"]["include"]  # type: ignore[index]
+    matrix_text = "\n".join(
+        f"{entry.get('paths', '')}\n{entry.get('ignore_args', '')}" for entry in matrix
+    )
+    assert "tests/e2e" not in matrix_text
+    assert "tests/cross_cutting" not in matrix_text
+
+
+def test_e2e_cross_cutting_runs_independently_of_fast_fanout() -> None:
+    """The dedicated e2e job should not wait on unrelated fast-test shards."""
+    job = _job("e2e-cross-cutting")
+    assert job["needs"] == ["changes"]
+
+    condition = str(job["if"])
+    assert "needs.changes.outputs.e2e == 'true'" in condition
+    assert "needs.changes.outputs.core_misc == 'true'" in condition
+    assert "needs.changes.outputs.execution_context == 'true'" in condition
+
+    path_filters = _path_filters()
+    assert ".github/workflows/ci-quality.yml" in path_filters["e2e"]
+
+    run_script = _job_run_script(
+        "e2e-cross-cutting",
+        "[ENFORCED] Run e2e and cross_cutting tests with coverage",
+    )
+    assert "tests/e2e/ tests/cross_cutting/" in run_script
+    assert "--durations=50" in run_script
+
+
+def test_e2e_cross_cutting_failures_are_quality_gated() -> None:
+    """The owner job for e2e/cross-cutting coverage must block merges on failure."""
+    quality_gate = _job("quality-gate")
+    assert "e2e-cross-cutting" in quality_gate["needs"]
+
+    run_script = _job_run_script("quality-gate", "Check all required jobs")
+    assert "needs.e2e-cross-cutting.result" in run_script

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -143,7 +143,6 @@ _CATEGORY_B_GRANDFATHERED_LEGACY: frozenset[str] = frozenset(
         "specify_cli.cli.commands._auth_doctor::compute_exit_code",
         "specify_cli.cli.commands._auth_doctor::render_report",
         "specify_cli.cli.commands._auth_doctor::render_report_json",
-        "specify_cli.cli.commands._branch_strategy_gate::ALREADY_CONFIRMED",
         "specify_cli.cli.commands._branch_strategy_gate::GateDecision",
         "specify_cli.cli.commands._branch_strategy_gate::GateOutcome",
         "specify_cli.cli.commands.agent.config::app",

--- a/uv.lock
+++ b/uv.lock
@@ -542,6 +542,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1611,6 +1620,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "pytestarch"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2121,6 +2143,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "pytestarch" },
     { name = "respx" },
 ]
@@ -2160,6 +2183,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.2.0" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0" },
     { name = "pytestarch", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "python-ulid", specifier = ">=3.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary
- split `integration-tests-core-misc` into directory-family matrix shards
- remove `tests/e2e/**` and `tests/cross_cutting/**` from core-misc pytest runs
- make `e2e-cross-cutting` the owner for e2e/cross-cutting coverage on e2e, core-misc, execution-context, and CI workflow PRs
- let `e2e-cross-cutting` run from `changes` instead of waiting behind fast-test fanout, then include it in the quality gate
- add `pytest-xdist` with `--dist loadfile` plus `--durations=50` on heavy pytest jobs
- gate heavy PR jobs for draft/WIP PRs unless `ci:full` or `ready-for-ci` is present
- add CI architectural guards for path ownership, quality-gate ownership, and legacy shard coverage parity
- remove a stale dead-symbol allowlist entry surfaced by the newly active architectural shard

## Why
Recent CI logs showed the critical path dominated by the serial `integration-tests-core-misc` bucket. The matrix split plus xdist should reduce that path materially. E2E/cross-cutting tests are now owned by the dedicated job and run in parallel, while still blocking merges when relevant.

## Adversarial review response
- Fixed stale `core_misc` path ownership of `tests/e2e/**`; e2e/cross-cutting paths now belong to the `e2e` filter.
- Added `.github/workflows/ci-quality.yml` and `tests/architectural/**` to `core_misc` so workflow/guard edits run the validating shard.
- Added `.github/workflows/ci-quality.yml` and core-misc/execution-context conditions to `e2e-cross-cutting` so cross-cutting coverage is not dropped for relevant source PRs.
- Added `e2e-cross-cutting` to `quality-gate` needs/result checks.
- Added a recursive collect-only architectural test proving legacy core-misc selected tests are covered by new shards plus the e2e owner job.

## Validation
- `/opt/homebrew/bin/uv lock --check`
- `git diff --check origin/main...HEAD`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'constant expression "false"' -ignore 'github.head_ref' .github/workflows/ci-quality.yml`\n- `.venv/bin/python -m pytest tests/architectural/test_ci_quality_path_filters.py -q` (`12 passed`)\n- `.venv/bin/python -m pytest tests/architectural/test_no_dead_symbols.py::test_no_public_symbol_in_all_is_unimported -q` (`1 passed`)\n- collect-only parity after reroll: `old=3362 new=3372 missing=0 extra=10`