### PR TITLE
fix(accept): honor --lenient for mission path conventions (#1892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the mapping succeeded but agents got an unparseable error instead of the result. `committed` is now a bool
   and the resulting `commit_sha` (or `null`) is exposed alongside it. (Findings 2 and 3 — `agent action
   implement --json` and `setup-plan`/`finalize-tasks` JSON preamble — are tracked separately.)
+- **`accept --lenient` now relaxes mission path conventions (issue #1892):** `spec-kitty accept` / `agent
+  mission accept` validated a mission's declared `paths` (`src/`, `tests/`, `contracts/` for software-dev)
+  unconditionally, so repos with a non-default layout (e.g. a Go service using `internal/` with no top-level
+  `tests/`) failed acceptance even with `--lenient` — the only workaround was creating throwaway empty
+  directories. Path conventions now block only in strict mode; under `--lenient` an unmet convention is
+  surfaced as a non-blocking warning. (A per-project `paths` override remains a possible follow-up.)
 - **Name-vs-authority remediation (mission #133; closes #1889, #1860, #1865, #1866, #1867, #1863, #1896, #1898, #1904, #1684, #1906):** (#1884/#1883/#1885 were independently fixed by PR #1910 and are verified-already-fixed here, not re-closed)
   binds the two remaining "a name/string shape is trusted as authority without cross-checking the declared authority"
   seams and ratchets them closed, and clears the live 3.2.0 release-blocker P0s rooted in that class. Topology

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -26,7 +26,7 @@ from specify_cli.mission_metadata import load_meta, record_acceptance, resolve_m
 from specify_cli.status import CanonicalStatusNotFoundError
 from specify_cli.status import Lane
 from specify_cli.status import EVENTS_FILENAME, StoreError
-from specify_cli.validators.paths import PathValidationError, validate_mission_paths
+from specify_cli.validators.paths import validate_mission_paths
 
 from specify_cli.task_utils import (
     LANES,
@@ -1135,27 +1135,44 @@ def collect_feature_summary(
     missing_required, missing_optional = _missing_artifacts(status_feature_dir)
 
     path_violations: list[str] = []
+    path_convention_warning: str | None = None
     try:
         mission = get_mission_for_feature(feature_dir)
     except MissionError:
         mission = None
 
     if mission and mission.config.paths:
-        try:
-            validate_mission_paths(
-                mission,
-                repo_root,
-                strict=True,
-                path_prefix=_path_prefix_for_mission(mission, feature_dir),
-            )
-        except PathValidationError as exc:
-            path_violations.append(exc.result.format_errors() or str(exc))
+        # Mission path conventions block acceptance by default, but under
+        # ``--lenient`` (``strict_metadata=False``) they are advisory: surface
+        # them as a non-blocking warning instead of a hard ``path_violations``
+        # so repos with a non-default layout (e.g. a Go service using
+        # ``internal/`` with no top-level ``tests/``) can be accepted with
+        # ``accept --lenient`` rather than the empty-directory workaround
+        # (issue #1892). ``validate_mission_paths`` is invoked non-strict here so
+        # we own the blocking decision rather than catching a raise.
+        path_result = validate_mission_paths(
+            mission,
+            repo_root,
+            strict=False,
+            path_prefix=_path_prefix_for_mission(mission, feature_dir),
+        )
+        if path_result.missing_paths:
+            if strict_metadata:
+                path_violations.append(
+                    path_result.format_errors() or "Path conventions not satisfied."
+                )
+            else:
+                path_convention_warning = (
+                    path_result.format_warnings() or "Path conventions not satisfied."
+                )
 
     warnings: list[str] = []
     if missing_optional:
         warnings.append("Optional artifacts missing: " + ", ".join(missing_optional))
     if path_violations:
         warnings.append("Path conventions not satisfied.")
+    elif path_convention_warning:
+        warnings.append(path_convention_warning)
 
     # T028: use coord-resolved read_feature_dir for lane-gate checks so that
     # lanes.json and acceptance-matrix.json are read from the coordination

--- a/src/specify_cli/cli/commands/accept.py
+++ b/src/specify_cli/cli/commands/accept.py
@@ -108,6 +108,21 @@ def _commit_residual_acceptance_artifacts(repo_root: Path, feature_slug: str) ->
     return True
 
 
+def _print_acceptance_warnings(summary: AcceptanceSummary) -> None:
+    """Render non-blocking ``summary.warnings`` in the human console.
+
+    The ``--json`` output already carries ``warnings``, but the human-readable
+    paths did not surface them, so a ``--lenient`` operator (issue #1892) got no
+    signal about what was downgraded from blocking to advisory. Shown only when
+    non-empty so a clean summary prints no spurious section.
+    """
+    if not summary.warnings:
+        return
+    console.print("\n[bold yellow]Warnings[/bold yellow]")
+    for warning in summary.warnings:
+        console.print(f"[yellow]- {warning}[/yellow]")
+
+
 def _print_acceptance_summary(summary: AcceptanceSummary) -> None:
     table = Table(title="Work Packages by Lane", header_style="cyan")
     table.add_column("Lane")
@@ -128,6 +143,8 @@ def _print_acceptance_summary(summary: AcceptanceSummary) -> None:
                 console.print(f"    • {value}")
     else:
         console.print("\n[green]No outstanding acceptance issues detected.[/green]")
+
+    _print_acceptance_warnings(summary)
 
     if summary.optional_missing:
         console.print(
@@ -191,6 +208,8 @@ def _print_acceptance_diagnosis(summary: AcceptanceSummary) -> None:
         console.print("\n[bold yellow]Blocked checks[/bold yellow]")
         for item in summary.blocked_checks:
             console.print(f"[yellow]- {item.check}[/yellow]: {item.detail}")
+
+    _print_acceptance_warnings(summary)
 
     if summary.recommended_fix_order:
         console.print("\n[bold]Recommended fix order[/bold]")

--- a/tests/cross_cutting/misc/test_acceptance_support.py
+++ b/tests/cross_cutting/misc/test_acceptance_support.py
@@ -660,3 +660,42 @@ def test_required_fields_still_enforced(feature_repo: Path, mission_slug: str) -
     wp_path.write_text(th.build_document("\n".join(lines_no_pid), body, padding), encoding="utf-8")
     summary = acc.collect_feature_summary(feature_repo, mission_slug, strict_metadata=True)
     assert any("missing shell_pid" in issue for issue in summary.metadata_issues), "Shell_pid should still be required"
+
+
+def test_lenient_downgrades_path_conventions_to_warning(
+    feature_repo: Path, mission_slug: str
+) -> None:
+    """``--lenient`` makes missing mission path conventions advisory (issue #1892).
+
+    Without ``--lenient`` (``strict_metadata=True``) a mission that declares
+    ``paths`` it cannot find still blocks acceptance via ``path_violations``;
+    with ``--lenient`` the same shortfall is surfaced as a non-blocking warning,
+    so repos with a non-default layout can be accepted.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    # feature_repo has no src/ tests/ contracts/ directories, so a software-dev
+    # mission's declared path conventions are unmet.
+    fake_mission = SimpleNamespace(
+        name="Software Dev Kitty",
+        config=SimpleNamespace(
+            paths={"workspace": "src", "tests": "tests", "deliverables": "contracts"}
+        ),
+    )
+
+    with patch("specify_cli.acceptance.get_mission_for_feature", return_value=fake_mission):
+        strict = acc.collect_feature_summary(
+            feature_repo, mission_slug, strict_metadata=True, mutate_matrix=False
+        )
+        lenient = acc.collect_feature_summary(
+            feature_repo, mission_slug, strict_metadata=False, mutate_matrix=False
+        )
+
+    # Strict: missing conventions block acceptance as path_violations.
+    assert strict.path_violations
+    assert any("expects" in violation for violation in strict.path_violations)
+
+    # Lenient: not blocking; surfaced as a warning instead.
+    assert lenient.path_violations == []
+    assert any("expects" in warning for warning in lenient.warnings)

--- a/tests/specify_cli/cli/commands/test_accept_warnings_render.py
+++ b/tests/specify_cli/cli/commands/test_accept_warnings_render.py
@@ -1,0 +1,81 @@
+"""The human-console accept summary must render ``summary.warnings``.
+
+Follow-on to #1892 (Lynn Cole's ``accept --lenient`` feature): that change
+downgrades unmet mission path conventions from a blocking ``path_violations``
+entry to a non-blocking ``AcceptanceSummary.warnings`` entry. The ``--json``
+output already carries ``warnings``, but the human-readable console renderer
+(`_print_acceptance_summary`) never printed them, so a ``--lenient`` operator
+not using ``--json`` got no signal about what was downgraded.
+
+These tests drive the console renderer directly with constructed summaries (a
+pure seam — no git/fixture scaffolding) and assert that a non-empty
+``warnings`` list is surfaced, while a clean summary shows no spurious warnings
+section.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+import specify_cli.cli.commands.accept as accept_cmd
+from specify_cli.acceptance import AcceptanceSummary
+from specify_cli.task_utils import LANES
+
+
+def _summary(*, warnings: list[str]) -> AcceptanceSummary:
+    """Build a minimal accept-ready summary carrying the given warnings."""
+    repo_root = Path("/tmp/repo")
+    feature_dir = repo_root / "kitty-specs" / "099-demo"
+    return AcceptanceSummary(
+        feature="099-demo",
+        repo_root=repo_root,
+        feature_dir=feature_dir,
+        tasks_dir=feature_dir / "tasks",
+        branch="kitty/mission-099-demo",
+        worktree_root=repo_root,
+        primary_repo_root=repo_root,
+        lanes={lane: [] for lane in LANES},
+        work_packages=[],
+        metadata_issues=[],
+        activity_issues=[],
+        unchecked_tasks=[],
+        needs_clarification=[],
+        missing_artifacts=[],
+        optional_missing=[],
+        git_dirty=[],
+        path_violations=[],
+        warnings=warnings,
+    )
+
+
+def _render(summary: AcceptanceSummary, monkeypatch: pytest.MonkeyPatch) -> str:
+    buf = StringIO()
+    monkeypatch.setattr(
+        accept_cmd, "console", Console(file=buf, highlight=False, markup=True, width=200)
+    )
+    accept_cmd._print_acceptance_summary(summary)
+    return buf.getvalue()
+
+
+def test_lenient_path_convention_warning_is_rendered_in_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A downgraded path-convention warning appears in the human console output."""
+    warning = "Mission 'Software Dev Kitty' expects tests/ but it is missing."
+    output = _render(_summary(warnings=[warning]), monkeypatch)
+
+    assert "Warnings" in output
+    assert "expects tests/" in output
+
+
+def test_clean_summary_renders_no_warnings_section(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A summary with no warnings must not print a spurious Warnings section."""
+    output = _render(_summary(warnings=[]), monkeypatch)
+
+    assert "Warnings" not in output


### PR DESCRIPTION
## Summary

Fixes **#1892**: `spec-kitty accept` / `agent mission accept` validated a mission's declared path conventions (software-dev: `src/`, `tests/`, `contracts/`) **unconditionally**, so repos with an idiomatic non-default layout — e.g. a Go service using `internal/` with tests colocated and no top-level `tests/` — failed acceptance *even with `--lenient`*. The only workaround was creating throwaway empty directories.

## Root cause

In `acceptance/__init__.py` `collect_feature_summary`, path conventions were checked with `validate_mission_paths(..., strict=True)` regardless of the `--lenient` flag (`--lenient` only set `strict_metadata=not lenient`, which gated metadata checks, not paths).

## Fix

Path validation now runs **non-strict** and the blocking decision is owned by `strict_metadata`:
- **without `--lenient`** (strict): missing convention paths remain blocking `path_violations` — unchanged behavior;
- **with `--lenient`**: the same shortfall is surfaced as a **non-blocking warning**, so the mission can be accepted.

Localized to `collect_feature_summary`, so it covers both `spec-kitty accept` and `spec-kitty agent mission accept` (they share this path).

## Tests

`test_lenient_downgrades_path_conventions_to_warning` asserts strict still blocks (`path_violations` populated) while `--lenient` downgrades the same shortfall to a warning. Full `test_acceptance_support.py` (19) + canonical/regression/validator acceptance suites (77) green; ruff/mypy clean (no new findings).

## Scope note

This implements the issue's **option 2** (`--lenient` relaxes path conventions). The **option 1** alternative — a per-project `.kittify`/charter `paths` override so a Go repo can declare `workspace: internal/` — is a larger config-schema change and is left as a possible follow-up.

---

Opened as **draft**; will mark ready once CI is green.
