### PR TITLE
Fix base_commit unknown recovery metadata

### DIFF
--- a/src/specify_cli/cli/commands/context.py
+++ b/src/specify_cli/cli/commands/context.py
@@ -106,7 +106,8 @@ def info_command(
         table.add_row("Work Package", f"[bold]{context.wp_id}[/bold]")
         table.add_row("Feature", context.mission_slug)
         table.add_row("Base Branch", f"[cyan]{context.base_branch}[/cyan]")
-        table.add_row("Base Commit", f"[dim]{context.base_commit[:12]}[/dim]")
+        base_commit = context.base_commit[:12] if context.base_commit else "unknown"
+        table.add_row("Base Commit", f"[dim]{base_commit}[/dim]")
         table.add_row("Dependencies", ", ".join(context.dependencies) if context.dependencies else "[dim]none[/dim]")
         table.add_row("Created", context.created_at)
         table.add_row("Worktree", context.worktree_path)

--- a/src/specify_cli/lanes/recovery.py
+++ b/src/specify_cli/lanes/recovery.py
@@ -17,6 +17,7 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from specify_cli.lanes.branch_naming import (
     BranchIdentityUnresolved,
@@ -256,9 +257,7 @@ def _resolve_mission_branch(feature_dir: Path, mission_slug: str) -> str:
     if mission_branch:
         return mission_branch
     try:
-        return mission_branch_name_required(
-            mission_slug, _mission_id_from_meta(feature_dir)
-        )
+        return cast(str, mission_branch_name_required(mission_slug, _mission_id_from_meta(feature_dir)))
     except BranchIdentityUnresolved as exc:
         # Re-raise with the feature directory in the next_step so a recovery
         # caller can locate the meta.json whose mission_id is missing.
@@ -620,7 +619,7 @@ def recover_context(
         text=True,
         check=False,
     )
-    base_commit = result.stdout.strip() if result.returncode == 0 else "unknown"
+    base_commit = result.stdout.strip() if result.returncode == 0 else None
 
     context = WorkspaceContext(
         wp_id=state.wp_id,

--- a/src/specify_cli/status/wp_metadata.py
+++ b/src/specify_cli/status/wp_metadata.py
@@ -337,7 +337,9 @@ class WPMetadata(BaseModel):
     @field_validator("base_commit")
     @classmethod
     def validate_base_commit(cls, v: str | None) -> str | None:
-        if v is not None and not re.match(r"^[0-9a-f]{7,40}$", v):
+        if v is None or v == "unknown":
+            return None
+        if not re.match(r"^[0-9a-f]{7,40}$", v):
             raise ValueError(f"Invalid base_commit: {v!r} (must be hex SHA)")
         return v
 

--- a/src/specify_cli/workspace/context.py
+++ b/src/specify_cli/workspace/context.py
@@ -162,7 +162,7 @@ class WorkspaceContext:
 
     # Base tracking
     base_branch: str  # Branch this was created from (e.g., "kitty/mission-010-feature-lane-a" or "main")
-    base_commit: str  # Git SHA this was created from
+    base_commit: str | None  # Git SHA this was created from; None when unavailable
 
     # Dependencies
     dependencies: list[str]  # List of WP IDs this depends on (e.g., ["WP01"])
@@ -198,6 +198,8 @@ class WorkspaceContext:
             raise ValueError("Workspace context is missing required lane_id")
         if not isinstance(filtered.get("lane_wp_ids"), list):
             raise ValueError("Workspace context is missing required lane_wp_ids")
+        if filtered.get("base_commit") == "unknown":
+            filtered["base_commit"] = None
         return cls(**filtered)
 
 

--- a/tests/lanes/test_implementation_recovery.py
+++ b/tests/lanes/test_implementation_recovery.py
@@ -360,6 +360,31 @@ class TestWorktreeRecovery:
         assert loaded.created_by == "recovery"
         assert loaded.lane_wp_ids == ["WP01", "WP02"]
 
+    def test_recover_context_uses_none_when_base_commit_unavailable(self, tmp_path: Path) -> None:
+        """Missing mission branch must not persist the legacy 'unknown' sentinel."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_git_repo(repo)
+        _setup_feature(repo)
+
+        state = RecoveryState(
+            wp_id="WP01",
+            lane_id="lane-a",
+            branch_name="kitty/mission-010-feat-lane-a",
+            branch_exists=True,
+            worktree_exists=True,
+            context_exists=False,
+            status_lane="planned",
+            has_commits=True,
+            recovery_action="recreate_context",
+        )
+
+        recover_context(repo, "010-feat", state)
+
+        loaded = load_context(repo, "010-feat-lane-a")
+        assert loaded is not None
+        assert loaded.base_commit is None
+
 
 class TestStatusReconciliation:
     """T009: Status reconciliation tests."""

--- a/tests/runtime/test_workspace_context_unit.py
+++ b/tests/runtime/test_workspace_context_unit.py
@@ -150,6 +150,34 @@ class TestCorruptedContext:
         assert loaded is None
         assert list_contexts(kittify_project) == []
 
+    def test_legacy_unknown_base_commit_normalized(self, kittify_project: Path) -> None:
+        context_file = kittify_project / ".kittify" / "workspaces" / "001-feature-lane-a.json"
+        context_file.write_text(
+            """
+{
+  "wp_id": "WP01",
+  "mission_slug": "001-feature",
+  "worktree_path": ".worktrees/001-feature-lane-a",
+  "branch_name": "kitty/mission-001-feature-lane-a",
+  "base_branch": "kitty/mission-001-feature",
+  "base_commit": "unknown",
+  "dependencies": [],
+  "created_at": "2026-01-25T12:00:00Z",
+  "created_by": "recovery",
+  "vcs_backend": "git",
+  "lane_id": "lane-a",
+  "lane_wp_ids": ["WP01"],
+  "current_wp": "WP01"
+}
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+        loaded = load_context(kittify_project, "001-feature-lane-a")
+
+        assert loaded is not None
+        assert loaded.base_commit is None
+
 
 class TestContextIndexAndResolution:
     def test_active_wp_resolution_uses_canonical_status_after_shared_lane_advances(self, kittify_project: Path) -> None:
@@ -276,6 +304,29 @@ class TestContextIndexAndResolution:
         refreshed = build_normalized_wp_index(kittify_project, "001-feature")
 
         assert refreshed["WP03"].metadata.execution_mode == "planning_artifact"
+
+    def test_build_normalized_wp_index_accepts_unrelated_legacy_unknown_base_commit(
+        self, kittify_project: Path
+    ) -> None:
+        feature_dir = _seed_mission(kittify_project)
+        tasks_dir = feature_dir / "tasks"
+        (tasks_dir / "WP01-legacy-base.md").write_text(
+            "---\nwork_package_id: WP01\ntitle: Legacy Base\nbase_commit: unknown\n---\n\nUpdate src/legacy.py.\n",
+            encoding="utf-8",
+        )
+        _write_wp(
+            tasks_dir,
+            "WP04",
+            "Current work",
+            "Update src/current.py.",
+            execution_mode="code_change",
+            owned_files=["src/current.py"],
+        )
+
+        index = build_normalized_wp_index(kittify_project, "001-feature")
+
+        assert index["WP01"].metadata.base_commit is None
+        assert index["WP04"].metadata.owned_files == ["src/current.py"]
 
     def test_save_context_does_not_drop_normalized_wp_cache(self, kittify_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         feature_dir = _seed_mission(kittify_project)

--- a/tests/specify_cli/cli/commands/test_context_info.py
+++ b/tests/specify_cli/cli/commands/test_context_info.py
@@ -1,0 +1,43 @@
+"""Tests for `spec-kitty context info` display behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import context
+from specify_cli.workspace.context import WorkspaceContext, save_context
+
+
+def test_context_info_displays_unknown_when_base_commit_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    save_context(
+        tmp_path,
+        WorkspaceContext(
+            wp_id="WP01",
+            mission_slug="001-feature",
+            worktree_path=".worktrees/001-feature-lane-a",
+            branch_name="kitty/mission-001-feature-lane-a",
+            base_branch="kitty/mission-001-feature",
+            base_commit=None,
+            dependencies=[],
+            created_at="2026-01-25T12:00:00Z",
+            created_by="recovery",
+            vcs_backend="git",
+            lane_id="lane-a",
+            lane_wp_ids=["WP01"],
+            current_wp="WP01",
+        ),
+    )
+    monkeypatch.setattr(context, "find_repo_root", lambda: tmp_path)
+
+    result = CliRunner().invoke(
+        context.app,
+        ["info", "--workspace", "001-feature-lane-a"],
+    )
+
+    assert result.exit_code == 0
+    assert "Base Commit" in result.stdout
+    assert "unknown" in result.stdout

--- a/tests/specify_cli/status/test_wp_metadata.py
+++ b/tests/specify_cli/status/test_wp_metadata.py
@@ -159,6 +159,7 @@ class TestWPMetadataValidators:
         with pytest.raises(ValidationError, match="title"):
             WPMetadata(work_package_id="WP01", title="   ")
 
+    @pytest.mark.fast
     def test_invalid_base_commit(self) -> None:
         with pytest.raises(ValidationError, match="base_commit"):
             WPMetadata(work_package_id="WP01", title="T", base_commit="not-hex")
@@ -174,6 +175,11 @@ class TestWPMetadataValidators:
 
     def test_base_commit_none_is_valid(self) -> None:
         meta = WPMetadata(work_package_id="WP01", title="T", base_commit=None)
+        assert meta.base_commit is None
+
+    @pytest.mark.fast
+    def test_legacy_unknown_base_commit_is_normalized_to_none(self) -> None:
+        meta = WPMetadata(work_package_id="WP01", title="T", base_commit="unknown")
         assert meta.base_commit is None
 
     def test_invalid_lane_value_raises(self) -> None:
@@ -524,6 +530,15 @@ class TestReadWpFrontmatter:
         )
         meta, _ = read_wp_frontmatter(wp_file)
         assert meta.shell_pid == 405597
+
+    def test_legacy_unknown_base_commit_in_file_is_normalized(self, tmp_path: Path) -> None:
+        wp_file = tmp_path / "WP01-legacy-base.md"
+        wp_file.write_text(
+            "---\nwork_package_id: WP01\ntitle: Legacy Base\nbase_commit: unknown\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+        meta, _ = read_wp_frontmatter(wp_file)
+        assert meta.base_commit is None
 
     def test_extra_fields_in_file(self, tmp_path: Path) -> None:
         """Fields formerly stored as extras are now declared on the model."""


### PR DESCRIPTION
## Summary
- normalize legacy `base_commit: unknown` WP frontmatter to `None` so mission-scoped metadata loading does not block unrelated WP review
- stop recovery from writing the legacy `unknown` sentinel when `git rev-parse` cannot resolve the mission branch
- allow workspace context JSON to load/display missing base commits safely

Fixes #1961

## Validation
- Loaded `debugger-debbie`; validated issue root cause against current `main` code and added regression coverage for both legacy reader and recovery writer paths.
- Loaded `architect-alphonso`; validated fix architecture as localized compatibility normalization plus producer correction, with display consumer guarded for `None`.
- Ran adversarial review of local diff; found and addressed missing `context info` display coverage and removed runtime `str()` coercion in favor of `typing.cast`.

## Tests
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_context_info.py tests/specify_cli/status/test_wp_metadata.py tests/runtime/test_workspace_context_unit.py tests/lanes/test_implementation_recovery.py -q`
- `.venv/bin/ruff check src/specify_cli/status/wp_metadata.py src/specify_cli/lanes/recovery.py src/specify_cli/workspace/context.py src/specify_cli/cli/commands/context.py tests/specify_cli/status/test_wp_metadata.py tests/runtime/test_workspace_context_unit.py tests/lanes/test_implementation_recovery.py tests/specify_cli/cli/commands/test_context_info.py`
- `.venv/bin/mypy src/specify_cli/status/wp_metadata.py src/specify_cli/lanes/recovery.py src/specify_cli/workspace/context.py src/specify_cli/cli/commands/context.py`
- `git diff --check`