### PR TITLE
fix: remove redundant template include catch

### DIFF
--- a/src/charter/context.py
+++ b/src/charter/context.py
@@ -406,14 +406,7 @@ def _render_template_include(
     from doctrine.resolver import ResolutionTier
     from doctrine.template_catalog import TierRoot, resolve_template_by_id
 
-    from charter.pack_context import CharterPackConfigError
-
-    try:
-        project_root = resolve_project_root(repo_root)
-    except CharterPackConfigError:
-        # Fail closed (parity with WP12): a malformed charter pack config
-        # must surface, not silently degrade to a partial template lookup.
-        raise
+    project_root = resolve_project_root(repo_root)
 
     tier_roots = [
         TierRoot(

--- a/tests/charter/test_context_include.py
+++ b/tests/charter/test_context_include.py
@@ -33,6 +33,7 @@ from typing import Any
 import pytest
 
 import charter.context as context_module
+from charter.pack_context import CharterPackConfigError
 from charter.context import build_charter_context_include
 
 
@@ -240,6 +241,21 @@ class TestTemplateInclude:
     def test_malformed_template_id_fails_closed(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="Malformed template selector"):
             build_charter_context_include(tmp_path, "template:no-slash-here")
+
+    def test_template_include_surfaces_pack_config_errors(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def _raise_pack_config_error(_repo_root: Path) -> Path | None:
+            raise CharterPackConfigError("broken pack config")
+
+        monkeypatch.setattr(context_module, "resolve_project_root", _raise_pack_config_error)
+
+        with pytest.raises(CharterPackConfigError, match="CHARTER_PACK_CONFIG_INVALID"):
+            build_charter_context_include(
+                tmp_path, "template:software-dev/spec-template.md"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the redundant `CharterPackConfigError` catch/rethrow in `charter.context._render_template_include`
- add a regression test that proves malformed pack config errors still surface fail-closed
- keep this PR focused on an actionable Sonar code smell while `main` nightly remains red on coverage/hotspot-review gate state

## Findings investigated
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- Latest scheduled `main` CI Quality run: `27491244612` on 2026-06-14 failed only in `sonarcloud` quality gate
- Current SonarCloud `main` gate: `new_coverage=68.7` and `new_security_hotspots_reviewed=0.0`
- Current SonarCloud hotspots to review are loopback-HTTP findings in `src/specify_cli/core/loopback_http.py`; those appear to be review-state localhost findings, not safe blanket HTTPS rewrites in this automation pass

## Validation
- `python3 -m pytest tests/charter/test_context_include.py -q`
- `python3 -m pytest tests/charter/test_context_include.py tests/charter/test_context.py -q`
- `.venv/bin/ruff check src/charter/context.py tests/charter/test_context_include.py`
