### PR TITLE
fix: guard merge bookkeeping mission slug paths

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -99,6 +99,7 @@ TARGET_BRANCH_NOT_SYNCHRONIZED = "TARGET_BRANCH_NOT_SYNCHRONIZED"
 TARGET_BRANCH_SYNC_INVARIANT = "local_target_branch_must_match_tracking_branch"
 _STATUS_EVENTS_FILENAME = "status.events.jsonl"
 _STATUS_FILENAME = "status.json"
+_MISSION_SLUG_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]+$", re.ASCII)
 
 # T011 — FR-009: push-error parser tokens (locked tuple — do not reorder or extend without a spec change)
 LINEAR_HISTORY_REJECTION_TOKENS: tuple[str, ...] = (
@@ -770,6 +771,21 @@ def _paths_have_status_changes(repo_root: Path, paths: list[Path]) -> bool:
     return bool((out_status or "").strip())
 
 
+def _validate_mission_slug_path_segment(mission_slug: str) -> str:
+    """Reject mission slugs unsafe for direct path composition."""
+    candidate = mission_slug.strip()
+    if (
+        not candidate
+        or candidate in {".", ".."}
+        or "/" in candidate
+        or "\\" in candidate
+        or not candidate.isascii()
+        or _MISSION_SLUG_PATH_SEGMENT_RE.fullmatch(candidate) is None
+    ):
+        raise ValueError(f"Mission slug must be a single safe path segment: {mission_slug!r}")
+    return candidate
+
+
 def _target_bookkeeping_status_paths(
     *,
     main_repo: Path,
@@ -782,8 +798,9 @@ def _target_bookkeeping_status_paths(
     worktree. The final merge bookkeeping commit runs from ``main_repo`` onto
     the target branch, so it must stage primary-checkout paths only.
     """
+    safe_mission_slug = _validate_mission_slug_path_segment(mission_slug)
     target_feature_dir = (
-        primary_feature_dir_for_mission(main_repo, mission_slug)
+        primary_feature_dir_for_mission(main_repo, safe_mission_slug)
         if is_under_worktrees_segment(status_feature_dir)
         else status_feature_dir
     )

--- a/tests/specify_cli/cli/commands/test_merge.py
+++ b/tests/specify_cli/cli/commands/test_merge.py
@@ -137,11 +137,25 @@ def test_target_bookkeeping_paths_keep_primary_surface(tmp_path: Path) -> None:
 
 def test_target_bookkeeping_paths_reject_path_traversal(tmp_path: Path) -> None:
     """Mission slugs must not project bookkeeping writes outside the repo root."""
-    with pytest.raises(ValueError, match="Refusing to access path outside"):
+    with pytest.raises(ValueError, match="single safe path segment"):
         _target_bookkeeping_status_paths(
             main_repo=tmp_path,
             mission_slug="../../escape",
             status_feature_dir=tmp_path / "kitty-specs" / "../../escape",
+        )
+
+
+@pytest.mark.parametrize("mission_slug", ["feature/with-slash", r"feature\\with-backslash", "naïve"])
+def test_target_bookkeeping_paths_reject_unsafe_mission_slug(
+    tmp_path: Path,
+    mission_slug: str,
+) -> None:
+    """Unsafe mission slugs are rejected before path composition."""
+    with pytest.raises(ValueError, match="single safe path segment"):
+        _target_bookkeeping_status_paths(
+            main_repo=tmp_path,
+            mission_slug=mission_slug,
+            status_feature_dir=tmp_path / "kitty-specs" / "safe-slug",
         )
 
 


### PR DESCRIPTION
## Summary
- reject unsafe mission slug path segments before merge bookkeeping composes target checkout paths
- keep the final merge bookkeeping flow unchanged for valid slugs while failing closed on traversal, backslash, and non-ASCII inputs
- add regression coverage for the new guard and existing bookkeeping path slices

## Validation
- uv run pytest tests/specify_cli/cli/commands/test_merge.py -q
- uv run pytest tests/merge/test_merge_done_recording.py -q -k bookkeeping
- uv run ruff check src/specify_cli/cli/commands/merge.py tests/specify_cli/cli/commands/test_merge.py

## Context
- fixes the only open SonarCloud-backed code-scanning alert from the scheduled `CI Quality` run on `main` at 2026-06-16T07:42:11Z
- no suppressions added
