### PR TITLE
Preformalize tool surface glossary terms

### DIFF
--- a/glossary/contexts/execution.md
+++ b/glossary/contexts/execution.md
@@ -14,6 +14,21 @@ Terms describing tool invocation and semantic safety gates during generation.
 
 ---
 
+### Tool Surface
+
+| | |
+|---|---|
+| **Definition** | A tool-visible artifact or configuration entry that Spec Kitty installs, verifies, repairs, or packages for a concrete execution tool. |
+| **Context** | Execution |
+| **Status** | candidate |
+| **Applicable to** | `3.x` |
+| **Examples** | slash command file, skill directory, custom agent profile file, hook config, MCP config, plugin manifest |
+| **Use when** | Describing install/config/doctor/plugin ownership for Claude Code, Codex, Copilot, Cursor, Windsurf, Kiro, or another concrete tool. |
+| **Do NOT use when** | Describing logical collaborator identity, assignment, handoff, or role; use [Agent](./identity.md#agent) or [Agent Profile](./identity.md#agent-profile) instead. |
+| **Related terms** | [Tool](#tool), [Slash Command](#slash-command), [Agent](./identity.md#agent) |
+
+---
+
 ### Slash Command
 
 | | |
@@ -223,4 +238,3 @@ Terms describing tool invocation and semantic safety gates during generation.
 | **Applicable to** | `3.x` |
 | **Examples** | git commit, pull request, PR comment, CI run result |
 | **Related terms** | [Effector](#effector) |
-

--- a/glossary/contexts/identity.md
+++ b/glossary/contexts/identity.md
@@ -25,6 +25,21 @@ Terms describing who performs work and who owns semantic decisions.
 
 ---
 
+### Agent Profile
+
+| | |
+|---|---|
+| **Definition** | Structured logical collaborator identity and behavior guidance, identified by a stable profile ID, that can govern assignment, handoff, role-scoped behavior, and tool-native custom-agent/subagent projection. |
+| **Context** | Identity |
+| **Status** | candidate |
+| **Applicable to** | `3.x` |
+| **Examples** | `architect-alphonso`, `researcher-robbie`, `implementer-ivan`, `reviewer-renata` |
+| **Use when** | Describing who the collaborator is, what role boundaries it follows, and how it should be selected or handed off to. |
+| **Do NOT use when** | Describing the generated file or host configuration that exposes the profile to Claude Code, Codex, Copilot, Cursor, Windsurf, or another tool; use [Tool Surface](./execution.md#tool-surface) instead. |
+| **Related terms** | [Agent](#agent), [Role](#role), [Tool](./execution.md#tool) |
+
+---
+
 ### Audience Persona
 
 | | |

--- a/glossary/naming-decision-tool-vs-agent.md
+++ b/glossary/naming-decision-tool-vs-agent.md
@@ -18,3 +18,12 @@
 
 - Use "tool" for install/config/invocation concerns
 - Use "agent" for assignment/handoff/role concerns
+
+## Derived Terms
+
+- **Tool surface**: installable, verifiable, or packageable artifact/configuration exposed to a concrete tool (for example a slash command file, skill directory, hook config, MCP config, custom agent profile file, or plugin manifest)
+- **Agent profile**: logical collaborator identity/role guidance projected into a tool-native custom-agent/subagent format when supported
+
+## Compatibility Note
+
+Some existing CLI commands and config keys still use historical names such as `spec-kitty agent config` and `.kittify/config.yaml` `agents.available`. New architecture, docs, and schemas should treat those as compatibility aliases for configured tools, not as permission to use "agent" for install/config concepts.


### PR DESCRIPTION
## Summary
- Add candidate glossary term for Tool Surface in the Execution context.
- Add candidate glossary term for Agent Profile in the Identity context.
- Extend the Tool vs Agent naming decision with derived terms and a compatibility note for legacy names like `spec-kitty agent config` and `agents.available`.

## Planning context
- Research gist: https://gist.github.com/robertDouglass/00ff7eac1f42a8e2fc7533d04bf6cda6
- Architecture gist: https://gist.github.com/robertDouglass/6d07f466457e8ba866df9d52b119784c

## Validation
- `git diff --check`