### PR TITLE
fix: harden sonar security findings

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1145,7 +1145,7 @@ def _ensure_workspace_materialized(
     workspace: ResolvedWorkspace,
     wp_id: str,
     create_workspace: Callable[[], None],
-) -> ResolvedWorkspace:
+) -> None:
     """Ensure the already-resolved *workspace* is materialized on disk.
 
     FR-008/#1832 (C-IC05) — single resolution path. *workspace* is the
@@ -1159,8 +1159,6 @@ def _ensure_workspace_materialized(
     workspace could be resolved" on a verified read-path — is exactly what this
     function eliminates.
 
-    Returns the (unchanged) resolved workspace once materialized.
-
     Raises:
         typer.Exit: husk detected, creation attempted from a worktree, or the
             path was not materialized after creation.
@@ -1170,7 +1168,7 @@ def _ensure_workspace_materialized(
         raise typer.Exit(1)
 
     if workspace.exists:
-        return workspace
+        return
 
     cwd = Path.cwd().resolve()
     if is_worktree_context(cwd):
@@ -1197,7 +1195,7 @@ def _ensure_workspace_materialized(
             f"for {wp_id} was not materialized."
         )
         raise typer.Exit(1)
-    return workspace
+    return
 
 
 @app.command(name="implement")
@@ -1416,9 +1414,7 @@ def implement(
                 actor=agent,
             )
 
-        workspace = _ensure_workspace_materialized(
-            workspace, normalized_wp_id, _create_workspace
-        )
+        _ensure_workspace_materialized(workspace, normalized_wp_id, _create_workspace)
         workspace_path = workspace.worktree_path
 
         subtask_ids = [str(item) for item in wp_meta.subtasks if isinstance(item, str)]

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -842,12 +842,20 @@ def _assert_status_surface_path_is_trusted(
     union of both roots would be a behavior change (research.md §(d)).
     """
     repo_resolved = get_main_repo_root(repo_root).resolve(strict=False)
-    trusted_root = (
-        (repo_resolved / WORKTREES_DIR).resolve(strict=False)
-        if is_under_worktrees_segment(status_feature_dir)
-        else (repo_resolved / KITTY_SPECS_DIR).resolve(strict=False)
-    )
-    return ensure_within_any(status_feature_dir, roots=[trusted_root])
+    worktrees_root = (repo_resolved / WORKTREES_DIR).resolve(strict=False)
+    kitty_specs_root = (repo_resolved / KITTY_SPECS_DIR).resolve(strict=False)
+    status_resolved = status_feature_dir.resolve(strict=False)
+    segment_claims_worktrees = is_under_worktrees_segment(status_feature_dir)
+    resolves_under_worktrees = status_resolved.is_relative_to(worktrees_root)
+    resolves_under_kitty_specs = status_resolved.is_relative_to(kitty_specs_root)
+
+    if segment_claims_worktrees != resolves_under_worktrees:
+        raise ValueError(f"Untrusted status surface path: {status_feature_dir}")
+    if not resolves_under_worktrees and not resolves_under_kitty_specs:
+        raise ValueError(f"Untrusted status surface path: {status_feature_dir}")
+
+    trusted_root = worktrees_root if resolves_under_worktrees else kitty_specs_root
+    return ensure_within_any(status_resolved, roots=[trusted_root])
 
 
 def _restore_optional_bytes(path: Path, original: bytes | None) -> None:

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -32,6 +32,7 @@ from contextlib import suppress
 from datetime import datetime, UTC
 from pathlib import Path
 from dataclasses import dataclass
+from typing import NoReturn
 
 import typer
 
@@ -218,7 +219,7 @@ def _emit(envelope: dict) -> None:
     print(json.dumps(envelope))
 
 
-def _fail(command: str, error_code: str, message: str, data: dict | None = None) -> None:
+def _fail(command: str, error_code: str, message: str, data: dict | None = None) -> NoReturn:
     """Print failure envelope and exit non-zero."""
     envelope = make_envelope(
         command=command,
@@ -364,10 +365,8 @@ def _resolve_mission_dir_or_fail(command: str, main_repo_root: Path, mission_slu
                 "primary_candidate": str(exc.primary_candidate),
             },
         )
-        raise  # unreachable: _fail exits
     if mission_dir is None:
         _fail(command, "MISSION_NOT_FOUND", _MISSION_NOT_FOUND_MESSAGE.format(mission=mission_slug))
-        raise  # unreachable: _fail exits
     return mission_dir
 
 

--- a/src/specify_cli/tool_surface/bundles/claude_wrapper.py
+++ b/src/specify_cli/tool_surface/bundles/claude_wrapper.py
@@ -75,8 +75,8 @@ echo Install spec-kitty: pip install spec-kitty-cli
 EXIT /B 1
 """
 
-# Octal mode bits for an executable file: rwxr-xr-x (755).
-_EXECUTABLE_MODE = 0o755
+# Octal mode bits for a user-only executable file: rwx------ (700).
+_EXECUTABLE_MODE = 0o700
 
 
 def write_wrappers(bundle_dir: Path, version: str) -> None:

--- a/tests/specify_cli/cli/commands/agent/test_implement_single_resolution.py
+++ b/tests/specify_cli/cli/commands/agent/test_implement_single_resolution.py
@@ -107,9 +107,9 @@ def test_already_materialized_workspace_is_consumed_without_re_resolution(
     def _create() -> None:  # pragma: no cover - must not be called
         raise AssertionError("create must not run when the workspace already exists")
 
-    result = _ensure_workspace_materialized(workspace, "WP05", _create)
+    _ensure_workspace_materialized(workspace, "WP05", _create)
 
-    assert result is workspace  # same resolved contract, consumed not rebuilt
+    assert workspace.exists  # same resolved contract, consumed not rebuilt
     assert resolve_calls == [], "single resolution path must not re-resolve"
 
 
@@ -145,10 +145,9 @@ def test_create_then_consume_resolved_context_no_no_workspace_error(
             "gitdir: /real/gitdir\n", encoding="utf-8"
         )
 
-    result = _ensure_workspace_materialized(workspace, "WP05", _create)
+    _ensure_workspace_materialized(workspace, "WP05", _create)
 
-    assert result is workspace
-    assert result.exists, "the materialized resolved workspace must report exists"
+    assert workspace.exists, "the materialized resolved workspace must report exists"
     assert re_resolution_calls == [], (
         "post-create verification must consume the resolved context, "
         "not re-resolve via a second authority"

--- a/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
+++ b/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
@@ -3,7 +3,7 @@
 Covers:
     - write_wrappers creates bin/spec-kitty-wrapper (bash) and .cmd (Windows)
     - Version placeholder is substituted with the real version
-    - bash wrapper is executable (mode 755)
+    - bash wrapper is executable (mode 700)
     - wrapper_bash_content / wrapper_cmd_content helper functions
     - Empty version raises ValueError
     - Wrappers are idempotent (second call overwrites cleanly)
@@ -64,9 +64,9 @@ class TestWriteWrappers:
         mode = os.stat(bash_path).st_mode
         # Must be executable by owner (user bit).
         assert mode & stat.S_IXUSR, "bash wrapper must be owner-executable"
-        # Must be executable by group and others too (755).
-        assert mode & stat.S_IXGRP, "bash wrapper must be group-executable"
-        assert mode & stat.S_IXOTH, "bash wrapper must be world-executable"
+        # Wrapper is user-only executable (700) to avoid widening access.
+        assert not mode & stat.S_IXGRP, "bash wrapper must not be group-executable"
+        assert not mode & stat.S_IXOTH, "bash wrapper must not be world-executable"
 
     def test_raises_on_empty_version(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="non-empty"):


### PR DESCRIPTION
## Summary
- harden merge status-surface trust checks so resolved topology must match the claimed surface
- mark orchestrator-api failure emission as non-returning and remove dead raises
- make workspace materialization a pure side-effect seam and tighten wrapper script permissions to user-only

## Validation
- `.venv/bin/pytest tests/specify_cli/cli/commands/agent/test_implement_single_resolution.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py tests/specify_cli/cli/commands/test_merge.py`
- `.venv/bin/pytest tests/next/test_query_mode_unit.py tests/specify_cli/cli/commands/test_next_fail_closed.py`
- `.venv/bin/ruff check src/specify_cli/orchestrator_api/commands.py src/specify_cli/cli/commands/agent/workflow.py src/specify_cli/cli/commands/merge.py src/specify_cli/tool_surface/bundles/claude_wrapper.py tests/specify_cli/cli/commands/agent/test_implement_single_resolution.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py`

## Notes
- GitHub code-scanning and dependabot alert API endpoints returned 404 for this public repo during the run, so the actionable scope here came from SonarCloud and repository code review.