### PR TITLE
fix(lint): resolve all ruff and mypy errors to zero

### DIFF
--- a/.kittify/overrides/scripts/tasks/tasks_cli.py
+++ b/.kittify/overrides/scripts/tasks/tasks_cli.py
@@ -435,7 +435,7 @@ def rollback_command(args: argparse.Namespace) -> None:
     update_command(args_for_update)
 
 
-def _resolve_mission(repo_root: Path, requested: str | None) -> str:
+def _resolve_mission(_repo_root: Path, requested: str | None) -> str:
     if requested:
         return requested
     raise TaskCliError(
@@ -512,6 +512,28 @@ def verify_command(args: argparse.Namespace) -> None:
     sys.exit(0 if summary.ok else 1)
 
 
+def _print_acceptance_result(result, mission_slug: str, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+        return
+    print(f"✅ Mission '{mission_slug}' accepted at {result.accepted_at} by {result.accepted_by}")
+    if result.accept_commit:
+        print(f"   Acceptance commit: {result.accept_commit}")
+    if result.parent_commit:
+        print(f"   Parent commit: {result.parent_commit}")
+    if result.notes:
+        print("\nNotes:")
+        for note in result.notes:
+            print(f"  {note}")
+    print("\nNext steps:")
+    for instruction in result.instructions:
+        print(f"  - {instruction}")
+    if result.cleanup_instructions:
+        print("\nCleanup:")
+        for instruction in result.cleanup_instructions:
+            print(f"  - {instruction}")
+
+
 def accept_command(args: argparse.Namespace) -> None:
     repo_root = find_repo_root()
     mission_slug = _resolve_mission(repo_root, args.mission)
@@ -555,26 +577,7 @@ def accept_command(args: argparse.Namespace) -> None:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    if args.json:
-        print(json.dumps(result.to_dict(), indent=2, default=str))
-        return
-
-    print(f"✅ Mission '{mission_slug}' accepted at {result.accepted_at} by {result.accepted_by}")
-    if result.accept_commit:
-        print(f"   Acceptance commit: {result.accept_commit}")
-    if result.parent_commit:
-        print(f"   Parent commit: {result.parent_commit}")
-    if result.notes:
-        print("\nNotes:")
-        for note in result.notes:
-            print(f"  {note}")
-    print("\nNext steps:")
-    for instruction in result.instructions:
-        print(f"  - {instruction}")
-    if result.cleanup_instructions:
-        print("\nCleanup:")
-        for instruction in result.cleanup_instructions:
-            print(f"  - {instruction}")
+    _print_acceptance_result(result, mission_slug, args.json)
 
 
 def _merge_actor(repo_root: Path) -> str:
@@ -626,6 +629,60 @@ def _finalize_merge_metadata(meta_path: Path | None, merge_commit: str) -> None:
         logger.warning("Could not finalize merge metadata: %s", exc)
 
 
+def _merge_dry_run(args, mission_slug: str, primary_repo_root: Path, repo_root: Path, in_worktree: bool) -> None:
+    steps = ["Planned actions:"]
+    steps.append(f"  - Checkout {args.target} in {primary_repo_root}")
+    steps.append("  - Fetch remote (if configured)")
+    if args.strategy == "squash":
+        steps.append(f"  - Merge {mission_slug} with --squash and commit")
+    elif args.strategy == "rebase":
+        steps.append(f"  - Rebase {mission_slug} onto {args.target} manually (command exits before merge)")
+    else:
+        steps.append(f"  - Merge {mission_slug} with --no-ff")
+    if args.push:
+        steps.append(f"  - Push {args.target} to origin (if upstream configured)")
+    if in_worktree and args.remove_worktree:
+        steps.append(f"  - Remove worktree at {repo_root}")
+    if args.delete_branch:
+        steps.append(f"  - Delete branch {mission_slug}")
+    print("\n".join(steps))
+
+
+def _merge_execute(git_fn, mission_slug: str, args, primary_repo_root: Path) -> Path | None:
+    if args.strategy == "squash":
+        merge_proc = git_fn(["merge", "--squash", mission_slug], check=False)
+    else:
+        merge_proc = git_fn(["merge", "--no-ff", "--no-commit", mission_slug], check=False)
+    if merge_proc.returncode != 0:
+        raise TaskCliError("Merge failed. Resolve conflicts manually, commit, then rerun with --keep-worktree --keep-branch.")
+    meta_path = _prepare_merge_metadata(primary_repo_root, mission_slug, args.target, args.strategy, args.push)
+    meta_rel = str(meta_path.relative_to(primary_repo_root)) if meta_path else None
+    if meta_rel:
+        git_fn(["add", meta_rel])
+    git_fn(["commit", "-m", f"Merge mission {mission_slug}"])
+    if meta_path:
+        merge_commit = git_fn(["rev-parse", "HEAD"]).stdout.strip()
+        _finalize_merge_metadata(meta_path, merge_commit)
+        git_fn(["add", meta_rel or str(meta_path.relative_to(primary_repo_root))])
+        git_fn(["commit", "--amend", "--no-edit"])
+    return meta_path
+
+
+def _merge_post(git_fn, args, mission_slug: str, has_remote: bool, in_worktree: bool, repo_root: Path) -> None:
+    if args.push and has_remote:
+        push_result = git_fn(["push", "origin", args.target], check=False)
+        if push_result.returncode != 0:
+            raise TaskCliError(f"Merge succeeded but push failed. Run `git push origin {args.target}` manually.")
+    elif args.push and not has_remote:
+        print("[spec-kitty] Skipping push: no remote configured.", file=sys.stderr)
+    if in_worktree and args.remove_worktree and repo_root.exists():
+        git_fn(["worktree", "remove", str(repo_root), "--force"])
+    if args.delete_branch:
+        delete = git_fn(["branch", "-d", mission_slug], check=False)
+        if delete.returncode != 0:
+            git_fn(["branch", "-D", mission_slug])
+
+
 def merge_command(args: argparse.Namespace) -> None:
     # merge_command needs the LOCAL git root (may be a worktree), not the main
     # repo root that find_repo_root() returns.  git rev-parse --show-toplevel
@@ -648,10 +705,8 @@ def merge_command(args: argparse.Namespace) -> None:
             "No auto-detection is performed."
         )
 
-    # Resolve target branch dynamically if not specified
     if args.target is None:
         from specify_cli.core.git_ops import resolve_primary_branch
-
         args.target = resolve_primary_branch(repo_root)
 
     if current_branch == args.target:
@@ -683,22 +738,7 @@ def merge_command(args: argparse.Namespace) -> None:
         ensure_clean(primary_repo_root)
 
     if args.dry_run:
-        steps = ["Planned actions:"]
-        steps.append(f"  - Checkout {args.target} in {primary_repo_root}")
-        steps.append("  - Fetch remote (if configured)")
-        if args.strategy == "squash":
-            steps.append(f"  - Merge {mission_slug} with --squash and commit")
-        elif args.strategy == "rebase":
-            steps.append(f"  - Rebase {mission_slug} onto {args.target} manually (command exits before merge)")
-        else:
-            steps.append(f"  - Merge {mission_slug} with --no-ff")
-        if args.push:
-            steps.append(f"  - Push {args.target} to origin (if upstream configured)")
-        if in_worktree and args.remove_worktree:
-            steps.append(f"  - Remove worktree at {repo_root}")
-        if args.delete_branch:
-            steps.append(f"  - Delete branch {mission_slug}")
-        print("\n".join(steps))
+        _merge_dry_run(args, mission_slug, primary_repo_root, repo_root, in_worktree)
         return
 
     def git(cmd: list[str], *, cwd: Path = primary_repo_root, check: bool = True) -> subprocess.CompletedProcess:
@@ -717,50 +757,8 @@ def merge_command(args: argparse.Namespace) -> None:
     if args.strategy == "rebase":
         raise TaskCliError("Rebase strategy requires manual steps. Run `git checkout {mission_slug}` followed by `git rebase {args.target}`.")
 
-    meta_path: Path | None = None
-    meta_rel: str | None = None
-
-    if args.strategy == "squash":
-        merge_proc = git(["merge", "--squash", mission_slug], check=False)
-        if merge_proc.returncode != 0:
-            raise TaskCliError("Merge failed. Resolve conflicts manually, commit, then rerun with --keep-worktree --keep-branch.")
-        meta_path = _prepare_merge_metadata(primary_repo_root, mission_slug, args.target, args.strategy, args.push)
-        if meta_path:
-            meta_rel = str(meta_path.relative_to(primary_repo_root))
-            git(["add", meta_rel])
-        git(["commit", "-m", f"Merge mission {mission_slug}"])
-    else:
-        merge_proc = git(["merge", "--no-ff", "--no-commit", mission_slug], check=False)
-        if merge_proc.returncode != 0:
-            raise TaskCliError("Merge failed. Resolve conflicts manually, commit, then rerun with --keep-worktree --keep-branch.")
-        meta_path = _prepare_merge_metadata(primary_repo_root, mission_slug, args.target, args.strategy, args.push)
-        if meta_path:
-            meta_rel = str(meta_path.relative_to(primary_repo_root))
-            git(["add", meta_rel])
-        git(["commit", "-m", f"Merge mission {mission_slug}"])
-
-    if meta_path:
-        merge_commit = git(["rev-parse", "HEAD"]).stdout.strip()
-        _finalize_merge_metadata(meta_path, merge_commit)
-        meta_rel = meta_rel or str(meta_path.relative_to(primary_repo_root))
-        git(["add", meta_rel])
-        git(["commit", "--amend", "--no-edit"])
-
-    if args.push and has_remote:
-        push_result = git(["push", "origin", args.target], check=False)
-        if push_result.returncode != 0:
-            raise TaskCliError(f"Merge succeeded but push failed. Run `git push origin {args.target}` manually.")
-    elif args.push and not has_remote:
-        print("[spec-kitty] Skipping push: no remote configured.", file=sys.stderr)
-
-    if in_worktree and args.remove_worktree and repo_root.exists():
-        git(["worktree", "remove", str(repo_root), "--force"])
-
-    if args.delete_branch:
-        delete = git(["branch", "-d", mission_slug], check=False)
-        if delete.returncode != 0:
-            git(["branch", "-D", mission_slug])
-
+    _merge_execute(git, mission_slug, args, primary_repo_root)
+    _merge_post(git, args, mission_slug, has_remote, in_worktree, repo_root)
     print(f"Merge complete: {mission_slug} -> {args.target}")
 
 

--- a/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py
+++ b/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/capture.py
@@ -184,8 +184,7 @@ Body for {wp_id}.
         ("WP03", Lane.IN_REVIEW, Lane.APPROVED, "APPROVED"),
         ("WP03", Lane.APPROVED, Lane.DONE, "DONE"),
     ]
-    counter = 0
-    for wp_id, from_lane, to_lane, tag in transitions:
+    for counter, (wp_id, from_lane, to_lane, tag) in enumerate(transitions):
         # Stable identity ULIDs derived from a counter so re-runs are identical.
         ulid = f"TESTBASELINE{tag}{wp_id}{counter:04d}"[:26].ljust(26, "0")
         append_event(
@@ -202,7 +201,6 @@ Body for {wp_id}.
                 execution_mode="direct_repo",
             ),
         )
-        counter += 1
     materialize(feature_dir)
 
     return root

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -306,12 +306,21 @@ register(
 
 
 # --- Agent Profile ---
+def _set_descriptions(props: dict, desc_map: dict) -> None:
+    for field_name, desc in desc_map.items():
+        if field_name in props:
+            props[field_name]["description"] = desc
+
+
+def _annotate_def(defs: dict, def_key: str, desc_map: dict) -> None:
+    def_dict = defs.get(def_key, {})
+    _set_descriptions(def_dict.get("properties", {}), desc_map)
+
+
 def _agent_profile_fixups(schema: dict) -> dict:
     """Add descriptions matching the hand-written schema."""
     props = schema.get("properties", {})
-
-    # Add descriptions to top-level properties
-    _desc_map = {
+    _set_descriptions(props, {
         "profile-id": "Unique identifier for this agent profile (kebab-case)",
         "name": "Human-readable name for this agent",
         "description": "Optional brief description",
@@ -324,126 +333,69 @@ def _agent_profile_fixups(schema: dict) -> dict:
         "routing-priority": "Priority for routing tasks to this agent (0-100, higher is more preferred)",
         "max-concurrent-tasks": "Maximum number of tasks this agent can handle concurrently",
         "initialization-declaration": "Agent's initialization prompt or declaration",
-    }
-    for field_name, desc in _desc_map.items():
-        if field_name in props:
-            props[field_name]["description"] = desc
+    })
 
-    # Add description to self-review-protocol
     if "self-review-protocol" in props:
         srp = props["self-review-protocol"]
-        # It may be a $ref; if it's inline, add description
         if "description" not in srp and "$ref" not in srp:
             srp["description"] = "Self-review checklist the agent runs before handing off work"
 
-    # Add descriptions to nested definitions
     defs = schema.get("definitions", {})
-
-    # Context sources
-    cs_def = defs.get("agent_context_sources", {})
-    cs_props = cs_def.get("properties", {})
-    _cs_descs = {
+    _annotate_def(defs, "agent_context_sources", {
         "doctrine-layers": "Doctrine layers this agent consults",
         "directives": "Directive IDs this agent references",
         "tactics": "Tactic IDs this agent references",
         "toolguides": "Toolguide IDs this agent references",
         "styleguides": "Styleguide IDs this agent references",
         "additional": "Additional context sources",
-    }
-    for field_name, desc in _cs_descs.items():
-        if field_name in cs_props:
-            cs_props[field_name]["description"] = desc
-
-    # Specialization
-    spec_def = defs.get("agent_specialization", {})
-    spec_props = spec_def.get("properties", {})
-    _spec_descs = {
+    })
+    _annotate_def(defs, "agent_specialization", {
         "primary-focus": "Primary area of specialization",
         "secondary-awareness": "Secondary areas agent is aware of",
         "avoidance-boundary": "What this agent explicitly avoids",
         "success-definition": "How success is defined for this agent",
-    }
-    for field_name, desc in _spec_descs.items():
-        if field_name in spec_props:
-            spec_props[field_name]["description"] = desc
-
-    # Collaboration
-    collab_def = defs.get("agent_collaboration", {})
-    collab_props = collab_def.get("properties", {})
-    _collab_descs = {
+    })
+    _annotate_def(defs, "agent_collaboration", {
         "handoff-to": "Roles/agents this agent hands off to",
         "handoff-from": "Roles/agents that hand off to this agent",
         "works-with": "Roles/agents this agent collaborates with",
         "output-artifacts": "Artifacts this agent produces",
         "operating-procedures": "Procedures this agent follows",
         "canonical-verbs": "Standard verbs for this agent's actions",
-    }
-    for field_name, desc in _collab_descs.items():
-        if field_name in collab_props:
-            collab_props[field_name]["description"] = desc
-
-    # Mode defaults
-    md_def = defs.get("agent_mode_default", {})
-    md_props = md_def.get("properties", {})
-    _md_descs = {
+    })
+    _annotate_def(defs, "agent_mode_default", {
         "mode": "Mode name",
         "description": "Mode description",
         "use-case": "When to use this mode",
-    }
-    for field_name, desc in _md_descs.items():
-        if field_name in md_props:
-            md_props[field_name]["description"] = desc
-
-    # Specialization context
-    sc_def = defs.get("agent_specialization_context", {})
-    sc_props = sc_def.get("properties", {})
-    _sc_descs = {
+    })
+    _annotate_def(defs, "agent_specialization_context", {
         "languages": "Programming languages this agent specializes in",
         "frameworks": "Frameworks this agent knows",
         "file-patterns": "File patterns this agent matches (glob patterns)",
         "domain-keywords": "Domain keywords for matching",
         "writing-style": "Preferred writing styles",
         "complexity-preference": "Task complexity preferences (low, medium, high)",
-    }
-    for field_name, desc in _sc_descs.items():
-        if field_name in sc_props:
-            sc_props[field_name]["description"] = desc
-
-    # Directive reference descriptions
-    dr_def = defs.get("agent_directive_reference", {})
-    dr_props = dr_def.get("properties", {})
-    _dr_descs = {
+    })
+    _annotate_def(defs, "agent_directive_reference", {
         "code": "Directive code",
         "name": "Directive name",
         "rationale": "Why this directive is referenced",
-    }
-    for field_name, desc in _dr_descs.items():
-        if field_name in dr_props:
-            dr_props[field_name]["description"] = desc
+    })
 
-    # Tactic/toolguide/styleguide reference descriptions
     for ref_def_name in ("agent_tactic_reference", "agent_toolguide_reference",
                          "agent_styleguide_reference"):
-        ref_def = defs.get(ref_def_name, {})
-        ref_props = ref_def.get("properties", {})
+        ref_props = defs.get(ref_def_name, {}).get("properties", {})
         kind = ref_def_name.replace("agent_", "").replace("_reference", "").capitalize()
         if "id" in ref_props:
             ref_props["id"]["description"] = f"{kind} ID"
         if "rationale" in ref_props:
             ref_props["rationale"]["description"] = f"Why this {kind.lower()} is referenced"
 
-    # Self-review step descriptions
-    srs_def = defs.get("self_review_step", {})
-    srs_props = srs_def.get("properties", {})
-    _srs_descs = {
+    _annotate_def(defs, "self_review_step", {
         "name": "Step name",
         "command": "Command to run for this step",
         "gate": "Pass/fail criteria for this step",
-    }
-    for field_name, desc in _srs_descs.items():
-        if field_name in srs_props:
-            srs_props[field_name]["description"] = desc
-
+    })
     return schema
 
 
@@ -763,13 +715,12 @@ def _add_minlength_to_string_fields(obj: Any, required_fields: list[str] | None 
     for field_name, prop_def in props.items():
         if not isinstance(prop_def, dict):
             continue
-        if prop_def.get("type") == "string" and field_name in required:
-            # Don't add minLength if there's already a pattern or minLength
-            if "pattern" not in prop_def and "minLength" not in prop_def:
-                prop_def["minLength"] = 1
+        if (prop_def.get("type") == "string" and field_name in required
+                and "pattern" not in prop_def and "minLength" not in prop_def):
+            prop_def["minLength"] = 1
 
     # Recurse into definitions
-    for def_name, def_body in obj.get("definitions", {}).items():
+    for _, def_body in obj.get("definitions", {}).items():
         if isinstance(def_body, dict) and "properties" in def_body:
             _add_minlength_to_string_fields(def_body)
 
@@ -948,10 +899,7 @@ def generate_schema(stem: str) -> dict:
     # For schemas with many enums (model-to-task_type), inline ALL enum refs.
     # For others, only inline ArtifactKind.
     enum_defs = {k for k, v in defs.items() if _is_enum_def(v)}
-    if enum_defs - {"ArtifactKind"}:
-        schema = _inline_all_enum_refs(raw, defs)
-    else:
-        schema = _inline_artifact_kind_refs(raw, defs)
+    schema = _inline_all_enum_refs(raw, defs) if enum_defs - {"ArtifactKind"} else _inline_artifact_kind_refs(raw, defs)
 
     # Phase 2: rename $defs → definitions, rewrite $ref paths
     if "$defs" in schema:

--- a/scripts/lint_canonical_producers.py
+++ b/scripts/lint_canonical_producers.py
@@ -136,7 +136,7 @@ import sys
 import tokenize
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from collections.abc import Iterable
 
 # --------------------------------------------------------------------------- #
 # Configuration                                                                #
@@ -373,11 +373,7 @@ def _dict_has_event_keys(node: ast.Dict) -> bool:
 
 def _dict_has_any_event_key(node: ast.Dict) -> bool:
     """True if a dict literal has `event_type` or `payload` as a string key."""
-    for key in node.keys:
-        if isinstance(key, ast.Constant) and isinstance(key.value, str):
-            if key.value in _EVENT_KEYS_REQUIRED:
-                return True
-    return False
+    return any(isinstance(key, ast.Constant) and isinstance(key.value, str) and key.value in _EVENT_KEYS_REQUIRED for key in node.keys)
 
 
 def _annotation_is_dict_str_any(annotation: ast.AST | None) -> bool:
@@ -401,9 +397,7 @@ def _annotation_is_dict_str_any(annotation: ast.AST | None) -> bool:
     # because they all reflect a hand-rolled return shape.
     if isinstance(second, ast.Name) and second.id in {"Any", "object"}:
         return True
-    if isinstance(second, ast.Attribute) and second.attr == "Any":
-        return True
-    return False
+    return bool(isinstance(second, ast.Attribute) and second.attr == "Any")
 
 
 # --------------------------------------------------------------------------- #
@@ -417,7 +411,7 @@ class _ParentTagger(ast.NodeTransformer):
 
     def visit(self, node: ast.AST) -> ast.AST:  # type: ignore[override]
         for child in ast.iter_child_nodes(node):
-            setattr(child, "_cp_parent", node)
+            child._cp_parent = node
             self.visit(child)
         return node
 
@@ -487,19 +481,18 @@ class _CanonicalProducerVisitor(ast.NodeVisitor):
         # dict that is then returned. Simple shape -- explicit return of a
         # dict literal -- is the documented hand-rolled case from rc14->rc22.
         for child in ast.walk(node):
-            if isinstance(child, ast.Return) and isinstance(child.value, ast.Dict):
-                if _dict_has_any_event_key(child.value):
-                    self._maybe_report(
-                        line=child.value.lineno,
-                        col=child.value.col_offset,
-                        code="CP002",
-                        message=(
-                            "function declared dict[str, Any] return builds "
-                            "event-shaped dict in body -- declare the "
-                            "canonical pydantic model as the return type and "
-                            "construct via that model"
-                        ),
-                    )
+            if isinstance(child, ast.Return) and isinstance(child.value, ast.Dict) and _dict_has_any_event_key(child.value):
+                self._maybe_report(
+                    line=child.value.lineno,
+                    col=child.value.col_offset,
+                    code="CP002",
+                    message=(
+                        "function declared dict[str, Any] return builds "
+                        "event-shaped dict in body -- declare the "
+                        "canonical pydantic model as the return type and "
+                        "construct via that model"
+                    ),
+                )
 
     # ------------------------------------------------------------------ CP003
     def visit_Call(self, node: ast.Call) -> None:

--- a/scripts/sync_all_contributors.py
+++ b/scripts/sync_all_contributors.py
@@ -81,8 +81,7 @@ def run_json(cmd: list[str]) -> object:
     completed = subprocess.run(
         cmd,
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     return json.loads(completed.stdout)
@@ -92,8 +91,7 @@ def run_text(cmd: list[str]) -> str:
     completed = subprocess.run(
         cmd,
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     return completed.stdout

--- a/scripts/tasks/task_helpers.py
+++ b/scripts/tasks/task_helpers.py
@@ -122,7 +122,7 @@ def run_git(args: list[str], cwd: Path, check: bool = True) -> subprocess.Comple
     except subprocess.CalledProcessError as exc:
         if check:
             message = exc.stderr.strip() or exc.stdout.strip() or "Unknown git error"
-            raise TaskCliError(message)
+            raise TaskCliError(message) from exc
         return exc
 
 

--- a/scripts/tasks/tasks_cli.py
+++ b/scripts/tasks/tasks_cli.py
@@ -428,12 +428,7 @@ def rollback_command(args: argparse.Namespace) -> None:
     if not wp_events:
         raise TaskCliError(f"No canonical status events for {wp_id}. Cannot determine the previous lane.")
 
-    if len(wp_events) == 1:
-        # Only one event: previous lane is the from_lane of that event
-        previous_lane_canonical = str(wp_events[0].from_lane)
-    else:
-        # Two or more events: previous lane is the to_lane of the second-to-last
-        previous_lane_canonical = str(wp_events[-2].to_lane)
+    previous_lane_canonical = str(wp_events[0].from_lane) if len(wp_events) == 1 else str(wp_events[-2].to_lane)
     # Map canonical lane back to standalone alias for ensure_lane
     # (e.g. "in_progress" is valid in canonical but standalone uses "doing")
     _REVERSE_ALIASES: dict[str, str] = {"in_progress": "doing"}
@@ -531,6 +526,28 @@ def verify_command(args: argparse.Namespace) -> None:
     sys.exit(0 if summary.ok else 1)
 
 
+def _print_acceptance_result(result, feature: str, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(result.to_dict(), indent=2))
+        return
+    print(f"✅ Feature '{feature}' accepted at {result.accepted_at} by {result.accepted_by}")
+    if result.accept_commit:
+        print(f"   Acceptance commit: {result.accept_commit}")
+    if result.parent_commit:
+        print(f"   Parent commit: {result.parent_commit}")
+    if result.notes:
+        print("\nNotes:")
+        for note in result.notes:
+            print(f"  {note}")
+    print("\nNext steps:")
+    for instruction in result.instructions:
+        print(f"  - {instruction}")
+    if result.cleanup_instructions:
+        print("\nCleanup:")
+        for instruction in result.cleanup_instructions:
+            print(f"  - {instruction}")
+
+
 def accept_command(args: argparse.Namespace) -> None:
     repo_root = find_repo_root()
     feature = _resolve_feature(repo_root, args.feature)
@@ -574,26 +591,7 @@ def accept_command(args: argparse.Namespace) -> None:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    if args.json:
-        print(json.dumps(result.to_dict(), indent=2))
-        return
-
-    print(f"✅ Feature '{feature}' accepted at {result.accepted_at} by {result.accepted_by}")
-    if result.accept_commit:
-        print(f"   Acceptance commit: {result.accept_commit}")
-    if result.parent_commit:
-        print(f"   Parent commit: {result.parent_commit}")
-    if result.notes:
-        print("\nNotes:")
-        for note in result.notes:
-            print(f"  {note}")
-    print("\nNext steps:")
-    for instruction in result.instructions:
-        print(f"  - {instruction}")
-    if result.cleanup_instructions:
-        print("\nCleanup:")
-        for instruction in result.cleanup_instructions:
-            print(f"  - {instruction}")
+    _print_acceptance_result(result, feature, args.json)
 
 
 def _merge_actor(repo_root: Path) -> str:
@@ -638,11 +636,64 @@ def _finalize_merge_metadata(meta_path: Path | None, merge_commit: str) -> None:
     if not meta_path or not meta_path.exists():
         return
 
+    import contextlib
     feature_dir = meta_path.parent
-    try:
+    with contextlib.suppress(ValueError, FileNotFoundError):
         finalize_merge(feature_dir, merged_commit=merge_commit)
-    except (ValueError, FileNotFoundError):
-        pass
+
+
+def _merge_dry_run(args, feature: str, primary_repo_root: Path, repo_root: Path, in_worktree: bool) -> None:
+    steps = ["Planned actions:"]
+    steps.append(f"  - Checkout {args.target} in {primary_repo_root}")
+    steps.append("  - Fetch remote (if configured)")
+    if args.strategy == "squash":
+        steps.append(f"  - Merge {feature} with --squash and commit")
+    elif args.strategy == "rebase":
+        steps.append(f"  - Rebase {feature} onto {args.target} manually (command exits before merge)")
+    else:
+        steps.append(f"  - Merge {feature} with --no-ff")
+    if args.push:
+        steps.append(f"  - Push {args.target} to origin (if upstream configured)")
+    if in_worktree and args.remove_worktree:
+        steps.append(f"  - Remove worktree at {repo_root}")
+    if args.delete_branch:
+        steps.append(f"  - Delete branch {feature}")
+    print("\n".join(steps))
+
+
+def _merge_execute(git_fn, feature: str, args, primary_repo_root: Path) -> Path | None:
+    if args.strategy == "squash":
+        merge_proc = git_fn(["merge", "--squash", feature], check=False)
+    else:
+        merge_proc = git_fn(["merge", "--no-ff", "--no-commit", feature], check=False)
+    if merge_proc.returncode != 0:
+        raise TaskCliError("Merge failed. Resolve conflicts manually, commit, then rerun with --keep-worktree --keep-branch.")
+    meta_path = _prepare_merge_metadata(primary_repo_root, feature, args.target, args.strategy, args.push)
+    meta_rel = str(meta_path.relative_to(primary_repo_root)) if meta_path else None
+    if meta_rel:
+        git_fn(["add", meta_rel])
+    git_fn(["commit", "-m", f"Merge feature {feature}"])
+    if meta_path:
+        merge_commit = git_fn(["rev-parse", "HEAD"]).stdout.strip()
+        _finalize_merge_metadata(meta_path, merge_commit)
+        git_fn(["add", meta_rel or str(meta_path.relative_to(primary_repo_root))])
+        git_fn(["commit", "--amend", "--no-edit"])
+    return meta_path
+
+
+def _merge_post(git_fn, args, feature: str, has_remote: bool, in_worktree: bool, repo_root: Path) -> None:
+    if args.push and has_remote:
+        push_result = git_fn(["push", "origin", args.target], check=False)
+        if push_result.returncode != 0:
+            raise TaskCliError(f"Merge succeeded but push failed. Run `git push origin {args.target}` manually.")
+    elif args.push and not has_remote:
+        print("[spec-kitty] Skipping push: no remote configured.", file=sys.stderr)
+    if in_worktree and args.remove_worktree and repo_root.exists():
+        git_fn(["worktree", "remove", str(repo_root), "--force"])
+    if args.delete_branch:
+        delete = git_fn(["branch", "-d", feature], check=False)
+        if delete.returncode != 0:
+            git_fn(["branch", "-D", feature])
 
 
 def merge_command(args: argparse.Namespace) -> None:
@@ -664,10 +715,8 @@ def merge_command(args: argparse.Namespace) -> None:
     else:
         feature = detect_mission_slug(find_repo_root(), cwd=repo_root)
 
-    # Resolve target branch dynamically if not specified
     if args.target is None:
         from specify_cli.core.git_ops import resolve_primary_branch
-
         args.target = resolve_primary_branch(repo_root)
 
     if current_branch == args.target:
@@ -699,22 +748,7 @@ def merge_command(args: argparse.Namespace) -> None:
         ensure_clean(primary_repo_root)
 
     if args.dry_run:
-        steps = ["Planned actions:"]
-        steps.append(f"  - Checkout {args.target} in {primary_repo_root}")
-        steps.append("  - Fetch remote (if configured)")
-        if args.strategy == "squash":
-            steps.append(f"  - Merge {feature} with --squash and commit")
-        elif args.strategy == "rebase":
-            steps.append(f"  - Rebase {feature} onto {args.target} manually (command exits before merge)")
-        else:
-            steps.append(f"  - Merge {feature} with --no-ff")
-        if args.push:
-            steps.append(f"  - Push {args.target} to origin (if upstream configured)")
-        if in_worktree and args.remove_worktree:
-            steps.append(f"  - Remove worktree at {repo_root}")
-        if args.delete_branch:
-            steps.append(f"  - Delete branch {feature}")
-        print("\n".join(steps))
+        _merge_dry_run(args, feature, primary_repo_root, repo_root, in_worktree)
         return
 
     def git(cmd: list[str], *, cwd: Path = primary_repo_root, check: bool = True) -> subprocess.CompletedProcess:
@@ -733,51 +767,8 @@ def merge_command(args: argparse.Namespace) -> None:
     if args.strategy == "rebase":
         raise TaskCliError("Rebase strategy requires manual steps. Run `git checkout {feature}` followed by `git rebase {args.target}`.")
 
-    meta_path: Path | None = None
-    meta_rel: str | None = None
-
-    if args.strategy == "squash":
-        merge_proc = git(["merge", "--squash", feature], check=False)
-        if merge_proc.returncode != 0:
-            raise TaskCliError("Merge failed. Resolve conflicts manually, commit, then rerun with --keep-worktree --keep-branch.")
-        meta_path = _prepare_merge_metadata(primary_repo_root, feature, args.target, args.strategy, args.push)
-        if meta_path:
-            meta_rel = str(meta_path.relative_to(primary_repo_root))
-            git(["add", meta_rel])
-        git(["commit", "-m", f"Merge feature {feature}"])
-    else:
-        merge_proc = git(["merge", "--no-ff", "--no-commit", feature], check=False)
-        if merge_proc.returncode != 0:
-            raise TaskCliError("Merge failed. Resolve conflicts manually, commit, then rerun with --keep-worktree --keep-branch.")
-        meta_path = _prepare_merge_metadata(primary_repo_root, feature, args.target, args.strategy, args.push)
-        if meta_path:
-            meta_rel = str(meta_path.relative_to(primary_repo_root))
-            git(["add", meta_rel])
-        git(["commit", "-m", f"Merge feature {feature}"])
-
-    if meta_path:
-        merge_commit = git(["rev-parse", "HEAD"]).stdout.strip()
-        _finalize_merge_metadata(meta_path, merge_commit)
-        meta_rel = meta_rel or str(meta_path.relative_to(primary_repo_root))
-        git(["add", meta_rel])
-        git(["commit", "--amend", "--no-edit"])
-
-    if args.push and has_remote:
-        push_result = git(["push", "origin", args.target], check=False)
-        if push_result.returncode != 0:
-            raise TaskCliError(f"Merge succeeded but push failed. Run `git push origin {args.target}` manually.")
-    elif args.push and not has_remote:
-        print("[spec-kitty] Skipping push: no remote configured.", file=sys.stderr)
-
-    if in_worktree and args.remove_worktree:
-        if repo_root.exists():
-            git(["worktree", "remove", str(repo_root), "--force"])
-
-    if args.delete_branch:
-        delete = git(["branch", "-d", feature], check=False)
-        if delete.returncode != 0:
-            git(["branch", "-D", feature])
-
+    _merge_execute(git, feature, args, primary_repo_root)
+    _merge_post(git, args, feature, has_remote, in_worktree, repo_root)
     print(f"Merge complete: {feature} -> {args.target}")
 
 

--- a/scripts/verify_occurrences.py
+++ b/scripts/verify_occurrences.py
@@ -185,10 +185,7 @@ def main(argv: list[str]) -> int:
         return 2
 
     is_index = "wps" in artifact and "must_be_zero" in artifact
-    if is_index:
-        failures = _verify_index(artifact)
-    else:
-        failures = _verify_per_wp(artifact)
+    failures = _verify_index(artifact) if is_index else _verify_per_wp(artifact)
 
     rel = os.path.relpath(artifact_path, REPO_ROOT)
     if failures:

--- a/src/mission_runtime/resolution.py
+++ b/src/mission_runtime/resolution.py
@@ -788,17 +788,17 @@ def resolve_action_context(
     if _ec_raw_lane == "uninitialized":
         _ec_raw_lane = Lane.PLANNED
     lane = resolve_lane_alias(_ec_raw_lane)
-    workspace = resolve_workspace_for_wp(repo_root, mission_slug, normalized_wp_id)
+    wp_workspace = resolve_workspace_for_wp(repo_root, mission_slug, normalized_wp_id)
 
     context.wp_id = normalized_wp_id
     context.wp_file = str(wp.path)
     context.lane = lane
-    context.lane_id = workspace.lane_id
-    context.branch_name = workspace.branch_name
-    context.execution_mode = workspace.execution_mode
-    context.resolution_kind = workspace.resolution_kind
+    context.lane_id = wp_workspace.lane_id
+    context.branch_name = wp_workspace.branch_name
+    context.execution_mode = wp_workspace.execution_mode
+    context.resolution_kind = wp_workspace.resolution_kind
     context.dependencies = dependencies
-    context.workspace_path = str(workspace.worktree_path)
+    context.workspace_path = str(wp_workspace.worktree_path)
 
     if action == "implement":
         command = f"spec-kitty agent action implement {normalized_wp_id}"

--- a/src/runtime/next/_internal_runtime/planner.py
+++ b/src/runtime/next/_internal_runtime/planner.py
@@ -348,7 +348,7 @@ def plan_next(
     # Blocked reason takes priority over everything.
     if snapshot.blocked_reason:
         return NextDecision(
-            kind=DecisionKind.blocked,
+            kind=DecisionKind.blocked.value,
             run_id=snapshot.run_id,
             mission_key=snapshot.mission_key,
             reason=snapshot.blocked_reason,
@@ -359,7 +359,7 @@ def plan_next(
         drift_reason = _check_template_drift(snapshot, live_template_path)
         if drift_reason:
             return NextDecision(
-                kind=DecisionKind.blocked,
+                kind=DecisionKind.blocked.value,
                 run_id=snapshot.run_id,
                 mission_key=snapshot.mission_key,
                 reason=drift_reason,
@@ -374,7 +374,7 @@ def plan_next(
         if req.decision_id.startswith("input:"):
             input_key = req.decision_id[len("input:"):]
         return NextDecision(
-            kind=DecisionKind.decision_required,
+            kind=DecisionKind.decision_required.value,
             run_id=snapshot.run_id,
             mission_key=snapshot.mission_key,
             step_id=req.step_id,
@@ -392,13 +392,13 @@ def plan_next(
         # Distinguish true completion from unschedulable DAG.
         if _has_remaining_steps(mission_template, snapshot):
             return NextDecision(
-                kind=DecisionKind.blocked,
+                kind=DecisionKind.blocked.value,
                 run_id=snapshot.run_id,
                 mission_key=snapshot.mission_key,
                 reason="No eligible steps: remaining steps have unmet dependencies.",
             )
         return NextDecision(
-            kind=DecisionKind.terminal,
+            kind=DecisionKind.terminal.value,
             run_id=snapshot.run_id,
             mission_key=snapshot.mission_key,
             reason="All mission steps completed",
@@ -409,7 +409,7 @@ def plan_next(
         if step.audit.enforcement == "blocking":
             # Blocking audit → decision_required; input_key is None for audit decisions.
             return NextDecision(
-                kind=DecisionKind.decision_required,
+                kind=DecisionKind.decision_required.value,
                 run_id=snapshot.run_id,
                 mission_key=snapshot.mission_key,
                 step_id=step.id,
@@ -432,7 +432,7 @@ def plan_next(
                 actor_context=actor_context,
             )
             return NextDecision(
-                kind=DecisionKind.step,
+                kind=DecisionKind.step.value,
                 run_id=snapshot.run_id,
                 mission_key=snapshot.mission_key,
                 step_id=step.id,
@@ -452,7 +452,7 @@ def plan_next(
         missing = missing_inputs[0]
         decision_id = f"input:{missing}"
         return NextDecision(
-            kind=DecisionKind.decision_required,
+            kind=DecisionKind.decision_required.value,
             run_id=snapshot.run_id,
             mission_key=snapshot.mission_key,
             step_id=step.id,
@@ -476,7 +476,7 @@ def plan_next(
     prompt = step.prompt or f"Execute step '{step.id}': {step.title}"
 
     return NextDecision(
-        kind=DecisionKind.step,
+        kind=DecisionKind.step.value,
         run_id=snapshot.run_id,
         mission_key=snapshot.mission_key,
         step_id=step.id,

--- a/src/runtime/next/_internal_runtime/schema.py
+++ b/src/runtime/next/_internal_runtime/schema.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 from spec_kitty_events.mission_next import RuntimeActorIdentity
 
 # ``specify_cli`` sits above ``runtime`` in the layer stack (runtime <-
@@ -433,7 +433,8 @@ class PromptStep(BaseModel):
     raci_override_reason: str | None = None
     agent_profile: str | None = Field(
         default=None,
-        alias="agent-profile",
+        validation_alias=AliasChoices("agent-profile", "agent_profile"),
+        serialization_alias="agent-profile",
         description="Profile id used as profile_hint when this step dispatches via composition.",
     )
     contract_ref: str | None = Field(

--- a/src/runtime/next/prompt_builder.py
+++ b/src/runtime/next/prompt_builder.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from runtime.next._internal_runtime.workflow_schema import WorkflowSequence
 
 from charter.context import build_charter_context
 from charter.scope import CharterScopeConflict, CharterScopeNotFound
@@ -37,7 +41,7 @@ from specify_cli.workspace.context import resolve_workspace_for_wp
 # ---------------------------------------------------------------------------
 
 
-def _workflow_for(mission_dir_str: str):
+def _workflow_for(mission_dir_str: str) -> WorkflowSequence:
     """Return the ``WorkflowSequence`` for *mission_dir_str*.
 
     Uses ``_resolve_workflow_for_mission`` from ``planner`` so the resolver

--- a/src/specify_cli/cli/commands/agent/context.py
+++ b/src/specify_cli/cli/commands/agent/context.py
@@ -68,14 +68,11 @@ def _find_feature_directory(
             "FEATURE_CONTEXT_UNRESOLVED", "--mission <slug> is required"
         )
     try:
-        feature_dir: Path = cast(
-            Path,
-            resolve_mission_read_path(
-                repo_root,
-                raw_handle,
-                mid8_from_slug(raw_handle),
-                require_exists=True,
-            ),
+        feature_dir: Path = resolve_mission_read_path(
+            repo_root,
+            raw_handle,
+            mid8_from_slug(raw_handle),
+            require_exists=True,
         )
     except MissionSelectorAmbiguous as exc:
         raise ActionContextError(exc.error_code, str(exc)) from exc

--- a/src/specify_cli/lanes/branch_naming.py
+++ b/src/specify_cli/lanes/branch_naming.py
@@ -168,7 +168,7 @@ def mission_branch_name(mission_slug: str, *, mission_id: str | None = None) -> 
     return f"{_MISSION_PREFIX}{mission_slug}"
 
 
-class BranchIdentityUnresolved(StructuredError):  # type: ignore[misc]
+class BranchIdentityUnresolved(StructuredError):
     """Raised when a mission branch cannot be composed without inventing identity.
 
     Fail-closed signal for seam 2 (FR-006): a *modern* mission whose ``mission_id``

--- a/src/specify_cli/lanes/recovery.py
+++ b/src/specify_cli/lanes/recovery.py
@@ -17,7 +17,6 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
 
 from specify_cli.lanes.branch_naming import (
     BranchIdentityUnresolved,
@@ -257,7 +256,7 @@ def _resolve_mission_branch(feature_dir: Path, mission_slug: str) -> str:
     if mission_branch:
         return mission_branch
     try:
-        return cast(str, mission_branch_name_required(mission_slug, _mission_id_from_meta(feature_dir)))
+        return mission_branch_name_required(mission_slug, _mission_id_from_meta(feature_dir))
     except BranchIdentityUnresolved as exc:
         # Re-raise with the feature directory in the next_step so a recovery
         # caller can locate the meta.json whose mission_id is missing.

--- a/src/specify_cli/skills/command_installer.py
+++ b/src/specify_cli/skills/command_installer.py
@@ -35,7 +35,7 @@ from typing import Any
 from specify_cli.skills import manifest_store
 from specify_cli.skills.manifest_store import ManifestEntry
 from specify_cli.skills import command_renderer
-from specify_cli.skills._agent_roster import SUPPORTED_AGENTS
+from specify_cli.skills._agent_roster import SUPPORTED_AGENTS as SUPPORTED_AGENTS
 from specify_cli.agent_upgrade_prompt import prepend_agent_upgrade_check
 from specify_cli.shims.registry import CONSUMER_SKILLS
 

--- a/src/specify_cli/tool_surface/profiles/renderers.py
+++ b/src/specify_cli/tool_surface/profiles/renderers.py
@@ -103,34 +103,6 @@ __all__ += [
 ]
 
 
-# A profile id becomes the *stem* of a native agent file (``<id>.md`` /
-# ``<id>.agent.md``). It must therefore be a single safe path segment: no path
-# separators, no traversal, no whitespace or control characters. The native
-# formats agree on this constraint, so the check is renderer-agnostic.
-_NATIVE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
-_NATIVE_NAME_TRAVERSAL = {".", ".."}
-
-
-def native_name_violation(profile_id: str) -> str | None:
-    """Return a reason string if ``profile_id`` is illegal as a native filename.
-
-    Returns ``None`` for a legal id. A violation means the id cannot be used as
-    the filename stem of a host-native agent file (``.claude/agents/<id>.md``)
-    without escaping the agents directory or producing an unsafe path — the
-    condition that surfaces as ``profile-name-invalid``.
-    """
-    if not profile_id:
-        return "empty profile id has no native filename stem"
-    if profile_id in _NATIVE_NAME_TRAVERSAL:
-        return f"profile id {profile_id!r} is a path-traversal segment"
-    if not _NATIVE_NAME_PATTERN.fullmatch(profile_id):
-        return (
-            f"profile id {profile_id!r} contains characters illegal in a "
-            "native agent filename (allowed: letters, digits, '.', '_', '-')"
-        )
-    return None
-
-
 @runtime_checkable
 class ProfileRenderer(Protocol):
     """Render contract a per-harness profile renderer must satisfy."""

--- a/src/specify_cli/upgrade/migrations/m_0_9_3_surface_repair_wiring.py
+++ b/src/specify_cli/upgrade/migrations/m_0_9_3_surface_repair_wiring.py
@@ -37,7 +37,7 @@ def _marker_path(project_path: Path) -> Path:
 
 
 @MigrationRegistry.register
-class SurfaceRepairWiringMigration(BaseMigration):  # type: ignore[misc]
+class SurfaceRepairWiringMigration(BaseMigration):
     """Sentinel migration: record that tool-surface repair wiring is active."""
 
     migration_id = "0_9_3_surface_repair_wiring"

--- a/src/specify_cli/upgrade/migrations/m_0_9_4_roo_deprecation.py
+++ b/src/specify_cli/upgrade/migrations/m_0_9_4_roo_deprecation.py
@@ -59,7 +59,7 @@ def _roo_in_config(project_path: Path) -> bool:
 
 
 @MigrationRegistry.register
-class RooDeprecationMigration(BaseMigration):  # type: ignore[misc]
+class RooDeprecationMigration(BaseMigration):
     """Emit Roo Code deprecation notice and remove roo from agent config."""
 
     migration_id = "0_9_4_roo_deprecation"


### PR DESCRIPTION
## Summary

- **ruff**: Eliminated all 23 violations across `scripts/` and `src/` — SIM/UP/B/ARG/F811/C901 rules.
- **mypy**: Eliminated all 7 errors across 6 source files — redundant cast, stale ignores, missing return type, variable type reassignment, `StrEnum` `Literal` incompatibility, pydantic alias re-export, and `SUPPORTED_AGENTS` explicit re-export.
- Both `ruff check .` and `mypy src/` now exit with zero issues on 998 source files.

## Key changes by category

**C901 complexity reduction** (extracting helpers to stay ≤15):
- `scripts/tasks/tasks_cli.py`: extracted `_merge_dry_run`, `_merge_execute`, `_merge_post`, `_print_acceptance_result`
- `.kittify/overrides/scripts/tasks/tasks_cli.py`: same pattern (uses `mission_slug` instead of `feature`)
- `scripts/generate_schemas.py`: extracted `_set_descriptions`, `_annotate_def`

**mypy fixes**:
- `src/runtime/next/_internal_runtime/schema.py`: `agent_profile` field switched to `AliasChoices("agent-profile", "agent_profile")` + `serialization_alias` — fixes `did you mean 'agent-profile'?` without the pydantic plugin
- `src/runtime/next/_internal_runtime/planner.py`: `DecisionKind.xxx` → `DecisionKind.xxx.value` for `Literal` type compatibility
- `src/mission_runtime/resolution.py`: renamed second `workspace` assignment to `wp_workspace` (type was `WorkspaceFragment` then `ResolvedWorkspace` — incompatible reassignment)
- `src/specify_cli/skills/command_installer.py`: `import SUPPORTED_AGENTS as SUPPORTED_AGENTS` for explicit re-export under `no_implicit_reexport`
- `src/runtime/next/prompt_builder.py`: added `-> WorkflowSequence` return type via `TYPE_CHECKING` import

**Ruff idiom fixes**: `contextlib.suppress`, `enumerate()`, ternaries, combined nested `if`s, `capture_output=True`, `from collections.abc import Iterable`, `raise X from exc`

**F811**: Removed duplicate `_NATIVE_NAME_PATTERN`, `_NATIVE_NAME_TRAVERSAL`, `native_name_violation` definitions in `renderers.py`.

## Test plan

- [x] `ruff check .` → `All checks passed!`
- [x] `mypy src/` → `Success: no issues found in 998 source files`
- [x] `pytest tests/ -x -q --ignore=tests/sync` → 4120 passed, 25 skipped, 22 xfailed (1 pre-existing failure in `test_charter_all_exports_are_defined` — confirmed identical on unmodified `main`, unrelated to this PR)
- [x] `pytest tests/sync/test_orphan_sweep.py -n0 -q` → 9 passed

## Sonar notes

No new suppressions added. All fixes are real code corrections, not noqa/type-ignore additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)