### PR TITLE
fix: harden Sonar security write paths

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -2377,7 +2377,7 @@ def setup_plan(
                 result["blocked_reason"] = plan_blocked_reason
             # FR-006 / D-5: surface the real commit hash and the typed no-op
             # classification instead of an opaque ``commit_created: None``.
-            if plan_commit_result is not None:
+            if isinstance(plan_commit_result, CommitToBranchResult):
                 result["commit_created"] = plan_commit_result.status == "committed"
                 result["commit_hash"] = plan_commit_result.commit_hash
                 result["commit_status"] = plan_commit_result.status

--- a/src/specify_cli/cli/commands/merge.py
+++ b/src/specify_cli/cli/commands/merge.py
@@ -853,8 +853,22 @@ def _assert_status_surface_path_is_trusted(
     # mission-spec path ratchet (test_no_raw_mission_spec_paths) while keeping that
     # ratchet active over the rest of this module.
     specs_root = (repo_resolved / KITTY_SPECS_DIR).resolve(strict=False)
-    status_resolved = status_feature_dir.resolve(strict=False)
-    segment_claims_worktrees = is_under_worktrees_segment(status_feature_dir)
+    # Absolutize the candidate (anchor a relative surface to the repo root) before
+    # any containment check, then reject — pre-resolution — a path that escapes the
+    # root its segment claims. Hardens the write path against a traversal/symlink
+    # surface that would otherwise only be caught after ``.resolve()`` (#2043 Sonar).
+    status_candidate = (
+        status_feature_dir
+        if status_feature_dir.is_absolute()
+        else repo_resolved / status_feature_dir
+    ).absolute()
+    segment_claims_worktrees = is_under_worktrees_segment(status_candidate)
+    claimed_root = worktrees_root if segment_claims_worktrees else specs_root
+    try:
+        status_candidate.relative_to(claimed_root)
+    except ValueError as exc:
+        raise ValueError(f"Untrusted status surface path: {status_feature_dir}") from exc
+    status_resolved = status_candidate.resolve(strict=False)
     resolves_under_worktrees = status_resolved.is_relative_to(worktrees_root)
     resolves_under_specs = status_resolved.is_relative_to(specs_root)
 

--- a/src/specify_cli/skills/verifier.py
+++ b/src/specify_cli/skills/verifier.py
@@ -21,6 +21,7 @@ from specify_cli.skills.paths import get_primary_global_skill_root
 from specify_cli.skills.registry import SkillRegistry
 from specify_cli.skills.command_renderer import ensure_skill_frontmatter
 from specify_cli.template import get_local_repo_root
+from specify_cli.upgrade.skill_update import is_external_symlink
 
 logger = logging.getLogger(__name__)
 
@@ -145,10 +146,22 @@ def repair_skills(
                 try:
                     dest.symlink_to(global_source)
                 except OSError:
-                    _copy_skill_file(source_path, dest, entry.skill_name, entry.source_file)
+                    _copy_skill_file(
+                        source_path,
+                        dest,
+                        project_path,
+                        entry.skill_name,
+                        entry.source_file,
+                    )
                     delivery_mode = "copy"
             else:
-                _copy_skill_file(source_path, dest, entry.skill_name, entry.source_file)
+                _copy_skill_file(
+                    source_path,
+                    dest,
+                    project_path,
+                    entry.skill_name,
+                    entry.source_file,
+                )
             new_hash = compute_content_hash(dest)
             # Update the manifest entry with the new hash
             manifest.add_entry(
@@ -259,8 +272,16 @@ def _project_managed_path(project_path: Path, installed_path: str) -> Path:
     return normalized
 
 
-def _copy_skill_file(source: Path, dest: Path, skill_name: str, source_file: str) -> None:
+def _copy_skill_file(
+    source: Path,
+    dest: Path,
+    project_root: Path,
+    skill_name: str,
+    source_file: str,
+) -> None:
     """Copy a managed skill file, normalizing SKILL.md frontmatter if needed."""
+    if is_external_symlink(dest, project_root):
+        raise OSError(f"Refusing to write managed skill outside project root via symlink: {dest}")
     if source_file == SKILL_MANIFEST_FILENAME:
         content = source.read_text(encoding="utf-8")
         dest.write_text(ensure_skill_frontmatter(content, skill_name), encoding="utf-8")

--- a/src/specify_cli/tool_surface/bundles/claude_wrapper.py
+++ b/src/specify_cli/tool_surface/bundles/claude_wrapper.py
@@ -79,6 +79,20 @@ EXIT /B 1
 _EXECUTABLE_MODE = 0o700
 
 
+def _write_owner_only_executable(path: Path, content: str) -> None:
+    """Write *content* to *path* via a fresh owner-only executable temp file."""
+    temp_path = path.parent / f".{path.name}.tmp"
+    temp_path.unlink(missing_ok=True)
+    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _EXECUTABLE_MODE)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write(content)
+        temp_path.replace(path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
 def write_wrappers(bundle_dir: Path, version: str) -> None:
     """Write ``bin/spec-kitty-wrapper`` and ``bin/spec-kitty-wrapper.cmd``.
 
@@ -106,11 +120,10 @@ def write_wrappers(bundle_dir: Path, version: str) -> None:
     bin_dir.mkdir(parents=True, exist_ok=True)
 
     bash_path = bin_dir / "spec-kitty-wrapper"
-    bash_path.write_text(
+    _write_owner_only_executable(
+        bash_path,
         _BASH_WRAPPER_TEMPLATE.format(version=version),
-        encoding="utf-8",
     )
-    os.chmod(bash_path, _EXECUTABLE_MODE)
 
     cmd_path = bin_dir / "spec-kitty-wrapper.cmd"
     cmd_path.write_text(

--- a/src/specify_cli/upgrade/skill_update.py
+++ b/src/specify_cli/upgrade/skill_update.py
@@ -155,8 +155,11 @@ def apply_text_replacements(
         content = content.replace(old, new)
 
     if content != original:
-        file_path.write_text(content, encoding="utf-8")
-        return True
+        project_root = _project_root_for_skill_path(file_path)
+        if project_root is None:
+            return False
+        wrote, _warning = write_skill_text(file_path, content, project_root)
+        return wrote
     return False
 
 
@@ -233,6 +236,20 @@ def is_external_symlink(dest: Path, project_root: Path) -> bool:
         return False
     except OSError:
         return False
+
+
+def _project_root_for_skill_path(file_path: Path) -> Path | None:
+    """Infer the project root for a file living under a known skill root."""
+    resolved = file_path.resolve(strict=False)
+    for parent in resolved.parents:
+        for skill_root in SKILL_ROOTS:
+            candidate_root = (parent / skill_root).resolve(strict=False)
+            try:
+                resolved.relative_to(candidate_root)
+            except ValueError:
+                continue
+            return parent
+    return None
 
 
 def write_skill_text(

--- a/src/specify_cli/upgrade/skill_update.py
+++ b/src/specify_cli/upgrade/skill_update.py
@@ -157,6 +157,16 @@ def apply_text_replacements(
     if content != original:
         project_root = _project_root_for_skill_path(file_path)
         if project_root is None:
+            # Fail-closed: a replacement was computed but the file is not under a
+            # recognized skill root, so the HOME-managed-symlink write guard cannot
+            # anchor it. Drop the write rather than write through an unverified
+            # path, but log it — a silent drop is indistinguishable from
+            # "no replacement needed" to callers (PR #2043 review, alphonso).
+            logger.warning(
+                "Skipping text replacement for %s: not under a recognized skill "
+                "root, cannot anchor the managed-symlink write guard.",
+                file_path,
+            )
             return False
         wrote, _warning = write_skill_text(file_path, content, project_root)
         return wrote

--- a/tests/architectural/untrusted_path_audit/inventory.md
+++ b/tests/architectural/untrusted_path_audit/inventory.md
@@ -28,7 +28,7 @@ added seam calls to `dossier/`, `events/`, `migration/`, and `review/arbiter`
 | cli/commands/decision.py:464 | mission_slug | Path-join (/) | routed-through-seam (TODO) | `repo_root / KITTY_SPECS_DIR / mission_slug` then `load_meta(...)` read; raw `--mission` slug, no seam at this site. Deferred (CLI-arg, load_meta read). |
 | cli/commands/merge.py:595 | mission_slug | Path-join (/) | unreachable | Builds a *relative* `kitty-specs/<slug>/status.events.jsonl` only to stringify into a `git show <ref>:<path>` argument; no local FS open — git resolves inside the tree object. (line shifted −1 by mission 01KVJPEQ read-side adoption rebase; then +5 by mission 01KVMBD6 #2057 god-tag comment) |
 | cli/commands/merge.py:597 | mission_slug | Path-join (/) | unreachable | Same git-ref-argument path as :595 (worktree-rewrite branch); no FS sink. (line shifted −1 by mission 01KVJPEQ; then +5 by mission 01KVMBD6 #2057 god-tag comment) |
-| cli/commands/merge.py:1112 | mission_slug | Path-join (/) | routed-through-seam (TODO) | `scan_specs / mission_slug / "meta.json"` then `read_text()` after `.exists()`; raw `--mission`/target slug, no seam. Deferred (CLI-arg, .exists()+read_text). (line shifted +5 by `_assert_status_surface_path_is_trusted` rename-comment, Op 01KVJK8R; then −1 by mission 01KVJPEQ read-side adoption rebase; then +5 by mission 01KVMBD6 #2057 god-tag comment) |
+| cli/commands/merge.py:1126 | mission_slug | Path-join (/) | routed-through-seam (TODO) | `scan_specs / mission_slug / "meta.json"` then `read_text()` after `.exists()`; raw `--mission`/target slug, no seam. Deferred (CLI-arg, .exists()+read_text). (line shifted +5 by `_assert_status_surface_path_is_trusted` rename-comment, Op 01KVJK8R; then −1 by mission 01KVJPEQ read-side adoption rebase; then +5 by mission 01KVMBD6 #2057 god-tag comment; then +14 by PR #2043 `_assert_status_surface_path_is_trusted` early-containment hardening) |
 | coordination/surface_resolver.py:472 | mission_slug | Path-join (/) | unreachable | Path composed solely to populate `StatusReadPathNotFound(coord_candidate=…)` inside a `raise`; never opened/written — fail-closed diagnostic payload. (line shifted by mission 01KVGCE8 collapse; then 518→472 by mission 01KVN754 WP04 coord-empty Option B deletion of CoordinationWorktreeEmpty + 2 helpers) |
 | coordination/surface_resolver.py:477 | mission_slug | Path-join (/) | unreachable | Same fail-closed `raise` payload (`primary_candidate=…`); diagnostic Path, no FS sink. (line shifted by mission 01KVGCE8 collapse; then 523→477 by mission 01KVN754 WP04) |
 | migration/mission_state.py:1053 | run_id | Path-join (/) | trusted-source | `run_id = _compute_run_id(...)` is a SHA-256 hex digest (16 chars) derived deterministically from repo-local file content hashes — it is never a CLI argument or external input. The segment is safe by construction. |
@@ -81,7 +81,7 @@ set by routing through the canonical seam (no longer discovered by `audit.py`):
   because the vulnerability is open. Verified by the WP02 mutation review.
 - **Deferred (CLI-arg, low-risk) → follow-up #2037:** `cli/commands/agent/mission.py:320`,
   `cli/commands/agent/tasks.py:1902`, `cli/commands/decision.py:464`,
-  `cli/commands/merge.py:1112` — CLI-sourced (`--mission`) slugs with only
+  `cli/commands/merge.py:1126` — CLI-sourced (`--mission`) slugs with only
   read-only / existence-probe sinks; lower-severity threat model than the
   server-side content paths. Tracked for hardening in #2037 (parent #1868).
 

--- a/tests/cross_cutting/misc/test_acceptance_support.py
+++ b/tests/cross_cutting/misc/test_acceptance_support.py
@@ -151,6 +151,13 @@ def test_accept_command_reports_approved_wps_without_closing(
     _approve_wp(feature_repo, mission_slug, "WP02")
     run(["git", "add", "."], cwd=feature_repo)
     run(["git", "commit", "-m", "Approve WPs"], cwd=feature_repo)
+    # Accept commits the acceptance meta through the protected-primary router
+    # (01KVMBD6). A flattened mission (no coordination_branch) commits to the
+    # current ref; 'main' is protected and would be refused, so run accept from
+    # the mission branch (kitty/mission-<slug> is never protected) — mirrors the
+    # sibling diagnose tests and real usage. The local-only auth gate does not
+    # fire in CI (remote-less, SaaS-config-less fixture).
+    run(["git", "checkout", "-b", f"kitty/mission-{mission_slug}"], cwd=feature_repo)
 
     monkeypatch.chdir(feature_repo)
     result = runner.invoke(
@@ -497,6 +504,11 @@ def test_accept_does_not_require_done_evidence_for_approved_wp(
     )
     run(["git", "add", "."], cwd=feature_repo)
     run(["git", "commit", "-m", "Force-approve WP01"], cwd=feature_repo)
+    # Run accept from the mission branch: a flattened mission's acceptance commit
+    # is refused on the protected primary 'main' (01KVMBD6). kitty/mission-<slug>
+    # is never protected. Mirrors the sibling tests; the auth gate does not fire
+    # in CI (remote-less fixture).
+    run(["git", "checkout", "-b", f"kitty/mission-{mission_slug}"], cwd=feature_repo)
 
     before_events = len(read_events(feature_dir))
     monkeypatch.chdir(feature_repo)

--- a/tests/specify_cli/cli/commands/test_merge.py
+++ b/tests/specify_cli/cli/commands/test_merge.py
@@ -965,3 +965,14 @@ def test_status_surface_rejects_path_under_neither_trusted_root(tmp_path: Path) 
             repo_root=tmp_path,
             status_feature_dir=stray_path,
         )
+
+
+def test_status_surface_rejects_lexical_escape_before_resolve(tmp_path: Path) -> None:
+    """Paths claiming kitty-specs but escaping it lexically are rejected pre-resolve."""
+    escape_path = tmp_path / "kitty-specs" / ".." / "outside" / "mission"
+
+    with pytest.raises(ValueError, match="Untrusted status surface path"):
+        _assert_status_surface_path_is_trusted(
+            repo_root=tmp_path,
+            status_feature_dir=escape_path,
+        )

--- a/tests/specify_cli/cli/commands/test_merge.py
+++ b/tests/specify_cli/cli/commands/test_merge.py
@@ -967,12 +967,38 @@ def test_status_surface_rejects_path_under_neither_trusted_root(tmp_path: Path) 
         )
 
 
-def test_status_surface_rejects_lexical_escape_before_resolve(tmp_path: Path) -> None:
-    """Paths claiming kitty-specs but escaping it lexically are rejected pre-resolve."""
-    escape_path = tmp_path / "kitty-specs" / ".." / "outside" / "mission"
+def test_status_surface_rejects_symlink_indirection_into_trusted_root(
+    tmp_path: Path,
+) -> None:
+    """A surface that LEXICALLY escapes the claimed root but RESOLVES into a
+    trusted root via a symlink is rejected by the pre-resolution guard (PR #2043).
+
+    This is the case ONLY the early ``relative_to(claimed_root)`` raise catches:
+    the resolved form IS under kitty-specs, so the post-resolution topology check
+    and the terminal ``ensure_within_any`` would ACCEPT it. The lexical-must-match
+    hardening is what rejects the symlink indirection — a status surface must be
+    addressed by its canonical path, not via an untrusted symlink redirection.
+
+    Mutation-verified: reverting the early ``relative_to`` raise makes this surface
+    pass (accepted), so this test genuinely guards that hardening — unlike a
+    ``kitty-specs/../outside`` vector, which the post-resolve "under neither root"
+    check already rejects on its own.
+    """
+    from specify_cli.core.constants import KITTY_SPECS_DIR
+
+    repo_resolved = tmp_path.resolve(strict=False)
+    (repo_resolved / KITTY_SPECS_DIR).mkdir()
+    # A neutrally-named symlink OUTSIDE kitty-specs that points INTO it.
+    decoy = repo_resolved / "decoy"
+    decoy.symlink_to(repo_resolved / KITTY_SPECS_DIR, target_is_directory=True)
+    surface = decoy / "mission"  # lexically under decoy; resolves under kitty-specs
+
+    # Only the lexical pre-resolution guard can reject this: the resolved form IS
+    # under the trusted kitty-specs root, and the segment claims neither root.
+    assert surface.resolve(strict=False).is_relative_to(repo_resolved / KITTY_SPECS_DIR)
 
     with pytest.raises(ValueError, match="Untrusted status surface path"):
         _assert_status_surface_path_is_trusted(
             repo_root=tmp_path,
-            status_feature_dir=escape_path,
+            status_feature_dir=surface,
         )

--- a/tests/specify_cli/skills/test_verifier.py
+++ b/tests/specify_cli/skills/test_verifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from specify_cli.skills.manifest import (
@@ -256,6 +257,37 @@ def test_repair_handles_missing_source(tmp_path: Path) -> None:
     repaired, failed = repair_skills(tmp_path, verify_result, registry)
     assert repaired == 0
     assert failed == 1
+
+
+def test_repair_rejects_external_symlink_destination(tmp_path: Path) -> None:
+    """Repair must not write through a managed-skill symlink escaping the repo."""
+    canonical = "---\nname: test-skill\n---\n# Canonical\nCorrect content.\n"
+    registry = _create_registry(tmp_path, "test-skill", {"SKILL.md": canonical})
+
+    external = tmp_path / "home" / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    external.parent.mkdir(parents=True, exist_ok=True)
+    external.write_text("EXTERNAL", encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    installed_path = ".claude/skills/test-skill/SKILL.md"
+    link_path = repo / installed_path
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(external, link_path)
+
+    entry = _make_entry(
+        skill_name="test-skill",
+        source_file="SKILL.md",
+        installed_path=installed_path,
+        content_hash="sha256:stale",
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), repo)
+
+    verify_result = VerifyResult(ok=False, missing=[entry])
+
+    repaired, failed = repair_skills(repo, verify_result, registry)
+    assert repaired == 0
+    assert failed == 1
+    assert external.read_text(encoding="utf-8") == "EXTERNAL"
 
 
 def test_repair_updates_manifest(tmp_path: Path) -> None:

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -472,6 +472,15 @@ def test_perform_acceptance_persists_accept_commit(tmp_path: Path) -> None:
     and the real SHA was never written back after the commit was created.
     """
     repo_root, feature_dir = _create_test_feature(tmp_path)
+    # perform_acceptance commits the acceptance meta through the protected-primary
+    # router (01KVMBD6). The flattened fixture mission commits to the current ref;
+    # 'main' is protected and would be refused, so run from the (never-protected)
+    # mission branch — the same pattern the sibling regression tests use.
+    subprocess.run(
+        ["git", "-C", str(repo_root), "checkout", "-b", f"kitty/mission-{_FEATURE_SLUG}"],
+        check=True,
+        capture_output=True,
+    )
 
     summary = collect_feature_summary(repo_root, _FEATURE_SLUG)
     result = perform_acceptance(summary, mode="local", actor="test-agent")

--- a/tests/specify_cli/test_analysis_report.py
+++ b/tests/specify_cli/test_analysis_report.py
@@ -361,7 +361,18 @@ def test_record_analysis_refuses_dirty_worktree_before_write(tmp_path, monkeypat
     assert not (feature_dir / ANALYSIS_REPORT_FILENAME).exists()
 
 
-def test_record_analysis_refuses_protected_branch_before_write(tmp_path, monkeypatch):
+def test_record_analysis_succeeds_on_protected_branch_via_materialize(tmp_path, monkeypatch):
+    """record-analysis no longer REFUSES on a protected primary (01KVMBD6 / WP02).
+
+    The protected-branch hard-refusal was removed: the report is written to the
+    primary checkout (a plain file write, not a git op) and the commit is routed
+    best-effort through ``commit_for_mission`` (materialize-then-retry). So on a
+    protected ``main`` the command now SUCCEEDS (exit 0, report written) rather
+    than failing with ``PROTECTED_BRANCH_REFUSED``. (Was
+    ``test_record_analysis_refuses_protected_branch_before_write`` — renamed; the
+    old refuse contract is superseded by the materialize-then-retry contract that
+    ``test_accept_protected_branch_materialize_then_retry`` pins for accept.)
+    """
     repo_root = tmp_path
     feature_dir = repo_root / "kitty-specs" / "sample-01KS"
     _write_required_artifacts(feature_dir)
@@ -369,9 +380,6 @@ def test_record_analysis_refuses_protected_branch_before_write(tmp_path, monkeyp
     input_file = tmp_path.parent / f"{tmp_path.name}-analysis.md"
     input_file.write_text("# Analysis\n\nPASS\n", encoding="utf-8")
 
-    # _enforce_analysis_report_write_preflight uses subprocess git rev-parse --show-toplevel
-    # to get the CWD git root for the branch check. chdir into tmp_path so the subprocess
-    # sees the tmp repo (branch "main", protected) rather than the CI runner's checkout.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
     monkeypatch.setattr("specify_cli.cli.commands.agent.mission.locate_project_root", lambda: repo_root)
@@ -384,9 +392,9 @@ def test_record_analysis_refuses_protected_branch_before_write(tmp_path, monkeyp
         ["record-analysis", "--mission", feature_dir.name, "--input-file", str(input_file), "--json"],
     )
 
-    assert result.exit_code == 1
-    assert emitted["error_code"] == "PROTECTED_BRANCH_REFUSED"
-    assert not (feature_dir / ANALYSIS_REPORT_FILENAME).exists()
+    assert result.exit_code == 0, result.output
+    assert emitted["success"] is True
+    assert (feature_dir / ANALYSIS_REPORT_FILENAME).exists()
 
 
 # --- analysis-findings/v1 structured carrier (FR-004 / #1819) ----------------

--- a/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
+++ b/tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py
@@ -79,6 +79,18 @@ class TestWriteWrappers:
         second = (tmp_path / "bin" / "spec-kitty-wrapper").read_bytes()
         assert first == second
 
+    def test_second_write_replaces_broad_existing_permissions(self, tmp_path: Path) -> None:
+        write_wrappers(tmp_path, "3.2.0")
+        bash_path = tmp_path / "bin" / "spec-kitty-wrapper"
+        os.chmod(bash_path, 0o755)
+
+        write_wrappers(tmp_path, "3.2.0")
+
+        mode = os.stat(bash_path).st_mode
+        assert mode & stat.S_IXUSR
+        assert not (mode & stat.S_IXGRP)
+        assert not (mode & stat.S_IXOTH)
+
 
 # ---------------------------------------------------------------------------
 # wrapper content helpers (pure, no I/O)

--- a/tests/specify_cli/upgrade/test_occurrence_classification.py
+++ b/tests/specify_cli/upgrade/test_occurrence_classification.py
@@ -42,7 +42,8 @@ IMPLEMENT_TEMPLATE_PATH = (
 @pytest.fixture()
 def sample_file(tmp_path: Path) -> Path:
     """Create a simple text file for replacement tests."""
-    p = tmp_path / "sample.txt"
+    p = tmp_path / ".claude" / "skills" / "demo-skill" / "sample.txt"
+    p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text("hello world\nfoo bar baz\n", encoding="utf-8")
     return p
 
@@ -89,7 +90,7 @@ class TestApplyTextReplacementsNoFilter:
         assert "qux bar baz" in content
 
     def test_handles_missing_file(self, tmp_path: Path) -> None:
-        missing = tmp_path / "does_not_exist.txt"
+        missing = tmp_path / ".claude" / "skills" / "demo-skill" / "does_not_exist.txt"
         result = apply_text_replacements(missing, [("a", "b")])
         assert result is False
 
@@ -130,7 +131,7 @@ class TestApplyTextReplacementsWithFilter:
 
     def test_filter_skips_before_reading(self, tmp_path: Path) -> None:
         """If the filter rejects, the file is never opened (even if missing)."""
-        missing = tmp_path / "no_such_file.txt"
+        missing = tmp_path / ".claude" / "skills" / "demo-skill" / "no_such_file.txt"
         result = apply_text_replacements(
             missing,
             [("a", "b")],


### PR DESCRIPTION
## Summary
- harden skill upgrade and repair write paths so managed files do not write through external symlinks
- tighten merge status-surface trust checks before symlink resolution and write owner-only Claude wrapper executables atomically
- guard `setup-plan --json` against non-typed mocked commit results so PR CI stays green

## Why
- addresses open SonarCloud/GitHub code-scanning alerts `#40`, `#41`, `#42`, and `#43`
- no suppressions added

## Validation
- `.venv/bin/pytest tests/specify_cli/upgrade/test_occurrence_classification.py tests/specify_cli/upgrade/test_skill_update_external_symlinks.py -q`
- `.venv/bin/pytest tests/specify_cli/skills/test_verifier.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py -q`
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_merge.py -q`
- `.venv/bin/pytest tests/agent/test_agent_feature.py::TestSetupPlanCommand::test_scaffolds_plan_template_json -q`
- `.venv/bin/ruff check src/specify_cli/cli/commands/agent/mission.py src/specify_cli/cli/commands/merge.py src/specify_cli/skills/verifier.py src/specify_cli/tool_surface/bundles/claude_wrapper.py src/specify_cli/upgrade/skill_update.py tests/specify_cli/cli/commands/test_merge.py tests/specify_cli/skills/test_verifier.py tests/specify_cli/tool_surface/bundles/test_claude_wrapper.py tests/specify_cli/upgrade/test_occurrence_classification.py`
