### PR TITLE
fix: tighten claude wrapper permissions

### DIFF
--- a/src/specify_cli/tool_surface/bundles/claude_wrapper.py
+++ b/src/specify_cli/tool_surface/bundles/claude_wrapper.py
@@ -75,8 +75,8 @@ echo Install spec-kitty: pip install spec-kitty-cli
 EXIT /B 1
 """
 
-# Octal mode bits for an executable file: rwxr-xr-x (755).
-_EXECUTABLE_MODE = 0o755
+# Octal mode bits for an executable file: rwxr-x--- (750).
+_EXECUTABLE_MODE = 0o750
 
 
 def write_wrappers(bundle_dir: Path, version: str) -> None:
@@ -84,7 +84,8 @@ def write_wrappers(bundle_dir: Path, version: str) -> None:
 
     Both files are generated under ``bundle_dir / "bin"`` with ``version``
     substituted for :data:`_VERSION_PLACEHOLDER`.  The bash script is made
-    executable (mode 755); Windows filesystem permissions are unchanged.
+    executable for the owner/group only (mode 750); Windows filesystem
+    permissions are unchanged.
 
     Parameters
     ----------

--- a/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
+++ b/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
@@ -3,7 +3,7 @@
 Covers:
     - write_wrappers creates bin/spec-kitty-wrapper (bash) and .cmd (Windows)
     - Version placeholder is substituted with the real version
-    - bash wrapper is executable (mode 755)
+    - bash wrapper is executable (mode 750)
     - wrapper_bash_content / wrapper_cmd_content helper functions
     - Empty version raises ValueError
     - Wrappers are idempotent (second call overwrites cleanly)
@@ -64,9 +64,9 @@ class TestWriteWrappers:
         mode = os.stat(bash_path).st_mode
         # Must be executable by owner (user bit).
         assert mode & stat.S_IXUSR, "bash wrapper must be owner-executable"
-        # Must be executable by group and others too (755).
+        # Must be executable by group too (750).
         assert mode & stat.S_IXGRP, "bash wrapper must be group-executable"
-        assert mode & stat.S_IXOTH, "bash wrapper must be world-executable"
+        assert not mode & stat.S_IXOTH, "bash wrapper must not be world-executable"
 
     def test_raises_on_empty_version(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="non-empty"):


### PR DESCRIPTION
## Summary
- tighten generated `bin/spec-kitty-wrapper` permissions from `0755` to `0750`
- update wrapper tests/docs to assert no world-executable bit
- note that open Sonar alert `pythonsecurity:S2083` in `merge.py` appears stale on older `main` commit `9f98d89fe137d9fc8ca2c347bbb3e7ceb1ec9de4`; current `main` already contains the hardening from #2018/#2019

## Validation
- `.venv/bin/pytest tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py -q`
- `.venv/bin/ruff check src/specify_cli/tool_surface/bundles/claude_wrapper.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py`
