### PR TITLE
Release spec-kitty-cli 3.2.0

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.0rc45
+  version: 3.2.0
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-16
+
+### ✨ Added / 🔧 Changed
+
+- Stable 3.2.0 release of the mission-runtime, profile-invocation, tool-surface,
+  branch-authority, and coordination-worktree line after the rc45 validation cycle.
+  This promotes the accumulated 3.2.0 release-candidate fixes to the default PyPI
+  channel.
+
 ## [3.2.0rc45] - 2026-06-15
 
 ### 🐛 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0rc45"
+version = "3.2.0"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2091,7 +2091,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.0rc45"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- promote spec-kitty-cli from 3.2.0rc45 to stable 3.2.0
- add 3.2.0 changelog entry
- keep uv.lock change scoped to the package version line

## Local verification
- uv lock --check
- python scripts/release/validate_release.py --mode branch --tag-pattern 'v*.*.*'
- python scripts/release/validate_release.py --mode tag --tag v3.2.0 --tag-pattern 'v*.*.*'
- uv sync --frozen --extra test --extra lint
- .venv/bin/python -m pytest -q tests/release (118 passed, 7 skipped)
- .venv/bin/python -m build --outdir /tmp/spec-kitty-cli-3.2.0.K6Hxs5
- .venv/bin/twine check /tmp/spec-kitty-cli-3.2.0.K6Hxs5/*
- .venv/bin/python scripts/release/check_exact_install.py --dist-dir /tmp/spec-kitty-cli-3.2.0.K6Hxs5 --package spec-kitty-cli --console-script spec-kitty --console-arg=--version
- .venv/bin/python scripts/release/check_shared_package_drift.py --check-installed