### PR TITLE
fix(tasks): make map-requirements --json serializable on auto-commit (#1891 Finding 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **`agent tasks map-requirements --json` no longer crashes on auto-commit (issue #1891, Finding 1):** the
+  command stored the `CommitResult` returned by `safe_commit()` directly in the `--json` payload, so on the
+  auto-commit success path `json.dumps` failed with *"Object of type CommitResult is not JSON serializable"* —
+  the mapping succeeded but agents got an unparseable error instead of the result. `committed` is now a bool
+  and the resulting `commit_sha` (or `null`) is exposed alongside it. (Findings 2 and 3 — `agent action
+  implement --json` and `setup-plan`/`finalize-tasks` JSON preamble — are tracked separately.)
 - **Name-vs-authority remediation (mission #133; closes #1889, #1860, #1865, #1866, #1867, #1863, #1896, #1898, #1904, #1684, #1906):** (#1884/#1883/#1885 were independently fixed by PR #1910 and are verified-already-fixed here, not re-closed)
   binds the two remaining "a name/string shape is trusted as authority without cross-checking the declared authority"
   seams and ratchets them closed, and clears the live 3.2.0 release-blocker P0s rooted in that class. Topology

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -3731,6 +3731,7 @@ def map_requirements(
 
         # Auto-commit written WP files (consistent with move-task / update-subtasks)
         committed = False
+        commit_sha: str | None = None
         if auto_commit:
             written_files: list[Path] = []
             for wp_id in new_mappings:
@@ -3741,7 +3742,10 @@ def map_requirements(
                 spec_number = mission_slug.split("-")[0] if "-" in mission_slug else mission_slug
                 commit_msg = f"chore: Map requirements for {', '.join(sorted(new_mappings))} on spec {spec_number}"
                 try:
-                    committed = safe_commit(
+                    # ``safe_commit`` returns a ``CommitResult`` (not a bool); keep
+                    # the JSON payload serializable by recording a bool plus the
+                    # resulting SHA rather than the raw object (issue #1891).
+                    commit_result = safe_commit(
                         repo_root=main_repo_root,
                         worktree_root=main_repo_root,
                         target=CommitTarget(ref=target_branch, kind=CommitTargetKind.PRIMARY),
@@ -3749,6 +3753,8 @@ def map_requirements(
                         paths=tuple(written_files),
                         capability=GuardCapability.STANDARD,
                     )
+                    committed = True
+                    commit_sha = commit_result.sha
                 except Exception as exc_commit:
                     if not json_output:
                         console.print(f"[yellow]Warning:[/yellow] Auto-commit skipped: {exc_commit}")
@@ -3760,6 +3766,7 @@ def map_requirements(
             "total_mappings": {wp_id: sorted(refs) for wp_id, refs in all_wp_refs.items() if refs},
             "coverage": coverage,
             "committed": committed,
+            "commit_sha": commit_sha,
         }
         if json_output:
             print(json.dumps(payload))

--- a/tests/specify_cli/test_cli/test_map_requirements.py
+++ b/tests/specify_cli/test_cli/test_map_requirements.py
@@ -613,3 +613,57 @@ class TestFinalizeTasksWithFrontmatterRefs:
         payload = json.loads(result.stdout.strip().splitlines()[-1])
         wp01_refs = payload["requirement_refs_parsed"]["WP01"]
         assert wp01_refs == ["FR-001", "FR-002", "FR-003", "NFR-001"]
+
+
+class TestMapRequirementsAutoCommitJson:
+    """Issue #1891 Finding 1: ``--json`` must serialize the commit result.
+
+    ``safe_commit`` returns a ``CommitResult`` (not a bool). Previously that
+    object was placed directly into the ``--json`` payload, so on the
+    auto-commit success path ``json.dumps`` failed with "Object of type
+    CommitResult is not JSON serializable" and the mutation's result was
+    unparseable by an orchestrating agent.
+    """
+
+    @patch("specify_cli.cli.commands.agent.tasks.safe_commit")
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_mission_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_auto_commit_json_payload_is_serializable(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        mock_safe_commit: Mock,
+        tmp_path: Path,
+    ) -> None:
+        from specify_cli.git.commit_helpers import CommitResult
+
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        mock_safe_commit.return_value = CommitResult(
+            sha="abc1234def", destination_ref="main", worktree_root=tmp_path
+        )
+        _setup_feature(tmp_path)
+
+        result = runner.invoke(
+            tasks_app,
+            [
+                "map-requirements",
+                "--wp",
+                "WP01",
+                "--refs",
+                "FR-001",
+                "--auto-commit",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        # Pre-fix this raised / produced an {"error": ...} payload.
+        payload = json.loads(result.stdout.strip())
+        assert payload["result"] == "success"
+        assert payload["committed"] is True
+        assert payload["commit_sha"] == "abc1234def"
+        mock_safe_commit.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes **Finding 1 of #1891**: `agent tasks map-requirements --json` returned `{"error": "Object of type CommitResult is not JSON serializable"}` on the auto-commit success path. The requirement mapping *succeeded* (frontmatter written) but an orchestrating agent received an unparseable error instead of the result.

## Root cause

`committed = safe_commit(...)` stores the returned **`CommitResult`** (sha / destination_ref / worktree_root) — not a bool — and that object was placed directly into the `--json` payload (`"committed": committed`), so `json.dumps` raised. Sibling auto-commit sites (`move-task`, `update-subtasks`) use the result only in boolean context, so they never hit it.

## Fix

- `committed` is now a `bool`, and the resulting `commit_sha` (or `null` when nothing was committed) is exposed alongside it — the payload is both valid and more useful.
- Human (non-`--json`) output is unchanged.

## Tests

New `TestMapRequirementsAutoCommitJson` drives the auto-commit success path with a stubbed `CommitResult` and asserts the payload parses with `committed: true` and a `commit_sha`. (Existing tests passed because their fixtures aren't git repos, so `safe_commit` raised and the success path never ran — which is why the bug shipped.) Full `test_map_requirements.py` (18) + `test_tasks.py` (21) green; ruff/mypy clean.

## Scope — deferred findings (tracked on the issue)

- **Finding 2** (`agent action implement --json` rejects the flag): deferred. That command is in the execution-context / workspace-resolution surface under active rework (#1619/#1666, overlaps #1832); adding a `--json` contract there risks colliding with in-flight work. Happy to coordinate as a follow-up.
- **Finding 3** (`setup-plan`/`finalize-tasks` emit human preamble before JSON): needs a careful per-path audit of those coordination-adjacent commands; tracked separately.

---

Opened as **draft**; will mark ready once CI is green.
