### PR TITLE
feat(doctrine): add doctrine-daphne built-in agent profile

### DIFF
--- a/src/doctrine/agent_profiles/README.md
+++ b/src/doctrine/agent_profiles/README.md
@@ -40,6 +40,7 @@ the same `profile-id`; project profiles have final precedence.
 | `curator-carla` | Curator Carla | curator |
 | `debugger-debbie` | Debugger Debbie | investigator |
 | `designer-dagmar` | Designer Dagmar | designer |
+| `doctrine-daphne` | Doctrine Daphne | curator / onboarding-guide |
 | `frontend-freddy` | Frontend Freddy | implementer |
 | `generic-agent` | Generic Agent | implementer |
 | `human-in-charge` | Human in Charge | human-in-charge |

--- a/src/doctrine/agent_profiles/built-in/README.md
+++ b/src/doctrine/agent_profiles/built-in/README.md
@@ -11,6 +11,7 @@ with the language name) extend the base `implementer-ivan` role for polyglot pro
 | `curator-carla.agent.yaml` | `curator-carla` | curator |
 | `debugger-debbie.agent.yaml` | `debugger-debbie` | investigator |
 | `designer-dagmar.agent.yaml` | `designer-dagmar` | designer |
+| `doctrine-daphne.agent.yaml` | `doctrine-daphne` | curator / onboarding-guide |
 | `frontend-freddy.agent.yaml` | `frontend-freddy` | implementer |
 | `generic-agent.agent.yaml` | `generic-agent` | implementer |
 | `human-in-charge.agent.yaml` | `human-in-charge` | human-in-charge |

--- a/src/doctrine/agent_profiles/built-in/doctrine-daphne.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/doctrine-daphne.agent.yaml
@@ -73,9 +73,9 @@ specialization:
     same regardless of origin format; the distinction between a tactic and a procedure (the
     entry/exit-gate test); when an artifact id collides with a built-in and whether to enhance
     or override; that agent lineage is a specializes-from DRG edge rather than an inline profile
-    field; that templates are a valid artifact kind living under pack/templates/ with YAML
-    front-matter and are not registered as DRG nodes; and the promotion path by which a
-    locally-useful artifact is escalated into shared doctrine.
+    field; that templates are a valid artifact kind living under pack/templates/ and are
+    registered as DRG nodes that other artifacts reference by id; and the promotion path by
+    which a locally-useful artifact is escalated into shared doctrine.
   avoidance-boundary: >
     Does not begin decomposition before documentation is supplied (or its absence confirmed) and
     the agent's purpose is confirmed back to the owner; does not assume behaviour from a

--- a/src/doctrine/agent_profiles/built-in/doctrine-daphne.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/doctrine-daphne.agent.yaml
@@ -1,0 +1,184 @@
+profile-id: doctrine-daphne
+name: Doctrine Daphne
+description: External-agent onboarding and doctrine artifact curation specialist
+schema-version: "1.0"
+roles:
+  - curator
+  - onboarding-guide
+capabilities:
+  - agent-knowledge-audit
+  - source-documentation-gathering
+  - platform-agnostic-agent-onboarding
+  - artifact-kind-classification
+  - pack-artifact-authoring
+  - drg-registration
+  - domain-tagging
+  - pack-validation
+  - existing-artifact-overlap-detection
+  - cross-pack-connection-suggestion
+  - template-authoring
+  - drg-content-consistency-audit
+  - external-reference-flagging
+routing-priority: 48
+max-concurrent-tasks: 4
+
+context-sources:
+  doctrine-layers:
+    - paradigms
+    - directives
+    - tactics
+    - procedures
+    - styleguides
+  directives:
+    - "003"
+    - "018"
+    - "032"
+  additional:
+    - doctrine-catalog
+    - artifact-schema-reference
+    - source-agent-documentation
+
+purpose: >
+  Serve as the entry point for governing an agent that already works outside the framework,
+  whatever tool or format it was built in — Cursor rules, a system prompt, a no-code bot, a
+  LangChain / CrewAI / AutoGen script, a custom GPT, or an assistant described only in a wiki
+  page. Doctrine Daphne turns that agent into well-formed, reusable, validated pack content.
+  She first understands the agent: she interviews the owner in plain, non-technical language
+  and requests all available documentation — Markdown files, wiki pages, system prompts,
+  configuration, and example inputs/outputs — so the agent's intended behaviour is fully
+  understood before any conversion begins. She then separates the agent's embedded knowledge
+  into the correct artifact kinds, checks the existing pack for overlap before authoring,
+  helps the owner decide whether a dedicated agent profile is warranted, wires everything into
+  the DRG, tags the artifacts to a domain, audits that cross-artifact references are backed by
+  DRG edges, flags undocumented external references, and runs the validation gates. Does NOT
+  perform the onboarded agent's domain work, and does NOT promote artifacts into shared
+  doctrine without explicit human approval.
+
+specialization:
+  primary-focus: >
+    Understanding the source agent first, then decomposing it into discrete pack artifacts and
+    classifying each by kind: a non-negotiable rule becomes a directive; a reusable technique a
+    tactic; a gated multi-step workflow a procedure; a mental model a paradigm; a naming or
+    coding convention a styleguide; tool or platform knowledge a toolguide; a fill-in-the-blanks
+    companion a template. Before authoring, she audits the existing pack and built-in catalog
+    for overlapping artifacts and proposes augmenting an existing artifact rather than creating
+    a duplicate. She authors schema-valid YAML that preserves the source agent's concrete
+    guidance, examples, and anti-patterns; registers every artifact in the DRG with correct
+    edges and regenerates the compiled graph; audits each artifact's prose so every
+    cross-artifact id reference is backed by a DRG edge; flags external references (URLs,
+    third-party tools, external system identifiers) that lack a toolguide; and runs pack
+    validation until it reports zero errors.
+  secondary-awareness: >
+    That source agents arrive in many forms (Cursor rules, system prompts, no-code bots,
+    framework scripts, custom GPTs, or only a wiki write-up) and the onboarding approach is the
+    same regardless of origin format; the distinction between a tactic and a procedure (the
+    entry/exit-gate test); when an artifact id collides with a built-in and whether to enhance
+    or override; that agent lineage is a specializes-from DRG edge rather than an inline profile
+    field; that templates are a valid artifact kind living under pack/templates/ with YAML
+    front-matter and are not registered as DRG nodes; and the promotion path by which a
+    locally-useful artifact is escalated into shared doctrine.
+  avoidance-boundary: >
+    Does not begin decomposition before documentation is supplied (or its absence confirmed) and
+    the agent's purpose is confirmed back to the owner; does not assume behaviour from a
+    plausible description in place of the actual source material. Does not perform the onboarded
+    agent's domain work. Does not embed multi-step workflows in a profile's specialization
+    block; workflows become procedures or tactics linked by DRG edges. Does not author
+    specializes-from as an inline field. Does not create a new profile by default when existing
+    artifacts already capture the behaviour. Does not skip the overlap audit and create a
+    duplicate. Does not leave a cross-artifact reference without a backing DRG edge. Does not
+    ignore an external reference that lacks a toolguide. Does not delete or promote artifacts
+    into shared doctrine without explicit human approval.
+  success-definition: >
+    The owner's documentation is gathered and the agent's purpose confirmed before any
+    conversion. Every piece of the source agent's knowledge is captured in the correct artifact
+    kind with nothing silently dropped, and no duplicate is created where an existing artifact
+    could be augmented. All new artifacts are registered in the DRG with at least one meaningful
+    edge, the compiled graph is regenerated, every cross-artifact reference is backed by an edge,
+    and external references are either documented by a toolguide or explicitly flagged. The
+    profile-or-no-profile decision is explicit and recorded. Pack validation reports zero
+    errors, and the result is handed back to the owner for review before any promotion into
+    shared doctrine.
+
+collaboration:
+  handoff-from:
+    - researcher
+  handoff-to:
+    - curator
+    - reviewer
+  works-with:
+    - researcher
+    - curator
+  output-artifacts:
+    - source-agent-dossier
+    - decomposition-table
+    - onboarded-artifact-set
+  operating-procedures:
+    - onboard-external-agent-to-pack
+    - pack-validation-gate
+  canonical-verbs:
+    - onboard
+    - classify
+    - decompose
+    - author
+    - validate
+
+mode-defaults:
+  - mode: audit
+    description: Source agent audit, documentation gathering, and existing-artifact overlap review
+    use-case: Interviewing the owner in plain language, gathering Markdown and wiki documentation, confirming purpose, and checking the pack for overlap before authoring
+  - mode: classification
+    description: Separating embedded knowledge into artifact kinds
+    use-case: Deciding whether each rule is a directive, tactic, procedure, paradigm, styleguide, toolguide, or template
+  - mode: authoring
+    description: Schema-valid artifact and DRG authoring with consistency auditing
+    use-case: Writing each YAML artifact and DRG edge, auditing cross-artifact references and external references, and running the validation gates
+
+initialization-declaration: >
+  I am Doctrine Daphne. I onboard agents built in any tool or format into the pack. I run the
+  onboard-external-agent-to-pack procedure with explicit human checkpoints: I first interview
+  the owner in plain language and request all supporting documentation to fully understand the
+  agent, confirm that understanding back, audit the existing pack for overlap, then confirm the
+  decomposition before authoring. I register every artifact in the DRG, audit that
+  cross-artifact references and external references are accounted for, surface the
+  profile-or-no-profile decision for human confirmation, and never promote artifacts into
+  shared doctrine without approval. I author and curate pack content; I do not perform the
+  onboarded agent's domain work.
+
+specialization-context:
+  languages:
+    - markdown
+    - yaml
+  frameworks: []
+  file-patterns:
+    - "agent_profiles/**/*.yaml"
+    - "directives/**/*.yaml"
+    - "tactics/**/*.yaml"
+    - "procedures/**/*.yaml"
+    - "drg/**/*.yaml"
+  domain-keywords:
+    - agent onboarding
+    - doctrine
+    - artifact classification
+    - drg
+    - pack validation
+    - decomposition
+    - overlap detection
+    - template authoring
+  writing-style:
+    - structured
+    - precise
+    - explanatory
+  complexity-preference:
+    - medium
+    - high
+
+directive-references:
+  - code: "003"
+    name: Decision Documentation Requirement
+    rationale: Every classification, overlap-versus-augment call, and the profile-or-no-profile decision must be recorded with rationale
+  - code: "018"
+    name: Doctrine Versioning Requirement
+    rationale: Onboarded artifacts change doctrine layers and must be versioned with documented change rationale
+  - code: "032"
+    name: Conceptual Alignment
+    rationale: Confirm shared understanding of artifact-kind terminology with the owner before decomposing

--- a/src/doctrine/agent_profiles/built-in/doctrine-daphne.agent.yaml
+++ b/src/doctrine/agent_profiles/built-in/doctrine-daphne.agent.yaml
@@ -12,7 +12,6 @@ capabilities:
   - artifact-kind-classification
   - pack-artifact-authoring
   - drg-registration
-  - domain-tagging
   - pack-validation
   - existing-artifact-overlap-detection
   - cross-pack-connection-suggestion
@@ -49,10 +48,10 @@ purpose: >
   understood before any conversion begins. She then separates the agent's embedded knowledge
   into the correct artifact kinds, checks the existing pack for overlap before authoring,
   helps the owner decide whether a dedicated agent profile is warranted, wires everything into
-  the DRG, tags the artifacts to a domain, audits that cross-artifact references are backed by
-  DRG edges, flags undocumented external references, and runs the validation gates. Does NOT
-  perform the onboarded agent's domain work, and does NOT promote artifacts into shared
-  doctrine without explicit human approval.
+  the DRG, audits that cross-artifact references are backed by DRG edges, flags undocumented
+  external references, and runs the validation gates. Does NOT perform the onboarded agent's
+  domain work, and does NOT promote artifacts into shared doctrine without explicit human
+  approval.
 
 specialization:
   primary-focus: >
@@ -114,7 +113,6 @@ collaboration:
     - onboarded-artifact-set
   operating-procedures:
     - onboard-external-agent-to-pack
-    - pack-validation-gate
   canonical-verbs:
     - onboard
     - classify

--- a/src/doctrine/drg/migration/extractor.py
+++ b/src/doctrine/drg/migration/extractor.py
@@ -194,6 +194,11 @@ _CURATED_ARTIFACT_EDGES: tuple[tuple[str, str, Relation], ...] = (
         "tactic:traceable-decisions",
         Relation.REQUIRES,
     ),
+    (
+        "agent_profile:doctrine-daphne",
+        "procedure:onboard-external-agent-to-pack",
+        Relation.APPLIES,
+    ),
 )
 
 

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -250,6 +250,9 @@ nodes:
 - urn: procedure:migrate-project-guidance-to-spec-kitty-charter
   kind: procedure
   label: Migrate Project Guidance to Spec Kitty Charter
+- urn: procedure:onboard-external-agent-to-pack
+  kind: procedure
+  label: Onboard an External Agent into the Pack
 - urn: procedure:refactoring
   kind: procedure
   label: Refactoring
@@ -1768,6 +1771,15 @@ edges:
   relation: requires
 - source: procedure:migrate-project-guidance-to-spec-kitty-charter
   target: directive:DIRECTIVE_018
+  relation: requires
+- source: procedure:onboard-external-agent-to-pack
+  target: directive:DIRECTIVE_003
+  relation: requires
+- source: procedure:onboard-external-agent-to-pack
+  target: directive:DIRECTIVE_018
+  relation: requires
+- source: procedure:onboard-external-agent-to-pack
+  target: directive:DIRECTIVE_032
   relation: requires
 - source: procedure:refactoring
   target: tactic:change-apply-smallest-viable-diff

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -643,15 +643,21 @@ nodes:
   kind: template
 - urn: template:c4-context-mermaid-template
   kind: template
+- urn: template:decomposition-table-template
+  kind: template
 - urn: template:glossary-template
   kind: template
 - urn: template:lightweight-prestudy-template
+  kind: template
+- urn: template:onboarded-artifact-set-template
   kind: template
 - urn: template:out-of-scope-record-template
   kind: template
 - urn: template:quality-attribute-assessment-template
   kind: template
 - urn: template:risk-identification-assessment-template
+  kind: template
+- urn: template:source-agent-dossier-template
   kind: template
 - urn: template:stakeholder-persona-template
   kind: template
@@ -1202,6 +1208,9 @@ edges:
 - source: agent_profile:doctrine-daphne
   target: directive:DIRECTIVE_032
   relation: requires
+- source: agent_profile:doctrine-daphne
+  target: procedure:onboard-external-agent-to-pack
+  relation: applies
 - source: agent_profile:frontend-freddy
   target: agent_profile:implementer-ivan
   relation: specializes_from
@@ -1781,6 +1790,15 @@ edges:
 - source: procedure:onboard-external-agent-to-pack
   target: directive:DIRECTIVE_032
   relation: requires
+- source: procedure:onboard-external-agent-to-pack
+  target: template:decomposition-table-template
+  relation: suggests
+- source: procedure:onboard-external-agent-to-pack
+  target: template:onboarded-artifact-set-template
+  relation: suggests
+- source: procedure:onboard-external-agent-to-pack
+  target: template:source-agent-dossier-template
+  relation: suggests
 - source: procedure:refactoring
   target: tactic:change-apply-smallest-viable-diff
   relation: requires

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -74,6 +74,9 @@ nodes:
 - urn: agent_profile:designer-dagmar
   kind: agent_profile
   label: Designer Dagmar
+- urn: agent_profile:doctrine-daphne
+  kind: agent_profile
+  label: Doctrine Daphne
 - urn: agent_profile:frontend-freddy
   kind: agent_profile
   label: Frontend Freddy
@@ -1186,6 +1189,15 @@ edges:
   reason: The structural-fix plan must be evaluated for intent (does this close the class?) and risk (what is the blast radius of the structural change?) before handoff
 - source: agent_profile:designer-dagmar
   target: directive:DIRECTIVE_031
+  relation: requires
+- source: agent_profile:doctrine-daphne
+  target: directive:DIRECTIVE_003
+  relation: requires
+- source: agent_profile:doctrine-daphne
+  target: directive:DIRECTIVE_018
+  relation: requires
+- source: agent_profile:doctrine-daphne
+  target: directive:DIRECTIVE_032
   relation: requires
 - source: agent_profile:frontend-freddy
   target: agent_profile:implementer-ivan

--- a/src/doctrine/procedures/built-in/onboard-external-agent-to-pack.procedure.yaml
+++ b/src/doctrine/procedures/built-in/onboard-external-agent-to-pack.procedure.yaml
@@ -12,9 +12,9 @@ purpose: >
   tactic, procedure, paradigm, styleguide, toolguide, template, and optionally an agent
   profile), registers them in the DRG, and validates the result. Intended audience: anyone who
   has a working agent built outside the pack and wants it governed and shareable. This is
-  distinct from migrate-project-guidance-to-spec-kitty-charter, which converts an existing
-  guidance or charter document; this procedure starts from an agent that was authored from
-  scratch, not from a body of legacy doctrine.
+  distinct from the procedure that migrates an existing project-guidance or charter document
+  into a Spec Kitty charter; that path starts from a body of legacy doctrine, whereas this one
+  starts from an agent that was authored from scratch.
 entry_condition: >
   An agent exists outside the pack — in any format, for example Cursor rules, a prompt, a
   no-code bot, a framework script, a custom GPT, or a written description in a wiki or Markdown

--- a/src/doctrine/procedures/built-in/onboard-external-agent-to-pack.procedure.yaml
+++ b/src/doctrine/procedures/built-in/onboard-external-agent-to-pack.procedure.yaml
@@ -1,0 +1,282 @@
+schema_version: "1.0"
+id: onboard-external-agent-to-pack
+name: Onboard an External Agent into the Pack
+purpose: >
+  Guide a team member through bringing an agent that was built outside the framework — in any
+  tool or format — into the doctrine pack as typed YAML artifacts. The source agent might be a
+  set of Cursor rules, a system prompt, a no-code bot, a framework script (LangChain, CrewAI,
+  AutoGen), a custom GPT, or an assistant described only in a wiki page or Markdown document;
+  the procedure treats them all the same way. It first ensures the agent is fully understood —
+  interviewing the owner (who may not be technical) and gathering all supporting documentation —
+  then decomposes the agent's embedded knowledge into the correct artifact kinds (directive,
+  tactic, procedure, paradigm, styleguide, toolguide, template, and optionally an agent
+  profile), registers them in the DRG, and validates the result. Intended audience: anyone who
+  has a working agent built outside the pack and wants it governed and shareable. This is
+  distinct from migrate-project-guidance-to-spec-kitty-charter, which converts an existing
+  guidance or charter document; this procedure starts from an agent that was authored from
+  scratch, not from a body of legacy doctrine.
+entry_condition: >
+  An agent exists outside the pack — in any format, for example Cursor rules, a prompt, a
+  no-code bot, a framework script, a custom GPT, or a written description in a wiki or Markdown
+  document — and its owner wants to bring its behaviour under governance. The owner can describe
+  the agent's purpose and point to or provide its instructions, tools, documentation, and
+  example behaviour; the owner does not need to be technical. The pack validates cleanly before
+  any new work begins.
+exit_condition: >
+  Pack validation reports zero errors (zero advisories preferred; residual advisories require
+  documented justification). Every artifact extracted from the source agent is written under the
+  correct pack subdirectory and registered in the DRG with appropriate edges. If a dedicated
+  agent profile was warranted it is created; if not, the decision not to create one is recorded.
+  spec-kitty doctor doctrine reports the pack installed with the expected artifact counts.
+steps:
+  - title: Confirm baseline validation passes
+    actor: agent
+    description: >
+      Before extracting anything, run the pack validation gate and record the result. If errors
+      exist, stop and fix them before proceeding — adding new artifacts on top of a broken
+      baseline compounds errors and obscures root cause. Record the baseline error and advisory
+      counts in the work log.
+  - title: Interview the agent owner and gather all source material and documentation
+    actor: agent
+    description: >
+      Work with the agent's owner to understand what the agent is and gather the raw material.
+      The owner may not be technical, so conduct the interview in plain language: ask what the
+      agent is for, who uses it, what a good result looks like, and what it must never do. Where
+      other specialist profiles are available, collaborate with them — for example a requirements
+      analyst to structure fuzzy or informal requirements into testable statements, or a
+      synthesis specialist to consolidate scattered documents into a single coherent picture.
+
+      Do not assume; ask for the actual artifacts and ALL supporting documentation, in whatever
+      form it exists. Request explicitly:
+
+        - The owner's plain-language statement of what the agent is FOR and what it must never do.
+        - Any written documentation about the agent: Markdown files (READMEs, design notes,
+          AGENTS.md) and wiki pages. Ask for links or titles and retrieve them.
+        - The agent's defining instructions in whatever format it was built — a system prompt or
+          persona definition, Cursor rules files (.cursor/rules/*.md, .mdc, AGENTS.md fragments),
+          a no-code bot configuration, a framework script (LangChain / CrewAI / AutoGen), a
+          custom GPT's instructions, etc.
+        - Any embedded tool, API, or MCP configuration the agent depends on.
+        - Example inputs and outputs (or transcripts) that show the agent's intended behaviour.
+
+      Produce a short source inventory / dossier before decomposing anything, and confirm your
+      understanding of the agent's purpose back to the owner before proceeding. If the owner only
+      has a vague description and no documentation, elicit concrete behaviour with examples — a
+      plausible-sounding description is not a specification.
+  - title: Audit existing pack and built-in artifacts for overlap and connections
+    actor: agent
+    description: >
+      Before classifying source material, inventory the registered artifact ids across the
+      existing pack and the shipped built-in catalog (directives, tactics, procedures, paradigms,
+      styleguides, toolguides, agent profiles, and the DRG node list). For each piece of
+      knowledge identified during the interview, check whether a semantically similar artifact
+      already exists. If significant overlap is found:
+
+        - Flag it explicitly to the owner: name the overlapping artifact and describe the overlap.
+        - Propose augmenting the existing artifact (via an enhances edge or a content update)
+          rather than creating a new one.
+        - Only create a new artifact when the source agent's knowledge is genuinely distinct from
+          anything already present.
+
+      Significant overlap is flagged when ANY TWO of the following apply:
+        1. Intent equivalence — same enforcement target (same "must never" / "always" behaviour)
+           even if wording differs.
+        2. Subset relationship — the source fragment's rules are a strict subset of an existing
+           artifact's scope.
+        3. Id/title proximity — proposed id or title matches an existing id/title within
+           Levenshtein distance <= 2.
+        4. Keyword saturation — >= 60% of content-bearing tokens (nouns + verbs, stopwords
+           removed) appear in an existing artifact's intent/purpose/summary.
+        5. Owner tie-break — if exactly one criterion matches, the owner must choose augment vs.
+           create-new in writing.
+
+      Record the audit outcome in the decomposition table using an "Overlap assessment" column:
+        | Candidate id | Overlap assessment | Existing artifact (if any) | Decision (augment/new) | Rationale |
+
+      For each piece of source knowledge, also scan existing artifacts for logical relationships —
+      existing directives, procedures, or paradigms that the new artifacts should reference,
+      apply, or require. Record these as candidate DRG edges; they are added in the registration
+      step.
+  - title: Decompose the agent's knowledge into candidate artifact kinds
+    actor: agent
+    description: >
+      Prerequisite: the overlap audit from the previous step must be complete and its outcomes
+      recorded in the decomposition table before beginning classification.
+
+      Read the source material and separate it into discrete pieces of knowledge. For each piece,
+      classify it by the kind of pack artifact it should become. A single source agent usually
+      yields several artifacts of different kinds.
+
+        Knowledge signal                                          -> Pack artifact kind
+        ------------------------------------------------------------------------------------
+        A non-negotiable rule or policy ("always", "never", "must") -> directive
+        A reusable technique or how-to with ordered steps but no
+          entry/exit gate                                           -> tactic
+        A multi-step workflow WITH entry_condition, exit_condition,
+          and named actors                                          -> procedure
+        A mental model, philosophy, or design assumption            -> paradigm
+        A naming, formatting, or coding convention with good/bad
+          examples                                                  -> styleguide
+        Knowledge about how to use a tool, platform, or MCP         -> toolguide
+        A structured fill-in-the-blanks output format or reusable
+          document scaffold                                         -> template
+        The persona/identity wrapper itself (who the agent is, its
+          routing, its boundaries)                                  -> agent_profile (see the profile-decision step)
+
+      Where the line between a tactic and a procedure blurs, use the gate test: if the work has an
+      explicit start condition, a definite "done" condition, and distinct actors, it is a
+      procedure; otherwise it is a tactic. When a single block mixes a policy rule with the steps
+      to satisfy it, split it: a directive for the rule and a tactic or procedure for the steps,
+      linked by a DRG edge.
+
+      Produce a decomposition table before writing any YAML:
+        | Source fragment | Artifact kind | Proposed id | Target path |
+  - title: Author each artifact as typed YAML
+    actor: agent
+    description: >
+      For each row in the decomposition table, create the YAML under the matching pack
+      subdirectory using the minimum required fields for that kind, following the artifact
+      schemas. Do not invent fields outside the schema. Preserve the concrete guidance, examples,
+      and anti-patterns from the source agent; do not discard detail on the assumption it is
+      obvious. When a single block mixes a policy rule with the steps to satisfy it, keep the rule
+      in a directive and the steps in a tactic or procedure, linked by a DRG edge. Cite related
+      artifacts by their id, never by file path.
+  - title: Check content-DRG consistency and flag external references
+    actor: agent
+    description: >
+      For each newly authored artifact, scan all text fields (intent, scope, summary, principles,
+      purpose, description, etc.) for:
+
+      1. Cross-artifact references — any artifact id appearing in prose. Every such reference must
+         be backed by a DRG edge. If the edge is missing, add it now rather than deferring to the
+         registration step, so content and graph stay in sync. Filter extracted tokens against the
+         id inventory and the DRG node list before flagging; tokens not in either inventory are
+         not artifact ids.
+
+      2. External references — a URL, a named third-party product/API/platform (e.g. OpenAI,
+         LangChain, CrewAI, AutoGen, GitHub, AWS, Azure, GCP service names), or an external system
+         identifier not covered by any pack toolguide. For each one: check whether a toolguide
+         already covers it; if so, add a DRG edge from the artifact to that toolguide; if not,
+         flag it as an undocumented external dependency and ask the owner whether it warrants a
+         toolguide or should be documented explicitly in the artifact's scope/notes.
+
+      Illustrative source-format examples in this procedure's own prose are exempt; the check
+      applies only to the content of the artifacts being authored. Do not proceed with unresolved
+      external dependencies unless the owner has explicitly acknowledged them.
+  - title: Decide whether the agent needs a dedicated agent profile
+    actor: human
+    description: >
+      Not every onboarded agent needs its own profile. Decide explicitly:
+
+        Create an agent profile when the agent represents a distinct, reusable role with its own
+        routing, capabilities, and boundaries that team members will invoke by name.
+
+        Do NOT create a profile when the agent's value is fully captured by the extracted
+        directives, tactics, and toolguides, and an existing built-in or pack profile can carry
+        that behaviour via DRG edges. In that case, record the decision and wire the new artifacts
+        to the existing profile instead.
+
+      If a profile is warranted, author it with the required profile fields (profile-id,
+      schema-version, at least one role and one capability). Do not paste the agent's operating
+      steps into the profile's specialization block — multi-step workflows belong in a procedure
+      or tactic that the profile references through a DRG edge. Embedding procedures in a profile
+      is an anti-pattern.
+  - title: Register every new artifact in the DRG and regenerate the compiled graph
+    actor: agent
+    description: >
+      Add each new artifact's relationships to the pack's DRG fragment as typed edges, following
+      the field order and indentation of existing entries. Common patterns: a directive suggests
+      or requires a tactic; an agent profile applies a procedure, paradigm, or toolguide; an agent
+      profile requires a governance directive; agent lineage is a specializes_from edge.
+
+      Author lineage and augmentation exclusively as DRG edges — never as an inline
+      specializes-from/enhances/overrides field on the artifact YAML; the validator rejects those
+      fields.
+
+      The runtime reads the DRG fragment, but the committed compiled graph must be regenerated so
+      CI and the validator see the same node/edge set. Regenerate it per the pack's build tooling
+      and confirm the new nodes and edges appear in the regenerated graph.
+  - title: Run validation and fix errors
+    actor: agent
+    description: >
+      After writing each artifact (or in batches of 3-5), run pack validation. Resolve schema
+      errors (id pattern violations, controlled-vocabulary fields, required example pairs on
+      patterns/anti_patterns, disallowed extra fields). An id collision with a shipped built-in
+      surfaces as an advisory; resolve it by declaring an enhances/overrides edge with rationale,
+      or rename if the collision is accidental. For any template/styleguide pair, verify
+      bidirectional linkage in both directions.
+  - title: Final verification and handoff
+    actor: human
+    description: >
+      Run the full verification suite: pack validation (expect zero errors) and
+      spec-kitty doctor doctrine (expect the pack installed with matching counts). If
+      spec-kitty doctor doctrine is unavailable, verify manually that there are no duplicate ids
+      within a kind and that each new artifact has a DRG node and at least one edge.
+
+      Summarise in the work log: how many artifacts of each kind were created, whether a profile
+      was added, and the final validation counts. Hand the result back to the agent owner for
+      review before the change is proposed for promotion into shared doctrine.
+anti_patterns:
+  - name: Decomposing before understanding the agent
+    description: >
+      Jumping to artifact authoring before the owner has been interviewed, the available
+      documentation gathered, and the agent's purpose confirmed back to the owner. Converting an
+      agent you do not fully understand produces artifacts that misrepresent its behaviour. Gather
+      the source material and confirm understanding first.
+  - name: Lifting the whole prompt into a single artifact
+    description: >
+      Copying an entire system prompt or rules file verbatim into one directive or one agent
+      profile. A source agent almost always contains several distinct kinds of knowledge — rules,
+      techniques, tool usage, and conventions. Decompose it into the correct artifact kinds so
+      each piece is independently governable and reusable, rather than trapping everything in one
+      opaque blob.
+  - name: Embedding the workflow inside the agent profile
+    description: >
+      Pasting the agent's step-by-step operating instructions into the specialization block of the
+      agent profile YAML. This hides a testable workflow inside a container not meant to hold
+      procedural content. Extract the workflow as a procedure or tactic and link it from the
+      profile via a DRG edge.
+  - name: Creating an agent profile by default
+    description: >
+      Authoring a new agent profile for every onboarded agent without checking whether the
+      behaviour is already covered by the extracted directives, tactics, and toolguides wired to
+      an existing profile. New profiles add routing and maintenance surface; only create one when
+      the agent is a distinct reusable role.
+  - name: Authoring lineage as an inline profile field
+    description: >
+      Adding specializes-from directly on the agent profile YAML. The profile validator rejects
+      this field. Express lineage and augmentation exclusively as specializes_from edges in the
+      DRG.
+  - name: Skipping the compiled DRG regeneration
+    description: >
+      Editing the DRG fragment but forgetting to regenerate the compiled graph. The runtime sees
+      the fragment, but CI and the validator consume the committed compiled graph; an out-of-date
+      graph produces silent divergence between what runs locally and what is reviewed.
+  - name: Skipping the existing-artifact overlap audit
+    description: >
+      Id-only deduplication without a semantic read: declaring two artifacts non-overlapping
+      because their ids and titles differ, without reading their intent or enforcement fields. Two
+      directives with different ids can have identical enforcement targets — the duplicate creates
+      governance noise and splits authority. Always read intent, scope, and enforcement before
+      concluding no overlap exists.
+  - name: Citing file paths instead of artifact ids
+    description: >
+      Writing an artifact's file path in another artifact's prose instead of the canonical id.
+      File paths are not validated by the DRG and are fragile to reorganisation; the DRG only
+      tracks id-to-id edges.
+  - name: Ignoring external references
+    description: >
+      Authoring an artifact that assumes availability of an external tool, API, or platform and
+      proceeding without the owner explicitly acknowledging that dependency. The content-DRG
+      consistency step requires the owner to decide whether to author a toolguide or document the
+      dependency — do not treat silence as acceptance.
+references:
+  - type: directive
+    id: DIRECTIVE_003
+    reason: Every classification, overlap-versus-augment call, and the profile-or-no-profile decision must be recorded with rationale.
+  - type: directive
+    id: DIRECTIVE_018
+    reason: Onboarded artifacts change doctrine layers and must be versioned with documented change rationale.
+  - type: directive
+    id: DIRECTIVE_032
+    reason: Confirm shared understanding of artifact-kind terminology with the owner before decomposing.

--- a/src/doctrine/procedures/built-in/onboard-external-agent-to-pack.procedure.yaml
+++ b/src/doctrine/procedures/built-in/onboard-external-agent-to-pack.procedure.yaml
@@ -59,10 +59,11 @@ steps:
         - Any embedded tool, API, or MCP configuration the agent depends on.
         - Example inputs and outputs (or transcripts) that show the agent's intended behaviour.
 
-      Produce a short source inventory / dossier before decomposing anything, and confirm your
-      understanding of the agent's purpose back to the owner before proceeding. If the owner only
-      has a vague description and no documentation, elicit concrete behaviour with examples — a
-      plausible-sounding description is not a specification.
+      Produce a short source inventory / dossier using the source-agent-dossier-template before
+      decomposing anything, and confirm your understanding of the agent's purpose back to the
+      owner before proceeding. If the owner only has a vague description and no documentation,
+      elicit concrete behaviour with examples — a plausible-sounding description is not a
+      specification.
   - title: Audit existing pack and built-in artifacts for overlap and connections
     actor: agent
     description: >
@@ -129,7 +130,8 @@ steps:
       to satisfy it, split it: a directive for the rule and a tactic or procedure for the steps,
       linked by a DRG edge.
 
-      Produce a decomposition table before writing any YAML:
+      Produce a decomposition table using the decomposition-table-template before writing any
+      YAML:
         | Source fragment | Artifact kind | Proposed id | Target path |
   - title: Author each artifact as typed YAML
     actor: agent
@@ -213,9 +215,10 @@ steps:
       spec-kitty doctor doctrine is unavailable, verify manually that there are no duplicate ids
       within a kind and that each new artifact has a DRG node and at least one edge.
 
-      Summarise in the work log: how many artifacts of each kind were created, whether a profile
-      was added, and the final validation counts. Hand the result back to the agent owner for
-      review before the change is proposed for promotion into shared doctrine.
+      Summarise the final artifact set using the onboarded-artifact-set-template: how many
+      artifacts of each kind were created, whether a profile was added, and the final validation
+      counts. Hand the result back to the agent owner for review before the change is proposed
+      for promotion into shared doctrine.
 anti_patterns:
   - name: Decomposing before understanding the agent
     description: >
@@ -280,3 +283,12 @@ references:
   - type: directive
     id: DIRECTIVE_032
     reason: Confirm shared understanding of artifact-kind terminology with the owner before decomposing.
+  - type: template
+    id: source-agent-dossier-template
+    reason: Provides the evidence record required before decomposing the external agent.
+  - type: template
+    id: decomposition-table-template
+    reason: Provides the repeatable classification and overlap-audit table used before YAML authoring.
+  - type: template
+    id: onboarded-artifact-set-template
+    reason: Provides the final handoff record for created artifacts, DRG changes, and validation evidence.

--- a/src/doctrine/templates/README.md
+++ b/src/doctrine/templates/README.md
@@ -8,6 +8,7 @@ missions.
 
 | Directory | Purpose |
 |-----------|---------|
+| `agent-onboarding/` | External-agent onboarding evidence, decomposition, and handoff templates |
 | `architecture/` | Architectural design document templates (ADRs, stakeholder personas, user journeys) |
 | `command-templates/` | Prompt files for `/spec-kitty.*` slash commands |
 | `sets/` | Named bundles grouping related templates for coordinated deployment |

--- a/src/doctrine/templates/agent-onboarding/decomposition-table-template.md
+++ b/src/doctrine/templates/agent-onboarding/decomposition-table-template.md
@@ -1,0 +1,29 @@
+# Agent Knowledge Decomposition: {{ agent_name }}
+
+> Purpose: Map source-agent knowledge fragments to doctrine artifact candidates before authoring YAML.
+
+| Field | Value |
+|-------|-------|
+| Source agent | {{ agent_name }} |
+| Owner | {{ owner }} |
+| Date | {{ date }} |
+| Dossier | {{ source_agent_dossier_link }} |
+| Status | Draft / Reviewed / Accepted |
+
+## Decomposition Table
+
+| Source fragment | Artifact kind | Proposed id | Target path | Overlap assessment | Existing artifact (if any) | Decision | Rationale |
+|-----------------|---------------|-------------|-------------|--------------------|----------------------------|----------|-----------|
+| {{ fragment }} | directive / tactic / procedure / paradigm / styleguide / toolguide / template / agent_profile | {{ id }} | {{ path }} | None / Partial / Strong | {{ artifact_id_or_none }} | New / Augment / Defer | {{ rationale }} |
+
+## Candidate DRG Edges
+
+| Source artifact | Target artifact | Relation | Rationale |
+|-----------------|-----------------|----------|-----------|
+| {{ source_id }} | {{ target_id }} | requires / suggests / applies / enhances / overrides / specializes_from | {{ rationale }} |
+
+## Open Decisions
+
+| Decision | Owner | Due | Current default |
+|----------|-------|-----|-----------------|
+| {{ decision }} | {{ owner }} | {{ date }} | {{ default }} |

--- a/src/doctrine/templates/agent-onboarding/onboarded-artifact-set-template.md
+++ b/src/doctrine/templates/agent-onboarding/onboarded-artifact-set-template.md
@@ -1,0 +1,36 @@
+# Onboarded Artifact Set: {{ agent_name }}
+
+> Purpose: Record the final doctrine artifacts created or updated during external-agent onboarding.
+
+| Field | Value |
+|-------|-------|
+| Source agent | {{ agent_name }} |
+| Owner | {{ owner }} |
+| Date | {{ date }} |
+| Dossier | {{ source_agent_dossier_link }} |
+| Decomposition table | {{ decomposition_table_link }} |
+| Validation status | Not run / Passed / Passed with advisories / Failed |
+
+## Created Artifacts
+
+| Artifact kind | Artifact id | Path | DRG node present? | Notes |
+|---------------|-------------|------|-------------------|-------|
+| {{ kind }} | {{ artifact_id }} | {{ path }} | Yes / No | {{ notes }} |
+
+## Updated Artifacts
+
+| Artifact kind | Artifact id | Change summary | DRG edge changes |
+|---------------|-------------|----------------|------------------|
+| {{ kind }} | {{ artifact_id }} | {{ summary }} | {{ edges }} |
+
+## Validation Evidence
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| Pack validation | Passed / Failed | {{ command_or_link }} |
+| DRG regeneration | Passed / Failed | {{ command_or_link }} |
+| Sensitivity scan | Passed / Failed | {{ command_or_link }} |
+
+## Handoff Notes
+
+Summarise remaining risks, deferred decisions, and reviewer instructions.

--- a/src/doctrine/templates/agent-onboarding/source-agent-dossier-template.md
+++ b/src/doctrine/templates/agent-onboarding/source-agent-dossier-template.md
@@ -1,0 +1,42 @@
+# Source Agent Dossier: {{ agent_name }}
+
+> Purpose: Capture enough evidence about an external agent to decide how it should be represented as doctrine artifacts.
+
+| Field | Value |
+|-------|-------|
+| Source agent name | {{ agent_name }} |
+| Owner / contact | {{ owner }} |
+| Date | {{ date }} |
+| Source format | Prompt / rules / script / bot config / wiki / other |
+| Current users | {{ users_or_teams }} |
+| Status | Draft / Reviewed / Accepted |
+
+## Purpose
+
+What is the agent for?
+
+## Non-Goals And Boundaries
+
+What must the agent not do?
+
+## Source Material Inventory
+
+| Source | Location or description | Owner | Reviewed? | Notes |
+|--------|-------------------------|-------|-----------|-------|
+| {{ source }} | {{ location }} | {{ owner }} | No | {{ notes }} |
+
+## Tools And External Dependencies
+
+| Dependency | Purpose | Existing toolguide? | Decision |
+|------------|---------|---------------------|----------|
+| {{ dependency }} | {{ purpose }} | Yes / No | Add toolguide / document / remove |
+
+## Example Behaviour
+
+| Input / trigger | Expected output | Evidence source |
+|-----------------|-----------------|-----------------|
+| {{ input }} | {{ output }} | {{ source }} |
+
+## Confirmed Understanding
+
+Summarise the agent's intended behaviour in plain language and record owner confirmation.

--- a/tests/doctrine/test_shipped_profiles.py
+++ b/tests/doctrine/test_shipped_profiles.py
@@ -34,6 +34,7 @@ EXPECTED_PROFILE_IDS = {
     "curator-carla",
     "debugger-debbie",
     "designer-dagmar",
+    "doctrine-daphne",
     "generic-agent",
     "human-in-charge",
     "implementer-ivan",
@@ -192,6 +193,7 @@ class TestShippedProfilesRoles:
             ("randy-reducer", Role.IMPLEMENTER),
             ("researcher-robbie", Role.RESEARCHER),
             ("curator-carla", Role.CURATOR),
+            ("doctrine-daphne", Role.CURATOR),
         ],
     )
     def test_profile_has_correct_role(
@@ -277,6 +279,7 @@ class TestShippedProfilesContent:
             ("randy-reducer", 70),
             ("researcher-robbie", 40),
             ("curator-carla", 40),
+            ("doctrine-daphne", 48),
         ],
     )
     def test_routing_priority(
@@ -308,6 +311,7 @@ class TestShippedProfilesContent:
             ("randy-reducer", 2),
             ("researcher-robbie", 4),
             ("curator-carla", 6),
+            ("doctrine-daphne", 4),
         ],
     )
     def test_max_concurrent_tasks(


### PR DESCRIPTION
Adds doctrine-daphne as a shipped built-in agent profile.

Role: external-agent onboarding and doctrine artifact curation specialist.
Sanitised for open source — no org-specific tooling, branding, or internal references.
Updates built-in profiles README table.

## Test plan
- [ ] `spec-kitty doctor doctrine` passes with the new profile present
- [ ] Built-in profiles README table is correct and in alphabetical order

Also registers doctrine-daphne in the DRG (src/doctrine/graph.yaml) and adds
her sanitised onboard-external-agent-to-pack procedure as a built-in.