### PR TITLE
refactor(implement): extract _resolve_lanes_dir() pure seam (#1993, fixes #1991)

### DIFF
--- a/src/specify_cli/cli/commands/implement.py
+++ b/src/specify_cli/cli/commands/implement.py
@@ -553,6 +553,22 @@ def _resolve_placement_ref(
     return placement.placement_ref if placement is not None else None
 
 
+def _resolve_lanes_dir(repo_root: Path, mission_slug: str) -> Path:
+    """Return the feature dir to read lanes.json from (coord-aware).
+
+    C-LANES-1 (#1991 / #1993): finalize-tasks commits lanes.json to the
+    coordination branch and deletes the primary-checkout copy. This resolver
+    prefers the coord-worktree surface (where the file lives) and falls back
+    to the primary checkout for flat/legacy topology. Distinct from
+    feature_dir (meta-anchored to primary) and _status_feature_dir
+    (status-emitter surface) — three artifact families, three surfaces.
+    """
+    d = resolve_feature_dir_for_mission(repo_root, mission_slug)
+    if not (d / "meta.json").exists():
+        d = candidate_feature_dir_for_mission(repo_root, mission_slug)
+    return d
+
+
 def _placement_coord_filter(placement_ref: CommitTarget | None) -> str | None:
     """Return the coord-owned-exclusion ref implied by the context placement.
 
@@ -954,18 +970,19 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         if auto_commit is None:
             auto_commit = get_auto_commit_default(repo_root)
         _feature_number, mission_slug = detect_feature_context(mission, feature, repo_root=repo_root)
-        feature_dir = resolve_feature_dir_for_mission(repo_root, mission_slug)
-        if not (feature_dir / "meta.json").exists():
-            feature_dir = candidate_feature_dir_for_mission(repo_root, mission_slug)
+        # C-LANES-1 (#1991 / #1993): lanes.json lives on the coord-worktree
+        # surface; _resolve_lanes_dir is the pure seam that returns the right
+        # surface without anchoring to primary. feature_dir starts from the same
+        # coord-aware result then gets the primary-meta fallback separately —
+        # three artifact families (lanes, status, meta), three surfaces.
+        _lanes_feature_dir: Path = _resolve_lanes_dir(repo_root, mission_slug)
+        feature_dir: Path = _lanes_feature_dir
         # FR-003 cascade layer 1: meta.json lives ONLY on the PRIMARY checkout —
-        # the coord worktree's mission dir never carries it. Both resolvers above
-        # are topology-aware and prefer the coord worktree once materialized, so
-        # ``feature_dir`` lands on a meta-less coord dir and every downstream
-        # meta read (``_ensure_vcs_in_meta``, identity resolution) fails with
-        # "meta.json not found". When the resolved dir lacks meta, anchor on the
-        # canonical primary dir so config is readable before topology is
-        # resolved. (The coord surface stays authoritative for STATUS reads,
-        # which route through the canonical surface authority, not this dir.)
+        # the coord worktree's mission dir never carries it. When the coord-aware
+        # result lacks meta, anchor on the canonical primary dir so config is
+        # readable before topology is resolved. (The coord surface stays
+        # authoritative for STATUS reads and lanes reads — only meta reads use
+        # the primary surface.)
         if not (feature_dir / "meta.json").exists():
             from specify_cli.missions._read_path_resolver import (
                 primary_feature_dir_for_mission,
@@ -1121,7 +1138,7 @@ def implement(  # noqa: C901 — orchestration function, complexity inherent
         lane = None
         from specify_cli.lanes.compute import is_planning_lane
         if not is_planning_lane(resolved_workspace):
-            lanes_manifest = require_lanes_json(feature_dir)
+            lanes_manifest = require_lanes_json(_lanes_feature_dir)
             lane = lanes_manifest.lane_for_wp(wp_id)
             if lane is None:
                 raise ValueError(f"{wp_id} is not assigned to any lane in lanes.json")

--- a/tests/agent/test_implement_command.py
+++ b/tests/agent/test_implement_command.py
@@ -608,3 +608,167 @@ class TestImplementCommand:
             kwargs = mock_create_lane_workspace.call_args.kwargs
             assert kwargs["lanes_manifest"] is None
             assert kwargs["resolved_workspace"].execution_mode == "planning_artifact"
+
+
+class TestResolveLanesDir:
+    """Unit tests for _resolve_lanes_dir — pure seam extracted per #1993.
+
+    Two mocks per test; the seam's logic is fully covered without the full
+    implement() orchestration scaffolding.
+    """
+
+    def test_returns_first_resolver_result_when_meta_present(self, tmp_path: Path) -> None:
+        """When the first resolver returns a dir that has meta.json, use it directly."""
+        from specify_cli.cli.commands.implement import _resolve_lanes_dir
+
+        good_dir = tmp_path / "primary"
+        good_dir.mkdir()
+        (good_dir / "meta.json").write_text("{}", encoding="utf-8")
+
+        with patch(
+            "specify_cli.cli.commands.implement.resolve_feature_dir_for_mission",
+            return_value=good_dir,
+        ) as mock_first:
+            result = _resolve_lanes_dir(tmp_path, "010-feature")
+
+        assert result == good_dir
+        mock_first.assert_called_once_with(tmp_path, "010-feature")
+
+    def test_falls_back_to_candidate_when_first_lacks_meta(self, tmp_path: Path) -> None:
+        """When first resolver returns a dir without meta.json (coord dir), candidate is used."""
+        from specify_cli.cli.commands.implement import _resolve_lanes_dir
+
+        coord_dir = tmp_path / "coord"
+        coord_dir.mkdir()
+        # no meta.json — coord topology
+
+        candidate_dir = tmp_path / "candidate"
+        candidate_dir.mkdir()
+
+        with (
+            patch(
+                "specify_cli.cli.commands.implement.resolve_feature_dir_for_mission",
+                return_value=coord_dir,
+            ),
+            patch(
+                "specify_cli.cli.commands.implement.candidate_feature_dir_for_mission",
+                return_value=candidate_dir,
+            ) as mock_candidate,
+        ):
+            result = _resolve_lanes_dir(tmp_path, "010-feature")
+
+        assert result == candidate_dir
+        mock_candidate.assert_called_once_with(tmp_path, "010-feature")
+
+
+class TestImplementCoordTopologyLanesJson:
+    """Regression tests for #1991: lanes.json read from coord worktree.
+
+    finalize-tasks writes lanes.json to the coordination branch and deletes
+    the primary-checkout copy. The implement validate block must read it
+    through _resolve_lanes_dir (the coord-aware surface), not through the
+    meta-anchored primary feature_dir.
+    """
+
+    def test_lanes_json_read_from_coord_dir_not_primary(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """lanes.json in coord dir only — implement must NOT fail with MissingLanesError."""
+        mission_slug = "010-feature"
+
+        # Primary checkout: meta.json + WP file + status — NO lanes.json
+        primary_dir = tmp_path / "kitty-specs" / mission_slug
+        create_meta_json(primary_dir)
+        wp_file = primary_dir / "tasks" / "WP01-setup.md"
+        wp_file.parent.mkdir(parents=True)
+        wp_file.write_text(
+            "---\nwork_package_id: WP01\ndependencies: []\n"
+            "execution_mode: code_change\nowned_files:\n  - src/wp01/**\n"
+            "authoritative_surface: src/wp01/\n---\n# WP01",
+            encoding="utf-8",
+        )
+        _seed_planned(primary_dir, "WP01")
+
+        # Coord dir: lanes.json + status — NO meta.json (mirrors real coord topology)
+        coord_dir = tmp_path / ".worktrees" / f"{mission_slug}-coord" / "kitty-specs" / mission_slug
+        coord_dir.mkdir(parents=True)
+        create_lanes_json(coord_dir, wp_ids=("WP01",))
+        _seed_planned(coord_dir, "WP01")
+
+        class _FakeStatusSurface:
+            read_dir = coord_dir
+
+        from specify_cli.workspace.context import ResolvedWorkspace
+
+        fake_workspace = ResolvedWorkspace(
+            mission_slug=mission_slug,
+            wp_id="WP01",
+            execution_mode="code_change",
+            mode_source="frontmatter",
+            resolution_kind="lane_workspace",
+            workspace_name=f"{mission_slug}-lane-a",
+            worktree_path=tmp_path / ".worktrees" / f"{mission_slug}-lane-a",
+            branch_name=f"kitty/mission-{mission_slug}-lane-a",
+            lane_id="lane-a",
+            lane_wp_ids=["WP01"],
+            context=None,
+        )
+
+        mock_gate = MagicMock()
+        mock_gate.passed = True
+        mock_gate.change_mode = None
+
+        with (
+            patch("specify_cli.cli.commands.implement.find_repo_root", return_value=tmp_path),
+            patch(
+                "specify_cli.cli.commands.implement.detect_feature_context",
+                return_value=("010", mission_slug),
+            ),
+            # _resolve_lanes_dir is the pure seam — return coord_dir directly.
+            # This replaces the 2-resolver cascade and is what #1993 extracted.
+            patch(
+                "specify_cli.cli.commands.implement._resolve_lanes_dir",
+                return_value=coord_dir,
+            ),
+            patch(
+                "specify_cli.cli.commands.implement.resolve_feature_target_branch",
+                return_value="main",
+            ),
+            patch("specify_cli.cli.commands.implement._ensure_planning_artifacts_committed_git"),
+            patch("specify_cli.cli.commands.implement._resolve_placement_ref", return_value=None),
+            patch(
+                "specify_cli.coordination.surface_resolver.resolve_status_surface_with_anchor",
+                return_value=_FakeStatusSurface(),
+            ),
+            patch(
+                "specify_cli.bulk_edit.gate.ensure_occurrence_classification_ready",
+                return_value=mock_gate,
+            ),
+            patch(
+                "specify_cli.next.runtime_bridge.build_operational_context_for_claim",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "specify_cli.cli.commands.implement.resolve_workspace_for_wp",
+                return_value=fake_workspace,
+            ),
+            patch(
+                "specify_cli.cli.commands.implement.create_lane_workspace",
+                side_effect=RuntimeError("__workspace_create_sentinel__"),
+            ),
+        ):
+            with pytest.raises(typer.Exit):
+                implement("WP01", feature=mission_slug, json_output=True, recover=False)
+
+        payload = json.loads(capsys.readouterr().out.strip())
+        error = payload.get("error", "")
+
+        assert "lanes.json is required" not in error, (
+            f"Implement read lanes.json from the primary dir (deleted by finalize-tasks) "
+            f"instead of the coord dir — #1991 regression. Got: {error!r}"
+        )
+        assert "__workspace_create_sentinel__" in error, (
+            f"Expected to pass lanes.json validation and reach workspace creation. Got: {error!r}"
+        )


### PR DESCRIPTION
## Summary

- Extracts `_resolve_lanes_dir(repo_root, mission_slug) -> Path` from the inline cascade in `implement()` — the coord-aware resolver that returns the surface where `finalize-tasks` wrote `lanes.json`.
- Fixes #1991: `require_lanes_json` now reads from `_lanes_feature_dir` (coord worktree) not `feature_dir` (primary checkout, where `finalize-tasks` deleted it after staging).
- Resolves the test-scaffolding smell in #1993: `TestResolveLanesDir` covers the logic with 2 mocks; `TestImplementCoordTopologyLanesJson` patches `_resolve_lanes_dir` directly instead of the two-resolver cascade.

Supersedes PR #1992 (same #1991 fix, cleaner structure).

## Design

Three artifact families, three surfaces in `implement()`:
| Artifact | Surface | Variable |
|---|---|---|
| `meta.json` | Primary checkout | `feature_dir` (primary fallback applied) |
| `status.events.jsonl` | Status-emitter (coord/primary) | `_status_feature_dir` via `resolve_status_surface_with_anchor` |
| `lanes.json` | Coord worktree (finalize-tasks write destination) | `_lanes_feature_dir` via `_resolve_lanes_dir` |

## TDD order (DIR-034)

1. Wrote `TestResolveLanesDir` → red (ImportError: `_resolve_lanes_dir` not found)
2. Extracted `_resolve_lanes_dir` → green
3. Wired into `implement()` + updated integration test

## Test plan

- [ ] `pytest tests/agent/test_implement_command.py` — 18/18 pass
- [ ] `TestResolveLanesDir::test_returns_first_resolver_result_when_meta_present` — flat topology
- [ ] `TestResolveLanesDir::test_falls_back_to_candidate_when_first_lacks_meta` — coord topology
- [ ] `TestImplementCoordTopologyLanesJson::test_lanes_json_read_from_coord_dir_not_primary` — regression for #1991
- [ ] `ruff check` clean, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)