### PR TITLE
fix(upgrade): compare-before-write at the metadata boundary (#1871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **`spec-kitty upgrade` no longer churns `metadata.yaml` on a no-op (issue #1871):** the "stamp
+  `last_upgraded_at` only on material change" rule lived in three divergent idioms, and the migrations-applied
+  root path plus `_stamp_schema_version` rewrote `metadata.yaml` (and advanced the timestamp / mtime) even when
+  every migration was already recorded. `ProjectMetadata.save()` now does a **masked compare-before-write**
+  (skipping the write when only the volatile `last_upgraded_at`/`schema_version` would change) and
+  `_stamp_schema_version` skips its re-dump when the rendered bytes already match disk. A genuine
+  version/migration/environment change still writes with a fresh timestamp; a no-op upgrade — including across a
+  fully-recorded version range, on both the root and worktree paths — is now zero writes. This closes the class
+  at the write boundary for upgrade/doctor/regeneration instead of adding a fourth per-path guard.
 - **`agent tasks map-requirements --json` no longer crashes on auto-commit (issue #1891, Finding 1):** the
   command stored the `CommitResult` returned by `safe_commit()` directly in the `--json` payload, so on the
   auto-commit success path `json.dumps` failed with *"Object of type CommitResult is not JSON serializable"* —

--- a/src/specify_cli/upgrade/metadata.py
+++ b/src/specify_cli/upgrade/metadata.py
@@ -20,6 +20,33 @@ _LEGACY_MIGRATION_ID_MAP: dict[str, str] = {
 }
 
 
+def _mask_volatile_metadata(text: str) -> str:
+    """Return ``text`` with volatile metadata lines neutralized for
+    compare-before-write (issue #1871).
+
+    Two fields must not, by themselves, force a rewrite of ``metadata.yaml``:
+
+    - ``last_upgraded_at`` — the migrations-applied upgrade path bumps it on
+      every successful run, even a no-op; masking its value lets a no-op save
+      compare equal and skip, keeping the on-disk timestamp stable.
+    - ``schema_version`` — ``ProjectMetadata.save`` does not emit it (it is
+      written separately by ``_stamp_schema_version``), so the on-disk file
+      carries it while freshly-rendered content does not; dropping the line
+      keeps the comparison apples-to-apples.
+    """
+    masked: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("schema_version:"):
+            continue
+        if stripped.startswith("last_upgraded_at:"):
+            indent = line[: len(line) - len(stripped)]
+            masked.append(f"{indent}last_upgraded_at: <masked>")
+            continue
+        masked.append(line)
+    return "\n".join(masked)
+
+
 @dataclass
 class MigrationRecord:
     """Record of a single migration application."""
@@ -136,11 +163,25 @@ class ProjectMetadata:
                 changed = True
         return changed
 
-    def save(self, kittify_dir: Path) -> None:
+    def save(self, kittify_dir: Path) -> bool:
         """Save metadata to .kittify/metadata.yaml.
+
+        Performs a masked compare-before-write (issue #1871): if the only
+        differences between the rendered content and the file already on disk
+        are the volatile ``last_upgraded_at`` timestamp (which the migrations-
+        applied upgrade path bumps unconditionally) and ``schema_version``
+        (written separately by ``_stamp_schema_version`` and intentionally
+        omitted here), the write is skipped. This stops no-op upgrades from
+        churning the file/mtime or advancing ``last_upgraded_at``, and closes
+        the class for every ``save()`` caller (upgrade/doctor/regeneration)
+        rather than adding per-path guards.
 
         Args:
             kittify_dir: Path to the .kittify directory
+
+        Returns:
+            ``True`` if the file was written; ``False`` if the write was
+            skipped because nothing material changed.
         """
         metadata_path = kittify_dir / "metadata.yaml"
 
@@ -176,7 +217,18 @@ class ProjectMetadata:
         buf = io.StringIO()
         buf.write(header)
         yaml.dump(data, buf, default_flow_style=False, sort_keys=False)
-        atomic_write(metadata_path, buf.getvalue(), mkdir=True)
+        new_content = buf.getvalue()
+
+        if metadata_path.exists():
+            try:
+                existing = metadata_path.read_text(encoding="utf-8-sig")
+            except OSError:
+                existing = None
+            if existing is not None and _mask_volatile_metadata(existing) == _mask_volatile_metadata(new_content):
+                return False
+
+        atomic_write(metadata_path, new_content, mkdir=True)
+        return True
 
     def has_migration(self, migration_id: str) -> bool:
         """Check if a migration has been successfully applied.

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -481,4 +481,16 @@ class MigrationRunner:
         buf = io.StringIO()
         buf.write(header)
         yaml.dump(data, buf, default_flow_style=False, sort_keys=False)
-        atomic_write(metadata_path, buf.getvalue(), mkdir=True)
+        rendered = buf.getvalue()
+
+        # Compare-before-write (issue #1871): skip the re-dump when the rendered
+        # bytes already match the file on disk, so a no-op upgrade does not
+        # reformat or mtime-churn an already-stamped metadata.yaml.
+        try:
+            current = metadata_path.read_text(encoding="utf-8-sig")
+        except OSError:
+            current = None
+        if current == rendered:
+            return
+
+        atomic_write(metadata_path, rendered, mkdir=True)

--- a/tests/upgrade/test_runner_status_classification.py
+++ b/tests/upgrade/test_runner_status_classification.py
@@ -345,3 +345,62 @@ def test_worktree_skipped_migration_keeps_last_upgraded_at_stable_on_rerun(
     skipped = [m for m in after_second.applied_migrations if m.id == migration.migration_id]
     assert len(skipped) == 1
     assert after_second.last_upgraded_at == stamp_first
+
+
+# ---------------------------------------------------------------------------
+# Issue #1871: compare-before-write at the metadata boundary. A no-op upgrade
+# must not churn metadata.yaml (bytes/mtime) or advance last_upgraded_at.
+# ---------------------------------------------------------------------------
+
+
+def test_save_skips_write_when_only_timestamp_changes(tmp_path: Path) -> None:
+    """save() is a no-op when only last_upgraded_at would change (issue #1871)."""
+    kdir = tmp_path / ".kittify"
+    kdir.mkdir()
+    metadata = ProjectMetadata(version="1.0.0", initialized_at=datetime(2026, 1, 1))
+
+    assert metadata.save(kdir) is True  # first write
+    path = kdir / "metadata.yaml"
+    before = path.read_bytes()
+
+    # Only the volatile timestamp differs → masked-equal → skip the write.
+    metadata.last_upgraded_at = datetime(2026, 6, 13, 12, 0, 0)
+    assert metadata.save(kdir) is False
+    assert path.read_bytes() == before
+
+    # A material change (version) is written.
+    metadata.version = "2.0.0"
+    assert metadata.save(kdir) is True
+    assert path.read_bytes() != before
+
+
+def test_root_upgrade_no_op_keeps_metadata_stable(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Re-running a no-op upgrade does not rewrite root metadata.yaml (issue #1871)."""
+    project_path = _setup_project(tmp_path)
+    migration = _NotNeededMigration()
+
+    def _run() -> None:
+        runner = MigrationRunner(project_path)
+        monkeypatch.setattr(runner.detector, "detect_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            "specify_cli.upgrade.runner.MigrationRegistry.get_applicable",
+            lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+        )
+        runner.upgrade("9.9.9", include_worktrees=False)
+
+    _run()
+    path = project_path / ".kittify" / "metadata.yaml"
+    after_first = path.read_bytes()
+    meta_first = ProjectMetadata.load(project_path / ".kittify")
+    assert meta_first is not None
+    stamp_first = meta_first.last_upgraded_at
+
+    _run()
+    # Byte-identical: neither save() nor _stamp_schema_version rewrote it.
+    assert path.read_bytes() == after_first
+    meta_second = ProjectMetadata.load(project_path / ".kittify")
+    assert meta_second is not None
+    assert meta_second.last_upgraded_at == stamp_first


### PR DESCRIPTION
## Summary

Fixes **#1871** (follow-up to #1857/#1838): `spec-kitty upgrade` rewrote `metadata.yaml` and advanced `last_upgraded_at`/mtime even on a **no-op** upgrade. The "stamp only on material change" rule had drifted into three divergent idioms, and the migrations-applied root path (`runner.py:176-179`) plus `_stamp_schema_version` always wrote — including re-runs across a fully-recorded version range.

## Fix — at the write boundary, not a fourth per-path guard

- **`ProjectMetadata.save()` → masked compare-before-write.** Before writing, it compares the rendered content against the on-disk file with the volatile fields masked: `last_upgraded_at` (bumped unconditionally by the root path) and `schema_version` (written separately by `_stamp_schema_version`, intentionally omitted by `save()`). If only those would change, the write is skipped and `save()` returns `False`. This makes the runner's unconditional save+stamp a no-op **without editing the runner** — the divergent idioms collapse to one boundary rule.
- **`_stamp_schema_version` → compare-before-write.** Skips its `atomic_write` when the rendered bytes already equal the file on disk.

Net: a genuine version / new-migration / environment change still writes with a fresh timestamp; a no-op upgrade is **zero writes** on both the root and worktree paths. Closes the class for upgrade/doctor/regeneration.

## Tests

- `test_save_skips_write_when_only_timestamp_changes` — masked `save()` skips on a timestamp-only delta, writes on a material change.
- `test_root_upgrade_no_op_keeps_metadata_stable` — a no-op root upgrade re-run leaves `metadata.yaml` **byte-identical** with a stable `last_upgraded_at` (this fails before the fix).

Full `tests/upgrade/` + `tests/specify_cli/upgrade/` (678) and init/metadata suites green; ruff/mypy clean. All `save()` callers (doctor/regeneration/init/charter-rename migration) reviewed — they write on real content changes or first-write.

---

Opened as **draft**; will mark ready once CI is green.
