### PR TITLE
fix: re-harden merge bookkeeping rollback paths

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -853,12 +853,18 @@ def _assert_bookkeeping_snapshot_path_is_trusted(
     """Reject rollback snapshot paths outside merge bookkeeping roots."""
     repo_resolved = get_main_repo_root(repo_root).resolve(strict=False)
     resolved_candidate = candidate.resolve(strict=False)
-    trusted_roots = (
+    trusted_dirs = (
         (repo_resolved / KITTY_SPECS_DIR).resolve(strict=False),
         (repo_resolved / WORKTREES_DIR).resolve(strict=False),
         (repo_resolved / KITTIFY_DIR / "runtime" / "merge").resolve(strict=False),
     )
-    if not any(resolved_candidate.is_relative_to(root) for root in trusted_roots):
+    trusted_files = (
+        (repo_resolved / KITTIFY_DIR / "merge-state.json").resolve(strict=False),
+    )
+    if not (
+        any(resolved_candidate.is_relative_to(root) for root in trusted_dirs)
+        or resolved_candidate in trusted_files
+    ):
         raise ValueError(
             f"Refusing bookkeeping snapshot path outside trusted repo roots: {candidate}"
         )
@@ -871,12 +877,16 @@ def _restore_final_bookkeeping_snapshots(
 ) -> None:
     """Best-effort restore for final merge bookkeeping rollback."""
     for path, original in snapshots.items():
-        with contextlib.suppress(OSError):
+        try:
             trusted_path = _assert_bookkeeping_snapshot_path_is_trusted(
                 repo_root=repo_root,
                 candidate=path,
             )
             _restore_optional_bytes(trusted_path, original)
+        except ValueError as exc:
+            logger.warning("Skipping untrusted bookkeeping rollback snapshot: %s", exc)
+        except OSError:
+            continue
 
 
 def _target_branch_still_at_baseline(

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -858,9 +858,7 @@ def _assert_bookkeeping_snapshot_path_is_trusted(
         (repo_resolved / WORKTREES_DIR).resolve(strict=False),
         (repo_resolved / KITTIFY_DIR / "runtime" / "merge").resolve(strict=False),
     )
-    trusted_files = (
-        (repo_resolved / KITTIFY_DIR / "merge-state.json").resolve(strict=False),
-    )
+    trusted_files = (repo_resolved / KITTIFY_DIR / "merge-state.json",)
     if not (
         any(resolved_candidate.is_relative_to(root) for root in trusted_dirs)
         or resolved_candidate in trusted_files

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -845,13 +845,38 @@ def _restore_optional_bytes(path: Path, original: bytes | None) -> None:
     path.write_bytes(original)
 
 
+def _assert_bookkeeping_snapshot_path_is_trusted(
+    *,
+    repo_root: Path,
+    candidate: Path,
+) -> Path:
+    """Reject rollback snapshot paths outside merge bookkeeping roots."""
+    repo_resolved = get_main_repo_root(repo_root).resolve(strict=False)
+    resolved_candidate = candidate.resolve(strict=False)
+    trusted_roots = (
+        (repo_resolved / KITTY_SPECS_DIR).resolve(strict=False),
+        (repo_resolved / WORKTREES_DIR).resolve(strict=False),
+        (repo_resolved / KITTIFY_DIR / "runtime" / "merge").resolve(strict=False),
+    )
+    if not any(resolved_candidate.is_relative_to(root) for root in trusted_roots):
+        raise ValueError(
+            f"Refusing bookkeeping snapshot path outside trusted repo roots: {candidate}"
+        )
+    return resolved_candidate
+
+
 def _restore_final_bookkeeping_snapshots(
+    repo_root: Path,
     snapshots: dict[Path, bytes | None],
 ) -> None:
     """Best-effort restore for final merge bookkeeping rollback."""
     for path, original in snapshots.items():
         with contextlib.suppress(OSError):
-            _restore_optional_bytes(path, original)
+            trusted_path = _assert_bookkeeping_snapshot_path_is_trusted(
+                repo_root=repo_root,
+                candidate=path,
+            )
+            _restore_optional_bytes(trusted_path, original)
 
 
 def _target_branch_still_at_baseline(
@@ -2512,7 +2537,7 @@ def _run_lane_based_merge_locked(
                     all_wp_ids=all_wp_ids,
                 )
             except Exception:
-                _restore_final_bookkeeping_snapshots(pre_target_bookkeeping_snapshots)
+                _restore_final_bookkeeping_snapshots(main_repo, pre_target_bookkeeping_snapshots)
                 raise
 
         # -- Mission-to-target merge (T010: honor strategy for this step only) --
@@ -2541,7 +2566,7 @@ def _run_lane_based_merge_locked(
                 lanes_manifest.target_branch,
                 target_baseline_sha,
             ):
-                _restore_final_bookkeeping_snapshots(pre_target_bookkeeping_snapshots)
+                _restore_final_bookkeeping_snapshots(main_repo, pre_target_bookkeeping_snapshots)
             raise
         mission_already_applied = getattr(mission_result, "already_applied", False) is True
         # FR-037 fail-loud: a no-op result is only acceptable when the mission
@@ -2568,7 +2593,7 @@ def _run_lane_based_merge_locked(
                 lanes_manifest.target_branch,
                 target_baseline_sha,
             ):
-                _restore_final_bookkeeping_snapshots(pre_target_bookkeeping_snapshots)
+                _restore_final_bookkeeping_snapshots(main_repo, pre_target_bookkeeping_snapshots)
             raise typer.Exit(1)
         if not mission_result.success:
             # T005: tolerate already-merged on retry
@@ -2583,7 +2608,7 @@ def _run_lane_based_merge_locked(
                     lanes_manifest.target_branch,
                     target_baseline_sha,
                 ):
-                    _restore_final_bookkeeping_snapshots(pre_target_bookkeeping_snapshots)
+                    _restore_final_bookkeeping_snapshots(main_repo, pre_target_bookkeeping_snapshots)
                 raise typer.Exit(1)
         else:
             console.print(f"\n[green]✓[/green] {lanes_manifest.mission_branch} → {lanes_manifest.target_branch}")
@@ -2636,7 +2661,7 @@ def _run_lane_based_merge_locked(
         # Modern lane mission could not record its post-merge review baseline.
         # Fail loudly — an apparently successful merge that drops the baseline
         # produces MISSION_REVIEW_MODE_MISMATCH downstream.
-        _restore_final_bookkeeping_snapshots(final_bookkeeping_snapshots)
+        _restore_final_bookkeeping_snapshots(main_repo, final_bookkeeping_snapshots)
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
 
@@ -2664,7 +2689,7 @@ def _run_lane_based_merge_locked(
                 all_wp_ids=all_wp_ids,
             )
         except Exception:
-            _restore_final_bookkeeping_snapshots(final_bookkeeping_snapshots)
+            _restore_final_bookkeeping_snapshots(main_repo, final_bookkeeping_snapshots)
             raise
 
     try:
@@ -2674,7 +2699,7 @@ def _run_lane_based_merge_locked(
             status_feature_dir=feature_dir,
         )
     except Exception:
-        _restore_final_bookkeeping_snapshots(final_bookkeeping_snapshots)
+        _restore_final_bookkeeping_snapshots(main_repo, final_bookkeeping_snapshots)
         raise
 
     # -- WP05/T007 FR-014: Post-merge working-tree invariant --
@@ -2732,7 +2757,7 @@ def _run_lane_based_merge_locked(
                     "\nUnexpected working-tree state after merge. "
                     "Run `git status` to investigate before retrying."
                 )
-            _restore_final_bookkeeping_snapshots(final_bookkeeping_snapshots)
+            _restore_final_bookkeeping_snapshots(main_repo, final_bookkeeping_snapshots)
             raise typer.Exit(1)
     else:
         console.print(
@@ -2771,7 +2796,7 @@ def _run_lane_based_merge_locked(
             )
         except Exception as exc:
             if not (isinstance(exc, SafeCommitRecoveryFailed) and exc.commit_sha is not None):
-                _restore_final_bookkeeping_snapshots(final_bookkeeping_snapshots)
+                _restore_final_bookkeeping_snapshots(main_repo, final_bookkeeping_snapshots)
             raise
     else:
         console.print("  [dim]No post-merge bookkeeping changes to commit; continuing cleanup.[/dim]")

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -898,11 +898,37 @@ def test_final_bookkeeping_rollback_restores_status_meta_and_state(tmp_path: Pat
     assert state_path.read_bytes() == b'{"completed_wps": []}\n'
 
 
-def test_final_bookkeeping_rollback_rejects_paths_outside_trusted_roots(
+def test_final_bookkeeping_rollback_skips_untrusted_path_and_preserves_original_error(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Rollback restore must never write outside merge bookkeeping roots."""
+    """Rollback restore must not mask the exception that triggered rollback."""
     escaped_path = tmp_path.parent / "escaped-status.json"
+    trailing_trusted_path = tmp_path / "kitty-specs" / "021-test" / "status.json"
+    trailing_trusted_path.parent.mkdir(parents=True)
+    trailing_trusted_path.write_text('{"WP01": "done"}\n', encoding="utf-8")
 
-    with pytest.raises(ValueError, match="outside trusted repo roots"):
-        _restore_final_bookkeeping_snapshots(tmp_path, {escaped_path: b"malicious\n"})
+    snapshots = {
+        escaped_path: b"malicious\n",
+        trailing_trusted_path: b'{"WP01": "approved"}\n',
+    }
+
+    with caplog.at_level("WARNING"), pytest.raises(RuntimeError, match="original failure"):
+        try:
+            raise RuntimeError("original failure")
+        except RuntimeError:
+            _restore_final_bookkeeping_snapshots(tmp_path, snapshots)
+            raise
+
+    assert not escaped_path.exists()
+    assert trailing_trusted_path.read_bytes() == b'{"WP01": "approved"}\n'
+    assert "Skipping untrusted bookkeeping rollback snapshot" in caplog.text
+
+
+def test_final_bookkeeping_rollback_trusts_legacy_merge_state_path(tmp_path: Path) -> None:
+    """Legacy merge state remains a trusted rollback snapshot target."""
+    legacy_state_path = tmp_path / ".kittify" / "merge-state.json"
+
+    _restore_final_bookkeeping_snapshots(tmp_path, {legacy_state_path: b'{"completed_wps": []}\n'})
+
+    assert legacy_state_path.read_bytes() == b'{"completed_wps": []}\n'

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -888,7 +888,7 @@ def test_final_bookkeeping_rollback_restores_status_meta_and_state(tmp_path: Pat
     target_meta.write_text('{"mission_slug": "m", "baseline_merge_commit": "HEAD~1"}\n', encoding="utf-8")
     state_path.write_text('{"completed_wps": ["WP01"]}\n', encoding="utf-8")
 
-    _restore_final_bookkeeping_snapshots(snapshots)
+    _restore_final_bookkeeping_snapshots(tmp_path, snapshots)
 
     assert coord_events.read_bytes() == b"approved-event\n"
     assert coord_status.read_bytes() == b'{"WP01": "approved"}\n'
@@ -896,3 +896,13 @@ def test_final_bookkeeping_rollback_restores_status_meta_and_state(tmp_path: Pat
     assert not target_status.exists()
     assert target_meta.read_bytes() == b'{"mission_slug": "m"}\n'
     assert state_path.read_bytes() == b'{"completed_wps": []}\n'
+
+
+def test_final_bookkeeping_rollback_rejects_paths_outside_trusted_roots(
+    tmp_path: Path,
+) -> None:
+    """Rollback restore must never write outside merge bookkeeping roots."""
+    escaped_path = tmp_path.parent / "escaped-status.json"
+
+    with pytest.raises(ValueError, match="outside trusted repo roots"):
+        _restore_final_bookkeeping_snapshots(tmp_path, {escaped_path: b"malicious\n"})


### PR DESCRIPTION
## Summary
- re-assert merge rollback snapshot paths against trusted bookkeeping roots before any restore write/unlink
- thread `main_repo` through rollback callers so restore validation can prove the trust boundary to Sonar
- add regression coverage for both successful rollback restore and path-escape rejection

## Validation
- `.venv/bin/ruff check src/specify_cli/cli/commands/merge.py tests/merge/test_merge_done_recording.py`
- `.venv/bin/pytest tests/merge/test_merge_done_recording.py -q`
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_merge.py -q`

## Sonar / security notes
- Addresses the open `pythonsecurity:S2083` / GitHub code-scanning alert on `src/specify_cli/cli/commands/merge.py` by making rollback restores fail closed outside trusted repo bookkeeping roots.
- Previous night's scheduled `CI Quality` run on `main` was `#2734` / `27602156830`; Sonar quality gate failed with this merge-path issue plus unreviewed loopback-only hotspots.
- Remaining Sonar hotspots in `src/specify_cli/core/loopback_http.py` are localhost-only `http://127.0.0.1` findings and still need Sonar UI review/rationale, not a code change in this PR.
