### PR TITLE
Release 3.2.0rc44

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc43
+  version: 3.2.0rc44
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0rc44] - 2026-06-14
+
 ### ✨ Added
 
+- **ToolSurfaceContract unified registry (mission `tool-surface-contract-01KV2K2P`, PR #1948):**
+  `src/specify_cli/tool_surface/` is now the bounded context for configured tool surface policy.
+  `spec-kitty doctor tool-surfaces --json` reports stable findings and repair commands across command
+  skills, doctrine skills, session/context surfaces, native agent profile projections, and plugin
+  bundle surfaces. `doctor skills --json` remains backward-compatible, legacy `agent config` flows
+  still work through the new contract, and fresh clones now get actionable generated-surface repair
+  plans instead of silent missing `.agents/skills/` drift.
 - **Branch-strategy recommendation in `/specify` (issue #765):** `spec-kitty agent mission branch-context`
   now resolves the repository's primary branch and emits a recommendation payload (`primary_branch`,
   `current_is_primary`, `recommended_strategy`, `reason`). The software-dev specify prompt consumes it to

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ It is probably overkill for one-off edits, tiny scripts, or teams that do not us
 - Keep architecture decisions, constraints, and acceptance criteria close to the code.
 - Build a governed software factory that can scale toward more autonomy without hiding review, test, or merge decisions.
 
-## Governed Agent Workflow
+## Governance layer
 
 Spec Kitty keeps runtime governance in the repo instead of treating it as
 agent-only prompt text. The trail model in [docs/trail-model.md](docs/trail-model.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc43"
+version = "3.2.0rc44"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/doctrine/tactics/built-in/testing/mutation-testing-workflow.tactic.yaml
+++ b/src/doctrine/tactics/built-in/testing/mutation-testing-workflow.tactic.yaml
@@ -62,7 +62,11 @@ references:
   # This workflow drives the language-specific mutation toolchains; cite the
   # toolguides it operationalizes so the tools are reachable from the workflow
   # that uses them (real "uses tool" relationship, per language).
-  - type: toolguide
+  - name: Python Mutation Tools
+    type: toolguide
     id: python-mutation-tools
-  - type: toolguide
+    when: Use when applying the mutation testing workflow to Python projects.
+  - name: TypeScript Mutation Tools
+    type: toolguide
     id: typescript-mutation-tools
+    when: Use when applying the mutation testing workflow to TypeScript projects.

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -159,8 +159,7 @@ def _stage_finalize_artifacts_in_coord_worktree(
             try:
                 if src.read_bytes() != dst.read_bytes():
                     logger.warning(
-                        "finalize residue cleanup skipped %s: primary copy "
-                        "diverged from the staged coordination copy",
+                        "finalize residue cleanup skipped %s: primary copy diverged from the staged coordination copy",
                         src.relative_to(repo_root),
                     )
                     continue
@@ -248,11 +247,7 @@ def _emit_check_prerequisites_result(
 ) -> None:
     """Emit prerequisite-check output in JSON or human form."""
     if json_output:
-        payload = (
-            _paths_only_payload(validation_result)
-            if paths_only
-            else dict(validation_result)
-        )
+        payload = _paths_only_payload(validation_result) if paths_only else dict(validation_result)
         _emit_json(
             _inject_branch_contract(
                 payload,
@@ -355,11 +350,14 @@ def _raw_frontmatter_has_field(wp_raw_content: str, field_name: str) -> bool:
     parts = wp_raw_content.split("---", 2)
     if len(parts) < 3:
         return False
-    return re.search(
-        rf"^\s*{re.escape(field_name)}\s*:",
-        parts[1],
-        re.MULTILINE,
-    ) is not None
+    return (
+        re.search(
+            rf"^\s*{re.escape(field_name)}\s*:",
+            parts[1],
+            re.MULTILINE,
+        )
+        is not None
+    )
 
 
 def _invalid_mission_specs_owned_files(
@@ -374,9 +372,7 @@ def _invalid_mission_specs_owned_files(
     return invalid
 
 
-globals()["_invalid_" + KITTY_SPECS_DIR.replace("-", "_") + "_owned_files"] = (
-    _invalid_mission_specs_owned_files
-)
+globals()["_invalid_" + KITTY_SPECS_DIR.replace("-", "_") + "_owned_files"] = _invalid_mission_specs_owned_files
 
 
 def _with_cli_version(payload: dict[str, object]) -> dict[str, object]:
@@ -396,6 +392,11 @@ def _with_mission_aliases(payload: dict[str, object]) -> dict[str, object]:
 def _emit_json(payload: dict[str, object]) -> None:
     """Emit a deterministic single JSON object."""
     print(json.dumps(_with_cli_version(_with_mission_aliases(payload))))
+
+
+def _ensure_branch_checked_out(*_args: object, **_kwargs: object) -> None:
+    """Compatibility shim for tests patching the retired checkout helper."""
+    return None
 
 
 def _utc_now_iso() -> str:
@@ -506,10 +507,7 @@ def _inject_branch_contract(
             )
         else:
             recommended_strategy = "stay"
-            recommendation_reason = (
-                f"You are on '{resolved_current_branch}', which is not the primary "
-                f"branch '{primary_branch}'; staying on it is fine."
-            )
+            recommendation_reason = f"You are on '{resolved_current_branch}', which is not the primary branch '{primary_branch}'; staying on it is fine."
         # ``branch_context`` is the same object stored in ``enriched`` above, so
         # updating it here also updates ``enriched['branch_context']``.
         branch_context["primary_branch"] = primary_branch
@@ -680,9 +678,7 @@ def _git_dirty_paths(repo_root: Path) -> list[str]:
     return dirty
 
 
-def _resolve_record_analysis_placement_ref(
-    repo_root: Path, feature_dir: Path
-) -> CommitTarget | None:
+def _resolve_record_analysis_placement_ref(repo_root: Path, feature_dir: Path) -> CommitTarget | None:
     """Resolve the context's artifact-placement ref for ``record-analysis``.
 
     Routes through the single canonical resolver (``resolve_action_context``,
@@ -830,11 +826,7 @@ def _enforce_analysis_report_write_preflight(
 
     dirty_paths = _git_dirty_paths(repo_root)
     if placement_ref is not None and placement_ref.kind is CommitTargetKind.COORDINATION:
-        dirty_paths = [
-            path
-            for path in dirty_paths
-            if Path(path).name not in COORD_OWNED_STATUS_FILES
-        ]
+        dirty_paths = [path for path in dirty_paths if Path(path).name not in COORD_OWNED_STATUS_FILES]
     if dirty_paths:
         payload = {
             "success": False,
@@ -1068,10 +1060,7 @@ def _try_advance_primary_ref(
             coord_owned_filenames=COORD_OWNED_STATUS_FILES,
         )
         if not json_output:
-            console.print(
-                f"[dim]→ Primary branch '{primary_branch}' "
-                f"fast-forwarded to {new_sha[:7]}[/dim]"
-            )
+            console.print(f"[dim]→ Primary branch '{primary_branch}' fast-forwarded to {new_sha[:7]}[/dim]")
     except (RefAdvanceDirtyWorktreeError, RefAdvanceError) as exc:
         if not json_output:
             console.print(
@@ -1081,9 +1070,7 @@ def _try_advance_primary_ref(
                 f"({exc})"
             )
     except Exception as exc:  # noqa: BLE001  # broad catch: best-effort only
-        logging.getLogger(__name__).debug(
-            "Unexpected error in _try_advance_primary_ref: %s", exc
-        )
+        logging.getLogger(__name__).debug("Unexpected error in _try_advance_primary_ref: %s", exc)
 
 
 def _commit_to_branch(
@@ -1125,9 +1112,7 @@ def _commit_to_branch(
     # Resolve the worktree the placement lands in. For a coordination placement
     # the commit must run against the coord worktree (HEAD == coord ref); for a
     # flattened/primary placement the main checkout is the worktree.
-    worktree_root, commit_paths = _planning_commit_worktree(
-        repo_root, mission_slug, placement, (file_path,)
-    )
+    worktree_root, commit_paths = _planning_commit_worktree(repo_root, mission_slug, placement, (file_path,))
 
     # Commit only this file (preserves staging area)
     commit_msg = f"Add {artifact_type} for feature {mission_slug}"
@@ -1152,9 +1137,7 @@ def _commit_to_branch(
             _warn_commit_failed(artifact_type, file_path, e, json_output)
             raise
     except RuntimeError as e:
-        if _safe_commit_empty_changeset_error(e) and _artifact_has_no_git_changes(
-            worktree_root, commit_paths[0]
-        ):
+        if _safe_commit_empty_changeset_error(e) and _artifact_has_no_git_changes(worktree_root, commit_paths[0]):
             _print_artifact_unchanged(artifact_type, json_output)
             return
 
@@ -1162,9 +1145,7 @@ def _commit_to_branch(
         raise
 
     if not json_output:
-        console.print(
-            f"[green]✓[/green] {artifact_type.capitalize()} committed to {placement.ref}"
-        )
+        console.print(f"[green]✓[/green] {artifact_type.capitalize()} committed to {placement.ref}")
 
     # WP09 / FR-010 (#1878): ff-merge treadmill elimination.  After a
     # coordination-branch write, auto-advance the primary branch ref so the
@@ -1214,9 +1195,7 @@ def _find_feature_directory(
     )
 
     if not explicit_feature:
-        raise ActionContextError(
-            "FEATURE_CONTEXT_UNRESOLVED", "--mission <slug> is required"
-        )
+        raise ActionContextError("FEATURE_CONTEXT_UNRESOLVED", "--mission <slug> is required")
     try:
         feature_dir = resolve_mission_read_path(
             repo_root,
@@ -1229,8 +1208,7 @@ def _find_feature_directory(
     except StatusReadPathNotFound as exc:
         raise ActionContextError(
             "FEATURE_CONTEXT_UNRESOLVED",
-            f"Mission not found for handle {explicit_feature!r}; checked the "
-            f"coordination worktree and the primary checkout. {exc}",
+            f"Mission not found for handle {explicit_feature!r}; checked the coordination worktree and the primary checkout. {exc}",
         ) from exc
     return cast(Path, feature_dir)
 
@@ -1518,10 +1496,7 @@ def create_mission(
             _emit_json(
                 {
                     "error_code": "BRANCH_STRATEGY_CONFIRMATION_REQUIRED",
-                    "error": (
-                        "PR-bound mission creation requires explicit branch-strategy "
-                        "confirmation in --json mode."
-                    ),
+                    "error": ("PR-bound mission creation requires explicit branch-strategy confirmation in --json mode."),
                     "branch_strategy_gate": "confirmation_required",
                     "current_branch": current_branch,
                     "merge_target_branch": effective_merge_target,
@@ -1533,10 +1508,7 @@ def create_mission(
         raise typer.Exit(1) from exc
 
     if gate_outcome.prompted and not gate_outcome.decision.proceed:
-        message = (
-            "Mission creation aborted by operator at branch-strategy gate. "
-            "Switch to a feature branch or pass `--branch-strategy already-confirmed`."
-        )
+        message = "Mission creation aborted by operator at branch-strategy gate. Switch to a feature branch or pass `--branch-strategy already-confirmed`."
         if json_output:
             _emit_json({"error": message, "branch_strategy_gate": "aborted"})
         else:
@@ -1634,10 +1606,7 @@ def create_mission(
             "scaffold_only": True,
             "requires_agent_authoring": True,
             "plan_guard": "SPEC_NOT_SUBSTANTIVE_OR_UNCOMMITTED",
-            "next_step": (
-                "Created scaffold only. Run `/spec-kitty.specify <intent>` in your agent "
-                "or edit and commit spec_file before `spec-kitty plan`."
-            ),
+            "next_step": ("Created scaffold only. Run `/spec-kitty.specify <intent>` in your agent or edit and commit spec_file before `spec-kitty plan`."),
             "origin_binding": {
                 "attempted": result.origin_binding_attempted,
                 "succeeded": result.origin_binding_succeeded,
@@ -1671,10 +1640,7 @@ def create_mission(
         # Issue #846: spec.md is no longer auto-committed at create time.
         # The agent commits it from /spec-kitty.specify after writing substantive content.
         console.print(f"   Meta committed to {result.target_branch}; spec.md scaffold left untracked")
-        console.print(
-            "   [yellow]Scaffold only:[/yellow] run [cyan]/spec-kitty.specify <intent>[/cyan] "
-            "in your agent, or edit and commit spec.md before planning."
-        )
+        console.print("   [yellow]Scaffold only:[/yellow] run [cyan]/spec-kitty.specify <intent>[/cyan] in your agent, or edit and commit spec.md before planning.")
 
 
 @app.command(name="check-prerequisites")
@@ -1811,9 +1777,7 @@ def record_analysis(
         # C-PLACE-1: the placement ref is the ONE CommitTarget that planning
         # artifacts (incl. analysis-report) AND status events resolve to. The
         # dirty-tree preflight uses it to ignore coord-owned residue (#1814).
-        placement_ref = _resolve_record_analysis_placement_ref(
-            repo_root, feature_dir
-        )
+        placement_ref = _resolve_record_analysis_placement_ref(repo_root, feature_dir)
         _enforce_analysis_report_write_preflight(
             cwd_repo_root,
             json_output=json_output,
@@ -1952,13 +1916,8 @@ def setup_plan(
 
             _scope = read_queue_scope_from_session() or read_queue_scope_from_credentials()
             if not _scope:
-                error_msg = (
-                    "SaaS sync cannot be guaranteed: no authenticated session/credentials found."
-                )
-                remediation = (
-                    "Run `spec-kitty auth login` or unset SPEC_KITTY_ENABLE_SAAS_SYNC "
-                    "before running setup-plan."
-                )
+                error_msg = "SaaS sync cannot be guaranteed: no authenticated session/credentials found."
+                remediation = "Run `spec-kitty auth login` or unset SPEC_KITTY_ENABLE_SAAS_SYNC before running setup-plan."
                 if json_output:
                     _emit_json(
                         {
@@ -2079,9 +2038,7 @@ def setup_plan(
         from specify_cli.missions._substantive import is_committed, is_substantive
 
         try:
-            _spec_placement: CommitTarget | None = _resolve_planning_placement(
-                repo_root, mission_slug
-            )
+            _spec_placement: CommitTarget | None = _resolve_planning_placement(repo_root, mission_slug)
         except Exception:  # noqa: BLE001 — broad catch intentional (C-004 strangler safety)
             _spec_placement = None
 
@@ -2300,9 +2257,7 @@ def setup_plan(
                     _gen_advance_wt: Path | None = None
                     with contextlib.suppress(Exception):  # Non-fatal
                         _gen_placement = _resolve_planning_placement(repo_root, mission_slug)
-                        _gen_wt, _gen_paths = _planning_commit_worktree(
-                            repo_root, mission_slug, _gen_placement, (meta_file,)
-                        )
+                        _gen_wt, _gen_paths = _planning_commit_worktree(repo_root, mission_slug, _gen_placement, (meta_file,))
                         safe_commit(
                             repo_root=repo_root,
                             worktree_root=_gen_wt,
@@ -2711,17 +2666,12 @@ def finalize_tasks(
 
             _ft_preflight = run_preflight(repo_root=repo_root, require_auth=False)
             if not _ft_preflight.ok:
-                console.print(
-                    "[red]Refusing `spec-kitty agent mission finalize-tasks`.[/red]"
-                )
+                console.print("[red]Refusing `spec-kitty agent mission finalize-tasks`.[/red]")
                 _ft_preflight.render(console)
                 if json_output:
                     _emit_json(
                         {
-                            "error": (
-                                "Boundary preflight refused finalize-tasks "
-                                "(FR-002 / FR-009)."
-                            ),
+                            "error": ("Boundary preflight refused finalize-tasks (FR-002 / FR-009)."),
                             "preflight": _ft_preflight.to_dict(),
                         }
                     )
@@ -2799,16 +2749,15 @@ def finalize_tasks(
         except PlanningBranchResolutionFailed as exc:
             error_msg = str(exc)
             if json_output:
-                _emit_json({
-                    "error": error_msg,
-                    "error_code": exc.error_code,
-                })
+                _emit_json(
+                    {
+                        "error": error_msg,
+                        "error_code": exc.error_code,
+                    }
+                )
             else:
                 console.print(f"[red]Error:[/red] {error_msg}")
-                console.print(
-                    "[yellow]Hint:[/yellow] re-run with "
-                    "[bold]--target-branch <ref>[/bold] to override."
-                )
+                console.print("[yellow]Hint:[/yellow] re-run with [bold]--target-branch <ref>[/bold] to override.")
             raise typer.Exit(1) from exc
         # WP09 / FR-010 (#1878): `_ensure_branch_checked_out` shim retired.
         # The primary-ref sync is now handled by `advance_branch_ref` after
@@ -2850,9 +2799,7 @@ def finalize_tasks(
         # exactly this set after staging (research R6 scoping: NEVER a path
         # that pre-existed this invocation, e.g. operator-authored files or
         # the WP/task inputs authored by earlier planning steps).
-        _preexisting_primary_files: set[Path] = {
-            path for path in planning_dir.rglob("*") if path.is_file()
-        }
+        _preexisting_primary_files: set[Path] = {path for path in planning_dir.rglob("*") if path.is_file()}
 
         # FR-009 / WP09 (closes #1163): scaffold ``issue-matrix.md`` whenever
         # ``spec.md`` references one or more GitHub issues (e.g. ``#1298``).
@@ -2868,10 +2815,7 @@ def finalize_tasks(
                 # Never block finalize-tasks on a scaffold failure — this is a
                 # convenience artifact, not a correctness gate.
                 if not json_output:
-                    console.print(
-                        "[yellow]Warning:[/yellow] could not scaffold "
-                        f"issue-matrix.md: {_issue_matrix_exc}"
-                    )
+                    console.print(f"[yellow]Warning:[/yellow] could not scaffold issue-matrix.md: {_issue_matrix_exc}")
             else:
                 if issue_matrix_path is not None and not json_output:
                     try:
@@ -2892,11 +2836,7 @@ def finalize_tasks(
             raise typer.Exit(1)
 
         # ─── FR-013: concern-refs coverage warnings ───────────────────────────
-        concern_coverage_warnings = (
-            check_concern_refs_coverage(wps_manifest)
-            if wps_manifest is not None
-            else []
-        )
+        concern_coverage_warnings = check_concern_refs_coverage(wps_manifest) if wps_manifest is not None else []
 
         # ─── TIER 1+: existing dependency resolution ──────────────────────────
         # Parse dependencies and requirement refs using 3-tier priority:
@@ -3147,11 +3087,7 @@ def finalize_tasks(
                         f"  Currently activated: {activated_list}\n"
                         f"  Resolution: {_resolution_cmd}"
                     )
-                    raise CharterActivationError(
-                        f"artifact={profile!r}, "
-                        f"activated={activated_list!r}, "
-                        f"resolution={_resolution_cmd!r}"
-                    )
+                    raise CharterActivationError(f"artifact={profile!r}, activated={activated_list!r}, resolution={_resolution_cmd!r}")
 
             # --- Dependency resolution with preserve-existing (T004) ---
             parsed_deps = wp_dependencies.get(wp_id, [])
@@ -3218,13 +3154,9 @@ def finalize_tasks(
             # nothing in source/tests). Respect an explicit empty list by
             # peeking at the raw frontmatter before inference fires.
             wp_raw_content = wp_file.read_text(encoding="utf-8")
-            owned_files_explicitly_empty = _owned_files_yaml_is_explicit_empty_list(
-                wp_raw_content
-            )
+            owned_files_explicitly_empty = _owned_files_yaml_is_explicit_empty_list(wp_raw_content)
             need_execution_mode_inference = not wp_meta.execution_mode
-            need_owned_files_inference = (
-                not wp_meta.owned_files and not owned_files_explicitly_empty
-            )
+            need_owned_files_inference = not wp_meta.owned_files and not owned_files_explicitly_empty
             if need_execution_mode_inference or need_owned_files_inference:
                 ownership, infer_warnings = infer_ownership(wp_raw_content, mission_slug)
                 all_ownership_warnings.extend(infer_warnings)
@@ -3343,14 +3275,8 @@ def finalize_tasks(
             # error; glob zero-match is a soft warning. create_intent from WP
             # frontmatter suppresses the hard error for planned-new-file paths.
             # (T015/T016/T017/T018 — FR-006, issue #1886)
-            _wp_create_intent: dict[str, list[str]] = {
-                wp_id: list(fm.create_intent)
-                for wp_id, fm in wp_frontmatters.items()
-                if fm.create_intent
-            }
-            glob_result = validate_glob_matches(
-                wp_manifests, repo_root, create_intent=_wp_create_intent
-            )
+            _wp_create_intent: dict[str, list[str]] = {wp_id: list(fm.create_intent) for wp_id, fm in wp_frontmatters.items() if fm.create_intent}
+            glob_result = validate_glob_matches(wp_manifests, repo_root, create_intent=_wp_create_intent)
             stderr_console = Console(stderr=True)
             # Route info notes (create_intent suppression) to stderr
             for note in glob_result.info:
@@ -3363,10 +3289,7 @@ def finalize_tasks(
             if not glob_result.passed:
                 for err in glob_result.errors:
                     stderr_console.print(f"[red]ERROR:[/red] Ownership: {err}")
-                error_msg = (
-                    "Ownership validation failed: literal-path owned_files entries "
-                    "match zero files. Fix the paths or add them to 'create_intent'."
-                )
+                error_msg = "Ownership validation failed: literal-path owned_files entries match zero files. Fix the paths or add them to 'create_intent'."
                 if json_output:
                     _emit_json(
                         {
@@ -3546,10 +3469,7 @@ def finalize_tasks(
                 wp_count=len(work_packages),
             )
         except Exception as _local_wp_exc:  # noqa: BLE001
-            console.print(
-                f"[yellow]Warning:[/yellow] Local canonical WPCreated/TasksCompleted "
-                f"persistence failed: {_local_wp_exc}"
-            )
+            console.print(f"[yellow]Warning:[/yellow] Local canonical WPCreated/TasksCompleted persistence failed: {_local_wp_exc}")
 
         # Bootstrap canonical status state for all WPs
         bootstrap_result = bootstrap_canonical_state(
@@ -3577,22 +3497,13 @@ def finalize_tasks(
             # initial check was somehow bypassed (e.g. direct call), we refuse to
             # write lanes.json with a phantom path rather than silently propagating
             # the error.
-            _lane_create_intent: dict[str, list[str]] = {
-                wp_id: list(fm.create_intent)
-                for wp_id, fm in wp_frontmatters.items()
-                if fm.create_intent
-            }
-            _lane_glob_result = validate_glob_matches(
-                wp_manifests, repo_root, create_intent=_lane_create_intent
-            )
+            _lane_create_intent: dict[str, list[str]] = {wp_id: list(fm.create_intent) for wp_id, fm in wp_frontmatters.items() if fm.create_intent}
+            _lane_glob_result = validate_glob_matches(wp_manifests, repo_root, create_intent=_lane_create_intent)
             if not _lane_glob_result.passed:
                 _lane_stderr = Console(stderr=True)
                 for err in _lane_glob_result.errors:
                     _lane_stderr.print(f"[red]ERROR:[/red] Lane-compute re-validation: {err}")
-                _lane_error_msg = (
-                    "Lane computation aborted: literal-path owned_files entries "
-                    "match zero files. Fix the paths before lanes.json is written."
-                )
+                _lane_error_msg = "Lane computation aborted: literal-path owned_files entries match zero files. Fix the paths before lanes.json is written."
                 if json_output:
                     _emit_json(
                         {
@@ -3644,8 +3555,7 @@ def finalize_tasks(
                             console.print(f"    coupling: {c}")
             if risk_report.exceeds_threshold and _policy.risk.mode == "block":
                 error_msg = (
-                    f"Parallelization risk {risk_report.overall_score:.2f} exceeds threshold "
-                    f"{risk_report.threshold:.2f}. Adjust the risk policy to proceed."
+                    f"Parallelization risk {risk_report.overall_score:.2f} exceeds threshold {risk_report.threshold:.2f}. Adjust the risk policy to proceed."
                 )
                 if json_output:
                     _emit_json(
@@ -3681,14 +3591,9 @@ def finalize_tasks(
                 # convenience artifact, not a correctness gate. Emit a
                 # copy-pasteable remediation command so operators can recover.
                 if not json_output:
+                    console.print(f"[yellow]Warning:[/yellow] could not scaffold acceptance-matrix.json: {_acc_matrix_exc}")
                     console.print(
-                        "[yellow]Warning:[/yellow] could not scaffold "
-                        f"acceptance-matrix.json: {_acc_matrix_exc}"
-                    )
-                    console.print(
-                        "[yellow]Hint:[/yellow] create it manually before "
-                        "acceptance:\n  spec-kitty agent mission finalize-tasks "
-                        f"--feature {mission_slug}"
+                        f"[yellow]Hint:[/yellow] create it manually before acceptance:\n  spec-kitty agent mission finalize-tasks --feature {mission_slug}"
                     )
             else:
                 if acceptance_matrix_path is not None and not json_output:
@@ -3759,11 +3664,7 @@ def finalize_tasks(
                 # finalize invocation materialized on the primary checkout are
                 # residue once staged on the coordination branch — the stager
                 # removes exactly those (and nothing pre-existing, R6).
-                _primary_created = frozenset(
-                    path
-                    for path in files_to_commit
-                    if path not in _preexisting_primary_files
-                )
+                _primary_created = frozenset(path for path in files_to_commit if path not in _preexisting_primary_files)
                 _commit_worktree_root, _commit_files = _planning_commit_worktree(
                     repo_root,
                     mission_slug,

--- a/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
+++ b/tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py
@@ -456,17 +456,19 @@ def _setup_lane_based_feature(tmp_path: Path, mission_slug: str = "061-lane-feat
     tasks_dir.mkdir(parents=True)
 
     (feature_dir / "spec.md").write_text(
-        "---\ntitle: Lane Feature\n---\n\n## Requirements\n\n"
-        "- FR-001: First requirement\n- FR-002: Second requirement\n",
+        "---\ntitle: Lane Feature\n---\n\n## Requirements\n\n- FR-001: First requirement\n- FR-002: Second requirement\n",
         encoding="utf-8",
     )
     (feature_dir / "tasks.md").write_text(
         "# Tasks\n\n## WP01\n\nNo dependencies.\n\n## WP02\n\nNo dependencies.\n",
         encoding="utf-8",
     )
-    (feature_dir / "meta.json").write_text(
-        json.dumps({"mission_slug": mission_slug}), encoding="utf-8"
-    )
+    (feature_dir / "meta.json").write_text(json.dumps({"mission_slug": mission_slug}), encoding="utf-8")
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "alpha.py").write_text("# alpha\n", encoding="utf-8")
+    (src_dir / "beta.py").write_text("# beta\n", encoding="utf-8")
 
     # Two independent WPs owning disjoint files → compute_lanes yields lanes.
     for wp_id, owned, refs in [
@@ -495,9 +497,7 @@ class TestFinalizeScaffoldsAcceptanceMatrix:
 
         patches = _common_patches(tmp_path, mission_slug)
         patches[f"{MODULE}._find_feature_directory"] = MagicMock(return_value=feature_dir)
-        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
-            return_value=_make_bootstrap_result()
-        )
+        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(return_value=_make_bootstrap_result())
 
         from specify_cli.cli.commands.agent.mission import finalize_tasks
 
@@ -533,9 +533,7 @@ class TestFinalizeScaffoldsAcceptanceMatrix:
 
         patches = _common_patches(tmp_path, mission_slug)
         patches[f"{MODULE}._find_feature_directory"] = MagicMock(return_value=feature_dir)
-        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
-            return_value=_make_bootstrap_result()
-        )
+        patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(return_value=_make_bootstrap_result())
 
         from specify_cli.cli.commands.agent.mission import finalize_tasks
 
@@ -550,9 +548,7 @@ class TestFinalizeScaffoldsAcceptanceMatrix:
             for p in ctx_patches.values():
                 p.stop()
 
-        assert not (feature_dir / "acceptance-matrix.json").exists(), (
-            "validate-only must not write the acceptance-matrix scaffold"
-        )
+        assert not (feature_dir / "acceptance-matrix.json").exists(), "validate-only must not write the acceptance-matrix scaffold"
 
     def test_explicit_frontmatter_dependencies_beat_tasks_md_parser(
         self,
@@ -602,9 +598,7 @@ class TestFinalizeScaffoldsAcceptanceMatrix:
         mission_slug = "060-test-feature"
         feature_dir = _setup_feature(tmp_path, mission_slug)
         (feature_dir / "tasks.md").write_text(
-            "# Tasks\n\n"
-            "## WP01\n\n**Dependencies**: WP02\n\n"
-            "## WP02\n\n**Dependencies**: WP01\n",
+            "# Tasks\n\n## WP01\n\n**Dependencies**: WP02\n\n## WP02\n\n**Dependencies**: WP01\n",
             encoding="utf-8",
         )
 
@@ -1172,9 +1166,7 @@ def _write_overlap_feature(
         encoding="utf-8",
     )
     (feature_dir / "tasks.md").write_text(tasks_md, encoding="utf-8")
-    (feature_dir / "meta.json").write_text(
-        json.dumps({"mission_slug": mission_slug}), encoding="utf-8"
-    )
+    (feature_dir / "meta.json").write_text(json.dumps({"mission_slug": mission_slug}), encoding="utf-8")
     for wp_id, owned, surface, deps, scope in wps:
         lines = [
             "---",
@@ -1206,9 +1198,7 @@ def _run_finalize_validate_only(
     """Run finalize-tasks --validate-only with the REAL ownership validator."""
     patches = _common_patches(tmp_path, mission_slug)
     del patches[f"{MODULE}.validate_ownership"]  # exercise the real validator
-    patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
-        return_value=_make_bootstrap_result()
-    )
+    patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(return_value=_make_bootstrap_result())
     from specify_cli.cli.commands.agent.mission import finalize_tasks
 
     started = [patch(target, value) for target, value in patches.items()]
@@ -1234,9 +1224,7 @@ def _run_finalize_validate_only(
 class TestOwnershipOverlapAcceptance:
     """Overlap fails for narrow WPs regardless of lane/dependency structure."""
 
-    def test_independent_wps_overlap_fails(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_independent_wps_overlap_fails(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """Two independent (different-lane) narrow WPs on the same files fail."""
         _write_overlap_feature(
             tmp_path,
@@ -1253,9 +1241,7 @@ class TestOwnershipOverlapAcceptance:
         assert isinstance(errors, list)
         assert any("WP01" in e and "WP02" in e for e in errors)
 
-    def test_dependent_wps_overlap_still_fails(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_dependent_wps_overlap_still_fails(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """WP02→WP01 dependency (one lane) does NOT exempt narrow overlap."""
         _write_overlap_feature(
             tmp_path,
@@ -1267,14 +1253,9 @@ class TestOwnershipOverlapAcceptance:
         )
         results = _run_finalize_validate_only(tmp_path, capsys)
         failures = [r for r in results if r.get("error") == "Ownership validation failed"]
-        assert failures, (
-            "a dependency hierarchy must NOT exempt overlapping narrow WPs; "
-            f"got {results}"
-        )
+        assert failures, f"a dependency hierarchy must NOT exempt overlapping narrow WPs; got {results}"
 
-    def test_codebase_wide_is_the_only_exemption(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_codebase_wide_is_the_only_exemption(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """A codebase-wide WP overlapping a narrow WP passes (end-to-end #1753)."""
         # Create the literal-path file so the glob-match validator doesn't
         # raise a hard error for a non-existent path (FR-006 / WP04).
@@ -1291,9 +1272,5 @@ class TestOwnershipOverlapAcceptance:
             tasks_md="# Tasks\n\n## WP01\n\nNo dependencies.\n\n## WP02\n\nDepends on WP01.\n",
         )
         results = _run_finalize_validate_only(tmp_path, capsys)
-        assert not [
-            r for r in results if r.get("error") == "Ownership validation failed"
-        ], f"codebase-wide WP must be exempt from overlap; got {results}"
-        assert any(
-            r.get("result") == "validation_passed" for r in results
-        ), f"expected validation_passed; got {results}"
+        assert not [r for r in results if r.get("error") == "Ownership validation failed"], f"codebase-wide WP must be exempt from overlap; got {results}"
+        assert any(r.get("result") == "validation_passed" for r in results), f"expected validation_passed; got {results}"

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/accept.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/accept.prompt.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/research.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/research.prompt.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-finalize.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks-finalize.prompt.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/accept.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/accept.toml
@@ -1,0 +1,125 @@
+description = "Validate an approved mission before merge"
+
+prompt = """
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+{{args}}
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.
+"""

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/research.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/research.toml
@@ -70,7 +70,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -126,7 +126,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -134,7 +134,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \\

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-finalize.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks-finalize.toml
@@ -141,7 +141,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/accept.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/accept.toml
@@ -1,0 +1,125 @@
+description = "Validate an approved mission before merge"
+
+prompt = """
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+{{args}}
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.
+"""

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/research.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/research.toml
@@ -70,7 +70,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
@@ -126,7 +126,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -134,7 +134,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \\

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-finalize.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks-finalize.toml
@@ -141,7 +141,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/roo/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/accept.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/accept.md
@@ -1,0 +1,125 @@
+---
+description: Validate an approved mission before merge
+---
+<!-- spec-kitty-command-version: 3.1.2a3 -->
+
+## Startup Upgrade Check
+
+Run this at most once per active agent session before the first Spec Kitty command workflow.
+If you already ran `spec-kitty upgrade --agent-check --json` in this session, reuse that result and skip this block.
+Do not run or announce an upgrade check again for later Spec Kitty commands in the same session.
+Otherwise, before continuing, run:
+
+```bash
+spec-kitty upgrade --agent-check --json
+```
+
+If JSON `action` is `none`, continue.
+If `action` is `auto_upgrade`, run `upgrade_command` before continuing. If it fails, tell the user and continue with the current Spec Kitty version.
+If `action` is `guidance`, show `upgrade_note` briefly, then continue.
+If `action` is `prompt`, ask the user with the host-native question UI when available:
+
+`Spec Kitty {latest_version} is available. You are on {installed_version}. Upgrade now?`
+
+Use these choices:
+
+1. Upgrade now (recommended) - record `upgrade_now`, run `upgrade_command`, then continue.
+2. Always keep me up to date - record `always`, run `upgrade_command`, then continue.
+3. Not now - record `not_now`, then continue.
+4. Never ask again - record `never_ask`, then continue.
+
+Record the selected choice before continuing:
+
+```bash
+spec-kitty upgrade --agent-choice <upgrade_now|always|not_now|never_ask> --agent-latest <latest_version> --json
+```
+
+If no host-native question UI is available, present the same four choices in plain text and wait for the user.
+In non-interactive hosts, choose `not_now` and continue.
+
+
+# /spec-kitty.accept - Validate Mission<!-- glossary:glossary:mission --> Readiness
+
+**Version**: 0.12.0+
+
+## Purpose
+
+Validate that every work package<!-- glossary:glossary:work-package --> is complete and the mission is ready to merge.
+This step runs the acceptance gate, surfaces any blocking diagnostics, and only
+clears the path to merge once the gate passes.
+
+---
+
+## 📍 WORKING DIRECTORY: Run from the MAIN repository<!-- glossary:glossary:repository --><!-- glossary:glossary:main-repository -->
+
+**IMPORTANT**: Acceptance runs from the primary repository checkout root, NOT
+from a work-package worktree.
+
+```bash
+# If you are inside a worktree, return to the main checkout first:
+cd $(git rev-parse --show-toplevel)
+```
+
+**In repos with multiple missions, always pass `--mission <handle>` to every spec-kitty command.** The `<handle>` can be the mission's `mission_id<!-- glossary:glossary:mission_id -->` (ULID), `mid8<!-- glossary:glossary:mid8 -->` (first 8 chars of the ULID), or `mission_slug<!-- glossary:glossary:mission_slug -->`. The resolver disambiguates by `mission_id` and returns a structured `MISSION_AMBIGUOUS_SELECTOR` error on ambiguity — there is no silent fallback.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Steps
+
+### 1. Run the Acceptance Gate
+
+Run the acceptance command from the repository root:
+
+```bash
+spec-kitty accept --mission <handle>
+```
+
+This validates that all work packages are `approved<!-- glossary:glossary:approved -->` or `done<!-- glossary:glossary:done -->`, checks the
+readiness gates, and reports what (if anything) still blocks merge.
+
+### 2. Inspect Acceptance Diagnostics
+
+Read the command output carefully:
+
+- If the gate **passes**, the output confirms the mission is ready to merge and
+  prints the merge instructions.
+- If the gate **fails**, the output lists each outstanding category (for
+  example: WPs not yet approved, failing checks, or unresolved review
+  feedback). Treat every outstanding item as a blocker.
+
+### 3. Resolve Any Gate Failures
+
+For each blocker reported:
+
+- Route the affected work package back through implement/review as needed.
+- Re-run the relevant tests or checks until they pass.
+- Re-run `spec-kitty accept --mission <handle>` and confirm the gate is now
+  clean. Do **not** force acceptance past an unresolved blocker.
+
+### 4. Proceed to Merge
+
+Only after the acceptance gate passes:
+
+```bash
+spec-kitty merge --mission <handle>
+```
+
+Follow the merge instructions printed by the acceptance command (and any
+cleanup steps it lists).
+
+## Output
+
+After completing this step:
+
+- The acceptance gate has passed for `<handle>`.
+- All blocking diagnostics have been resolved (or none were present).
+- Merge instructions have been surfaced to the operator.
+
+**Next step**: `spec-kitty next --agent <name>` will advance to merge, or run
+`spec-kitty merge --mission <handle>` directly.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/research.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/research.md
@@ -71,7 +71,7 @@ This command creates research artifacts in your feature directory. You must be i
 
 **Correct the issue:**
 1. Navigate to your repository root checkout: `cd /path/to/project/root`
-2. Verify you're on the correct feature branch: `git branch --show-current`
+2. Verify you're on the correct feature branch<!-- glossary:glossary:feature-branch -->: `git branch --show-current`
 3. Then run this research command again
 
 ---

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
@@ -127,7 +127,7 @@ Never talk generically about `main` or "the default branch". Name the actual bra
 
 The helper JSON also returns a primary-branch recommendation payload:
 
-- `primary_branch` — the repository's primary branch (e.g. `main`)
+- `primary_branch` — the repository's primary branch<!-- glossary:glossary:primary-branch --> (e.g. `main`)
 - `current_is_primary` — `true` when you are standing on that primary branch
 - `recommended_strategy` — `feature-branch` (start a dedicated branch) or `stay`
 - `reason` — a human-readable explanation you should relay to the user
@@ -135,7 +135,7 @@ The helper JSON also returns a primary-branch recommendation payload:
 When `current_is_primary` is `true`, you **must** have an explicit branching-strategy conversation **before** calling `create`:
 
 1. Relay the `reason` to the user and ask whether they expect to open a pull request for this work later (the default assumption for mission work is yes).
-2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
+2. **If they expect a PR (recommended path):** recommend starting on a dedicated feature branch<!-- glossary:glossary:feature-branch --> now, and propose a name derived from the confirmed slug — e.g. `feat/<slug>` (use `fix/<slug>` for a bug-fix mission). Pass that branch to `create` with `--start-branch` so the CLI creates/switches to it before writing any mission artifacts:
 
    ```bash
    spec-kitty agent mission create "<slug>" \

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-finalize.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks-finalize.md
@@ -142,7 +142,35 @@ The JSON output includes:
 - `"wp_count"` — number of WP files processed
 - `"dependencies_parsed"` — dependency relationships found
 - `"requirement_refs_parsed"` — requirement reference mapping found
+- `"ownership_warnings"` — soft warnings (glob-pattern zero-match, audit coverage)
 - Validation details when checks fail (`missing_requirement_refs_wps`, `unknown_requirement_refs`, `unmapped_functional_requirements`)
+
+**CRITICAL — Ownership warnings require action before proceeding:**
+
+If `ownership_warnings` is non-empty, or if the command emits `ERROR: Ownership`
+lines to stderr, you MUST act on each issue before starting implementation:
+
+- **Hard error** (`ownership_literal_path_errors` present, exit 1): A
+  `owned_files` entry is a literal file path that does not exist in the
+  repository. Fix by:
+  1. Correcting the path (typo / wrong relative path), or
+  2. Adding the path to `create_intent` in the WP frontmatter if the file will
+     be created by this WP (planned-new-file).
+
+  **Do NOT proceed to implement while any hard error is present.**
+
+- **Soft warning** (`ownership_warnings` non-empty, exit 0): A `owned_files`
+  glob pattern matched zero files. This may indicate in-flight work. Verify the
+  pattern is correct and adjust if needed before starting implementation.
+
+Example `create_intent` frontmatter for a planned-new-file entry:
+
+```yaml
+owned_files:
+  - "src/specify_cli/new_module.py"
+create_intent:
+  - "src/specify_cli/new_module.py"  # will be created by this WP
+```
 
 ### 4. Verify
 

--- a/tests/specify_cli/regression/test_twelve_agent_parity.py
+++ b/tests/specify_cli/regression/test_twelve_agent_parity.py
@@ -34,7 +34,7 @@ from unittest.mock import patch
 import pytest
 
 from specify_cli.core.config import AGENT_COMMAND_CONFIG
-from specify_cli.skills.command_installer import CANONICAL_COMMANDS as COMMAND_SKILL_COMMANDS
+from specify_cli.skills.command_installer import PROMPT_BACKED_COMMANDS
 from specify_cli.template.asset_generator import render_command_template
 
 # ---------------------------------------------------------------------------
@@ -43,14 +43,7 @@ from specify_cli.template.asset_generator import render_command_template
 
 pytestmark = [pytest.mark.unit]
 
-TEMPLATES_DIR = (
-    Path(__file__).parent.parent.parent.parent
-    / "src"
-    / "doctrine"
-    / "missions"
-    / "mission-steps"
-    / "software-dev"
-)
+TEMPLATES_DIR = Path(__file__).parent.parent.parent.parent / "src" / "doctrine" / "missions" / "mission-steps" / "software-dev"
 
 BASELINE_DIR = Path(__file__).parent / "_twelve_agent_baseline"
 
@@ -58,8 +51,13 @@ BASELINE_DIR = Path(__file__).parent / "_twelve_agent_baseline"
 # Command-skill agents are absent: they use the Agent Skills pipeline.
 NON_MIGRATED_AGENTS: tuple[str, ...] = tuple(AGENT_COMMAND_CONFIG.keys())
 
-# Canonical command templates to test (one prompt.md source file per command).
-CANONICAL_COMMANDS: tuple[str, ...] = COMMAND_SKILL_COMMANDS
+# Canonical prompt-backed command templates to test (one prompt.md source file per command).
+#
+# ``command_installer.CANONICAL_COMMANDS`` also includes thin CLI-wrapper
+# Agent Skills such as ``dashboard``, ``merge``, and ``status``. Those do not
+# have software-dev prompt templates and are covered by command-skill tests,
+# not by this non-migrated command-file renderer regression.
+CANONICAL_COMMANDS: tuple[str, ...] = PROMPT_BACKED_COMMANDS
 
 # Fixed version for rendering (must match what was used when capturing the
 # baseline; see _twelve_agent_baseline/__init__.py).
@@ -131,11 +129,7 @@ def test_command_output_unchanged(agent: str, command: str) -> None:
         return
 
     if not snap.exists():
-        pytest.fail(
-            f"Baseline missing for {agent}/{command} at {snap}.\n"
-            f"Regenerate with: PYTEST_UPDATE_SNAPSHOTS=1 pytest "
-            f"tests/specify_cli/regression/ -v"
-        )
+        pytest.fail(f"Baseline missing for {agent}/{command} at {snap}.\nRegenerate with: PYTEST_UPDATE_SNAPSHOTS=1 pytest tests/specify_cli/regression/ -v")
 
     expected = snap.read_text(encoding="utf-8")
     assert produced == expected, (
@@ -174,27 +168,19 @@ def test_non_migrated_agents_count() -> None:
     agent alongside the 12 existing non-migrated agents. Command-skill agents remain
     absent (they use the Agent Skills pipeline — see AGENT_SKILL_CONFIG).
     """
-    assert len(NON_MIGRATED_AGENTS) == 13, (
-        f"Expected 13 non-migrated agents, got {len(NON_MIGRATED_AGENTS)}: "
-        f"{NON_MIGRATED_AGENTS}"
-    )
+    assert len(NON_MIGRATED_AGENTS) == 13, f"Expected 13 non-migrated agents, got {len(NON_MIGRATED_AGENTS)}: {NON_MIGRATED_AGENTS}"
 
 
 def test_codex_not_in_agent_command_config() -> None:
     """codex must NOT be in AGENT_COMMAND_CONFIG (migrated to Agent Skills)."""
     assert "codex" not in AGENT_COMMAND_CONFIG, (
-        "codex was found in AGENT_COMMAND_CONFIG. "
-        "Mission 083 migrated codex to the Agent Skills pipeline; "
-        "it must not appear in the command-file registry."
+        "codex was found in AGENT_COMMAND_CONFIG. Mission 083 migrated codex to the Agent Skills pipeline; it must not appear in the command-file registry."
     )
 
 
 def test_vibe_not_in_agent_command_config() -> None:
     """vibe must NOT be in AGENT_COMMAND_CONFIG (uses Agent Skills pipeline)."""
-    assert "vibe" not in AGENT_COMMAND_CONFIG, (
-        "vibe was found in AGENT_COMMAND_CONFIG. "
-        "Vibe uses the Agent Skills pipeline, not the command-file pipeline."
-    )
+    assert "vibe" not in AGENT_COMMAND_CONFIG, "vibe was found in AGENT_COMMAND_CONFIG. Vibe uses the Agent Skills pipeline, not the command-file pipeline."
 
 
 def test_pi_and_letta_not_in_agent_command_config() -> None:
@@ -208,22 +194,17 @@ def test_agent_baseline_directory_exists(agent: str) -> None:
     """Each non-migrated agent must have a baseline directory."""
     agent_dir = BASELINE_DIR / agent
     assert agent_dir.is_dir(), (
-        f"Baseline directory missing for agent '{agent}' at {agent_dir}.\n"
-        f"Regenerate with: PYTEST_UPDATE_SNAPSHOTS=1 pytest "
-        f"tests/specify_cli/regression/ -v"
+        f"Baseline directory missing for agent '{agent}' at {agent_dir}.\nRegenerate with: PYTEST_UPDATE_SNAPSHOTS=1 pytest tests/specify_cli/regression/ -v"
     )
 
 
 @pytest.mark.parametrize("agent", NON_MIGRATED_AGENTS)
 def test_agent_baseline_file_count(agent: str) -> None:
-    """Each agent baseline directory must contain exactly 11 command files."""
+    """Each agent baseline directory must contain one file per prompt-backed command."""
     agent_dir = BASELINE_DIR / agent
     if not agent_dir.is_dir():
         pytest.skip(f"Baseline dir missing for {agent}")
-    files = [
-        f for f in agent_dir.iterdir()
-        if f.is_file() and not f.name.startswith(".")
-    ]
+    files = [f for f in agent_dir.iterdir() if f.is_file() and not f.name.startswith(".")]
     assert len(files) == len(CANONICAL_COMMANDS), (
         f"Agent '{agent}' baseline has {len(files)} files, "
         f"expected {len(CANONICAL_COMMANDS)} (one per canonical command).\n"
@@ -242,7 +223,7 @@ def test_agent_outputs_contain_arg_placeholder(agent: str) -> None:
     config = AGENT_COMMAND_CONFIG[agent]
     expected_placeholder = config["arg_format"]
     # Only commands that forward user args will have the placeholder —
-    # check all 11 templates and verify at least one contains the placeholder.
+    # check every prompt-backed template and verify at least one contains it.
     found_any = False
     for command in CANONICAL_COMMANDS:
         snap = _baseline_path(agent, command)

--- a/tests/sync/test_strict_json_stdout.py
+++ b/tests/sync/test_strict_json_stdout.py
@@ -86,6 +86,7 @@ import pytest
 
 pytestmark = [pytest.mark.unit, pytest.mark.git_repo]
 
+
 def _repo_root() -> pathlib.Path:
     """Locate the worktree root by walking up from this test file."""
     return pathlib.Path(__file__).resolve().parents[2]
@@ -201,14 +202,8 @@ async def test_websocket_client_connect_failure_routes_diagnostics_to_stderr(
             with pytest.raises(type(exc_to_raise)):
                 await ws_client.connect()
             captured = capsys.readouterr()
-            assert captured.out == "", (
-                f"[{label}] stdout must remain empty during sync failures; "
-                f"got: {captured.out!r}"
-            )
-            assert expected_substring in captured.err, (
-                f"[{label}] expected diagnostic on stderr; "
-                f"stderr={captured.err!r}"
-            )
+            assert captured.out == "", f"[{label}] stdout must remain empty during sync failures; got: {captured.out!r}"
+            assert expected_substring in captured.err, f"[{label}] expected diagnostic on stderr; stderr={captured.err!r}"
             assert ws_client.connected is False
             assert ws_client.status == client_module.ConnectionStatus.OFFLINE
 
@@ -227,14 +222,8 @@ async def test_websocket_client_connect_failure_routes_diagnostics_to_stderr(
         with pytest.raises(RuntimeError):
             await ws_client.connect()
         captured = capsys.readouterr()
-        assert captured.out == "", (
-            "[ws-connect-failure] stdout must remain empty; "
-            f"got: {captured.out!r}"
-        )
-        assert "Sync WebSocket connection failed" in captured.err, (
-            f"[ws-connect-failure] expected stderr diagnostic; "
-            f"stderr={captured.err!r}"
-        )
+        assert captured.out == "", f"[ws-connect-failure] stdout must remain empty; got: {captured.out!r}"
+        assert "Sync WebSocket connection failed" in captured.err, f"[ws-connect-failure] expected stderr diagnostic; stderr={captured.err!r}"
     finally:
         logger.handlers.clear()
         for handler in prior_handlers:
@@ -352,9 +341,7 @@ def _augment_pythonpath(env: dict[str, str]) -> dict[str, str]:
     """
     src_dir = str(_worktree_src())
     existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = (
-        src_dir + os.pathsep + existing if existing else src_dir
-    )
+    env["PYTHONPATH"] = src_dir + os.pathsep + existing if existing else src_dir
     return env
 
 
@@ -382,6 +369,29 @@ def _run_cli_isolated(
         cwd=str(cwd),
         timeout=60,
     )
+
+
+def _stop_isolated_sync_daemon(env_overrides: Mapping[str, str]) -> None:
+    """Stop any sync daemon started inside the isolated subprocess home."""
+    env = os.environ.copy()
+    env.update(env_overrides)
+    env = _augment_pythonpath(env)
+    script = (
+        "from specify_cli.sync.daemon import stop_sync_daemon\n"
+        "ok, message = stop_sync_daemon(timeout=5.0)\n"
+        "print(message)\n"
+        "raise SystemExit(0 if ok or message == 'No sync daemon metadata found.' else 1)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(pathlib.Path(env_overrides["HOME"])),
+        timeout=15,
+    )
+    assert result.returncode == 0, f"isolated sync daemon cleanup failed.\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
 
 
 def _resolve_in_tree_specify_cli(env_overrides: Mapping[str, str]) -> pathlib.Path:
@@ -459,9 +469,7 @@ def test_agent_tasks_status_json_strict_with_sync_enabled_isolated(
     resolved_path = _resolve_in_tree_specify_cli(env_overrides)
     worktree_src = _worktree_src().resolve()
     assert resolved_path.is_relative_to(worktree_src), (
-        f"subprocess resolved specify_cli at {resolved_path}, "
-        f"expected a path under {worktree_src}. "
-        f"PYTHONPATH override is not taking effect."
+        f"subprocess resolved specify_cli at {resolved_path}, expected a path under {worktree_src}. PYTHONPATH override is not taking effect."
     )
 
     # `agent tasks status` refuses early on detached HEAD; GitHub's
@@ -472,12 +480,15 @@ def test_agent_tasks_status_json_strict_with_sync_enabled_isolated(
     # duration of the subprocess invocation and restore the original
     # ref afterwards. The git tree itself is unchanged — only the
     # symbolic ref moves.
-    prior_head = subprocess.run(
-        ["git", "symbolic-ref", "--quiet", "HEAD"],
-        cwd=str(repo),
-        capture_output=True,
-        text=True,
-    ).stdout.strip() or None
+    prior_head = (
+        subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "HEAD"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        or None
+    )
     if prior_head is None:
         prior_head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
@@ -496,18 +507,21 @@ def test_agent_tasks_status_json_strict_with_sync_enabled_isolated(
         prior_head_sha = None
 
     try:
-        result = _run_cli_isolated(
-            [
-                "agent",
-                "tasks",
-                "status",
-                "--mission",
-                "private-teamspace-ingress-safeguards-01KQH03Y",
-                "--json",
-            ],
-            env_overrides=env_overrides,
-            cwd=repo,
-        )
+        try:
+            result = _run_cli_isolated(
+                [
+                    "agent",
+                    "tasks",
+                    "status",
+                    "--mission",
+                    "private-teamspace-ingress-safeguards-01KQH03Y",
+                    "--json",
+                ],
+                env_overrides=env_overrides,
+                cwd=repo,
+            )
+        finally:
+            _stop_isolated_sync_daemon(env_overrides)
     finally:
         if prior_head_sha is not None:
             # Restore detached HEAD pointing at the original commit so the
@@ -534,9 +548,7 @@ def test_agent_tasks_status_json_strict_with_sync_enabled_isolated(
     # NFR-003: stdout must round-trip through json.loads as a single
     # JSON document. Any leaked diagnostic text would break this.
     parsed = json.loads(result.stdout)
-    assert isinstance(parsed, dict), (
-        f"expected top-level JSON object, got {type(parsed).__name__}"
-    )
+    assert isinstance(parsed, dict), f"expected top-level JSON object, got {type(parsed).__name__}"
 
     # FR-009: no sync-diagnostic emoji or prose on stdout.
     assert "Connection failed" not in result.stdout
@@ -548,9 +560,7 @@ def test_agent_tasks_status_json_strict_with_sync_enabled_isolated(
     # the subprocess must not have touched the real user's home.
     real_home = pathlib.Path(os.path.expanduser("~"))
     fake_home = pathlib.Path(env_overrides["HOME"]).resolve()
-    assert real_home.resolve() != fake_home, (
-        "fake home must differ from real home - fixture invariant"
-    )
+    assert real_home.resolve() != fake_home, "fake home must differ from real home - fixture invariant"
 
 
 @pytest.mark.slow
@@ -595,10 +605,7 @@ def test_sync_diagnostic_emits_to_stderr_with_strict_json_command(
     # Pre-flight: prove in-tree package will win.
     resolved_path = _resolve_in_tree_specify_cli(env_overrides)
     worktree_src = _worktree_src().resolve()
-    assert resolved_path.is_relative_to(worktree_src), (
-        f"subprocess resolved specify_cli at {resolved_path}, "
-        f"expected under {worktree_src}"
-    )
+    assert resolved_path.is_relative_to(worktree_src), f"subprocess resolved specify_cli at {resolved_path}, expected under {worktree_src}"
 
     # The Python script that exercises the resolver and emits strict
     # JSON afterwards. We attach a stderr handler to the sync._team
@@ -635,10 +642,7 @@ def test_sync_diagnostic_emits_to_stderr_with_strict_json_command(
         timeout=60,
     )
 
-    assert proc.returncode == 0, (
-        "diagnostic-path probe must exit 0 (FR-010 local-success).\n"
-        f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
-    )
+    assert proc.returncode == 0, f"diagnostic-path probe must exit 0 (FR-010 local-success).\nstdout={proc.stdout!r}\nstderr={proc.stderr!r}"
 
     # NFR-003: stdout is strict JSON.
     parsed = json.loads(proc.stdout)
@@ -646,9 +650,7 @@ def test_sync_diagnostic_emits_to_stderr_with_strict_json_command(
     assert parsed.get("result") == "success"
     # The resolver must return None for a shared-only session after a
     # failed rehydrate -- the whole point of FR-002.
-    assert parsed.get("team_id") is None, (
-        f"expected team_id=None for shared-only session, got {parsed!r}"
-    )
+    assert parsed.get("team_id") is None, f"expected team_id=None for shared-only session, got {parsed!r}"
 
     # FR-009: no diagnostic prose on stdout.
     assert "direct ingress skipped" not in proc.stdout
@@ -658,10 +660,7 @@ def test_sync_diagnostic_emits_to_stderr_with_strict_json_command(
     # Cycle-2 fix: prove the diagnostic path actually fired. Without
     # this assertion the test could silently fall through the
     # ``get_current_session() is None`` branch and look passing.
-    diagnostic_present = (
-        "direct ingress skipped" in proc.stderr
-        or "direct_ingress_missing_private_team" in proc.stderr
-    )
+    diagnostic_present = "direct ingress skipped" in proc.stderr or "direct_ingress_missing_private_team" in proc.stderr
     assert diagnostic_present, (
         "expected 'direct ingress skipped' / "
         "'direct_ingress_missing_private_team' on stderr after seeding "
@@ -686,9 +685,7 @@ def _scaffold_minimal_kittify_repo(repo_root: pathlib.Path) -> None:
     ``agents.available`` lookups; project metadata is filled with stable
     placeholders.
     """
-    subprocess.run(
-        ["git", "init", "-q"], cwd=repo_root, check=True, capture_output=True
-    )
+    subprocess.run(["git", "init", "-q"], cwd=repo_root, check=True, capture_output=True)
     subprocess.run(
         [
             "git",
@@ -710,14 +707,7 @@ def _scaffold_minimal_kittify_repo(repo_root: pathlib.Path) -> None:
     kittify.mkdir(parents=True, exist_ok=True)
     (repo_root / "kitty-specs").mkdir(parents=True, exist_ok=True)
     (kittify / "config.yaml").write_text(
-        "vcs:\n"
-        "  type: git\n"
-        "agents:\n"
-        "  available:\n"
-        "  - claude\n"
-        "project:\n"
-        "  uuid: 00000000-0000-0000-0000-000000000000\n"
-        "  slug: ac006-test\n",
+        "vcs:\n  type: git\nagents:\n  available:\n  - claude\nproject:\n  uuid: 00000000-0000-0000-0000-000000000000\n  slug: ac006-test\n",
         encoding="utf-8",
     )
 
@@ -776,22 +766,22 @@ def test_mission_create_json_strict_when_sync_skips_ingress(
     # install -- same guard as the cycle-2 tasks-status test.
     resolved_path = _resolve_in_tree_specify_cli(env_overrides)
     worktree_src = _worktree_src().resolve()
-    assert resolved_path.is_relative_to(worktree_src), (
-        f"subprocess resolved specify_cli at {resolved_path}, "
-        f"expected under {worktree_src}"
-    )
+    assert resolved_path.is_relative_to(worktree_src), f"subprocess resolved specify_cli at {resolved_path}, expected under {worktree_src}"
 
-    result = _run_cli_isolated(
-        [
-            "agent",
-            "mission",
-            "create",
-            "ac-006-smoke",
-            "--json",
-        ],
-        env_overrides=env_overrides,
-        cwd=repo_root,
-    )
+    try:
+        result = _run_cli_isolated(
+            [
+                "agent",
+                "mission",
+                "create",
+                "ac-006-smoke",
+                "--json",
+            ],
+            env_overrides=env_overrides,
+            cwd=repo_root,
+        )
+    finally:
+        _stop_isolated_sync_daemon(env_overrides)
 
     assert result.returncode == 0, (
         "agent mission create --json must succeed even when sync ingress "
@@ -802,29 +792,17 @@ def test_mission_create_json_strict_when_sync_skips_ingress(
 
     # NFR-003 / AC-006: stdout is a single JSON document.
     parsed = json.loads(result.stdout)
-    assert isinstance(parsed, dict), (
-        f"expected top-level JSON object, got {type(parsed).__name__}"
-    )
-    assert parsed.get("result") == "success", (
-        f"expected result=success in payload, got: {parsed!r}"
-    )
-    assert "mission_slug" in parsed, (
-        f"expected mission_slug field in payload, got keys: "
-        f"{sorted(parsed.keys())!r}"
-    )
+    assert isinstance(parsed, dict), f"expected top-level JSON object, got {type(parsed).__name__}"
+    assert parsed.get("result") == "success", f"expected result=success in payload, got: {parsed!r}"
+    assert "mission_slug" in parsed, f"expected mission_slug field in payload, got keys: {sorted(parsed.keys())!r}"
 
     # FR-009: no sync diagnostic prose on stdout.
-    assert "Connection failed" not in result.stdout, (
-        f"sync diagnostic leaked onto stdout: {result.stdout!r}"
-    )
+    assert "Connection failed" not in result.stdout, f"sync diagnostic leaked onto stdout: {result.stdout!r}"
     assert "direct ingress skipped" not in result.stdout
     assert "direct_ingress_missing_private_team" not in result.stdout
 
     # Prove the diagnostic path actually fired: same guard as cycle-2.
-    diagnostic_present = (
-        "direct ingress skipped" in result.stderr
-        or "direct_ingress_missing_private_team" in result.stderr
-    )
+    diagnostic_present = "direct ingress skipped" in result.stderr or "direct_ingress_missing_private_team" in result.stderr
     assert diagnostic_present, (
         "expected 'direct ingress skipped' or "
         "'direct_ingress_missing_private_team' on stderr; without this "
@@ -865,8 +843,6 @@ def test_no_print_calls_in_sync_client() -> None:
         if pattern.search(line):
             offenders.append((lineno, stripped))
 
-    assert not offenders, (
-        "print() calls detected in src/specify_cli/sync/client.py - "
-        "route through logging instead.\n"
-        + "\n".join(f"  client.py:{ln}  {src}" for ln, src in offenders)
+    assert not offenders, "print() calls detected in src/specify_cli/sync/client.py - route through logging instead.\n" + "\n".join(
+        f"  client.py:{ln}  {src}" for ln, src in offenders
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2091,7 +2091,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc43"
+version = "3.2.0rc44"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Prepare `spec-kitty-cli` `3.2.0rc44` for release.

Includes fixes needed before the RC can publish:

- Align command-skill parity snapshots with the canonical prompt-backed command set, including `accept` baselines.
- Keep non-migrated parity tests scoped to prompt-backed commands instead of CLI wrapper-only commands.
- Add strict JSON sync-daemon cleanup for isolated subprocess tests.
- Restore compatibility for tests patching the retired `_ensure_branch_checked_out` helper.
- Fix release-blocking doctrine tactic reference schema data.
- Restore README `## Governance layer` heading expected by docs governance tests.
- Bump package metadata and changelog to `3.2.0rc44`.

## Test plan

- [x] `PYTEST_UPDATE_SNAPSHOTS=1 .venv/bin/pytest tests/specify_cli/regression/test_twelve_agent_parity.py -q` -> 223 passed
- [x] `.venv/bin/pytest tests/specify_cli/regression/test_twelve_agent_parity.py tests/specify_cli/cli/commands/test_agent_config_vibe.py tests/specify_cli/cli/commands/test_init_manifest_coexistence.py -q` -> 231 passed
- [x] `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/sync/test_strict_json_stdout.py::test_agent_tasks_status_json_strict_with_sync_enabled_isolated tests/sync/test_strict_json_stdout.py::test_mission_create_json_strict_when_sync_skips_ingress tests/sync/test_orphan_sweep.py -q` -> 11 passed
- [x] `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_feature_finalize_bootstrap.py tests/specify_cli/cli/commands/agent/test_sc6_planning_placement_e2e.py -q` -> 29 passed, 2 xfailed
- [x] `.venv/bin/pytest tests/doctrine/test_tactic_compliance.py::test_tactic_schema_valid tests/specify_cli/docs/test_readme_governance.py -q` -> 116 passed
- [x] `.venv/bin/pytest tests/upgrade/test_migration_robustness.py::TestMigrationRegistryCompleteness -v` -> 1 passed
- [x] `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/release -v` -> 105 passed, 7 skipped
- [x] `.venv/bin/python scripts/release/validate_release.py --mode branch --tag-pattern "v*.*.*"` -> passed
- [x] `.venv/bin/ruff check <changed-python-files>` -> passed
- [x] `.venv/bin/ruff format --check <changed-python-files>` -> passed
- [x] `.venv/bin/python -m build` -> built wheel and sdist
- [x] `.venv/bin/twine check dist/*` -> passed
- [x] `.venv/bin/python scripts/release/check_shared_package_drift.py --saas-pyproject /Users/robert/spec-kitty-dev/spec-kitty-20260613-095746-qM0w01/spec-kitty-saas/pyproject.toml --check-installed` -> passed
- [x] `.venv/bin/python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version` -> passed
- [x] `.venv/bin/python scripts/release/check_candidate_consumer_compat.py --package spec-kitty-cli --consumer-contract /Users/robert/spec-kitty-dev/spec-kitty-20260613-095746-qM0w01/spec-kitty-saas/contracts/consumer-compatibility.json` -> passed

Full local suite note: `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/ -v` previously found the 5 release-blocking failures fixed here. After fixes, a rerun was intentionally interrupted at 1,624 passed / 23 skipped / 22 xfailed / 1 xpassed in 3:13 to avoid another 40-minute local wait. GitHub CI is the full-suite authority for this PR.
