### PR TITLE
Fix full strict mypy gate

### DIFF
--- a/src/charter/_activation_render.py
+++ b/src/charter/_activation_render.py
@@ -234,7 +234,7 @@ def _render_when_clause(
     # action.
     action_label = (
         _action_label_for(action)
-        if declared_action in (None, *_WILDCARD_TOKENS)
+        if declared_action is None or declared_action in _WILDCARD_TOKENS
         else _action_label_for(declared_action)
     )
 

--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -12,9 +12,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
+    from charter.activations import ActivationEntry
     from charter.pack_context import PackContext
     from charter.scope import CharterScope
     from doctrine.drg.models import DRGGraph
+    import doctrine.service as _doctrine_service_module
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
@@ -41,7 +43,7 @@ from charter.governance_references import (
     render_governance_references,
 )
 from charter.language_scope import infer_repo_languages
-from charter.schemas import DoctrineSelectionConfig
+from charter.schemas import DirectivesConfig, DoctrineSelectionConfig
 from doctrine.agent_profiles import AgentProfile, AgentProfileRepository
 from doctrine.spdd_reasons import append_spdd_reasons_guidance, is_spdd_reasons_active
 from kernel.atomic import atomic_write
@@ -1255,7 +1257,11 @@ def _build_action_org_source_map(
     return source_map
 
 
-def _build_doctrine_service(repo_root: Path, *, org_roots: list[Path] | None = None) -> object:
+def _build_doctrine_service(
+    repo_root: Path,
+    *,
+    org_roots: list[Path] | None = None,
+) -> _doctrine_service_module.DoctrineService:
     """Build a DoctrineService for the given repo root.
 
     The project-root candidate list (in priority order):
@@ -2529,7 +2535,7 @@ def _render_selection_block(
     return "\n\n".join(blocks)
 
 
-def _load_governance_activations(repo_root: Path) -> list[object]:
+def _load_governance_activations(repo_root: Path) -> list[ActivationEntry]:
     """Best-effort load of ``GovernanceConfig.activations`` for *repo_root*.
 
     The activation registry is a top-level governance field (per
@@ -2925,7 +2931,7 @@ def _project_directive_entries(repo_root: Path) -> list[dict[str, object]]:
 
 def _load_project_directives(
     repo_root: Path,
-    load_directives_config: Callable[[Path], _DirectivesConfigLike],
+    load_directives_config: Callable[[Path], DirectivesConfig],
 ) -> tuple[dict[str, object], list[str]]:
     try:
         directives_cfg = load_directives_config(repo_root)

--- a/src/charter/extractor.py
+++ b/src/charter/extractor.py
@@ -792,7 +792,8 @@ def _generated_directive_placeholder_id(item_text: str) -> str | None:
     match = _GENERATED_DIRECTIVE_PLACEHOLDER_RE.match(item_text.strip())
     if not match:
         return None
-    return match.group("directive_id")
+    directive_id = match.group("directive_id")
+    return str(directive_id)
 
 
 def _generated_directive_placeholder_warning(directive_id: str) -> str:

--- a/src/charter/resolver.py
+++ b/src/charter/resolver.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from charter.catalog import DoctrineCatalog, load_doctrine_catalog
 from charter.reference_resolver import resolve_references_transitively
@@ -38,6 +38,7 @@ __all__ = [
 if TYPE_CHECKING:
     from doctrine.agent_profiles.profile import AgentProfile
     from doctrine.drg.models import DRGGraph
+    from doctrine.missions.mission_step_repository import _PackContextLike
     from doctrine.paradigms.models import Paradigm
     from doctrine.procedures.models import Procedure
     import doctrine.service as _doctrine_service_module
@@ -445,7 +446,7 @@ def resolve_mission_steps(
 
     return MissionStepRepository.default().resolve_all_for_mission_type(
         mission_type_id,
-        pack_context=pack_context,
+        pack_context=cast("_PackContextLike | None", pack_context),
     )
 
 
@@ -456,4 +457,3 @@ def _merge_unique(primary: list[str], secondary: list[str]) -> list[str]:
         if item and item not in merged:
             merged.append(item)
     return merged
-

--- a/src/charter/synthesizer/resynthesize_pipeline.py
+++ b/src/charter/synthesizer/resynthesize_pipeline.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from doctrine.drg.loader import load_graph_or_dir
 from doctrine.drg.models import DRGEdge, DRGGraph, DRGNode
@@ -563,15 +563,12 @@ def _load_merged_drg(
     """
     project_graph_dir = repo_root / _KITTIFY_DIRNAME / "doctrine"
     if not project_graph_dir.exists():
-        # cast: charter.* follow_imports=skip collapses SynthesisRequest.drg_snapshot
-        # to Any; the field is typed Mapping[str, Any] in request.py.
-        return cast("Mapping[str, Any]", request.drg_snapshot)
+        return request.drg_snapshot
 
     try:
         project_graph_model = load_graph_or_dir(project_graph_dir)
     except Exception:  # noqa: BLE001
-        # cast: same follow_imports=skip boundary as above.
-        return cast("Mapping[str, Any]", request.drg_snapshot)
+        return request.drg_snapshot
     project_graph = project_graph_model.model_dump(mode="json")
 
     # Merge: combine nodes from both graphs (project overlay + built-in snapshot)

--- a/src/charter/synthesizer/write_pipeline.py
+++ b/src/charter/synthesizer/write_pipeline.py
@@ -200,16 +200,12 @@ def _artifact_filename(kind: str, slug: str, artifact_id: str | None = None) -> 
     - tactic:    ``<slug>.tactic.yaml``
     - styleguide: ``<slug>.styleguide.yaml``
     """
-    # cast: charter.* follow_imports=skip collapses the imported artifact_filename
-    # return to Any; the function is typed -> str in artifact_naming.py.
-    return cast(str, artifact_filename(kind, slug, artifact_id))
+    return artifact_filename(kind, slug, artifact_id)
 
 
 def _doctrine_kind_subdir(kind: str) -> str:
     """Return the doctrine subdirectory name for a given artifact kind."""
-    # cast: charter.* follow_imports=skip collapses the imported doctrine_kind_subdir
-    # return to Any; the function is typed -> str in artifact_naming.py.
-    return cast(str, doctrine_kind_subdir(kind))
+    return doctrine_kind_subdir(kind)
 
 
 def _compute_content_hash(yaml_bytes: bytes) -> str:

--- a/src/specify_cli/auth/transport.py
+++ b/src/specify_cli/auth/transport.py
@@ -143,7 +143,7 @@ def _emit_user_facing_failure_once(message: str) -> None:
             _user_facing_failure_emitted = True
     if first:
         # Lazy import to avoid a hard cycle at module load.
-        from specify_cli.sync import emit_diagnostic
+        from specify_cli.sync.diagnose import emit_diagnostic
 
         # Single user-facing line, routed through the canonical helper
         # so it CANNOT accidentally land on stdout.

--- a/src/specify_cli/charter_runtime/lint/checks/org_layer.py
+++ b/src/specify_cli/charter_runtime/lint/checks/org_layer.py
@@ -154,7 +154,7 @@ class OrgCharterDeviationChecker:
 
         # Optional dependency on WP09's module.  When absent, advisory is a no-op.
         try:
-            from specify_cli.doctrine.org_charter import (  # type: ignore[attr-defined]
+            from specify_cli.doctrine.org_charter import (
                 load_org_charter_policies,
             )
         except ImportError:

--- a/src/specify_cli/charter_runtime/preflight/cli.py
+++ b/src/specify_cli/charter_runtime/preflight/cli.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from specify_cli.charter_runtime.preflight.result import CharterPreflightResult
 from specify_cli.charter_runtime.preflight.runner import run_charter_preflight
 from specify_cli.task_utils import TaskCliError, find_repo_root
 
@@ -100,7 +101,7 @@ def charter_preflight(
     raise typer.Exit(code=0)
 
 
-def _render_human(result) -> None:  # noqa: ANN001 — internal renderer, takes CharterPreflightResult.
+def _render_human(result: CharterPreflightResult) -> None:
     """Print a compact human summary."""
     headline_colour = "green" if result.passed else "red"
     headline = "PASSED" if result.passed else "BLOCKED"

--- a/src/specify_cli/charter_runtime/preflight/hook.py
+++ b/src/specify_cli/charter_runtime/preflight/hook.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
+from typing import Any, TextIO
 
 import typer
 
@@ -34,7 +35,7 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 
-def run_charter_preflight(**kwargs) -> CharterPreflightResult:
+def run_charter_preflight(**kwargs: Any) -> CharterPreflightResult:
     """Patchable lazy wrapper for the framework-free preflight runner."""
     from specify_cli.charter_runtime.preflight.runner import run_charter_preflight as _run
 
@@ -45,7 +46,7 @@ def run_preflight_or_abort(
     repo_root: Path,
     *,
     consumer: str,
-    stderr=None,
+    stderr: TextIO | None = None,
 ) -> CharterPreflightResult:
     """Run charter preflight; abort the process if it fails.
 

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -980,7 +980,7 @@ def _resolve_planning_branch(
     del repo_root  # No longer used; kept in signature for API stability.
     if target_branch_override is not None and target_branch_override.strip():
         return target_branch_override.strip()
-    return cast(str, load_mission_target_branch(feature_dir))
+    return load_mission_target_branch(feature_dir)
 
 
 def _artifact_has_no_git_changes(repo_root: Path, file_path: Path) -> bool:
@@ -1236,7 +1236,7 @@ def _find_feature_directory(
             "FEATURE_CONTEXT_UNRESOLVED",
             f"Mission not found for handle {explicit_feature!r}; checked the coordination worktree and the primary checkout. {exc}",
         ) from exc
-    return cast(Path, feature_dir)
+    return feature_dir
 
 
 def _list_feature_spec_candidates(repo_root: Path) -> list[dict[str, object]]:
@@ -2388,7 +2388,7 @@ def _find_latest_feature_worktree(repo_root: Path) -> Path | None:
 
 def _find_feature_worktree(repo_root: Path, mission_slug: str) -> Path | None:
     """Find a deterministic worktree for a feature slug."""
-    return cast(Path | None, resolve_feature_worktree(repo_root, mission_slug))
+    return resolve_feature_worktree(repo_root, mission_slug)
 
 
 def _get_current_branch(repo_root: Path) -> str:
@@ -3894,4 +3894,4 @@ def _parse_requirement_ids_from_spec_md(spec_content: str) -> dict[str, list[str
     """Parse requirement IDs from spec.md content."""
     from specify_cli.requirement_mapping import parse_requirement_ids_from_spec_md
 
-    return cast(dict[str, list[str]], parse_requirement_ids_from_spec_md(spec_content))
+    return parse_requirement_ids_from_spec_md(spec_content)

--- a/src/specify_cli/cli/commands/agent_retrospect.py
+++ b/src/specify_cli/cli/commands/agent_retrospect.py
@@ -427,10 +427,13 @@ def synthesize_cmd(
     # ------------------------------------------------------------------
     retro_file = _retro_path(repo_root, resolved.mission_slug, mission_id)
     outcome = "retrospective_synthesized"
-    generator_record = None
+    record: RetrospectiveRecord | None = None
+    generator_record: GenRetrospectiveRecord | None = None
+    _fabricated_empty = False
     try:
         record = read_record(retro_file)
     except FileNotFoundError as exc:
+        missing_record_exc = exc
         # T028: Default path — error with RETROSPECTIVE_RECORD_MISSING (exit 1).
         # Legacy path preserved behind --fabricate-empty flag.
         if not fabricate_empty:
@@ -456,7 +459,7 @@ def synthesize_cmd(
                     f"No retrospective record found for this mission.\n"
                     f"Author one with: [bold]spec-kitty retrospect create --mission {resolved.mission_slug}[/bold]"
                 )
-            raise typer.Exit(1) from exc
+            raise typer.Exit(1) from missing_record_exc
 
         # --fabricate-empty: legacy auto-fabrication path
         feature_dir = resolved.feature_dir
@@ -521,9 +524,9 @@ def synthesize_cmd(
                         }
                     )
                 )
-                raise typer.Exit(0) from exc
+                raise typer.Exit(0) from missing_record_exc
             _err_console.print(f"[red]Error:[/red] {msg}")
-            raise typer.Exit(3) from exc
+            raise typer.Exit(3) from missing_record_exc
     except (YAMLParseError, SchemaError) as exc:
         try:
             generator_record = read_gen_record(retro_file)
@@ -562,7 +565,11 @@ def synthesize_cmd(
     # When --fabricate-empty created the record, _fabricated_empty is True and
     # record is not defined (the gen record format is incompatible with Pydantic
     # read_record). The fabricated record has no proposals by definition.
-    all_proposals = [] if locals().get("_fabricated_empty") or generator_record is not None else record.proposals
+    if _fabricated_empty or generator_record is not None:
+        all_proposals = []
+    else:
+        assert record is not None
+        all_proposals = record.proposals
 
     if proposal_id:
         # --proposal-id filter: restrict approved_proposal_ids to those listed

--- a/src/specify_cli/cli/commands/charter/__init__.py
+++ b/src/specify_cli/cli/commands/charter/__init__.py
@@ -187,6 +187,7 @@ __all__ = [
     "_list_resynthesis_topics",
     "_has_generated_artifacts",
     "_materialize_fresh_doctrine",
+    "_planned_fresh_doctrine_deletes",
     "_planned_fresh_doctrine_paths",
     "_MINIMAL_FRESH_DOCTRINE_PROVENANCE_TEMPLATE",
     # Widen helpers

--- a/src/specify_cli/cli/commands/charter/_fresh_doctrine.py
+++ b/src/specify_cli/cli/commands/charter/_fresh_doctrine.py
@@ -64,7 +64,7 @@ def _fresh_seed_manifest_text() -> str:
     except Exception:
         synthesizer_version = "unknown"
 
-    without_hash = {
+    without_hash: dict[str, object] = {
         "schema_version": "2",
         "mission_id": None,
         "created_at": "1970-01-01T00:00:00+00:00",

--- a/src/specify_cli/cli/commands/charter/_status_collectors.py
+++ b/src/specify_cli/cli/commands/charter/_status_collectors.py
@@ -6,8 +6,9 @@ serialises to JSON or renders to the console. Kept in their own module so
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from specify_cli.task_utils import TaskCliError
 
@@ -28,7 +29,11 @@ def _collect_charter_sync_status(repo_root: Path) -> dict[str, Any]:
     try:
         from charter.hasher import is_stale
 
-        sync_result = _charter_pkg.ensure_charter_bundle_fresh(repo_root)
+        ensure_fresh = cast(
+            Callable[[Path], Any],
+            _charter_pkg.__dict__["ensure_charter_bundle_fresh"],
+        )
+        sync_result = ensure_fresh(repo_root)
         # Generate glossary entity pages (non-blocking; silent on failure)
         try:
             from glossary.entity_pages import GlossaryEntityPageRenderer

--- a/src/specify_cli/cli/commands/charter/_synthesis.py
+++ b/src/specify_cli/cli/commands/charter/_synthesis.py
@@ -480,3 +480,22 @@ from specify_cli.cli.commands.charter._fresh_doctrine import (  # noqa: E402,F40
     _planned_fresh_doctrine_deletes,
     _planned_fresh_doctrine_paths,
 )
+
+__all__ = [
+    "_MINIMAL_FRESH_DOCTRINE_PROVENANCE_TEMPLATE",
+    "_build_synthesis_request",
+    "_build_synthesis_validation_callback",
+    "_collect_evidence_result",
+    "_extract_artifact_id_from_provenance",
+    "_has_generated_artifacts",
+    "_list_resynthesis_topics",
+    "_load_written_artifacts_from_manifest",
+    "_materialize_fresh_doctrine",
+    "_planned_fresh_doctrine_deletes",
+    "_planned_fresh_doctrine_paths",
+    "_provenance_to_planned_artifacts",
+    "_read_written_artifacts_from_manifest",
+    "_run_synthesis_dry_run",
+    "_run_synthesis_dry_run_with_artifacts",
+    "_staged_to_planned_artifacts",
+]

--- a/src/specify_cli/cli/commands/charter/lint.py
+++ b/src/specify_cli/cli/commands/charter/lint.py
@@ -1,7 +1,7 @@
 """``spec-kitty charter lint`` command (WP06 per-subcommand split)."""
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
 
@@ -12,6 +12,9 @@ from specify_cli.cli.commands.charter._common import _emit_error
 
 # Test-patch shim — see ``synthesize.py``.
 import specify_cli.cli.commands.charter as _charter_pkg
+
+if TYPE_CHECKING:
+    from charter.drg import OrgDRGFragment
 
 __all__ = ["charter_lint"]
 
@@ -121,7 +124,7 @@ def charter_lint(
     # — programmatic consumers read provenance from the merged DRG via
     # ``charter.drg.merge_three_layers`` directly.
     org_layer_summary: list[str] = []
-    org_fragments: list = []
+    org_fragments: list[OrgDRGFragment] = []
     try:
         from charter.drg import OrgDRGFragment, load_org_drg
 

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -179,13 +179,13 @@ def _emit_workspace_husk_fix(repo_root: Path, json_output: bool) -> None:
         *fix_result.skipped_registered,
         *fix_result.skipped_appeared_valid,
     ]
-    payload: dict[str, object] = {
+    fix_payload: dict[str, object] = {
         **report.to_dict(),
         **fix_result.to_dict(),
         "healthy": not remaining,
     }
     if json_output:
-        console.print_json(json.dumps(payload, indent=2))
+        console.print_json(json.dumps(fix_payload, indent=2))
         raise typer.Exit(0 if not remaining else 1)
 
     for removed in fix_result.removed:

--- a/src/specify_cli/cli/commands/retrospect.py
+++ b/src/specify_cli/cli/commands/retrospect.py
@@ -21,7 +21,7 @@ import json
 import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import typer
 from rich.console import Console
@@ -48,7 +48,7 @@ from specify_cli.retrospective import (
     PolicyResolutionError,
 )
 from specify_cli.retrospective.writer import resolve_existing_record_path
-from specify_cli.retrospective.schema import GenActor, GenProvenance
+from specify_cli.retrospective.schema import GenActor, GenProvenance, ProvenanceKind
 from specify_cli.retrospective.summary import classify_mission_record
 from specify_cli.status import read_events
 from specify_cli.status import TERMINAL_LANES
@@ -332,8 +332,10 @@ def create_cmd(
         raise typer.Exit(1) from exc
 
     # Determine write mode
-    write_mode = "overwrite" if overwrite else ("update" if update else "error")
-    provenance_kind = "explicit_create"
+    write_mode: Literal["error", "overwrite", "update"] = (
+        "overwrite" if overwrite else ("update" if update else "error")
+    )
+    provenance_kind: ProvenanceKind = "explicit_create"
 
     # Generate the record
     try:

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -21,9 +21,10 @@ import subprocess  # noqa: F401  (monkeypatched in tests)
 import sys
 import tomllib
 from pathlib import Path
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal
 
 import typer
+from rich.console import Console
 
 from specify_cli.cli.commands._test_env_check import (  # noqa: F401
     TestExtraMissing,
@@ -364,7 +365,7 @@ def _same_path(left: Path, right: Path) -> bool:
 
 def _resolve_repo_root(console: object) -> Path:
     try:
-        return cast("Path", find_repo_root())
+        return find_repo_root()
     except TaskCliError as exc:
         console.print(f"[red]Error:[/red] {exc}")  # type: ignore[attr-defined]
         raise typer.Exit(2) from exc
@@ -396,12 +397,9 @@ def _resolve_mode_or_exit(
     baseline_merge_commit: str | None,
 ) -> tuple[MissionReviewMode, bool]:
     try:
-        return cast(
-            "tuple[MissionReviewMode, bool]",
-            resolve_mode(
-                cli_flag=cli_mode,
-                baseline_merge_commit=baseline_merge_commit,
-            ),
+        return resolve_mode(
+            cli_flag=cli_mode,
+            baseline_merge_commit=baseline_merge_commit,
         )
     except ModeMismatchError as exc:
         diagnostic = {
@@ -419,7 +417,7 @@ def _resolve_mode_or_exit(
 def _record_gate(
     gates_recorded: list[GateRecord],
     *,
-    gate_id: str,
+    gate_id: Literal["gate_1", "gate_2", "gate_3", "gate_4"],
     name: str,
     result: Literal["pass", "fail"],
 ) -> None:
@@ -437,7 +435,7 @@ def _record_gate(
 def _run_lane_gate(
     feature_dir: Path,
     repo_root: Path,
-    console: object,
+    console: Console,
     findings: list[dict[str, str]],
     gates_recorded: list[GateRecord],
 ) -> None:
@@ -451,7 +449,7 @@ def _run_dead_code_gate(
     *,
     baseline_merge_commit: str | None,
     repo_root: Path,
-    console: object,
+    console: Console,
     findings: list[dict[str, str]],
     mission_id: str | None,
     mission_slug: str,

--- a/src/specify_cli/cli/commands/safe_commit_cmd.py
+++ b/src/specify_cli/cli/commands/safe_commit_cmd.py
@@ -23,7 +23,6 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import cast
 
 import typer
 from rich.console import Console
@@ -58,7 +57,7 @@ def _current_worktree_root() -> Path:
     )
     if result.returncode == 0 and result.stdout.strip():
         return Path(result.stdout.strip()).resolve()
-    return cast(Path, find_repo_root())
+    return find_repo_root()
 
 
 def _changed_paths_under(repo_root: Path, rel_dir: str) -> list[str]:

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -12,7 +12,6 @@ import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import cast
 
 from specify_cli.coordination.outbound import queue_saas_emission
 from specify_cli.core.commit_guard import GuardCapability
@@ -242,7 +241,7 @@ def _identity_for_request(request: TransitionRequest) -> _TransactionIdentity:
     mission_id: str | None = None
     mid8: str | None = None
     meta_exists = isinstance(meta, dict)
-    if meta_exists:
+    if isinstance(meta, dict):
         raw_coord = meta.get("coordination_branch")
         raw_mission_id = meta.get("mission_id")
         raw_mid8 = meta.get("mid8")
@@ -368,7 +367,7 @@ def _read_events_from_transaction_target(
     mission_slug: str,
 ) -> list[StatusEvent]:
     """Read target status events without creating worktrees or commits."""
-    return cast(list[StatusEvent], read_event_log(_read_contract_from_transaction_target(identity, mission_slug)))
+    return read_event_log(_read_contract_from_transaction_target(identity, mission_slug))
 
 
 def read_current_wp_state_transactional(
@@ -414,7 +413,7 @@ def read_current_wp_state_transactional(
             # converted genesis-corruption signals into "unseeded WP" (#1736
             # dormant mask 1).
             return Lane.GENESIS, None
-    return cast(tuple[Lane, str | None], wp_lane_actor_from_events(events, wp_id))
+    return wp_lane_actor_from_events(events, wp_id)
 
 
 def _read_contract_from_transaction_target(
@@ -592,13 +591,10 @@ def emit_status_transition_batch_transactional(
 
     identity = _identity_for_request(first)
     if not _transaction_topology_available(identity, mission_slug):
-        return cast(
-            list[StatusEvent],
-            _emit.emit_status_transition_batch(
-                requests,
-                ensure_sync_daemon=ensure_sync_daemon,
-                sync_dossier=sync_dossier,
-            ),
+        return _emit.emit_status_transition_batch(
+            requests,
+            ensure_sync_daemon=ensure_sync_daemon,
+            sync_dossier=sync_dossier,
         )
 
     with BookkeepingTransaction.acquire(

--- a/src/specify_cli/coordination/transaction.py
+++ b/src/specify_cli/coordination/transaction.py
@@ -524,6 +524,17 @@ def _unlink_confined_artifact_path(worktree_root: Path, path: Path) -> None:
 # callers that imported it through this module.
 from specify_cli.status.emit import build_status_event  # noqa: E402,F401
 
+__all__ = [
+    "BookkeepingCommitFailed",
+    "BookkeepingDoubleEventId",
+    "BookkeepingError",
+    "BookkeepingLockTimeout",
+    "BookkeepingPolicyRefused",
+    "BookkeepingTransaction",
+    "BookkeepingWorktreeMissing",
+    "build_status_event",
+]
+
 
 # ---------------------------------------------------------------------------
 # Transaction

--- a/src/specify_cli/doctrine/org_charter_loader.py
+++ b/src/specify_cli/doctrine/org_charter_loader.py
@@ -55,7 +55,7 @@ def load_org_charter_json_block(org_roots: list[Path] | None) -> dict[str, Any]:
         return dict(_EMPTY_BLOCK)
 
     try:
-        from specify_cli.doctrine.org_charter import (  # type: ignore[attr-defined]
+        from specify_cli.doctrine.org_charter import (
             load_org_charter_policy,
         )
     except ImportError:

--- a/src/specify_cli/doctrine/pack_assembler.py
+++ b/src/specify_cli/doctrine/pack_assembler.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -116,8 +117,10 @@ def _read_id(path: Path) -> str | None:
         data = _yaml().load(path)
     except (YAMLError, OSError):
         return None
-    if isinstance(data, dict) and isinstance(data.get("id"), str):
-        return data["id"]
+    if isinstance(data, dict):
+        raw_id = data.get("id")
+        if isinstance(raw_id, str):
+            return raw_id
     return None
 
 
@@ -455,24 +458,28 @@ def _copy_drg_fragments(
     count = 0
     seq = 0
     seen_edges: set[tuple[str, str, str]] = set()
+    load_graph_fn: Callable[[Path], Any] | None = None
+    drg_load_error: type[Exception] = Exception
 
     if force:
         # Drop duplicate edges across packs; preserve unique ones in order.
         try:
             from doctrine.drg.loader import DRGLoadError, load_graph
         except ModuleNotFoundError:
-            load_graph = None  # type: ignore[assignment]
-            DRGLoadError = Exception  # type: ignore[assignment]
+            pass
+        else:
+            load_graph_fn = load_graph
+            drg_load_error = DRGLoadError
 
     for pack, fragments in fragments_by_pack.items():
         for fragment in fragments:
             seq += 1
             dest_name = f"{seq:03d}-{pack.name}-{fragment.name}"
             dest = drg_out / dest_name
-            if force and load_graph is not None:
+            if force and load_graph_fn is not None:
                 try:
-                    graph = load_graph(fragment)
-                except DRGLoadError:
+                    graph = load_graph_fn(fragment)
+                except drg_load_error:
                     shutil.copy2(fragment, dest)
                     count += 1
                     continue
@@ -523,7 +530,7 @@ def _merge_org_charters_to_output(
 
     # Lazy import — model may not exist yet.
     try:
-        from specify_cli.doctrine.org_charter import (  # type: ignore[attr-defined]
+        from specify_cli.doctrine.org_charter import (
             OrgCharterPolicy,
         )
     except ModuleNotFoundError:

--- a/src/specify_cli/doctrine/pack_validator.py
+++ b/src/specify_cli/doctrine/pack_validator.py
@@ -75,6 +75,7 @@ __all__ = [
 from doctrine.drg.org_pack_loader import augmentation_plural_kinds
 
 _AUGMENTATION_PLURAL_KINDS: frozenset[str] = augmentation_plural_kinds()
+FragmentIntent = dict[str, dict[str, tuple[dict[str, str], Path]]]
 
 
 # ---------------------------------------------------------------------------
@@ -376,7 +377,7 @@ def validate_pack(pack_dir: Path) -> ValidationResult:
     # field-based pass can suppress same-ID advisories for artifacts whose
     # intent is declared via DRG edges instead of inline fields.
     built_in_ids_per_kind = _load_built_in_ids_per_kind()
-    fragment_intent: dict = {}
+    fragment_intent: FragmentIntent = {}
     if drg_dir.is_dir():
         fragment_intent = _collect_fragment_edge_intent(drg_dir)
     intent_errors, intent_advisories = _intent_aware_collision_messages(
@@ -624,7 +625,7 @@ def _load_built_in_ids_per_kind() -> dict[str, set[str]]:
 def _intent_aware_collision_messages(
     pack_artifacts: dict[str, dict[str, tuple[dict[str, Any], Path]]],
     built_in_ids_per_kind: dict[str, set[str]],
-    fragment_intent: dict | None = None,
+    fragment_intent: FragmentIntent | None = None,
 ) -> tuple[list[ValidationIssue], list[ValidationIssue]]:
     """Emit intent-aware errors and advisories for pack artifacts.
 
@@ -772,7 +773,7 @@ def _urn_to_plural(urn: str) -> tuple[str, str] | None:
 
 def _collect_fragment_edge_intent(
     drg_dir: Path,
-) -> dict[str, dict[str, tuple[dict[str, str], Path]]]:
+) -> FragmentIntent:
     """Read augmentation/lineage intent from DRG fragment edges.
 
     Returns ``{plural: {artifact_id: (intent, fragment_path)}}`` where
@@ -814,7 +815,7 @@ def _collect_fragment_edge_intent(
 
 
 def _intent_aware_collision_messages_from_edges(
-    fragment_intent: dict[str, dict[str, tuple[dict[str, str], Path]]],
+    fragment_intent: FragmentIntent,
     built_in_ids_per_kind: dict[str, set[str]],
     field_artifacts: dict[str, dict[str, tuple[dict[str, Any], Path]]],
 ) -> tuple[list[ValidationIssue], list[ValidationIssue]]:
@@ -943,7 +944,7 @@ def _validate_org_charter(
 
     # Lazy import — WP09 has not necessarily shipped yet.
     try:
-        from specify_cli.doctrine.org_charter import (  # type: ignore[attr-defined]
+        from specify_cli.doctrine.org_charter import (
             OrgCharterPolicy,
         )
     except ModuleNotFoundError:

--- a/src/specify_cli/events/decision_log.py
+++ b/src/specify_cli/events/decision_log.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 def _generate_event_id() -> str:
     """Generate a ULID-format event ID."""
     try:
-        import ulid  # type: ignore[import-untyped]
+        import ulid
         return str(ulid.ULID())
     except ImportError:
         # Fallback: use a UUID4-based ID if ulid not available.

--- a/src/specify_cli/runtime/bootstrap.py
+++ b/src/specify_cli/runtime/bootstrap.py
@@ -38,7 +38,7 @@ def _get_cli_version() -> str:
     """
     fallback = "0.0.0-dev"
     try:
-        from specify_cli import __version__ as _version  # type: ignore[attr-defined]
+        from specify_cli import __version__ as _version
     except Exception:  # noqa: BLE001
         logger.warning(
             "Could not import specify_cli.__version__ during runtime bootstrap; "

--- a/src/specify_cli/runtime/resolver.py
+++ b/src/specify_cli/runtime/resolver.py
@@ -19,6 +19,7 @@ import sys
 import warnings
 from functools import lru_cache
 from pathlib import Path
+from typing import Protocol
 
 # Single source of truth for the resolution enum / result dataclass.
 # Re-exported via the charter.resolution facade (which itself re-exports
@@ -44,6 +45,17 @@ __all__ = [
 from specify_cli.runtime.home import get_kittify_home, get_package_asset_root
 
 logger = logging.getLogger(__name__)
+
+
+class _CharterTemplateResolver(Protocol):
+    def resolve_command_template_path(self, mission: str, command: str) -> Path | None:
+        ...
+
+    def resolve_content_template_path(self, mission: str, name: str) -> Path | None:
+        ...
+
+    def resolve_mission_config_path(self, mission: str) -> Path | None:
+        ...
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +137,7 @@ def _reset_migrate_nudge() -> None:
 
 
 @lru_cache(maxsize=8)
-def _charter_template_resolver_for(missions_root: str):
+def _charter_template_resolver_for(missions_root: str) -> _CharterTemplateResolver:
     """Return a charter template resolver for ``missions_root``.
 
     Kept at the Tier-5 boundary so package-default filesystem access remains
@@ -146,9 +158,11 @@ def _package_default_path(
     """Resolve package defaults through charter's doctrine facade."""
     charter_resolver = _charter_template_resolver_for(str(pkg_missions))
     if subdir == "command-templates":
-        return charter_resolver.resolve_command_template_path(mission, Path(name).stem)
+        resolved = charter_resolver.resolve_command_template_path(mission, Path(name).stem)
+        return resolved if isinstance(resolved, Path) else None
     if subdir == "templates":
-        return charter_resolver.resolve_content_template_path(mission, name)
+        resolved = charter_resolver.resolve_content_template_path(mission, name)
+        return resolved if isinstance(resolved, Path) else None
 
     pkg_path = pkg_missions / mission / subdir / name
     return pkg_path if pkg_path.is_file() else None

--- a/src/specify_cli/skills/command_renderer.py
+++ b/src/specify_cli/skills/command_renderer.py
@@ -492,6 +492,6 @@ def render(
         body=prepend_agent_upgrade_check(body),
         source_template=template_path.resolve(),
         source_hash=source_hash,
-        agent_key=agent_key,  # type: ignore[arg-type]
+        agent_key=agent_key,
         spec_kitty_version=spec_kitty_version,
     )

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -7,7 +7,6 @@ WP state. No frontmatter reads or writes occur in this module.
 """
 
 from pathlib import Path
-from typing import cast
 
 from .models import (
     AgentAssignment,
@@ -192,9 +191,7 @@ def uninitialized_status_error(mission_slug: str, wp_id: str, feature_dir: Path)
     """Return the cycle-aware missing-status message without eager dependency-graph imports."""
     from .uninitialized_hint import uninitialized_status_error as _uninitialized_status_error
 
-    # cast: follow_imports=skip makes _uninitialized_status_error return Any;
-    # the real signature (uninitialized_hint.py) returns str.
-    return cast(str, _uninitialized_status_error(mission_slug, wp_id, feature_dir))
+    return _uninitialized_status_error(mission_slug, wp_id, feature_dir)
 
 # The canonical status artifacts (event log + snapshot). On coordination-topology
 # missions these are owned by the transactional status emitter on the coordination

--- a/src/specify_cli/status/aggregate.py
+++ b/src/specify_cli/status/aggregate.py
@@ -28,7 +28,7 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
 
@@ -155,7 +155,7 @@ class ActiveWPStatus:
     """
 
     wp_id: str
-    current_lane: Lane
+    current_lane: Lane | str
     last_event: StatusEvent | None
 
 
@@ -291,9 +291,7 @@ class MissionStatus:
             is_registered_coord_worktree,
         )
 
-        # cast: follow_imports=skip makes is_registered_coord_worktree return Any;
-        # the real signature returns bool.
-        return cast(bool, is_registered_coord_worktree(read_dir, repo_root=repo_root))
+        return is_registered_coord_worktree(read_dir, repo_root=repo_root)
 
     @classmethod
     def _resolve_read_dir(

--- a/src/specify_cli/status/progress.py
+++ b/src/specify_cli/status/progress.py
@@ -14,7 +14,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from specify_cli.identity.aliases import with_tracked_mission_slug_aliases
 from specify_cli.mission_metadata import mission_identity_fields
@@ -91,27 +91,22 @@ class ProgressResult:
         return compute_done_percentage(self.done_count, self.total_count)
 
     def to_dict(self) -> dict[str, Any]:
-        # cast: follow_imports=skip makes with_tracked_mission_slug_aliases return Any;
-        # the real signature (identity.aliases) returns dict[str, Any].
-        return cast(
-            "dict[str, Any]",
-            with_tracked_mission_slug_aliases(
-                {
-                    **mission_identity_fields(
-                        self.mission_slug,
-                        self.mission_number,
-                        self.mission_type,
-                    ),
-                    "percentage": round(self.percentage, 4),
-                    "progress_semantics": PROGRESS_SEMANTICS,
-                    "weighted_percentage": round(self.percentage, 4),
-                    "done_percentage": round(self.done_percentage, 4),
-                    "done_count": self.done_count,
-                    "total_count": self.total_count,
-                    "per_lane_counts": self.per_lane_counts,
-                    "per_wp": [wp.to_dict() for wp in self.per_wp],
-                }
-            ),
+        return with_tracked_mission_slug_aliases(
+            {
+                **mission_identity_fields(
+                    self.mission_slug,
+                    self.mission_number,
+                    self.mission_type,
+                ),
+                "percentage": round(self.percentage, 4),
+                "progress_semantics": PROGRESS_SEMANTICS,
+                "weighted_percentage": round(self.percentage, 4),
+                "done_percentage": round(self.done_percentage, 4),
+                "done_count": self.done_count,
+                "total_count": self.total_count,
+                "per_lane_counts": self.per_lane_counts,
+                "per_wp": [wp.to_dict() for wp in self.per_wp],
+            }
         )
 
 

--- a/src/specify_cli/status/transitions.py
+++ b/src/specify_cli/status/transitions.py
@@ -22,6 +22,16 @@ from specify_cli.status_lanes import LANE_ALIASES, TERMINAL_LANES
 from .models import GuardContext, Lane
 from .wp_state import InvalidTransitionError, wp_state_for
 
+__all__ = [
+    "ALLOWED_TRANSITIONS",
+    "CANONICAL_LANES",
+    "LANE_ALIASES",
+    "TERMINAL_LANES",
+    "is_terminal",
+    "resolve_lane_alias",
+    "validate_transition",
+]
+
 
 def _derive_allowed_transitions() -> frozenset[tuple[str, str]]:
     """Derive the edge set from the FSM's per-state ``allowed_targets()``.

--- a/src/specify_cli/status/uninitialized_hint.py
+++ b/src/specify_cli/status/uninitialized_hint.py
@@ -16,7 +16,6 @@ CLI) call into it.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
 
 from pydantic import ValidationError
 
@@ -71,7 +70,7 @@ def find_wp_dependency_cycles(feature_dir: Path) -> list[list[str]] | None:
     graph = _build_wp_dependency_graph(feature_dir)
     if not graph:
         return None
-    return cast("list[list[str]] | None", detect_cycles(graph))
+    return detect_cycles(graph)
 
 
 def _format_cycles(cycles: list[list[str]]) -> str:

--- a/src/specify_cli/sync/body_transport.py
+++ b/src/specify_cli/sync/body_transport.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from specify_cli.auth.http import request_with_stdlib_fallback_sync
 from specify_cli.sync._team import CATEGORY_MISSING_PRIVATE_TEAM

--- a/src/specify_cli/sync/config.py
+++ b/src/specify_cli/sync/config.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-import toml  # type: ignore[import-untyped]
+import toml
 
 from specify_cli.core.atomic import atomic_write
 

--- a/src/specify_cli/sync/diagnose.py
+++ b/src/specify_cli/sync/diagnose.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import ValidationError as PydanticValidationError
 
-from spec_kitty_events import Event  # type: ignore[import-not-found]
+from spec_kitty_events import Event
 # Canonical event-type registry (Priivacy-ai/spec-kitty#1222).
 #
 # Diagnose recognises ANY event type the canonical events package models —

--- a/src/specify_cli/sync/orphan_sweep.py
+++ b/src/specify_cli/sync/orphan_sweep.py
@@ -25,7 +25,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
 
-import psutil  # type: ignore[import-untyped]
+import psutil
 
 from specify_cli.sync.daemon import (
     DAEMON_PORT_MAX_ATTEMPTS,

--- a/src/specify_cli/sync/owner.py
+++ b/src/specify_cli/sync/owner.py
@@ -43,7 +43,7 @@ from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
-import psutil  # type: ignore[import-untyped]
+import psutil
 
 from specify_cli.sync.daemon import (
     DAEMON_EXEC_ARG_PREFIX,

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, UTC
 from pathlib import Path
 from typing import Any, Protocol
 
-import toml  # type: ignore[import-untyped]
+import toml
 
 
 class _BatchEventResultLike(Protocol):

--- a/src/specify_cli/tool_surface/providers/managed_skills.py
+++ b/src/specify_cli/tool_surface/providers/managed_skills.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Protocol, cast
 
 from specify_cli.core.config import AGENT_SKILL_CONFIG, SKILL_CLASS_WRAPPER
 from specify_cli.skills import installer as skill_installer
@@ -100,15 +100,8 @@ class _RepairProto(Protocol):
         self,
         project_path: Path,
         verify_result: _VerifyResultProto,
-        registry: _RegistryProto,
+        registry: SkillRegistry,
     ) -> tuple[int, int]:
-        ...
-
-
-class _RegistryProto(Protocol):
-    """Subset of ``SkillRegistry`` needed to decide if a registry is usable."""
-
-    def discover_skills(self) -> Sequence[Any]:
         ...
 
 
@@ -135,7 +128,7 @@ class ManagedSkillsProvider:
         self,
         verifier: _VerifierProto | None = None,
         installer: _RepairProto | None = None,
-        registry_factory: Callable[[], _RegistryProto] | None = None,
+        registry_factory: Callable[[], SkillRegistry] | None = None,
     ) -> None:
         # All collaborators are accepted for dependency injection in tests. By
         # default the module-level functions from ``skills.verifier`` are used
@@ -147,9 +140,9 @@ class ManagedSkillsProvider:
             verifier if verifier is not None else skill_verifier
         )
         self._installer: _RepairProto = (
-            installer if installer is not None else skill_verifier
+            installer if installer is not None else cast(_RepairProto, skill_verifier)
         )
-        self._registry_factory: Callable[[], _RegistryProto] = (
+        self._registry_factory: Callable[[], SkillRegistry] = (
             registry_factory
             if registry_factory is not None
             else SkillRegistry.from_package
@@ -329,7 +322,7 @@ class ManagedSkillsProvider:
     @staticmethod
     def _install_expected(
         project_root: Path,
-        registry: _RegistryProto,
+        registry: SkillRegistry,
         tool_keys: tuple[str, ...],
         ids: tuple[str, ...],
     ) -> RepairResult:
@@ -364,7 +357,7 @@ class ManagedSkillsProvider:
             )
         return RepairResult(repaired=ids, dry_run=False)
 
-    def _resolve_registry(self) -> _RegistryProto | None:
+    def _resolve_registry(self) -> SkillRegistry | None:
         registry = self._registry_factory()
         if registry.discover_skills():
             return registry

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc43_retire_profile_context_command.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc43_retire_profile_context_command.py
@@ -7,6 +7,7 @@ consumer registry, so this forward migration removes stale generated copies.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 from ..registry import MigrationRegistry
@@ -59,7 +60,7 @@ class RetireProfileContextCommandMigration(BaseMigration):
         )
 
 
-def _iter_existing_profile_context_files(project_path: Path):
+def _iter_existing_profile_context_files(project_path: Path) -> Iterator[Path]:
     for agent_root, subdir in get_agent_dirs_for_project(project_path):
         agent_dir = project_path / agent_root / subdir
         if not agent_dir.exists():

--- a/src/specify_cli/upgrade/migrations/m_3_3_0_op_record_schema_v2.py
+++ b/src/specify_cli/upgrade/migrations/m_3_3_0_op_record_schema_v2.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -139,7 +139,7 @@ def _map_completed_line(
         )
     except ValidationError:
         return None
-    return cast(str, event.to_jsonl_line())
+    return event.to_jsonl_line()
 
 
 def _plan_file(path: Path) -> _FilePlan:


### PR DESCRIPTION
## Summary
- Fixes #1958 by resolving the full strict mypy gate across `src/specify_cli`, `src/charter`, and `src/doctrine`.
- Replaces stale casts/ignores with precise annotations, protocols, literals, and explicit compatibility exports.
- Preserves legacy runtime behavior including the `uninitialized` status sentinel and patchable charter status helper surface.

## Verification
- `.venv/bin/mypy --strict src/specify_cli src/charter src/doctrine`
- `.venv/bin/ruff check src/specify_cli src/charter src/doctrine`
- `.venv/bin/pytest -q tests/charter/test_context_activation_render.py ... tests/sync/test_config_background_daemon.py` (2447 passed)
- `.venv/bin/pytest -q tests/architectural/test_no_dead_symbols.py tests/specify_cli/cli/commands/test_charter_status_provenance.py tests/agent/cli/commands/test_charter_status_cli.py`
- `.venv/bin/pytest -q tests/charter/test_resolver.py tests/doctrine/missions/test_mission_step_resolver.py`

## Notes
- Full `PWHEADLESS=1 .venv/bin/pytest -q tests/` was attempted and stopped after an introduced dead-symbol failure; that failure was fixed and covered by the architectural test above. The full 25,621-test suite was not rerun to completion locally.