### PR TITLE
Fix Sonar duplicated literals in charter section bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,19 @@ Python 3.11+. Follow standard conventions. Any changes to `__init__.py` require 
 
 **Pre-push: run the terminology guard when touching `src/doctrine/` or user-facing prose.** Some repo-wide gates run only in CI's `integration-tests-core-misc` job, NOT in the `fast-tests-*` suites — so a forbidden-term regression passes local doctrine runs and only fails at CI. Before pushing doctrine/prose changes, run `pytest tests/architectural/test_no_legacy_terminology.py` (≈0.1 s); it enforces the Terminology Canon (e.g. canonical `status commit` not `ceremony`; `Mission` not `feature`). The full `tests/architectural/` suite is the complete safety net.
 
+## Sonar Expectations
+
+Treat these as code-shaping constraints, not post-hoc cleanup:
+
+- **Complexity ceiling is 15.** Ruff `C901` and Sonar `S3776` are aligned (`[tool.ruff.lint.mccabe].max-complexity = 15`). When touching a function near that limit, keep it at `<=15` by extracting small helpers, flattening nested conditionals, or separating lookup/build/emit phases. Do **not** leave a function at 16+ and assume "tests passing" is enough.
+- **Repeated non-trivial literals become constants.** If a string/path/message/help text appears `>=3` times in the same module, hoist it to a named module constant instead of duplicating it. This is the default response to Sonar `S1192`.
+- **Do not leave empty or effect-free exception handlers.** If an `except` block does nothing meaningful, either remove it and let the exception propagate, or add the concrete recovery/logging/translation logic Sonar expects.
+- **Every new branch/helper needs tests in the same PR.** Sonar's project gate is dominated by new-code coverage; extracting helpers without adding focused tests simply moves the failure. When you add or refactor logic, add narrow tests that execute the new branches/helpers directly.
+- **Prefer testable extractions.** Sonar generally rewards pure/helper extraction plus focused tests. If a function is large, extract deterministic subroutines with stable inputs/outputs, then test those paths instead of only relying on a broad integration test.
+- **Prefer real fixes over suppression.** Do not add `# noqa`, `# type: ignore`, or Sonar suppression comments to silence maintainability findings unless the tool is materially wrong about correct code. If suppression is unavoidable, keep it narrow and explain why the code is safe.
+- **Loopback/local-only HTTP is a special case.** Do not "fix" localhost/127.0.0.1 control-plane URLs by forcing HTTPS when the transport is intentionally loopback-only. Keep the safe loopback semantics, add/keep regression tests, and record the rationale in the PR if Sonar raises a hotspot. Code change and hotspot review are separate actions.
+- **PR description must call out remaining Sonar UI work.** If the code is correct but Sonar still needs hotspot review or UI-side rationale application, say so explicitly in the PR body so a later agent does not waste time trying to "fix" it in code.
+
 ## Recent Changes
 
 - **068**: `src/specify_cli/post_merge/` (AST-based stale-assertion analyzer), `agent tests` CLI subgroup, `agent/release.py prep` subcommand, FR-019 safe_commit fix in `_run_lane_based_merge`, FR-021 `scan_recovery_state` + `implement --base`

--- a/src/charter/context_renderers/section_bodies.py
+++ b/src/charter/context_renderers/section_bodies.py
@@ -31,17 +31,19 @@ __all__ = [
 ]
 
 
+TERMINOLOGY_CANON = "Terminology Canon"
+CODE_REVIEW_CHECKLIST = "Code Review Checklist"
+REGRESSION_VIGILANCE = "Regression Vigilance"
+_COMMON_ACTION_CRITICAL_SECTIONS = [
+    TERMINOLOGY_CANON,
+    CODE_REVIEW_CHECKLIST,
+    REGRESSION_VIGILANCE,
+]
+
+
 ACTION_CRITICAL_SECTIONS: dict[str, list[str]] = {
-    "implement": [
-        "Terminology Canon",
-        "Code Review Checklist",
-        "Regression Vigilance",
-    ],
-    "review": [
-        "Terminology Canon",
-        "Code Review Checklist",
-        "Regression Vigilance",
-    ],
+    "implement": list(_COMMON_ACTION_CRITICAL_SECTIONS),
+    "review": list(_COMMON_ACTION_CRITICAL_SECTIONS),
 }
 """Mapping of action -> ordered list of charter section names whose body
 the resolver MUST surface (or fetch-substitute).  Future missions may
@@ -50,9 +52,9 @@ an empty block."""
 
 
 CRITICAL_SECTION_WHEN_CLAUSES: dict[str, str] = {
-    "Terminology Canon": "rename or introduce a term in the diff",
-    "Code Review Checklist": "prepare a WP for review",
-    "Regression Vigilance": "perform a terminology cutover",
+    TERMINOLOGY_CANON: "rename or introduce a term in the diff",
+    CODE_REVIEW_CHECKLIST: "prepare a WP for review",
+    REGRESSION_VIGILANCE: "perform a terminology cutover",
 }
 """Per-section when-doing clause used when the verbatim body is missing.
 

--- a/tests/doctrine/drg/test_validator_profile_edges.py
+++ b/tests/doctrine/drg/test_validator_profile_edges.py
@@ -185,3 +185,55 @@ class TestWiredIntoValidateGraph:
         )
         errors = validate_graph(graph)
         assert any("must be an agent_profile" in e for e in errors)
+
+    def test_duplicate_edges_are_reported(self) -> None:
+        graph = _graph(
+            [_profile("child"), _profile("parent")],
+            [
+                DRGEdge(
+                    source="agent_profile:child",
+                    target="agent_profile:parent",
+                    relation=Relation.REQUIRES,
+                ),
+                DRGEdge(
+                    source="agent_profile:child",
+                    target="agent_profile:parent",
+                    relation=Relation.REQUIRES,
+                ),
+            ],
+        )
+        errors = validate_graph(graph)
+        assert any("Duplicate edge" in e for e in errors)
+
+    def test_requires_cycle_is_reported(self) -> None:
+        graph = _graph(
+            [_profile("a"), _profile("b")],
+            [
+                DRGEdge(
+                    source="agent_profile:a",
+                    target="agent_profile:b",
+                    relation=Relation.REQUIRES,
+                ),
+                DRGEdge(
+                    source="agent_profile:b",
+                    target="agent_profile:a",
+                    relation=Relation.REQUIRES,
+                ),
+            ],
+        )
+        errors = validate_graph(graph)
+        assert any("Cycle in requires" in e for e in errors)
+
+    def test_dangling_source_is_reported(self) -> None:
+        graph = _graph(
+            [_profile("parent")],
+            [
+                DRGEdge(
+                    source="agent_profile:ghost",
+                    target="agent_profile:parent",
+                    relation=Relation.REQUIRES,
+                )
+            ],
+        )
+        errors = validate_graph(graph)
+        assert any("Dangling source" in e for e in errors)

--- a/tests/specify_cli/cli/commands/agent/test_review_lane_fix.py
+++ b/tests/specify_cli/cli/commands/agent/test_review_lane_fix.py
@@ -6,6 +6,7 @@ compatibility and execution_context detection parity.
 """
 import pytest
 from pathlib import Path
+from types import SimpleNamespace
 from specify_cli.status.models import Lane, StatusEvent
 
 
@@ -232,3 +233,65 @@ class TestLegacyJsonlCompatibility:
         assert events[0].force is False
         is_claimed = _is_review_claimed_workflow(events[0])
         assert is_claimed is True
+
+
+class TestFindFirstForReviewWp:
+    """Regression coverage for workflow._find_first_for_review_wp."""
+
+    @staticmethod
+    def _write_wp(path: Path, wp_id: str) -> None:
+        path.write_text(
+            f"---\nwork_package_id: {wp_id}\n---\nBody\n",
+            encoding="utf-8",
+        )
+
+    def test_prefers_explicit_for_review_lane(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from specify_cli.cli.commands.agent import workflow
+        import specify_cli.status as status_module
+
+        feature_dir = tmp_path / "kitty-specs" / "test-feature"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        self._write_wp(tasks_dir / "WP01-alpha.md", "WP01")
+        self._write_wp(tasks_dir / "WP02-beta.md", "WP02")
+        seed_event = _make_event(Lane.FOR_REVIEW, wp_id="WP02")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("specify_cli.core.paths.is_worktree_context", lambda _path: False)
+        monkeypatch.setattr(workflow, "resolve_feature_dir_for_mission", lambda _repo, _slug: feature_dir)
+        monkeypatch.setattr(status_module, "read_events", lambda _feature_dir: [seed_event])
+        monkeypatch.setattr(
+            status_module,
+            "reduce",
+            lambda _events: SimpleNamespace(
+                work_packages={
+                    "WP01": {"lane": Lane.IN_REVIEW},
+                    "WP02": {"lane": Lane.FOR_REVIEW},
+                }
+            ),
+        )
+
+        assert workflow._find_first_for_review_wp(tmp_path, "test-feature") == "WP02"
+
+    def test_falls_back_to_claimed_in_review_wp(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from specify_cli.cli.commands.agent import workflow
+        import specify_cli.status as status_module
+
+        feature_dir = tmp_path / "kitty-specs" / "test-feature"
+        tasks_dir = feature_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        self._write_wp(tasks_dir / "WP01-alpha.md", "WP01")
+
+        claimed_event = _make_event(Lane.IN_REVIEW, wp_id="WP01")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("specify_cli.core.paths.is_worktree_context", lambda _path: False)
+        monkeypatch.setattr(workflow, "resolve_feature_dir_for_mission", lambda _repo, _slug: feature_dir)
+        monkeypatch.setattr(status_module, "read_events", lambda _feature_dir: [claimed_event])
+        monkeypatch.setattr(
+            status_module,
+            "reduce",
+            lambda _events: SimpleNamespace(work_packages={"WP01": {"lane": Lane.IN_REVIEW}}),
+        )
+
+        assert workflow._find_first_for_review_wp(tmp_path, "test-feature") == "WP01"

--- a/tests/specify_cli/core/test_worktree.py
+++ b/tests/specify_cli/core/test_worktree.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from specify_cli.core.worktree import create_wp_workspace
+from specify_cli.core.worktree import _existing_worktree_is_valid, create_wp_workspace
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +220,38 @@ class TestCodeChangeWorkspace:
                 workspace_name="kitty/mission-test-feature-lane-a",
                 wp_frontmatter=_make_frontmatter(execution_mode="code_change"),
             )
+
+
+class TestExistingWorktreeValidity:
+    """Exercise the VCS/.git fallback matrix for existing worktree reuse."""
+
+    def test_returns_true_when_vcs_reports_repo(self, tmp_path: Path) -> None:
+        workspace_path = tmp_path / ".worktrees" / "lane-a"
+        workspace_path.mkdir(parents=True)
+
+        mock_vcs = MagicMock()
+        mock_vcs.is_repo.return_value = True
+
+        with patch("specify_cli.core.worktree.get_vcs", return_value=mock_vcs):
+            assert _existing_worktree_is_valid(workspace_path) is True
+
+    def test_falls_back_to_git_marker_when_vcs_probe_errors(self, tmp_path: Path) -> None:
+        workspace_path = tmp_path / ".worktrees" / "lane-b"
+        workspace_path.mkdir(parents=True)
+        (workspace_path / ".git").write_text("gitdir: /tmp/example\n", encoding="utf-8")
+
+        with patch("specify_cli.core.worktree.get_vcs", side_effect=RuntimeError("boom")):
+            assert _existing_worktree_is_valid(workspace_path) is True
+
+    def test_returns_false_when_vcs_false_and_no_git_marker(self, tmp_path: Path) -> None:
+        workspace_path = tmp_path / ".worktrees" / "lane-c"
+        workspace_path.mkdir(parents=True)
+
+        mock_vcs = MagicMock()
+        mock_vcs.is_repo.return_value = False
+
+        with patch("specify_cli.core.worktree.get_vcs", return_value=mock_vcs):
+            assert _existing_worktree_is_valid(workspace_path) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extract shared action-critical section names into constants
- reuse the shared constants in `ACTION_CRITICAL_SECTIONS` and `CRITICAL_SECTION_WHEN_CLAUSES`
- clear the Sonar duplicated-literal findings in `section_bodies.py` without behavior changes
- add focused regression tests around nightly-flagged helper seams in `worktree.py`, `doctrine/drg/validator.py`, and `workflow.py` to reduce real Sonar new-code coverage debt without changing runtime behavior
- codify explicit Sonar-facing implementation rules in `AGENTS.md` so future agents apply the same remediation patterns consistently

## Validation
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/charter/test_context_section_bodies.py tests/specify_cli/core/test_worktree.py tests/doctrine/drg/test_validator_profile_edges.py tests/specify_cli/cli/commands/agent/test_review_lane_fix.py -q --tb=short`
- `.venv/bin/ruff check src/charter/context_renderers/section_bodies.py tests/charter/test_context_section_bodies.py tests/specify_cli/core/test_worktree.py tests/doctrine/drg/test_validator_profile_edges.py tests/specify_cli/cli/commands/agent/test_review_lane_fix.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/architectural/test_no_legacy_terminology.py -q --tb=short`

## Context
- GitHub code scanning alerts: none open
- GitHub dependabot/security alerts: none open
- SonarCloud nightly `main` run on 2026-06-13 failed its quality gate at commit `649781d68`; some reported smells were already fixed later on `main`, so this branch focuses on still-actionable code-backed debt
- `main` Sonar quality gate is still blocked by `new_security_hotspots_reviewed=0%`, which requires Sonar UI review rather than a code change
