### PR TITLE
fix(#1968): resolve managed artifacts during lane auto-rebase

### DIFF
--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -44,8 +44,7 @@ from specify_cli.merge.conflict_classifier import (
     classify,
     validate_resolution,
 )
-from specify_cli.status.event_log_merge import EventLogMergeError, merge_event_log_texts
-from specify_cli.status.reducer import materialize
+from specify_cli.status import EventLogMergeError, materialize, merge_event_log_texts
 
 __all__ = [
     "AutoRebaseReport",

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -395,6 +395,18 @@ def _staged_status_artifact_dirs(worktree: Path) -> tuple[set[Path], str | None]
     return feature_dirs, None
 
 
+def _status_json_already_classified(
+    file_path: Path,
+    classifications: list[ConflictClassification],
+) -> bool:
+    return any(
+        classification.file_path == file_path
+        and isinstance(classification.resolution, Auto)
+        and classification.resolution.rule_id == RULE_ID_STATUS_JSON
+        for classification in classifications
+    )
+
+
 def _refresh_status_json_for_staged_artifacts(
     worktree: Path,
     classifications: list[ConflictClassification],
@@ -407,6 +419,8 @@ def _refresh_status_json_for_staged_artifacts(
 
     for feature_dir in sorted(feature_dirs, key=lambda path: path.as_posix()):
         file_path = feature_dir / "status.json"
+        if _status_json_already_classified(file_path, classifications):
+            continue
         classification, halt_reason = _resolve_status_json(file_path, worktree)
         if halt_reason is not None:
             return halt_reason

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -265,6 +265,10 @@ def _resolve_status_json(
     worktree: Path,
 ) -> tuple[ConflictClassification | None, str | None]:
     rel_path = _relative_path(file_path, worktree)
+    event_log_error = _hydrate_status_events_from_index(file_path.parent, worktree)
+    if event_log_error is not None:
+        return None, event_log_error
+
     try:
         materialize(file_path.parent)
     except Exception as exc:  # noqa: BLE001 - surface reducer/store failures to operator
@@ -274,6 +278,29 @@ def _resolve_status_json(
     if not ok:
         return None, f"{RULE_ID_STATUS_JSON}: git add --sparse {rel_path} failed: {message}"
     return _managed_classification(file_path, RULE_ID_STATUS_JSON), None
+
+
+def _hydrate_status_events_from_index(feature_dir: Path, worktree: Path) -> str | None:
+    """Ensure materialize() can read event rows hidden by sparse checkout."""
+    events_path = feature_dir / "status.events.jsonl"
+    if events_path.exists():
+        return None
+
+    rel_path = _relative_path(events_path, worktree)
+    index_text = _git_show_stage(worktree, rel_path, 0)
+    if index_text is None:
+        return None
+
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        events_path.write_text(index_text, encoding="utf-8")
+    except OSError as exc:
+        return f"{RULE_ID_STATUS_JSON}: could not hydrate {rel_path}: {exc!r}"
+
+    ok, message = _stage_sparse(worktree, rel_path)
+    if not ok:
+        return f"{RULE_ID_STATUS_JSON}: git add --sparse {rel_path} failed: {message}"
+    return None
 
 
 def _resolve_managed_artifact_conflicts(

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -364,15 +364,21 @@ def _merge_head_exists(worktree: Path) -> bool:
 
 
 def _staged_status_event_dirs(worktree: Path) -> tuple[set[Path], str | None]:
-    result = _run(["git", "diff", "--name-only", "--cached"], worktree)
+    result = _run(["git", "diff", "--name-status", "--cached"], worktree)
     if result.returncode != 0:
         return set(), result.stderr.strip() or result.stdout.strip()
 
     feature_dirs: set[Path] = set()
     for raw in result.stdout.splitlines():
-        rel_path = raw.strip()
-        if rel_path and _is_status_events_path(rel_path):
-            feature_dirs.add((worktree / rel_path).parent)
+        status, _, rel_path = raw.strip().partition("\t")
+        if not rel_path and status:
+            rel_path = status
+            status = ""
+        if not rel_path or not _is_status_events_path(rel_path):
+            continue
+        if status.startswith("D"):
+            return set(), f"{RULE_ID_STATUS_EVENTS}: refusing staged deletion of {rel_path}"
+        feature_dirs.add((worktree / rel_path).parent)
     return feature_dirs, None
 
 

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -34,6 +34,10 @@ from pathlib import Path
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.core.file_lock import MachineFileLock
+from specify_cli.lanes.merge import (
+    _ensure_event_log_merge_driver_config,
+    _make_merge_env,
+)
 from specify_cli.lanes.models import ExecutionLane
 from specify_cli.merge.conflict_classifier import (
     RULE_ID_INIT_IMPORTS,
@@ -102,6 +106,7 @@ def _run(
         capture_output=True,
         text=True,
         check=check,
+        env=_make_merge_env(),
     )
 
 
@@ -309,7 +314,7 @@ def _hydrate_status_events_from_index(feature_dir: Path, worktree: Path) -> str 
     rel_path = _relative_path(events_path, worktree)
     index_text = _git_show_stage(worktree, rel_path, 0)
     if index_text is None:
-        return None
+        return f"{RULE_ID_STATUS_JSON}: missing authoritative {rel_path}"
 
     events_path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -367,6 +372,59 @@ def _resolve_managed_artifact_conflicts(
 def _merge_head_exists(worktree: Path) -> bool:
     result = _run(["git", "rev-parse", "-q", "--verify", "MERGE_HEAD"], worktree)
     return result.returncode == 0
+
+
+def _git_ref_has_path(worktree: Path, ref: str, rel_path: str) -> bool:
+    result = _run(["git", "cat-file", "-e", f"{ref}:{rel_path}"], worktree)
+    return result.returncode == 0
+
+
+def _status_artifact_paths_from_ref(
+    worktree: Path,
+    ref: str,
+) -> tuple[set[str], str | None]:
+    result = _run(
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", KITTY_SPECS_DIR],
+        worktree,
+    )
+    if result.returncode != 0:
+        return set(), result.stderr.strip() or result.stdout.strip()
+    return {
+        rel_path
+        for rel_path in result.stdout.splitlines()
+        if _is_status_events_path(rel_path) or _is_status_json_path(rel_path)
+    }, None
+
+
+def _refuse_preexisting_lane_status_deletions(
+    worktree: Path,
+    mission_branch: str,
+) -> str | None:
+    merge_base = _run(["git", "merge-base", "HEAD", mission_branch], worktree)
+    if merge_base.returncode != 0:
+        return (
+            f"{RULE_ID_STATUS_EVENTS}: could not find merge base with "
+            f"{mission_branch}: {(merge_base.stderr or merge_base.stdout).strip()}"
+        )
+    base_ref = merge_base.stdout.strip()
+
+    base_paths, error = _status_artifact_paths_from_ref(worktree, base_ref)
+    if error is not None:
+        return f"{RULE_ID_STATUS_EVENTS}: could not inspect base status artifacts: {error}"
+    mission_paths, error = _status_artifact_paths_from_ref(worktree, mission_branch)
+    if error is not None:
+        return (
+            f"{RULE_ID_STATUS_EVENTS}: could not inspect coordination status "
+            f"artifacts: {error}"
+        )
+
+    for rel_path in sorted(base_paths & mission_paths):
+        if not _git_ref_has_path(worktree, "HEAD", rel_path):
+            return (
+                f"{RULE_ID_STATUS_EVENTS}: refusing pre-existing lane-side "
+                f"deletion of coordination-owned status artifact {rel_path}"
+            )
+    return None
 
 
 def _staged_status_artifact_dirs(worktree: Path) -> tuple[set[Path], str | None]:
@@ -756,6 +814,21 @@ def attempt_auto_rebase(
        commits with the audit message.
     """
     _git_user_env_ready(worktree_path)
+
+    halt_reason = _refuse_preexisting_lane_status_deletions(
+        worktree_path,
+        mission_branch,
+    )
+    if halt_reason is not None:
+        return AutoRebaseReport(
+            lane_id=lane.lane_id,
+            attempted=True,
+            succeeded=False,
+            classifications=(),
+            halt_reason=halt_reason,
+        )
+
+    _ensure_event_log_merge_driver_config(repo_root)
 
     merge_result = _run(
         ["git", "merge", "--no-edit", "--no-ff", "--no-commit", mission_branch],

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -358,6 +358,42 @@ def _resolve_managed_artifact_conflicts(
     return remaining, None
 
 
+def _merge_head_exists(worktree: Path) -> bool:
+    result = _run(["git", "rev-parse", "-q", "--verify", "MERGE_HEAD"], worktree)
+    return result.returncode == 0
+
+
+def _staged_status_event_dirs(worktree: Path) -> tuple[set[Path], str | None]:
+    result = _run(["git", "diff", "--name-only", "--cached"], worktree)
+    if result.returncode != 0:
+        return set(), result.stderr.strip() or result.stdout.strip()
+
+    feature_dirs: set[Path] = set()
+    for raw in result.stdout.splitlines():
+        rel_path = raw.strip()
+        if rel_path and _is_status_events_path(rel_path):
+            feature_dirs.add((worktree / rel_path).parent)
+    return feature_dirs, None
+
+
+def _refresh_status_json_for_staged_events(
+    worktree: Path,
+    classifications: list[ConflictClassification],
+) -> str | None:
+    feature_dirs, error = _staged_status_event_dirs(worktree)
+    if error is not None:
+        return f"{RULE_ID_STATUS_JSON}: could not inspect staged paths: {error}"
+
+    for feature_dir in sorted(feature_dirs, key=lambda path: path.as_posix()):
+        file_path = feature_dir / "status.json"
+        classification, halt_reason = _resolve_status_json(file_path, worktree)
+        if halt_reason is not None:
+            return halt_reason
+        assert classification is not None
+        classifications.append(classification)
+    return None
+
+
 def _split_into_regions(
     text: str,
 ) -> tuple[list[tuple[bool, str]], int]:
@@ -671,8 +707,8 @@ def attempt_auto_rebase(
 
     The caller has already determined the lane is stale. This function:
 
-    1. Runs ``git merge <mission_branch>`` inside ``worktree_path``.
-    2. If clean, returns ``succeeded=True``.
+    1. Runs ``git merge --no-commit <mission_branch>`` inside ``worktree_path``.
+    2. If clean, refreshes any staged status snapshots and commits the merge.
     3. Classifies each conflict region. Any ``Manual`` aborts the merge and
        returns ``succeeded=False``.
     4. Applies ``Auto`` resolutions, regenerates ``uv.lock`` if needed, runs
@@ -682,15 +718,43 @@ def attempt_auto_rebase(
     _git_user_env_ready(worktree_path)
 
     merge_result = _run(
-        ["git", "merge", "--no-edit", "--no-ff", mission_branch],
+        ["git", "merge", "--no-edit", "--no-ff", "--no-commit", mission_branch],
         worktree_path,
     )
     if merge_result.returncode == 0:
+        clean_classifications: list[ConflictClassification] = []
+        halt_reason = _refresh_status_json_for_staged_events(
+            worktree_path, clean_classifications
+        )
+        if halt_reason is not None:
+            return _abort_with_failure(
+                worktree_path, lane.lane_id, clean_classifications, halt_reason,
+            )
+
+        sparse_error = _reapply_sparse_checkout(worktree_path)
+        if sparse_error is not None:
+            return _abort_with_failure(
+                worktree_path, lane.lane_id, clean_classifications,
+                f"sparse checkout cleanup failed: {sparse_error}",
+            )
+
+        if _merge_head_exists(worktree_path):
+            commit_result = _run(
+                ["git", "-c", "commit.gpgsign=false", "commit", "--no-edit"],
+                worktree_path,
+            )
+            if commit_result.returncode != 0:
+                return _abort_with_failure(
+                    worktree_path, lane.lane_id, clean_classifications,
+                    f"merge commit failed: "
+                    f"{(commit_result.stderr or commit_result.stdout).strip()}",
+                )
+
         return AutoRebaseReport(
             lane_id=lane.lane_id,
             attempted=True,
             succeeded=True,
-            classifications=(),
+            classifications=tuple(clean_classifications),
         )
 
     conflicted = _list_conflicted_files(worktree_path)

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -395,6 +395,8 @@ def _refresh_status_json_for_staged_events(
 ) -> str | None:
     feature_dirs, error = _staged_status_event_dirs(worktree)
     if error is not None:
+        if error.startswith(f"{RULE_ID_STATUS_EVENTS}:"):
+            return error
         return f"{RULE_ID_STATUS_JSON}: could not inspect staged paths: {error}"
 
     for feature_dir in sorted(feature_dirs, key=lambda path: path.as_posix()):
@@ -670,6 +672,12 @@ def _finalize_auto_rebase(
         _run(
             ["git", "add", str(init_path.relative_to(worktree_path))],
             worktree_path,
+        )
+
+    halt_reason = _refresh_status_json_for_staged_events(worktree_path, classifications)
+    if halt_reason is not None:
+        return _abort_with_failure(
+            worktree_path, lane_id, classifications, halt_reason,
         )
 
     sparse_error = _reapply_sparse_checkout(worktree_path)

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -217,11 +217,18 @@ def _resolve_status_events(
     worktree: Path,
 ) -> tuple[ConflictClassification | None, str | None]:
     rel_path = _relative_path(file_path, worktree)
-    stage_texts = [
-        text
+    stage_text_by_number = {
+        stage: text
         for stage in (1, 2, 3)
         if (text := _git_show_stage(worktree, rel_path, stage)) is not None
-    ]
+    }
+    if 2 not in stage_text_by_number or 3 not in stage_text_by_number:
+        return None, (
+            f"{RULE_ID_STATUS_EVENTS}: refusing status.events.jsonl deletion "
+            f"conflict for {rel_path}"
+        )
+
+    stage_texts = list(stage_text_by_number.values())
     if not stage_texts:
         return None, f"{RULE_ID_STATUS_EVENTS}: no index stages found for {rel_path}"
 

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -32,6 +32,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.core.file_lock import MachineFileLock
 from specify_cli.lanes.models import ExecutionLane
 from specify_cli.merge.conflict_classifier import (
@@ -43,6 +44,8 @@ from specify_cli.merge.conflict_classifier import (
     classify,
     validate_resolution,
 )
+from specify_cli.status.event_log_merge import EventLogMergeError, merge_event_log_texts
+from specify_cli.status.reducer import materialize
 
 __all__ = [
     "AutoRebaseReport",
@@ -50,6 +53,9 @@ __all__ = [
 ]
 
 _UV_LOCK_FILENAME = "uv.lock"
+RULE_ID_STATUS_EVENTS = "R-STATUS-EVENTS-JSONL-UNION"
+RULE_ID_STATUS_JSON = "R-STATUS-JSON-REMATERIALIZE"
+RULE_ID_COORDINATION_ARTIFACT = "R-COORDINATION-ARTIFACT-THEIRS"
 
 
 @dataclass(frozen=True)
@@ -112,6 +118,199 @@ def _list_conflicted_files(worktree: Path) -> list[Path]:
             continue
         paths.append(worktree / name)
     return paths
+
+
+def _relative_path(file_path: Path, worktree: Path) -> str:
+    return file_path.relative_to(worktree).as_posix()
+
+
+def _path_parts(rel_path: str) -> tuple[str, ...]:
+    return tuple(Path(rel_path).parts)
+
+
+def _is_status_events_path(rel_path: str) -> bool:
+    parts = _path_parts(rel_path)
+    return (
+        len(parts) >= 3
+        and parts[0] == KITTY_SPECS_DIR
+        and parts[-1] == "status.events.jsonl"
+    )
+
+
+def _is_status_json_path(rel_path: str) -> bool:
+    parts = _path_parts(rel_path)
+    return (
+        len(parts) >= 3
+        and parts[0] == KITTY_SPECS_DIR
+        and parts[-1] == "status.json"
+    )
+
+
+def _is_coordination_owned_artifact(rel_path: str) -> bool:
+    parts = _path_parts(rel_path)
+    if len(parts) < 3 or parts[0] != KITTY_SPECS_DIR:
+        return False
+
+    name = parts[-1]
+    if name in {"tasks.md", "lanes.json", "acceptance-matrix.json"}:
+        return True
+
+    return (
+        len(parts) >= 4
+        and parts[2] == "tasks"
+        and name.startswith("WP")
+        and name.endswith(".md")
+    )
+
+
+def _git_show_stage(worktree: Path, rel_path: str, stage: int) -> str | None:
+    result = _run(["git", "show", f":{stage}:{rel_path}"], worktree)
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _stage_sparse(worktree: Path, rel_path: str) -> tuple[bool, str | None]:
+    result = _run(["git", "add", "--sparse", rel_path], worktree)
+    if result.returncode != 0:
+        return False, result.stderr.strip() or result.stdout.strip()
+    return True, None
+
+
+def _remove_sparse(worktree: Path, rel_path: str) -> tuple[bool, str | None]:
+    target = worktree / rel_path
+    if target.exists():
+        try:
+            target.unlink()
+        except OSError as exc:
+            return False, f"could not remove {rel_path}: {exc!r}"
+    result = _run(["git", "rm", "-f", "--ignore-unmatch", "--sparse", rel_path], worktree)
+    if result.returncode != 0:
+        return False, result.stderr.strip() or result.stdout.strip()
+    return True, None
+
+
+def _managed_classification(file_path: Path, rule_id: str) -> ConflictClassification:
+    return ConflictClassification(
+        file_path=file_path,
+        hunk_text="",
+        resolution=Auto(merged_text="", rule_id=rule_id),
+    )
+
+
+def _resolve_status_events(
+    file_path: Path,
+    worktree: Path,
+) -> tuple[ConflictClassification | None, str | None]:
+    rel_path = _relative_path(file_path, worktree)
+    stage_texts = [
+        text
+        for stage in (1, 2, 3)
+        if (text := _git_show_stage(worktree, rel_path, stage)) is not None
+    ]
+    if not stage_texts:
+        return None, f"{RULE_ID_STATUS_EVENTS}: no index stages found for {rel_path}"
+
+    try:
+        merged_text = merge_event_log_texts(*stage_texts)
+    except EventLogMergeError as exc:
+        return None, f"{RULE_ID_STATUS_EVENTS}: {exc}"
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        file_path.write_text(merged_text, encoding="utf-8")
+    except OSError as exc:
+        return None, f"{RULE_ID_STATUS_EVENTS}: could not write {rel_path}: {exc!r}"
+
+    ok, message = _stage_sparse(worktree, rel_path)
+    if not ok:
+        return None, f"{RULE_ID_STATUS_EVENTS}: git add --sparse {rel_path} failed: {message}"
+    return _managed_classification(file_path, RULE_ID_STATUS_EVENTS), None
+
+
+def _resolve_take_theirs(
+    file_path: Path,
+    worktree: Path,
+) -> tuple[ConflictClassification | None, str | None]:
+    rel_path = _relative_path(file_path, worktree)
+    theirs = _git_show_stage(worktree, rel_path, 3)
+    if theirs is None:
+        ok, message = _remove_sparse(worktree, rel_path)
+        if not ok:
+            return None, (
+                f"{RULE_ID_COORDINATION_ARTIFACT}: git rm --sparse {rel_path} "
+                f"failed: {message}"
+            )
+        return _managed_classification(file_path, RULE_ID_COORDINATION_ARTIFACT), None
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        file_path.write_text(theirs, encoding="utf-8")
+    except OSError as exc:
+        return None, (
+            f"{RULE_ID_COORDINATION_ARTIFACT}: could not write {rel_path}: {exc!r}"
+        )
+
+    ok, message = _stage_sparse(worktree, rel_path)
+    if not ok:
+        return None, (
+            f"{RULE_ID_COORDINATION_ARTIFACT}: git add --sparse {rel_path} "
+            f"failed: {message}"
+        )
+    return _managed_classification(file_path, RULE_ID_COORDINATION_ARTIFACT), None
+
+
+def _resolve_status_json(
+    file_path: Path,
+    worktree: Path,
+) -> tuple[ConflictClassification | None, str | None]:
+    rel_path = _relative_path(file_path, worktree)
+    try:
+        materialize(file_path.parent)
+    except Exception as exc:  # noqa: BLE001 - surface reducer/store failures to operator
+        return None, f"{RULE_ID_STATUS_JSON}: could not materialize {rel_path}: {exc!r}"
+
+    ok, message = _stage_sparse(worktree, rel_path)
+    if not ok:
+        return None, f"{RULE_ID_STATUS_JSON}: git add --sparse {rel_path} failed: {message}"
+    return _managed_classification(file_path, RULE_ID_STATUS_JSON), None
+
+
+def _resolve_managed_artifact_conflicts(
+    conflicted: list[Path],
+    worktree: Path,
+    classifications: list[ConflictClassification],
+) -> tuple[list[Path], str | None]:
+    """Resolve Spec Kitty-owned planning artifacts before generic text rules."""
+    remaining: list[Path] = []
+    status_json_paths: list[Path] = []
+
+    for file_path in conflicted:
+        rel_path = _relative_path(file_path, worktree)
+        if _is_status_events_path(rel_path):
+            classification, halt_reason = _resolve_status_events(file_path, worktree)
+        elif _is_status_json_path(rel_path):
+            status_json_paths.append(file_path)
+            continue
+        elif _is_coordination_owned_artifact(rel_path):
+            classification, halt_reason = _resolve_take_theirs(file_path, worktree)
+        else:
+            remaining.append(file_path)
+            continue
+
+        if halt_reason is not None:
+            return remaining, halt_reason
+        assert classification is not None
+        classifications.append(classification)
+
+    for file_path in status_json_paths:
+        classification, halt_reason = _resolve_status_json(file_path, worktree)
+        if halt_reason is not None:
+            return remaining, halt_reason
+        assert classification is not None
+        classifications.append(classification)
+
+    return remaining, None
 
 
 def _split_into_regions(
@@ -450,6 +649,13 @@ def attempt_auto_rebase(
     classifications: list[ConflictClassification] = []
     init_py_touched: list[Path] = []
     uvlock_seen = False
+    conflicted, halt_reason = _resolve_managed_artifact_conflicts(
+        conflicted, worktree_path, classifications
+    )
+    if halt_reason is not None:
+        return _abort_with_failure(
+            worktree_path, lane.lane_id, classifications, halt_reason,
+        )
 
     for file_path in conflicted:
         if file_path.name == _UV_LOCK_FILENAME:

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -177,6 +177,20 @@ def _stage_sparse(worktree: Path, rel_path: str) -> tuple[bool, str | None]:
     return True, None
 
 
+def _sparse_checkout_enabled(worktree: Path) -> bool:
+    result = _run(["git", "config", "--bool", "core.sparseCheckout"], worktree)
+    return result.returncode == 0 and result.stdout.strip().lower() == "true"
+
+
+def _reapply_sparse_checkout(worktree: Path) -> str | None:
+    if not _sparse_checkout_enabled(worktree):
+        return None
+    result = _run(["git", "sparse-checkout", "reapply"], worktree)
+    if result.returncode != 0:
+        return result.stderr.strip() or result.stdout.strip()
+    return None
+
+
 def _remove_sparse(worktree: Path, rel_path: str) -> tuple[bool, str | None]:
     target = worktree / rel_path
     if target.exists():
@@ -310,14 +324,17 @@ def _resolve_managed_artifact_conflicts(
 ) -> tuple[list[Path], str | None]:
     """Resolve Spec Kitty-owned planning artifacts before generic text rules."""
     remaining: list[Path] = []
-    status_json_paths: list[Path] = []
+    status_json_paths_by_dir: dict[Path, Path] = {}
+    status_refresh_dirs: set[Path] = set()
 
     for file_path in conflicted:
         rel_path = _relative_path(file_path, worktree)
         if _is_status_events_path(rel_path):
             classification, halt_reason = _resolve_status_events(file_path, worktree)
+            status_refresh_dirs.add(file_path.parent)
         elif _is_status_json_path(rel_path):
-            status_json_paths.append(file_path)
+            status_json_paths_by_dir[file_path.parent] = file_path
+            status_refresh_dirs.add(file_path.parent)
             continue
         elif _is_coordination_owned_artifact(rel_path):
             classification, halt_reason = _resolve_take_theirs(file_path, worktree)
@@ -330,7 +347,8 @@ def _resolve_managed_artifact_conflicts(
         assert classification is not None
         classifications.append(classification)
 
-    for file_path in status_json_paths:
+    for feature_dir in sorted(status_refresh_dirs, key=lambda path: path.as_posix()):
+        file_path = status_json_paths_by_dir.get(feature_dir, feature_dir / "status.json")
         classification, halt_reason = _resolve_status_json(file_path, worktree)
         if halt_reason is not None:
             return remaining, halt_reason
@@ -460,6 +478,9 @@ def _abort_with_failure(
 ) -> AutoRebaseReport:
     """Run ``git merge --abort`` and return a failure ``AutoRebaseReport``."""
     _run(["git", "merge", "--abort"], worktree_path)
+    sparse_error = _reapply_sparse_checkout(worktree_path)
+    if sparse_error is not None:
+        halt_reason = f"{halt_reason}; sparse checkout cleanup failed: {sparse_error}"
     return AutoRebaseReport(
         lane_id=lane_id,
         attempted=True,
@@ -600,6 +621,13 @@ def _finalize_auto_rebase(
         _run(
             ["git", "add", str(init_path.relative_to(worktree_path))],
             worktree_path,
+        )
+
+    sparse_error = _reapply_sparse_checkout(worktree_path)
+    if sparse_error is not None:
+        return _abort_with_failure(
+            worktree_path, lane_id, classifications,
+            f"sparse checkout cleanup failed: {sparse_error}",
         )
 
     rule_ids_used = sorted(

--- a/src/specify_cli/lanes/auto_rebase.py
+++ b/src/specify_cli/lanes/auto_rebase.py
@@ -370,30 +370,36 @@ def _merge_head_exists(worktree: Path) -> bool:
     return result.returncode == 0
 
 
-def _staged_status_event_dirs(worktree: Path) -> tuple[set[Path], str | None]:
+def _staged_status_artifact_dirs(worktree: Path) -> tuple[set[Path], str | None]:
     result = _run(["git", "diff", "--name-status", "--cached"], worktree)
     if result.returncode != 0:
         return set(), result.stderr.strip() or result.stdout.strip()
 
     feature_dirs: set[Path] = set()
     for raw in result.stdout.splitlines():
-        status, _, rel_path = raw.strip().partition("\t")
-        if not rel_path and status:
-            rel_path = status
-            status = ""
-        if not rel_path or not _is_status_events_path(rel_path):
+        fields = raw.strip().split("\t")
+        if not fields:
             continue
-        if status.startswith("D"):
-            return set(), f"{RULE_ID_STATUS_EVENTS}: refusing staged deletion of {rel_path}"
-        feature_dirs.add((worktree / rel_path).parent)
+        status = fields[0]
+        rel_paths = fields[1:] or [status]
+        for rel_path in rel_paths:
+            if _is_status_events_path(rel_path):
+                if status.startswith(("D", "R")):
+                    return set(), (
+                        f"{RULE_ID_STATUS_EVENTS}: refusing staged deletion "
+                        f"of {rel_path}"
+                    )
+                feature_dirs.add((worktree / rel_path).parent)
+            elif _is_status_json_path(rel_path):
+                feature_dirs.add((worktree / rel_path).parent)
     return feature_dirs, None
 
 
-def _refresh_status_json_for_staged_events(
+def _refresh_status_json_for_staged_artifacts(
     worktree: Path,
     classifications: list[ConflictClassification],
 ) -> str | None:
-    feature_dirs, error = _staged_status_event_dirs(worktree)
+    feature_dirs, error = _staged_status_artifact_dirs(worktree)
     if error is not None:
         if error.startswith(f"{RULE_ID_STATUS_EVENTS}:"):
             return error
@@ -674,7 +680,7 @@ def _finalize_auto_rebase(
             worktree_path,
         )
 
-    halt_reason = _refresh_status_json_for_staged_events(worktree_path, classifications)
+    halt_reason = _refresh_status_json_for_staged_artifacts(worktree_path, classifications)
     if halt_reason is not None:
         return _abort_with_failure(
             worktree_path, lane_id, classifications, halt_reason,
@@ -744,7 +750,7 @@ def attempt_auto_rebase(
     )
     if merge_result.returncode == 0:
         clean_classifications: list[ConflictClassification] = []
-        halt_reason = _refresh_status_json_for_staged_events(
+        halt_reason = _refresh_status_json_for_staged_artifacts(
             worktree_path, clean_classifications
         )
         if halt_reason is not None:

--- a/src/specify_cli/lanes/lifecycle_sync.py
+++ b/src/specify_cli/lanes/lifecycle_sync.py
@@ -17,7 +17,7 @@ LANE_AUTO_REBASE_FAILED = "LANE_AUTO_REBASE_FAILED"
 WORKTREES_DIRNAME = ".worktrees"
 
 
-@dataclass(frozen=True)
+@dataclass
 class LaneAutoRebaseSyncError(RuntimeError):
     """Structured failure for a lane sync-point auto-rebase refusal."""
 
@@ -85,7 +85,7 @@ def _resolve_lane_branch(
     planning_base_branch: str,
     mission_id: str | None,
 ) -> str:
-    candidates = []
+    candidates: list[str] = []
     if mission_id and len(mission_id) >= 8:
         candidates.append(
             lane_branch_name(

--- a/src/specify_cli/lanes/merge.py
+++ b/src/specify_cli/lanes/merge.py
@@ -248,7 +248,7 @@ def _branch_exists(repo_root: Path, branch: str) -> bool:
     # Routes the existence check through the shared lanes/_git helper while
     # preserving the merge pipeline's single env authority (_make_merge_env);
     # the env composes through rather than forking the helper (#1904).
-    return _shared_branch_exists(repo_root, branch, env=_make_merge_env())
+    return bool(_shared_branch_exists(repo_root, branch, env=_make_merge_env()))
 
 
 def _git_config_get(repo_root: Path, key: str) -> str | None:

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -107,6 +107,7 @@ from .bootstrap import (
 from .event_log_merge import (
     EventLogMergeError,
     merge_event_log_files,
+    merge_event_log_texts,
 )
 from .identity_audit import (
     IdentityState,
@@ -191,7 +192,7 @@ def uninitialized_status_error(mission_slug: str, wp_id: str, feature_dir: Path)
     """Return the cycle-aware missing-status message without eager dependency-graph imports."""
     from .uninitialized_hint import uninitialized_status_error as _uninitialized_status_error
 
-    return _uninitialized_status_error(mission_slug, wp_id, feature_dir)
+    return str(_uninitialized_status_error(mission_slug, wp_id, feature_dir))
 
 # The canonical status artifacts (event log + snapshot). On coordination-topology
 # missions these are owned by the transactional status emitter on the coordination
@@ -293,6 +294,7 @@ __all__ = [
     "fix_workspace_husks",
     "is_dossier_snapshot",
     "merge_event_log_files",
+    "merge_event_log_texts",
     "register_dossier_sync_handler",
     "register_lifecycle_saas_fanout_handler",
     "register_saas_fanout_handler",

--- a/src/specify_cli/status/event_log_merge.py
+++ b/src/specify_cli/status/event_log_merge.py
@@ -11,36 +11,39 @@ class EventLogMergeError(Exception):
     """Raised when an event-log merge cannot be completed safely."""
 
 
+def read_event_log_text(text: str, *, source: str = "<memory>") -> list[dict[str, Any]]:
+    """Read status.events.jsonl-style content from an in-memory string."""
+    events: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise EventLogMergeError(
+                f"{source}: invalid JSON on line {line_number}: {exc}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise EventLogMergeError(
+                f"{source}: line {line_number} is not a JSON object"
+            )
+        event_id = payload.get("event_id")
+        if not isinstance(event_id, str) or not event_id.strip():
+            raise EventLogMergeError(
+                f"{source}: line {line_number} is missing a valid event_id"
+            )
+        # Non-status event types (e.g. tracker events) may lack 'at' or
+        # 'timestamp'; accept them and sort them first via empty-string key.
+        events.append(payload)
+    return events
+
+
 def _read_event_file(path: Path) -> list[dict[str, Any]]:
     """Read a status.events.jsonl-style file from an arbitrary path."""
     if not path.exists():
         return []
-
-    events: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line_number, raw_line in enumerate(handle, start=1):
-            stripped = raw_line.strip()
-            if not stripped:
-                continue
-            try:
-                payload = json.loads(stripped)
-            except json.JSONDecodeError as exc:
-                raise EventLogMergeError(
-                    f"{path}: invalid JSON on line {line_number}: {exc}"
-                ) from exc
-            if not isinstance(payload, dict):
-                raise EventLogMergeError(
-                    f"{path}: line {line_number} is not a JSON object"
-                )
-            event_id = payload.get("event_id")
-            if not isinstance(event_id, str) or not event_id.strip():
-                raise EventLogMergeError(
-                    f"{path}: line {line_number} is missing a valid event_id"
-                )
-            # Non-status event types (e.g. tracker events) may lack 'at' or
-            # 'timestamp'; accept them and sort them first via empty-string key.
-            events.append(payload)
-    return events
+    return read_event_log_text(path.read_text(encoding="utf-8"), source=str(path))
 
 
 def merge_event_payloads(*event_groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -63,6 +66,17 @@ def merge_event_payloads(*event_groups: list[dict[str, Any]]) -> list[dict[str, 
             str(payload["event_id"]),
         ),
     )
+
+
+def merge_event_log_texts(*texts: str) -> str:
+    """Union JSONL event-log texts and serialize deterministic JSONL."""
+    merged = merge_event_payloads(
+        *[
+            read_event_log_text(text, source=f"<merge-stage-{idx}>")
+            for idx, text in enumerate(texts, start=1)
+        ]
+    )
+    return "".join(json.dumps(event, sort_keys=True) + "\n" for event in merged)
 
 
 def merge_event_log_files(

--- a/tests/integration/test_lane_lifecycle_sync.py
+++ b/tests/integration/test_lane_lifecycle_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -25,6 +26,30 @@ def _run(cmd: list[str], cwd: Path, *, check: bool = True) -> subprocess.Complet
         text=True,
         check=check,
     )
+
+
+def _status_event(
+    event_id: str,
+    *,
+    mission_slug: str,
+    to_lane: str,
+) -> str:
+    return json.dumps(
+        {
+            "actor": "tester",
+            "at": "2026-06-15T04:00:00Z",
+            "event_id": event_id,
+            "execution_mode": "worktree",
+            "force": False,
+            "from_lane": "genesis",
+            "mission_slug": mission_slug,
+            "reason": None,
+            "review_ref": None,
+            "to_lane": to_lane,
+            "wp_id": "WP01",
+        },
+        sort_keys=True,
+    ) + "\n"
 
 
 def _init_repo(tmp_path: Path, mission_slug: str) -> tuple[Path, Path, str, str]:
@@ -72,7 +97,11 @@ def test_lifecycle_sync_clean_rebase_updates_lane_worktree(tmp_path: Path) -> No
 
     _run(["git", "switch", coordination_branch], repo)
     (feature_dir / "status.events.jsonl").write_text(
-        '{"wp_id":"WP01","to_lane":"claimed"}\n',
+        _status_event(
+            "01AAA000000000000000000001",
+            mission_slug="sync-clean",
+            to_lane="claimed",
+        ),
         encoding="utf-8",
     )
     _run(["git", "add", "kitty-specs/sync-clean/status.events.jsonl"], repo)
@@ -106,7 +135,11 @@ def test_lifecycle_sync_recreates_missing_lane_worktree(tmp_path: Path) -> None:
 
     _run(["git", "switch", coordination_branch], repo)
     (feature_dir / "status.events.jsonl").write_text(
-        '{"wp_id":"WP01","to_lane":"in_review"}\n',
+        _status_event(
+            "01BBB000000000000000000002",
+            mission_slug="sync-missing-worktree",
+            to_lane="in_review",
+        ),
         encoding="utf-8",
     )
     _run(

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -743,6 +743,71 @@ class TestAutoRebaseAdditive:
         assert committed_status["event_count"] == 3
         assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
 
+    def test_clean_status_events_deletion_fails_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-delete-clean"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed deletion status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / status_events_rel).unlink()
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "mission: delete status events"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        (repo / "src").mkdir(exist_ok=True)
+        (repo / "src" / "lane-only.txt").write_text("lane\n", encoding="utf-8")
+        _run(["git", "add", "src/lane-only.txt"], repo)
+        _run(["git", "commit", "-m", "lane: unrelated work"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "refusing staged deletion" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
+        assert (worktree_b / status_events_rel).exists()
+        assert (worktree_b / status_json_rel).exists()
+        assert "status.events.jsonl" not in _run(
+            ["git", "status", "--porcelain"],
+            worktree_b,
+        ).stdout
+
 
 class TestAutoRebaseSemanticConflict:
     """T045 — Negative: a semantic conflict falls through to Manual."""

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -1163,6 +1163,61 @@ class TestAutoRebaseAdditive:
         assert not (worktree_b / status_json_rel).exists()
         assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
 
+    def test_clean_status_json_only_change_is_rematerialized(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-clean-status-json-only"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed status snapshot artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / status_json_rel).write_text("not-json\n", encoding="utf-8")
+        _run(["git", "add", str(status_json_rel)], repo)
+        _run(["git", "commit", "-m", "mission: corrupt derived status snapshot"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        (worktree_b / "src").mkdir(exist_ok=True)
+        (worktree_b / "src" / "lane-only.txt").write_text("lane\n", encoding="utf-8")
+        _run(["git", "add", "src/lane-only.txt"], worktree_b)
+        _run(["git", "commit", "-m", "lane: unrelated work"], worktree_b)
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_status = json.loads((worktree_b / status_json_rel).read_text(encoding="utf-8"))
+        assert committed_status["event_count"] == 1
+        assert sorted(committed_status["work_packages"]) == ["WP01"]
+        assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
+
     def test_clean_status_events_deletion_fails_closed(
         self,
         tmp_path: Path,

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -430,6 +430,182 @@ class TestAutoRebaseAdditive:
         }
         assert committed_status["event_count"] == 3
         assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+
+    def test_status_events_conflict_rematerializes_unconflicted_status_json(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-event-only"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "mission: append event"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        _write_status_events(repo / status_events_rel, [base_event, lane_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "lane: append event"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _run(["git", "sparse-checkout", "init", "--no-cone"], worktree_b)
+        _run(
+            [
+                "git",
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                f"!{status_events_rel.as_posix()}",
+                f"!{status_json_rel.as_posix()}",
+            ],
+            worktree_b,
+        )
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_status = json.loads(
+            _run(["git", "show", f"HEAD:{status_json_rel.as_posix()}"], worktree_b).stdout
+        )
+        assert committed_status["event_count"] == 3
+        assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+
+    def test_failed_sparse_status_resolution_reapplies_sparse_checkout(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-sparse-failure"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        (repo / ".gitattributes").write_text(
+            "kitty-specs/**/status.events.jsonl merge=union\n",
+            encoding="utf-8",
+        )
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", ".gitattributes", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed failure status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / status_events_rel).write_text(
+            json.dumps({"event_id": "01BBB000000000000000000002"}) + "\n",
+            encoding="utf-8",
+        )
+        (repo / status_json_rel).write_text('{"event_count": 2, "side": "mission"}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "mission: invalid status event"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).write_text('{"event_count": 2, "side": "lane"}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "lane: status json drift"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _run(["git", "sparse-checkout", "init", "--no-cone"], worktree_b)
+        _run(
+            [
+                "git",
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                f"!{status_events_rel.as_posix()}",
+                f"!{status_json_rel.as_posix()}",
+            ],
+            worktree_b,
+        )
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "Invalid event structure" in report.halt_reason
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
 
 
 class TestAutoRebaseSemanticConflict:

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -903,6 +903,266 @@ class TestAutoRebaseAdditive:
         assert committed_status["event_count"] == 3
         assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
 
+    def test_mixed_conflict_clean_status_events_deletion_fails_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-mixed-delete"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed mixed deletion status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / status_events_rel).unlink()
+        _write_pyproject(repo / "pyproject.toml", ["alpha", "bravo", "charlie"])
+        _run(["git", "add", str(status_events_rel), "pyproject.toml"], repo)
+        _run(["git", "commit", "-m", "mission: delete status events and add charlie"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _write_pyproject(worktree_b / "pyproject.toml", ["alpha", "bravo", "delta"])
+        _run(["git", "add", "pyproject.toml"], worktree_b)
+        _run(["git", "commit", "-m", "lane: add delta"], worktree_b)
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "refusing staged deletion" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
+        assert (worktree_b / status_events_rel).exists()
+        assert (worktree_b / status_json_rel).exists()
+        assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
+
+    def test_mixed_conflict_clean_event_log_driver_refreshes_status_json(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        driver_script = tmp_path / "event_log_driver.py"
+        _write_event_log_driver_script(driver_script)
+        _configure_event_log_merge_driver(repo, driver_script)
+        mission_slug = "1968-mixed-driver"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        (repo / ".gitattributes").write_text(
+            "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log\n",
+            encoding="utf-8",
+        )
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", ".gitattributes", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed mixed driver status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        _write_pyproject(repo / "pyproject.toml", ["alpha", "bravo", "charlie"])
+        _run(["git", "add", str(status_events_rel), "pyproject.toml"], repo)
+        _run(["git", "commit", "-m", "mission: events and charlie"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _write_status_events(worktree_b / status_events_rel, [base_event, lane_event])
+        _write_pyproject(worktree_b / "pyproject.toml", ["alpha", "bravo", "delta"])
+        _run(["git", "add", str(status_events_rel), "pyproject.toml"], worktree_b)
+        _run(["git", "commit", "-m", "lane: events and delta"], worktree_b)
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_status = json.loads((worktree_b / status_json_rel).read_text(encoding="utf-8"))
+        committed_events = [
+            json.loads(line)
+            for line in (worktree_b / status_events_rel).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [event["event_id"] for event in committed_events] == [
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+            "01CCC000000000000000000003",
+        ]
+        assert committed_status["event_count"] == 3
+        assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
+        assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
+
+    def test_sparse_mixed_conflict_clean_event_log_driver_refreshes_status_json(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        driver_script = tmp_path / "event_log_driver.py"
+        _write_event_log_driver_script(driver_script)
+        _configure_event_log_merge_driver(repo, driver_script)
+        mission_slug = "1968-sparse-mixed-driver"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        (repo / ".gitattributes").write_text(
+            "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log\n",
+            encoding="utf-8",
+        )
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", ".gitattributes", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed sparse mixed driver status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        _write_pyproject(repo / "pyproject.toml", ["alpha", "bravo", "charlie"])
+        _run(["git", "add", str(status_events_rel), "pyproject.toml"], repo)
+        _run(["git", "commit", "-m", "mission: sparse events and charlie"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        _write_status_events(repo / status_events_rel, [base_event, lane_event])
+        _write_pyproject(repo / "pyproject.toml", ["alpha", "bravo", "delta"])
+        _run(["git", "add", str(status_events_rel), "pyproject.toml"], repo)
+        _run(["git", "commit", "-m", "lane: sparse events and delta"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _run(["git", "sparse-checkout", "init", "--no-cone"], worktree_b)
+        _run(
+            [
+                "git",
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                f"!{status_events_rel.as_posix()}",
+                f"!{status_json_rel.as_posix()}",
+            ],
+            worktree_b,
+        )
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_status = json.loads(
+            _run(["git", "show", f"HEAD:{status_json_rel.as_posix()}"], worktree_b).stdout
+        )
+        committed_events = [
+            json.loads(line)
+            for line in _run(
+                ["git", "show", f"HEAD:{status_events_rel.as_posix()}"],
+                worktree_b,
+            ).stdout.splitlines()
+        ]
+        assert [event["event_id"] for event in committed_events] == [
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+            "01CCC000000000000000000003",
+        ]
+        assert committed_status["event_count"] == 3
+        assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+        assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
+
     def test_clean_status_events_deletion_fails_closed(
         self,
         tmp_path: Path,

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -9,6 +9,7 @@ these tests construct a minimal real git repository in ``tmp_path``.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import tomllib
 from pathlib import Path
@@ -76,6 +77,38 @@ def _write_pyproject(path: Path, deps: list[str]) -> None:
     path.write_text(body)
 
 
+def _status_event(
+    event_id: str,
+    *,
+    at: str,
+    mission_slug: str,
+    wp_id: str,
+    from_lane: str,
+    to_lane: str,
+) -> dict[str, object]:
+    return {
+        "actor": "tester",
+        "at": at,
+        "event_id": event_id,
+        "execution_mode": "worktree",
+        "force": False,
+        "from_lane": from_lane,
+        "mission_slug": mission_slug,
+        "reason": None,
+        "review_ref": None,
+        "to_lane": to_lane,
+        "wp_id": wp_id,
+    }
+
+
+def _write_status_events(path: Path, events: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(event, sort_keys=True) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+
 class TestAutoRebaseAdditive:
     """T044 — Happy path: two lanes add distinct deps; auto-resolve."""
 
@@ -137,6 +170,158 @@ class TestAutoRebaseAdditive:
         assert log.returncode == 0
         assert "auto-rebase(lane=lane-a)" in log.stdout
         assert "R-PYPROJECT-DEPS-UNION" in log.stdout
+
+    def test_managed_planning_artifacts_are_resolved_deterministically(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-managed-artifacts"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        task_rel = mission_dir / "tasks" / "WP08-renderer-unit-tests.md"
+        lanes_rel = mission_dir / "lanes.json"
+
+        mission_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP08",
+            from_lane="planned",
+            to_lane="in_progress",
+        )
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [mission_event])
+        (repo / status_json_rel).write_text('{"stale": "mission"}\n', encoding="utf-8")
+        (repo / task_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / task_rel).write_text("# WP08\ncoordination copy\n", encoding="utf-8")
+        (repo / lanes_rel).write_text('{"coordination": true}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "mission: managed artifacts"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _write_status_events(worktree_b / status_events_rel, [lane_event])
+        (worktree_b / status_json_rel).write_text('{"stale": "lane"}\n', encoding="utf-8")
+        (worktree_b / task_rel).parent.mkdir(parents=True, exist_ok=True)
+        (worktree_b / task_rel).write_text("# WP08\nlane copy\n", encoding="utf-8")
+        (worktree_b / lanes_rel).write_text('{"coordination": false}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], worktree_b)
+        _run(["git", "commit", "-m", "lane: managed artifacts"], worktree_b)
+
+        lane = _make_lane()
+        report = attempt_auto_rebase(
+            lane=lane,
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        events = [
+            json.loads(line)
+            for line in (worktree_b / status_events_rel).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [event["event_id"] for event in events] == [
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+        ]
+        status = json.loads((worktree_b / status_json_rel).read_text(encoding="utf-8"))
+        assert status["event_count"] == 2
+        assert status["work_packages"]["WP08"]["lane"] == "in_progress"
+        assert (worktree_b / task_rel).read_text(encoding="utf-8") == "# WP08\ncoordination copy\n"
+        assert json.loads((worktree_b / lanes_rel).read_text(encoding="utf-8")) == {
+            "coordination": True
+        }
+
+        rule_ids = {
+            classification.resolution.rule_id
+            for classification in report.classifications
+            if hasattr(classification.resolution, "rule_id")
+        }
+        assert "R-STATUS-EVENTS-JSONL-UNION" in rule_ids
+        assert "R-STATUS-JSON-REMATERIALIZE" in rule_ids
+        assert "R-COORDINATION-ARTIFACT-THEIRS" in rule_ids
+
+    def test_status_events_modify_delete_conflict_uses_index_stages(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-modify-delete"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        status_events_rel = (
+            Path("kitty-specs") / mission_slug / "status.events.jsonl"
+        )
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "seed status events"], repo)
+        _run(["git", "branch", mission_branch, "main"], repo)
+
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "mission: append status event"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        (worktree_b / status_events_rel).unlink()
+        _run(["git", "add", str(status_events_rel)], worktree_b)
+        _run(["git", "commit", "-m", "lane: delete status events"], worktree_b)
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        events = [
+            json.loads(line)
+            for line in (worktree_b / status_events_rel).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [event["event_id"] for event in events] == [
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+        ]
 
 
 class TestAutoRebaseSemanticConflict:

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -723,6 +723,16 @@ class TestAutoRebaseAdditive:
         )
 
         assert report.succeeded is True, report.halt_reason
+        rule_ids = [
+            getattr(classification.resolution, "rule_id", None)
+            for classification in report.classifications
+        ]
+        assert rule_ids == [
+            "R-STATUS-EVENTS-JSONL-UNION",
+            "R-STATUS-JSON-REMATERIALIZE",
+        ]
+        subject = _run(["git", "log", "-1", "--pretty=%s"], worktree_b).stdout.strip()
+        assert subject.startswith("auto-rebase(lane=lane-a): 2 conflicts resolved")
         committed_status = json.loads(
             _run(["git", "show", f"HEAD:{status_json_rel.as_posix()}"], worktree_b).stdout
         )

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -323,6 +323,114 @@ class TestAutoRebaseAdditive:
             "01BBB000000000000000000002",
         ]
 
+    def test_sparse_status_json_uses_index_status_events_when_hidden(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-sparse-status"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        (repo / ".gitattributes").write_text(
+            "kitty-specs/**/status.events.jsonl merge=union\n",
+            encoding="utf-8",
+        )
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", ".gitattributes", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed sparse status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        (repo / status_json_rel).write_text('{"event_count": 2, "side": "mission"}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "mission: status artifacts"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        _write_status_events(repo / status_events_rel, [base_event, lane_event])
+        (repo / status_json_rel).write_text('{"event_count": 2, "side": "lane"}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "lane: status artifacts"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _run(["git", "sparse-checkout", "init", "--no-cone"], worktree_b)
+        _run(
+            [
+                "git",
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                f"!{status_events_rel.as_posix()}",
+                f"!{status_json_rel.as_posix()}",
+            ],
+            worktree_b,
+        )
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_status = json.loads(
+            _run(["git", "show", f"HEAD:{status_json_rel.as_posix()}"], worktree_b).stdout
+        )
+        committed_events = [
+            json.loads(line)
+            for line in _run(
+                ["git", "show", f"HEAD:{status_events_rel.as_posix()}"],
+                worktree_b,
+            ).stdout.splitlines()
+        ]
+        assert {event["event_id"] for event in committed_events} == {
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+            "01CCC000000000000000000003",
+        }
+        assert committed_status["event_count"] == 3
+        assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
+
 
 class TestAutoRebaseSemanticConflict:
     """T045 — Negative: a semantic conflict falls through to Manual."""

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -10,7 +10,9 @@ these tests construct a minimal real git repository in ``tmp_path``.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -20,6 +22,7 @@ from specify_cli.lanes.auto_rebase import AutoRebaseReport, attempt_auto_rebase
 from specify_cli.lanes.models import ExecutionLane
 
 pytestmark = pytest.mark.git_repo
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _run(cmd: list[str], cwd: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -106,6 +109,49 @@ def _write_status_events(path: Path, events: list[dict[str, object]]) -> None:
     path.write_text(
         "".join(json.dumps(event, sort_keys=True) + "\n" for event in events),
         encoding="utf-8",
+    )
+
+
+def _write_event_log_driver_script(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "import sys",
+                f"sys.path.insert(0, {str(REPO_ROOT / 'src')!r})",
+                "from specify_cli.status.event_log_merge import merge_event_log_files",
+                "merge_event_log_files(",
+                "    base_path=Path(sys.argv[1]),",
+                "    ours_path=Path(sys.argv[2]),",
+                "    theirs_path=Path(sys.argv[3]),",
+                ")",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _configure_event_log_merge_driver(repo: Path, script_path: Path) -> None:
+    _run(
+        [
+            "git",
+            "config",
+            "--local",
+            "merge.spec-kitty-event-log.name",
+            "Spec Kitty event log union merge",
+        ],
+        repo,
+    )
+    _run(
+        [
+            "git",
+            "config",
+            "--local",
+            "merge.spec-kitty-event-log.driver",
+            f"{shlex.quote(sys.executable)} {shlex.quote(str(script_path))} %O %A %B",
+        ],
+        repo,
     )
 
 
@@ -606,6 +652,96 @@ class TestAutoRebaseAdditive:
         assert "Invalid event structure" in report.halt_reason
         assert not (worktree_b / status_events_rel).exists()
         assert not (worktree_b / status_json_rel).exists()
+
+    def test_clean_event_log_merge_driver_refreshes_status_json(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        driver_script = tmp_path / "event_log_driver.py"
+        _write_event_log_driver_script(driver_script)
+        _configure_event_log_merge_driver(repo, driver_script)
+        mission_slug = "1968-clean-driver"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        (repo / ".gitattributes").write_text(
+            "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log\n",
+            encoding="utf-8",
+        )
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", ".gitattributes", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed production driver status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        (repo / status_json_rel).write_text('{"event_count": 2, "side": "mission"}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "mission: event log and stale snapshot"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        _write_status_events(repo / status_events_rel, [base_event, lane_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "lane: event log only"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_status = json.loads((worktree_b / status_json_rel).read_text(encoding="utf-8"))
+        committed_events = [
+            json.loads(line)
+            for line in (worktree_b / status_events_rel).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [event["event_id"] for event in committed_events] == [
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+            "01CCC000000000000000000003",
+        ]
+        assert committed_status["event_count"] == 3
+        assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
 
 
 class TestAutoRebaseSemanticConflict:

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -10,6 +10,7 @@ these tests construct a minimal real git repository in ``tmp_path``.
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -150,6 +151,29 @@ def _configure_event_log_merge_driver(repo: Path, script_path: Path) -> None:
             "--local",
             "merge.spec-kitty-event-log.driver",
             f"{shlex.quote(sys.executable)} {shlex.quote(str(script_path))} %O %A %B",
+        ],
+        repo,
+    )
+
+
+def _configure_production_event_log_merge_driver(repo: Path) -> None:
+    _run(
+        [
+            "git",
+            "config",
+            "--local",
+            "merge.spec-kitty-event-log.name",
+            "Spec Kitty event log union merge",
+        ],
+        repo,
+    )
+    _run(
+        [
+            "git",
+            "config",
+            "--local",
+            "merge.spec-kitty-event-log.driver",
+            "spec-kitty merge-driver-event-log %O %A %B",
         ],
         repo,
     )
@@ -362,7 +386,7 @@ class TestAutoRebaseAdditive:
 
         assert report.succeeded is False
         assert report.halt_reason is not None
-        assert "refusing status.events.jsonl deletion conflict" in report.halt_reason
+        assert "pre-existing lane-side deletion" in report.halt_reason
         assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
         assert not (worktree_b / status_events_rel).exists()
         assert "status.events.jsonl" not in _run(
@@ -520,7 +544,7 @@ class TestAutoRebaseAdditive:
 
         assert report.succeeded is False
         assert report.halt_reason is not None
-        assert "refusing status.events.jsonl deletion conflict" in report.halt_reason
+        assert "pre-existing lane-side deletion" in report.halt_reason
         assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
         assert not (worktree_b / status_events_rel).exists()
         assert not (worktree_b / status_json_rel).exists()
@@ -1059,6 +1083,104 @@ class TestAutoRebaseAdditive:
         assert sorted(committed_status["work_packages"]) == ["WP01", "WP02", "WP03"]
         assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
 
+    def test_production_event_log_driver_uses_current_venv_before_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        fake_spec_kitty = fake_bin / (
+            "spec-kitty.cmd" if sys.platform == "win32" else "spec-kitty"
+        )
+        if sys.platform == "win32":
+            fake_spec_kitty.write_text("@echo off\r\nexit /b 0\r\n", encoding="utf-8")
+        else:
+            fake_spec_kitty.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_spec_kitty.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH",
+            str(fake_bin) + os.pathsep + os.environ.get("PATH", ""),
+        )
+
+        _configure_production_event_log_merge_driver(repo)
+        mission_slug = "1968-production-driver-path"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        (repo / ".gitattributes").write_text(
+            "kitty-specs/**/status.events.jsonl merge=spec-kitty-event-log\n",
+            encoding="utf-8",
+        )
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", ".gitattributes", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed production driver path artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "mission: append event"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _write_status_events(worktree_b / status_events_rel, [base_event, lane_event])
+        _run(["git", "add", str(status_events_rel)], worktree_b)
+        _run(["git", "commit", "-m", "lane: append event"], worktree_b)
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is True, report.halt_reason
+        committed_events = [
+            json.loads(line)
+            for line in (worktree_b / status_events_rel).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [event["event_id"] for event in committed_events] == [
+            "01AAA000000000000000000001",
+            "01BBB000000000000000000002",
+            "01CCC000000000000000000003",
+        ]
+        committed_status = json.loads((worktree_b / status_json_rel).read_text(encoding="utf-8"))
+        assert committed_status["event_count"] == 3
+
     def test_sparse_mixed_conflict_clean_event_log_driver_refreshes_status_json(
         self,
         tmp_path: Path,
@@ -1226,6 +1348,108 @@ class TestAutoRebaseAdditive:
         committed_status = json.loads((worktree_b / status_json_rel).read_text(encoding="utf-8"))
         assert committed_status["event_count"] == 1
         assert sorted(committed_status["work_packages"]) == ["WP01"]
+        assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
+
+    def test_clean_status_json_only_change_without_event_log_fails_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-status-json-no-events"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_json_rel = mission_dir / "status.json"
+
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(status_json_rel)], repo)
+        _run(["git", "commit", "-m", "seed status snapshot without events"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / status_json_rel).write_text("not-json\n", encoding="utf-8")
+        _run(["git", "add", str(status_json_rel)], repo)
+        _run(["git", "commit", "-m", "mission: corrupt orphaned status snapshot"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        (worktree_b / "src").mkdir(exist_ok=True)
+        (worktree_b / "src" / "lane-only.txt").write_text("lane\n", encoding="utf-8")
+        _run(["git", "add", "src/lane-only.txt"], worktree_b)
+        _run(["git", "commit", "-m", "lane: unrelated work"], worktree_b)
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "missing authoritative" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
+        assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
+
+    def test_preexisting_lane_status_events_deletion_fails_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-preexisting-delete"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / "README.md").write_text("mission\n", encoding="utf-8")
+        _run(["git", "add", "README.md"], repo)
+        _run(["git", "commit", "-m", "mission: unrelated work"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        (worktree_b / status_events_rel).unlink()
+        _run(["git", "add", str(status_events_rel)], worktree_b)
+        _run(["git", "commit", "-m", "lane: delete status events"], worktree_b)
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "pre-existing lane-side deletion" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
+        assert not (worktree_b / status_events_rel).exists()
         assert _run(["git", "status", "--porcelain"], worktree_b).stdout == ""
 
     def test_clean_status_events_deletion_fails_closed(

--- a/tests/lanes/test_auto_rebase_additive.py
+++ b/tests/lanes/test_auto_rebase_additive.py
@@ -305,7 +305,7 @@ class TestAutoRebaseAdditive:
         assert "R-STATUS-JSON-REMATERIALIZE" in rule_ids
         assert "R-COORDINATION-ARTIFACT-THEIRS" in rule_ids
 
-    def test_status_events_modify_delete_conflict_uses_index_stages(
+    def test_status_events_lane_delete_conflict_fails_closed(
         self,
         tmp_path: Path,
     ) -> None:
@@ -350,6 +350,7 @@ class TestAutoRebaseAdditive:
         (worktree_b / status_events_rel).unlink()
         _run(["git", "add", str(status_events_rel)], worktree_b)
         _run(["git", "commit", "-m", "lane: delete status events"], worktree_b)
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
 
         report = attempt_auto_rebase(
             lane=_make_lane(),
@@ -359,15 +360,174 @@ class TestAutoRebaseAdditive:
             worktree_path=worktree_b,
         )
 
-        assert report.succeeded is True, report.halt_reason
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "refusing status.events.jsonl deletion conflict" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
+        assert not (worktree_b / status_events_rel).exists()
+        assert "status.events.jsonl" not in _run(
+            ["git", "status", "--porcelain"],
+            worktree_b,
+        ).stdout
+
+    def test_status_events_coordination_delete_conflict_fails_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-coordination-delete"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        status_events_rel = (
+            Path("kitty-specs") / mission_slug / "status.events.jsonl"
+        )
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        lane_event = _status_event(
+            "01CCC000000000000000000003",
+            at="2026-06-15T04:02:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP03",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "seed status events"], repo)
+        _run(["git", "branch", mission_branch, "main"], repo)
+
+        _run(["git", "checkout", mission_branch], repo)
+        (repo / status_events_rel).unlink()
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "mission: delete status events"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        worktree_b = _make_lane_worktree(repo, mission_slug, "lane-a", branch_b)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _write_status_events(worktree_b / status_events_rel, [base_event, lane_event])
+        _run(["git", "add", str(status_events_rel)], worktree_b)
+        _run(["git", "commit", "-m", "lane: append status event"], worktree_b)
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "refusing status.events.jsonl deletion conflict" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
         events = [
             json.loads(line)
             for line in (worktree_b / status_events_rel).read_text(encoding="utf-8").splitlines()
         ]
         assert [event["event_id"] for event in events] == [
             "01AAA000000000000000000001",
-            "01BBB000000000000000000002",
+            "01CCC000000000000000000003",
         ]
+        assert "status.events.jsonl" not in _run(
+            ["git", "status", "--porcelain"],
+            worktree_b,
+        ).stdout
+
+    def test_sparse_status_events_delete_conflict_reapplies_sparse_checkout(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        mission_slug = "1968-sparse-delete-conflict"
+        mission_branch = f"kitty/mission-{mission_slug}"
+        branch_b = f"kitty/mission-{mission_slug}-lane-a"
+        mission_dir = Path("kitty-specs") / mission_slug
+        status_events_rel = mission_dir / "status.events.jsonl"
+        status_json_rel = mission_dir / "status.json"
+        base_event = _status_event(
+            "01AAA000000000000000000001",
+            at="2026-06-15T04:00:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+        mission_event = _status_event(
+            "01BBB000000000000000000002",
+            at="2026-06-15T04:01:00Z",
+            mission_slug=mission_slug,
+            wp_id="WP02",
+            from_lane="genesis",
+            to_lane="planned",
+        )
+
+        _write_status_events(repo / status_events_rel, [base_event])
+        (repo / status_json_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo / status_json_rel).write_text('{"event_count": 1}\n', encoding="utf-8")
+        _run(["git", "add", str(mission_dir)], repo)
+        _run(["git", "commit", "-m", "seed sparse deletion status artifacts"], repo)
+
+        _run(["git", "branch", mission_branch, "main"], repo)
+        _run(["git", "checkout", mission_branch], repo)
+        _write_status_events(repo / status_events_rel, [base_event, mission_event])
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "mission: append status event"], repo)
+
+        _run(["git", "checkout", "-b", branch_b, "main"], repo)
+        (repo / status_events_rel).unlink()
+        _run(["git", "add", str(status_events_rel)], repo)
+        _run(["git", "commit", "-m", "lane: delete status events"], repo)
+        _run(["git", "checkout", "main"], repo)
+
+        worktree_b = repo / ".worktrees" / f"{mission_slug}-lane-a"
+        worktree_b.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "worktree", "add", str(worktree_b), branch_b], repo)
+        _run(["git", "config", "user.email", "test@spec-kitty"], worktree_b)
+        _run(["git", "config", "user.name", "test"], worktree_b)
+        _run(["git", "sparse-checkout", "init", "--no-cone"], worktree_b)
+        _run(
+            [
+                "git",
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                "/*",
+                f"!{status_events_rel.as_posix()}",
+                f"!{status_json_rel.as_posix()}",
+            ],
+            worktree_b,
+        )
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+        pre_sync_head = _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip()
+
+        report = attempt_auto_rebase(
+            lane=_make_lane(),
+            branch=branch_b,
+            mission_branch=mission_branch,
+            repo_root=repo,
+            worktree_path=worktree_b,
+        )
+
+        assert report.succeeded is False
+        assert report.halt_reason is not None
+        assert "refusing status.events.jsonl deletion conflict" in report.halt_reason
+        assert _run(["git", "rev-parse", "HEAD"], worktree_b).stdout.strip() == pre_sync_head
+        assert not (worktree_b / status_events_rel).exists()
+        assert not (worktree_b / status_json_rel).exists()
+        assert "status.events.jsonl" not in _run(
+            ["git", "status", "--porcelain"],
+            worktree_b,
+        ).stdout
 
     def test_sparse_status_json_uses_index_status_events_when_hidden(
         self,


### PR DESCRIPTION
## Summary
- resolve Spec Kitty-owned lane auto-rebase conflicts before generic classifier fallback
- union `status.events.jsonl` from git index stages, rematerialize `status.json`, and take coordination-owned planning artifacts from the coordination side
- add regressions for add/add managed artifacts and modify/delete status event logs

Fixes #1968

## Validation
- `.venv/bin/pytest tests/lanes/test_auto_rebase_additive.py tests/merge/test_conflict_classifier.py tests/status/test_event_log_merge.py -q`
- `.venv/bin/ruff check src/specify_cli/lanes/auto_rebase.py src/specify_cli/status/event_log_merge.py tests/lanes/test_auto_rebase_additive.py tests/status/test_event_log_merge.py`
- `.venv/bin/mypy src/specify_cli/lanes/auto_rebase.py src/specify_cli/status/event_log_merge.py`