### PR TITLE
fix: resolve SonarCloud security findings

### DIFF
--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -850,6 +850,29 @@ def _assert_status_surface_path_is_trusted(
     return ensure_within_any(status_feature_dir, roots=[trusted_root])
 
 
+def _assert_status_surface_file_path_is_trusted(
+    *,
+    repo_root: Path,
+    status_feature_dir: Path,
+    filename: str,
+) -> Path:
+    """Reject status-surface child paths outside the exact bookkeeping files."""
+    if filename not in {_STATUS_EVENTS_FILENAME, _STATUS_FILENAME}:
+        raise ValueError(f"Refusing untrusted status filename: {filename}")
+    trusted_surface = _assert_status_surface_path_is_trusted(
+        repo_root=repo_root,
+        status_feature_dir=status_feature_dir,
+    )
+    candidate = trusted_surface / filename
+    if candidate.is_symlink():
+        raise ValueError(f"Refusing symlinked status surface path: {candidate}")
+    return ensure_within_any(
+        candidate,
+        roots=[],
+        files=[trusted_surface / _STATUS_EVENTS_FILENAME, trusted_surface / _STATUS_FILENAME],
+    )
+
+
 def _restore_optional_bytes(path: Path, original: bytes | None) -> None:
     if original is None:
         path.unlink(missing_ok=True)
@@ -935,40 +958,48 @@ def _project_status_bookkeeping_to_target(
         mission_slug=mission_slug,
         status_feature_dir=status_feature_dir,
     )
-    _assert_status_surface_path_is_trusted(
+    trusted_status_feature_dir = _assert_status_surface_path_is_trusted(
         repo_root=main_repo,
         status_feature_dir=status_feature_dir,
     )
-    _assert_status_path_within_target_surface(
+    trusted_target_events_path = _assert_status_path_within_target_surface(
         repo_root=main_repo,
         mission_slug=mission_slug,
         candidate=target_events_path,
     )
-    _assert_status_path_within_target_surface(
+    trusted_target_status_path = _assert_status_path_within_target_surface(
         repo_root=main_repo,
         mission_slug=mission_slug,
         candidate=target_status_path,
     )
-    if not is_under_worktrees_segment(status_feature_dir):
-        return target_events_path, target_status_path
+    if not is_under_worktrees_segment(trusted_status_feature_dir):
+        return trusted_target_events_path, trusted_target_status_path
 
-    target_events_path.parent.mkdir(parents=True, exist_ok=True)
-    source_events_path = status_feature_dir / _STATUS_EVENTS_FILENAME
-    source_status_path = status_feature_dir / _STATUS_FILENAME
+    trusted_target_events_path.parent.mkdir(parents=True, exist_ok=True)
+    source_events_path = _assert_status_surface_file_path_is_trusted(
+        repo_root=main_repo,
+        status_feature_dir=trusted_status_feature_dir,
+        filename=_STATUS_EVENTS_FILENAME,
+    )
+    source_status_path = _assert_status_surface_file_path_is_trusted(
+        repo_root=main_repo,
+        status_feature_dir=trusted_status_feature_dir,
+        filename=_STATUS_FILENAME,
+    )
     source_events_bytes = _read_optional_bytes(source_events_path)
     source_status_bytes = _read_optional_bytes(source_status_path)
-    original_events_bytes = _read_optional_bytes(target_events_path)
-    original_status_bytes = _read_optional_bytes(target_status_path)
+    original_events_bytes = _read_optional_bytes(trusted_target_events_path)
+    original_status_bytes = _read_optional_bytes(trusted_target_status_path)
     try:
         if source_events_bytes is not None:
-            target_events_path.write_bytes(source_events_bytes)
+            trusted_target_events_path.write_bytes(source_events_bytes)
         if source_status_bytes is not None:
-            target_status_path.write_bytes(source_status_bytes)
+            trusted_target_status_path.write_bytes(source_status_bytes)
     except OSError:
-        _restore_optional_bytes(target_events_path, original_events_bytes)
-        _restore_optional_bytes(target_status_path, original_status_bytes)
+        _restore_optional_bytes(trusted_target_events_path, original_events_bytes)
+        _restore_optional_bytes(trusted_target_status_path, original_status_bytes)
         raise
-    return target_events_path, target_status_path
+    return trusted_target_events_path, trusted_target_status_path
 
 
 def _already_baked(merge_state: MergeState | None) -> bool:

--- a/src/specify_cli/dashboard/templates/glossary.html
+++ b/src/specify_cli/dashboard/templates/glossary.html
@@ -192,6 +192,17 @@ body {
   border-radius: 4px;
   padding: 2px 5px;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 
 .search-wrap {
   position: relative;
@@ -481,6 +492,7 @@ body {
 <div class="toolbar">
   <div class="search-wrap">
     <span class="search-icon">🔍</span>
+    <label for="search" class="sr-only">Search glossary terms</label>
     <input
       type="search"
       class="search-input"

--- a/src/specify_cli/tool_surface/bundles/claude_wrapper.py
+++ b/src/specify_cli/tool_surface/bundles/claude_wrapper.py
@@ -75,8 +75,8 @@ echo Install spec-kitty: pip install spec-kitty-cli
 EXIT /B 1
 """
 
-# Octal mode bits for an executable file: rwxr-xr-x (755).
-_EXECUTABLE_MODE = 0o755
+# Owner-only executable file permissions: rwx------ (700).
+_EXECUTABLE_MODE = 0o700
 
 
 def write_wrappers(bundle_dir: Path, version: str) -> None:
@@ -84,7 +84,7 @@ def write_wrappers(bundle_dir: Path, version: str) -> None:
 
     Both files are generated under ``bundle_dir / "bin"`` with ``version``
     substituted for :data:`_VERSION_PLACEHOLDER`.  The bash script is made
-    executable (mode 755); Windows filesystem permissions are unchanged.
+    owner-executable (mode 700); Windows filesystem permissions are unchanged.
 
     Parameters
     ----------

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -854,6 +854,29 @@ def test_project_status_bookkeeping_rejects_wrong_primary_mission_surface(
         )
 
 
+def test_project_status_bookkeeping_rejects_tainted_status_file_symlink(
+    coord_branch_mission: dict,
+) -> None:
+    """Coord status reads must stay pinned to the exact two trusted filenames."""
+    repo_root = coord_branch_mission["repo_root"]
+    coord_specs = coord_branch_mission["coord_specs"]
+
+    outside = repo_root / "outside.json"
+    outside.write_text('{"WP01": "stolen"}\n', encoding="utf-8")
+    (coord_specs / "status.events.jsonl").write_text("new-done-event\n", encoding="utf-8")
+    status_path = coord_specs / "status.json"
+    if status_path.exists() or status_path.is_symlink():
+        status_path.unlink()
+    status_path.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symlinked status surface path"):
+        _project_status_bookkeeping_to_target(
+            main_repo=repo_root,
+            mission_slug=_COORD_SLUG,
+            status_feature_dir=coord_specs,
+        )
+
+
 def test_final_bookkeeping_rollback_restores_status_meta_and_state(tmp_path: Path) -> None:
     """Final bookkeeping rollback restores every mutable surface it snapshots."""
     coord_events = tmp_path / ".worktrees" / "m-coord" / "kitty-specs" / "m" / "status.events.jsonl"

--- a/tests/specify_cli/dashboard/test_glossary_handler.py
+++ b/tests/specify_cli/dashboard/test_glossary_handler.py
@@ -556,6 +556,7 @@ class TestGlossaryPage:
         text = body.decode("utf-8")
         assert 'id="validation-banner"' in text
         assert "fetch('/api/glossary-health')" in text
+        assert '<label for="search" class="sr-only">Search glossary terms</label>' in text
 
     def test_glossary_page_uses_cached_bytes(self, tmp_path):
         """Module-level _GLOSSARY_HTML_BYTES is reused for each request."""

--- a/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
+++ b/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
@@ -64,9 +64,8 @@ class TestWriteWrappers:
         mode = os.stat(bash_path).st_mode
         # Must be executable by owner (user bit).
         assert mode & stat.S_IXUSR, "bash wrapper must be owner-executable"
-        # Must be executable by group and others too (755).
-        assert mode & stat.S_IXGRP, "bash wrapper must be group-executable"
-        assert mode & stat.S_IXOTH, "bash wrapper must be world-executable"
+        assert not (mode & stat.S_IRWXG), "bash wrapper must not grant group permissions"
+        assert not (mode & stat.S_IRWXO), "bash wrapper must not grant other permissions"
 
     def test_raises_on_empty_version(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="non-empty"):

--- a/tests/test_dashboard/test_glossary_handler.py
+++ b/tests/test_dashboard/test_glossary_handler.py
@@ -448,6 +448,7 @@ class TestGlossaryPage:
         assert 'class="sidebar-item active" href="/glossary"' in body
         assert 'id="validation-banner"' in body
         assert "fetch('/api/glossary-health')" in body
+        assert '<label for="search" class="sr-only">Search glossary terms</label>' in body
         assert "prefers-color-scheme: dark" not in body
 
 


### PR DESCRIPTION
## Summary
- harden merge bookkeeping projection against symlink/path-tainted status file reads
- restrict generated Claude wrapper permissions to owner-only execution
- add an accessible label for the glossary search field

## Validation
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache .venv/bin/pytest tests/merge/test_merge_done_recording.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py tests/specify_cli/dashboard/test_glossary_handler.py tests/test_dashboard/test_glossary_handler.py`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache .venv/bin/pytest tests/specify_cli/cli/commands/test_merge.py`
- `UV_CACHE_DIR=/tmp/spec-kitty-uv-cache .venv/bin/ruff check src/specify_cli/cli/commands/merge.py src/specify_cli/tool_surface/bundles/claude_wrapper.py tests/merge/test_merge_done_recording.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py tests/specify_cli/dashboard/test_glossary_handler.py tests/test_dashboard/test_glossary_handler.py`

## Notes
- Investigated the two open loopback-HTTP Sonar hotspots in `src/specify_cli/core/loopback_http.py`; they remain localhost-only helpers bound to `127.0.0.1`, so no suppression or code change was added in this PR.
- No warning suppressions were introduced.