### PR TITLE
fix: reduce nightly sonar literal duplication

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -76,6 +76,7 @@ PRIMARY_ARTIFACT_FILES = (
 _PROJECT_CONFIG_RELPATH = ".kittify/config.yaml"
 _DECISION_ID_MARKER = "decision_id:"
 _ACCEPTED_READY_LANES = frozenset({"approved", "done"})
+_PATH_CONVENTIONS_NOT_SATISFIED = "Path conventions not satisfied."
 
 # Paths written by the accept pipeline itself.  These must be excluded from the
 # git-dirty gate so that a second accept run on unchanged mission state produces
@@ -1159,18 +1160,18 @@ def collect_feature_summary(
         if path_result.missing_paths:
             if strict_metadata:
                 path_violations.append(
-                    path_result.format_errors() or "Path conventions not satisfied."
+                    path_result.format_errors() or _PATH_CONVENTIONS_NOT_SATISFIED
                 )
             else:
                 path_convention_warning = (
-                    path_result.format_warnings() or "Path conventions not satisfied."
+                    path_result.format_warnings() or _PATH_CONVENTIONS_NOT_SATISFIED
                 )
 
     warnings: list[str] = []
     if missing_optional:
         warnings.append("Optional artifacts missing: " + ", ".join(missing_optional))
     if path_violations:
-        warnings.append("Path conventions not satisfied.")
+        warnings.append(_PATH_CONVENTIONS_NOT_SATISFIED)
     elif path_convention_warning:
         warnings.append(path_convention_warning)
 

--- a/src/specify_cli/calibration/walker.py
+++ b/src/specify_cli/calibration/walker.py
@@ -44,6 +44,17 @@ from specify_cli.calibration.inequality import InequalityResult, assert_inequali
 # Data models
 # ---------------------------------------------------------------------------
 
+ACTION_RESEARCH_GATHERING = "action:research/gathering"
+DIRECTIVE_003 = "directive:DIRECTIVE_003"
+DIRECTIVE_010 = "directive:DIRECTIVE_010"
+DIRECTIVE_037 = "directive:DIRECTIVE_037"
+TACTIC_ADR_DRAFTING_WORKFLOW = "tactic:adr-drafting-workflow"
+TACTIC_PREMORTEM_RISK_IDENTIFICATION = "tactic:premortem-risk-identification"
+TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW = "tactic:requirements-validation-workflow"
+AGENT_PROFILE_PLANNER_PRITI = "agent_profile:planner-priti"
+AGENT_PROFILE_IMPLEMENTER_IVAN = "agent_profile:implementer-ivan"
+AGENT_PROFILE_RETROSPECTIVE_FACILITATOR = "agent_profile:retrospective-facilitator"
+
 
 @dataclass(frozen=True)
 class EdgeChange:
@@ -99,25 +110,25 @@ _REQUIRED_SCOPE: dict[tuple[str, str], frozenset[str]] = {
     # software-dev
     # ------------------------------------------------------------------
     ("software-dev", "action:software-dev/specify"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("software-dev", "action:software-dev/plan"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:adr-drafting-workflow",
-        "tactic:premortem-risk-identification",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_ADR_DRAFTING_WORKFLOW,
+        TACTIC_PREMORTEM_RISK_IDENTIFICATION,
         "tactic:problem-decomposition",
-        "tactic:requirements-validation-workflow",
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("software-dev", "action:software-dev/tasks"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
         "directive:DIRECTIVE_024",
-        "tactic:adr-drafting-workflow",
+        TACTIC_ADR_DRAFTING_WORKFLOW,
         "tactic:problem-decomposition",
-        "tactic:requirements-validation-workflow",
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("software-dev", "action:software-dev/implement"): frozenset({
         "directive:DIRECTIVE_024",
@@ -150,86 +161,86 @@ _REQUIRED_SCOPE: dict[tuple[str, str], frozenset[str]] = {
         "tactic:stopping-conditions",
     }),
     ("software-dev", "action:software-dev/retrospect"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
     }),
 
     # ------------------------------------------------------------------
     # research
     # ------------------------------------------------------------------
     ("research", "action:research/scoping"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:requirements-validation-workflow",
-        "tactic:premortem-risk-identification",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
+        TACTIC_PREMORTEM_RISK_IDENTIFICATION,
     }),
     ("research", "action:research/methodology"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:adr-drafting-workflow",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_ADR_DRAFTING_WORKFLOW,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
-    ("research", "action:research/gathering"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_037",
-        "tactic:requirements-validation-workflow",
+    ("research", ACTION_RESEARCH_GATHERING): frozenset({
+        DIRECTIVE_003,
+        DIRECTIVE_037,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("research", "action:research/synthesis"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:premortem-risk-identification",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_PREMORTEM_RISK_IDENTIFICATION,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("research", "action:research/output"): frozenset({
-        "directive:DIRECTIVE_010",
-        "directive:DIRECTIVE_037",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_010,
+        DIRECTIVE_037,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("research", "action:research/retrospect"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
     }),
 
     # ------------------------------------------------------------------
     # documentation
     # ------------------------------------------------------------------
     ("documentation", "action:documentation/audit"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_037",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_037,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("documentation", "action:documentation/design"): frozenset({
         "directive:DIRECTIVE_001",
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:adr-drafting-workflow",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_ADR_DRAFTING_WORKFLOW,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("documentation", "action:documentation/discover"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:premortem-risk-identification",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_PREMORTEM_RISK_IDENTIFICATION,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("documentation", "action:documentation/generate"): frozenset({
-        "directive:DIRECTIVE_010",
-        "directive:DIRECTIVE_037",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_010,
+        DIRECTIVE_037,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("documentation", "action:documentation/publish"): frozenset({
-        "directive:DIRECTIVE_010",
-        "directive:DIRECTIVE_037",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_010,
+        DIRECTIVE_037,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("documentation", "action:documentation/validate"): frozenset({
-        "directive:DIRECTIVE_010",
-        "directive:DIRECTIVE_037",
-        "tactic:premortem-risk-identification",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_010,
+        DIRECTIVE_037,
+        TACTIC_PREMORTEM_RISK_IDENTIFICATION,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("documentation", "action:documentation/retrospect"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
     }),
 
     # ------------------------------------------------------------------
@@ -239,10 +250,10 @@ _REQUIRED_SCOPE: dict[tuple[str, str], frozenset[str]] = {
     # ask-user                                   → software-dev/specify
     # retrospective                              → software-dev/retrospect
     # ------------------------------------------------------------------
-    ("erp-custom", "action:research/gathering"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_037",
-        "tactic:requirements-validation-workflow",
+    ("erp-custom", ACTION_RESEARCH_GATHERING): frozenset({
+        DIRECTIVE_003,
+        DIRECTIVE_037,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("erp-custom", "action:software-dev/implement"): frozenset({
         "directive:DIRECTIVE_024",
@@ -260,13 +271,13 @@ _REQUIRED_SCOPE: dict[tuple[str, str], frozenset[str]] = {
         "toolguide:efficient-local-tooling",
     }),
     ("erp-custom", "action:software-dev/specify"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
-        "tactic:requirements-validation-workflow",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
+        TACTIC_REQUIREMENTS_VALIDATION_WORKFLOW,
     }),
     ("erp-custom", "action:software-dev/retrospect"): frozenset({
-        "directive:DIRECTIVE_003",
-        "directive:DIRECTIVE_010",
+        DIRECTIVE_003,
+        DIRECTIVE_010,
     }),
 }
 
@@ -277,20 +288,20 @@ _REQUIRED_SCOPE: dict[tuple[str, str], frozenset[str]] = {
 # Maps mission_key → list of (step_id, action_urn, profile_urn)
 _MISSION_STEPS: dict[str, list[tuple[str, str, str]]] = {
     "software-dev": [
-        ("specify",    "action:software-dev/specify",    "agent_profile:planner-priti"),
-        ("plan",       "action:software-dev/plan",       "agent_profile:planner-priti"),
-        ("tasks",      "action:software-dev/tasks",      "agent_profile:planner-priti"),
-        ("implement",  "action:software-dev/implement",  "agent_profile:implementer-ivan"),
+        ("specify",    "action:software-dev/specify",    AGENT_PROFILE_PLANNER_PRITI),
+        ("plan",       "action:software-dev/plan",       AGENT_PROFILE_PLANNER_PRITI),
+        ("tasks",      "action:software-dev/tasks",      AGENT_PROFILE_PLANNER_PRITI),
+        ("implement",  "action:software-dev/implement",  AGENT_PROFILE_IMPLEMENTER_IVAN),
         ("review",     "action:software-dev/review",     "agent_profile:reviewer-renata"),
-        ("retrospect", "action:software-dev/retrospect", "agent_profile:retrospective-facilitator"),
+        ("retrospect", "action:software-dev/retrospect", AGENT_PROFILE_RETROSPECTIVE_FACILITATOR),
     ],
     "research": [
         ("scoping",     "action:research/scoping",     "agent_profile:researcher-robbie"),
         ("methodology", "action:research/methodology", "agent_profile:researcher-robbie"),
-        ("gathering",   "action:research/gathering",   "agent_profile:researcher-robbie"),
+        ("gathering",   ACTION_RESEARCH_GATHERING,     "agent_profile:researcher-robbie"),
         ("synthesis",   "action:research/synthesis",   "agent_profile:researcher-robbie"),
         ("output",      "action:research/output",      "agent_profile:researcher-robbie"),
-        ("retrospect",  "action:research/retrospect",  "agent_profile:retrospective-facilitator"),
+        ("retrospect",  "action:research/retrospect",  AGENT_PROFILE_RETROSPECTIVE_FACILITATOR),
     ],
     "documentation": [
         ("audit",       "action:documentation/audit",    "agent_profile:curator-carla"),
@@ -299,16 +310,16 @@ _MISSION_STEPS: dict[str, list[tuple[str, str, str]]] = {
         ("generate",    "action:documentation/generate", "agent_profile:curator-carla"),
         ("publish",     "action:documentation/publish",  "agent_profile:curator-carla"),
         ("validate",    "action:documentation/validate", "agent_profile:curator-carla"),
-        ("retrospect",  "action:documentation/retrospect", "agent_profile:retrospective-facilitator"),
+        ("retrospect",  "action:documentation/retrospect", AGENT_PROFILE_RETROSPECTIVE_FACILITATOR),
     ],
     "erp-custom": [
-        ("query-erp",         "action:research/gathering",       "agent_profile:researcher-robbie"),
-        ("lookup-provider",   "action:research/gathering",       "agent_profile:researcher-robbie"),
-        ("ask-user",          "action:software-dev/specify",     "agent_profile:implementer-ivan"),
-        ("create-js",         "action:software-dev/implement",   "agent_profile:implementer-ivan"),
-        ("refactor-function", "action:software-dev/implement",   "agent_profile:implementer-ivan"),
-        ("write-report",      "action:research/gathering",       "agent_profile:researcher-robbie"),
-        ("retrospective",     "action:software-dev/retrospect",  "agent_profile:retrospective-facilitator"),
+        ("query-erp",         ACTION_RESEARCH_GATHERING,         "agent_profile:researcher-robbie"),
+        ("lookup-provider",   ACTION_RESEARCH_GATHERING,         "agent_profile:researcher-robbie"),
+        ("ask-user",          "action:software-dev/specify",     AGENT_PROFILE_IMPLEMENTER_IVAN),
+        ("create-js",         "action:software-dev/implement",   AGENT_PROFILE_IMPLEMENTER_IVAN),
+        ("refactor-function", "action:software-dev/implement",   AGENT_PROFILE_IMPLEMENTER_IVAN),
+        ("write-report",      ACTION_RESEARCH_GATHERING,         "agent_profile:researcher-robbie"),
+        ("retrospective",     "action:software-dev/retrospect",  AGENT_PROFILE_RETROSPECTIVE_FACILITATOR),
     ],
 }
 

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -609,7 +609,7 @@ def _switch_to_start_branch(repo_root: Path | None, start_branch: str) -> str:
     if not branch:
         raise ValueError("--start-branch requires a non-empty branch name.")
     if repo_root is None:
-        raise ValueError("Could not locate project root. Run from within spec-kitty repository.")
+        raise ValueError(PROJECT_ROOT_NOT_FOUND_MESSAGE)
 
     check_ref = subprocess.run(
         ["git", "check-ref-format", "--branch", branch],
@@ -1322,7 +1322,7 @@ def branch_context(
     try:
         repo_root = locate_project_root()
         if repo_root is None:
-            error_msg = "Could not locate project root. Run from within spec-kitty repository."
+            error_msg = PROJECT_ROOT_NOT_FOUND_MESSAGE
             if json_output:
                 _emit_json({"error": error_msg})
             else:
@@ -1959,7 +1959,7 @@ def setup_plan(
 
         repo_root = locate_project_root()
         if repo_root is None:
-            error_msg = "Could not locate project root. Run from within spec-kitty repository."
+            error_msg = PROJECT_ROOT_NOT_FOUND_MESSAGE
             if json_output:
                 _emit_json({"error": error_msg})
             else:


### PR DESCRIPTION
## Summary
- hoist the fresh Sonar-opened duplicated literals in `calibration/walker.py`
- reuse canonical path/project-root messages in acceptance and agent mission code
- leave the two `src/specify_cli/core/loopback_http.py` Sonar hotspots as review-only because they are intentional loopback-only HTTP endpoints, not actionable HTTPS rewrites

## Validation
- `.venv/bin/ruff check src/specify_cli/calibration/walker.py src/specify_cli/acceptance/__init__.py src/specify_cli/cli/commands/agent/mission.py`
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 .venv/bin/pytest tests/calibration/test_walker.py tests/cross_cutting/misc/test_acceptance_support.py -k 'lenient or walker' tests/specify_cli/cli/commands/test_accept_warnings_render.py tests/agent/test_agent_feature.py -k 'project_root or branch_context' -q`

## Remote triage
- GitHub Dependabot alerts: none open
- GitHub code-scanning alerts: none open
- SonarCloud hotspots still open: 2 loopback-only `encrypt-data` reviews on `src/specify_cli/core/loopback_http.py` line 17; code remains intentionally loopback-only per repo guidance, so follow-up is Sonar UI review rather than code change
