### PR TITLE
docs: correct retired `agent workflow implement` command (#1874)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ Full docs: [CONTRIBUTING.md](CONTRIBUTING.md#release-process)
 2. Update agent wrappers to use the resolver.
 3. Update templates, skills, and docs together.
 
-**Testing:** Unit coverage for workspace resolution + integration coverage for `agent workflow implement/review`.
+**Testing:** Unit coverage for workspace resolution + integration coverage for `agent action implement/review`.
 
 **Status source of truth:** Feature metadata on main branch, not the open worktree.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **Docs: corrected the retired `spec-kitty agent workflow implement` command (issue #1874):** the
+  `agent workflow` command group no longer exists (the canonical form is `spec-kitty agent action
+  implement` / `… review`). Updated the user-facing `docs/how-to/implement-work-package.md` and the
+  `AGENTS.md` testing note. (The same stale command also appears in the PowerShell toolguide and the
+  documentation/research per-WP task-prompt templates; those are rendered into the twelve-agent command
+  snapshots, whose baselines are already drifted on `main`, so that replacement is left to the
+  cli-reference-audit sweep which can regenerate the baselines in one pass.)
 - **`spec-kitty upgrade` no longer churns `metadata.yaml` on a no-op (issue #1871):** the "stamp
   `last_upgraded_at` only on material change" rule lived in three divergent idioms, and the migrations-applied
   root path plus `_stamp_schema_version` rewrote `metadata.yaml` (and advanced the timestamp / mtime) even when

--- a/docs/how-to/implement-work-package.md
+++ b/docs/how-to/implement-work-package.md
@@ -47,7 +47,7 @@ If the WP depends on another WP, task finalization will already have assigned it
 In your terminal:
 
 ```bash
-cd <path printed by spec-kitty agent workflow implement>
+cd <path printed by spec-kitty agent action implement>
 ```
 
 Implement the prompt, run required tests, and commit your changes in that workspace. Sequential WPs in the same lane reuse the same worktree, for example `.worktrees/###-feature-lane-a`.


### PR DESCRIPTION
## Summary

Fixes **#1874 (part 1)**: `spec-kitty agent workflow implement` is a retired/broken command (the `agent workflow` group no longer exists — `spec-kitty agent action implement`/`review` is canonical). Updated the user-facing how-to and the `AGENTS.md` testing note.

## Changes
- `docs/how-to/implement-work-package.md:50` — `agent workflow implement` → `agent action implement` (the cited line; it now matches the bidirectionally-linked `worktrees-with-mcp-agents.md`).
- `AGENTS.md` — same correction in the testing note.

## Deliberately scoped out (with rationale)
- **PowerShell toolguide + documentation/research per-WP task-prompt templates** carry the same stale command, but they render into the twelve-agent command snapshots — and **those baselines are already drifted on `main`** (`specify`/`research`/`tasks-finalize` twelve-agent parity fails on a clean checkout, independent of this change). Regenerating them here would absorb that unrelated pre-existing drift, so this replacement is left to the cli-reference-audit sweep (#3-2-cli-reference-audit-meta-issues), which can regenerate the baselines in one pass. **Heads-up:** that pre-existing parity drift is worth a look on its own (observed locally on clean `origin/main`; worth confirming in CI, since path-filtering may be masking it).
- **Untouched on purpose:** the upgrade migrations (`m_0_10_6`, `m_0_11_3`) match the old string for *detection*; `kitty-specs/**` historical artifacts; the `docs/development/` audit/checklist files that *document* the problem; and generated agent copies (`.claude/`, `.agents/skills/`) that regenerate from the `src/doctrine` sources.

## Part 2 (optional, deferred)
The Serena/OpenCode MCP worktree-config snippets (#631) need verified per-tool config specifics I won't fabricate into docs; the current generic guidance is accurate. Left with #631; happy to add accurate snippets if someone confirms the exact settings.

## Validation
Terminology guard green; pure-prose change with **zero snapshot impact** (twelve-agent parity failure count is identical with and without this change — the failures are all pre-existing).

---

Opened as **draft**; will mark ready once CI is green.
